### PR TITLE
Allow pulling vindexes from HuggingFace model repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1236,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1993,7 +2016,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokenizers",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -2034,7 +2057,9 @@ dependencies = [
  "memmap2",
  "metal",
  "ndarray",
+ "objc",
  "openblas-src",
+ "rayon",
  "serde_json",
 ]
 
@@ -2056,15 +2081,22 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_approx_eq",
+ "async-stream",
  "blas-src",
+ "futures",
  "larql-compute",
  "larql-core",
  "larql-models",
+ "larql-router-protocol",
  "larql-vindex",
  "libc",
  "memmap2",
+ "minijinja",
+ "minijinja-contrib",
  "ndarray",
  "openblas-src",
+ "rand 0.8.6",
+ "rand_distr",
  "rayon",
  "reqwest",
  "safetensors",
@@ -2073,8 +2105,11 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokenizers",
+ "tokio",
+ "tonic",
  "wasmtime",
  "wasmtime-wasi",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -2099,6 +2134,7 @@ dependencies = [
 name = "larql-models"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "memmap2",
  "ndarray",
  "safetensors",
@@ -2161,17 +2197,22 @@ dependencies = [
 name = "larql-server"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "axum",
  "axum-server",
+ "base64 0.22.1",
  "clap",
+ "futures",
  "larql-compute",
  "larql-inference",
  "larql-models",
  "larql-router-protocol",
  "larql-vindex",
+ "libc",
  "memmap2",
  "prost",
  "protobuf-src",
+ "rayon",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2183,6 +2224,8 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -2203,6 +2246,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokenizers",
 ]
@@ -2414,12 +2458,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minijinja"
 version = "2.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
 dependencies = [
  "memo-map",
+ "serde",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45092d80391870622fcf3bd82f5d2af18f99533ea60debb4bc9db0c76f0e809a"
+dependencies = [
+ "minijinja",
  "serde",
 ]
 
@@ -3410,6 +3474,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,11 +4259,13 @@ dependencies = [
  "prost",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4334,6 +4434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,7 +4517,7 @@ dependencies = [
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4455,6 +4561,48 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip 3.0.0",
+]
 
 [[package]]
 name = "valuable"
@@ -4973,6 +5121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5505,7 +5662,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/crates/larql-vindex/src/format/huggingface/download.rs
+++ b/crates/larql-vindex/src/format/huggingface/download.rs
@@ -12,6 +12,42 @@ use crate::format::filenames::*;
 use super::publish::get_hf_token;
 use super::{VINDEX_CORE_FILES, VINDEX_WEIGHT_FILES};
 
+const HF_PULL_REPO_TYPES: [hf_hub::RepoType; 2] =
+    [hf_hub::RepoType::Model, hf_hub::RepoType::Dataset];
+
+fn hf_repo(
+    api: &hf_hub::api::sync::Api,
+    repo_id: &str,
+    revision: Option<&str>,
+    repo_type: hf_hub::RepoType,
+) -> hf_hub::api::sync::ApiRepo {
+    if let Some(rev) = revision {
+        api.repo(hf_hub::Repo::with_revision(
+            repo_id.to_string(),
+            repo_type,
+            rev.to_string(),
+        ))
+    } else {
+        api.repo(hf_hub::Repo::new(repo_id.to_string(), repo_type))
+    }
+}
+
+fn repo_type_cache_prefix(repo_type: hf_hub::RepoType) -> &'static str {
+    match repo_type {
+        hf_hub::RepoType::Model => "models",
+        hf_hub::RepoType::Dataset => "datasets",
+        hf_hub::RepoType::Space => "spaces",
+    }
+}
+
+fn repo_type_resolve_prefix(repo_type: hf_hub::RepoType) -> &'static str {
+    match repo_type {
+        hf_hub::RepoType::Model => "",
+        hf_hub::RepoType::Dataset => "datasets/",
+        hf_hub::RepoType::Space => "spaces/",
+    }
+}
+
 /// Resolve an `hf://` path to a local directory, downloading if needed.
 ///
 /// Supports:
@@ -36,26 +72,31 @@ pub fn resolve_hf_vindex(hf_path: &str) -> Result<PathBuf, VindexError> {
     let api = hf_hub::api::sync::Api::new()
         .map_err(|e| VindexError::Parse(format!("HuggingFace API init failed: {e}")))?;
 
-    let repo = if let Some(ref rev) = revision {
-        api.repo(hf_hub::Repo::with_revision(
-            repo_id.clone(),
-            hf_hub::RepoType::Dataset,
-            rev.clone(),
-        ))
-    } else {
-        api.repo(hf_hub::Repo::new(
-            repo_id.clone(),
-            hf_hub::RepoType::Dataset,
-        ))
-    };
-
-    // Download index.json first (small, tells us what we need)
-    let index_path = repo.get(INDEX_JSON).map_err(|e| {
-        VindexError::Parse(format!(
-            "failed to download index.json from hf://{}: {e}",
-            repo_id
-        ))
-    })?;
+    // Prefer model repos because `larql publish` defaults to `repo_type = "model"`,
+    // but keep dataset fallback for older vindex repos and docs examples.
+    let mut last_err = None;
+    let (repo, index_path) = HF_PULL_REPO_TYPES
+        .into_iter()
+        .find_map(|repo_type| {
+            let repo = hf_repo(&api, &repo_id, revision.as_deref(), repo_type);
+            match repo.get(INDEX_JSON) {
+                Ok(path) => Some((repo, path)),
+                Err(e) => {
+                    last_err = Some(e.to_string());
+                    None
+                }
+            }
+        })
+        .ok_or_else(|| {
+            VindexError::Parse(format!(
+                "failed to download index.json from hf://{}{}",
+                repo_id,
+                last_err
+                    .as_deref()
+                    .map(|e| format!(": {e}"))
+                    .unwrap_or_default()
+            ))
+        })?;
 
     let vindex_dir = index_path
         .parent()
@@ -89,24 +130,20 @@ pub fn download_hf_weights(hf_path: &str) -> Result<(), VindexError> {
     let api = hf_hub::api::sync::Api::new()
         .map_err(|e| VindexError::Parse(format!("HuggingFace API init failed: {e}")))?;
 
-    let repo = if let Some(ref rev) = revision {
-        api.repo(hf_hub::Repo::with_revision(
-            repo_id.clone(),
-            hf_hub::RepoType::Dataset,
-            rev.clone(),
-        ))
-    } else {
-        api.repo(hf_hub::Repo::new(
-            repo_id.clone(),
-            hf_hub::RepoType::Dataset,
-        ))
-    };
-
-    for filename in VINDEX_WEIGHT_FILES {
-        let _ = repo.get(filename); // optional, skip if not in repo
+    for repo_type in HF_PULL_REPO_TYPES {
+        let repo = hf_repo(&api, &repo_id, revision.as_deref(), repo_type);
+        if repo.get(INDEX_JSON).is_err() {
+            continue;
+        }
+        for filename in VINDEX_WEIGHT_FILES {
+            let _ = repo.get(filename); // optional, skip if not in repo
+        }
+        return Ok(());
     }
 
-    Ok(())
+    Err(VindexError::Parse(format!(
+        "failed to fetch index.json from hf://{repo_id}"
+    )))
 }
 
 /// Re-exported from hf-hub 0.5 so callers don't have to depend on
@@ -145,9 +182,10 @@ fn cached_snapshot_file(
     repo_id: &str,
     revision: Option<&str>,
     filename: &str,
+    repo_type: hf_hub::RepoType,
 ) -> Option<(PathBuf, u64)> {
-    let (etag, size) = head_etag_and_size(repo_id, revision, filename)?;
-    let repo_dir = hf_cache_repo_dir(repo_id)?;
+    let (etag, size) = head_etag_and_size(repo_id, revision, filename, repo_type)?;
+    let repo_dir = hf_cache_repo_dir(repo_id, repo_type)?;
     let blob_path = repo_dir.join("blobs").join(&etag);
     let meta = std::fs::metadata(&blob_path).ok()?;
     if !meta.is_file() {
@@ -191,9 +229,11 @@ fn head_etag_and_size(
     repo_id: &str,
     revision: Option<&str>,
     filename: &str,
+    repo_type: hf_hub::RepoType,
 ) -> Option<(String, u64)> {
     let rev = revision.unwrap_or("main");
-    let url = format!("https://huggingface.co/datasets/{repo_id}/resolve/{rev}/{filename}");
+    let prefix = repo_type_resolve_prefix(repo_type);
+    let url = format!("https://huggingface.co/{prefix}{repo_id}/resolve/{rev}/{filename}");
     let token = get_hf_token().ok();
 
     // **No redirects.** HF LFS files 302 → S3, and `X-Linked-Etag` +
@@ -249,7 +289,7 @@ fn strip_etag_quoting(raw: &str) -> String {
 /// `~/.cache/huggingface/hub/datasets--{owner}--{name}/`. Honours
 /// `HF_HOME` and `HUGGINGFACE_HUB_CACHE` env overrides that hf-hub itself
 /// respects.
-fn hf_cache_repo_dir(repo_id: &str) -> Option<PathBuf> {
+fn hf_cache_repo_dir(repo_id: &str, repo_type: hf_hub::RepoType) -> Option<PathBuf> {
     let hub_root = if let Ok(hub) = std::env::var("HUGGINGFACE_HUB_CACHE") {
         PathBuf::from(hub)
     } else if let Ok(hf_home) = std::env::var("HF_HOME") {
@@ -262,7 +302,7 @@ fn hf_cache_repo_dir(repo_id: &str) -> Option<PathBuf> {
             .join("hub")
     };
     let safe = repo_id.replace('/', "--");
-    Some(hub_root.join(format!("datasets--{safe}")))
+    Some(hub_root.join(format!("{}--{safe}", repo_type_cache_prefix(repo_type))))
 }
 
 /// Like [`resolve_hf_vindex`], but drives a progress reporter per file.
@@ -299,56 +339,51 @@ where
     let api = hf_hub::api::sync::Api::new()
         .map_err(|e| VindexError::Parse(format!("HuggingFace API init failed: {e}")))?;
 
-    let repo = if let Some(ref rev) = revision {
-        api.repo(hf_hub::Repo::with_revision(
-            repo_id.clone(),
-            hf_hub::RepoType::Dataset,
-            rev.clone(),
-        ))
-    } else {
-        api.repo(hf_hub::Repo::new(
-            repo_id.clone(),
-            hf_hub::RepoType::Dataset,
-        ))
-    };
+    for repo_type in HF_PULL_REPO_TYPES {
+        let repo = hf_repo(&api, &repo_id, revision.as_deref(), repo_type);
 
-    // Helper: one file, with cache short-circuit. Returns the resolved
-    // on-disk path. The cache check fires the progress reporter so the
-    // bar shows a filled-to-100% track tagged with the filename — users
-    // see that the file was served from cache, not re-downloaded.
-    let mut fetch = |filename: &str, label: &str| -> Option<PathBuf> {
-        if let Some((cached_path, size)) =
-            cached_snapshot_file(&repo_id, revision.as_deref(), filename)
-        {
-            // Tag the progress message so the bar visibly distinguishes
-            // "cached" from "just downloaded very fast". Callers rendering
-            // the bar see the prefix at init time and can restyle.
-            let mut p = progress(label);
-            let tagged = format!("{filename} [cached]");
-            p.init(size as usize, &tagged);
-            p.update(size as usize);
-            p.finish();
-            return Some(cached_path);
-        }
-        repo.download_with_progress(filename, progress(label)).ok()
-    };
+        // Helper: one file, with cache short-circuit. Returns the resolved
+        // on-disk path. The cache check fires the progress reporter so the
+        // bar shows a filled-to-100% track tagged with the filename — users
+        // see that the file was served from cache, not re-downloaded.
+        let mut fetch = |filename: &str, label: &str| -> Option<PathBuf> {
+            if let Some((cached_path, size)) =
+                cached_snapshot_file(&repo_id, revision.as_deref(), filename, repo_type)
+            {
+                // Tag the progress message so the bar visibly distinguishes
+                // "cached" from "just downloaded very fast". Callers rendering
+                // the bar see the prefix at init time and can restyle.
+                let mut p = progress(label);
+                let tagged = format!("{filename} [cached]");
+                p.init(size as usize, &tagged);
+                p.update(size as usize);
+                p.finish();
+                return Some(cached_path);
+            }
+            repo.download_with_progress(filename, progress(label)).ok()
+        };
 
-    // index.json drives everything — we need its snapshot dir to know
-    // where the rest of the files live. Cache-hit or download.
-    let index_path = fetch(INDEX_JSON, INDEX_JSON).ok_or_else(|| {
-        VindexError::Parse(format!("failed to fetch index.json from hf://{repo_id}"))
-    })?;
-    let vindex_dir = index_path
-        .parent()
-        .ok_or_else(|| VindexError::Parse("cannot determine vindex directory".into()))?
-        .to_path_buf();
-
-    for filename in VINDEX_CORE_FILES {
-        if *filename == INDEX_JSON {
+        // index.json drives everything — we need its snapshot dir to know
+        // where the rest of the files live. Cache-hit or download.
+        let Some(index_path) = fetch(INDEX_JSON, INDEX_JSON) else {
             continue;
+        };
+        let vindex_dir = index_path
+            .parent()
+            .ok_or_else(|| VindexError::Parse("cannot determine vindex directory".into()))?
+            .to_path_buf();
+
+        for filename in VINDEX_CORE_FILES {
+            if *filename == INDEX_JSON {
+                continue;
+            }
+            // Optional files — ignore failures (missing from repo is fine).
+            let _ = fetch(filename, filename);
         }
-        // Optional files — ignore failures (missing from repo is fine).
-        let _ = fetch(filename, filename);
+        return Ok(vindex_dir);
     }
-    Ok(vindex_dir)
+
+    Err(VindexError::Parse(format!(
+        "failed to fetch index.json from hf://{repo_id}"
+    )))
 }


### PR DESCRIPTION
`larql publish` defaults to HuggingFace model repos, but the pull/download path only tried dataset repos. That makes public vindexes published as model repos fail to pull.

This changes the HF vindex resolver to:

- try model repos first, matching the publish default;
- fall back to dataset repos for compatibility with existing examples or older artifacts;
- use the matching cache directory prefix (`models--...` vs `datasets--...`);
- use the matching direct resolve URL for the progress/cache HEAD probe.

Observed failure before this patch:

```sh
larql pull hf://chrishayuk/gemma-3-4b-it-vindex-browse
```

failed with:

```text
Error: parse error: failed to fetch index.json from hf://chrishayuk/gemma-3-4b-it-vindex-browse
```

The repo is public as a model repo; the dataset API path is the mismatch.

Validation:

```sh
cargo fmt --check --package larql-vindex
cargo check -p larql-vindex      # passes when the FreeBSD OpenBLAS dependency fix from #58 is applied
cargo build -p larql-cli --release
./target/release/larql pull hf://chrishayuk/gemma-3-4b-it-vindex-browse
./target/release/larql show hf://chrishayuk/gemma-3-4b-it-vindex-browse
```

The pull now resolves and caches:

```text
models--chrishayuk--gemma-3-4b-it-vindex-browse/snapshots/1b2bd5adbe745891465d561c82da852d6b65529b
```

and reports the expected browse vindex metadata:

```text
34 layers, hidden_size=2560, dtype=F32, level=browse
```
