### PR TITLE
build(compute): widen cargo rerun-if-changed to csrc/

### DIFF
--- a/crates/larql-compute/build.rs
+++ b/crates/larql-compute/build.rs
@@ -1,4 +1,10 @@
 fn main() {
+    // Rebuild if anything under csrc/ changes (new .c, new .h, modified source).
+    // The cc crate only auto-tracks files passed to .file(); this widens the net so
+    // a new or modified C source always triggers recompilation of q4_dot.
+    println!("cargo:rerun-if-changed=csrc");
+    println!("cargo:rerun-if-changed=build.rs");
+
     let mut build = cc::Build::new();
     build.file("csrc/q4_dot.c");
     build.opt_level(3);


### PR DESCRIPTION
## Summary

Fixes #14.

Add `cargo:rerun-if-changed=csrc` and `cargo:rerun-if-changed=build.rs` to `crates/larql-compute/build.rs` so any change under `csrc/` (new `.c`, new `.h`, or modified source) forces the build script to re-run and the `cc` crate to re-check its inputs.

## Why

The `cc` crate only auto-emits `rerun-if-changed` for files explicitly passed to `.file()`. That leaves two holes:

1. **New files don't trigger rebuilds.** A newly added `.c` or `.h` under `csrc/` is invisible to cargo's fingerprint until someone wires it into `build.rs`.
2. **Stale object files can survive branch transitions.** If the same `target/` has been used across branches where `csrc/q4_dot.c` differs, cargo can trust a cached `.o` compiled from a previous version of the source. The build script doesn't re-run, because no tracked input changed from cargo's view.

I hit the second case while working on an x86_64 scalar fallback for the Q4_0 kernel (will send that as a separate PR). After merging the kernel fix locally, tests kept failing until `cargo clean -p larql-compute` forced a rebuild. See #14 for the full context.

Widening the fingerprint to the whole `csrc/` directory is belt-and-suspenders over the per-`.file()` tracking — 2 lines, no runtime cost.

## Changes

- `crates/larql-compute/build.rs`: two `println!("cargo:rerun-if-changed=...")` lines.

## Test plan

- [x] `cargo test -p larql-compute --lib` still passes.
- [x] Verified adding a new file under `csrc/` now triggers a rebuild of `larql-compute` (previously it did not).
- [x] Verified modifying `csrc/q4_dot.c` still triggers a rebuild (regression check on existing behavior).

## Note

`cargo:rerun-if-changed=build.rs` is emitted implicitly by cargo already, but stating it explicitly makes the intent survive future refactors (e.g. if someone splits build.rs into multiple files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)