### PR TITLE
feat(extract): per-expert top-K SVD summary tier for many-experts MoE (rebased from #42)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,6 +2324,7 @@ dependencies = [
  "memmap2",
  "mockito",
  "ndarray",
+ "rand 0.8.6",
  "rayon",
  "reqwest",
  "safetensors",

--- a/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
@@ -26,6 +26,16 @@ pub struct ExtractIndexArgs {
     #[arg(long, default_value = "10")]
     down_top_k: usize,
 
+    /// Per-expert top-K right singular vectors of `gate_proj` to store
+    /// instead of the full per-expert gate matrix. Default `0` = disabled
+    /// (write full per-expert gate, original behaviour). Set e.g. `64` to
+    /// produce a tractable summary vindex for many-experts MoE models
+    /// (DeepSeek-V4-Pro at 384 experts/layer would otherwise need ~370 GB
+    /// of gate_vectors; with `--summary-features-per-expert 64` it shrinks
+    /// to ~11 GB).
+    #[arg(long, default_value = "0")]
+    summary_features_per_expert: usize,
+
     /// How much of the model to include in the vindex. Each tier is a
     /// strict superset of the previous:
     ///
@@ -300,6 +310,16 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
             down_q4k: args.down_q4k,
             feature_major_down: args.feature_major_down,
         };
+
+        // Per-expert SVD-summary tier — opt-in via flag. Threaded as env var
+        // so the streaming gate path can read it without an API break.
+        if args.summary_features_per_expert > 0 {
+            std::env::set_var(
+                "LARQL_SUMMARY_FEATURES_PER_EXPERT",
+                args.summary_features_per_expert.to_string(),
+            );
+        }
+
         larql_vindex::build_vindex_streaming(
             &model_path,
             &tokenizer,

--- a/crates/larql-vindex/Cargo.toml
+++ b/crates/larql-vindex/Cargo.toml
@@ -22,6 +22,9 @@ ndarray = "0.16"
 # Parallelism for the direct-Q4K matmul kernel (feature walk).
 rayon = "1.10"
 
+# RNG for randomized SVD (per-expert MoE summary tier in extract/moe_svd.rs).
+rand = "0.8"
+
 # Tokenizer (for embeddings loading + token resolution)
 tokenizers = "0.21"
 

--- a/crates/larql-vindex/src/extract/mod.rs
+++ b/crates/larql-vindex/src/extract/mod.rs
@@ -7,6 +7,7 @@ pub mod callbacks;
 pub mod checkpoint;
 pub mod constants;
 pub mod metadata;
+pub mod moe_svd;
 pub mod stage_labels;
 pub mod streaming;
 

--- a/crates/larql-vindex/src/extract/moe_svd.rs
+++ b/crates/larql-vindex/src/extract/moe_svd.rs
@@ -1,0 +1,124 @@
+//! Per-expert top-K SVD for MoE summary vindexes.
+//!
+//! When a model has more experts per layer than the canonical browse-tier
+//! gate format can fit (Mixtral has 8 experts per layer, DeepSeek-V4-Pro
+//! has 384), writing the full per-expert gate matrix produces hundreds of
+//! GB of features. This module compresses each expert's gate_proj down to
+//! its top-K right singular vectors via subspace iteration — the same
+//! representation that `notebooks/moe_vindex_builder.py` produces at the
+//! Python/Modal layer, but here as a pure-Rust streaming step inside
+//! `larql extract`.
+//!
+//! Output layout per expert: `[K, hidden_size] f32` rows = right singular
+//! vectors of `gate_proj` (treating `gate_proj` as `out × hidden`).
+//!
+//! The implementation is intentionally LAPACK-free — uses `ndarray` +
+//! `rand` only. Speed comes from `rayon` parallelism across experts.
+
+use ndarray::{s, Array2, ArrayView2};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+/// Compute the top-K right singular vectors of `a` (shape `[m, n]`) via
+/// subspace iteration. Returns a `[K, n]` matrix whose rows are the
+/// approximate right singular vectors, sorted by descending singular value.
+///
+/// # Algorithm
+///
+/// Standard randomized power iteration for partial SVD:
+/// 1. Sample `V0` of shape `(n, K+oversample)` uniformly in [-0.5, 0.5).
+/// 2. For `p_iters` rounds:
+///    - `W = A @ V`        (`m × K+os`)
+///    - `U = orth(W)`       via modified Gram-Schmidt
+///    - `Z = A^T @ U`       (`n × K+os`)
+///    - `V = orth(Z)`       via modified Gram-Schmidt
+/// 3. Return `V[:, :K]^T` (the first K columns transposed).
+///
+/// At the typical (m=2048, n=4096, K=64) shape this performs ~10 GFLOPs
+/// per call and gives ≥3 digits of agreement with full SVD for the top
+/// singular vectors (verified separately via Python comparison harness).
+pub fn top_k_right_singular_vectors(
+    a: ArrayView2<f32>,
+    k: usize,
+    p_iters: usize,
+    seed: u64,
+) -> Array2<f32> {
+    let (m, n) = a.dim();
+    let oversample = 10usize;
+    let kp = (k + oversample).min(m).min(n);
+
+    // Random init V0 — n × kp.
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut v: Array2<f32> = Array2::from_shape_fn((n, kp), |_| rng.gen::<f32>() - 0.5);
+
+    let at = a.t();
+    for _ in 0..p_iters {
+        let w = a.dot(&v);
+        let u = modified_gram_schmidt(w.view());
+        let z = at.dot(&u);
+        v = modified_gram_schmidt(z.view());
+    }
+
+    // Final pass: one more matmul to align V with singular value order.
+    let w = a.dot(&v);
+    let u = modified_gram_schmidt(w.view());
+    let z = at.dot(&u);
+    let v_final = modified_gram_schmidt(z.view());
+
+    // Take first K columns and return as K × n (rows = singular vectors).
+    v_final.slice(s![.., ..k]).t().to_owned()
+}
+
+/// Modified Gram-Schmidt orthonormalization of the columns of `m`.
+/// Output shape == input shape. Numerically stabler than classical GS
+/// for the moderate condition numbers we hit here.
+fn modified_gram_schmidt(m: ArrayView2<f32>) -> Array2<f32> {
+    let (rows, cols) = m.dim();
+    let mut q = m.to_owned();
+
+    for j in 0..cols {
+        // Normalize column j
+        let norm: f32 = q.column(j).iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 1e-12 {
+            q.column_mut(j).map_inplace(|x| *x /= norm);
+        }
+        // Orthogonalize remaining columns against column j
+        for k in (j + 1)..cols {
+            let dot: f32 = (0..rows).map(|i| q[(i, j)] * q[(i, k)]).sum();
+            for i in 0..rows {
+                q[(i, k)] -= dot * q[(i, j)];
+            }
+        }
+    }
+    q
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    #[test]
+    fn rank_one_matrix_recovers_top_singular_vector() {
+        // A = u * v^T with v = (1,2,3,4)/sqrt(30), should recover v as top-1.
+        let v_true = vec![1.0f32, 2.0, 3.0, 4.0];
+        let v_norm: f32 = v_true.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let v_unit: Vec<f32> = v_true.iter().map(|x| x / v_norm).collect();
+        let u_true = vec![0.5f32, 0.5, 0.5, 0.5];
+
+        let a = Array2::from_shape_fn((4, 4), |(i, j)| u_true[i] * v_unit[j] * 7.0);
+        let v_est = top_k_right_singular_vectors(a.view(), 1, 5, 42);
+        let v_row = v_est.row(0);
+
+        // Sign may flip — compare absolute dot product.
+        let cos: f32 = v_row.iter().zip(v_unit.iter()).map(|(a, b)| a * b).sum();
+        assert!(cos.abs() > 0.99, "expected cos~1, got {cos}");
+    }
+
+    #[test]
+    fn returns_correct_shape() {
+        let a = Array2::<f32>::eye(8);
+        let vt = top_k_right_singular_vectors(a.view(), 3, 3, 0);
+        assert_eq!(vt.dim(), (3, 8));
+    }
+}

--- a/crates/larql-vindex/src/extract/streaming/stages/gate_vectors.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/gate_vectors.rs
@@ -152,7 +152,23 @@ impl<'a> StreamingContext<'a> {
                     offset += length;
                 }
             } else if self.is_moe && self.n_experts > 0 {
-                // Standard MoE (Mixtral): per-expert gate tensors
+                // Standard MoE (Mixtral): per-expert gate tensors. Two modes:
+                //
+                //  • Default: write the full per-expert gate matrix
+                //    (shape [num_features, hidden]) — fine for low-expert-count
+                //    MoE (Mixtral's 8 per layer = ~1.8 GB/layer at hidden=4096).
+                //
+                //  • Summary: when LARQL_SUMMARY_FEATURES_PER_EXPERT is set
+                //    to a positive integer K, do a top-K randomized SVD of
+                //    each expert's gate_proj and write only the top-K right
+                //    singular vectors (K × hidden floats per expert). Required
+                //    for many-experts MoE (DeepSeek-V4 family at 256-384
+                //    experts/layer would otherwise produce 100s of GB).
+                let summary_k = std::env::var("LARQL_SUMMARY_FEATURES_PER_EXPERT")
+                    .ok()
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .unwrap_or(0);
+
                 let mut total_features = 0usize;
                 let mut layer_bytes = 0u64;
                 let mut features_per_expert = 0usize;
@@ -166,10 +182,29 @@ impl<'a> StreamingContext<'a> {
                     if let Some(tensor) =
                         get_tensor_f32(&self.shard_mmaps, &self.tensor_index, &gate_key)?
                     {
-                        features_per_expert = tensor.shape()[0];
-                        total_features += features_per_expert;
-                        let data = tensor.as_slice().unwrap();
-                        layer_bytes += write_floats(&mut gate_file, data, self.dtype)?;
+                        let data: Vec<f32>;
+                        let n_feat: usize;
+                        if summary_k > 0 && tensor.shape()[0] > summary_k {
+                            // SVD-summary path: top-K right singular vectors.
+                            // Seed with (layer, expert) so re-runs are
+                            // bit-identical but per-expert uncorrelated.
+                            let seed = ((layer as u64) << 32) | (expert as u64);
+                            let vt = crate::extract::moe_svd::top_k_right_singular_vectors(
+                                tensor.view(),
+                                summary_k,
+                                /*p_iters=*/ 4,
+                                seed,
+                            );
+                            n_feat = summary_k;
+                            data = vt.as_slice().unwrap().to_vec();
+                        } else {
+                            // Full-matrix path: original behaviour.
+                            n_feat = tensor.shape()[0];
+                            data = tensor.as_slice().unwrap().to_vec();
+                        }
+                        features_per_expert = n_feat;
+                        total_features += n_feat;
+                        layer_bytes += write_floats(&mut gate_file, &data, self.dtype)?;
                     }
                 }
 


### PR DESCRIPTION
Forward-port of @mikeumus's #42 onto current main. Authorship preserved as \`Mike Mooring <mike@divinci.ai>\`.

## Why

Many-expert MoE models blow up the existing per-expert gate writer:

\`\`\`
43 layers × 256 experts × 2048 × 4096 × 4 bytes ≈ 370 GB    DeepSeek-V4-Flash
43 layers × 384 experts × 2048 × 4096 × 4 bytes ≈ 555 GB    DeepSeek-V4-Pro
\`\`\`

just for \`gate_vectors.bin\`. That's not a \"browse tier\" anymore.

## What lands

An **opt-in summary tier** that compresses each expert's \`gate_proj\` to its top-K right singular vectors via subspace iteration. At K=64:

\`\`\`
43 layers × 256 experts × 64 × 4096 × 4 bytes ≈ 11 GB
\`\`\`

— the same representation \`moe_vindex_builder.py\` (Python/Modal) already produces, but as a pure-Rust streaming step inside \`larql extract\`.

### Pieces

- **New module** \`crates/larql-vindex/src/extract/moe_svd.rs\` (+124) — pure-Rust randomized SVD via subspace iteration + modified Gram-Schmidt. **No LAPACK dep.** Adds \`rand = \"0.8\"\` to larql-vindex. Two unit tests verify rank-1 recovery + output shape.
- **New CLI flag** \`--summary-features-per-expert <K>\` on \`larql extract\`. Default \`0\` = disabled (original behaviour preserved). Threaded into the streaming extract via the \`LARQL_SUMMARY_FEATURES_PER_EXPERT\` env var to avoid breaking \`build_vindex_streaming\`'s public signature.
- **Streaming Standard-MoE branch** (\`extract/streaming/stages/gate_vectors.rs\`): when env var > 0 AND the gate matrix has more rows than K, compute top-K Vt and write only those rows. Otherwise unchanged.
- **Determinism**: per-expert seed = \`(layer << 32) | expert\`, so re-runs are bit-identical.

## Conflict resolutions vs. #42

- **Modify/delete on \`extract/streaming.rs\`.** Original commit modified the pre-split \`extract/streaming.rs\`. Main has since split it into \`extract/streaming/{mod, context, tensor_io, stages/...}.rs\`; the Standard-MoE branch now lives at \`extract/streaming/stages/gate_vectors.rs:154\`. Forward-ported the SVD branch logic there.
- **\`extract/mod.rs\` content conflict.** Their \`pub mod moe_svd\` declaration vs. main's added \`checkpoint\` / \`constants\` / \`metadata\` / \`stage_labels\` modules. Combined alphabetically.
- **CLI \`Q4kWriteOptions\` content conflict.** Their version dropped \`feature_major_down\` (which doesn't exist on their fork base). Kept main's full struct + still added the env-var setter for the SVD flag.
- Cleaned up an unused \`Axis\` import that triggered a build warning.

## Validation

- \`cargo check -p larql-vindex --lib --tests\` ✓
- \`cargo check -p larql-cli --bins --tests\` ✓
- \`cargo test -p larql-vindex --lib\` — 934 pass (2 new tests in \`moe_svd\`)
- \`cargo fmt --check -p larql-vindex\` ✓
- @mikeumus runtime-validated end-to-end on \`unsloth/DeepSeek-V4-Flash\` in #42: ~11 GB / ~30 min on CPU, runnable end-to-end from \`larql pull\` to \`larql show\` to inference walks.

## Stack

This is the sixth of seven mikeumus PRs. **Independent of the DeepSeek-V4 stack** infrastructurally (no #74-#77 deps), but synergistic: the V4 dtypes / arch / streaming dequant changes make V4 weights *loadable*, and this PR makes V4 weights *tractable to extract*. Together they unblock running larql against V4 family models.

One PR remaining after this: #43 (env-var cap on \`down_meta\` features), which is a one-line change building on this branch.

Closes #42.