### PR TITLE
fix(extract): accept GGUF input (file or directory) — closes #131

### DIFF
--- a/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
@@ -282,13 +282,58 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
 
         let output = &args.output;
 
-        // Find or create tokenizer
-        let tok_path = model_path.join(TOKENIZER_JSON);
+        // Detect GGUF source. `resolve_model_path` returns either a directory
+        // (safetensors or GGUF) or a single `.gguf` file. We classify here so
+        // we can pick the right loader and resolve sibling files (tokenizer,
+        // HF metadata) from the correct directory.
+        let is_gguf_file = model_path.is_file()
+            && model_path
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("gguf"));
+        let gguf_dir = if model_path.is_dir() {
+            std::fs::read_dir(&model_path)
+                .ok()
+                .and_then(|entries| {
+                    entries.filter_map(|e| e.ok()).map(|e| e.path()).find(|p| {
+                        p.extension()
+                            .is_some_and(|ext| ext.eq_ignore_ascii_case("gguf"))
+                    })
+                })
+                .filter(|_| {
+                    // Only treat the dir as GGUF if no safetensors are present.
+                    std::fs::read_dir(&model_path)
+                        .map(|entries| {
+                            !entries.filter_map(|e| e.ok()).any(|e| {
+                                e.path()
+                                    .extension()
+                                    .is_some_and(|ext| ext.eq_ignore_ascii_case("safetensors"))
+                            })
+                        })
+                        .unwrap_or(false)
+                })
+        } else {
+            None
+        };
+        let is_gguf_source = is_gguf_file || gguf_dir.is_some();
+
+        // Sibling-file lookup directory: a `.gguf` file's siblings live in
+        // its parent; a model directory's siblings are itself.
+        let sibling_dir = if model_path.is_file() {
+            model_path
+                .parent()
+                .ok_or_else(|| format!("model path has no parent: {}", model_path.display()))?
+                .to_path_buf()
+        } else {
+            model_path.clone()
+        };
+
+        // Find or load tokenizer (sibling to the GGUF file or in the model dir).
+        let tok_path = sibling_dir.join(TOKENIZER_JSON);
         let tokenizer = if tok_path.exists() {
             larql_vindex::tokenizers::Tokenizer::from_file(&tok_path)
                 .map_err(|e| format!("failed to load tokenizer: {e}"))?
         } else {
-            return Err(format!("tokenizer.json not found at {}", model_path.display()).into());
+            return Err(format!("tokenizer.json not found at {}", tok_path.display()).into());
         };
 
         let weight_opts = larql_vindex::WriteWeightsOptions {
@@ -330,27 +375,89 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
             );
         }
 
-        larql_vindex::build_vindex_streaming(
-            &model_path,
-            &tokenizer,
-            model_name,
-            output,
-            args.down_top_k,
-            level,
-            dtype,
-            args.quant,
-            weight_opts,
-            q4k_opts,
-            args.drop_gate_vectors,
-            &mut callbacks,
-        )?;
+        if is_gguf_source {
+            // GGUF path: the streaming pipeline mmaps safetensors-only, so we
+            // fall back to the in-memory loader. `load_model_dir_validated`
+            // already auto-detects GGUF (single file or directory containing
+            // a `.gguf`) and dequantises tensors to f32, producing the same
+            // `ModelWeights` shape the in-memory build path expects.
+            let load_target: std::path::PathBuf = if let Some(gguf) = gguf_dir {
+                // Directory with a single GGUF (possibly multi-shard): point
+                // the loader at shard-1 if a `*-00001-of-*.gguf` naming is
+                // present, otherwise at the largest GGUF in the dir.
+                gguf
+            } else {
+                model_path.clone()
+            };
+            eprintln!("  GGUF source detected — loading via in-memory path");
+            let weights = larql_models::load_model_dir_validated(&load_target)
+                .map_err(|e| format!("failed to load GGUF model: {e}"))?;
+
+            larql_vindex::build_vindex(
+                &weights,
+                &tokenizer,
+                model_name,
+                output,
+                args.down_top_k,
+                level,
+                dtype,
+                &mut callbacks,
+            )?;
+
+            // FFN / attention / norms — only needed at inference or all levels.
+            // Matches what `build_vindex_streaming` does internally for the
+            // safetensors path and what `--from-vectors --level inference`
+            // does for the externally-built path.
+            if matches!(
+                level,
+                larql_vindex::ExtractLevel::Attention
+                    | larql_vindex::ExtractLevel::Inference
+                    | larql_vindex::ExtractLevel::All
+            ) {
+                match args.quant {
+                    larql_vindex::QuantFormat::Q4K => {
+                        larql_vindex::write_model_weights_kquant_with_opts(
+                            &weights,
+                            output,
+                            &mut callbacks,
+                            q4k_opts,
+                        )?;
+                    }
+                    larql_vindex::QuantFormat::None => {
+                        larql_vindex::write_model_weights_with_opts(
+                            &weights,
+                            output,
+                            &mut callbacks,
+                            weight_opts,
+                        )?;
+                    }
+                }
+            }
+        } else {
+            // Safetensors path: streaming mmap, no full model load.
+            larql_vindex::build_vindex_streaming(
+                &model_path,
+                &tokenizer,
+                model_name,
+                output,
+                args.down_top_k,
+                level,
+                dtype,
+                args.quant,
+                weight_opts,
+                q4k_opts,
+                args.drop_gate_vectors,
+                &mut callbacks,
+            )?;
+        }
 
         // Opportunistically copy HF metadata (tokenizer_config.json,
         // special_tokens_map.json, generation_config.json) from the source
         // directory into the vindex. Chat-template-aware runtimes read
         // `tokenizer_config.json::chat_template` from here; missing files
