### PR TITLE
feat(android): enable aarch64-linux-android cross-compilation

### DIFF
--- a/crates/larql-compute/Cargo.toml
+++ b/crates/larql-compute/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["matmul", "metal", "gpu", "quantization", "blas"]
 categories = ["science"]
 
 [dependencies]
-# Matrix types
-ndarray = { version = "0.16", features = ["blas"] }
+# Matrix types — blas feature added per-platform below where a backend exists
+ndarray = "0.16"
 # MoE expert parallelism: top-k experts run independently per token.
 rayon = "1.10"
 # Wire-format constants (Q4_K_BLOCK_ELEMS, etc.) for padding decisions.
@@ -18,6 +18,7 @@ rayon = "1.10"
 larql-models = { path = "../larql-models" }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["openblas"], default-features = false }
 openblas-src = { version = "0.10", features = ["system"] }
 
@@ -28,9 +29,11 @@ metal = { version = "0.29", optional = true }
 # specifically `MTLCommandBuffer.GPUStartTime/GPUEndTime` for production
 # decode timing diagnostics. Same major version metal-rs uses internally.
 objc = { version = "0.2", optional = true }
+ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["accelerate"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["openblas"], default-features = false }
 openblas-src = { version = "0.10", features = ["system"] }
 

--- a/crates/larql-compute/src/lib.rs
+++ b/crates/larql-compute/src/lib.rs
@@ -57,6 +57,12 @@
 //!   multi-layer pipeline, zero-copy mmap buffers.
 //! - `cuda`: (planned) CUDA GPU backend.
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "windows"
+))]
 extern crate blas_src;
 
 pub mod backend;

--- a/crates/larql-inference/Cargo.toml
+++ b/crates/larql-inference/Cargo.toml
@@ -27,8 +27,8 @@ memmap2 = "0.9"
 # System
 libc = "0.2"
 
-# Matrix ops (BLAS-accelerated)
-ndarray = { version = "0.16", features = ["blas"] }
+# Matrix ops (BLAS-accelerated on supported platforms; pure-Rust ndarray on Android)
+ndarray = "0.16"
 
 # Parallelism for the walk loop (per-feature work is embarrassingly parallel).
 rayon = "1.10"
@@ -67,13 +67,16 @@ anyhow = "1"
 
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["openblas"], default-features = false }
 openblas-src = { version = "0.10", features = ["system"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["accelerate"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["openblas"], default-features = false }
 openblas-src = { version = "0.10", features = ["system"] }
 

--- a/crates/larql-inference/src/lib.rs
+++ b/crates/larql-inference/src/lib.rs
@@ -40,6 +40,12 @@
 //! See `examples/mech_interp_demo.rs` for an end-to-end walkthrough on
 //! synthetic weights (no vindex required).
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "windows"
+))]
 extern crate blas_src;
 
 pub mod attention;

--- a/crates/larql-kv/Cargo.toml
+++ b/crates/larql-kv/Cargo.toml
@@ -17,20 +17,23 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
-ndarray = { version = "0.16", features = ["blas"] }
+ndarray = "0.16"
 zip = { version = "2", default-features = false }
 
 rand = "0.8"
 rand_distr = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["openblas"], default-features = false }
 openblas-src = { version = "0.10", features = ["system"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["accelerate"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["openblas"], default-features = false }
 openblas-src = { version = "0.10", features = ["system"] }
 

--- a/crates/larql-kv/src/lib.rs
+++ b/crates/larql-kv/src/lib.rs
@@ -8,6 +8,12 @@
 //! hidden state (shape `[1, hidden_dim]`). The caller applies `final_norm +
 //! lm_head` to get logits — see `larql_inference::forward::hidden_to_raw_logits`.
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "windows"
+))]
 extern crate blas_src;
 
 pub mod accuracy;


### PR DESCRIPTION
## Summary

Cherry-picked from #94 — credits @metavacua as the original author of this change. Pulls in only the BLAS-gating commit. None of #94's other scope (workflow rewrites, REUSE/AGPL re-licensing, wasmtime→wasmi swap, compliance pipeline) is included here.

- Gates `extern crate blas_src` and the ndarray `blas` feature behind a 4-OS `cfg` (linux/freebsd/macos/windows).
- On Android, ndarray falls back to its pure-Rust matrixmultiply path.
- All existing platforms keep their existing BLAS backends unchanged.

Affected crates: `larql-compute`, `larql-inference`, `larql-kv`.

## Build instructions (machine-local, not committed)

NDK linker/ar entries in `.cargo/config.toml` plus:

```sh
export ANDROID_NDK_ROOT=/path/to/android-ndk-r27c
export CC_aarch64_linux_android=$NDK_BIN/aarch64-linux-android21-clang
export CXX_aarch64_linux_android=$NDK_BIN/aarch64-linux-android21-clang++
export AR_aarch64_linux_android=$NDK_BIN/llvm-ar
export OPENSSL_DIR=/path/to/openssl-android-arm64
export OPENSSL_STATIC=1
export RUSTFLAGS="-C target-feature=+dotprod"   # required by sdot in q4k kernel

cargo build --target aarch64-linux-android
```

#94 confirmed this produces valid Android ELF64 PIE binaries.

## Test plan

- [x] `cargo test -p larql-compute --lib` — 162 passed / 0 failed
- [x] `cargo test -p larql-inference --lib` — 907 passed / 0 failed
- [x] `cargo test -p larql-inference --tests` — 14 passed / 0 failed
- [x] `cargo test -p larql-kv --lib` — 200 passed / 0 failed
- [ ] `cargo build --target aarch64-linux-android` (requires NDK; verified upstream in #94)

## Notes

- `dotprod` requirement in `q4k_q8k_dot.rs` targets ARMv8.2+ (Cortex-A55 / ~2017+); a `#[cfg(target_feature = "dotprod")]` scalar fallback would broaden device coverage but is out of scope here.
- `armv7-linux-androideabi` (32-bit) is blocked upstream by Cranelift lacking a 32-bit ARM backend — also out of scope.

Supersedes scope from #94 (which should be closed in favour of focused follow-ups).