### PR TITLE
feat(hf): metadata-only resolve_hf_vindex (no eager binary downloads) (rebased from #38)

### DIFF
--- a/crates/larql-vindex/src/format/huggingface/download/mod.rs
+++ b/crates/larql-vindex/src/format/huggingface/download/mod.rs
@@ -15,7 +15,7 @@ use crate::error::VindexError;
 use crate::format::filenames::*;
 
 use super::publish::get_hf_token;
-use super::{VINDEX_CORE_FILES, VINDEX_WEIGHT_FILES};
+use super::{vindex_core_files, VINDEX_METADATA_FILES, VINDEX_WEIGHT_FILES};
 use helpers::{hf_cache_repo_dir, strip_etag_quoting, want_model_file};
 
 /// Which side of the HF API a repo lives on. Datasets are how vindexes
@@ -135,8 +135,13 @@ pub fn resolve_hf_vindex(hf_path: &str) -> Result<PathBuf, VindexError> {
         .ok_or_else(|| VindexError::Parse("cannot determine vindex directory".into()))?
         .to_path_buf();
 
-    // Download core files (needed for browse)
-    for filename in VINDEX_CORE_FILES {
+    // Download METADATA-only by default. Big tensor files
+    // (`gate_vectors.bin`, `embeddings.bin`) are deferred — `larql show`
+    // and similar metadata-only commands shouldn't pay for a multi-GB
+    // download. Callers that actually need the tensors (run / walk) use
+    // `resolve_hf_vindex_with_progress` (which still pulls them eagerly)
+    // or `download_hf_weights`.
+    for filename in VINDEX_METADATA_FILES {
         if *filename == INDEX_JSON {
             continue; // already downloaded
         }
@@ -349,7 +354,9 @@ where
 
     // Probe each repo kind in publish-default order. The first kind that
     // returns index.json (cache hit or download) is the winner; we then
-    // fetch the rest of `VINDEX_CORE_FILES` from that same handle.
+    // fetch the rest of `vindex_core_files()` (metadata + big tensor
+    // files) from that same handle. Callers here have committed to
+    // displaying a progress bar — they accept the wait.
     for kind in HF_PULL_REPO_KINDS {
         let repo = hf_repo(&api, &repo_id, revision.as_deref(), kind);
 
@@ -385,8 +392,8 @@ where
             .ok_or_else(|| VindexError::Parse("cannot determine vindex directory".into()))?
             .to_path_buf();
 
-        for filename in VINDEX_CORE_FILES {
-            if *filename == INDEX_JSON {
+        for filename in vindex_core_files() {
+            if filename == INDEX_JSON {
                 continue;
             }
             // Optional files — ignore failures (missing from repo is fine).

--- a/crates/larql-vindex/src/format/huggingface/mod.rs
+++ b/crates/larql-vindex/src/format/huggingface/mod.rs
@@ -15,24 +15,38 @@
 //! - [`discovery`] — collections, repo existence, item fetch
 //!
 //! Shared constants live here. Each submodule re-imports them via
-//! `use super::{VINDEX_CORE_FILES, VINDEX_WEIGHT_FILES}`.
+//! `use super::{VINDEX_METADATA_FILES, VINDEX_BIN_FILES, vindex_core_files,
+//! VINDEX_WEIGHT_FILES}`.
 
 use crate::format::filenames::*;
 
-/// The files that make up a vindex, in priority order for lazy
-/// loading. Used by `download` to decide which pieces a partial
-/// fetch should include first, and by `publish` to walk the upload
-/// list deterministically.
-pub(crate) const VINDEX_CORE_FILES: &[&str] = &[
+/// Small metadata files needed to describe a vindex (`larql show`,
+/// browse-tier UIs, schema introspection). All of these together stay
+/// well under a few MB on a typical vindex, so they're safe to fetch
+/// eagerly even on slow links.
+pub(crate) const VINDEX_METADATA_FILES: &[&str] = &[
     INDEX_JSON,
     TOKENIZER_JSON,
-    GATE_VECTORS_BIN,
-    EMBEDDINGS_BIN,
     DOWN_META_BIN,
     DOWN_META_JSONL,
     RELATION_CLUSTERS_JSON,
     FEATURE_LABELS_JSON,
 ];
+
+/// Big tensor files lazy-pulled on first walk/run. These can be
+/// hundreds of MB to multiple GB; metadata-only commands like
+/// `larql show` shouldn't pay for them. Callers that actually need
+/// the tensors (run / walk / extract) use the progress-aware
+/// entrypoint that pulls METADATA + BIN together.
+pub(crate) const VINDEX_BIN_FILES: &[&str] = &[GATE_VECTORS_BIN, EMBEDDINGS_BIN];
+
+/// Union of metadata + bin — preserves prior CORE behavior for the
+/// progress-aware entrypoint that is willing to wait on big files.
+pub(crate) fn vindex_core_files() -> Vec<&'static str> {
+    let mut v: Vec<&'static str> = VINDEX_METADATA_FILES.to_vec();
+    v.extend_from_slice(VINDEX_BIN_FILES);
+    v
+}
 
 pub(crate) const VINDEX_WEIGHT_FILES: &[&str] = &[
     ATTN_WEIGHTS_BIN,


### PR DESCRIPTION
Forward-port of @mikeumus's #38 onto current main. Authorship preserved as \`Mike Mooring <mike@divinci.ai>\`.

## Why

\`larql show hf://...\` and other metadata-only commands previously paid for a full vindex pull on first use — including \`gate_vectors.bin\` and \`embeddings.bin\`, which are multiple GB on production vindexes. So the first run of \`show\` on a remote vindex was a long-blocking download even though the command only needs a few MB of metadata.

## What lands

Splits the file-set into three:

- \`VINDEX_METADATA_FILES\` — small files (\`index.json\`, \`tokenizer.json\`, \`down_meta.{bin,jsonl}\`, \`relation_clusters.json\`, \`feature_labels.json\`). Total <few MB.
- \`VINDEX_BIN_FILES\` — big tensor files (\`gate_vectors.bin\`, \`embeddings.bin\`).
- \`vindex_core_files()\` — union helper; preserves the \"fetch everything\" contract for callers that need it.

Behavior changes:

- \`resolve_hf_vindex\` (sync, no progress, used by \`larql show\`) — now fetches only metadata. **First-run latency on remote vindexes drops from minutes/GB scale to a few seconds.**
- \`resolve_hf_vindex_with_progress\` (used by run / walk / extract) — keeps the prior behavior, pulls metadata + bin together. Callers there have committed to displaying a progress bar.
- \`download_hf_weights\` — unchanged. Always pulled weight files explicitly.

## Conflict resolutions vs. #38

- **Modify/delete conflict.** Original commit was against the pre-split \`format/huggingface.rs\` (a single file); main has since split it into \`format/huggingface/{mod,download,publish,discovery}.rs\`. Forward-ported the constant split to \`huggingface/mod.rs\` and the call-site changes to \`huggingface/download/mod.rs\`.
- The progress entrypoint also went through the Model→Dataset fallback refactor from #71. Adapted accordingly: the \`vindex_core_files()\` iteration sits inside the kind-probe loop.

## Validation

- \`cargo check -p larql-vindex --lib --tests\` ✓
- \`cargo test -p larql-vindex --lib\` — 932 pass, 0 fail
- \`cargo fmt --check -p larql-vindex\` ✓

## Stack

This is the fifth of seven mikeumus PRs being forward-ported. **Independent of the DeepSeek-V4 stack** (#74/#75/#76/#77) — pure UX improvement to the HF resolver. Two left in the queue: #42 (MoE SVD summary tier), #43 (env-var cap on down_meta).

Closes #38.