### PR TITLE
fix(larql-vindex): prevent overflow in lm_head vocab calculation on 32-bit hosts

### DIFF
--- a/crates/larql-vindex/src/index/storage/lm_head/loaders.rs
+++ b/crates/larql-vindex/src/index/storage/lm_head/loaders.rs
@@ -54,7 +54,14 @@ impl VectorIndex {
         if self.vocab_size == 0 && self.hidden_size > 0 {
             let bytes = mmap.len();
             let denom = self.hidden_size * Q4_BYTES_PER_ELEM_NUM;
-            if let Some(vocab) = (bytes * Q4_BYTES_PER_ELEM_DEN).checked_div(denom) {
+            // u64 multiply guards 32-bit hosts (e.g. armv7-android) where
+            // `bytes * Q4_BYTES_PER_ELEM_DEN` can overflow `usize` before the
+            // division for large lm_head mmaps.
+            if let Some(vocab) = (bytes as u64)
+                .checked_mul(Q4_BYTES_PER_ELEM_DEN as u64)
+                .and_then(|v| v.checked_div(denom as u64))
+                .and_then(|v| usize::try_from(v).ok())
+            {
                 if vocab > 0 {
                     self.vocab_size = vocab;
                 }


### PR DESCRIPTION
## Summary

`bytes * Q4_BYTES_PER_ELEM_DEN` in `load_lm_head_q4` is computed in `usize`, which on 32-bit targets (e.g. `armv7-linux-androideabi`) wraps before the division for large lm_head mmaps and silently produces the wrong `vocab_size`.

The fix promotes the multiply to `u64` with `checked_mul` / `checked_div`, then narrows back via `usize::try_from`. **No behaviour change on 64-bit hosts.**

Cherry-picked from #94's review (credit @metavacua, who surfaced this while attempting an `armv7-android` cross-build).

## Test plan

- [x] `cargo test -p larql-vindex --lib` — 968 passed / 0 failed (including the 3 `load_lm_head_q4_*` tests that pin the vocab-inference path)
- [x] `cargo test -p larql-vindex --tests` — 212 passed / 0 failed across 20 integration binaries

Note: the existing tests cover happy-path correctness on 64-bit but do not directly exercise the 32-bit overflow that this fix prevents — a 32-bit cross-build job in CI would be the canonical regression test. Out of scope for this PR.