### PR TITLE
ci(windows): single-threaded BLAS + cargo runner; revert dead cfg gate (cherry-pick of #117)

### DIFF
--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -101,6 +101,30 @@ jobs:
       - name: Clippy
         run: cargo clippy -p larql-inference --lib --tests --benches --no-deps -- -D warnings
 
+      # On Windows OpenBLAS' matmul intermittently emits
+      # `BLAS : Bad memory unallocation!` and returns a
+      # partially-stale buffer, causing sync-vs-async (and
+      # sync-vs-legacy) parity tests to randomly diverge.
+      # `OPENBLAS_NUM_THREADS=1` + `OMP_NUM_THREADS=1` disable
+      # OpenBLAS' internal threading, and `RUST_TEST_THREADS=1`
+      # serialises the cargo test runner so multiple Rust threads
+      # can't race on OpenBLAS' global buffer pool. The combination
+      # eliminates the warning on Windows. Linux + macOS keep
+      # multi-threaded execution. The inference test set finishes
+      # in ~3 s, so single-threaded on Windows is negligible.
+      #
+      # These env vars MUST be unset (not empty) on non-Windows:
+      # `RUST_TEST_THREADS=''` panics the test runner. We use a
+      # gated GITHUB_ENV write rather than a step-level `env:` map,
+      # because the latter materialises empty strings on non-Windows.
+      - name: Force single-threaded BLAS + test runner (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          "OPENBLAS_NUM_THREADS=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "OMP_NUM_THREADS=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "RUST_TEST_THREADS=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       # `cargo test` runs lib tests + integration tests; #[ignore]
       # markers on weight-dependent goldens keep them out of the
       # default set. Bench targets compile-check via `--benches` above.

--- a/crates/larql-compute/src/async_compute_backend/cpu.rs
+++ b/crates/larql-compute/src/async_compute_backend/cpu.rs
@@ -219,10 +219,10 @@ mod tests {
         let tokens = vec![0u32, 1, 2];
         let h_in = crate::forward::embed_tokens_pub(&weights, &tokens);
 
-        let (h_sync, _handle_sync) = backend
+        let (h_sync, handle_sync) = backend
             .attention_prefill(&weights, &h_in, 0, None, None)
             .expect("sync prefill");
-        let (h_async_handle, _handle_async) =
+        let (h_async_handle, handle_async) =
             backend.attention_prefill_async(&weights, &h_in, 0, None, None);
         let h_async = h_async_handle.read();
 
@@ -236,21 +236,16 @@ mod tests {
             "attention_prefill_async hidden vs sync attention_prefill",
         );
 
-        // K/V parity is intermittently violated on Windows: OpenBLAS
-        // emits `BLAS : Bad memory unallocation!` and occasionally
-        // returns a partially-stale buffer where one row's worth of
-        // f32 K values diverges by ~0.6 (much larger than the
-        // documented BLAS-reduction-order drift). The hidden-state
-        // check above already covers the math; gating K/V on
-        // `not(windows)` keeps the property where the BLAS layer is
-        // sane and doesn't flake CI elsewhere.
-        #[cfg(not(windows))]
-        {
-            let (k_sync, v_sync) = backend.read_kv_to_host(&_handle_sync).unwrap();
-            let (k_async, v_async) = backend.read_kv_to_host(&_handle_async).unwrap();
-            assert_array_close(&k_sync, &k_async, "prefill K");
-            assert_array_close(&v_sync, &v_async, "prefill V");
-        }
+        // K/V parity holds on every platform once the Windows CI
+        // job sets `OPENBLAS_NUM_THREADS=1` + `OMP_NUM_THREADS=1` +
+        // `RUST_TEST_THREADS=1` (root-cause fix for the
+        // `BLAS : Bad memory unallocation!` flake — see
+        // `.github/workflows/larql-inference.yml`). The earlier
+        // `#[cfg(not(windows))]` gate is gone with the CI fix.
+        let (k_sync, v_sync) = backend.read_kv_to_host(&handle_sync).unwrap();
+        let (k_async, v_async) = backend.read_kv_to_host(&handle_async).unwrap();
+        assert_array_close(&k_sync, &k_async, "prefill K");
+        assert_array_close(&v_sync, &v_async, "prefill V");
     }
 
     #[test]


### PR DESCRIPTION
Cherry-pick of @deem0n's #117 against current main. The source-side
revert was applied to the post-ADR-0022 file location
(\`crates/larql-compute/src/async_compute_backend/cpu.rs\`) instead
of the now-shim \`crates/larql-inference\` location.

Supersedes #117. Closes the loop on the Windows OpenBLAS flake.

## Changes

- \`.github/workflows/larql-inference.yml\`: new Windows-only step
  before \`cargo test\` writes \`OPENBLAS_NUM_THREADS=1\` +
  \`OMP_NUM_THREADS=1\` + \`RUST_TEST_THREADS=1\` to \`$GITHUB_ENV\`.
  Linux + macOS unchanged.
- \`crates/larql-compute/src/async_compute_backend/cpu.rs\`: revert
  the \`#[cfg(not(windows))]\` gate around the K/V parity assertion
  in \`attention_prefill_async_matches_sync\`. The companion gate in
  the step test was already gone via the ADR-0022 move.

## Why the CI fix is sufficient

OpenBLAS' Windows port races on its worker pool when cargo runs
multiple test threads in parallel. Forcing thread counts to 1 in
both BLAS and cargo eliminates the race. inference tests finish in
~3s on Windows even single-threaded, so the perf cost is negligible.

## Validation

\`\`\`
cargo test -p larql-compute --lib async_compute_backend::cpu::tests::attention_prefill_async_matches_sync   OK
\`\`\`

The Windows CI step will run on this PR's first push.

Credit to @deem0n.