-        // are silently skipped.
-        if let Err(e) = larql_vindex::snapshot_hf_metadata(&model_path, output) {
+        // are silently skipped. Use the sibling-file dir (parent of a GGUF
+        // file, or the model dir itself).
+        if let Err(e) = larql_vindex::snapshot_hf_metadata(&sibling_dir, output) {
             eprintln!("  warning: failed to snapshot HF metadata: {e}");
         }
     }


### PR DESCRIPTION
## Summary

Restores GGUF input to `larql extract`. Both the single-file form and the directory-with-GGUF form failed on current `main` (see issue #131 for the full repro + trace). After this PR, both forms work again and produce inference-level vindexes.

## What broke (briefly — full detail in #131)

1. **Single GGUF file** → `extract_index_cmd.rs:286` was joining the file path with `tokenizer.json`, producing `<file.gguf>/tokenizer.json` which never exists. Errored before any pipeline ran.
2. **GGUF directory** → `build_vindex_streaming` mmaps `*.safetensors` only and errored with `no safetensors files in <dir>` — even when the directory had a `.gguf` + `config.json` + `tokenizer.json`.

## What this PR does

- **Sibling-file lookup uses the right directory** — parent of a `.gguf` file, or the model dir itself.
- **GGUF dispatch** — when the source is a GGUF (file *or* a directory containing a `.gguf` with no safetensors alongside), route to the existing in-memory path:
  - `larql_models::load_model_dir_validated` already auto-detects GGUF and dequantises tensors → `ModelWeights` (docstring at `loading/safetensors.rs:63-68` already promises this).
  - `larql_vindex::build_vindex` writes the browse stages.
  - For `attention` / `inference` / `all` levels, `write_model_weights_with_opts` (or `write_model_weights_kquant_with_opts` under `--quant q4k`) writes FFN/attn/norms.
  - This mirrors what `--from-vectors --level inference` already does in the same file (lines 233-253), so no new public API surface.
- **Safetensors path is unchanged** — same `build_vindex_streaming` invocation as before.

## Trade-off

The GGUF path keeps the full dequantised `ModelWeights` in RAM during extract (no streaming). This is the same trade-off the prior binary made — GGUFs lose the safetensors streaming advantage because tensors are interleaved with quantisation blocks and need full dequant before they can be consumed sequentially. Adding a true streaming GGUF reader is out of scope here; this PR restores parity with prior behaviour.

## Verification

- `cargo check -p larql-cli` — clean
- `cargo test -p larql-cli --bin larql` — 214 passed, 0 failed
- Manual smoke test against `llama3.1-8b-instruct-q4.gguf` (Q4_0): both `extract <dir>` and `extract <file>` correctly load, dispatch to the in-memory path, and write `gate_vectors.bin` (3.7 GB) + `embeddings.bin` (1.0 GB) + `down_meta` at browse level.
- Tested against Bonsai-1.7B-Q1 too: dispatch works, but Bonsai's `type_id 41` (1-bit format) hits an existing limitation in `larql_models::loading::gguf` dequant — unrelated to this PR. Standard Q4_0/Q4_K/Q5_K/Q6_K/Q8_0 all load fine.

Closes #131.