### PR TITLE
ci(windows): drop OpenBLAS, fall back to pure-Rust ndarray matmul

### DIFF
--- a/crates/larql-compute/Cargo.toml
+++ b/crates/larql-compute/Cargo.toml
@@ -28,10 +28,25 @@ openblas-src = { version = "0.10", features = ["system"] }
 ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["accelerate"] }
 
+# Windows: no BLAS *backend*. The system OpenBLAS has a memory-pool
+# race that even `OPENBLAS_NUM_THREADS=1` + `OMP_NUM_THREADS=1` +
+# `RUST_TEST_THREADS=1` doesn't fully eliminate (`BLAS : Bad memory
+# unallocation!` warning, ~0.6 K-buffer drift on successive matmuls
+# producing intermittent failures across
+# larql-kv::{vindex_compare, markov_residual} self-equality tests).
+# The CI env-var fix (#124) reduced the rate but didn't close it.
+#
+# Dropping ndarray's `blas` feature on Windows routes matmul through
+# the pure-Rust path — slower on Windows production inference but
+# deterministic. `blas-src` is kept as a featureless dep so the
+# `extern crate blas_src;` declarations across this crate's tests /
+# examples / benches still compile (the crate is essentially empty
+# without a backend feature, so nothing links to OpenBLAS).
+# Mac (Accelerate) and Linux (OpenBLAS, which works correctly there)
+# are unchanged.
 [target.'cfg(target_os = "windows")'.dependencies]
-ndarray = { version = "0.16", features = ["blas"] }
-blas-src = { version = "0.10", features = ["openblas"], default-features = false }
-openblas-src = { version = "0.10", features = ["system"] }
+ndarray = "0.16"
+blas-src = { version = "0.10", default-features = false }
 
 
 [features]

--- a/crates/larql-inference/Cargo.toml
+++ b/crates/larql-inference/Cargo.toml
@@ -84,10 +84,12 @@ openblas-src = { version = "0.10", features = ["system"] }
 ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["accelerate"] }
 
+# Windows: no BLAS backend. See `larql-compute/Cargo.toml` for the
+# rationale. `blas-src` kept featureless so existing `extern crate
+# blas_src;` declarations still compile.
 [target.'cfg(target_os = "windows")'.dependencies]
-ndarray = { version = "0.16", features = ["blas"] }
-blas-src = { version = "0.10", features = ["openblas"], default-features = false }
-openblas-src = { version = "0.10", features = ["system"] }
+ndarray = "0.16"
+blas-src = { version = "0.10", default-features = false }
 
 [features]
 default = []

--- a/crates/larql-kv/Cargo.toml
+++ b/crates/larql-kv/Cargo.toml
@@ -34,10 +34,14 @@ openblas-src = { version = "0.10", features = ["system"] }
 ndarray = { version = "0.16", features = ["blas"] }
 blas-src = { version = "0.10", features = ["accelerate"] }
 
+# Windows: no BLAS backend. See `larql-compute/Cargo.toml` for the
+# rationale — the system OpenBLAS race manifests primarily here,
+# where most of the "compare two compute paths against self" tests
+# live (vindex_compare, markov_residual). `blas-src` kept featureless
+# so existing `extern crate blas_src;` declarations still compile.
 [target.'cfg(target_os = "windows")'.dependencies]
-ndarray = { version = "0.16", features = ["blas"] }
-blas-src = { version = "0.10", features = ["openblas"], default-features = false }
-openblas-src = { version = "0.10", features = ["system"] }
+ndarray = "0.16"
+blas-src = { version = "0.10", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
Root-cause fix for the Windows OpenBLAS memory-pool race that has
been intermittently failing larql-kv and larql-inference tests. The
\`BLAS : Bad memory unallocation!\` warning we kept seeing was real —
OpenBLAS's internal memory pool is unsafe even single-threaded on
the Windows runner, and the \`OPENBLAS_NUM_THREADS=1\` +
\`RUST_TEST_THREADS=1\` env-var workaround from #124 was a partial
mitigation, not a root-cause fix.

## Pattern observed across recent PRs

Tests that compare two compute paths against each other fail
intermittently on Windows. Different tests fail on different runs:

| Test | Where | Symptom |
|---|---|---|
| \`attention_prefill_async_matches_sync\` | larql-compute | K-buffer drift ~0.6 |
| \`decode_step_quant_w2_cached_matches_recompute_from_residuals\` | larql-kv markov_residual | hidden state drift ~0.06 |
| \`compare_many_against_self_aggregates_argmax_agreement\` | larql-kv vindex_compare | argmax disagreement on identical inputs |
| \`compare_prompt_against_self_gives_perfect_agreement\` | larql-kv vindex_compare | same |
| \`bf16_output_is_close_to_markov_residual_baseline\` | larql-kv markov_residual_codec | drift past tolerance |

All of them go through \`ndarray::dot\` → cblas_sgemm. The buffer
returned is partially stale on some calls, which only happens on
Windows OpenBLAS.

## Fix

Drop ndarray's \`blas\` feature on Windows. The pure-Rust fallback
matmul is deterministic across calls. Mac (Accelerate) and Linux
(OpenBLAS, where it works correctly) are unchanged.

Files:
- \`crates/larql-compute/Cargo.toml\`
- \`crates/larql-kv/Cargo.toml\`
- \`crates/larql-inference/Cargo.toml\`

## Perf trade-off

Windows production inference will run ~5-20× slower on the f32
matmul paths (attention, residual norm, predict-from-residual).
The Q4_K / Q6_K decode kernels use custom Rust code that doesn't
route through ndarray's BLAS shim — those are unaffected.

Mac (Metal) and Linux (OpenBLAS) remain the perf-targeted platforms.

## Validation

\`\`\`
cargo build  -p larql-compute -p larql-kv -p larql-inference   OK on macOS
cargo test   -p larql-kv --lib                                 600 pass
cargo test   -p larql-inference --lib                          1034 pass
\`\`\`

The real test is the Windows CI run on this PR. If the previously-
intermittent self-equality tests now pass cleanly, the OpenBLAS race
hypothesis is confirmed.