### PR TITLE
chore(ci): add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependabot — keep GitHub Actions versions current.
+#
+# Cargo and pip are intentionally not tracked here:
+#   - cargo: workspace deps move via PRs that update Cargo.lock directly;
+#     Dependabot's per-crate Cargo.toml proposals don't match how this
+#     repo bumps versions.
+#   - pip: Python bindings use uv (`crates/larql-python/uv.lock`), which
+#     Dependabot's pip ecosystem doesn't read.
+#
+# Actions are the one place Dependabot is well-supported and worth the noise.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    # One grouped PR per week instead of one per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Weekly grouped Dependabot PRs for GitHub Actions version bumps. One PR per week, not one per action.

Cargo and pip are intentionally out of scope — see the file's own comments for why.

Cherry-picked from #94 (credit @metavacua), with the AGPL-fork copyright header stripped and the comments rewritten to remove references to infrastructure that doesn't exist in this repo (cocogitto, REUSE.toml, validate.yml, gitignored Cargo.lock).

## Test plan

- [ ] After merge, watch for Dependabot's initial scan; expect a grouped PR if any action versions are out of date.

Configuration-only change. No code paths touched.