### PR TITLE
fix: wire --metal into remote FFN path, add post-FFN norms, flush stdout (cherry-pick of #115)

### DIFF
--- a/crates/larql-cli/src/commands/primary/run_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd.rs
@@ -281,6 +281,7 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
             args.max_tokens,
             &args.ffn_dispatch,
             args.ffn_predispatch_iters,
+            args.metal,
         );
     }
 
@@ -535,6 +536,8 @@ fn run_with_moe_shards(
     if !result.tokens.is_empty() {
         println!();
     }
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+
     let n = result.decode_ms.len();
     if n > 0 {
         let avg = result.decode_ms.iter().sum::<f64>() / n as f64;
@@ -583,6 +586,7 @@ fn run_with_remote_ffn(
     max_tokens: usize,
     dispatch: &str,
     predispatch_iters: usize,
+    metal: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use larql_inference::{
         generate_with_remote_ffn, generate_with_remote_ffn_batch, LayerShardedBackend,
@@ -590,7 +594,20 @@ fn run_with_remote_ffn(
     use std::time::Duration;
 
     let timeout = Duration::from_secs(ffn_timeout_secs);
-    let backend = larql_compute::default_backend();
+    let backend: Box<dyn larql_compute::ComputeBackend> = if metal {
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        {
+            larql_compute_metal::metal_backend()
+                .map(|m| Box::new(m) as Box<dyn larql_compute::ComputeBackend>)
+                .unwrap_or_else(larql_compute::cpu_backend)
+        }
+        #[cfg(not(all(feature = "gpu", target_os = "macos")))]
+        {
+            return Err("`--metal` requires the `gpu` feature on macOS".into());
+        }
+    } else {
+        larql_compute::cpu_backend()
+    };
     eprintln!("Connecting to remote FFN at {ffn_url}…");
     let remote = LayerShardedBackend::connect(ffn_url, timeout)
         .map_err(|e| format!("failed to connect to remote FFN server: {e}"))?;
@@ -644,6 +661,8 @@ fn run_with_remote_ffn(
     if !result.tokens.is_empty() {
         println!();
     }
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+
     let n = result.decode_ms.len();
     if n > 0 {
         let avg = result.decode_ms.iter().sum::<f64>() / n as f64;

--- a/crates/larql-inference/src/layer_graph/grid/remote_ffn.rs
+++ b/crates/larql-inference/src/layer_graph/grid/remote_ffn.rs
@@ -54,9 +54,11 @@ pub fn generate_with_remote_ffn(
         let x_tok: Vec<f32> = tok_embed.as_slice().unwrap_or(&[]).to_vec();
 
         let mut moe_fn = |layer: usize, h_post_attn: &[f32]| -> Vec<f32> {
-            let x = ndarray::Array2::from_shape_vec((1, hidden), h_post_attn.to_vec())
+            let h_normed = apply_norm_for_ffn(weights, h_post_attn, layer);
+            let x = ndarray::Array2::from_shape_vec((1, hidden), h_normed)
                 .expect("shape must match hidden");
-            remote.forward(layer, &x).row(0).to_vec()
+            let raw_out = remote.forward(layer, &x).row(0).to_vec();
+            apply_post_ffn_norm(weights, &raw_out, layer)
         };
 
         let h = backend.decode_token_with_moe(&layers, &x_tok, hidden, intermediate, &mut moe_fn);
@@ -181,6 +183,25 @@ fn apply_norm_for_ffn(weights: &ModelWeights, h_post_attn: &[f32], layer: usize)
     let normed = match pre_ffn_key {
         Some(ref key) => apply_norm(weights, &h, key, norm_offset),
         None => rms_norm(&h, None, norm_offset),
+    };
+    normed.row(0).to_vec()
+}
+
+fn apply_post_ffn_norm(weights: &ModelWeights, ffn_out: &[f32], layer: usize) -> Vec<f32> {
+    let arch = &*weights.arch;
+    let norm_offset = arch.norm_weight_offset();
+    let key = arch.post_feedforward_layernorm_key(layer);
+    let h = ndarray::Array2::from_shape_vec((1, ffn_out.len()), ffn_out.to_vec())
+        .expect("apply_post_ffn_norm: shape error");
+    let normed = match key {
+        Some(ref k) => apply_norm(weights, &h, k, norm_offset),
+        None => {
+            if arch.has_post_norms() {
+                rms_norm(&h, None, norm_offset)
+            } else {
+                return ffn_out.to_vec();
+            }
+        }
     };
     normed.row(0).to_vec()
 }

--- a/crates/larql-inference/src/layer_graph/grid/remote_ffn.rs
+++ b/crates/larql-inference/src/layer_graph/grid/remote_ffn.rs
@@ -187,21 +187,34 @@ fn apply_norm_for_ffn(weights: &ModelWeights, h_post_attn: &[f32], layer: usize)
     normed.row(0).to_vec()
 }
 
+/// Apply the post-FFN normalisation that the local forward path
+/// applies to a layer's FFN output before the residual add.
+///
+/// Remote FFN servers return the raw FFN result; the caller is
+/// responsible for the matching post-norm so that remote and local
+/// paths stay bit-equivalent. Three cases:
+///   * arch has no post-norms (older Llama/Mistral-style) → pass
+///     through unchanged. Checked first because the default
+///     `post_feedforward_layernorm_key` impl returns `Some` for
+///     every arch, so without this gate every pre-norm arch would
+///     get an unwanted identity-weight RMS norm and diverge from
+///     the local forward path.
+///   * arch advertises a `post_feedforward_layernorm_key` for this
+///     layer → apply that named norm.
+///   * arch has post-norms but no per-layer key → identity-weight
+///     RMS norm.
 fn apply_post_ffn_norm(weights: &ModelWeights, ffn_out: &[f32], layer: usize) -> Vec<f32> {
     let arch = &*weights.arch;
+    if !arch.has_post_norms() {
+        return ffn_out.to_vec();
+    }
     let norm_offset = arch.norm_weight_offset();
     let key = arch.post_feedforward_layernorm_key(layer);
     let h = ndarray::Array2::from_shape_vec((1, ffn_out.len()), ffn_out.to_vec())
         .expect("apply_post_ffn_norm: shape error");
     let normed = match key {
         Some(ref k) => apply_norm(weights, &h, k, norm_offset),
-        None => {
-            if arch.has_post_norms() {
-                rms_norm(&h, None, norm_offset)
-            } else {
-                return ffn_out.to_vec();
-            }
-        }
+        None => rms_norm(&h, None, norm_offset),
     };
     normed.row(0).to_vec()
 }
@@ -442,4 +455,93 @@ pub fn generate_with_remote_ffn_batch(
         decode_ms,
         ffn_rtt_ms,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_norm_for_ffn, apply_post_ffn_norm};
+    use larql_models::test_fixtures::{make_gemma3_test_weights, make_test_weights};
+
+    fn approx_eq(a: &[f32], b: &[f32], tol: f32) -> bool {
+        a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| (x - y).abs() <= tol)
+    }
+
+    // ── apply_post_ffn_norm ─────────────────────────────────────────
+
+    #[test]
+    fn apply_post_ffn_norm_passthrough_when_arch_has_no_post_norms() {
+        // TinyModel arch reports `has_post_norms() == false`. The
+        // helper must short-circuit and return the input verbatim:
+        // remote FFN servers running against pre-Gemma-style archs
+        // see the FFN output flow straight into the residual add.
+        let w = make_test_weights();
+        let hidden = w.hidden_size;
+        let ffn_out: Vec<f32> = (0..hidden).map(|i| i as f32 - 7.0).collect();
+        let out = apply_post_ffn_norm(&w, &ffn_out, 0);
+        assert_eq!(out, ffn_out);
+    }
+
+    #[test]
+    fn apply_post_ffn_norm_applies_named_norm_when_key_present() {
+        // Gemma 3 arch supplies `post_feedforward_layernorm_key` for
+        // every layer; the helper must route through `apply_norm`.
+        // With identity-weight norms the output is RMS-normalised
+        // (variance scaled) but distinct from a non-unit-RMS input —
+        // "norm never ran" is the exact bug this helper closes for
+        // remote FFN paths on post-norm archs.
+        let w = make_gemma3_test_weights();
+        let hidden = w.hidden_size;
+        let ffn_out: Vec<f32> = (0..hidden).map(|i| (i as f32) * 0.5 + 1.0).collect();
+        let out = apply_post_ffn_norm(&w, &ffn_out, 0);
+        assert_eq!(out.len(), hidden);
+        assert!(
+            !approx_eq(&out, &ffn_out, 1e-6),
+            "post-FFN norm must transform the input on a post-norm arch"
+        );
+        let rms = (out.iter().map(|x| x * x).sum::<f32>() / hidden as f32).sqrt();
+        assert!(
+            (rms - 1.0).abs() < 1e-3,
+            "identity-weight post-FFN norm should rescale to unit RMS (got {rms})"
+        );
+    }
+
+    #[test]
+    fn apply_post_ffn_norm_layer_keys_distinct_per_layer() {
+        // Per-layer key lookup: both layers must succeed and produce
+        // hidden-sized output. Regression surface is a hardcoded
+        // layer index in the helper.
+        let w = make_gemma3_test_weights();
+        let ffn_out: Vec<f32> = vec![0.25; w.hidden_size];
+        let out0 = apply_post_ffn_norm(&w, &ffn_out, 0);
+        let out1 = apply_post_ffn_norm(&w, &ffn_out, 1);
+        assert_eq!(out0.len(), w.hidden_size);
+        assert_eq!(out1.len(), w.hidden_size);
+    }
+
+    // ── apply_norm_for_ffn (parallel helper, previously untested) ───
+
+    #[test]
+    fn apply_norm_for_ffn_uses_pre_feedforward_key_on_post_norm_arch() {
+        // Post-norm archs (Gemma 3) route the pre-FFN norm through
+        // `pre_feedforward_layernorm`, not `post_attention_layernorm`.
+        // Local forward and remote-FFN caller must agree.
+        let w = make_gemma3_test_weights();
+        let h_post_attn: Vec<f32> = (0..w.hidden_size).map(|i| i as f32 * 0.3).collect();
+        let out = apply_norm_for_ffn(&w, &h_post_attn, 0);
+        assert_eq!(out.len(), w.hidden_size);
+        let rms = (out.iter().map(|x| x * x).sum::<f32>() / w.hidden_size as f32).sqrt();
+        assert!((rms - 1.0).abs() < 1e-3, "expected unit-RMS, got {rms}");
+    }
+
+    #[test]
+    fn apply_norm_for_ffn_uses_post_attention_key_on_pre_norm_arch() {
+        // Pre-norm archs (TinyModel, Llama/Mistral layout) route the
+        // pre-FFN norm through `post_attention_layernorm`. The
+        // identity-weight fixture means we mainly assert shape and
+        // that the call doesn't panic on the key the function selected.
+        let w = make_test_weights();
+        let h_post_attn: Vec<f32> = (0..w.hidden_size).map(|i| (i as f32 - 5.0) * 0.4).collect();
+        let out = apply_norm_for_ffn(&w, &h_post_attn, 0);
+        assert_eq!(out.len(), w.hidden_size);
+    }
 }


### PR DESCRIPTION
Cherry-pick of @MELDApps's PR #115, keeping the four legitimate
fixes and dropping the decode-loop changes (`break;` left mid-loop,
two debug `eprintln!`s, and removal of the Q8K fast path) that the
author themselves flagged as work-in-progress (\"multi-token decode
zero hidden state issue remains unresolved\").

Closes #114 partially — the prefill path is fixed; the decode-loop
norm gap stays open for a follow-up that preserves the Q8K fast path.

## Commits

1. **MELDApps** — the four cherry-picked fixes (stdout flush, metal
   wiring, prefill pre-FFN norm, `apply_post_ffn_norm` helper).
2. **chrishayuk** — five unit tests + one bug fix the tests caught.

## What was kept from #115

- `run_with_remote_ffn` / `run_with_moe_shards` now flush stdout
  after each token loop so output appears immediately.
- `run_with_remote_ffn` wires `--metal`: uses `metal_backend()` when
  set (with CPU fallback if init fails) instead of always-CPU.
- Prefill `moe_fn` in `generate_with_remote_ffn` now applies the
  matching pre-FFN norm (`apply_norm_for_ffn`) and post-FFN norm
  (new `apply_post_ffn_norm` helper) so the remote path's residual
  stream stays bit-equivalent to the local forward path on post-norm
  archs (Gemma 3 / 4).

## What was dropped from #115

- `break;` inserted mid-decode-loop (debug code; would have caused
  the very \"multi-token decode produces zeros\" symptom #114 documents).
- Two `eprintln!(\"[debug] ...\")` lines in `generate_with_remote_ffn`
  and `generate_with_remote_ffn_batch`.
- Removal of the Q8K quantisation fast path
  (`forward_single_q8k`) in the decode `moe_fn` — that's a real perf
  regression and orthogonal to the norm bug.
- Cosmetic empty-line additions across `compute-metal/decode/*.rs`.
- Type-ascription-only change in `run_with_moe_shards` (the PR claimed
  Bug 4b wired `--metal` into MoE shards too, but `default_backend()`
  is already CPU-only and the change is a no-op).

## Bug caught by tests

The PR's `apply_post_ffn_norm` had an ordering bug: the default trait
impl of `post_feedforward_layernorm_key` returns `Some(key)` for every
arch, so the original `match key { Some(_) => apply_norm, None =>
check has_post_norms }` ordering never reached the passthrough branch
on pre-norm archs — it applied an identity-weight RMS norm and
diverged from the local forward path. Fixed in commit 2 by checking
`has_post_norms()` first.

## Validation

```
cargo build  -p larql-inference -p larql-cli            OK
cargo test   -p larql-inference --lib                   1030 pass, 4 ignored
cargo clippy -p larql-inference -p larql-cli --tests    clean
```

New unit tests (all pass):
```
test layer_graph::grid::remote_ffn::tests::apply_post_ffn_norm_passthrough_when_arch_has_no_post_norms ... ok
test layer_graph::grid::remote_ffn::tests::apply_post_ffn_norm_applies_named_norm_when_key_present     ... ok
test layer_graph::grid::remote_ffn::tests::apply_post_ffn_norm_layer_keys_distinct_per_layer           ... ok
test layer_graph::grid::remote_ffn::tests::apply_norm_for_ffn_uses_pre_feedforward_key_on_post_norm_arch ... ok
test layer_graph::grid::remote_ffn::tests::apply_norm_for_ffn_uses_post_attention_key_on_pre_norm_arch  ... ok
```

Credit to @MELDApps for the original work.