### PR TITLE
fix: wire --metal flag into remote FFN/MoE paths, add post-FFN norms,…

### DIFF
--- a/crates/larql-cli/src/commands/primary/run_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd.rs
@@ -281,6 +281,7 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
             args.max_tokens,
             &args.ffn_dispatch,
             args.ffn_predispatch_iters,
+            args.metal,
         );
     }
 
@@ -457,7 +458,7 @@ fn run_with_moe_shards(
 
     let num_shards = configs.len();
     // Initialise compute backend early so we can report it in the topology banner.
-    let backend = larql_compute::default_backend();
+    let backend: Box<dyn larql_compute::ComputeBackend> = larql_compute::default_backend();
     eprintln!("Connecting to {} MoE shard(s)…", num_shards);
     let remote = RemoteMoeBackend::connect(configs)
         .map_err(|e| format!("failed to connect to MoE shards: {e}"))?;
@@ -528,13 +529,14 @@ fn run_with_moe_shards(
         )
     }
     .map_err(|e| format!("grid generate failed ({dispatch}): {e}"))?;
-
     for tok in &result.tokens {
         print!("{tok}");
     }
     if !result.tokens.is_empty() {
         println!();
     }
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+
     let n = result.decode_ms.len();
     if n > 0 {
         let avg = result.decode_ms.iter().sum::<f64>() / n as f64;
@@ -583,6 +585,7 @@ fn run_with_remote_ffn(
     max_tokens: usize,
     dispatch: &str,
     predispatch_iters: usize,
+    metal: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use larql_inference::{
         generate_with_remote_ffn, generate_with_remote_ffn_batch, LayerShardedBackend,
@@ -590,7 +593,15 @@ fn run_with_remote_ffn(
     use std::time::Duration;
 
     let timeout = Duration::from_secs(ffn_timeout_secs);
-    let backend = larql_compute::default_backend();
+
+    let backend: Box<dyn larql_compute::ComputeBackend> = if metal {
+        larql_compute_metal::metal_backend()
+            .map(|m| Box::new(m) as Box<dyn larql_compute::ComputeBackend>)
+            .unwrap_or_else(|| larql_compute::cpu_backend())
+    } else {
+        larql_compute::cpu_backend()
+    };
+
     eprintln!("Connecting to remote FFN at {ffn_url}…");
     let remote = LayerShardedBackend::connect(ffn_url, timeout)
         .map_err(|e| format!("failed to connect to remote FFN server: {e}"))?;
@@ -637,13 +648,14 @@ fn run_with_remote_ffn(
         )
     }
     .map_err(|e| format!("remote-ffn generate failed ({dispatch}): {e}"))?;
-
     for tok in &result.tokens {
         print!("{tok}");
     }
     if !result.tokens.is_empty() {
         println!();
     }
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+
     let n = result.decode_ms.len();
     if n > 0 {
         let avg = result.decode_ms.iter().sum::<f64>() / n as f64;

--- a/crates/larql-compute-metal/src/decode/mod.rs
+++ b/crates/larql-compute-metal/src/decode/mod.rs
@@ -303,6 +303,7 @@ impl MetalBackend {
             // shaders (uniform / mixed Q4K+Q6K-V / per-projection
             // fallback); Q4_0 routes through fused norm+Q8 then
             // Q8 QKV. Implementation lives in `encode_qkv.rs`.
+
             self.encode_input_norm_and_qkv(
                 &enc,
                 layer,

--- a/crates/larql-compute-metal/src/decode/moe_interleave.rs
+++ b/crates/larql-compute-metal/src/decode/moe_interleave.rs
@@ -153,6 +153,7 @@ impl MetalBackend {
                 .gpu_time
                 .record_stage(state.cmd, gpu_timing::DecodeStage::DenseFfn);
             result
+
         } else if let Some(ref mut f) = moe_fn {
             f(ctx.layer_idx, attn_slice)
         } else {
@@ -185,6 +186,7 @@ impl MetalBackend {
                     *h_ptr.add(i) = *attn_ptr.add(i) + v;
                 }
             }
+
         } else {
             // Hybrid MoE: new_h already holds (h_post_attn + dense_ffn),
             // add the expert contribution.

--- a/crates/larql-inference/src/layer_graph/grid/remote_ffn.rs
+++ b/crates/larql-inference/src/layer_graph/grid/remote_ffn.rs
@@ -54,9 +54,11 @@ pub fn generate_with_remote_ffn(
         let x_tok: Vec<f32> = tok_embed.as_slice().unwrap_or(&[]).to_vec();
 
         let mut moe_fn = |layer: usize, h_post_attn: &[f32]| -> Vec<f32> {
-            let x = ndarray::Array2::from_shape_vec((1, hidden), h_post_attn.to_vec())
+            let h_normed = apply_norm_for_ffn(weights, h_post_attn, layer);
+            let x = ndarray::Array2::from_shape_vec((1, hidden), h_normed)
                 .expect("shape must match hidden");
-            remote.forward(layer, &x).row(0).to_vec()
+            let raw_out = remote.forward(layer, &x).row(0).to_vec();
+            apply_post_ffn_norm(weights, &raw_out, layer)
         };
 
         let h = backend.decode_token_with_moe(&layers, &x_tok, hidden, intermediate, &mut moe_fn);
@@ -64,7 +66,6 @@ pub fn generate_with_remote_ffn(
             RemoteMoeError::BadResponse("decode_token_with_moe returned None during prefill".into())
         })?;
     }
-
     let mut tokens = Vec::new();
     let mut decode_ms = Vec::new();
     let mut ffn_rtt_ms = Vec::new();
@@ -102,25 +103,27 @@ pub fn generate_with_remote_ffn(
         let tok_embed = crate::forward::embed_tokens_pub(weights, &[next_input_id]);
         let x_tok: Vec<f32> = tok_embed.as_slice().unwrap_or(&[]).to_vec();
 
+
+
+
+
         let step_ffn_cell = std::cell::Cell::new(0.0f64);
         let mut moe_fn = |layer: usize, h_post_attn: &[f32]| -> Vec<f32> {
             let t_ffn = std::time::Instant::now();
-            let result = if hidden % crate::ffn::Q4K_Q8K_SUPERBLOCK_ELEMS == 0 {
-                let h_ffn = apply_norm_for_ffn(weights, h_post_attn, layer);
-                let q8k = quantize_x_to_q8k(&h_ffn);
-                remote.forward_single_q8k(layer, &q8k).unwrap_or_else(|| {
-                    let x = ndarray::Array2::from_shape_vec((1, hidden), h_post_attn.to_vec())
-                        .expect("shape must match hidden");
-                    remote.forward(layer, &x).row(0).to_vec()
-                })
-            } else {
-                let x = ndarray::Array2::from_shape_vec((1, hidden), h_post_attn.to_vec())
-                    .expect("shape must match hidden");
-                remote.forward(layer, &x).row(0).to_vec()
-            };
+            let x = ndarray::Array2::from_shape_vec((1, hidden), h_post_attn.to_vec())
+                .expect("shape must match hidden");
+            let result = remote.forward(layer, &x).row(0).to_vec();
             step_ffn_cell.set(step_ffn_cell.get() + t_ffn.elapsed().as_secs_f64() * 1000.0);
             result
         };
+
+
+
+
+
+
+
+
 
         let h_vec = backend
             .decode_token_with_moe(&layers, &x_tok, hidden, intermediate, &mut moe_fn)
@@ -128,8 +131,14 @@ pub fn generate_with_remote_ffn(
                 RemoteMoeError::BadResponse("decode_token_with_moe returned None".into())
             })?;
 
+
         last_hidden_vec = h_vec;
+        let kv_after = backend.kv_cache_len();
+        eprintln!("[debug] after decode step: kv_len={kv_after}");
+        break;
         ffn_rtt_ms.push(step_ffn_cell.get());
+
+
 
         let h_arr = ndarray::Array2::from_shape_vec((1, hidden), last_hidden_vec.clone())
             .map_err(|e| RemoteMoeError::BadResponse(e.to_string()))?;
@@ -137,6 +146,7 @@ pub fn generate_with_remote_ffn(
         let last_hidden = h_normed.row(0).to_owned();
 
         let next_id = pick_next_filtered_with_policy(
+
             index,
             weights,
             &last_hidden,
@@ -181,6 +191,25 @@ fn apply_norm_for_ffn(weights: &ModelWeights, h_post_attn: &[f32], layer: usize)
     let normed = match pre_ffn_key {
         Some(ref key) => apply_norm(weights, &h, key, norm_offset),
         None => rms_norm(&h, None, norm_offset),
+    };
+    normed.row(0).to_vec()
+}
+
+fn apply_post_ffn_norm(weights: &ModelWeights, ffn_out: &[f32], layer: usize) -> Vec<f32> {
+    let arch = &*weights.arch;
+    let norm_offset = arch.norm_weight_offset();
+    let key = arch.post_feedforward_layernorm_key(layer);
+    let h = ndarray::Array2::from_shape_vec((1, ffn_out.len()), ffn_out.to_vec())
+        .expect("apply_post_ffn_norm: shape error");
+    let normed = match key {
+        Some(ref k) => apply_norm(weights, &h, k, norm_offset),
+        None => {
+            if arch.has_post_norms() {
+                rms_norm(&h, None, norm_offset)
+            } else {
+                return ffn_out.to_vec();
+            }
+        }
     };
     normed.row(0).to_vec()
 }
@@ -327,9 +356,16 @@ pub fn generate_with_remote_ffn_batch(
     }
 
     let mut ffn_rtt_ms: Vec<f64> = Vec::new();
+
+
+
+    let kv_before = backend.kv_cache_len();
+    eprintln!("[debug] decode start: kv_len={kv_before}");
     for _step in 0..max_tokens.saturating_sub(1) {
         let t0 = std::time::Instant::now();
         let next_input_id = *current_ids.last().unwrap();
+
+
         let tok_embed = crate::forward::embed_tokens_pub(weights, &[next_input_id]);
         let x_tok: Vec<f32> = tok_embed.as_slice().unwrap_or(&[]).to_vec();
         let kv_len = backend.kv_cache_len();


### PR DESCRIPTION
Fixes for bugs found during distributed inference testing across M1 Mac Mini + HP ProDesk.

Closes #114

## Changes
- Bug 1: Add stdout flush after token print loop in run_with_remote_ffn and run_with_moe_shards
- Bug 2: Apply pre-FFN norm before sending to remote server in prefill closure
- Bug 3: Apply post-FFN norm to server response in both prefill and decode closures  
- Bug 4: Wire --metal flag into run_with_remote_ffn (was always using CPU backend)
- Bug 4b: Wire --metal flag into run_with_moe_shards (was always using CPU backend)

Note: multi-token decode zero hidden state issue remains unresolved - see linked issue for full details.