### PR TITLE
ci: restore bench-regress.sh, swap protoc action for chocolatey, drop stale Windows cfg gates

### DIFF
--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -79,9 +79,8 @@ jobs:
       # files for the rationale.
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: choco install protoc -y --no-progress
 
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v5

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -77,9 +77,8 @@ jobs:
       # `larql-router-protocol`. See its build.rs for the rationale.
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: choco install protoc -y --no-progress
 
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v5

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -82,11 +82,16 @@ jobs:
 
       # protoc on PATH satisfies the `cfg(not(windows))` skip in
       # `larql-router-protocol`. See its build.rs for the rationale.
+      # protoc on PATH satisfies the `cfg(not(windows))` skip in
+      # `larql-router-protocol`'s build.rs. Use chocolatey rather than
+      # `arduino/setup-protoc@v3` — the action hits a GitHub API path
+      # that intermittently fails with `Bad credentials` even when
+      # `repo-token` is passed (Node-20 deprecation surface also).
+      # Chocolatey is preinstalled on the windows-latest runner.
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: choco install protoc -y --no-progress
 
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v5

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -73,9 +73,8 @@ jobs:
       # its build.rs for the rationale.
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: choco install protoc -y --no-progress
 
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v5

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -82,9 +82,8 @@ jobs:
       # falls back to whatever `protoc` is on PATH — install one here.
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: choco install protoc -y --no-progress
 
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v5

