### PR TITLE
fix(license): pin evalexpr to v11.3.1 (MIT) to avoid AGPL-3.0 at v12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "evalexpr"
-version = "12.0.3"
+version = "11.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae893d2d5e908b78f151ed89de3bfc272cdf6d368c7ed866942f98e24dea208a"
+checksum = "b6aff27af350e7b53e82aac3e5ab6389abd8f280640ac034508dff0608c4c7e5"
 
 [[package]]
 name = "fallible-iterator"

--- a/crates/model-compute/Cargo.toml
+++ b/crates/model-compute/Cargo.toml
@@ -17,7 +17,7 @@ wasm = ["dep:wasmtime"]
 thiserror = { workspace = true }
 
 # Feature: native kernels
-evalexpr = { version = "12", optional = true }
+evalexpr = { version = "11", optional = true }
 chrono = { version = "0.4", optional = true, default-features = false, features = ["std", "clock"] }
 
 # Feature: wasm host


### PR DESCRIPTION
## Summary
- `evalexpr` v12.0.3 relicensed to `AGPL-3.0-only`, incompatible with the project's `Apache-2.0` distribution (would impose AGPL §13 network-disclosure on downstream).
- Pin to `evalexpr = "11"`, which resolves to `v11.3.1` under `MIT`. The `eval()` + `Value` API used by `crates/model-compute/src/native/arithmetic.rs` is identical, so no source changes required.
- `cargo metadata` scan confirms zero AGPL packages remain in the dep graph.

Fixes #44.

## Test plan
- [x] `cargo build -p model-compute` — clean
- [x] `cargo test -p model-compute` — 30/30 unit + doc tests pass
- [x] `cargo check --workspace` — clean
- [x] AGPL audit: `cargo metadata` reports no AGPL-licensed packages