### PR TITLE
feat(extract): cap down_meta feature count via LARQL_SUMMARY_FEATURES_PER_EXPERT (rebased from #43)

### DIFF
--- a/crates/larql-vindex/src/extract/streaming/stages/down_meta.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/down_meta.rs
@@ -136,9 +136,30 @@ impl<'a> StreamingContext<'a> {
                 continue;
             }
 
+            // Same `LARQL_SUMMARY_FEATURES_PER_EXPERT` env that gates the
+            // gate-vectors SVD path also caps how many down_proj feature
+            // columns we compute meta for. Without this cap, many-experts
+            // MoE explodes:
+            //   43 layers × 256 experts × 2048 features × (vocab × hidden)
+            //   ≈ 12 PFLOPs ≈ 67 hours of CPU.
+            // With K=64: ~32× speedup → ~2 hrs total. Limitation: records
+            // meta for the first K columns rather than the SVD-selected
+            // most-important features. Acceptable for the summary tier —
+            // full meta is still available via the default
+            // `--summary-features-per-expert 0`.
+            let summary_k = std::env::var("LARQL_SUMMARY_FEATURES_PER_EXPERT")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(0);
+
             let mut feature_offset = 0usize;
             for w_down in &down_matrices {
-                let num_features = w_down.shape()[1];
+                let full_features = w_down.shape()[1];
+                let num_features = if summary_k > 0 && full_features > summary_k {
+                    summary_k
+                } else {
+                    full_features
+                };
                 let batch_size = FEATURE_PROJECTION_BATCH;
 
                 for batch_start in (0..num_features).step_by(batch_size) {


### PR DESCRIPTION
Forward-port of @mikeumus's #43 onto current main, on top of the SVD summary tier from #80 (was #42). Authorship preserved as \`Mike Mooring <mike@divinci.ai>\`.

## Why

The same \`LARQL_SUMMARY_FEATURES_PER_EXPERT\` env var that #80 wired into \`gate_vectors\` extraction also gates the much-more-expensive \`down_meta\` extraction. Without it, many-experts MoE blows out the CPU-time budget:

\`\`\`
43 layers × 256 experts × 2048 features × (vocab=129k × hidden=4k)
≈ 12 PFLOPs ≈ 67 hours of CPU even on H100 host CPUs
\`\`\`

With K=64: **~32× speedup → ~2 hours total** instead of ~67.

## What lands

A 22-line addition to the \`down_meta\` per-layer loop: read \`LARQL_SUMMARY_FEATURES_PER_EXPERT\` once at the top, then truncate \`num_features\` per expert to the first K columns when summary mode is active.

\`\`\`rust
let summary_k = std::env::var(\"LARQL_SUMMARY_FEATURES_PER_EXPERT\")
    .ok()
    .and_then(|s| s.parse::<usize>().ok())
    .unwrap_or(0);

// inside the per-expert loop:
let full_features = w_down.shape()[1];
let num_features = if summary_k > 0 && full_features > summary_k {
    summary_k
} else {
    full_features
};
\`\`\`

**Default off** (\`summary_k = 0\` = original behaviour preserved). Users wanting full per-feature meta keep the default \`--summary-features-per-expert 0\` from #80's CLI flag.

## Limitation acknowledged in the commit

The first-K columns are not the SVD-selected \"most-important\" features (unlike the gate_vectors path in #80, which does pick top-K via SVD). Acceptable for the summary tier; users who want full meta drop the flag.

## Conflict resolutions vs. #43

- **Modify/delete on \`extract/streaming.rs\`** (same pattern as #75/#77/#79/#80). Main has since split it into \`extract/streaming/{mod, stages/...}.rs\`; the down_proj meta loop now lives at \`extract/streaming/stages/down_meta.rs:139\`. Forward-ported the summary_k cap there.

## Validation

- \`cargo check -p larql-vindex --lib --tests\` ✓
- \`cargo test -p larql-vindex --lib\` — 934 pass, 0 fail
- \`cargo fmt --check -p larql-vindex\` ✓
- @mikeumus runtime-validated end-to-end — see #43 / #42's body for the V4-Flash extraction timing.

## Stack — final entry

This is the **last** of seven mikeumus PRs forward-ported. Full stack:

- ✅ #74 (was #35) — FP8/I8 dtypes (merged)
- ✅ #75 (was #37) — MXFP4 per-expert dequant
- ✅ #76 (was #39) — DeepSeekV4Arch (merged)
- ✅ #77 (was #40) — MXFP4-aware streaming (merged)
- ✅ #79 (was #38) — metadata-only HF resolve (merged)
- ✅ #80 (was #42) — MoE SVD summary tier (merged)
- ✅ this PR (was #43) — down_meta summary cap
- ❌ #36 closed (superseded by #71's Model→Dataset fallback)

Closes #43.