### PR TITLE
feat(mxfp4): per-expert dequantization for DeepSeek-V4 layout (rebased from #37)

### DIFF
--- a/crates/larql-models/src/loading/safetensors.rs
+++ b/crates/larql-models/src/loading/safetensors.rs
@@ -244,10 +244,25 @@ fn load_model_dir_filtered_with_validation(
                     }
                 }
             } else {
+                // Per-expert MXFP4 detection (DeepSeek-V4 family): each expert's
+                // gate/up/down is stored as a separate (.weight=I8, .scale=F8_E8M0)
+                // pair, distinct from GPT-OSS's fused `gate_up_proj_blocks` +
+                // `scales` tensors handled by `load_mxfp4_expert_tensors` above.
+                // The detector returns the set of consumed tensor names so the
+                // main loop below skips them. No-op for non-V4 architectures.
+                let v4_dequantized_keys =
+                    dequantize_per_expert_mxfp4(&st, &tensor_names, prefixes, &mut tensors)?;
+
                 for (name, view) in st.tensors() {
                     let key = normalize_key(&name, prefixes);
                     let shape = view.shape();
                     if skip_key(&key) {
+                        continue;
+                    }
+
+                    // Skip tensors consumed by the V4 dequantizer (both .weight
+                    // and the companion .scale).
+                    if v4_dequantized_keys.contains(&name) {
                         continue;
                     }
 
@@ -561,6 +576,111 @@ fn load_mxfp4_expert_tensors(
 
 fn mxfp4_expert_key(layer_prefix: &str, expert_id: usize, projection: &str) -> String {
     format!("{layer_prefix}.{BLOCK_SPARSE_EXPERTS_PREFIX}.{expert_id}.{projection}.weight")
+}
+
+/// Per-expert MXFP4 dequantization (DeepSeek-V4 family).
+///
+/// DeepSeek-V4 stores expert weights one (.weight, .scale) pair per
+/// (expert, projection) — `layers.X.ffn.experts.E.w1.weight` (I8 packed FP4) +
+/// `layers.X.ffn.experts.E.w1.scale` (F8_E8M0 scales), ditto w2/w3. This is
+/// distinct from GPT-OSS's fused `experts.gate_up_proj_blocks` layout that
+/// `load_mxfp4_expert_tensors` handles.
+///
+/// Detects the format by scanning for `*.experts.<digit>.w[123].weight` tensors
+/// with `I8` dtype. For each match, looks up the companion `.scale` (`F8_E8M0`)
+/// and dequantizes via `quant::mxfp4::dequantize_expert`.
+///
+/// Returns the set of tensor names that were consumed (both `.weight` and
+/// `.scale`) so the main loading loop can skip them.
+fn dequantize_per_expert_mxfp4(
+    st: &safetensors::SafeTensors,
+    tensor_names: &[String],
+    prefixes: &[&str],
+    tensors: &mut HashMap<String, crate::WeightArray>,
+) -> Result<std::collections::HashSet<String>, ModelError> {
+    use std::collections::HashSet;
+    let mut consumed: HashSet<String> = HashSet::new();
+
+    // Match V4-style per-expert weights: any tensor name containing
+    // ".experts.<int>.w<1|2|3>.weight" — broad enough to catch both the
+    // full `model.layers.X.ffn.experts.E.wY.weight` (HF default) and any
+    // shortened variant (`layers.X.ffn.experts.E.wY.weight`).
+    let is_v4_expert_weight = |name: &str| -> bool {
+        if !name.ends_with(".w1.weight")
+            && !name.ends_with(".w2.weight")
+            && !name.ends_with(".w3.weight")
+        {
+            return false;
+        }
+        // Must have ".experts.<digit>" before the .wN.weight suffix
+        if let Some(idx) = name.rfind(".experts.") {
+            let after = &name[idx + ".experts.".len()..];
+            if let Some(dot) = after.find('.') {
+                return after[..dot].chars().all(|c| c.is_ascii_digit());
+            }
+        }
+        false
+    };
+
+    for name in tensor_names {
+        if !is_v4_expert_weight(name) {
+            continue;
+        }
+
+        let weight_view = match st.tensor(name) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        // V4 packed FP4 weights are stored as I8 (signed) per the safetensors header.
+        if weight_view.dtype() != safetensors::Dtype::I8 {
+            continue;
+        }
+
+        let scale_name = name.replacen(".weight", ".scale", 1);
+        let scale_view = match st.tensor(&scale_name) {
+            Ok(v) => v,
+            Err(_) => continue, // No scale companion → not MXFP4, leave to main loop.
+        };
+        if scale_view.dtype() != safetensors::Dtype::F8_E8M0 {
+            continue;
+        }
+
+        // Shape sanity. weight: (out_features, packed_in/2). scale: (out_features, groups).
+        let w_shape = weight_view.shape();
+        let s_shape = scale_view.shape();
+        if w_shape.len() != 2 || s_shape.len() != 2 {
+            continue;
+        }
+        if w_shape[0] != s_shape[0] {
+            continue;
+        }
+
+        let out_features = w_shape[0];
+        let groups = s_shape[1];
+        let in_features = groups * 32;
+
+        // Assert layout consistency: weight cols × 2 (nibbles per byte) == groups × 32.
+        if w_shape[1] * 2 != in_features {
+            continue;
+        }
+
+        let unpacked = crate::quant::mxfp4::dequantize_expert(
+            weight_view.data(),
+            scale_view.data(),
+            out_features,
+            groups,
+        )?;
+
+        let key = normalize_key(name, prefixes);
+        let arr = Array2::from_shape_vec((out_features, in_features), unpacked)
+            .map_err(|e| ModelError::Parse(e.to_string()))?;
+        tensors.insert(key, arr.into_shared());
+
+        consumed.insert(name.clone());
+        consumed.insert(scale_name);
+    }
+
+    Ok(consumed)
 }
 
 pub(crate) fn normalize_key(key: &str, prefixes: &[&str]) -> String {


### PR DESCRIPTION
Forward-port of @mikeumus's #37 onto current main, on top of the FP8/I8 dtype support from #74. Authorship preserved as \`Mike Mooring <mike@divinci.ai>\`.

## What lands

A new \`dequantize_per_expert_mxfp4\` helper in \`crates/larql-models/src/loading/safetensors.rs\` that handles DeepSeek-V4's per-expert MXFP4 layout:

\`\`\`
layers.X.ffn.experts.E.w1.weight    I8 (packed FP4 nibbles)
layers.X.ffn.experts.E.w1.scale     F8_E8M0 (per-group scales)
\`\`\`

This is distinct from GPT-OSS's fused \`experts.gate_up_proj_blocks\` + \`scales\` layout that \`load_mxfp4_expert_tensors\` already handles.

The detector scans for \`*.experts.<digit>.w[123].weight\` tensors with \`I8\` dtype, pairs each with its \`.scale\` companion (\`F8_E8M0\`), and dequantizes via \`quant::mxfp4::dequantize_expert\`. Returns the set of consumed tensor names so the main loop skips them. **No-op for non-V4 architectures** — it only fires when both the I8 weight and F8_E8M0 scale companion are present.

## Conflict resolutions vs. #37

- Original commit replaced main's standard \`else\` branch wholesale, dropping the **PackedBF16 (Gemma 4 26B A4B) raw-bytes path**. Resolved by integrating: V4 dequant runs first, then PackedBF16 mmap-byte-ranges, then standard f32 conversion. All three coexist in the same else branch.
- \`mxfp4_expert_key\` helper (added on main between #37 and now) preserved.
- \`pub(crate)\` visibility on \`normalize_key\` preserved (the original commit's diff context dropped it).
- \`quant::mxfp4::dequantize_expert\` signature on current main returns \`Result<Vec<f32>, ModelError>\` rather than \`Vec<f32>\` — added \`?\` to propagate.

## Validation

- \`cargo check -p larql-models -p larql-vindex -p larql-inference -p larql-cli --lib --tests\` ✓
- \`cargo test -p larql-models --lib\` — 188 pass, 0 fail
- \`cargo fmt --check -p larql-models\` ✓

The detector logic is untouched from @mikeumus's original commit; the only behavioural change is the early-return guarding (e.g. \`if w_shape[1] * 2 != in_features { continue; }\`) is preserved verbatim, so the no-op-on-non-V4 contract holds.

## Stack

This is the second of seven mikeumus PRs being forward-ported. Foundation is #74 (now merged); next up: #39 (DeepSeekV4Arch tensor naming) and #40 (MXFP4-aware streaming gate_vectors), which both build on the dtype + dequant primitives now in main.

Closes #37.