### PR TITLE
feat(safetensors): support F8_E4M3 / F8_E5M2 / F8_E8M0 / I8 dtypes (rebased from #35)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,8 +1548,21 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
  "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3776,10 +3795,11 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safetensors"
-version = "0.5.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc0cdb7198d738a111f6df8fef42cb175412c311d0c4ac9126ff4e550ad1a0e8"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
 dependencies = [
+ "hashbrown 0.16.1",
  "serde",
  "serde_json",
 ]

--- a/crates/larql-cli/Cargo.toml
+++ b/crates/larql-cli/Cargo.toml
@@ -23,7 +23,7 @@ indicatif = "0.17"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 base64 = "0.22"
 tokenizers = "0.21"
-safetensors = "0.5"
+safetensors = "0.7"
 memmap2 = "0.9"
 ndarray = "0.16"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/larql-cli/src/commands/extraction/compile_cmd/save.rs
+++ b/crates/larql-cli/src/commands/extraction/compile_cmd/save.rs
@@ -110,7 +110,7 @@ pub fn write_safetensors(
         );
     }
 
-    let serialized = serialize(&views, &None)?;
+    let serialized = serialize(&views, None)?;
     std::fs::write(path, serialized)?;
     Ok(())
 }

--- a/crates/larql-inference/Cargo.toml
+++ b/crates/larql-inference/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8"
 rand_distr = "0.4"
 
 # Model weights
-safetensors = "0.5"
+safetensors = "0.7"
 memmap2 = "0.9"
 
 # System

--- a/crates/larql-models/Cargo.toml
+++ b/crates/larql-models/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 # Model weight loading
-safetensors = "0.5"
+safetensors = "0.7"
 memmap2 = "0.9"
 
 [dev-dependencies]

--- a/crates/larql-models/src/loading/safetensors.rs
+++ b/crates/larql-models/src/loading/safetensors.rs
@@ -584,8 +584,98 @@ fn tensor_to_f32(view: &safetensors::tensor::TensorView<'_>) -> Result<Vec<f32>,
         }
         safetensors::Dtype::F16 => Ok(half::decode_f16(view.data())),
         safetensors::Dtype::BF16 => Ok(half::decode_bf16(view.data())),
+
+        // ── FP8 / I8 — used by DeepSeek-V4 (MXFP4 experts), GPT-OSS, etc. ──
+        // Decoded bit-pattern → f32 in isolation. MXFP4 unpacking proper (where
+        // an I8 packed-nibble weight is paired with its F8_E8M0 scale companion)
+        // happens at the FFN tensor loading layer — `tensor_to_f32` sees one
+        // tensor at a time and can't look at companions.
+        safetensors::Dtype::F8_E4M3 => Ok(decode_f8_e4m3(view.data())),
+        safetensors::Dtype::F8_E5M2 => Ok(decode_f8_e5m2(view.data())),
+        safetensors::Dtype::F8_E8M0 => Ok(decode_f8_e8m0(view.data())),
+        safetensors::Dtype::I8 => Ok(view.data().iter().map(|&b| (b as i8) as f32).collect()),
+
         other => Err(ModelError::UnsupportedDtype(format!("{other:?}"))),
     }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// FP8 / E8M0 decoders — bit-pattern → f32. Operate per-byte on the raw view.
