### PR TITLE
Fixes MacOS build issue

### DIFF
--- a/crates/larql-python/Cargo.toml
+++ b/crates/larql-python/Cargo.toml
@@ -10,6 +10,9 @@ description = "Python bindings for LARQL knowledge graph engine and vindex"
 name = "_native"
 crate-type = ["cdylib"]
 
+[build-dependencies]
+pyo3-build-config = "0.24"
+
 [dependencies]
 larql-core = { path = "../larql-core" }
 larql-inference = { path = "../larql-inference" }

--- a/crates/larql-python/build.rs
+++ b/crates/larql-python/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}


### PR DESCRIPTION
I'm not a Rust dev, so I asked Cursor for help getting it to build (#25) and it told me the following. It did fix the build, and the reasoning makes sense at a high level, but I really don't know anything about Cargo build dependencies or Rust, so hopefully it's at least a sane approach.

---
### What went wrong

- Failure was in **`larql-python`**, when linking the **`cdylib`** (`lib_native.dylib` / `_native`).
- The crate uses PyO3 with **`extension-module`**. That mode is for **Python extension modules**: you **do not link** `libpython`, so symbols like `_PyDict_New`, `_PyBaseObject_Type`, etc. are **supposed** to stay undefined in the `.dylib` until Python loads it.
- On **macOS**, the linker will not allow that unless you pass **`-undefined dynamic_lookup`** (often as two link args: `-undefined` and `dynamic_lookup`). Without that, the link step fails with **hundreds of “Undefined symbols for architecture arm64”** referencing `Py*` / `__Py_*`.

The **`ld: warning: … built for newer 'macOS' version (26.2) than being linked (11.0)`** lines are a separate, mild version-mismatch warning; the **hard error** was the missing Python symbols.

### Why PyO3 didn’t “just fix it”

PyO3 **used to** emit those linker flags from its build script. They **stopped** doing that because Cargo could wrongly **forward** `rustc-cdylib-link-arg` to **other** crates in the workspace. So PyO3’s docs now say **your** crate should set the flags (e.g. via **`pyo3_build_config::add_extension_module_link_args()`** in your own `build.rs`).

### What we changed (the fix)

In **`crates/larql-python`**:

1. **`build.rs`** — calls `pyo3_build_config::add_extension_module_link_args()` so on macOS the **`cdylib`** link gets `-undefined` / `dynamic_lookup`.
2. **`Cargo.toml`** — **`[build-dependencies] pyo3-build-config = "0.24"`** (aligned with PyO3 0.24).

That’s the whole fix for that linker failure.

---

**Note:** **`crates/larql-server/build.rs`** is unrelated: it only sets **`PROTOC`** and compiles **protobuf** for gRPC. The Python/macOS issue was **only** in **`larql-python`**.