### PR TITLE
feat(ggml): add Q3_K and Q5_K dequantization (types 11 and 13)

### DIFF
--- a/crates/larql-models/src/quant/ggml/mod.rs
+++ b/crates/larql-models/src/quant/ggml/mod.rs
@@ -25,12 +25,16 @@ use super::half::{decode_bf16, decode_f16};
 use crate::detect::ModelError;
 
 pub mod legacy;
+pub mod q3_k;
 pub mod q4_k;
+pub mod q5_k;
 pub mod q6_k;
 pub mod quantize;
 
 pub use legacy::{dequantize_q4_0, dequantize_q5_0, dequantize_q5_1};
+pub use q3_k::dequantize_q3_k;
 pub use q4_k::{dequantize_q4_k, q4k_row_dot, q4k_row_scaled_add};
+pub use q5_k::dequantize_q5_k;
 pub use q6_k::{dequantize_q6_k, q6k_row_dot, q6k_row_scaled_add};
 pub use quantize::{quantize_q4_0, quantize_q8_0};
 
@@ -90,6 +94,16 @@ pub const Q4_K_BLOCK_BYTES: usize = 144;
 /// Elements per Q4_K super-block.
 pub const Q4_K_BLOCK_ELEMS: usize = K_QUANT_BLOCK_ELEMS;
 
+/// Bytes per Q3_K super-block (256 elements): 32 hmask + 64 qs + 12 scales + 2 d.
+pub const Q3_K_BLOCK_BYTES: usize = 110;
+/// Elements per Q3_K super-block.
+pub const Q3_K_BLOCK_ELEMS: usize = K_QUANT_BLOCK_ELEMS;
+
+/// Bytes per Q5_K super-block (256 elements): 2 d + 2 dmin + 12 scales + 32 qh + 128 qs.
+pub const Q5_K_BLOCK_BYTES: usize = 176;
+/// Elements per Q5_K super-block.
+pub const Q5_K_BLOCK_ELEMS: usize = K_QUANT_BLOCK_ELEMS;
+
 /// Bytes per Q6_K super-block (256 elements): 128 + 64 + 16 + 2.
 pub const Q6_K_BLOCK_BYTES: usize = 210;
 /// Elements per Q6_K super-block.
@@ -142,7 +156,9 @@ pub fn tensor_data_size(tensor_type: u32, n_elements: usize) -> Result<usize, Mo
         TYPE_Q5_0 => Ok(n_elements / LEGACY_BLOCK_ELEMS * Q5_0_BLOCK_BYTES),
         TYPE_Q5_1 => Ok(n_elements / LEGACY_BLOCK_ELEMS * Q5_1_BLOCK_BYTES),
         TYPE_Q8_0 => Ok(n_elements / LEGACY_BLOCK_ELEMS * Q8_0_BLOCK_BYTES),
+        TYPE_Q3_K => Ok(n_elements / K_QUANT_BLOCK_ELEMS * Q3_K_BLOCK_BYTES),
         TYPE_Q4_K => Ok(n_elements / K_QUANT_BLOCK_ELEMS * Q4_K_BLOCK_BYTES),
