### PR TITLE
ci(windows): single-threaded BLAS + cargo runner; revert #113 source gates

### DIFF
--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -101,6 +101,30 @@ jobs:
       - name: Clippy
         run: cargo clippy -p larql-inference --lib --tests --benches --no-deps -- -D warnings
 
+      # On Windows OpenBLAS' matmul intermittently emits
+      # `BLAS : Bad memory unallocation!` and returns a
+      # partially-stale buffer, causing sync-vs-async (and
+      # sync-vs-legacy) parity tests to randomly diverge.
+      # `OPENBLAS_NUM_THREADS=1` + `OMP_NUM_THREADS=1` disable
+      # OpenBLAS' internal threading, and `RUST_TEST_THREADS=1`
+      # serialises the cargo test runner so multiple Rust threads
+      # can't race on OpenBLAS' global buffer pool. The combination
+      # eliminates the warning on Windows. Linux + macOS keep
+      # multi-threaded execution. The inference test set finishes
+      # in ~3 s, so single-threaded on Windows is negligible.
+      #
+      # These env vars MUST be unset (not empty) on non-Windows:
+      # `RUST_TEST_THREADS=''` panics the test runner. We use a
+      # gated GITHUB_ENV write rather than a step-level `env:` map,
+      # because the latter materialises empty strings on non-Windows.
+      - name: Force single-threaded BLAS + test runner (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          "OPENBLAS_NUM_THREADS=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "OMP_NUM_THREADS=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "RUST_TEST_THREADS=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       # `cargo test` runs lib tests + integration tests; #[ignore]
       # markers on weight-dependent goldens keep them out of the
       # default set. Bench targets compile-check via `--benches` above.

--- a/crates/larql-inference/src/async_compute_backend/cpu.rs
+++ b/crates/larql-inference/src/async_compute_backend/cpu.rs
@@ -205,22 +205,11 @@ mod tests {
             "attention_step_async hidden vs sync KvDispatch::attention_step",
         );
 
-        // Handle mutations must also match. K/V parity is gated off on
-        // Windows for the same OpenBLAS reason documented in the sibling
-        // `attention_prefill_async_matches_sync` test below: successive
-        // matmuls occasionally hand back a partially-stale buffer with one
-        // row of f32 K values diverging by ~0.9 (well past
-        // `ATTN_MAX_DIFF`), accompanied by a `BLAS : Bad memory
-        // unallocation!` warning. The hidden-state check above already
-        // covers the math; gating K/V on `not(windows)` keeps the
-        // property where the BLAS layer is sane.
-        #[cfg(not(windows))]
-        {
-            let (k_sync, v_sync) = backend.read_kv_to_host(&handle_sync).unwrap();
-            let (k_async, v_async) = backend.read_kv_to_host(&handle_async).unwrap();
-            assert_array_close(&k_sync, &k_async, "post-step K");
-            assert_array_close(&v_sync, &v_async, "post-step V");
-        }
+        // Handle mutations must also match (same tolerance).
+        let (k_sync, v_sync) = backend.read_kv_to_host(&handle_sync).unwrap();
+        let (k_async, v_async) = backend.read_kv_to_host(&handle_async).unwrap();
+        assert_array_close(&k_sync, &k_async, "post-step K");
+        assert_array_close(&v_sync, &v_async, "post-step V");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the per-test `#[cfg(not(windows))]` workaround landed in
#113 with a CI-level root-cause fix for the Windows OpenBLAS
flakiness, then reverts the source-level gate so the test suite
stays equally strict on all platforms.

## What was happening

The Windows test job for `larql-inference` has been intermittently
failing with `BLAS : Bad memory unallocation!` printed by OpenBLAS,
followed by a sync-vs-async parity assertion failing with a
partially-stale buffer. PR #113 gated the K/V check of
`attention_step_async_matches_sync` on `not(windows)` to make the
specific failure stop. But subsequent CI runs hit a different
assertion each time — sometimes hidden-state mismatch in
`attention_prefill_async_matches_sync` (`max_diff 0.166 > tol 0.1`),
sometimes `forward_from_layer_async_matches_sync`, sometimes
`infer_patched_with_knn_store_override_routes_through`, sometimes
`kv_dispatch::cpu::tests::attention_prefill_matches_legacy_run_attention_with_kv_backend`.
Each new failure mode would need its own `#[cfg(not(windows))]` —
classic whack-a-mole.

## Root cause

OpenBLAS' single-threaded mode still uses a global buffer pool.
`cargo test`'s parallel runner spawns multiple Rust threads, each
of which can call into matmul concurrently — and **those Rust
threads race on the global OpenBLAS buffer pool**, producing the
`Bad memory unallocation!` warning and a partially-stale return
buffer. Setting only `OPENBLAS_NUM_THREADS=1` is not enough
(verified — still flakes).

## Fix

A single new step in `.github/workflows/larql-inference.yml`, gated
on `runner.os == 'Windows'`, that writes three env vars to
`$GITHUB_ENV`:

- `OPENBLAS_NUM_THREADS=1` — kill OpenBLAS' internal threading
- `OMP_NUM_THREADS=1` — same, for OpenMP-built variants
- `RUST_TEST_THREADS=1` — serialise the cargo test runner so only
  one Rust thread is ever inside OpenBLAS at a time

The `GITHUB_ENV` write is preferred over a step-level `env:` map
because the latter materialises empty strings on non-Windows
matrix legs, and `RUST_TEST_THREADS=''` panics the rust test
runner.

The second commit reverts PR #113 — the source-level
`#[cfg(not(windows))]` gates are no longer needed.

## Verification

Run [26158082012](https://github.com/deem0n/larql/actions/runs/26158082012)
on `deem0n/larql:windows-fix-blas-threads` (an earlier iteration of
this branch, before the revert was added):

```
test - windows-latest    success
test - ubuntu-latest     success
test - macos-14          success
coverage - ubuntu        success
```

That run was with the CI fix in place but BEFORE removing #113's
source gates. With the gates removed (this PR's head), local
`cargo test -p larql-inference --lib` on macOS still passes all
1291 tests — verified.

## Test plan

All confirmed green on this PR's head against
`chrishayuk/larql:main` (workflow `larql-inference`, run
[26160681337](https://github.com/chrishayuk/larql/actions/runs/26160681337)):

- [x] `test - windows-latest` green — the Windows BLAS flake is gone
- [x] `test - ubuntu-latest` green — revert doesn't regress Linux
- [x] `test - macos-14` green — revert doesn't regress macOS
- [x] `coverage - ubuntu` green (larql-inference)
- [x] Sibling workflows unaffected: `larql-cli`, `larql-lql`,
  `larql-server` test jobs, `bench-regress`, `shannon-verify` all
  green
- [x] Local `cargo test -p larql-inference --lib` on macOS passes
  all 1291 tests with the #113 gates removed

Note: an unrelated `coverage - ubuntu` job in the `larql-server`
workflow fails on `routes/openai/completions.rs` (70.34% < 86.00%
policy threshold). That file is not touched by this PR and the
failure reproduces on `main`; it is a pre-existing baseline issue.

## Follow-up (not in this PR)

There are three older `#[cfg(not(windows))]` gates that pre-date
#113 and were added for the same root cause:

- `larql-inference/src/trace/capture.rs:291`
  (`trace_final_residual_matches_raw_forward_logits`)
- `larql-compute/src/backend/helpers.rs:97`
  (`dot_proj_gpu_some_backend_matches_fallback`)
- `larql-inference/src/async_compute_backend/cpu.rs:247`
  (`attention_prefill_async_matches_sync` K/V parity)

If this PR is accepted and proves out, a follow-up could remove
those too. Kept out of this PR to keep the scope to "swap #113 for
the env-var fix".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
