### PR TITLE
fixed compilation not working by adding selection for correct backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ See [docs/residual-trace.md](docs/residual-trace.md) for the full writeup.
 
 ## Building & Testing
 
+(Needs Openblas under Linux)
 ```bash
 cargo build --release                    # optimised build
 cargo build --release --features metal   # with Metal GPU backend

--- a/crates/larql-compute/Cargo.toml
+++ b/crates/larql-compute/Cargo.toml
@@ -11,11 +11,17 @@ categories = ["science"]
 [dependencies]
 # Matrix types
 ndarray = { version = "0.16", features = ["blas"] }
-blas-src = { version = "0.10", features = ["accelerate"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+blas-src = { version = "0.10", features = ["openblas"] }
+
+
 
 # Metal GPU (macOS only, optional)
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = { version = "0.29", optional = true }
+blas-src = { version = "0.10", features = ["accelerate"] }
+
 
 [features]
 default = []

--- a/crates/larql-inference/Cargo.toml
+++ b/crates/larql-inference/Cargo.toml
@@ -26,10 +26,16 @@ libc = "0.2"
 
 # Matrix ops (BLAS-accelerated)
 ndarray = { version = "0.16", features = ["blas"] }
-blas-src = { version = "0.10", features = ["accelerate"] }
 
 # Tokenizer
 tokenizers = "0.21"
+
+
+[target.'cfg(target_os = "linux")'.dependencies]
+blas-src = { version = "0.10", features = ["openblas"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+blas-src = { version = "0.10", features = ["accelerate"] }
 
 [features]
 default = []


### PR DESCRIPTION
This should fix the error mentioned in #4 also specified that OpenBlas is needed under Linux in the Readme file for Linux. 

I could only test this under Linux and it compiled fine so Tests under Mac are still needed. 