### PR TITLE
fix(ci): route bench-regress to new crate homes after Metal extraction

### DIFF
--- a/scripts/bench-regress.sh
+++ b/scripts/bench-regress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bench regression detector — runs `benches/quant_matvec` against a saved
+# Bench regression detector — runs Criterion benches against a saved
 # baseline and exits non-zero if any cell regresses beyond `THRESHOLD`.
 #
 # Workflow:
@@ -18,17 +18,28 @@ set -euo pipefail
 
 BASELINE_NAME="${BASELINE_NAME:-main}"
 THRESHOLD="${THRESHOLD:-0.10}"   # 10 % slowdown = regression
-FEATURES="${FEATURES:---features metal}"
 # Benches to gate on. Override with `BENCHES="quant_matvec"` to focus.
-BENCHES="${BENCHES:-quant_matvec matmul linalg}"
+# Default set picks up the surfaces where the next throughput cliff
+# would surface first: quant matvec / f32 matmul (Metal) + cholesky /
+# ridge solve (CPU). Format: `<crate>:<bench-name>` so the script can
+# route across the split crates (ADR-019 extracted Metal benches to
+# `larql-compute-metal`).
+BENCHES="${BENCHES:-larql-compute-metal:quant_matvec larql-compute-metal:matmul larql-compute:linalg}"
 
 cmd="${1:-check}"
 
 run_all() {
     local mode=$1   # save-baseline | baseline
-    for bench in $BENCHES; do
-        echo "[bench-regress] -> $bench ($mode $BASELINE_NAME)"
-        cargo bench -p larql-compute --bench "$bench" $FEATURES \
+    for spec in $BENCHES; do
+        crate="${spec%%:*}"
+        bench="${spec##*:}"
+        if [ "$crate" = "$bench" ]; then
+            # Back-compat: bare bench name → assume larql-compute-metal,
+            # since that's where the quant kernels live now.
+            crate="larql-compute-metal"
+        fi
+        echo "[bench-regress] -> $crate / $bench ($mode $BASELINE_NAME)"
+        cargo bench -p "$crate" --bench "$bench" \
             -- "--$mode" "$BASELINE_NAME" 2>&1
     done
 }
@@ -61,8 +72,10 @@ Run '$0 save' on main first."
         echo "  check — run benches and fail if any cell regressed vs baseline"
         echo
         echo "env vars: BASELINE_NAME (default: main), THRESHOLD (default: 0.10),"
-        echo "          FEATURES (default: --features metal),"
-        echo "          BENCHES (default: 'quant_matvec matmul linalg')"
+        echo "          BENCHES (default:"
+        echo "            'larql-compute-metal:quant_matvec"
+        echo "             larql-compute-metal:matmul"
+        echo "             larql-compute:linalg')"
         exit 2
         ;;
 esac


### PR DESCRIPTION
\`bench-regress\` has been red on every push to main since #129
restored the script. Root cause: it defaults to
\`cargo bench -p larql-compute --bench <name> --features metal\`,
but ADR-019 split the Metal-bound benches out into
\`larql-compute-metal\` and dropped the \`metal\` feature from
\`larql-compute\`. Result:

\`\`\`
error: the package 'larql-compute' does not contain this feature: metal
make: *** [bench-save] Error 101
\`\`\`

## Fix

\`BENCHES\` now uses \`<crate>:<bench-name>\` specs so each bench
gets routed to the crate that owns it:

| bench | crate |
|---|---|
| \`quant_matvec\` | \`larql-compute-metal\` |
| \`matmul\` | \`larql-compute-metal\` |
| \`linalg\` | \`larql-compute\` |

\`run_all\` parses \`<crate>:<bench>\` and dispatches each one. Bare
bench names (for back-compat with older invocations) default to
\`larql-compute-metal\` since that's where the quant kernels live now.
\`FEATURES\` env var is gone — no feature flag is needed under the
post-extraction layout.

## Validation

\`\`\`
cargo bench -p larql-compute-metal --bench quant_matvec --no-run   OK
cargo bench -p larql-compute-metal --bench matmul --no-run         OK
cargo bench -p larql-compute       --bench linalg --no-run         OK
bash scripts/bench-regress.sh check  (no baseline)                 exit=2 (neutral, workflow-handled)
\`\`\`