### PR TITLE
Add FreeBSD OpenBLAS target dependencies

### DIFF
--- a/crates/larql-compute/Cargo.toml
+++ b/crates/larql-compute/Cargo.toml
@@ -17,7 +17,7 @@ rayon = "1.10"
 # Tests/benches depend on it too — keep both lists in sync.
 larql-models = { path = "../larql-models" }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 blas-src = { version = "0.10", features = ["openblas"], default-features = false }
 openblas-src = { version = "0.10", features = ["system"] }
 

--- a/crates/larql-inference/Cargo.toml
+++ b/crates/larql-inference/Cargo.toml
@@ -64,7 +64,7 @@ wasmtime-wasi = "29"
 anyhow = "1"
 
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 blas-src = { version = "0.10", features = ["openblas"], default-features = false }
 openblas-src = { version = "0.10", features = ["system"] }
 


### PR DESCRIPTION
This makes the CPU/OpenBLAS backend build on FreeBSD by using the same system OpenBLAS dependency setup as Linux.

Without this, `larql-compute` reaches `extern crate blas_src` on FreeBSD, but no target-specific `blas-src` dependency is enabled, causing:

```text
error[E0463]: can't find crate for `blas_src`
```

FreeBSD packages OpenBLAS as a system library, matching the existing Linux setup:

```text
/usr/local/lib/libopenblas.so.0
```

Verified on FreeBSD 15 with:

```sh
cargo build -p larql-cli --release
cargo test -p larql-compute --lib
```

`cargo test -p larql-compute --lib` passed 126 tests.
