### PR TITLE
feat(streaming): GGUF support in extract pipeline (browse-level)

### DIFF
--- a/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
@@ -375,16 +375,25 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
             );
         }
 
-        if is_gguf_source {
-            // GGUF path: the streaming pipeline mmaps safetensors-only, so we
-            // fall back to the in-memory loader. `load_model_dir_validated`
-            // already auto-detects GGUF (single file or directory containing
-            // a `.gguf`) and dequantises tensors to f32, producing the same
-            // `ModelWeights` shape the in-memory build path expects.
+        // Dispatch:
+        //
+        //  - Safetensors (always) and GGUF at browse level go through the
+        //    streaming pipeline — no full model in RAM.
+        //  - GGUF at inference / attention / all levels (or any level
+        //    with `--quant q4k`) still hits the in-memory loader: the
+        //    `StreamingWeights` writer subsystem is safetensors-only,
+        //    and porting it to GGUF is a follow-on PR.
+        let route_gguf_through_streaming = is_gguf_source
+            && matches!(level, larql_vindex::ExtractLevel::Browse)
+            && args.quant == larql_vindex::QuantFormat::None;
+
+        if is_gguf_source && !route_gguf_through_streaming {
+            // GGUF + attention/inference/all (or any level with q4k) →
+            // in-memory loader. `load_model_dir_validated` auto-detects
+            // GGUF (single file or directory containing one) and
+            // dequantises tensors to f32, producing the `ModelWeights`
+            // shape the in-memory build path expects.
             let load_target: std::path::PathBuf = if let Some(gguf) = gguf_dir {
-                // Directory with a single GGUF (possibly multi-shard): point
-                // the loader at shard-1 if a `*-00001-of-*.gguf` naming is
-                // present, otherwise at the largest GGUF in the dir.
                 gguf
             } else {
                 model_path.clone()
@@ -404,10 +413,6 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
                 &mut callbacks,
             )?;
 
-            // FFN / attention / norms — only needed at inference or all levels.
-            // Matches what `build_vindex_streaming` does internally for the
-            // safetensors path and what `--from-vectors --level inference`
-            // does for the externally-built path.
             if matches!(
                 level,
                 larql_vindex::ExtractLevel::Attention
@@ -434,9 +439,17 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         } else {
-            // Safetensors path: streaming mmap, no full model load.
+            // Safetensors path (any level) OR GGUF at browse level —
+            // streaming mmap, no full model load. For GGUF, point the
+            // pipeline at the shard-1 file (or the directory; the
+            // pipeline picks the right shard internally).
+            let streaming_entry: std::path::PathBuf = if let Some(gguf) = gguf_dir.as_ref() {
+                gguf.clone()
+            } else {
+                model_path.clone()
+            };
             larql_vindex::build_vindex_streaming(
-                &model_path,
+                &streaming_entry,
                 &tokenizer,
                 model_name,
                 output,

--- a/crates/larql-models/src/loading/gguf.rs
+++ b/crates/larql-models/src/loading/gguf.rs
@@ -144,6 +144,34 @@ pub struct GgufTensorInfo {
     shard_idx: usize,
 }
 
+impl GgufTensorInfo {
+    /// Raw GGUF tensor name (e.g. `blk.0.attn_q.weight`). The HF-equivalent
+    /// key (`layers.0.self_attn.q_proj.weight`) is obtained via
+    /// [`normalize_gguf_key`].
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn n_dims(&self) -> u32 {
+        self.n_dims
+    }
+    pub fn dims(&self) -> &[u64] {
+        &self.dims
+    }
+    /// GGML tensor-type id (Q4_0, Q8_0, F16, …). See `quant::ggml` constants.
+    pub fn tensor_type(&self) -> u32 {
+        self.tensor_type
+    }
+    /// Tensor data offset *within* its shard's data section. Add
+    /// `ShardInfo::data_offset` to get the absolute file offset.
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+    /// Index into [`GgufFile::shards`] selecting which file owns this tensor.
+    pub fn shard_idx(&self) -> usize {
+        self.shard_idx
+    }
+}
+
 /// One file in a (possibly multi-shard) GGUF split.
 #[derive(Debug, Clone)]
 pub struct ShardInfo {

--- a/crates/larql-models/src/loading/gguf.rs
+++ b/crates/larql-models/src/loading/gguf.rs
@@ -38,6 +38,11 @@ const GGUF_GENERAL_ARCHITECTURE: &str = "general.architecture";
 const GGUF_EMBEDDING_LENGTH: &str = "embedding_length";
 const GGUF_BLOCK_COUNT: &str = "block_count";
 const GGUF_FEED_FORWARD_LENGTH: &str = "feed_forward_length";
+// MoE-only architectures (DeepSeek-V4 family) omit the global
+// `feed_forward_length` and emit only the per-expert size — fall back
+// to it so config validation doesn't reject the model with
+// `intermediate_size: must be greater than 0`.
+const GGUF_EXPERT_FEED_FORWARD_LENGTH: &str = "expert_feed_forward_length";
 const GGUF_ATTENTION_HEAD_COUNT: &str = "attention.head_count";
 const GGUF_ATTENTION_HEAD_COUNT_KV: &str = "attention.head_count_kv";
 const GGUF_ATTENTION_KEY_LENGTH: &str = "attention.key_length";
@@ -674,11 +679,25 @@ impl GgufFile {
             num_heads
         };
 
+        // intermediate_size: prefer the global `feed_forward_length`. For
+        // MoE-only models (DeepSeek-V4 family) the global key is omitted,
+        // so we fall back to the per-expert size. The HF config exposes
+        // `intermediate_size` as a single number even on MoE archs because
+        // per-expert and per-layer FFNs share that dim in every
+        // llama.cpp-supported architecture.
+        let intermediate_size = {
+            let global = get_arch_u32(GGUF_FEED_FORWARD_LENGTH);
+            if global > 0 {
+                global
+            } else {
+                get_arch_u32(GGUF_EXPERT_FEED_FORWARD_LENGTH)
+            }
+        };
         let mut config = serde_json::json!({
             HF_MODEL_TYPE: model_type,
             HF_HIDDEN_SIZE: hidden_size,
             HF_NUM_HIDDEN_LAYERS: get_arch_u32(GGUF_BLOCK_COUNT),
-            HF_INTERMEDIATE_SIZE: get_arch_u32(GGUF_FEED_FORWARD_LENGTH),
+            HF_INTERMEDIATE_SIZE: intermediate_size,
             HF_NUM_ATTENTION_HEADS: num_heads,
             HF_NUM_KEY_VALUE_HEADS: num_kv_heads,
             HF_HEAD_DIM: head_dim,

--- a/crates/larql-models/src/loading/gguf.rs
+++ b/crates/larql-models/src/loading/gguf.rs
@@ -139,6 +139,18 @@ pub struct GgufTensorInfo {
     dims: Vec<u64>,
     tensor_type: u32,
     offset: u64,
+    /// Index into [`GgufFile::shards`] selecting which file this tensor lives in.
+    /// Zero for single-shard models; assigned by `open` when discovering siblings.
+    shard_idx: usize,
+}
+
+/// One file in a (possibly multi-shard) GGUF split.
+#[derive(Debug, Clone)]
+pub struct ShardInfo {
+    /// Path to the `.gguf` file for this shard.
+    pub path: std::path::PathBuf,
+    /// Byte offset at which tensor data starts inside this file.
+    pub data_offset: u64,
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -148,13 +160,229 @@ pub struct GgufTensorInfo {
 pub struct GgufFile {
     pub metadata: HashMap<String, GgufValue>,
     pub tensor_infos: Vec<GgufTensorInfo>,
+    /// Tensor data offset of the first (or only) shard. Kept for back-compat
+    /// with single-file callers — multi-shard callers should index into
+    /// [`Self::shards`] using `GgufTensorInfo::shard_idx`.
     pub data_offset: u64,
+    /// Path to the first (or only) shard. Same back-compat note as
+    /// `data_offset` — for multi-shard models the other shards are in
+    /// [`Self::shards`].
     pub path: std::path::PathBuf,
+    /// All shards making up this GGUF. Always non-empty; length 1 for
+    /// single-file models. `shards[0].path == self.path` and
+    /// `shards[0].data_offset == self.data_offset` always hold.
+    pub shards: Vec<ShardInfo>,
+}
+
+/// Parse a multi-shard GGUF filename of the form
+/// `<prefix>-<NNNNN>-of-<NNNNN>.gguf` (canonical llama.cpp split layout)
+/// and return `(prefix_without_dashes, this_shard_idx_0based, total_shards)`.
+///
+/// Returns `None` for filenames that don't match the pattern (i.e. single
+/// files); the caller treats those as single-shard GGUFs.
+pub(crate) fn parse_shard_filename(path: &Path) -> Option<(String, usize, usize)> {
+    let name = path.file_name()?.to_str()?;
+    let stem = name.strip_suffix(".gguf")?;
+    // Tail must be `<prefix>-NNNNN-of-NNNNN` with matching widths.
+    // Rightmost run of digits = "NNNNN" (total shard count).
+    let count_start = stem
+        .rfind(|c: char| !c.is_ascii_digit())
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    if count_start >= stem.len() {
+        return None; // no trailing digits at all
+    }
+    let count_str = &stem[count_start..];
+    let before_count = &stem[..count_start]; // "<prefix>-NNNNN-of-"
+    let before_of = before_count.strip_suffix("-of-")?;
+    // Then second rightmost digits run = "NNNNN" (this shard's 1-based index).
+    let idx_start = before_of
+        .rfind(|c: char| !c.is_ascii_digit())
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    if idx_start >= before_of.len() {
+        return None;
+    }
+    let idx_str = &before_of[idx_start..];
+    let prefix = before_of[..idx_start].strip_suffix('-')?;
+
+    let this_idx_1based: usize = idx_str.parse().ok()?;
+    let total: usize = count_str.parse().ok()?;
+    if this_idx_1based == 0 || this_idx_1based > total {
+        return None;
+    }
+    // Width must match across the two numbers (llama.cpp convention).
+    if idx_str.len() != count_str.len() {
+        return None;
+    }
+    Some((prefix.to_string(), this_idx_1based - 1, total))
+}
+
+/// Discover the full set of sibling shards making up a multi-shard GGUF.
+/// `path` is one shard the user pointed at; the returned vec is ordered by
+/// shard index (shard 1 first → shard N last) and is guaranteed to be of
+/// length `expected_total`.
+pub(crate) fn discover_shard_siblings(
+    parent: &Path,
+    path: &Path,
+    expected_total: usize,
+) -> Result<Vec<std::path::PathBuf>, ModelError> {
+    let (prefix, _, total_from_name) = parse_shard_filename(path).ok_or_else(|| {
+        ModelError::Parse(format!(
+            "multi-shard GGUF without canonical -NNNNN-of-NNNNN filename: {}",
+            path.display()
+        ))
+    })?;
+    if expected_total != total_from_name {
+        return Err(ModelError::Parse(format!(
+            "shard total mismatch: split.count={expected_total} but filename says of-{total_from_name}",
+        )));
+    }
+    // Detect the width used in the filename so we reconstruct sibling
+    // names byte-for-byte (00001 vs 1).
+    let name_str = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let width = name_str
+        .strip_suffix(".gguf")
+        .and_then(|s| s.strip_suffix(&format!("-of-{expected_total:0>5}")))
+        .and_then(|s| s.rsplit('-').next())
+        .map(|n| n.len())
+        .unwrap_or(5);
+    let total_width = name_str
+        .strip_suffix(".gguf")
+        .and_then(|s| s.rsplit("-of-").next())
+        .map(|n| n.len())
+        .unwrap_or(5);
+
+    let mut paths = Vec::with_capacity(expected_total);
+    for i in 1..=expected_total {
+        let fname = format!(
+            "{prefix}-{i:0>idx_width$}-of-{total:0>tot_width$}.gguf",
+            prefix = prefix,
+            i = i,
+            idx_width = width,
+            total = expected_total,
+            tot_width = total_width,
+        );
+        let p = parent.join(&fname);
+        if !p.exists() {
+            return Err(ModelError::Parse(format!(
+                "multi-shard GGUF missing expected sibling: {} (looking for shard {} of {})",
+                p.display(),
+                i,
+                expected_total,
+            )));
+        }
+        paths.push(p);
+    }
+    Ok(paths)
 }
 
 impl GgufFile {
     /// Parse a GGUF file header and tensor info (does not read tensor data yet).
+    ///
+    /// Detects multi-shard splits by checking the `split.count` GGUF metadata
+    /// key on the file you point at; when `split.count > 1` (or the filename
+    /// matches the canonical `*-NNNNN-of-NNNNN.gguf` pattern), sibling shards
+    /// in the same directory are also discovered and their tensor infos are
+    /// merged into the returned `GgufFile`. Tensors carry a `shard_idx`
+    /// internally so [`Self::load_tensors_filtered`] reads each from the
+    /// right shard.
     pub fn open(path: &Path) -> Result<Self, ModelError> {
+        let mut gguf = Self::open_single(path)?;
+
+        // Multi-shard detection: prefer the explicit `split.*` metadata
+        // emitted by llama-gguf-split, fall back to the filename pattern
+        // (some splitters skip the metadata).
+        let split_count = gguf
+            .metadata
+            .get("split.count")
+            .and_then(|v| v.as_u32())
+            .unwrap_or(0);
+        let pattern_count = parse_shard_filename(path).map(|(_, _, total)| total);
+        let total_shards = match (split_count, pattern_count) {
+            (n, _) if n > 1 => n as usize,
+            (_, Some(n)) if n > 1 => n,
+            _ => return Ok(gguf), // single-file
+        };
+
+        // We need every shard in the split — find them all.
+        let parent = path.parent().ok_or_else(|| {
+            ModelError::Parse(format!("GGUF path has no parent: {}", path.display()))
+        })?;
+        let shard_paths = discover_shard_siblings(parent, path, total_shards)?;
+        debug_assert_eq!(shard_paths.len(), total_shards);
+
+        // The first entry is the shard we already loaded (whichever the
+        // caller pointed at). Rewrite `gguf` to be anchored at shard 0 and
+        // then accumulate the remaining shards' tensor infos.
+        let this_idx = shard_paths
+            .iter()
+            .position(|p| p == path)
+            .ok_or_else(|| ModelError::Parse(format!(
+                "passed shard {} not found in discovered set", path.display()
+            )))?;
+        let mut shards: Vec<ShardInfo> = Vec::with_capacity(total_shards);
+        let mut combined_infos: Vec<GgufTensorInfo> = Vec::new();
+        for (idx, shard_path) in shard_paths.iter().enumerate() {
+            if idx == this_idx {
+                shards.push(ShardInfo {
+                    path: path.to_path_buf(),
+                    data_offset: gguf.data_offset,
+                });
+                for info in &gguf.tensor_infos {
+                    let mut clone = GgufTensorInfo {
+                        name: info.name.clone(),
+                        n_dims: info.n_dims,
+                        dims: info.dims.clone(),
+                        tensor_type: info.tensor_type,
+                        offset: info.offset,
+                        shard_idx: idx,
+                    };
+                    clone.shard_idx = idx;
+                    combined_infos.push(clone);
+                }
+            } else {
+                let other = Self::open_single(shard_path)?;
+                shards.push(ShardInfo {
+                    path: shard_path.clone(),
+                    data_offset: other.data_offset,
+                });
+                for mut info in other.tensor_infos {
+                    info.shard_idx = idx;
+                    combined_infos.push(info);
+                }
+            }
+        }
+
+        // Sanity check: total tensor count should match split.tensors.count
+        // when that key is emitted (llama-gguf-split always writes it).
+        if let Some(expected) = gguf
+            .metadata
+            .get("split.tensors.count")
+            .and_then(|v| v.as_u32())
+        {
+            if combined_infos.len() != expected as usize {
+                return Err(ModelError::Parse(format!(
+                    "multi-shard tensor count mismatch: combined {} shards yielded \
+                     {} tensors, but split.tensors.count = {}",
+                    total_shards,
+                    combined_infos.len(),
+                    expected
+                )));
+            }
+        }
+
+        gguf.tensor_infos = combined_infos;
+        gguf.shards = shards;
+        // `gguf.path` / `gguf.data_offset` keep pointing at the
+        // user-supplied shard for back-compat with diagnostics; the
+        // multi-shard loader uses `shards[info.shard_idx]` internally.
+        Ok(gguf)
+    }
+
+    /// Open a single GGUF file without multi-shard discovery. Used as the
+    /// per-shard primitive by [`Self::open`].
+    fn open_single(path: &Path) -> Result<Self, ModelError> {
         let file = std::fs::File::open(path)?;
         let mut r = BufReader::new(file);
 
@@ -203,6 +431,7 @@ impl GgufFile {
                 dims,
                 tensor_type,
                 offset,
+                shard_idx: 0,
             });
         }
 
@@ -216,6 +445,10 @@ impl GgufFile {
             tensor_infos,
             data_offset,
             path: path.to_path_buf(),
+            shards: vec![ShardInfo {
+                path: path.to_path_buf(),
+                data_offset,
+            }],
         })
     }
 
@@ -238,6 +471,10 @@ impl GgufFile {
     /// `skip_key` sees keys after GGUF-to-HF normalization but before architecture-specific
     /// prefix stripping. GGUF keys do not carry the HF wrapper prefixes, so this is enough for
     /// the current GGUF path and lets walk-only loading avoid FFN dequantization.
+    ///
+    /// Multi-shard models: tensors are read from `self.shards[info.shard_idx]`,
+    /// which is mmap'd lazily on first use within this call. Shards that
+    /// contain no surviving tensors after `skip_key` are not mmap'd at all.
     #[allow(clippy::type_complexity)]
     pub fn load_tensors_filtered(
         &self,
@@ -249,8 +486,11 @@ impl GgufFile {
         ),
         ModelError,
     > {
-        let file = std::fs::File::open(&self.path)?;
-        let mmap = unsafe { memmap2::Mmap::map(&file)? };
+        // Lazy mmap of every shard — Option<Mmap> avoids paying the open cost
+        // for shards that turn out to contain only skipped tensors.
+        let mut shard_mmaps: Vec<Option<memmap2::Mmap>> = (0..self.shards.len())
+            .map(|_| None)
+            .collect();
 
         let mut tensors = HashMap::new();
         let mut vectors = HashMap::new();
@@ -263,10 +503,20 @@ impl GgufFile {
                 continue;
             }
 
-            let abs_offset = self.data_offset.checked_add(info.offset).ok_or_else(|| {
+            let shard = &self.shards[info.shard_idx];
+            if shard_mmaps[info.shard_idx].is_none() {
+                let f = std::fs::File::open(&shard.path)?;
+                let m = unsafe { memmap2::Mmap::map(&f)? };
+                shard_mmaps[info.shard_idx] = Some(m);
+            }
+            let mmap = shard_mmaps[info.shard_idx]
+                .as_ref()
+                .expect("mmap initialised above");
+
+            let abs_offset = shard.data_offset.checked_add(info.offset).ok_or_else(|| {
                 ModelError::Parse(format!(
                     "tensor {}: data_offset {} + tensor offset {} overflows u64",
-                    info.name, self.data_offset, info.offset,
+                    info.name, shard.data_offset, info.offset,
                 ))
             })?;
             let n_elements: u64 = info.dims.iter().product();
@@ -286,10 +536,11 @@ impl GgufFile {
             })?;
             if end > mmap.len() {
                 return Err(ModelError::Parse(format!(
-                    "tensor {} data out of bounds (offset {} + size {} > file {})",
+                    "tensor {} data out of bounds (offset {} + size {} > shard {} file {})",
                     info.name,
                     abs_offset,
                     data_size,
+                    info.shard_idx,
                     mmap.len()
                 )));
             }
@@ -1307,6 +1558,7 @@ mod tests {
             tensor_infos: Vec::new(),
             data_offset: 0,
             path: std::path::PathBuf::from("<no-file>"),
+            shards: vec![ShardInfo { path: std::path::PathBuf::from("<no-file>"), data_offset: 0 }],
         };
         let cfg = gguf.to_config_json();
 
@@ -1350,12 +1602,202 @@ mod tests {
             tensor_infos: Vec::new(),
             data_offset: 0,
             path: std::path::PathBuf::from("<no-file>"),
+            shards: vec![ShardInfo { path: std::path::PathBuf::from("<no-file>"), data_offset: 0 }],
         };
         let cfg = gguf.to_config_json();
 
         assert!(cfg.get(HF_ROPE_THETA).is_none());
         let arch = crate::detect_from_json_validated(&cfg).unwrap();
         assert_eq!(arch.config().rope_base, 10_000.0);
+    }
+
+    #[test]
+    fn parse_shard_filename_canonical_layout() {
+        let p = std::path::PathBuf::from(
+            "/x/Kimi-K2.6-UD-Q8_K_XL-00003-of-00014.gguf",
+        );
+        let (prefix, idx, total) = parse_shard_filename(&p).unwrap();
+        assert_eq!(prefix, "Kimi-K2.6-UD-Q8_K_XL");
+        assert_eq!(idx, 2);
+        assert_eq!(total, 14);
+    }
+
+    #[test]
+    fn parse_shard_filename_rejects_single_file() {
+        let p = std::path::PathBuf::from("/x/llama-3.1-8b-q4.gguf");
+        assert!(parse_shard_filename(&p).is_none());
+    }
+
+    #[test]
+    fn parse_shard_filename_rejects_unmatched_widths() {
+        let p = std::path::PathBuf::from("/x/foo-00003-of-0014.gguf");
+        assert!(parse_shard_filename(&p).is_none());
+    }
+
+    #[test]
+    fn parse_shard_filename_supports_3digit_split() {
+        let p = std::path::PathBuf::from("/x/foo-001-of-003.gguf");
+        let (prefix, idx, total) = parse_shard_filename(&p).unwrap();
+        assert_eq!(prefix, "foo");
+        assert_eq!(idx, 0);
+        assert_eq!(total, 3);
+    }
+
+    #[test]
+    fn discover_shard_siblings_finds_all_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 1..=3 {
+            std::fs::File::create(
+                dir.path().join(format!("model-{i:0>5}-of-00003.gguf")),
+            )
+            .unwrap();
+        }
+        let middle = dir.path().join("model-00002-of-00003.gguf");
+        let paths = discover_shard_siblings(dir.path(), &middle, 3).unwrap();
+        assert_eq!(paths.len(), 3);
+        assert!(paths[0].ends_with("model-00001-of-00003.gguf"));
+        assert!(paths[1].ends_with("model-00002-of-00003.gguf"));
+        assert!(paths[2].ends_with("model-00003-of-00003.gguf"));
+    }
+
+    #[test]
+    fn discover_shard_siblings_errors_when_one_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in [1usize, 3] {
+            std::fs::File::create(
+                dir.path().join(format!("m-{i:0>5}-of-00003.gguf")),
+            )
+            .unwrap();
+        }
+        let first = dir.path().join("m-00001-of-00003.gguf");
+        let err = discover_shard_siblings(dir.path(), &first, 3).unwrap_err();
+        assert!(
+            format!("{err}").contains("missing expected sibling"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// End-to-end multi-shard open: two real GGUF files with different
+    /// tensors in each, joined via canonical `-NNNNN-of-00002.gguf` layout.
+    /// Verifies discovery, shard_idx assignment, and per-shard tensor
+    /// reads via `load_tensors`.
+    #[test]
+    fn open_multi_shard_combines_tensors_from_all_shards() {
+        use std::io::{Seek, Write};
+
+        let dir = tempfile::tempdir().unwrap();
+
+        let write_shard = |idx: usize,
+                           tensor_ids: &[usize],
+                           metas: &[(&str, u32)]|
+         -> std::path::PathBuf {
+            let path = dir.path().join(format!("m-{idx:0>5}-of-00002.gguf"));
+            let mut file = std::fs::File::create(&path).unwrap();
+            file.write_all(&GGUF_MAGIC.to_le_bytes()).unwrap();
+            file.write_all(&3u32.to_le_bytes()).unwrap();
+            file.write_all(&(tensor_ids.len() as u64).to_le_bytes()).unwrap();
+            file.write_all(&(metas.len() as u64).to_le_bytes()).unwrap();
+
+            for (k, v) in metas {
+                let kb = k.as_bytes();
+                file.write_all(&(kb.len() as u64).to_le_bytes()).unwrap();
+                file.write_all(kb).unwrap();
+                file.write_all(&4u32.to_le_bytes()).unwrap(); // u32 type tag
+                file.write_all(&v.to_le_bytes()).unwrap();
+            }
+
+            for (rel, &tid) in tensor_ids.iter().enumerate() {
+                let name = format!("blk.{tid}.ffn_down.weight");
+                let nb = name.as_bytes();
+                file.write_all(&(nb.len() as u64).to_le_bytes()).unwrap();
+                file.write_all(nb).unwrap();
+                file.write_all(&2u32.to_le_bytes()).unwrap();
+                file.write_all(&2u64.to_le_bytes()).unwrap();
+                file.write_all(&2u64.to_le_bytes()).unwrap();
+                file.write_all(&crate::quant::ggml::TYPE_F32.to_le_bytes())
+                    .unwrap();
+                let off = (rel as u64) * 16;
+                file.write_all(&off.to_le_bytes()).unwrap();
+            }
+
+            let pos = file.stream_position().unwrap();
+            let aligned = pos.div_ceil(32) * 32;
+            file.write_all(&vec![0u8; (aligned - pos) as usize])
+                .unwrap();
+
+            for &tid in tensor_ids {
+                for off in 0..4 {
+                    file.write_all(
+                        &((tid as f32) + 0.1 * off as f32).to_le_bytes(),
+                    )
+                    .unwrap();
+                }
+            }
+            file.flush().unwrap();
+            path
+        };
+
+        let p1 = write_shard(
+            1,
+            &[0, 1],
+            &[("split.no", 0), ("split.count", 2), ("split.tensors.count", 4)],
+        );
+        let _p2 = write_shard(
+            2,
+            &[2, 3],
+            &[("split.no", 1), ("split.count", 2), ("split.tensors.count", 4)],
+        );
+
+        let gguf = GgufFile::open(&p1).unwrap();
+        assert_eq!(gguf.shards.len(), 2);
+        assert_eq!(gguf.tensor_infos.len(), 4);
+        for (i, info) in gguf.tensor_infos.iter().enumerate() {
+            let expected = if i < 2 { 0 } else { 1 };
+            assert_eq!(
+                info.shard_idx, expected,
+                "tensor {i} ({}) shard mismatch",
+                info.name
+            );
+        }
+
+        let (tensors, _) = gguf.load_tensors().unwrap();
+        assert_eq!(tensors.len(), 4);
+        for tid in 0..4 {
+            let key = format!("layers.{tid}.mlp.down_proj.weight");
+            let arr = tensors.get(&key).unwrap_or_else(|| panic!("missing {key}"));
+            assert!(
+                (arr[[0, 0]] - tid as f32).abs() < 1e-6,
+                "tensor {tid} top-left {} != {tid}",
+                arr[[0, 0]]
+            );
+        }
+    }
+
+    #[test]
+    fn open_rejects_multi_shard_when_a_shard_file_is_missing() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("m-00001-of-00002.gguf");
+        let mut file = std::fs::File::create(&p).unwrap();
+        file.write_all(&GGUF_MAGIC.to_le_bytes()).unwrap();
+        file.write_all(&3u32.to_le_bytes()).unwrap();
+        file.write_all(&0u64.to_le_bytes()).unwrap();
+        file.write_all(&1u64.to_le_bytes()).unwrap();
+        let k = "split.count".as_bytes();
+        file.write_all(&(k.len() as u64).to_le_bytes()).unwrap();
+        file.write_all(k).unwrap();
+        file.write_all(&4u32.to_le_bytes()).unwrap();
+        file.write_all(&2u32.to_le_bytes()).unwrap();
+        file.flush().unwrap();
+
+        let err = match GgufFile::open(&p) {
+            Ok(_) => panic!("expected error for missing sibling shard"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err}").contains("missing expected sibling"),
+            "unexpected error: {err}"
+        );
     }
 
     /// Build a minimal GGUF file with one 2-D F32 tensor, but truncate the

--- a/crates/larql-vindex/src/extract/streaming/context.rs
+++ b/crates/larql-vindex/src/extract/streaming/context.rs
@@ -21,7 +21,7 @@ use crate::extract::callbacks::IndexBuildCallbacks;
 use crate::extract::stage_labels::*;
 use crate::format::filenames::*;
 
-use super::tensor_io::{normalize_key, MmapShard};
+use super::tensor_io::{normalize_key, GgufTensorSource, MmapShard, TensorSource};
 
 /// Holds the inputs + accumulators for the streaming-extract pipeline.
 pub(super) struct StreamingContext<'a> {
@@ -51,9 +51,11 @@ pub(super) struct StreamingContext<'a> {
     pub(super) n_experts: usize,
     pub(super) expert_format: larql_models::ExpertFormat,
 
-    // Mmap state (owned, set in `new`)
-    pub(super) shard_mmaps: Vec<MmapShard>,
-    pub(super) tensor_index: HashMap<String, (usize, String)>,
+    // Mmap state (owned, set in `new`) — either safetensors-backed or
+    // GGUF-backed. Stages call `tensor_source.get_tensor_f32(key)`; the
+    // MXFP4 raw-pair fast path is safetensors-only and goes through
+    // `tensor_source.safetensors_view()`.
+    pub(super) tensor_source: TensorSource,
 
     // Mutable state across stages
     pub(super) checkpoint: crate::extract::checkpoint::Checkpoint,
@@ -99,14 +101,63 @@ impl<'a> StreamingContext<'a> {
             .map(|s| s.to_string())
             .collect();
 
-        // Mmap all safetensors files (model_dir, with `weights/` fallback).
-        let st_files = discover_safetensors(model_dir)?;
-
+        // Build a tensor source — either a safetensors mmap set (HF
+        // canonical) or a GGUF mmap set. GGUF detection: either the
+        // caller pointed at a single `.gguf` file directly, or the
+        // directory contains at least one `.gguf` file (we take the
+        // first one matching `*-00001-of-*.gguf`, or the largest if no
+        // multi-shard naming is present, and let `GgufFile::open`
+        // discover the rest of the split via `split.count` metadata).
         callbacks.on_stage(STAGE_LOADING);
-        eprintln!(
-            "  Streaming mode: {} safetensors shards (mmap'd, not loaded)",
-            st_files.len()
-        );
+        let tensor_source = if let Some(gguf_path) = detect_gguf_entry(model_dir)? {
+            eprintln!(
+                "  Streaming mode: GGUF input at {} (shards discovered, mmap'd, not loaded)",
+                gguf_path.display(),
+            );
+            let gguf = larql_models::loading::gguf::GgufFile::open(&gguf_path)
+                .map_err(|e| VindexError::Parse(format!("open GGUF: {e}")))?;
+            eprintln!(
+                "  GGUF: {} tensors across {} shard(s)",
+                gguf.tensor_infos.len(),
+                gguf.shards.len(),
+            );
+            TensorSource::Gguf(GgufTensorSource::from_gguf(
+                gguf,
+                hidden_size,
+                intermediate_size,
+            )?)
+        } else {
+            let st_files = discover_safetensors(model_dir)?;
+            eprintln!(
+                "  Streaming mode: {} safetensors shards (mmap'd, not loaded)",
+                st_files.len(),
+            );
+            // SAFETY: We need to hold both the mmap and the SafeTensors that borrows from it.
+            // The mmaps are kept alive in `shard_mmaps` for the lifetime of the context.
+            let shard_mmaps: Vec<MmapShard> = st_files
+                .iter()
+                .map(|path| {
+                    let file = std::fs::File::open(path).unwrap();
+                    let mmap = unsafe { memmap2::Mmap::map(&file).unwrap() };
+                    MmapShard { _file: file, mmap }
+                })
+                .collect();
+
+            let prefix_refs: Vec<&str> = prefixes.iter().map(|s| s.as_str()).collect();
+            let mut tensor_index: HashMap<String, (usize, String)> = HashMap::new();
+            for (shard_idx, shard) in shard_mmaps.iter().enumerate() {
+                let st = safetensors::SafeTensors::deserialize(&shard.mmap)
+                    .map_err(|e| VindexError::Parse(e.to_string()))?;
+                for name in st.names() {
+                    let key = normalize_key(name, &prefix_refs);
+                    tensor_index.insert(key.clone(), (shard_idx, name.to_string()));
+                }
+            }
+            TensorSource::Safetensors {
+                shards: shard_mmaps,
+                index: tensor_index,
+            }
+        };
 
         // Checkpoint setup with auto-resume. A compatible checkpoint
         // from a previous interrupted run is reused; phases it marked
@@ -137,30 +188,6 @@ impl<'a> StreamingContext<'a> {
             }
         };
 
-        // SAFETY: We need to hold both the mmap and the SafeTensors that borrows from it.
-        // We use a two-phase approach: first mmap all files, then deserialize.
-        // The mmaps are kept alive in `shard_mmaps` for the lifetime of the context.
-        let shard_mmaps: Vec<MmapShard> = st_files
-            .iter()
-            .map(|path| {
-                let file = std::fs::File::open(path).unwrap();
-                let mmap = unsafe { memmap2::Mmap::map(&file).unwrap() };
-                MmapShard { _file: file, mmap }
-            })
-            .collect();
-
-        // Build a tensor index: key → (shard_idx, tensor_name).
-        let prefix_refs: Vec<&str> = prefixes.iter().map(|s| s.as_str()).collect();
-        let mut tensor_index: HashMap<String, (usize, String)> = HashMap::new();
-        for (shard_idx, shard) in shard_mmaps.iter().enumerate() {
-            let st = safetensors::SafeTensors::deserialize(&shard.mmap)
-                .map_err(|e| VindexError::Parse(e.to_string()))?;
-            for name in st.names() {
-                let key = normalize_key(name, &prefix_refs);
-                tensor_index.insert(key.clone(), (shard_idx, name.to_string()));
-            }
-        }
-
         callbacks.on_stage_done(STAGE_LOADING, 0.0);
 
         Ok(Self {
@@ -184,8 +211,7 @@ impl<'a> StreamingContext<'a> {
             is_moe,
             n_experts,
             expert_format,
-            shard_mmaps,
-            tensor_index,
+            tensor_source,
             checkpoint,
             layer_infos: Vec::new(),
             vocab_size: 0,
@@ -209,6 +235,52 @@ impl<'a> StreamingContext<'a> {
         crate::extract::checkpoint::Checkpoint::clear(self.output_dir)?;
         Ok(())
     }
+}
+
+/// Detect a GGUF entry point from `model_dir`. Accepts:
+///  - a single `.gguf` file (returned as-is),
+///  - a directory containing one or more `.gguf` files (returns the
+///    shard-1 file if multi-shard naming is present, otherwise the
+///    largest `.gguf`).
+///
+/// Returns `Ok(None)` when no GGUF is present — caller falls back to
+/// the safetensors discovery path.
+fn detect_gguf_entry(model_dir: &Path) -> Result<Option<PathBuf>, VindexError> {
+    if model_dir.is_file()
+        && model_dir.extension().is_some_and(|e| e == "gguf")
+    {
+        return Ok(Some(model_dir.to_path_buf()));
+    }
+    if !model_dir.is_dir() {
+        return Ok(None);
+    }
+    let mut gguf_files: Vec<PathBuf> = std::fs::read_dir(model_dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|e| e == "gguf"))
+        .collect();
+    if gguf_files.is_empty() {
+        return Ok(None);
+    }
+    // Prefer shard-1 when canonical multi-shard naming is present.
+    gguf_files.sort();
+    if let Some(shard1) = gguf_files.iter().find(|p| {
+        p.file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.contains("-00001-of-"))
+            .unwrap_or(false)
+    }) {
+        return Ok(Some(shard1.clone()));
+    }
+    // Fallback: pick the largest file (single-shard or anomalous naming).
+    let mut largest: Option<(u64, PathBuf)> = None;
+    for p in gguf_files {
+        let size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
+        if largest.as_ref().map_or(true, |(s, _)| size > *s) {
+            largest = Some((size, p));
+        }
+    }
+    Ok(largest.map(|(_, p)| p))
 }
 
 /// Find every `*.safetensors` shard for a model. Looks in `model_dir`

--- a/crates/larql-vindex/src/extract/streaming/mod.rs
+++ b/crates/larql-vindex/src/extract/streaming/mod.rs
@@ -23,7 +23,7 @@ mod context;
 mod stages;
 mod tensor_io;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::config::dtype::StorageDtype;
 use crate::config::types::QuantFormat;
@@ -60,9 +60,20 @@ pub fn build_vindex_streaming(
         ));
     }
 
-    // Detect architecture.
-    let arch = larql_models::detect_architecture_validated(model_dir)
-        .map_err(|e| VindexError::Parse(e.to_string()))?;
+    // Detect architecture. For safetensors input this reads `config.json`
+    // from `model_dir`; for GGUF input the architecture lives in the
+    // file metadata, so we open the entry GGUF, build a config.json
+    // equivalent, and detect from that.
+    let arch = if let Some(gguf_path) = detect_gguf_entry_for_arch(model_dir)? {
+        let gguf = larql_models::loading::gguf::GgufFile::open(&gguf_path)
+            .map_err(|e| VindexError::Parse(format!("open GGUF for arch detection: {e}")))?;
+        let cfg_json = gguf.to_config_json();
+        larql_models::detect_from_json_validated(&cfg_json)
+            .map_err(|e| VindexError::Parse(e.to_string()))?
+    } else {
+        larql_models::detect_architecture_validated(model_dir)
+            .map_err(|e| VindexError::Parse(e.to_string()))?
+    };
     // Reject unsupported attention layouts (e.g. MLA on standard Q/K/V/O
     // manifests) before any output directory or checkpoint is created.
     crate::format::weights::ensure_extract_level_supported(&*arch, extract_level)?;
@@ -85,6 +96,9 @@ pub fn build_vindex_streaming(
         callbacks,
     )?;
 
+    // The arch-detection helper here mirrors `context::detect_gguf_entry`
+    // (private to that module) — kept inline rather than re-exported
+    // because the use site is a single call. (See note at the helper.)
     ctx.write_gate_vectors()?;
     ctx.write_router_weights()?;
     ctx.write_embeddings()?;
@@ -95,4 +109,44 @@ pub fn build_vindex_streaming(
     ctx.finalize()?;
 
     Ok(())
+}
+
+/// Mirror of `context::detect_gguf_entry` used only for architecture
+/// detection — kept here to avoid making the context-private helper
+/// pub(super) just for one call. See `context.rs::detect_gguf_entry`
+/// for the contract.
+fn detect_gguf_entry_for_arch(model_dir: &Path) -> Result<Option<PathBuf>, VindexError> {
+    if model_dir.is_file()
+        && model_dir.extension().is_some_and(|e| e == "gguf")
+    {
+        return Ok(Some(model_dir.to_path_buf()));
+    }
+    if !model_dir.is_dir() {
+        return Ok(None);
+    }
+    let mut gguf_files: Vec<PathBuf> = std::fs::read_dir(model_dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|e| e == "gguf"))
+        .collect();
+    if gguf_files.is_empty() {
+        return Ok(None);
+    }
+    gguf_files.sort();
+    if let Some(shard1) = gguf_files.iter().find(|p| {
+        p.file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.contains("-00001-of-"))
+            .unwrap_or(false)
+    }) {
+        return Ok(Some(shard1.clone()));
+    }
+    let mut largest: Option<(u64, PathBuf)> = None;
+    for p in gguf_files {
+        let size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
+        if largest.as_ref().map_or(true, |(s, _)| size > *s) {
+            largest = Some((size, p));
+        }
+    }
+    Ok(largest.map(|(_, p)| p))
 }

--- a/crates/larql-vindex/src/extract/streaming/stages/down_meta.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/down_meta.rs
@@ -6,7 +6,7 @@ use crate::error::VindexError;
 use crate::extract::constants::FEATURE_PROJECTION_BATCH;
 use crate::extract::stage_labels::*;
 use crate::extract::streaming::context::StreamingContext;
-use crate::extract::streaming::tensor_io::{get_tensor_f32, normalize_key};
+use crate::extract::streaming::tensor_io::normalize_key;
 use crate::format::filenames::*;
 
 impl<'a> StreamingContext<'a> {
@@ -57,16 +57,24 @@ impl<'a> StreamingContext<'a> {
             let down_matrices: Vec<Array2<f32>> = if self.expert_format
                 == larql_models::ExpertFormat::PackedMxfp4
             {
-                // MXFP4: dequantize down_proj_blocks
+                // MXFP4: dequantize down_proj_blocks. Safetensors-only —
+                // GGUF has no equivalent packed-MXFP4 format.
+                let (shard_mmaps, tensor_index) = match self.tensor_source.safetensors_view() {
+                    Some(v) => v,
+                    None => {
+                        self.callbacks.on_layer_done(COMP_DOWN, layer, 0.0);
+                        continue;
+                    }
+                };
                 let blocks_key = self.arch.packed_down_blocks_key(layer).unwrap_or_default();
                 let scales_key = self.arch.packed_down_scales_key(layer).unwrap_or_default();
                 if let (Some(bi), Some(si)) = (
-                    self.tensor_index.get(&blocks_key),
-                    self.tensor_index.get(&scales_key),
+                    tensor_index.get(&blocks_key),
+                    tensor_index.get(&scales_key),
                 ) {
-                    let bst = safetensors::SafeTensors::deserialize(&self.shard_mmaps[bi.0].mmap)
+                    let bst = safetensors::SafeTensors::deserialize(&shard_mmaps[bi.0].mmap)
                         .map_err(|e| VindexError::Parse(e.to_string()))?;
-                    let sst = safetensors::SafeTensors::deserialize(&self.shard_mmaps[si.0].mmap)
+                    let sst = safetensors::SafeTensors::deserialize(&shard_mmaps[si.0].mmap)
                         .map_err(|e| VindexError::Parse(e.to_string()))?;
                     let bv = bst
                         .tensor(&bi.1)
@@ -101,7 +109,7 @@ impl<'a> StreamingContext<'a> {
                 // Expert down matrices live per-layer at `layers/layer_{L:02}.weights`
                 // (Q4_K), written by the q4k weight writer.
                 let down_key = normalize_key(&self.arch.ffn_down_key(layer), &prefixes);
-                match get_tensor_f32(&self.shard_mmaps, &self.tensor_index, &down_key)? {
+                match self.tensor_source.get_tensor_f32(&down_key)? {
                     Some(t) => vec![t],
                     None => {
                         self.callbacks.on_layer_done(COMP_DOWN, layer, 0.0);
@@ -113,8 +121,7 @@ impl<'a> StreamingContext<'a> {
                 for expert in 0..self.n_experts {
                     if let Some(key) = self.arch.expert_ffn_down_key(layer, expert) {
                         let nk = normalize_key(&key, &prefixes);
-                        if let Some(t) = get_tensor_f32(&self.shard_mmaps, &self.tensor_index, &nk)?
-                        {
+                        if let Some(t) = self.tensor_source.get_tensor_f32(&nk)? {
                             mats.push(t);
                         }
                     }
@@ -122,7 +129,7 @@ impl<'a> StreamingContext<'a> {
                 mats
             } else {
                 let down_key = normalize_key(&self.arch.ffn_down_key(layer), &prefixes);
-                match get_tensor_f32(&self.shard_mmaps, &self.tensor_index, &down_key)? {
+                match self.tensor_source.get_tensor_f32(&down_key)? {
                     Some(t) => vec![t],
                     None => {
                         self.callbacks.on_layer_done(COMP_DOWN, layer, 0.0);

--- a/crates/larql-vindex/src/extract/streaming/stages/down_meta.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/down_meta.rs
@@ -47,8 +47,12 @@ impl<'a> StreamingContext<'a> {
 
         let prefixes: Vec<&str> = self.prefixes.iter().map(|s| s.as_str()).collect();
         let down_layer_count = if resumed_down { 0 } else { self.num_layers };
-        for (layer, layer_down_meta) in all_down_meta.iter_mut().enumerate().take(down_layer_count)
-        {
+        // Index-based loop (rather than `iter_mut().enumerate()`) so the
+        // mutable borrow on `all_down_meta[layer]` is released between
+        // iterations — letting the per-layer incremental flush below take
+        // an immutable borrow of the whole accumulator.
+        for layer in 0..down_layer_count {
+            let layer_down_meta = &mut all_down_meta[layer];
             self.callbacks
                 .on_layer_start(COMP_DOWN, layer, self.num_layers);
             let start = std::time::Instant::now();
@@ -241,9 +245,23 @@ impl<'a> StreamingContext<'a> {
 
             self.callbacks
                 .on_layer_done(COMP_DOWN, layer, start.elapsed().as_secs_f64() * 1000.0);
+
+            // Incremental flush: after each layer's projection finishes,
+            // snapshot the accumulator to `down_meta.bin` so an interrupted
+            // run preserves completed layers. `write_binary` already uses
+            // a tempfile + atomic rename so the on-disk file is never in
+            // a partial state. Cost is one ~1.5 MB write per layer — well
+            // under the per-layer matmul time even on dense models.
+            crate::format::down_meta::write_binary(
+                self.output_dir,
+                &all_down_meta,
+                self.down_top_k,
+            )?;
         }
 
         if !resumed_down {
+            // Final write (idempotent — same content as the last
+            // per-layer snapshot above when the loop ran to completion).
             crate::format::down_meta::write_binary(
                 self.output_dir,
                 &all_down_meta,

--- a/crates/larql-vindex/src/extract/streaming/stages/embeddings.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/embeddings.rs
@@ -3,7 +3,7 @@
 use crate::error::VindexError;
 use crate::extract::stage_labels::*;
 use crate::extract::streaming::context::StreamingContext;
-use crate::extract::streaming::tensor_io::{get_tensor_f32, normalize_key};
+use crate::extract::streaming::tensor_io::normalize_key;
 use crate::format::filenames::*;
 
 impl<'a> StreamingContext<'a> {
@@ -12,7 +12,9 @@ impl<'a> StreamingContext<'a> {
         self.callbacks.on_stage(STAGE_EMBEDDINGS);
         let prefixes: Vec<&str> = self.prefixes.iter().map(|s| s.as_str()).collect();
         let embed_key = normalize_key(self.arch.embed_key(), &prefixes);
-        let embed = get_tensor_f32(&self.shard_mmaps, &self.tensor_index, &embed_key)?
+        let embed = self
+            .tensor_source
+            .get_tensor_f32(&embed_key)?
             .ok_or_else(|| VindexError::MissingTensor(embed_key.clone()))?;
         self.vocab_size = embed.shape()[0];
         let embed_data = embed.as_slice().unwrap();

--- a/crates/larql-vindex/src/extract/streaming/stages/gate_vectors.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/gate_vectors.rs
@@ -7,7 +7,7 @@ use crate::config::VindexLayerInfo;
 use crate::error::VindexError;
 use crate::extract::stage_labels::*;
 use crate::extract::streaming::context::StreamingContext;
-use crate::extract::streaming::tensor_io::{get_tensor_f32, normalize_key, GateSink};
+use crate::extract::streaming::tensor_io::{normalize_key, GateSink};
 use crate::format::filenames::*;
 
 impl<'a> StreamingContext<'a> {
@@ -64,7 +64,25 @@ impl<'a> StreamingContext<'a> {
             if self.expert_format == larql_models::ExpertFormat::PackedMxfp4 {
                 // MXFP4 packed experts: dequantize gate_up_proj_blocks per layer
                 // The fused tensor is [num_experts, 2*intermediate, groups, 16]
-                // First half of output features = gate, second half = up
+                // First half of output features = gate, second half = up.
+                //
+                // GGUF has no equivalent packed-MXFP4 format, so this branch
+                // is safetensors-only — the `safetensors_view()` accessor
+                // returns `None` for GGUF and we silently skip the layer
+                // (the dispatcher won't route GGUF input here in practice
+                // because GGUF DeepSeek-V4 weights use standard blockwise
+                // quants, not the MXFP4 packing format).
+                let (shard_mmaps, tensor_index) = match self.tensor_source.safetensors_view() {
+                    Some(v) => v,
+                    None => {
+                        self.callbacks.on_layer_done(
+                            COMP_GATE,
+                            layer,
+                            start.elapsed().as_secs_f64() * 1000.0,
+                        );
+                        continue;
+                    }
+                };
                 let blocks_key = self
                     .arch
                     .packed_gate_up_blocks_key(layer)
@@ -75,15 +93,15 @@ impl<'a> StreamingContext<'a> {
                     .unwrap_or_default();
 
                 if let (Some(blocks_info), Some(scales_info)) = (
-                    self.tensor_index.get(&blocks_key),
-                    self.tensor_index.get(&scales_key),
+                    tensor_index.get(&blocks_key),
+                    tensor_index.get(&scales_key),
                 ) {
                     let blocks_st = safetensors::SafeTensors::deserialize(
-                        &self.shard_mmaps[blocks_info.0].mmap,
+                        &shard_mmaps[blocks_info.0].mmap,
                     )
                     .map_err(|e| VindexError::Parse(e.to_string()))?;
                     let scales_st = safetensors::SafeTensors::deserialize(
-                        &self.shard_mmaps[scales_info.0].mmap,
+                        &shard_mmaps[scales_info.0].mmap,
                     )
                     .map_err(|e| VindexError::Parse(e.to_string()))?;
 
@@ -135,9 +153,7 @@ impl<'a> StreamingContext<'a> {
                 // Hybrid MoE (Gemma 4 26B A4B): packed experts stored separately.
                 // gate_vectors.bin uses the dense FFN gate for KNN walk routing.
                 let gate_key = normalize_key(&self.arch.ffn_gate_key(layer), &prefixes);
-                if let Some(tensor) =
-                    get_tensor_f32(&self.shard_mmaps, &self.tensor_index, &gate_key)?
-                {
+                if let Some(tensor) = self.tensor_source.get_tensor_f32(&gate_key)? {
                     let num_features = tensor.shape()[0];
                     let data = tensor.as_slice().unwrap();
                     let length = write_floats(&mut gate_file, data, self.dtype)?;
@@ -179,9 +195,7 @@ impl<'a> StreamingContext<'a> {
                         None => continue,
                     };
 
-                    if let Some(tensor) =
-                        get_tensor_f32(&self.shard_mmaps, &self.tensor_index, &gate_key)?
-                    {
+                    if let Some(tensor) = self.tensor_source.get_tensor_f32(&gate_key)? {
                         let data: Vec<f32>;
                         let n_feat: usize;
                         if summary_k > 0 && tensor.shape()[0] > summary_k {
@@ -222,9 +236,7 @@ impl<'a> StreamingContext<'a> {
             } else {
                 // Dense: single gate matrix per layer
                 let gate_key = normalize_key(&self.arch.ffn_gate_key(layer), &prefixes);
-                if let Some(tensor) =
-                    get_tensor_f32(&self.shard_mmaps, &self.tensor_index, &gate_key)?
-                {
+                if let Some(tensor) = self.tensor_source.get_tensor_f32(&gate_key)? {
                     let num_features = tensor.shape()[0];
                     let data = tensor.as_slice().unwrap();
                     let length = write_floats(&mut gate_file, data, self.dtype)?;

--- a/crates/larql-vindex/src/extract/streaming/stages/model_weights.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/model_weights.rs
@@ -18,10 +18,30 @@ impl<'a> StreamingContext<'a> {
         if !needs_weights {
             return Ok(());
         }
-        let shard_refs: Vec<&[u8]> = self.shard_mmaps.iter().map(|s| s.mmap.as_ref()).collect();
+        // `StreamingWeights` is a safetensors-only writer subsystem
+        // (Q4_K + f32 weight writers walk safetensors crate views
+        // directly). GGUF input is supported at browse level (where
+        // `needs_weights == false`) and below only; inference / Q4K
+        // levels for GGUF need a separate writer pass that streams
+        // per-tensor through `larql_models::quant::ggml::dequantize` —
+        // tracked as a follow-on PR.
+        let (shard_mmaps, tensor_index) = match (
+            self.tensor_source.safetensors_mmap_refs(),
+            self.tensor_source.safetensors_index(),
+        ) {
+            (Some(m), Some(i)) => (m, i),
+            _ => {
+                return Err(VindexError::Parse(
+                    "GGUF input + extract-level requiring attention/FFN weights is not yet \
+                     implemented (browse-level GGUF works; inference/Q4K GGUF requires \
+                     per-tensor streaming through ggml::dequantize)"
+                        .to_string(),
+                ));
+            }
+        };
         let streaming_source = crate::format::weights::StreamingWeights {
-            shard_mmaps: &shard_refs,
-            tensor_index: &self.tensor_index,
+            shard_mmaps: &shard_mmaps,
+            tensor_index,
             arch: &*self.arch,
             num_layers: self.num_layers,
         };

--- a/crates/larql-vindex/src/extract/streaming/stages/router_weights.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/router_weights.rs
@@ -5,7 +5,7 @@ use std::io::{BufWriter, Write};
 use crate::error::VindexError;
 use crate::extract::stage_labels::*;
 use crate::extract::streaming::context::StreamingContext;
-use crate::extract::streaming::tensor_io::{get_tensor_f32, normalize_key};
+use crate::extract::streaming::tensor_io::normalize_key;
 use crate::format::filenames::*;
 
 impl<'a> StreamingContext<'a> {
@@ -28,9 +28,7 @@ impl<'a> StreamingContext<'a> {
                 .map(|k| normalize_key(&k, &prefixes))
                 .unwrap_or_default();
 
-            if let Some(tensor) =
-                get_tensor_f32(&self.shard_mmaps, &self.tensor_index, &router_key)?
-            {
+            if let Some(tensor) = self.tensor_source.get_tensor_f32(&router_key)? {
                 let data = tensor.as_slice().unwrap();
                 let bytes = crate::config::dtype::encode_floats(data, self.dtype);
                 router_file.write_all(&bytes)?;
@@ -38,8 +36,7 @@ impl<'a> StreamingContext<'a> {
 
             // Also try router bias
             let bias_key = router_key.replace(".weight", ".bias");
-            if let Some(tensor) = get_tensor_f32(&self.shard_mmaps, &self.tensor_index, &bias_key)?
-            {
+            if let Some(tensor) = self.tensor_source.get_tensor_f32(&bias_key)? {
                 let data = tensor.as_slice().unwrap();
                 let bytes = crate::config::dtype::encode_floats(data, self.dtype);
                 // Write bias after weight for each layer

--- a/crates/larql-vindex/src/extract/streaming/tensor_io.rs
+++ b/crates/larql-vindex/src/extract/streaming/tensor_io.rs
@@ -1,14 +1,21 @@
-//! Safetensors-mmap helpers for the streaming extraction pipeline.
+//! Mmap-based tensor source for the streaming extraction pipeline.
 //!
 //! Named `tensor_io` rather than `safetensors` to avoid shadowing the
 //! external `safetensors` crate inside the parent module.
 //!
-//! - `MmapShard` keeps the file handle + mmap alive for the lifetime of
-//!   one extraction.
-//! - `GateSink` is the gate-vector writer abstraction (real file or
-//!   `/dev/null` when `--drop-gate-vectors` is set).
-//! - `get_tensor_f32` reads a 2D tensor by key and dequantises to f32.
-//! - `normalize_key` strips a fixed prefix list from a tensor key.
+//! Two backing formats:
+//!  - **safetensors**: HF-canonical layout, key already in HF form after
+//!    `normalize_key` strips the architecture-specific prefix.
+//!  - **GGUF**: llama.cpp blockwise quants (Q4_K, Q4_0, BF16, F32, …),
+//!    keyed by GGUF tensor name (`blk.L.attn_q.weight`) and mapped back
+//!    to HF form via [`larql_models::loading::gguf::normalize_gguf_key`].
+//!
+//! Types:
+//!  - [`MmapShard`] keeps a safetensors file handle + mmap alive.
+//!  - [`TensorSource`] dispatches `get_tensor_f32` over either backend.
+//!  - [`GateSink`] is the gate-vector writer abstraction (real file or
+//!    `/dev/null` when `--drop-gate-vectors` is set).
+//!  - `normalize_key` strips a fixed prefix list from a safetensors key.
 
 use std::collections::HashMap;
 use std::io::{BufWriter, Write};
@@ -21,6 +28,261 @@ use crate::error::VindexError;
 pub(super) struct MmapShard {
     pub(super) _file: std::fs::File,
     pub(super) mmap: memmap2::Mmap,
+}
+
+/// Tensor source for the streaming pipeline. Dispatches `get_tensor_f32`
+/// between mmap'd safetensors and mmap'd GGUF blockwise-quantised tensors.
+///
+/// The MXFP4 raw-pair path (packed expert gate_up/down in DeepSeek-V4)
+/// is safetensors-only — GGUF stores the same expert tensors as standard
+/// blockwise quants (Q4_0/Q4_K/…) handled by `get_tensor_f32` directly.
+pub(super) enum TensorSource {
+    Safetensors {
+        shards: Vec<MmapShard>,
+        /// hf_key → (shard_idx, safetensors-internal name)
+        index: HashMap<String, (usize, String)>,
+    },
+    Gguf(GgufTensorSource),
+}
+
+/// GGUF backend for [`TensorSource`]. Owns the parsed `GgufFile` (multi-
+/// shard aware) plus one mmap per shard. Eager mmap is cheap (virtual
+/// address space, not RAM) so the OS only pages in tensors we touch.
+///
+/// Holds the architecture config so `get_tensor_f32` can apply the same
+/// canonical orientation the in-memory loader runs via `orient_in_place`
+/// (GGUF stores ffn tensors in PyTorch shape which may be the transpose
+/// of the HF Linear convention — without correction, `tensor.shape()[0]`
+/// is `hidden_size` instead of `intermediate_size` and downstream
+/// matmul produces NaN).
+pub(super) struct GgufTensorSource {
+    pub(super) gguf: larql_models::loading::gguf::GgufFile,
+    pub(super) shard_mmaps: Vec<memmap2::Mmap>,
+    /// hf_key (after `normalize_gguf_key`) → index into `gguf.tensor_infos`.
+    pub(super) index: HashMap<String, usize>,
+    /// Canonical hidden_size — used to orient ffn tensors to HF Linear shape.
+    hidden_size: usize,
+    /// Canonical intermediate_size (dense FFN). Some MoE architectures
+    /// have a separate `moe_intermediate_size` — that's handled at the
+    /// call site since the streaming pipeline matches the in-memory
+    /// loader's behavior of skipping 3D-packed expert tensors anyway.
+    intermediate_size: usize,
+}
+
+impl TensorSource {
+    /// Read a 2D tensor by HF-canonical key, dequantising to f32. Returns
+    /// `Ok(None)` if the key is absent, the tensor is not 2D, or the
+    /// dtype is unsupported by this code path (matching the safetensors
+    /// historical contract).
+    pub(super) fn get_tensor_f32(&self, key: &str) -> Result<Option<Array2<f32>>, VindexError> {
+        match self {
+            TensorSource::Safetensors { shards, index } => get_tensor_f32(shards, index, key),
+            TensorSource::Gguf(g) => g.get_tensor_f32(key),
+        }
+    }
+
+    /// Borrow the safetensors backing data for raw-pair access (MXFP4
+    /// expert gate_up/down). Returns `None` for the GGUF variant — GGUF
+    /// has no MXFP4-packed format.
+    pub(super) fn safetensors_view(
+        &self,
+    ) -> Option<(&[MmapShard], &HashMap<String, (usize, String)>)> {
+        match self {
+            TensorSource::Safetensors { shards, index } => Some((shards, index)),
+            TensorSource::Gguf(_) => None,
+        }
+    }
+
+    /// Borrow the safetensors shards as `&[u8]` slices, for callers that
+    /// need to hand the raw mmap to a separate writer subsystem
+    /// (`StreamingWeights`). Returns `None` for the GGUF variant.
+    pub(super) fn safetensors_mmap_refs(&self) -> Option<Vec<&[u8]>> {
+        match self {
+            TensorSource::Safetensors { shards, .. } => {
+                Some(shards.iter().map(|s| s.mmap.as_ref()).collect())
+            }
+            TensorSource::Gguf(_) => None,
+        }
+    }
+
+    /// Borrow the safetensors tensor index. Returns `None` for the GGUF
+    /// variant.
+    pub(super) fn safetensors_index(&self) -> Option<&HashMap<String, (usize, String)>> {
+        match self {
+            TensorSource::Safetensors { index, .. } => Some(index),
+            TensorSource::Gguf(_) => None,
+        }
+    }
+
+}
+
+impl GgufTensorSource {
+    /// Build a `GgufTensorSource` from an already-opened `GgufFile`. The
+    /// caller is responsible for parsing the header (`GgufFile::open`);
+    /// this just mmaps each shard and builds the hf_key → tensor_info
+    /// index.
+    ///
+    /// `hidden_size` and `intermediate_size` come from the detected
+    /// architecture and drive the canonical FFN orientation applied
+    /// inside `get_tensor_f32` (mirrors `orient_in_place` in the
+    /// in-memory loader).
+    pub(super) fn from_gguf(
+        gguf: larql_models::loading::gguf::GgufFile,
+        hidden_size: usize,
+        intermediate_size: usize,
+    ) -> Result<Self, VindexError> {
+        let mut shard_mmaps: Vec<memmap2::Mmap> = Vec::with_capacity(gguf.shards.len());
+        for shard in &gguf.shards {
+            let file = std::fs::File::open(&shard.path)
+                .map_err(|e| VindexError::Parse(format!("open {}: {e}", shard.path.display())))?;
+            // SAFETY: shard files are owned, immutable input.
+            let mmap = unsafe { memmap2::Mmap::map(&file) }
+                .map_err(|e| VindexError::Parse(format!("mmap {}: {e}", shard.path.display())))?;
+            shard_mmaps.push(mmap);
+        }
+
+        let mut index: HashMap<String, usize> = HashMap::with_capacity(gguf.tensor_infos.len());
+        for (i, info) in gguf.tensor_infos.iter().enumerate() {
+            let hf_key = larql_models::loading::gguf::normalize_gguf_key(info.name());
+            // First-write wins: if the same hf_key normalises twice (it
+            // shouldn't, but defensively), keep the earlier one rather
+            // than silently flipping shard_idx on the caller.
+            index.entry(hf_key).or_insert(i);
+        }
+
+        Ok(Self {
+            gguf,
+            shard_mmaps,
+            index,
+            hidden_size,
+            intermediate_size,
+        })
+    }
+
+    /// Inspect a normalised HF key and return the canonical `(rows, cols)`
+    /// shape expected by downstream stages — or `None` for keys that are
+    /// already shape-correct as stored in GGUF (embed, lm_head, norms).
+    ///
+    /// The pattern matching mirrors `load_gguf`'s `orient_in_place` calls
+    /// for ffn_gate / ffn_up / ffn_down (+ MoE per-expert variants the
+    /// streaming path would reach if GGUF stored experts 2D — currently
+    /// they're 3D-packed and skipped here as in the in-memory loader).
+    fn expected_shape(&self, key: &str) -> Option<(usize, usize)> {
+        let h = self.hidden_size;
+        let m = self.intermediate_size;
+        if h == 0 || m == 0 {
+            return None;
+        }
+        // Order matters: check the more specific `down_proj` before
+        // generic `proj` to avoid the gate/up branches catching down.
+        if key.ends_with("down_proj.weight") || key.contains(".down_proj.") {
+            return Some((h, m));
+        }
+        if key.ends_with("gate_proj.weight")
+            || key.contains(".gate_proj.")
+            || key.ends_with("up_proj.weight")
+            || key.contains(".up_proj.")
+        {
+            return Some((m, h));
+        }
+        None
+    }
+
+    /// Transpose if the current shape is `(cols, rows)` instead of the
+    /// expected `(rows, cols)`. Mirror of `load_gguf::orient_in_place`.
+    fn orient(&self, arr: Array2<f32>, expected: (usize, usize)) -> Array2<f32> {
+        let (er, ec) = expected;
+        if er == ec {
+            return arr;
+        }
+        let s = arr.shape();
+        if s[0] == er && s[1] == ec {
+            return arr;
+        }
+        if s[0] == ec && s[1] == er {
+            let mut out = Array2::<f32>::zeros((er, ec));
+            out.assign(&arr.t());
+            return out;
+        }
+        // Shape doesn't match either orientation — return as-is and let
+        // the caller's shape check surface the mismatch.
+        arr
+    }
+
+    fn get_tensor_f32(&self, key: &str) -> Result<Option<Array2<f32>>, VindexError> {
+        let info_idx = match self.index.get(key) {
+            Some(&i) => i,
+            None => return Ok(None),
+        };
+        let info = &self.gguf.tensor_infos[info_idx];
+        if info.n_dims() != 2 {
+            return Ok(None);
+        }
+
+        let shard_idx = info.shard_idx();
+        let mmap = &self.shard_mmaps[shard_idx];
+        let data_offset = self.gguf.shards[shard_idx].data_offset;
+        let abs_offset = data_offset
+            .checked_add(info.offset())
+            .ok_or_else(|| VindexError::Parse(format!(
+                "gguf tensor {}: data_offset {data_offset} + offset {} overflows",
+                info.name(),
+                info.offset(),
+            )))?;
+
+        let dims = info.dims();
+        let n_elements: u64 = dims.iter().product();
+        let n_elements_usize = usize::try_from(n_elements).map_err(|_| {
+            VindexError::Parse(format!(
+                "gguf tensor {}: n_elements {n_elements} exceeds usize",
+                info.name(),
+            ))
+        })?;
+
+        let data_size =
+            larql_models::quant::ggml::tensor_data_size(info.tensor_type(), n_elements_usize)
+                .map_err(|e| VindexError::Parse(e.to_string()))?;
+        let abs_offset_usize = usize::try_from(abs_offset).map_err(|_| {
+            VindexError::Parse(format!(
+                "gguf tensor {}: abs_offset {abs_offset} exceeds usize",
+                info.name(),
+            ))
+        })?;
+        let end = abs_offset_usize
+            .checked_add(data_size)
+            .ok_or_else(|| VindexError::Parse(format!(
+                "gguf tensor {}: offset+size overflows",
+                info.name(),
+            )))?;
+        if end > mmap.len() {
+            return Err(VindexError::Parse(format!(
+                "gguf tensor {} out of bounds: end {end} > shard len {}",
+                info.name(),
+                mmap.len(),
+            )));
+        }
+
+        let raw = &mmap[abs_offset_usize..end];
+        let floats = larql_models::quant::ggml::dequantize(raw, info.tensor_type(), n_elements_usize)
+            .map_err(|e| VindexError::Parse(e.to_string()))?;
+
+        // GGUF dim ordering: dims[0] = columns (innermost/fastest),
+        // dims[1] = rows (outermost). Raw bytes are contiguous along
+        // dims[0], so reshaping to (rows, cols) = (dims[1], dims[0])
+        // gives ndarray's row-major layout matching the HF convention.
+        let ne0 = dims[0] as usize;
+        let ne1 = dims[1] as usize;
+        let arr = Array2::from_shape_vec((ne1, ne0), floats)
+            .map_err(|e| VindexError::Parse(format!("gguf tensor {}: {e}", info.name())))?;
+
+        // Apply canonical orientation when the key is a known FFN
+        // tensor — matches `orient_in_place` in the in-memory loader.
+        let arr = match self.expected_shape(key) {
+            Some(expected) => self.orient(arr, expected),
+            None => arr,
+        };
+        Ok(Some(arr))
+    }
 }
 
 /// Sink for gate-vector bytes. With `--drop-gate-vectors` the writer


### PR DESCRIPTION
## Summary

Adds GGUF to the streaming-extract pipeline alongside safetensors. Today GGUF input is routed through the in-memory `load_model_dir_validated` path which dequantises every tensor to f32 in RAM — fine for small models but architecturally unworkable for ≥70B GGUFs (Kimi K2.6 at 554 GB, DS-V4-Flash at 127 GB).

## Design — TensorSource enum

```rust
enum TensorSource {
    Safetensors { shards, index },   // existing
    Gguf(GgufTensorSource),          // new
}
```

`StreamingContext::new` detects the input format (a `.gguf` file directly, or a directory whose first / largest `.gguf` shard is used as the entry point) and constructs the appropriate variant. Each stage now calls `self.tensor_source.get_tensor_f32(key)` for the canonical 2D dequant path. The MXFP4 raw-pair access (DeepSeek-V4 packed `gate_up_proj_blocks` / `down_proj_blocks`) stays safetensors-only — GGUF has no equivalent packed format.

### GGUF specifics

- Multi-shard splits are handled via `GgufFile::open` (#136). Each shard is mmap'd eagerly — virtual address space only, the OS pages in only the tensors we touch.
- Per-tensor read does `data_offset + offset` into the right shard, slices `tensor_data_size` bytes, and dequantises via `larql_models::quant::ggml::dequantize` (Q4_K / Q5_K / Q6_K / Q8_0 / BF16 / F32 etc — all already supported).
- Dim ordering follows `load_gguf`'s reshape-to-`(dims[1], dims[0])` convention. **Canonical FFN orientation** (the in-memory loader's `orient_in_place`) is applied here too, driven by `(hidden_size, intermediate_size)` from the detected architecture — without it `tensor.shape()[0]` would be `hidden` instead of `intermediate` for some quants and downstream matmul would produce NaN.

### CLI routing

| Input | Level / quant | Path |
|---|---|---|
| safetensors | any | streaming |
| GGUF | --level browse (and no quant) | streaming (new) |
| GGUF | attention / inference / all | in-memory (unchanged) |
| GGUF | any level with --quant q4k | in-memory (unchanged) |

Inference / Q4K levels for GGUF still need the `StreamingWeights` writer subsystem ported to read tensors via `ggml::dequantize` per tensor — tracked as a follow-on PR. The stage gate returns a clear `VindexError::Parse(…)` if the user requests an unsupported level/quant combo for GGUF input.

## Validation

- DS-R1-0528-Qwen3-8B-Q3_K_L (10 GB, dense, mixed Q3_K / Q4_K / Q6_K) → 3.4 GB gate_vectors.bin + 1.2 GB embeddings.bin written cleanly through the streaming path. Resident memory stays at the per-layer-tensor scale, not the full-model scale.
- 1074 existing vindex unit tests pass.

## Known gap (pre-existing)

The streaming pipeline's MoE branch looks up per-expert 2D keys (`mlp.experts.K.gate_proj.weight`) which GGUF stores as 3D-packed tensors (`blk.L.ffn_gate_exps.weight`, `[hidden, intermediate, n_experts]`). Both streaming and in-memory `load_gguf` currently skip these 3D tensors. Unpacking them lives in the same follow-on PR as inference-level GGUF.

## Test plan

- [x] cargo check --workspace clean
- [x] cargo test -p larql-vindex --lib — 1074 / 1074 pass
- [x] End-to-end on dense GGUF (Qwen3-8B Q3_K_L) — gate_vectors.bin + embeddings.bin populated correctly
- [ ] End-to-end on multi-shard GGUF (Kimi K2.6 at browse level) — pending, this PR unblocks it
- [ ] Inference / Q4K for GGUF — follow-on PR