### PR TITLE
fix(python): point at larql-vindex after walker module move

### DIFF
--- a/crates/larql-python/src/lib.rs
+++ b/crates/larql-python/src/lib.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use larql_core as lq;
-use larql_inference as li;
+use larql_vindex as lv;
 
 mod session;
 mod trace_py;
@@ -647,7 +647,7 @@ fn weight_walk(
     top_k: usize,
     min_score: f32,
 ) -> PyResult<PyGraph> {
-    let config = li::WalkConfig { top_k, min_score };
+    let config = lv::WalkConfig { top_k, min_score };
     let layers: Option<Vec<usize>> = layer.map(|l| vec![l]);
 
     let mut graph = lq::Graph::new();
@@ -660,9 +660,9 @@ fn weight_walk(
         serde_json::Value::String("weight-walk".to_string()),
     );
 
-    let mut callbacks = li::walker::weight_walker::SilentWalkCallbacks;
+    let mut callbacks = lv::walker::weight_walker::SilentWalkCallbacks;
 
-    li::walk_model(
+    lv::walk_model(
         model_path,
         layers.as_deref(),
         &config,
@@ -688,10 +688,10 @@ fn attention_walk(
     top_k: usize,
     min_score: f32,
 ) -> PyResult<PyGraph> {
-    let walker = li::AttentionWalker::load(model_path)
+    let walker = lv::AttentionWalker::load(model_path)
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-    let config = li::WalkConfig { top_k, min_score };
+    let config = lv::WalkConfig { top_k, min_score };
 
     let mut graph = lq::Graph::new();
     graph.metadata.insert(
@@ -708,7 +708,7 @@ fn attention_walk(
         None => (0..walker.num_layers()).collect(),
     };
 
-    let mut callbacks = li::walker::weight_walker::SilentWalkCallbacks;
+    let mut callbacks = lv::walker::weight_walker::SilentWalkCallbacks;
     for &l in &layers {
         walker
             .walk_layer(l, &config, &mut graph, &mut callbacks)


### PR DESCRIPTION
The 2026-05-09 \`refactor of vindex and compute\` (\`3944359\`) moved the walker subsystem (\`WalkConfig\`, \`AttentionWalker\`, \`walk_model\`, \`walker::weight_walker::SilentWalkCallbacks\`) from \`larql-inference\` to \`larql-vindex\`. \`larql-python\` still imported them via \`use larql_inference as li\`, leaving its lib uncompilable on main:

\`\`\`
error[E0422]: cannot find struct, variant or union type \`WalkConfig\` in crate \`li\`
error[E0433]: failed to resolve: could not find \`walker\` in \`li\`
error[E0425]: cannot find function \`walk_model\` in crate \`li\`
error[E0422]: cannot find struct, variant or union type \`AttentionWalker\` in crate \`li\`
\`\`\`

Switches the import to \`use larql_vindex as lv\` and updates the four call-sites in \`crates/larql-python/src/lib.rs\` accordingly. No behavioural change — the walker types are the same code, just in a different crate.

This commit was originally on the \`fix/config-json-required-fields\` branch (\`0a1c1f3\`); rebased onto current \`origin/main\` so the post-#79/#80/#81 forward-port stack is preserved.

## Validation

- \`cargo build --workspace --lib\` ✓ (was failing on main with 6 unresolved-import errors in larql-python)
- \`cargo check -p larql-python --lib\` ✓
- \`cargo fmt --check -p larql-python\` ✓
- \`cargo clippy -p larql-python --lib --no-deps -- -D warnings\` ✓