--- a/crates/larql-compute/src/backend/helpers.rs
+++ b/crates/larql-compute/src/backend/helpers.rs
@@ -87,14 +87,11 @@ mod tests {
     /// `Some(CpuBackend)` → goes through trait, must equal the `None`
     /// fallback (both are CPU paths, just routed differently).
     ///
-    /// Skipped on Windows: OpenBLAS on the Windows runner corrupts the
-    /// f32 sgemm output of the second back-to-back call (entire columns
-    /// drift by ~0.6, accompanied by `BLAS : Bad memory unallocation!`
-    /// on stderr — see PR 104 CI 2026-05-17). The trait correctness
-    /// contract is covered by the other backends in the same suite;
-    /// this test exists to pin "Some(CpuBackend) ≡ None fallback" and
-    /// there's nothing we can do at this layer about the OpenBLAS bug.
-    #[cfg(not(windows))]
+    /// The previous `#[cfg(not(windows))]` gate worked around a Windows
+    /// OpenBLAS race that drifted f32 sgemm output across back-to-back
+    /// calls. #127 dropped OpenBLAS on Windows in favour of ndarray's
+    /// pure-Rust matmul, so the test passes deterministically there
+    /// now.
     #[test]
     fn dot_proj_gpu_some_backend_matches_fallback() {
         let a = synth(4, 8, 1);

--- a/crates/larql-inference/src/trace/capture.rs
+++ b/crates/larql-inference/src/trace/capture.rs
@@ -151,11 +151,6 @@ mod tests {
     use super::*;
     use crate::ffn::FfnBackend;
     use crate::forward::trace_forward_with_ffn;
-    // `forward_raw_logits` / `hidden_to_raw_logits` are only used by
-    // `trace_final_residual_matches_raw_forward_logits`, which is gated
-    // off on Windows. Keep the imports under the same gate so `clippy
-    // -D warnings` doesn't trip on unused imports.
-    #[cfg(not(windows))]
     use crate::forward::{forward_raw_logits, hidden_to_raw_logits};
     use crate::test_utils::make_test_weights;
     use larql_models::ModelWeights;
@@ -282,13 +277,11 @@ mod tests {
     }
 
     // `trace()` and `forward_raw_logits()` compute the same forward pass
-    // but through slightly different BLAS dispatch paths. Linux + macOS
-    // produce bit-stable enough output that the residual matches within
-    // 1e-4; Windows OpenBLAS uses parallel reduction whose summation
-    // order isn't reproducible across these two paths, so the residual
-    // diverges by ~1e-1 well past the tolerance. Same pattern, same gate
-    // as `generate_cached_hooked_with_noop_matches_baseline`.
-    #[cfg(not(windows))]
+    // through slightly different dispatch paths. The previous Windows
+    // gate worked around OpenBLAS's non-reproducible parallel-reduction
+    // order; #127 dropped OpenBLAS on Windows in favour of ndarray's
+    // pure-Rust matmul, so the residual matches within 1e-4 on every
+    // platform now.
     #[test]
     fn trace_final_residual_matches_raw_forward_logits() {
         let w = weights();

--- a/scripts/bench-regress.sh
+++ b/scripts/bench-regress.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Bench regression detector — runs `benches/quant_matvec` against a saved
+# baseline and exits non-zero if any cell regresses beyond `THRESHOLD`.
+#
+# Workflow:
+#   1. On `main`, save a baseline:
+#        scripts/bench-regress.sh save
+#   2. On a feature branch / PR, compare against it:
+#        scripts/bench-regress.sh check
+#
+# Catches the next 4× throughput cliff (the kind the q4_matvec_v4 row-drop
+# bug caused) at PR time, not weeks later when goldens fail.
+#
+# Plug into CI: call `bash scripts/bench-regress.sh check` after
+# `cargo test`. Exits 0 = clean, 1 = regression detected, 2 = no baseline.
+
+set -euo pipefail
+
+BASELINE_NAME="${BASELINE_NAME:-main}"
+THRESHOLD="${THRESHOLD:-0.10}"   # 10 % slowdown = regression
+FEATURES="${FEATURES:---features metal}"
+# Benches to gate on. Override with `BENCHES="quant_matvec"` to focus.
+BENCHES="${BENCHES:-quant_matvec matmul linalg}"
+
+cmd="${1:-check}"
+
+run_all() {
+    local mode=$1   # save-baseline | baseline
+    for bench in $BENCHES; do
+        echo "[bench-regress] -> $bench ($mode $BASELINE_NAME)"
+        cargo bench -p larql-compute --bench "$bench" $FEATURES \
+            -- "--$mode" "$BASELINE_NAME" 2>&1
+    done
+}
+
+case "$cmd" in
+    save)
+        echo "[bench-regress] saving baseline '$BASELINE_NAME' across: $BENCHES"
+        run_all save-baseline
+        echo "[bench-regress] baseline saved under target/criterion/"
+        ;;
+    check)
+        if [ ! -d "target/criterion" ]; then
+            echo "[bench-regress] no baseline found at target/criterion/. \
+Run '$0 save' on main first."
+            exit 2
+        fi
+        echo "[bench-regress] checking against baseline '$BASELINE_NAME' \
+(threshold=${THRESHOLD}, benches=$BENCHES)…"
+        out=$(run_all baseline)
+        echo "$out"
+        if echo "$out" | grep -q "Performance has regressed"; then
+            echo "[bench-regress] FAIL — regression detected vs baseline '$BASELINE_NAME'"
+            exit 1
+        fi
+        echo "[bench-regress] OK — no regression vs baseline '$BASELINE_NAME'"
+        ;;
+    *)
+        echo "usage: $0 {save|check}"
+        echo "  save  — record current bench results as the baseline"
+        echo "  check — run benches and fail if any cell regressed vs baseline"
+        echo
+        echo "env vars: BASELINE_NAME (default: main), THRESHOLD (default: 0.10),"
+        echo "          FEATURES (default: --features metal),"
+        echo "          BENCHES (default: 'quant_matvec matmul linalg')"
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
Three CI hygiene fixes that have been red on main since #127 landed
(and earlier — bench-regress has been red for a week).

## 1. Restore \`scripts/bench-regress.sh\`

Deleted in commit \`bd4ac025\` (2026-05-17) but Makefile + workflow
still reference it. Restored verbatim — same contract, no behavior
change.

## 2. Replace \`arduino/setup-protoc@v3\` with chocolatey

That action intermittently fails with \`Error: Bad credentials\` even
when \`repo-token\` is passed (latest case: today's main CI run
\`26330979026\`). It's also flagged for Node-20 deprecation.

\`choco install protoc -y\` is preinstalled and reliable. Applied
across all 5 workflows that pull in \`larql-router-protocol\`
(\`larql-cli\`, \`larql-inference\`, \`larql-kv\`, \`larql-lql\`,
\`larql-server\`).

## 3. Drop three stale \`#[cfg(not(windows))]\` gates

Workarounds for the OpenBLAS race that #127 root-caused away. With
ndarray's pure-Rust matmul on Windows, both tests pass deterministically:

  - \`larql-compute/src/backend/helpers.rs::tests::dot_proj_gpu_some_backend_matches_fallback\`
  - \`larql-inference/src/trace/capture.rs::tests::trace_final_residual_matches_raw_forward_logits\`

Matches @deem0n's intent in #118 (which is currently reverting #125 +
#126 + #127 due to base drift — closing that PR in favour of this
clean version against current main).

## Validation

```
cargo fmt --all -- --check                       clean
cargo build --workspace --tests --examples --benches  clean
cargo clippy --tests --examples --benches --no-deps   clean
cargo test  ...lib                               614 + 1034 + 600 tests pass
```