+// Standard Open Compute Project encodings; verified against the F8_E*M* table
+// in the safetensors crate (≥ 0.7).
+// ────────────────────────────────────────────────────────────────────────────
+
+/// FP8 E4M3 (FN, finite-only): 1 sign + 4 exponent + 3 mantissa bits, bias 7.
+/// NaN encoded at 0x7F / 0xFF (Open Compute convention).
+#[inline]
+fn decode_f8_e4m3(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .iter()
+        .map(|&b| {
+            let sign = (b >> 7) & 1;
+            let exp_bits = (b >> 3) & 0x0F;
+            let mant_bits = b & 0x07;
+            let v = if exp_bits == 0 {
+                (mant_bits as f32) / 8.0 * 2f32.powi(1 - 7)
+            } else if exp_bits == 0x0F && mant_bits == 0x07 {
+                f32::NAN
+            } else {
+                let m = 1.0 + (mant_bits as f32) / 8.0;
+                m * 2f32.powi(exp_bits as i32 - 7)
+            };
+            if sign == 1 {
+                -v
+            } else {
+                v
+            }
+        })
+        .collect()
+}
+
+/// FP8 E5M2: 1 sign + 5 exponent + 2 mantissa bits, bias 15.
+#[inline]
+fn decode_f8_e5m2(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .iter()
+        .map(|&b| {
+            let sign = (b >> 7) & 1;
+            let exp_bits = (b >> 2) & 0x1F;
+            let mant_bits = b & 0x03;
+            let v = if exp_bits == 0 {
+                (mant_bits as f32) / 4.0 * 2f32.powi(1 - 15)
+            } else if exp_bits == 0x1F {
+                if mant_bits == 0 {
+                    f32::INFINITY
+                } else {
+                    f32::NAN
+                }
+            } else {
+                let m = 1.0 + (mant_bits as f32) / 4.0;
+                m * 2f32.powi(exp_bits as i32 - 15)
+            };
+            if sign == 1 {
+                -v
+            } else {
+                v
+            }
+        })
+        .collect()
+}
+
+/// FP8 E8M0 (Open Compute Microscaling MX format scale): 8 exponent bits, no
+/// sign or mantissa. Value = 2^(byte - 127). Byte 0xFF reserved as NaN.
+#[inline]
+fn decode_f8_e8m0(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .iter()
+        .map(|&b| {
+            if b == 0xFF {
+                f32::NAN
+            } else {
+                2f32.powi(b as i32 - 127)
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/larql-vindex/Cargo.toml
+++ b/crates/larql-vindex/Cargo.toml
@@ -32,7 +32,7 @@ sha2 = "0.10"
 base64 = "0.22"
 
 # Model weights (for safetensors loading during extract)
-safetensors = "0.5"
+safetensors = "0.7"
 memmap2 = "0.9"
 
 # Refcounted, slice-cheap byte handle returned by the `VindexStorage`

--- a/crates/larql-vindex/benches/extract_throughput.rs
+++ b/crates/larql-vindex/benches/extract_throughput.rs
@@ -114,7 +114,7 @@ fn make_model(dir: &Path, hidden: usize, intermediate: usize, num_layers: usize,
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(dir.join("model.safetensors"), &serialized).unwrap();
 }
 

--- a/crates/larql-vindex/benches/q4k_vs_f32.rs
+++ b/crates/larql-vindex/benches/q4k_vs_f32.rs
@@ -111,7 +111,7 @@ fn make_model(dir: &Path, hidden: usize, intermediate: usize, num_layers: usize,
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(dir.join("model.safetensors"), &serialized).unwrap();
 }
 

--- a/crates/larql-vindex/examples/q4k_demo.rs
+++ b/crates/larql-vindex/examples/q4k_demo.rs
@@ -346,7 +346,7 @@ fn make_synthetic_model(
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(dir.join("model.safetensors"), &serialized).unwrap();
 }
 

--- a/crates/larql-vindex/src/walker/test_fixture.rs
+++ b/crates/larql-vindex/src/walker/test_fixture.rs
@@ -216,7 +216,7 @@ fn write_safetensors(dir: &Path, tensors: &HashMap<String, (Vec<f32>, Vec<usize>
             .unwrap(),
         );
     }
-    let serialized = safetensors::tensor::serialize(&data_map, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(&data_map, None).unwrap();
     std::fs::write(dir.join("model.safetensors"), serialized).unwrap();
 }
 

--- a/crates/larql-vindex/tests/golden_resume.rs
+++ b/crates/larql-vindex/tests/golden_resume.rs
@@ -111,7 +111,7 @@ fn write_synth_model(model_dir: &Path) {
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(model_dir.join("model.safetensors"), &serialized).unwrap();
 
     let tok_json =

--- a/crates/larql-vindex/tests/test_streaming_stages_moe.rs
+++ b/crates/larql-vindex/tests/test_streaming_stages_moe.rs
@@ -130,7 +130,7 @@ fn write_synthetic_mixtral_model(
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(model_dir.join("model.safetensors"), serialized).unwrap();
 
     // Minimal BPE tokenizer — enough for safetensors-backed extracts
@@ -367,7 +367,7 @@ fn write_synthetic_gemma4_hybrid_moe(
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(model_dir.join("model.safetensors"), serialized).unwrap();
 
     let tok_json =
@@ -622,7 +622,7 @@ fn write_synthetic_gpt_oss_model(
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(model_dir.join("model.safetensors"), serialized).unwrap();
 
     let tok_json =

--- a/crates/larql-vindex/tests/test_vindex.rs
+++ b/crates/larql-vindex/tests/test_vindex.rs
@@ -2561,7 +2561,7 @@ fn streaming_extract_from_safetensors() {
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(model_dir.join("model.safetensors"), &serialized).unwrap();
 
     // Write tokenizer
@@ -2765,7 +2765,7 @@ fn streaming_extract_q4k_from_safetensors() {
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(model_dir.join("model.safetensors"), &serialized).unwrap();
 
     let tok_json =
@@ -3729,7 +3729,7 @@ fn streaming_extract_q4k_carries_ple_tensors() {
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(model_dir.join("model.safetensors"), &serialized).unwrap();
 
     let tok_json =
@@ -4018,7 +4018,7 @@ fn streaming_extract_preserves_per_layer_intermediate_for_variable_ffn() {
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(model_dir.join("model.safetensors"), &serialized).unwrap();
 
     let tok_json =

--- a/crates/larql-vindex/tests/test_vindex_to_q4k.rs
+++ b/crates/larql-vindex/tests/test_vindex_to_q4k.rs
@@ -244,7 +244,7 @@ fn write_synthetic_llama_model(
             )
         })
         .collect();
-    let serialized = safetensors::tensor::serialize(views, &None).unwrap();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
     std::fs::write(model_dir.join("model.safetensors"), serialized).unwrap();
     let tok_json =
         r#"{"version":"1.0","model":{"type":"BPE","vocab":{},"merges":[]},"added_tokens":[]}"#;


### PR DESCRIPTION
Forward-port of @mikeumus's #35 onto current main. The original branch was based on April-24 main and carried ~17k LOC of Divinci-AI fork drift (RFC-0001 commands, Python bindings, fork-specific docs) that doesn't belong upstream — this branch carries only the actual feature commit (\`01e5f0d\`).

Authorship preserved as \`Mike Mooring <mike@divinci.ai>\` on the rebased commit.

## What lands

- **Bumps \`safetensors\` 0.5 → 0.7** across \`larql-cli\`, \`larql-inference\`, \`larql-models\`, \`larql-vindex\`. Required for the new FP8 dtype variants.
- **New per-byte decoders** in \`crates/larql-models/src/loading/safetensors.rs\`: \`decode_f8_e4m3\`, \`decode_f8_e5m2\`, \`decode_f8_e8m0\`. Standard Open Compute Project encodings, verified against the F8_E*M* table in safetensors 0.7.
- **\`tensor_to_f32\` learns four new dtypes**: \`F8_E4M3\`, \`F8_E5M2\`, \`F8_E8M0\`, \`I8\`. Each decodes bit-pattern → f32 in isolation. MXFP4 unpacking proper (I8 packed nibbles paired with F8_E8M0 scales) happens at the FFN tensor loading layer — \`tensor_to_f32\` sees one tensor at a time and can't look at companions.
- **API call-site update for safetensors 0.7**: \`serialize(&views, &None)\` → \`serialize(&views, None)\` across 8 test / bench / example files in \`larql-vindex\`. Mechanical signature change in the new safetensors API.

## Conflict resolutions vs. #35

- The four \`*.bak.bak\` files (sed leftovers acknowledged in #35's own follow-up cleanup commit) were dropped.
- \`bench_cmd.rs\` had unrelated fork drift (the Divinci-AI fork stripped the \`metal\` feature gate and Metal backend dispatch). Kept main's version — the Metal backend dispatch stays.
- \`safetensors.rs\` had a structural conflict where main had added a \`#[cfg(test)] mod tests\` block at the file tail and the cherry-picked commit added FP8 decoder fns in the same area. Merged: decoders now sit between \`decode_dtype\` and \`mod tests\`, then formatted via \`cargo fmt\`.

## Validation

- \`cargo check -p larql-models -p larql-vindex -p larql-inference -p larql-cli --lib --tests\` ✓
- \`cargo test -p larql-models -p larql-vindex -p larql-inference --lib\` — 932 pass, 0 fail
- \`cargo fmt --check\` ✓ on the four crates touched
- @mikeumus runtime-validated FP8 dtypes for the DeepSeek-V4 / MXFP4 use case in #35; the dtype-decoder logic is unchanged here.

## Foundations for follow-up PRs

This PR is the foundation. The remaining mikeumus PRs in this stack build on top:
- #37 (MXFP4 per-expert dequant) consumes \`F8_E8M0\` + \`I8\` here for the scale/nibble pairing
- #39 (DeepSeekV4Arch tensor naming) maps the V4 tensor layout these dtypes ship in
- #40 (MXFP4-aware streaming gate_vectors) wires that into the streaming extract path

Closes #35.

Note: examples in \`crates/larql-compute/examples/\` (\`demo_architecture\`, \`compare_ollama\`, \`diag_decode_pipeline\`) fail to compile; verified the same failure exists on \`origin/main\` untouched, so unrelated to this PR.