### PR TITLE
feat(extract): MXFP4-aware streaming gate_vectors path (rebased from #40)

### DIFF
--- a/crates/larql-vindex/src/extract/streaming/tensor_io.rs
+++ b/crates/larql-vindex/src/extract/streaming/tensor_io.rs
@@ -70,6 +70,43 @@ pub(super) fn get_tensor_f32(
         return Ok(None);
     }
 
+    // MXFP4 (DeepSeek-V4 expert weights): the streaming extract has its own
+    // f32 decoder separate from `larql-models::loading::safetensors`, so the
+    // I8+F8_E8M0 pairing has to be detected here too. Without it,
+    // `gate_vectors.bin` came out 0 bytes for V4 models because every layer's
+    // gate fell into the catch-all `_ => return Ok(None)` below.
+    //
+    // Detection contract: `.weight` tensor with `I8` dtype and a `.scale`
+    // companion of dtype `F8_E8M0` whose row count matches and whose column
+    // count divides the unpacked-cols evenly into a sane group size
+    // {16, 32, 64, 128}. Anything else falls through to the dtype match.
+    if view.dtype() == safetensors::Dtype::I8 && tensor_name.ends_with(".weight") {
+        let scale_name = tensor_name.replacen(".weight", ".scale", 1);
+        if let Ok(scale_view) = st.tensor(&scale_name) {
+            if scale_view.dtype() == safetensors::Dtype::F8_E8M0 {
+                let s_shape = scale_view.shape();
+                if s_shape.len() == 2 && s_shape[0] == shape[0] {
+                    let cols_unpacked = shape[1] * 2;
+                    if s_shape[1] > 0 && cols_unpacked % s_shape[1] == 0 {
+                        let group_size = cols_unpacked / s_shape[1];
+                        if [16usize, 32, 64, 128].contains(&group_size) {
+                            let unpacked = larql_models::quant::mxfp4::dequantize_expert(
+                                view.data(),
+                                scale_view.data(),
+                                shape[0],
+                                s_shape[1],
+                            )
+                            .map_err(|e| VindexError::Parse(e.to_string()))?;
+                            let arr = Array2::from_shape_vec((shape[0], cols_unpacked), unpacked)
+                                .map_err(|e| VindexError::Parse(e.to_string()))?;
+                            return Ok(Some(arr));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     let data = match view.dtype() {
         safetensors::Dtype::F32 => view
             .data()
@@ -78,7 +115,7 @@ pub(super) fn get_tensor_f32(
             .collect(),
         safetensors::Dtype::F16 => crate::format::quant::half::decode_f16(view.data()),
         safetensors::Dtype::BF16 => crate::format::quant::half::decode_bf16(view.data()),
-        _ => return Ok(None), // skip non-float
+        _ => return Ok(None), // skip non-float (and non-MXFP4) tensors
     };
 
     let arr = Array2::from_shape_vec((shape[0], shape[1]), data)


### PR DESCRIPTION
Forward-port of @mikeumus's #40 onto current main, on top of the #74/#75/#76 stack. Authorship preserved as \`Mike Mooring <mike@divinci.ai>\`.

## What lands

The streaming extract has its own \`get_tensor_f32\` helper, separate from \`larql-models::loading::safetensors::tensor_to_f32\` (patched via #74). It silently returned \`None\` for any non-{F32, F16, BF16} dtype, so per-expert MXFP4 gates (I8 packed nibbles + F8_E8M0 scales, the DeepSeek-V4 layout) were skipped during \`gate_vectors.bin\` extraction — **every layer recorded \"0.0s\" and the output file was 0 bytes**.

This PR adds an I8+F8_E8M0 detection path at the top of \`get_tensor_f32\`:

- \`.weight\` tensor with \`I8\` dtype, **and**
- a \`.scale\` companion of dtype \`F8_E8M0\` with matching rows, **and**
- cols-unpacked / scale-cols implies a sane group size {16, 32, 64, 128}

→ Unpack via \`larql_models::quant::mxfp4::dequantize_expert\` and return the resulting f32 \`Array2\` directly. Anything that doesn't match those three conditions falls through to the existing dtype match unchanged.

## Conflict resolutions vs. #40

- **Modify/delete conflict.** Original commit modified \`extract/streaming.rs\` (a single file). Main has refactored it into \`extract/streaming/{mod,tensor_io,context,stages/...}.rs\`. \`get_tensor_f32\` now lives at \`extract/streaming/tensor_io.rs:51\`. Applied the patch there.
- Original commit's path was \`crate::format::quant::mxfp4::dequantize_expert\` (a fork-side module not on upstream). Routed instead to \`larql_models::quant::mxfp4::dequantize_expert\` — same primitive, lives in the larql-models crate, already a workspace dependency of larql-vindex.
- The dequantizer on current main returns \`Result<Vec<f32>, ModelError>\` (PR #75 / your #37 added the error path). Wrapped with \`.map_err(|e| VindexError::Parse(e.to_string()))?\` to bridge into \`VindexError\`.
- Adapter to the function's new shape: it now takes \`(shards, index, key)\` rather than \`(st, tensor_name)\`. The MXFP4 detection works against the \`SafeTensors\` deserialised inside the function and uses the same \`tensor_name\` lookup, so the actual logic is unchanged.

## Validation

- \`cargo check -p larql-vindex --lib --tests\` ✓
- \`cargo test -p larql-vindex --lib\` — 932 pass, 0 fail
- \`cargo fmt --check -p larql-vindex\` ✓
- @mikeumus runtime-validated end-to-end on a DeepSeek-V4 model in #40: \`gate_vectors.bin\` grows from 0 B to ~1 GB with real f32 data.

## Stack

This is the fourth of seven mikeumus PRs being forward-ported. Closes the DeepSeek-V4 + MXFP4 quartet started by #74/#75/#76:

- ✅ #74 (was #35) — FP8/I8 dtypes (merged)
- ⏳ #75 (was #37) — per-expert MXFP4 dequant (open)
- ⏳ #76 (was #39) — DeepSeekV4Arch tensor naming (open)
- 🆕 #77 (this) — MXFP4-aware streaming gate_vectors path

Three remaining mikeumus PRs are independent of the V4 stack: #38 (metadata-only HF resolve), #42 (MoE SVD summary tier), #43 (down_meta env-var cap).

Closes #40.