### PR TITLE
chore: fix 3 example clippy lints + 1 broken doc-test

### DIFF
--- a/crates/larql-compute/src/lib.rs
+++ b/crates/larql-compute/src/lib.rs
@@ -136,17 +136,17 @@ pub use cpu::CpuBackend;
 /// macOS via Accelerate, OpenBLAS on Linux/Windows).
 ///
 /// Callers that want GPU compose an explicit fallback chain via the
-/// relevant backend crate:
+/// relevant backend crate (requires a workspace dep on the backend
+/// crate, so this is shown `ignore` here — `larql-compute` doesn't
+/// take `larql-compute-metal` as a dep to avoid the circular pull):
 ///
-/// ```rust,no_run
-/// # #[cfg(target_os = "macos")] {
+/// ```rust,ignore
 /// use larql_compute::{cpu_backend, ComputeBackend};
 ///
 /// let backend: Box<dyn ComputeBackend> =
 ///     larql_compute_metal::metal_backend()
 ///         .map(|m| Box::new(m) as Box<dyn ComputeBackend>)
 ///         .unwrap_or_else(|| cpu_backend());
-/// # }
 /// ```
 ///
 /// [`default_backend`] is a synonym kept for backwards compatibility

--- a/crates/larql-inference/examples/predict_from_residual.rs
+++ b/crates/larql-inference/examples/predict_from_residual.rs
@@ -47,12 +47,14 @@ fn load_prompts(path: &std::path::Path) -> Result<Vec<String>, Box<dyn std::erro
         .collect())
 }
 
+type ForwardResult = Result<(Array2<f32>, Vec<Array2<f32>>), Box<dyn std::error::Error>>;
+
 fn run_full_forward(
     weights: &larql_models::ModelWeights,
     tokenizer: &tokenizers::Tokenizer,
     token_ids: &[u32],
     substitutions: &[(usize, &[f32])],
-) -> Result<(Array2<f32>, Vec<Array2<f32>>), Box<dyn std::error::Error>> {
+) -> ForwardResult {
     // Returns (final_h, captured_actuals) — one captured residual per
     // substitution, recorded just before the substitution writes.
     let dense_ffn = WeightFfn { weights };

--- a/crates/larql-inference/examples/probe_contribution_distribution.rs
+++ b/crates/larql-inference/examples/probe_contribution_distribution.rs
@@ -369,7 +369,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             if num_features == 0 {
                 continue;
             }
-            let should_analyze = layer_filter.as_ref().map_or(true, |lf| lf.contains(&layer));
+            let should_analyze = layer_filter.as_ref().is_none_or(|lf| lf.contains(&layer));
             if !should_analyze {
                 continue;
             }

--- a/crates/larql-inference/examples/probe_residual_stream.rs
+++ b/crates/larql-inference/examples/probe_residual_stream.rs
@@ -26,31 +26,12 @@ use std::path::PathBuf;
 use larql_inference::forward;
 use larql_inference::InferenceModel;
 use larql_vindex::{SilentLoadCallbacks, VectorIndex};
-use ndarray::Array2;
 
 fn value_after(args: &[String], flag: &str) -> Option<String> {
     args.iter()
         .position(|a| a == flag)
         .and_then(|i| args.get(i + 1))
         .cloned()
-}
-
-fn pre_ffn_norm(
-    weights: &larql_models::ModelWeights,
-    h_post_attn: &Array2<f32>,
-    layer: usize,
-) -> Array2<f32> {
-    let arch = &*weights.arch;
-    let norm_offset = arch.norm_weight_offset();
-    let key = if arch.has_post_norms() {
-        arch.pre_feedforward_layernorm_key(layer)
-    } else {
-        Some(arch.post_attention_layernorm_key(layer))
-    };
-    match key {
-        Some(k) => forward::apply_norm(weights, h_post_attn, &k, norm_offset),
-        None => larql_compute::residual::rms_norm_for_arch(h_post_attn, None, norm_offset, arch),
-    }
 }
 
 fn load_corpus_json(path: &PathBuf) -> Result<Vec<String>, Box<dyn std::error::Error>> {


### PR DESCRIPTION
Local stricter validation (\`cargo clippy --workspace --tests
--examples --benches --no-deps -- -D warnings\` + \`cargo test --doc\`)
caught four pre-existing issues. CI currently runs clippy as
\`--lib --tests --benches\` (no \`--examples\`) and skips \`--doc\` for
\`larql-compute\`, so these slipped through.

## Fixes

- \`examples/probe_contribution_distribution.rs\` — \`map_or(true, …)\` → \`is_none_or(…)\`
- \`examples/predict_from_residual.rs\` — extracted complex \`Result\` type to \`ForwardResult\` alias
- \`examples/probe_residual_stream.rs\` — removed unused \`pre_ffn_norm\` fn + orphan \`use Array2\` import
- \`larql-compute/src/lib.rs\` cpu_backend doc — fence \`rust,no_run\` → \`rust,ignore\` (referenced \`larql_compute_metal\`, which is not a dep of \`larql-compute\`)

## Validation

\`\`\`
cargo fmt --all -- --check                                                       clean
cargo build --workspace --tests --examples --benches                             clean
cargo clippy --workspace --tests --examples --benches --no-deps -- -D warnings   clean (stricter than CI)
cargo clippy --workspace --lib --tests --benches --no-deps -- -D warnings        clean (matches CI)
cargo test --workspace --lib                                                     5077 pass, 0 fail
cargo test -p larql-compute --doc                                                1 pass, 2 ignored, 0 fail
```