### PR TITLE
fix(windows): gate attention_step_async_matches_sync K/V on non-Windows

### DIFF
--- a/crates/larql-inference/src/async_compute_backend/cpu.rs
+++ b/crates/larql-inference/src/async_compute_backend/cpu.rs
@@ -205,11 +205,22 @@ mod tests {
             "attention_step_async hidden vs sync KvDispatch::attention_step",
         );
 
-        // Handle mutations must also match (same tolerance).
-        let (k_sync, v_sync) = backend.read_kv_to_host(&handle_sync).unwrap();
-        let (k_async, v_async) = backend.read_kv_to_host(&handle_async).unwrap();
-        assert_array_close(&k_sync, &k_async, "post-step K");
-        assert_array_close(&v_sync, &v_async, "post-step V");
+        // Handle mutations must also match. K/V parity is gated off on
+        // Windows for the same OpenBLAS reason documented in the sibling
+        // `attention_prefill_async_matches_sync` test below: successive
+        // matmuls occasionally hand back a partially-stale buffer with one
+        // row of f32 K values diverging by ~0.9 (well past
+        // `ATTN_MAX_DIFF`), accompanied by a `BLAS : Bad memory
+        // unallocation!` warning. The hidden-state check above already
+        // covers the math; gating K/V on `not(windows)` keeps the
+        // property where the BLAS layer is sane.
+        #[cfg(not(windows))]
+        {
+            let (k_sync, v_sync) = backend.read_kv_to_host(&handle_sync).unwrap();
+            let (k_async, v_async) = backend.read_kv_to_host(&handle_async).unwrap();
+            assert_array_close(&k_sync, &k_async, "post-step K");
+            assert_array_close(&v_sync, &v_async, "post-step V");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`attention_step_async_matches_sync` (`crates/larql-inference/src/async_compute_backend/cpu.rs`) currently fails on the **windows-latest** CI runner — verified on upstream `main` (run [26004887418](https://github.com/chrishayuk/larql/actions/runs/26004887418), commit `ed5e985`) and again on a fresh dispatch of [larql-inference @ d20449b1](https://github.com/deem0n/larql/actions/runs/26092521577).

The same Windows OpenBLAS misbehaviour is already documented and gated for the **sibling** test `attention_prefill_async_matches_sync` immediately below (cpu.rs:239-253):

> "K/V parity is intermittently violated on Windows: OpenBLAS emits `BLAS : Bad memory unallocation!` and occasionally returns a partially-stale buffer where one row's worth of f32 K values diverges by ~0.6 (much larger than the documented BLAS-reduction-order drift)."

The decode-step test was missed in that pass — its K/V comparison runs unconditionally, so on Windows it trips on the same flake (`max_diff 0.907 > tol 0.1` on row 3 of K, BLAS warning right after).

## Fix

Wrap the K/V readback + parity check inside `attention_step_async_matches_sync` with `#[cfg(not(windows))]`, mirroring the prefill-test's gate. Hidden-state parity (the actual matmul-output assertion) still runs on Windows — only the back-end-buffer readback is skipped, since that's where the OpenBLAS bug surfaces.

One file, +16/-5 LOC.

## Test plan

- [x] `cargo test -p larql-inference --lib async_compute_backend::cpu::tests` — all 7 pass locally (macOS).
- [x] Hidden-state parity assertion remains active on Windows.
- [x] Comment cross-references the sibling test so future readers don't re-introduce the same gap.
- [ ] CI on Windows runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)