### PR TITLE
test(windows): remove stale #[cfg(not(windows))] gates (follow-up to #117)

### DIFF
--- a/crates/larql-compute/src/backend/helpers.rs
+++ b/crates/larql-compute/src/backend/helpers.rs
@@ -86,15 +86,6 @@ mod tests {
 
     /// `Some(CpuBackend)` → goes through trait, must equal the `None`
     /// fallback (both are CPU paths, just routed differently).
-    ///
-    /// Skipped on Windows: OpenBLAS on the Windows runner corrupts the
-    /// f32 sgemm output of the second back-to-back call (entire columns
-    /// drift by ~0.6, accompanied by `BLAS : Bad memory unallocation!`
-    /// on stderr — see PR 104 CI 2026-05-17). The trait correctness
-    /// contract is covered by the other backends in the same suite;
-    /// this test exists to pin "Some(CpuBackend) ≡ None fallback" and
-    /// there's nothing we can do at this layer about the OpenBLAS bug.
-    #[cfg(not(windows))]
     #[test]
     fn dot_proj_gpu_some_backend_matches_fallback() {
         let a = synth(4, 8, 1);

--- a/crates/larql-inference/src/trace/capture.rs
+++ b/crates/larql-inference/src/trace/capture.rs
@@ -151,11 +151,6 @@ mod tests {
     use super::*;
     use crate::ffn::FfnBackend;
     use crate::forward::trace_forward_with_ffn;
-    // `forward_raw_logits` / `hidden_to_raw_logits` are only used by
-    // `trace_final_residual_matches_raw_forward_logits`, which is gated
-    // off on Windows. Keep the imports under the same gate so `clippy
-    // -D warnings` doesn't trip on unused imports.
-    #[cfg(not(windows))]
     use crate::forward::{forward_raw_logits, hidden_to_raw_logits};
     use crate::test_utils::make_test_weights;
     use larql_models::ModelWeights;
@@ -281,14 +276,6 @@ mod tests {
         }
     }
 
-    // `trace()` and `forward_raw_logits()` compute the same forward pass
-    // but through slightly different BLAS dispatch paths. Linux + macOS
-    // produce bit-stable enough output that the residual matches within
-    // 1e-4; Windows OpenBLAS uses parallel reduction whose summation
-    // order isn't reproducible across these two paths, so the residual
-    // diverges by ~1e-1 well past the tolerance. Same pattern, same gate
-    // as `generate_cached_hooked_with_noop_matches_baseline`.
-    #[cfg(not(windows))]
     #[test]
     fn trace_final_residual_matches_raw_forward_logits() {
         let w = weights();


### PR DESCRIPTION
## Summary

Rebased on `main` per maintainer request. The CI-level fix that
landed in #124 (`OPENBLAS_NUM_THREADS=1` +
`OMP_NUM_THREADS=1` + `RUST_TEST_THREADS=1` on Windows)
eliminates the underlying OpenBLAS race on the global buffer
pool, so the two remaining stale `#[cfg(not(windows))]` test
gates that pre-date #113/#124 can come out.

## What's removed

- **`crates/larql-inference/src/trace/capture.rs`** — gate on
  `trace_final_residual_matches_raw_forward_logits` and the
  matching gate on its `forward_raw_logits` /
  `hidden_to_raw_logits` imports (which only existed to keep
  `clippy -D warnings` quiet while the test was gated).
- **`crates/larql-compute/src/backend/helpers.rs`** — gate on
  `dot_proj_gpu_some_backend_matches_fallback` and its
  "Skipped on Windows" doc paragraph.

Net diff: **2 files, 0 / −22**.

(The third gate originally targeted in this PR —
`attention_prefill_async_matches_sync` K/V check in
`larql-compute/async_compute_backend/cpu.rs` — was already
removed by #124, so it isn't in this diff.)

## Test plan

Local verification on macOS, branched off current
`chrishayuk/larql:main` (i.e. with #124's CI fix in place):

- [x] `cargo check -p larql-inference -p larql-compute --lib --tests` — clean
- [x] `cargo clippy -p larql-inference -p larql-compute --lib --tests --no-deps -- -D warnings` — clean (the previously-gated imports are now unconditionally used)
- [x] `cargo fmt -p larql-inference -p larql-compute -- --check` — clean
- [x] `trace_final_residual_matches_raw_forward_logits` — passes
- [x] `dot_proj_gpu_some_backend_matches_fallback` — passes

CI verification (the real proof — these are tests that previously
flaked or were skipped on Windows):

- [ ] `larql-inference test - windows-latest` green
- [ ] `larql-inference test - ubuntu-latest` green
- [ ] `larql-inference test - macos-14` green
- [ ] `larql-compute test · windows-latest` green
- [ ] `larql-compute test · ubuntu-latest` green
- [ ] `larql-compute test · macos-14` green
- [ ] `coverage - ubuntu` green (both larql-inference and larql-compute)

If Windows CI flakes on either of the two resurrected tests, that
would mean #124's env-var fix isn't fully covering them, and this
PR should be held — the goal is to bring Windows up to
Linux/macOS coverage, not to re-introduce flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