+        TYPE_Q5_K => Ok(n_elements / K_QUANT_BLOCK_ELEMS * Q5_K_BLOCK_BYTES),
         TYPE_Q6_K => Ok(n_elements / K_QUANT_BLOCK_ELEMS * Q6_K_BLOCK_BYTES),
         _ => Err(ModelError::Parse(format!(
             "tensor_data_size: unsupported type id {tensor_type}"
@@ -203,7 +219,9 @@ pub fn dequantize(
         TYPE_Q8_0 => legacy::dequantize_q8_0(data, n_elements),
         TYPE_Q5_0 => dequantize_q5_0(data, n_elements),
         TYPE_Q5_1 => dequantize_q5_1(data, n_elements),
+        TYPE_Q3_K => dequantize_q3_k(data, n_elements),
         TYPE_Q4_K => dequantize_q4_k(data, n_elements),
+        TYPE_Q5_K => dequantize_q5_k(data, n_elements),
         TYPE_Q6_K => dequantize_q6_k(data, n_elements),
         other => Err(ModelError::UnsupportedDtype(format!("GGML type {other}"))),
     }

--- a/crates/larql-models/src/quant/ggml/q3_k.rs
+++ b/crates/larql-models/src/quant/ggml/q3_k.rs
@@ -1,0 +1,192 @@
+//! Q3_K dequantization (GGML type 11).
+//!
+//! Block layout (110 bytes, 256 elements):
+//!   [  0.. 32]  hmask   — 1 high bit per element (packed, 32 bytes = 256 bits)
+//!   [ 32.. 96]  qs      — 2 low bits per element (packed, 64 bytes = 128 pairs)
+//!   [ 96..108]  scales  — 12 bytes → 16 six-bit signed scale values (centred at 32)
+//!   [108..110]  d       — f16 global scale
+
+use super::check_block_input;
+use crate::detect::ModelError;
+use crate::quant::half::f16_to_f32;
+
+pub const Q3_K_BLOCK_BYTES: usize = 110;
+const Q3_K_BLOCK_ELEMS: usize = 256;
+
+/// 12 packed bytes → 16 six-bit values (as i8, centred: subtract 32).
+#[inline]
+fn unpack_q3k_scales(sc: &[u8]) -> [i8; 16] {
+    let mut aux = [0u32; 4];
+    aux[0] = u32::from_le_bytes([sc[0], sc[1], sc[2], sc[3]]);
+    aux[1] = u32::from_le_bytes([sc[4], sc[5], sc[6], sc[7]]);
+    aux[2] = u32::from_le_bytes([sc[8], sc[9], sc[10], sc[11]]);
+
+    const KMASK1: u32 = 0x03030303;
+    const KMASK2: u32 = 0x0f0f0f0f;
+
+    let tmp = aux[2];
+    aux[2] = ((aux[0] >> 4) & KMASK2) | (((tmp >> 4) & KMASK1) << 4);
+    aux[3] = ((aux[1] >> 4) & KMASK2) | (((tmp >> 6) & KMASK1) << 4);
+    aux[0] = (aux[0] & KMASK2) | ((tmp & KMASK1) << 4);
+    aux[1] = (aux[1] & KMASK2) | (((tmp >> 2) & KMASK1) << 4);
+
+    // Each byte in aux[0..4] is a 6-bit scale; subtract 32 to centre.
+    let bytes = [
+        aux[0].to_le_bytes(),
+        aux[1].to_le_bytes(),
+        aux[2].to_le_bytes(),
+        aux[3].to_le_bytes(),
+    ];
+    let mut out = [0i8; 16];
+    for (i, b) in bytes.iter().flatten().enumerate() {
+        out[i] = (*b as i8).wrapping_sub(32);
+    }
+    out
+}
+
+pub fn dequantize_q3_k(data: &[u8], n_elements: usize) -> Result<Vec<f32>, ModelError> {
+    let n_blocks = check_block_input("Q3_K", data, n_elements, Q3_K_BLOCK_ELEMS, Q3_K_BLOCK_BYTES)?;
+
+    let mut out = Vec::with_capacity(n_elements);
+
+    for b in 0..n_blocks {
+        let block = &data[b * Q3_K_BLOCK_BYTES..][..Q3_K_BLOCK_BYTES];
+
+        let hmask = &block[0..32];
+        let qs = &block[32..96];
+        let d_all = f16_to_f32(u16::from_le_bytes([block[108], block[109]]));
+
+        let scales = unpack_q3k_scales(&block[96..108]);
+
+        // Two halves of 128 elements each (n=0, n=128).
+        // Within each half: 4 groups of 32 elements, each group split into
+        // two sub-groups of 16. The shift advances by 2 bits per group,
+        // and the high-bit mask bit `m` advances one position per sub-group.
+        let mut m: u8 = 1; // high-bit selector bitmask, walks through hmask bits
+        let mut is: usize = 0; // scale index
+        let mut q_off: usize = 0; // byte offset into qs
+
+        for _n in 0..2 {
+            let mut shift = 0u32;
+            for _j in 0..4 {
+                let dl0 = d_all * (scales[is] as f32);
+                is += 1;
+                for l in 0..16 {
+                    let q2 = (qs[q_off + l] >> shift) & 3;
+                    let high = if hmask[l] & m != 0 { 0i32 } else { -4 };
+                    out.push(dl0 * ((q2 as i32 + high) as f32));
+                }
+
+                let dl1 = d_all * (scales[is] as f32);
+                is += 1;
+                for l in 0..16 {
+                    let q2 = (qs[q_off + 16 + l] >> shift) & 3;
+                    let high = if hmask[16 + l] & m != 0 { 0i32 } else { -4 };
+                    out.push(dl1 * ((q2 as i32 + high) as f32));
+                }
+
+                shift += 2;
+                m <<= 1;
+            }
+            q_off += 32;
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_block(d_bits: u16, hmask: [u8; 32], qs: [u8; 64], scales: [u8; 12]) -> Vec<u8> {
+        let mut b = Vec::with_capacity(Q3_K_BLOCK_BYTES);
+        b.extend_from_slice(&hmask);
+        b.extend_from_slice(&qs);
+        b.extend_from_slice(&scales);
+        b.extend_from_slice(&d_bits.to_le_bytes());
+        assert_eq!(b.len(), Q3_K_BLOCK_BYTES);
+        b
+    }
+
+    #[test]
+    fn hbit_set_no_subtract() {
+        // d=1.0 (f16 0x3C00), all scales raw=32 → signed scale=0, output=0
+        // except we need non-zero scale to see signal.
+        // Use scales=33 raw → signed=1, d=1.0, q2=1, hmask bit set → val=1*1=1.0
+        let d_bits: u16 = 0x3C00; // f16 1.0
+        let mut scales_raw = [0u8; 12];
+        // Pack raw value 33 into all 16 positions.
+        // After unpack, aux bytes are the raw 6-bit values.
+        // Simplest: zero scales (raw=32, signed=0), output=0 regardless.
+        // Use a non-trivial block: scales all 0x20 (raw 32 → signed 0 → skip).
+        // Actually let's encode raw=33 for scale[0].
+        // The unpack xforms are complex; use raw=32 (output=0) and test sign only.
+        // Test: hmask bit set = high=0, hmask bit clear = high=-4.
+
+        // scales all = 0x20 each byte before unpack (→ signed=0, all outputs 0)
+        // → useless for sign test. Use d=1.0, scale[0]=1 (raw 33), q=1.
+        // Encoding raw=33 in scale position 0 is inside aux[0] low nibble.
+        // After unpack: aux[0] = (aux[0] & KMASK2) | ...; for scale[0],
+        // it comes from aux[0] byte 0 & 0x0F | upper bits from tmp.
+        // If tmp=aux[2]=0 and aux[0]=0x21 (lo nibble=1, hi nibble=2=raw upper for [4]):
+        // scale[0] = 0x21 & 0x0F | 0 = 1 → signed = 1-32 = -31. Too complex.
+        // Just use a zero-scale test and a separate known-value test.
+
+        let _ = make_block(d_bits, [0xFF; 32], [0u8; 64], scales_raw);
+        // All hmask bits set, scale=0 → all outputs 0.
+        let block = make_block(d_bits, [0xFF; 32], [0u8; 64], scales_raw);
+        let out = dequantize_q3_k(&block, Q3_K_BLOCK_ELEMS).unwrap();
+        assert_eq!(out.len(), Q3_K_BLOCK_ELEMS);
+        assert!(
+            out.iter().all(|&v| v == 0.0),
+            "all zero-scale → zero output"
+        );
+
+        // Verify output count is always 256.
+        scales_raw[0] = 0xFF;
+        let block2 = make_block(d_bits, [0u8; 32], [0u8; 64], scales_raw);
+        let out2 = dequantize_q3_k(&block2, Q3_K_BLOCK_ELEMS).unwrap();
+        assert_eq!(out2.len(), Q3_K_BLOCK_ELEMS);
+    }
+
+    #[test]
+    fn hmask_clear_subtracts_4() {
+        // Predictable block: d=1.0, tmp=0 so unpack is simple, scale[0] = -31.
+        //
+        //   aux[0] = aux[1] = 0x01010101, aux[2] = 0 (tmp = 0):
+        //   → scale byte 0 = aux[0] byte0 & 0x0F | 0 = 1 → signed = 1 - 32 = -31.
+        //
+        // With negative scale:
+        //   hmask bit 0 clear → val = (-31) * (q2 - 4) = (-31) * (0 - 4) = 124.0
+        //   hmask bit 1 set   → val = (-31) * (q2 + 0) = (-31) * (0 + 0) =   0.0
+        let d_bits: u16 = 0x3C00; // f16 1.0
+        let mut sb = [0u8; 12];
+        sb[0..4].copy_from_slice(&0x01010101u32.to_le_bytes());
+        sb[4..8].copy_from_slice(&0x01010101u32.to_le_bytes());
+        sb[8..12].copy_from_slice(&0u32.to_le_bytes()); // tmp=0
+
+        // hmask[0] = 0 → elem[0] high bit clear → subtract 4
+        let mut hmask = [0xFFu8; 32];
+        hmask[0] = 0xFE; // bit0 clear → elem 0 gets -4; all others set → +0
+
+        let block = make_block(d_bits, hmask, [0u8; 64], sb);
+        let out = dequantize_q3_k(&block, Q3_K_BLOCK_ELEMS).unwrap();
+
+        // scale[0] = -31, d=1.0, q2=0 for elem0.
+        // elem 0: hmask bit clear → val = (-31) * (0 - 4) = 124.0
+        // elem 1: hmask bit set   → val = (-31) * (0 + 0) = 0.0
+        assert!(
+            (out[0] - 124.0).abs() < 0.5,
+            "elem0 expected ~124.0, got {}",
+            out[0]
+        );
+        assert!(out[1].abs() < 0.5, "elem1 expected 0.0, got {}", out[1]);
+    }
+
+    #[test]
+    fn wrong_size_returns_error() {
+        let result = dequantize_q3_k(&[0u8; 5], 256);
+        assert!(result.is_err());
+    }
+}

--- a/crates/larql-models/src/quant/ggml/q4_k.rs
+++ b/crates/larql-models/src/quant/ggml/q4_k.rs
@@ -90,7 +90,7 @@ pub(super) fn q4k_row_dot_scalar(data: &[u8], x: &[f32], n_blocks: usize) -> f32
 
 /// 12 packed bytes → 8 six-bit scales + 8 six-bit mins.
 #[inline]
-fn unpack_q4k_scales(scales_bytes: &[u8]) -> ([u8; 8], [u8; 8]) {
+pub(super) fn unpack_q4k_scales(scales_bytes: &[u8]) -> ([u8; 8], [u8; 8]) {
     let mut scales = [0u8; 8];
     let mut mins = [0u8; 8];
     for j in 0..4 {

--- a/crates/larql-models/src/quant/ggml/q5_k.rs
+++ b/crates/larql-models/src/quant/ggml/q5_k.rs
@@ -1,0 +1,123 @@
+//! Q5_K dequantization (GGML type 13).
+//!
+//! Block layout (176 bytes, 256 elements):
+//!   [  0..  2]  d       — f16 global scale
+//!   [  2..  4]  dmin    — f16 global min
+//!   [  4.. 16]  scales  — 12 bytes → 8 six-bit scales + 8 six-bit mins (same as Q4_K)
+//!   [ 16.. 48]  qh      — 1 high bit per element (packed, 32 bytes = 256 bits)
+//!   [ 48..176]  qs      — 4 low bits per element (packed, 128 bytes = 256 nibbles)
+
+use super::check_block_input;
+use super::q4_k::unpack_q4k_scales;
+use crate::detect::ModelError;
+use crate::quant::half::f16_to_f32;
+
+pub const Q5_K_BLOCK_BYTES: usize = 176;
+const Q5_K_BLOCK_ELEMS: usize = 256;
+
+pub fn dequantize_q5_k(data: &[u8], n_elements: usize) -> Result<Vec<f32>, ModelError> {
+    let n_blocks = check_block_input("Q5_K", data, n_elements, Q5_K_BLOCK_ELEMS, Q5_K_BLOCK_BYTES)?;
+
+    let mut out = Vec::with_capacity(n_elements);
+
+    for b in 0..n_blocks {
+        let block = &data[b * Q5_K_BLOCK_BYTES..][..Q5_K_BLOCK_BYTES];
+
+        let d = f16_to_f32(u16::from_le_bytes([block[0], block[1]]));
+        let dmin = f16_to_f32(u16::from_le_bytes([block[2], block[3]]));
+        let (scales, mins) = unpack_q4k_scales(&block[4..16]);
+
+        let qh = &block[16..48];
+        let ql = &block[48..176];
+
+        // 4 iterations × 64 elements. u1/u2 walk through the high-bit mask.
+        let mut u1: u8 = 1;
+        let mut u2: u8 = 2;
+        let mut is: usize = 0; // scale/min index (0..8)
+        let mut ql_off: usize = 0; // byte offset into ql (advances 32 per iteration)
+
+        for _ in 0..4 {
+            let d1 = d * (scales[is] as f32);
+            let m1 = dmin * (mins[is] as f32);
+            is += 1;
+            let d2 = d * (scales[is] as f32);
+            let m2 = dmin * (mins[is] as f32);
+            is += 1;
+
+            for l in 0..32 {
+                let lo = ql[ql_off + l] & 0x0F;
+                let hi = if qh[l] & u1 != 0 { 16u8 } else { 0u8 };
+                out.push(d1 * ((lo + hi) as f32) - m1);
+            }
+            for l in 0..32 {
+                let lo = ql[ql_off + l] >> 4;
+                let hi = if qh[l] & u2 != 0 { 16u8 } else { 0u8 };
+                out.push(d2 * ((lo + hi) as f32) - m2);
+            }
+
+            ql_off += 32;
+            u1 <<= 2;
+            u2 <<= 2;
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_block(d: u16, dmin: u16, scales: [u8; 12], qh: [u8; 32], qs: [u8; 128]) -> Vec<u8> {
+        let mut b = Vec::with_capacity(Q5_K_BLOCK_BYTES);
+        b.extend_from_slice(&d.to_le_bytes());
+        b.extend_from_slice(&dmin.to_le_bytes());
+        b.extend_from_slice(&scales);
+        b.extend_from_slice(&qh);
+        b.extend_from_slice(&qs);
+        assert_eq!(b.len(), Q5_K_BLOCK_BYTES);
+        b
+    }
+
+    #[test]
+    fn zero_scales_all_zero() {
+        // With scales=0 and mins=0, all outputs = d*q - 0 = 0 when q=0.
+        let block = make_block(0x3C00, 0x0000, [0u8; 12], [0u8; 32], [0u8; 128]);
+        let out = dequantize_q5_k(&block, Q5_K_BLOCK_ELEMS).unwrap();
+        assert_eq!(out.len(), Q5_K_BLOCK_ELEMS);
+        // scale[0]=0, all qs=0 → output = d*0*0 - dmin*0*0 = 0
+        assert!(out.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn high_bit_set_adds_16() {
+        // d=1.0, dmin=0, scales[0]=1 (raw), mins[0]=0.
+        // scales bytes: just aux[0] byte0 = 1, rest = 0
+        // After unpack: scales[0] = scales_bytes[0] & 0x3F = 1.
+        let mut sc = [0u8; 12];
+        sc[0] = 1; // scale[0]=1, all others 0
+                   // qh[0] bit0 set → hi=16 for ql[0].
+        let mut qh = [0u8; 32];
+        qh[0] = 0x01; // bit0 set → u1(=1) matches → elem 0 gets hi=16
+        let mut qs = [0u8; 128];
+        qs[0] = 0x01; // lo nibble = 1 for elem 0
+
+        let block = make_block(0x3C00, 0x0000, sc, qh, qs);
+        let out = dequantize_q5_k(&block, Q5_K_BLOCK_ELEMS).unwrap();
+
+        // elem 0: d=1.0, scale=1, lo=1, hi=16 → 1.0 * (1+16) - 0 = 17.0
+        assert!(
+            (out[0] - 17.0).abs() < 0.01,
+            "expected 17.0, got {}",
+            out[0]
+        );
+        // elem 1: qs[0] hi nibble = 0, qh[0] bit1=0 → u2(=2) not set → hi=0 → 0.0
+        // but d2=scale[1]*d=0 → also 0.0
+        assert!((out[32] - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn wrong_size_returns_error() {
+        assert!(dequantize_q5_k(&[0u8; 10], 256).is_err());
+    }
+}


### PR DESCRIPTION
## What

Implements scalar dequantization for two missing K-quant formats:

| Type | ID | Block size | Elements/block |
|------|----|-----------|----------------|
| Q3_K | 11 | 110 bytes | 256 |
| Q5_K | 13 | 176 bytes | 256 |

Both `tensor_data_size()` and `dequantize()` in `mod.rs` are wired up.

## Why

Without these, `larql convert gguf-to-vindex` fails with `unsupported type id 11/13` on any model that uses Q3_K or Q5_K tensors. This includes:

- **DeepSeek-R1-0528-Qwen3-8B-Q3_K_L** — 145 Q3_K tensors + 108 Q5_K tensors + 1 Q6_K
- **DeepSeek-V4-Flash-Q3_K_M** (multi-shard, separate PR) — same types
- Any model quantised with llama.cpp Q3_K_S / Q3_K_M / Q3_K_L / Q5_K_S / Q5_K_M

## Implementation

**`q3_k.rs`** — `dequantize_q3_k()`
- Block layout: `hmask[0..32]` · `qs[32..96]` · `scales[96..108]` · `d[108..110]`
- `unpack_q3k_scales()`: 12 bytes → 16 six-bit signed values using the `kmask1=0x03030303` / `kmask2=0x0F0F0F0F` shuffle from `dequantize_row_q3_K` in llama.cpp
- Two-half loop (128 + 128 elements), `m` bitmask walks through `hmask`; clear bit → subtract 4 from q2 value

**`q5_k.rs`** — `dequantize_q5_k()`
- Block layout: `d[0..2]` · `dmin[2..4]` · `scales[4..16]` · `qh[16..48]` · `qs[48..176]`
- Reuses `pub(super) unpack_q4k_scales()` from `q4_k.rs` (same 12-byte format as Q4_K)
- `u1`/`u2` bitmask pair walks through `qh`; set bit → add 16 to 4-bit nibble
- 4 iterations × 64 elements, matching `dequantize_row_q5_K` in llama.cpp

**`q4_k.rs`** — `unpack_q4k_scales` visibility changed `fn` → `pub(super)` so Q5_K can share it without duplication.

## Testing

Unit tests in each module:
- `q3_k`: zero-scale all-zero output, hmask-clear subtracts 4, wrong-size error
- `q5_k`: zero-scale all-zero output, high-bit adds 16, wrong-size error

End-to-end: `larql convert gguf-to-vindex` on `DeepSeek-R1-0528-Qwen3-8B-Q3_K_L.gguf` completes through dequantization without errors (145 Q3_K + 108 Q5_K tensors dequantized cleanly).

All 82 existing larql-models tests continue to pass.