### PR TITLE
fix(larql-models): use checked_div for head_dim derivation

### DIFF
--- a/crates/larql-models/src/detect.rs
+++ b/crates/larql-models/src/detect.rs
@@ -169,10 +169,8 @@ fn parse_model_config(config: &serde_json::Value) -> ModelConfig {
         .map(|v| v as usize)
         .unwrap_or(if default_head_dim > 0 {
             default_head_dim
-        } else if num_q_heads > 0 {
-            hidden_size / num_q_heads
         } else {
-            0
+            hidden_size.checked_div(num_q_heads).unwrap_or(0)
         });
     let num_kv_heads = text_config["num_key_value_heads"].as_u64().unwrap_or(4) as usize;
     // RoPE base: check rope_parameters.full_attention.rope_theta (Gemma 4),


### PR DESCRIPTION
## Summary

Resolves a `clippy::manual_checked_ops` failure in `crates/larql-models/src/detect.rs` that breaks the `larql-models` workflow under `-D warnings`.

The lint flags the `else if num_q_heads > 0 { hidden_size / num_q_heads } else { 0 }` pattern and recommends `hidden_size.checked_div(num_q_heads).unwrap_or(0)`. `checked_div` returns `None` iff the divisor is `0`, so the rewrite is behaviorally identical.

## Why this PR

This issue is **pre-existing on `main`** -- `git diff` against `main` for this file is empty -- but the workflow only retriggers on file changes that match its `paths:` filter. PR #48 bumped `Cargo.lock`, which retriggered the job under newer clippy and surfaced the lint. Landing this on `main` lets PR #48 (and any future PR) re-run cleanly.

## Test plan

- [x] `cargo clippy -p larql-models --all-targets -- -D warnings` -- clean
- [x] `cargo check -p larql-models --all-targets` -- clean
- [x] `cargo test -p larql-models --lib` -- 179 passed