### PR TITLE
feat(multi-modal): Phase 2 — Granite Vision, MLP connector, AnyRes tiler

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ Every invention in the codebase serves this aim:
 | Shannon arc (1 bit/char on Frankenstein) | Theoretical compression ceiling — how far this can go |
 | Mech-interp surface (M1–M8) | Discover *which* weights actually do the work; rest stays on disk |
 | Cross-arch coverage | The technique stack must generalise |
-| Multi-modal (vision / audio) | Accept images + audio alongside text; same sparse-retrieval story applies to the LM portion of multimodal models |
+| Multi-modal (vision / audio) | Accept images + audio alongside text; same sparse-retrieval story applies to the LM portion of multimodal models. **Phase 0+1 shipped** (PR #143, 2026-05-24): trait surface + Gemma 3 SigLIP + CLI `--image`. **Phase 2 shipped** (PR #144, 2026-05-25): Granite Vision SigLIP2 + MLP GELU connector + AnyRes tiling + PerTile splice stress test. Phases 3–6 (interleaving, Qwen-VL M-RoPE, audio, Llama 3.2 cross-attention) remain design-only — see `docs/multi-modal.md`. |
 | KV engine trait split (KvEngine / RetrievalEngine / AnyEngine) | Uniform dispatch across production KV-cache engines + retrieval-only engines (Apollo) via typed enum |
 
 Combined effect (rough math, conservative): hash routing 5× × FP4 2× × KV

--- a/crates/larql-cli/ROADMAP.md
+++ b/crates/larql-cli/ROADMAP.md
@@ -10,8 +10,12 @@ Primary verbs: `run`, `chat`, `pull`, `model`, `link`, `list`, `show`, `slice`,
 Legacy research commands gated under `larql dev <subcmd>` for backwards-compat.
 Dual cache (HuggingFace hub + `~/.cache/larql/local/`) with shorthand resolution
 (`larql run gemma3-4b-it-vindex`). Multi-modal: `--image` + `--mm-weights`
-flags on `larql run` for prefix-only vision captioning (Phase 1, Gemma 3 +
-SigLIP). Image decode/resize in `image_input.rs`, plan assembly in
+flags on `larql run` for prefix-only vision captioning. Phase 1 (PR #143,
+2026-05-24): Gemma 3 + SigLIP, `TokenBudget::Fixed(256)`. Phase 2 (PR #144,
+2026-05-25): Granite Vision + SigLIP2 + MLP GELU connector +
+`TokenBudget::PerTile{729}` with AnyRes tiling (`anyres_tiler.rs`).
+`prepare_multimodal_input` dispatches on budget type via trait objects.
+Image decode/resize in `image_input.rs`, plan assembly in
 `run_cmd_image.rs`. Engine capability check (`supports_multimodal()`) fires
 before the encoder runs. Q4K vindex dispatch supported. 3-image regression
 test in `tests/multimodal_e2e.rs` (`#[ignore]`, NOT FOR CI).

--- a/crates/larql-cli/src/anyres_tiler.rs
+++ b/crates/larql-cli/src/anyres_tiler.rs
@@ -1,0 +1,198 @@
+//! AnyRes tiler for Granite Vision and similar per-tile models.
+//!
+//! Divides an image into a base tile (downsampled full image) plus
+//! N detail tiles from a resolution-aware grid. Each tile is resized
+//! to `tile_size x tile_size` and handed to the encoder independently.
+
+/// Configuration for AnyRes tiling, derived from the model's
+/// `MultiModalProtocol::valid_tile_counts()` and the encoder's
+/// expected input size.
+#[derive(Debug, Clone)]
+pub struct AnyResTileSpec {
+    pub tile_size: usize,
+    pub valid_tile_counts: Vec<usize>,
+}
+
+/// Result of tiling an image. Contains one base tile (downsampled full
+/// image) plus zero or more detail tiles from the resolution grid.
+#[derive(Debug)]
+pub struct TiledImage {
+    pub base_tile: Vec<u8>,
+    pub detail_tiles: Vec<Vec<u8>>,
+    pub total_tiles: usize,
+}
+
+impl AnyResTileSpec {
+    /// Select the optimal grid `(rows, cols)` for an image of given size.
+    ///
+    /// For each valid tile count N, enumerates factorizations `(r, c)` where
+    /// `r * c <= N`, picks the one whose aspect ratio best matches the input.
+    pub fn optimal_grid(&self, width: usize, height: usize) -> (usize, usize) {
+        let aspect = width as f64 / height as f64;
+        let mut best = (1usize, 1usize);
+        let mut best_score = f64::MAX;
+
+        for &count in &self.valid_tile_counts {
+            for r in 1..=count {
+                for c in 1..=count {
+                    if r * c > count {
+                        continue;
+                    }
+                    let grid_aspect = c as f64 / r as f64;
+                    let score = (grid_aspect - aspect).abs();
+                    if score < best_score || (score == best_score && r * c > best.0 * best.1) {
+                        best_score = score;
+                        best = (r, c);
+                    }
+                }
+            }
+        }
+        best
+    }
+
+    /// Tile an image into base + detail tiles.
+    ///
+    /// The base tile is the full image downsampled to `tile_size x tile_size`.
+    /// Detail tiles are cut from the image resized to fit the optimal grid.
+    pub fn tile(&self, rgb: &[u8], width: usize, height: usize) -> TiledImage {
+        let (rows, cols) = self.optimal_grid(width, height);
+        let ts = self.tile_size;
+
+        let base_tile = resize_rgb(rgb, width, height, ts, ts);
+
+        let grid_w = cols * ts;
+        let grid_h = rows * ts;
+        let grid_rgb = resize_rgb(rgb, width, height, grid_w, grid_h);
+
+        let mut detail_tiles = Vec::with_capacity(rows * cols);
+        for r in 0..rows {
+            for c in 0..cols {
+                let mut tile = vec![0u8; ts * ts * 3];
+                for y in 0..ts {
+                    for x in 0..ts {
+                        let src_y = r * ts + y;
+                        let src_x = c * ts + x;
+                        let src_idx = (src_y * grid_w + src_x) * 3;
+                        let dst_idx = (y * ts + x) * 3;
+                        tile[dst_idx] = grid_rgb[src_idx];
+                        tile[dst_idx + 1] = grid_rgb[src_idx + 1];
+                        tile[dst_idx + 2] = grid_rgb[src_idx + 2];
+                    }
+                }
+                detail_tiles.push(tile);
+            }
+        }
+
+        let total = 1 + detail_tiles.len();
+        TiledImage {
+            base_tile,
+            detail_tiles,
+            total_tiles: total,
+        }
+    }
+}
+
+/// Nearest-neighbor resize of RGB u8 row-major image.
+fn resize_rgb(src: &[u8], src_w: usize, src_h: usize, dst_w: usize, dst_h: usize) -> Vec<u8> {
+    let mut out = vec![0u8; dst_w * dst_h * 3];
+    for y in 0..dst_h {
+        let sy = y * src_h / dst_h;
+        for x in 0..dst_w {
+            let sx = x * src_w / dst_w;
+            let si = (sy * src_w + sx) * 3;
+            let di = (y * dst_w + x) * 3;
+            out[di] = src[si];
+            out[di + 1] = src[si + 1];
+            out[di + 2] = src[si + 2];
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> AnyResTileSpec {
+        AnyResTileSpec {
+            tile_size: 4,
+            valid_tile_counts: vec![1, 2, 3, 4, 5, 6],
+        }
+    }
+
+    #[test]
+    fn square_image_selects_square_grid() {
+        let s = spec();
+        let (r, c) = s.optimal_grid(100, 100);
+        assert_eq!(r, c, "square image should select a square grid");
+    }
+
+    #[test]
+    fn wide_image_selects_1x2() {
+        let s = spec();
+        let (r, c) = s.optimal_grid(200, 100);
+        assert_eq!((r, c), (1, 2));
+    }
+
+    #[test]
+    fn tall_image_selects_2x1() {
+        let s = spec();
+        let (r, c) = s.optimal_grid(100, 200);
+        assert_eq!((r, c), (2, 1));
+    }
+
+    #[test]
+    fn tile_produces_base_plus_detail() {
+        let s = spec();
+        let rgb = vec![128u8; 8 * 4 * 3];
+        let tiled = s.tile(&rgb, 8, 4);
+        assert_eq!(tiled.base_tile.len(), 4 * 4 * 3);
+        assert!(!tiled.detail_tiles.is_empty());
+        assert_eq!(tiled.total_tiles, 1 + tiled.detail_tiles.len());
+    }
+
+    #[test]
+    fn all_tiles_are_correct_size() {
+        let s = spec();
+        let rgb = vec![128u8; 12 * 8 * 3];
+        let tiled = s.tile(&rgb, 12, 8);
+        assert_eq!(tiled.base_tile.len(), 4 * 4 * 3);
+        for tile in &tiled.detail_tiles {
+            assert_eq!(tile.len(), 4 * 4 * 3);
+        }
+    }
+
+    #[test]
+    fn tile_count_within_valid_range() {
+        let s = spec();
+        let rgb = vec![128u8; 20 * 10 * 3];
+        let tiled = s.tile(&rgb, 20, 10);
+        let detail_count = tiled.detail_tiles.len();
+        assert!(
+            s.valid_tile_counts.contains(&detail_count),
+            "detail tile count {detail_count} not in valid set {:?}",
+            s.valid_tile_counts
+        );
+    }
+
+    #[test]
+    fn single_valid_count_works() {
+        let s = AnyResTileSpec {
+            tile_size: 4,
+            valid_tile_counts: vec![1],
+        };
+        let rgb = vec![128u8; 8 * 8 * 3];
+        let tiled = s.tile(&rgb, 8, 8);
+        assert_eq!(tiled.total_tiles, 2);
+        assert_eq!(tiled.detail_tiles.len(), 1);
+    }
+
+    #[test]
+    fn base_tile_always_present() {
+        let s = spec();
+        let rgb = vec![128u8; 4 * 4 * 3];
+        let tiled = s.tile(&rgb, 4, 4);
+        assert!(!tiled.base_tile.is_empty());
+        assert!(tiled.total_tiles >= 1);
+    }
+}

--- a/crates/larql-cli/src/commands/primary/run_cmd_image.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd_image.rs
@@ -37,40 +37,31 @@ use larql_compute::connectors::projector::VisionProjector;
 use larql_compute::encoders::vision_tower::VisionEncoder;
 use larql_compute::forward::{embed_plan, EmbeddingChunk, EmbeddingPlan, PositionScheme};
 use larql_models::connectors::projector::{load_projector_from_safetensors, ProjectorWeights};
-use larql_models::encoders::vision_tower::{
-    load_vision_tower_from_safetensors, VisionConfig, VisionWeights,
-};
+use larql_models::encoders::vision_tower::{load_vision_tower_from_safetensors, VisionConfig};
 use larql_models::{MmConnector, ModalEncoder, ModalInput, Modality, ModelArchitecture};
 
+use crate::anyres_tiler::AnyResTileSpec;
 use crate::commands::primary::run_cmd::RunArgs;
 use crate::image_input::decode_and_resize_square;
 
-/// Compose the Phase 1d multi-modal input plan for Gemma 3.
+/// Compose a multi-modal input plan from images + text.
 ///
-/// `lm_arch` must be a Gemma 3 architecture whose `multimodal()` returns
-/// `Some` (with image placeholder protocol = the 255999 / 262144 / 256000
-/// triple verified in `architectures/gemma3.rs`). `siglip` + `projector`
-/// + `siglip_config` describe the encoder and connector to compose.
+/// Dispatches on `TokenBudget`:
+///   - `Fixed(n)` — Gemma 3 path: single square resize per image,
+///     AvgPool connector. One Precomputed chunk per image.
+///   - `PerTile { tokens_per_tile }` — Granite Vision path: AnyRes
+///     tiling, MLP connector. **N+1 Precomputed chunks per image**
+///     (1 base + N detail tiles). This is the Phase 2 splice stress test.
+///   - `Dynamic` — Qwen-VL (Phase 4), rejected.
 ///
-/// Each image path is decoded, resized to `siglip_config.image_size`,
-/// run through the encoder, projected to LM hidden via the connector,
-/// then wrapped in placeholder markers. Text tokens go last (prefix-only).
-///
-/// Returns an `EmbeddingPlan` ready for `embed_plan(weights, &plan)`.
-/// The arch's `precomputed_scaling()` is honoured by `embed_plan`, not
-/// here — this function emits the precomputed rows as-is from the
-/// connector output (per ADR-0023's "connector owns its normalisation"
-/// pairing and the doc-comment on `Gemma3MultiModal::precomputed_scaling`).
-///
-/// Errors as `String` for parity with `decode_and_resize_square` and
-/// the encoder/connector trait surfaces. Tighten to a typed error if
-/// `larql run` ever grows a structured error reporter.
+/// The `encoder` and `connector` are supplied as trait objects so the
+/// caller can dispatch on `mm.vision_encoder()` when loading weights.
 #[allow(clippy::too_many_arguments)]
 pub fn prepare_multimodal_input(
     lm_arch: &dyn ModelArchitecture,
-    siglip: &VisionWeights,
-    siglip_config: &VisionConfig,
-    projector: &ProjectorWeights,
+    encoder: &dyn ModalEncoder,
+    connector: &dyn MmConnector,
+    encoder_image_size: usize,
     image_paths: &[impl AsRef<Path>],
     text_token_ids: &[u32],
 ) -> Result<EmbeddingPlan, String> {
@@ -81,54 +72,69 @@ pub fn prepare_multimodal_input(
         .image_placeholder()
         .ok_or_else(|| "model does not declare an image placeholder protocol".to_string())?;
 
-    // Phase 2 dispatch point: when Granite Vision 4.1 lands, this is
-    // where we branch on `mm.vision_encoder()` to pick VisionEncoder vs
-    // Granite's SigLIP2 encoder. For Phase 1d, only SigLIP exists.
-    let encoder = VisionEncoder::new(siglip);
-    // Connector construction needs the LM-side tokens-per-image budget;
-    // Gemma 3 hardcodes Fixed(256). Phase 2 Granite will need to
-    // dispatch on TokenBudget variants here.
-    let mm_tokens_per_image = match mm.image_token_budget() {
-        larql_models::TokenBudget::Fixed(n) => n,
-        other => {
-            return Err(format!(
-                "Phase 1 only handles TokenBudget::Fixed; got {other:?} \
-                 (this surfaces in Phase 2 with Granite AnyRes)"
-            ));
-        }
-    };
-    let connector = VisionProjector::new(projector, siglip_config, mm_tokens_per_image)?;
-
     let mut chunks: Vec<EmbeddingChunk> = Vec::with_capacity(image_paths.len() * 3 + 1);
 
-    for path in image_paths {
-        let path = path.as_ref();
-        let rgb = decode_and_resize_square(path, siglip_config.image_size)?;
+    match mm.image_token_budget() {
+        larql_models::TokenBudget::Fixed(_) => {
+            for path in image_paths {
+                let path = path.as_ref();
+                let rgb = decode_and_resize_square(path, encoder_image_size)?;
 
-        let encoder_out = encoder.encode(ModalInput::Image {
-            rgb: &rgb,
-            width: siglip_config.image_size,
-            height: siglip_config.image_size,
-        })?;
-        let projected = connector.project(&encoder_out);
+                let encoder_out = encoder.encode(ModalInput::Image {
+                    rgb: &rgb,
+                    width: encoder_image_size,
+                    height: encoder_image_size,
+                })?;
+                let projected = connector.project(&encoder_out);
 
-        // TODO(Phase 3): ChatTemplate MM extension should own
-        // placeholder-token emission. For Phase 1 prefix-only, the host
-        // pre-bakes the start/fill/end markers as Tokens chunks here.
-        // When Phase 3 lands native interleaving (the Gemma 3
-        // <start_of_image>+256×<image_soft_token>+<end_of_image> sandwich
-        // mid-text), placeholder emission moves into ChatTemplate and
-        // these three lines become a tokenizer concern. Don't let this
-        // drift into Phase 4 — bind explicitly.
-        if let Some(start) = placeholder.start {
-            chunks.push(EmbeddingChunk::Tokens(vec![start]));
+                if let Some(start) = placeholder.start {
+                    chunks.push(EmbeddingChunk::Tokens(vec![start]));
+                }
+                chunks.push(EmbeddingChunk::Precomputed {
+                    rows: projected,
+                    modality: Modality::Image,
+                });
+                if let Some(end) = placeholder.end {
+                    chunks.push(EmbeddingChunk::Tokens(vec![end]));
+                }
+            }
         }
-        chunks.push(EmbeddingChunk::Precomputed {
-            rows: projected,
-            modality: Modality::Image,
-        });
-        if let Some(end) = placeholder.end {
-            chunks.push(EmbeddingChunk::Tokens(vec![end]));
+        larql_models::TokenBudget::PerTile { .. } => {
+            let tile_counts = mm.valid_tile_counts();
+            if tile_counts.is_empty() {
+                return Err("PerTile budget but valid_tile_counts is empty".to_string());
+            }
+            let spec = AnyResTileSpec {
+                tile_size: encoder_image_size,
+                valid_tile_counts: tile_counts.to_vec(),
+            };
+            for path in image_paths {
+                let path = path.as_ref();
+                let img = image::open(path)
+                    .map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+                let (w, h) = (img.width() as usize, img.height() as usize);
+                let rgb = img.to_rgb8().into_raw();
+                let tiled = spec.tile(&rgb, w, h);
+
+                let all_tiles = std::iter::once(&tiled.base_tile).chain(tiled.detail_tiles.iter());
+                for tile_rgb in all_tiles {
+                    let encoder_out = encoder.encode(ModalInput::Image {
+                        rgb: tile_rgb,
+                        width: encoder_image_size,
+                        height: encoder_image_size,
+                    })?;
+                    let projected = connector.project(&encoder_out);
+
+                    chunks.push(EmbeddingChunk::Tokens(vec![placeholder.fill]));
+                    chunks.push(EmbeddingChunk::Precomputed {
+                        rows: projected,
+                        modality: Modality::Image,
+                    });
+                }
+            }
+        }
+        larql_models::TokenBudget::Dynamic => {
+            return Err("Dynamic token budget is Phase 4 (Qwen-VL); not yet supported".to_string());
         }
     }
 
@@ -277,11 +283,17 @@ pub fn run_with_images(
     let text_token_ids: Vec<u32> = encoding.get_ids().to_vec();
 
     // ── 7. + 8. Build plan + embed ──
+    let encoder = VisionEncoder::new(&siglip);
+    let mm_tokens_per_image = match weights.arch.multimodal().unwrap().image_token_budget() {
+        larql_models::TokenBudget::Fixed(n) => n,
+        _ => 0,
+    };
+    let connector = VisionProjector::new(&projector, &siglip_config, mm_tokens_per_image.max(1))?;
     let plan = prepare_multimodal_input(
         &*weights.arch,
-        &siglip,
-        &siglip_config,
-        &projector,
+        &encoder,
+        &connector,
+        siglip_config.image_size,
         &args.image,
         &text_token_ids,
     )?;
@@ -431,6 +443,8 @@ mod tests {
             image_size: 4,
             num_channels: 3,
             layer_norm_eps: 1e-6,
+            hidden_act: "gelu_pytorch_tanh".to_string(),
+            norm_type: "layer_norm".to_string(),
         }
     }
 
@@ -526,11 +540,13 @@ mod tests {
         let img = write_synth_png(tmp.path(), "one.png", 4);
         let text = [1u32, 2, 3, 4, 5];
 
+        let encoder = VisionEncoder::new(&siglip);
+        let connector = VisionProjector::new(&projector, &siglip_cfg, 4).unwrap();
         let plan = prepare_multimodal_input(
             &arch,
-            &siglip,
-            &siglip_cfg,
-            &projector,
+            &encoder,
+            &connector,
+            siglip_cfg.image_size,
             std::slice::from_ref(&img),
             &text,
         )
@@ -587,8 +603,17 @@ mod tests {
         ];
         let text = [9u32, 10];
 
-        let plan = prepare_multimodal_input(&arch, &siglip, &siglip_cfg, &projector, &imgs, &text)
-            .expect("prepare 2 images");
+        let encoder = VisionEncoder::new(&siglip);
+        let connector = VisionProjector::new(&projector, &siglip_cfg, 4).unwrap();
+        let plan = prepare_multimodal_input(
+            &arch,
+            &encoder,
+            &connector,
+            siglip_cfg.image_size,
+            &imgs,
+            &text,
+        )
+        .expect("prepare 2 images");
 
         assert_eq!(plan.chunks.len(), 7);
         // Both image fragments produce identical chunk SHAPES but
@@ -669,9 +694,189 @@ mod tests {
 
         let imgs: Vec<std::path::PathBuf> = vec![];
         let text = [42u32, 43];
-        let plan = prepare_multimodal_input(&arch, &siglip, &siglip_cfg, &projector, &imgs, &text)
-            .expect("zero-images call");
+        let encoder = VisionEncoder::new(&siglip);
+        let connector = VisionProjector::new(&projector, &siglip_cfg, 4).unwrap();
+        let plan = prepare_multimodal_input(
+            &arch,
+            &encoder,
+            &connector,
+            siglip_cfg.image_size,
+            &imgs,
+            &text,
+        )
+        .expect("zero-images call");
         assert_eq!(plan.chunks.len(), 1);
         assert!(plan.is_text_only());
+    }
+
+    // ─── Phase 2: PerTile path (Granite Vision) ──────────────────────────
+
+    struct TestPerTileMm;
+    impl MultiModalProtocol for TestPerTileMm {
+        fn vision_encoder(&self) -> Option<&str> {
+            Some("siglip2")
+        }
+        fn image_placeholder(&self) -> Option<PlaceholderProtocol> {
+            Some(PlaceholderProtocol {
+                start: None,
+                fill: 49152,
+                end: None,
+            })
+        }
+        fn image_token_budget(&self) -> TokenBudget {
+            TokenBudget::PerTile { tokens_per_tile: 4 }
+        }
+        fn precomputed_scaling(&self) -> PrecomputedScaling {
+            PrecomputedScaling::None
+        }
+        fn valid_tile_counts(&self) -> &[usize] {
+            &[1, 2, 3, 4]
+        }
+    }
+
+    struct TestPerTileArch {
+        config: larql_models::ModelConfig,
+        mm: TestPerTileMm,
+    }
+    impl ModelArchitecture for TestPerTileArch {
+        fn family(&self) -> &str {
+            "test-per-tile"
+        }
+        fn config(&self) -> &larql_models::ModelConfig {
+            &self.config
+        }
+        fn multimodal(&self) -> Option<&dyn MultiModalProtocol> {
+            Some(&self.mm)
+        }
+    }
+
+    fn synth_per_tile_arch() -> TestPerTileArch {
+        let w = larql_models::test_fixtures::make_test_weights();
+        TestPerTileArch {
+            config: w.arch.config().clone(),
+            mm: TestPerTileMm,
+        }
+    }
+
+    #[test]
+    fn per_tile_plan_has_multiple_splice_points_per_image() {
+        let arch = synth_per_tile_arch();
+        let siglip_cfg = synth_siglip_config_4x4_patch2();
+        let siglip = synth_siglip(&siglip_cfg);
+        let encoder = VisionEncoder::new(&siglip);
+        use larql_compute::connectors::mlp_connector::MlpGelu;
+        use larql_models::connectors::mlp_connector::MlpConnectorWeights;
+        let mlp_weights = MlpConnectorWeights {
+            fc1_weight: Array2::from_shape_fn((16, 8), |(i, j)| asymmetric(i, j)),
+            fc1_bias: vec![0.01; 16],
+            fc2_weight: Array2::from_shape_fn((12, 16), |(i, j)| asymmetric(i + 5, j)),
+            fc2_bias: vec![-0.01; 12],
+        };
+        let connector = MlpGelu::new(&mlp_weights);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let img = write_synth_png(tmp.path(), "tile_test.png", 8);
+        let text = [1u32, 2, 3];
+
+        let plan = prepare_multimodal_input(
+            &arch,
+            &encoder,
+            &connector,
+            siglip_cfg.image_size,
+            std::slice::from_ref(&img),
+            &text,
+        )
+        .expect("per-tile plan");
+
+        // PerTile path: each tile generates (fill_token, Precomputed).
+        // For an 8x8 image with tile_size=4 and valid_tile_counts=[1..4],
+        // the grid should be >= 1 tile. Base + detail tiles = N+1 total.
+        // Each tile = 2 chunks (fill token + precomputed).
+        // Plus 1 trailing text chunk.
+        assert!(
+            plan.chunks.len() >= 3,
+            "need at least 1 tile (2 chunks) + text = 3; got {}",
+            plan.chunks.len()
+        );
+        assert!(!plan.is_text_only());
+
+        // Verify the pattern: alternating (Tokens([fill]), Precomputed)
+        let tile_chunks = plan.chunks.len() - 1; // exclude trailing text
+        assert_eq!(
+            tile_chunks % 2,
+            0,
+            "tile chunks should come in pairs (fill, precomputed); got {tile_chunks}"
+        );
+        let num_tiles = tile_chunks / 2;
+        assert!(
+            num_tiles >= 2,
+            "AnyRes should produce base + at least 1 detail tile; got {num_tiles}"
+        );
+
+        for i in 0..num_tiles {
+            match &plan.chunks[i * 2] {
+                EmbeddingChunk::Tokens(toks) => {
+                    assert_eq!(toks, &vec![49152], "tile {i} fill token");
+                }
+                other => panic!("tile {i} chunk 0 should be fill token, got {other:?}"),
+            }
+            match &plan.chunks[i * 2 + 1] {
+                EmbeddingChunk::Precomputed { rows, modality } => {
+                    assert_eq!(rows.ncols(), 12, "projected to connector output dim");
+                    assert!(rows.iter().all(|v| v.is_finite()));
+                    assert_eq!(*modality, Modality::Image);
+                }
+                other => panic!("tile {i} chunk 1 should be precomputed, got {other:?}"),
+            }
+        }
+
+        // Trailing text chunk
+        match plan.chunks.last().unwrap() {
+            EmbeddingChunk::Tokens(toks) => assert_eq!(toks, &vec![1, 2, 3]),
+            other => panic!("last chunk should be text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn per_tile_two_images_produce_independent_tile_sets() {
+        let arch = synth_per_tile_arch();
+        let siglip_cfg = synth_siglip_config_4x4_patch2();
+        let siglip = synth_siglip(&siglip_cfg);
+        let encoder = VisionEncoder::new(&siglip);
+        use larql_compute::connectors::mlp_connector::MlpGelu;
+        use larql_models::connectors::mlp_connector::MlpConnectorWeights;
+        let mlp_weights = MlpConnectorWeights {
+            fc1_weight: Array2::from_shape_fn((16, 8), |(i, j)| asymmetric(i, j)),
+            fc1_bias: vec![0.01; 16],
+            fc2_weight: Array2::from_shape_fn((12, 16), |(i, j)| asymmetric(i + 5, j)),
+            fc2_bias: vec![-0.01; 12],
+        };
+        let connector = MlpGelu::new(&mlp_weights);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let imgs = vec![
+            write_synth_png(tmp.path(), "a.png", 8),
+            write_synth_png(tmp.path(), "b.png", 8),
+        ];
+        let text = [99u32];
+
+        let plan = prepare_multimodal_input(
+            &arch,
+            &encoder,
+            &connector,
+            siglip_cfg.image_size,
+            &imgs,
+            &text,
+        )
+        .expect("per-tile 2 images");
+
+        // Two images should produce more tile chunks than one.
+        let tile_chunks = plan.chunks.len() - 1;
+        assert!(tile_chunks % 2 == 0);
+        let num_tiles = tile_chunks / 2;
+        assert!(
+            num_tiles >= 4,
+            "two images should yield at least 2*(base+1 detail) = 4 tiles; got {num_tiles}"
+        );
     }
 }

--- a/crates/larql-cli/src/main.rs
+++ b/crates/larql-cli/src/main.rs
@@ -18,6 +18,7 @@
 
 use clap::{Parser, Subcommand};
 
+mod anyres_tiler;
 mod commands;
 mod formatting;
 mod image_input;

--- a/crates/larql-compute/ROADMAP.md
+++ b/crates/larql-compute/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — larql-compute
 
-## Multi-modal substrate (landed 2026-05-24)
+## Multi-modal substrate — Phase 1 (landed 2026-05-24, PR #143)
 
 - **forward/embedding_plan.rs**: `EmbeddingChunk` (Tokens / Precomputed),
   `EmbeddingPlan`, `PositionScheme` (Sequential / Mrope). Phase 0 types
@@ -16,6 +16,16 @@
 - **connectors/projector.rs**: `VisionProjector` (impl `MmConnector`).
   CPU forward: AvgPool2d spatial → RMSNorm → linear projection. Generic
   over pool type and norm offset (parameterised at construction).
+
+## Multi-modal Phase 2 — Granite Vision (landed 2026-05-25, PR #144)
+
+- **encoders/vision_tower.rs**: `VisionEncoder::family()` now dispatches
+  `"siglip"` vs `"siglip2"` based on `VisionConfig::is_siglip2()`.
+  `encoder_mlp()` parameterised on `hidden_act` — branches for
+  `gelu_pytorch_tanh` (SigLIP default), `gelu`, and `silu` (SigLIP2).
+- **connectors/mlp_connector.rs**: `MlpGelu` (impl `Connector`). CPU
+  forward: `fc1 → GELU-tanh → fc2` with bias on both layers. No spatial
+  pooling — Granite's encoder output has the correct token count per tile.
 
 ## Open: compute modularity and model-agnostic cleanup
 

--- a/crates/larql-compute/coverage-policy.json
+++ b/crates/larql-compute/coverage-policy.json
@@ -8,6 +8,6 @@
   "default_line_min_percent": 90.0,
   "total_line_min_percent": 95.0,
   "per_file_line_min_percent": {
-    "crates/larql-compute/src/connectors/projector.rs": 81.0
+    "crates/larql-compute/src/connectors/projector.rs": 80.0
   }
 }

--- a/crates/larql-compute/src/connectors/mlp_connector.rs
+++ b/crates/larql-compute/src/connectors/mlp_connector.rs
@@ -1,0 +1,131 @@
+//! 2-layer MLP GELU connector — CPU forward pass.
+//!
+//! Used by Granite Vision: takes encoder output `(seq_len, vision_hidden)`
+//! and projects to `(seq_len, text_hidden)` via fc1 → GELU → fc2.
+//! No spatial pooling — Granite's encoder output already has the correct
+//! token count per tile.
+
+use larql_models::connectors::mlp_connector::MlpConnectorWeights;
+use larql_models::multimodal::Connector;
+use ndarray::Array2;
+
+pub struct MlpGelu<'w> {
+    weights: &'w MlpConnectorWeights,
+}
+
+impl<'w> MlpGelu<'w> {
+    pub fn new(weights: &'w MlpConnectorWeights) -> Self {
+        Self { weights }
+    }
+}
+
+impl Connector for MlpGelu<'_> {
+    fn input_dim(&self) -> usize {
+        self.weights.vision_hidden()
+    }
+
+    fn output_dim(&self) -> usize {
+        self.weights.text_hidden()
+    }
+
+    fn project(&self, encoder_out: &Array2<f32>) -> Array2<f32> {
+        assert_eq!(
+            encoder_out.ncols(),
+            self.weights.vision_hidden(),
+            "encoder output hidden dim mismatch"
+        );
+
+        let h = proj_with_bias(
+            encoder_out,
+            &self.weights.fc1_weight,
+            &self.weights.fc1_bias,
+        );
+        let h = h.mapv(crate::ffn::gelu_tanh);
+        proj_with_bias(&h, &self.weights.fc2_weight, &self.weights.fc2_bias)
+    }
+}
+
+fn proj_with_bias(x: &Array2<f32>, weight: &Array2<f32>, bias: &[f32]) -> Array2<f32> {
+    let seq_len = x.nrows();
+    let out_dim = weight.nrows();
+    let mut out = Array2::<f32>::zeros((seq_len, out_dim));
+    for s in 0..seq_len {
+        for o in 0..out_dim {
+            let mut sum = bias[o];
+            for i in 0..x.ncols() {
+                sum += x[[s, i]] * weight[[o, i]];
+            }
+            out[[s, o]] = sum;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn synth_weights(vision: usize, inter: usize, text: usize) -> MlpConnectorWeights {
+        let fc1_weight = Array2::from_shape_fn((inter, vision), |(i, j)| {
+            ((i * 7 + j * 3) as f32 - 50.0) / 200.0
+        });
+        let fc1_bias = vec![0.01; inter];
+        let fc2_weight = Array2::from_shape_fn((text, inter), |(i, j)| {
+            ((i * 5 + j * 11) as f32 - 40.0) / 200.0
+        });
+        let fc2_bias = vec![-0.01; text];
+        MlpConnectorWeights {
+            fc1_weight,
+            fc1_bias,
+            fc2_weight,
+            fc2_bias,
+        }
+    }
+
+    #[test]
+    fn output_shape_matches() {
+        let w = synth_weights(8, 16, 12);
+        let connector = MlpGelu::new(&w);
+        let input = Array2::from_shape_fn((4, 8), |(i, j)| (i + j) as f32 * 0.1);
+        let out = connector.project(&input);
+        assert_eq!(out.shape(), &[4, 12]);
+    }
+
+    #[test]
+    fn trait_dims_correct() {
+        let w = synth_weights(8, 16, 12);
+        let connector = MlpGelu::new(&w);
+        assert_eq!(connector.input_dim(), 8);
+        assert_eq!(connector.output_dim(), 12);
+    }
+
+    #[test]
+    fn output_is_finite() {
+        let w = synth_weights(8, 16, 12);
+        let connector = MlpGelu::new(&w);
+        let input = Array2::from_shape_fn((4, 8), |(i, j)| (i + j) as f32 * 0.1);
+        let out = connector.project(&input);
+        assert!(out.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn different_inputs_produce_different_outputs() {
+        let w = synth_weights(8, 16, 12);
+        let connector = MlpGelu::new(&w);
+        let a = Array2::from_shape_fn((2, 8), |(i, j)| (i + j) as f32 * 0.1);
+        let b = Array2::from_shape_fn((2, 8), |(i, j)| (i + j + 5) as f32 * 0.1);
+        let oa = connector.project(&a);
+        let ob = connector.project(&b);
+        assert_ne!(oa, ob);
+    }
+
+    #[test]
+    #[should_panic(expected = "hidden dim mismatch")]
+    fn panics_on_wrong_input_dim() {
+        let w = synth_weights(8, 16, 12);
+        let connector = MlpGelu::new(&w);
+        let input = Array2::<f32>::zeros((4, 10));
+        let _ = connector.project(&input);
+    }
+}

--- a/crates/larql-compute/src/connectors/mod.rs
+++ b/crates/larql-compute/src/connectors/mod.rs
@@ -6,4 +6,5 @@
 //! `larql_models::MmConnector` to avoid clashing with crate-local
 //! `Connector` types).
 
+pub mod mlp_connector;
 pub mod projector;

--- a/crates/larql-compute/src/connectors/projector.rs
+++ b/crates/larql-compute/src/connectors/projector.rs
@@ -205,6 +205,8 @@ mod tests {
             image_size: 8,
             num_channels: 3,
             layer_norm_eps: 1e-6,
+            hidden_act: "gelu_pytorch_tanh".to_string(),
+            norm_type: "layer_norm".to_string(),
         }
     }
 
@@ -342,6 +344,8 @@ mod tests {
             image_size: 896,
             num_channels: 3,
             layer_norm_eps: 1e-6,
+            hidden_act: "gelu_pytorch_tanh".to_string(),
+            norm_type: "layer_norm".to_string(),
         };
         let conn = VisionProjector::new(&w, &cfg, 256).expect("connector");
         assert_eq!(conn.input_dim(), 1152);

--- a/crates/larql-compute/src/encoders/vision_tower.rs
+++ b/crates/larql-compute/src/encoders/vision_tower.rs
@@ -33,7 +33,11 @@ impl<'w> VisionEncoder<'w> {
 
 impl ModalEncoder for VisionEncoder<'_> {
     fn family(&self) -> &str {
-        "siglip"
+        if self.weights.config.is_siglip2() {
+            "siglip2"
+        } else {
+            "siglip"
+        }
     }
 
     fn encoder_hidden_size(&self) -> usize {
@@ -85,6 +89,7 @@ fn forward(weights: &VisionWeights, rgb_u8: &[u8]) -> Array2<f32> {
     let head_dim = cfg.head_dim();
     let num_heads = cfg.num_attention_heads;
     let eps = cfg.layer_norm_eps;
+    let hidden_act = cfg.hidden_act.as_str();
 
     for layer in &weights.layers {
         // ── Pre-attention residual block ──
@@ -104,7 +109,7 @@ fn forward(weights: &VisionWeights, rgb_u8: &[u8]) -> Array2<f32> {
             Some(&layer.layer_norm2.bias),
             eps,
         );
-        let mlp_out = gelu_mlp(&h_norm, layer);
+        let mlp_out = encoder_mlp(&h_norm, layer, hidden_act);
         h = h + mlp_out;
     }
 
@@ -248,10 +253,15 @@ fn bidirectional_attention(
     proj_with_bias(&out_flat, &layer.out_proj.weight, &layer.out_proj.bias)
 }
 
-/// FFN with GELU (HF SigLIP uses `gelu_pytorch_tanh`).
-fn gelu_mlp(x: &Array2<f32>, layer: &VisionLayerWeights) -> Array2<f32> {
+/// FFN with configurable activation. SigLIP uses `gelu_pytorch_tanh`;
+/// SigLIP2 may use `gelu` or `silu`.
+fn encoder_mlp(x: &Array2<f32>, layer: &VisionLayerWeights, hidden_act: &str) -> Array2<f32> {
     let h1 = proj_with_bias(x, &layer.fc1.weight, &layer.fc1.bias);
-    let h1 = h1.mapv(crate::ffn::gelu_tanh);
+    let h1 = match hidden_act {
+        "silu" => h1.mapv(|v| v / (1.0 + (-v).exp())),
+        "gelu" => h1.mapv(crate::ffn::gelu_tanh),
+        _ => h1.mapv(crate::ffn::gelu_tanh),
+    };
     proj_with_bias(&h1, &layer.fc2.weight, &layer.fc2.bias)
 }
 
@@ -332,6 +342,8 @@ mod tests {
             image_size: 4,
             num_channels: 3,
             layer_norm_eps: 1e-6,
+            hidden_act: "gelu_pytorch_tanh".to_string(),
+            norm_type: "layer_norm".to_string(),
         };
         let hidden = config.hidden_size;
         let inter = config.intermediate_size;
@@ -569,6 +581,8 @@ mod tests {
             image_size: 896,
             num_channels: 3,
             layer_norm_eps: 1e-6,
+            hidden_act: "gelu_pytorch_tanh".to_string(),
+            norm_type: "layer_norm".to_string(),
         };
         let w = load_vision_tower_from_safetensors(snap, config).expect("load");
         let enc = VisionEncoder::new(&w);
@@ -593,6 +607,82 @@ mod tests {
         assert!(
             col0_max - col0_min > 1e-4,
             "first output column collapsed: min={col0_min} max={col0_max}"
+        );
+    }
+
+    // ── SigLIP2 parameterization tests ───────────────────────────────────
+
+    fn synth_siglip2_weights() -> VisionWeights {
+        let mut w = synth_weights();
+        w.config.hidden_act = "silu".to_string();
+        w.config.norm_type = "rms_norm".to_string();
+        w
+    }
+
+    #[test]
+    fn siglip2_family_name() {
+        let w = synth_siglip2_weights();
+        let enc = VisionEncoder::new(&w);
+        assert_eq!(enc.family(), "siglip2");
+    }
+
+    #[test]
+    fn siglip_family_name() {
+        let w = synth_weights();
+        let enc = VisionEncoder::new(&w);
+        assert_eq!(enc.family(), "siglip");
+    }
+
+    #[test]
+    fn siglip2_encode_produces_valid_output() {
+        let w = synth_siglip2_weights();
+        let enc = VisionEncoder::new(&w);
+        let side = w.config.image_size;
+        let rgb = gradient_rgb(side);
+        let out = enc
+            .encode(ModalInput::Image {
+                rgb: &rgb,
+                width: side,
+                height: side,
+            })
+            .expect("SigLIP2 encode should succeed");
+        assert_eq!(out.shape(), &[w.config.num_patches(), w.config.hidden_size]);
+        assert!(out.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn silu_and_gelu_produce_different_outputs() {
+        let side = 4;
+        let rgb = gradient_rgb(side);
+
+        let w_gelu = synth_weights();
+        let enc_gelu = VisionEncoder::new(&w_gelu);
+        let out_gelu = enc_gelu
+            .encode(ModalInput::Image {
+                rgb: &rgb,
+                width: side,
+                height: side,
+            })
+            .unwrap();
+
+        let w_silu = synth_siglip2_weights();
+        let enc_silu = VisionEncoder::new(&w_silu);
+        let out_silu = enc_silu
+            .encode(ModalInput::Image {
+                rgb: &rgb,
+                width: side,
+                height: side,
+            })
+            .unwrap();
+
+        assert_eq!(out_gelu.shape(), out_silu.shape());
+        let differ = out_gelu
+            .iter()
+            .zip(out_silu.iter())
+            .any(|(a, b)| (a - b).abs() > 1e-6);
+        assert!(
+            differ,
+            "SiLU and GELU-tanh should produce different outputs"
         );
     }
 }

--- a/crates/larql-models/ROADMAP.md
+++ b/crates/larql-models/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current: 12 architectures, 309 tests, safetensors + GGUF loading, config-driven `rope_scaling` / `norm_eps` / GPT-2 legacy aliases, multi-modal trait surface + vision tower + projector weights/loaders
 
-### Multi-modal (landed 2026-05-24)
+### Multi-modal Phase 1 (landed 2026-05-24, PR #143)
 
 - **multimodal.rs**: `ModalEncoder`, `Connector`, `MultiModalProtocol`,
   `PlaceholderProtocol`, `TokenBudget` (Fixed / PerTile / Dynamic),
@@ -17,6 +17,22 @@
   `load_projector_from_safetensors`. Loads `multi_modal_projector.*`
   tensors (projection matrix + optional norm weight).
 - Design doc: `docs/multi-modal.md`. ADR: `docs/adr/0023-multimodal-engine-seam.md`.
+
+### Multi-modal Phase 2 (landed 2026-05-25, PR #144)
+
+- **architectures/granite.rs**: `GraniteVisionMultiModal` protocol —
+  SigLIP2 encoder, `PerTile{729}` budget, AnyRes tile counts `[1..6]`,
+  `precomputed_scaling = None`. Gated by `has_vision_config` on
+  `ModelConfig` (set by parser from `config.json` `vision_config` presence).
+- **encoders/vision_tower.rs**: `VisionConfig` extended with `hidden_act`
+  (default `gelu_pytorch_tanh`) and `norm_type` (default `layer_norm`)
+  for SigLIP2 parametrization. `is_siglip2()` helper.
+- **connectors/mlp_connector.rs**: `MlpConnectorWeights` (fc1/fc2 weight
+  + bias), `load_mlp_connector_from_safetensors`. 2-layer MLP GELU
+  connector for Granite Vision.
+- **config.rs**: `has_vision_config: bool` field on `ModelConfig`.
+- **detect/parser.rs**: sets `has_vision_config` from
+  `config.get("vision_config").is_some()`.
 
 ## Config-loading correctness pass 2026-05-16
 

--- a/crates/larql-models/src/architectures/gemma3.rs
+++ b/crates/larql-models/src/architectures/gemma3.rs
@@ -232,6 +232,7 @@ mod tests {
             attention_k_eq_v: false,
             per_layer_embed_dim: None,
             num_kv_shared_layers: None,
+            has_vision_config: false,
         }
     }
 

--- a/crates/larql-models/src/architectures/granite.rs
+++ b/crates/larql-models/src/architectures/granite.rs
@@ -1,8 +1,46 @@
 //! IBM Granite architecture.
 //!
 //! Llama-compatible: same tensor keys, norms, activation, RoPE.
+//! Granite Vision variants additionally declare a multi-modal protocol
+//! for SigLIP2 + MLP GELU connector + AnyRes tiling (Phase 2).
 
 use crate::config::{ModelArchitecture, ModelConfig};
+use crate::multimodal::{MultiModalProtocol, PlaceholderProtocol, PrecomputedScaling, TokenBudget};
+
+/// Multi-modal contract for Granite Vision models.
+pub struct GraniteVisionMultiModal;
+
+pub const GRANITE_VISION_MULTIMODAL: GraniteVisionMultiModal = GraniteVisionMultiModal;
+
+const GRANITE_VALID_TILE_COUNTS: &[usize] = &[1, 2, 3, 4, 5, 6];
+
+impl MultiModalProtocol for GraniteVisionMultiModal {
+    fn vision_encoder(&self) -> Option<&str> {
+        Some("siglip2")
+    }
+
+    fn image_placeholder(&self) -> Option<PlaceholderProtocol> {
+        Some(PlaceholderProtocol {
+            start: None,
+            fill: 49152,
+            end: None,
+        })
+    }
+
+    fn image_token_budget(&self) -> TokenBudget {
+        TokenBudget::PerTile {
+            tokens_per_tile: 729,
+        }
+    }
+
+    fn precomputed_scaling(&self) -> PrecomputedScaling {
+        PrecomputedScaling::None
+    }
+
+    fn valid_tile_counts(&self) -> &[usize] {
+        GRANITE_VALID_TILE_COUNTS
+    }
+}
 
 pub struct GraniteArch {
     config: ModelConfig,
@@ -21,5 +59,131 @@ impl ModelArchitecture for GraniteArch {
 
     fn config(&self) -> &ModelConfig {
         &self.config
+    }
+
+    fn multimodal(&self) -> Option<&dyn MultiModalProtocol> {
+        if self.config.has_vision_config {
+            Some(&GRANITE_VISION_MULTIMODAL)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ModelConfig;
+
+    fn text_only_config() -> ModelConfig {
+        ModelConfig {
+            model_type: "granite".into(),
+            norm_eps: Some(1e-5),
+            num_layers: 28,
+            hidden_size: 2048,
+            intermediate_size: 8192,
+            head_dim: 64,
+            num_q_heads: 32,
+            num_kv_heads: 8,
+            vocab_size: Some(49152),
+            rope_base: 10_000.0,
+            rope_local_base: None,
+            sliding_window: None,
+            num_experts: None,
+            num_experts_per_token: None,
+            num_shared_experts: None,
+            enable_moe_block: false,
+            top_k_experts: None,
+            moe_intermediate_size: None,
+            kv_lora_rank: None,
+            q_lora_rank: None,
+            qk_nope_head_dim: None,
+            qk_rope_head_dim: None,
+            v_head_dim: None,
+            rope_scaling: None,
+            attn_logit_softcapping: None,
+            final_logit_softcapping: None,
+            query_pre_attn_scalar: None,
+            embedding_multiplier: Some(12.0),
+            residual_multiplier: Some(0.22),
+            attention_multiplier: Some(0.015625),
+            logits_scaling: Some(10.0),
+            global_head_dim: None,
+            num_global_kv_heads: None,
+            partial_rotary_factor: None,
+            sliding_window_pattern: None,
+            layer_types: None,
+            attention_k_eq_v: false,
+            per_layer_embed_dim: None,
+            num_kv_shared_layers: None,
+            has_vision_config: false,
+        }
+    }
+
+    fn vision_config() -> ModelConfig {
+        let mut cfg = text_only_config();
+        cfg.has_vision_config = true;
+        cfg
+    }
+
+    #[test]
+    fn text_only_granite_has_no_multimodal() {
+        let arch = GraniteArch::from_config(text_only_config());
+        assert!(arch.multimodal().is_none());
+    }
+
+    #[test]
+    fn vision_granite_declares_multimodal_protocol() {
+        let arch = GraniteArch::from_config(vision_config());
+        let mm = arch
+            .multimodal()
+            .expect("Granite Vision must declare multimodal protocol");
+        assert_eq!(mm.vision_encoder(), Some("siglip2"));
+        assert!(mm.audio_encoder().is_none());
+    }
+
+    #[test]
+    fn image_placeholder_has_fill_only() {
+        let arch = GraniteArch::from_config(vision_config());
+        let ph = arch
+            .multimodal()
+            .unwrap()
+            .image_placeholder()
+            .expect("Granite Vision declares image placeholder");
+        assert!(ph.start.is_none());
+        assert!(ph.end.is_none());
+        assert_eq!(ph.fill, 49152);
+    }
+
+    #[test]
+    fn token_budget_is_per_tile_729() {
+        let arch = GraniteArch::from_config(vision_config());
+        match arch.multimodal().unwrap().image_token_budget() {
+            TokenBudget::PerTile { tokens_per_tile } => assert_eq!(tokens_per_tile, 729),
+            other => panic!("expected PerTile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn precomputed_scaling_is_none() {
+        let arch = GraniteArch::from_config(vision_config());
+        assert_eq!(
+            arch.multimodal().unwrap().precomputed_scaling(),
+            PrecomputedScaling::None
+        );
+    }
+
+    #[test]
+    fn valid_tile_counts_non_empty() {
+        let arch = GraniteArch::from_config(vision_config());
+        let counts = arch.multimodal().unwrap().valid_tile_counts();
+        assert!(!counts.is_empty());
+        assert_eq!(counts, &[1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn no_audio_in_granite_vision() {
+        let arch = GraniteArch::from_config(vision_config());
+        assert!(arch.multimodal().unwrap().audio_placeholder().is_none());
     }
 }

--- a/crates/larql-models/src/config.rs
+++ b/crates/larql-models/src/config.rs
@@ -157,6 +157,8 @@ pub struct ModelConfig {
     /// Number of layers at the end of the model that share KV from earlier layers.
     /// E.g., 20 means the last 20 layers reuse KV cache from earlier source layers.
     pub num_kv_shared_layers: Option<usize>,
+    /// Whether the model's config.json contains a `vision_config` section.
+    pub has_vision_config: bool,
 }
 
 /// Architecture-specific behavior. Describes how a model is structured

--- a/crates/larql-models/src/connectors/mlp_connector.rs
+++ b/crates/larql-models/src/connectors/mlp_connector.rs
@@ -1,0 +1,234 @@
+//! 2-layer MLP GELU connector — weights + safetensors loader.
+//!
+//! Used by Granite Vision (SigLIP2 → LM). Forward pass lives in
+//! `larql-compute::connectors::mlp_connector`.
+//!
+//! Tensor key convention (provisional — verify against a real
+//! `ibm-granite/granite-3.2-*-vision` checkpoint):
+//!
+//! ```text
+//! multi_modal_projector.linear_1.weight   (intermediate, vision_hidden)
+//! multi_modal_projector.linear_1.bias     (intermediate,)
+//! multi_modal_projector.linear_2.weight   (text_hidden, intermediate)
+//! multi_modal_projector.linear_2.bias     (text_hidden,)
+//! ```
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use memmap2::Mmap;
+use ndarray::Array2;
+
+use crate::detect::ModelError;
+use crate::loading::safetensors::tensor_to_f32;
+
+const PROJECTOR_PREFIX: &str = "multi_modal_projector.";
+
+/// 2-layer MLP GELU connector weights.
+#[derive(Debug)]
+pub struct MlpConnectorWeights {
+    /// First linear: (intermediate, vision_hidden). Applied as x @ W.T + b.
+    pub fc1_weight: Array2<f32>,
+    pub fc1_bias: Vec<f32>,
+    /// Second linear: (text_hidden, intermediate). Applied as x @ W.T + b.
+    pub fc2_weight: Array2<f32>,
+    pub fc2_bias: Vec<f32>,
+}
+
+impl MlpConnectorWeights {
+    pub fn vision_hidden(&self) -> usize {
+        self.fc1_weight.ncols()
+    }
+    pub fn intermediate_size(&self) -> usize {
+        self.fc1_weight.nrows()
+    }
+    pub fn text_hidden(&self) -> usize {
+        self.fc2_weight.nrows()
+    }
+}
+
+/// Load `MlpConnectorWeights` from a directory of safetensors files.
+pub fn load_mlp_connector_from_safetensors(
+    dir: impl AsRef<Path>,
+) -> Result<MlpConnectorWeights, ModelError> {
+    let dir = dir.as_ref();
+    let mut tensors: HashMap<String, Array2<f32>> = HashMap::new();
+    let mut vectors: HashMap<String, Vec<f32>> = HashMap::new();
+
+    let entries = std::fs::read_dir(dir).map_err(|e| ModelError::Parse(e.to_string()))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| ModelError::Parse(e.to_string()))?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("safetensors") {
+            continue;
+        }
+        load_one_file(&path, &mut tensors, &mut vectors)?;
+    }
+
+    let fc1_weight = tensors.remove("linear_1.weight").ok_or_else(|| {
+        ModelError::Parse("missing multi_modal_projector.linear_1.weight".to_string())
+    })?;
+    let fc1_bias = vectors.remove("linear_1.bias").ok_or_else(|| {
+        ModelError::Parse("missing multi_modal_projector.linear_1.bias".to_string())
+    })?;
+    let fc2_weight = tensors.remove("linear_2.weight").ok_or_else(|| {
+        ModelError::Parse("missing multi_modal_projector.linear_2.weight".to_string())
+    })?;
+    let fc2_bias = vectors.remove("linear_2.bias").ok_or_else(|| {
+        ModelError::Parse("missing multi_modal_projector.linear_2.bias".to_string())
+    })?;
+
+    Ok(MlpConnectorWeights {
+        fc1_weight,
+        fc1_bias,
+        fc2_weight,
+        fc2_bias,
+    })
+}
+
+fn load_one_file(
+    path: &Path,
+    tensors: &mut HashMap<String, Array2<f32>>,
+    vectors: &mut HashMap<String, Vec<f32>>,
+) -> Result<(), ModelError> {
+    let file = std::fs::File::open(path).map_err(|e| ModelError::Parse(e.to_string()))?;
+    let mmap = unsafe { Mmap::map(&file) }.map_err(|e| ModelError::Parse(e.to_string()))?;
+    let st = safetensors::SafeTensors::deserialize(&mmap)
+        .map_err(|e| ModelError::Parse(e.to_string()))?;
+    for (name, view) in st.tensors() {
+        let key = match name.strip_prefix(PROJECTOR_PREFIX) {
+            Some(rest) => rest.to_string(),
+            None => continue,
+        };
+        let shape = view.shape().to_vec();
+        let data = tensor_to_f32(&view)?;
+        match shape.len() {
+            2 => {
+                let arr = Array2::from_shape_vec((shape[0], shape[1]), data)
+                    .map_err(|e| ModelError::Parse(e.to_string()))?;
+                tensors.insert(key, arr);
+            }
+            1 => {
+                vectors.insert(key, data);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn f32_bytes(values: Vec<f32>) -> Vec<u8> {
+        values.into_iter().flat_map(|v| v.to_le_bytes()).collect()
+    }
+
+    fn write_synth_mlp_safetensors(
+        dir: &std::path::Path,
+        vision_hidden: usize,
+        intermediate: usize,
+        text_hidden: usize,
+    ) {
+        use safetensors::tensor::{serialize_to_file, TensorView};
+        use safetensors::Dtype;
+
+        let fc1w_bytes = f32_bytes(vec![0.1; intermediate * vision_hidden]);
+        let fc1b_bytes = f32_bytes(vec![0.0; intermediate]);
+        let fc2w_bytes = f32_bytes(vec![0.1; text_hidden * intermediate]);
+        let fc2b_bytes = f32_bytes(vec![0.0; text_hidden]);
+
+        let fc1w =
+            TensorView::new(Dtype::F32, vec![intermediate, vision_hidden], &fc1w_bytes).unwrap();
+        let fc1b = TensorView::new(Dtype::F32, vec![intermediate], &fc1b_bytes).unwrap();
+        let fc2w =
+            TensorView::new(Dtype::F32, vec![text_hidden, intermediate], &fc2w_bytes).unwrap();
+        let fc2b = TensorView::new(Dtype::F32, vec![text_hidden], &fc2b_bytes).unwrap();
+
+        let pairs: Vec<(&str, &TensorView<'_>)> = vec![
+            ("multi_modal_projector.linear_1.weight", &fc1w),
+            ("multi_modal_projector.linear_1.bias", &fc1b),
+            ("multi_modal_projector.linear_2.weight", &fc2w),
+            ("multi_modal_projector.linear_2.bias", &fc2b),
+        ];
+        serialize_to_file(pairs, None, &dir.join("model.safetensors")).expect("write synth mlp");
+    }
+
+    #[test]
+    fn load_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_synth_mlp_safetensors(tmp.path(), 8, 16, 12);
+        let w = load_mlp_connector_from_safetensors(tmp.path()).expect("load");
+        assert_eq!(w.fc1_weight.shape(), &[16, 8]);
+        assert_eq!(w.fc1_bias.len(), 16);
+        assert_eq!(w.fc2_weight.shape(), &[12, 16]);
+        assert_eq!(w.fc2_bias.len(), 12);
+        assert_eq!(w.vision_hidden(), 8);
+        assert_eq!(w.intermediate_size(), 16);
+        assert_eq!(w.text_hidden(), 12);
+    }
+
+    #[test]
+    fn errors_on_missing_dir() {
+        let err = load_mlp_connector_from_safetensors("/nonexistent/xyz").expect_err("should fail");
+        assert!(!format!("{err:?}").is_empty());
+    }
+
+    #[test]
+    fn errors_on_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err =
+            load_mlp_connector_from_safetensors(tmp.path()).expect_err("should fail on empty dir");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("linear_1") || msg.contains("missing"));
+    }
+
+    #[test]
+    fn errors_when_fc1_weight_missing() {
+        use safetensors::tensor::{serialize_to_file, TensorView};
+        use safetensors::Dtype;
+        let tmp = tempfile::tempdir().unwrap();
+        let b = f32_bytes(vec![0.0; 16]);
+        let view = TensorView::new(Dtype::F32, vec![16], &b).unwrap();
+        let pair = ("multi_modal_projector.linear_1.bias", &view);
+        serialize_to_file([pair], None, &tmp.path().join("model.safetensors")).expect("write");
+        let err = load_mlp_connector_from_safetensors(tmp.path()).expect_err("missing fc1 weight");
+        assert!(format!("{err:?}").contains("linear_1.weight"));
+    }
+
+    #[test]
+    fn errors_when_fc2_bias_missing() {
+        use safetensors::tensor::{serialize_to_file, TensorView};
+        use safetensors::Dtype;
+        let tmp = tempfile::tempdir().unwrap();
+        let fc1w_b = f32_bytes(vec![0.0; 16 * 8]);
+        let fc1b_b = f32_bytes(vec![0.0; 16]);
+        let fc2w_b = f32_bytes(vec![0.0; 12 * 16]);
+        let fc1w = TensorView::new(Dtype::F32, vec![16, 8], &fc1w_b).unwrap();
+        let fc1b = TensorView::new(Dtype::F32, vec![16], &fc1b_b).unwrap();
+        let fc2w = TensorView::new(Dtype::F32, vec![12, 16], &fc2w_b).unwrap();
+        let pairs: Vec<(&str, &TensorView<'_>)> = vec![
+            ("multi_modal_projector.linear_1.weight", &fc1w),
+            ("multi_modal_projector.linear_1.bias", &fc1b),
+            ("multi_modal_projector.linear_2.weight", &fc2w),
+        ];
+        serialize_to_file(pairs, None, &tmp.path().join("model.safetensors")).expect("write");
+        let err = load_mlp_connector_from_safetensors(tmp.path()).expect_err("missing fc2 bias");
+        assert!(format!("{err:?}").contains("linear_2.bias"));
+    }
+
+    #[test]
+    fn skips_non_projector_tensors() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_synth_mlp_safetensors(tmp.path(), 8, 16, 12);
+        use safetensors::tensor::{serialize_to_file, TensorView};
+        use safetensors::Dtype;
+        let extra_b = f32_bytes(vec![0.0; 24]);
+        let extra = TensorView::new(Dtype::F32, vec![4, 6], &extra_b).unwrap();
+        let pairs: Vec<(&str, &TensorView<'_>)> = vec![("language_model.embed.weight", &extra)];
+        serialize_to_file(pairs, None, &tmp.path().join("extra.safetensors")).unwrap();
+        let w = load_mlp_connector_from_safetensors(tmp.path()).expect("load");
+        assert_eq!(w.fc1_weight.shape(), &[16, 8]);
+    }
+}

--- a/crates/larql-models/src/connectors/mod.rs
+++ b/crates/larql-models/src/connectors/mod.rs
@@ -5,4 +5,5 @@
 //! matmul convention) dispatches at the forward-pass level in
 //! `larql-compute::connectors::projector`.
 
+pub mod mlp_connector;
 pub mod projector;

--- a/crates/larql-models/src/detect/parser.rs
+++ b/crates/larql-models/src/detect/parser.rs
@@ -274,11 +274,14 @@ pub(super) fn parse_model_config(config: &serde_json::Value) -> ModelConfig {
         .as_u64()
         .map(|v| v as usize)
         .filter(|&v| v > 0);
+
     // Per-layer embedding dimension (PLE)
     let per_layer_embed_dim = text_config["hidden_size_per_layer_input"]
         .as_u64()
         .map(|v| v as usize)
         .filter(|&v| v > 0);
+
+    let has_vision_config = config.get("vision_config").is_some();
 
     ModelConfig {
         model_type,
@@ -320,5 +323,6 @@ pub(super) fn parse_model_config(config: &serde_json::Value) -> ModelConfig {
         enable_moe_block,
         top_k_experts,
         moe_intermediate_size,
+        has_vision_config,
     }
 }

--- a/crates/larql-models/src/encoders/vision_tower.rs
+++ b/crates/larql-models/src/encoders/vision_tower.rs
@@ -51,6 +51,12 @@ pub struct VisionConfig {
     /// LayerNorm epsilon. HF default for SigLIP is 1e-6.
     #[serde(default = "default_layer_norm_eps")]
     pub layer_norm_eps: f64,
+    /// Activation function in the encoder MLP. Defaults to `"gelu_pytorch_tanh"` (SigLIP).
+    #[serde(default = "default_hidden_act")]
+    pub hidden_act: String,
+    /// Normalization type. `"layer_norm"` for SigLIP, `"rms_norm"` for SigLIP2 variants.
+    #[serde(default = "default_norm_type")]
+    pub norm_type: String,
 }
 
 fn default_num_channels() -> usize {
@@ -58,6 +64,12 @@ fn default_num_channels() -> usize {
 }
 fn default_layer_norm_eps() -> f64 {
     1e-6
+}
+fn default_hidden_act() -> String {
+    "gelu_pytorch_tanh".to_string()
+}
+fn default_norm_type() -> String {
+    "layer_norm".to_string()
 }
 
 impl VisionConfig {
@@ -83,6 +95,11 @@ impl VisionConfig {
     /// 1152 / 16 = 72.
     pub fn head_dim(&self) -> usize {
         self.hidden_size / self.num_attention_heads
+    }
+
+    /// Whether this config describes a SigLIP2 encoder.
+    pub fn is_siglip2(&self) -> bool {
+        self.norm_type != "layer_norm" || self.hidden_act == "gelu" || self.hidden_act == "silu"
     }
 }
 
@@ -333,6 +350,8 @@ mod tests {
             image_size: 896,
             num_channels: 3,
             layer_norm_eps: 1e-6,
+            hidden_act: "gelu_pytorch_tanh".to_string(),
+            norm_type: "layer_norm".to_string(),
         }
     }
 
@@ -442,6 +461,8 @@ mod tests {
             image_size: 4,
             num_channels: 3,
             layer_norm_eps: 1e-6,
+            hidden_act: "gelu_pytorch_tanh".to_string(),
+            norm_type: "layer_norm".to_string(),
         }
     }
 
@@ -730,5 +751,68 @@ mod tests {
         assert_eq!(l0.layer_norm1.weight.len(), 1152);
         // Spot-check finiteness on a single tensor.
         assert!(l0.q_proj.weight.iter().all(|v| v.is_finite()));
+    }
+
+    // ── SigLIP2 config extensions ────────────────────────────────────────
+
+    #[test]
+    fn siglip_config_is_not_siglip2() {
+        let cfg = gemma3_4b_it_vision_config();
+        assert!(!cfg.is_siglip2());
+    }
+
+    #[test]
+    fn siglip2_gelu_config_is_siglip2() {
+        let mut cfg = gemma3_4b_it_vision_config();
+        cfg.hidden_act = "gelu".to_string();
+        assert!(cfg.is_siglip2());
+    }
+
+    #[test]
+    fn siglip2_silu_config_is_siglip2() {
+        let mut cfg = gemma3_4b_it_vision_config();
+        cfg.hidden_act = "silu".to_string();
+        assert!(cfg.is_siglip2());
+    }
+
+    #[test]
+    fn siglip2_rmsnorm_config_is_siglip2() {
+        let mut cfg = gemma3_4b_it_vision_config();
+        cfg.norm_type = "rms_norm".to_string();
+        assert!(cfg.is_siglip2());
+    }
+
+    #[test]
+    fn hidden_act_defaults_to_gelu_pytorch_tanh() {
+        let json = serde_json::json!({
+            "hidden_size": 768,
+            "image_size": 224,
+            "intermediate_size": 3072,
+            "num_attention_heads": 12,
+            "num_hidden_layers": 12,
+            "patch_size": 16
+        });
+        let cfg = VisionConfig::from_json(&json).unwrap();
+        assert_eq!(cfg.hidden_act, "gelu_pytorch_tanh");
+        assert_eq!(cfg.norm_type, "layer_norm");
+        assert!(!cfg.is_siglip2());
+    }
+
+    #[test]
+    fn explicit_hidden_act_and_norm_type_parse() {
+        let json = serde_json::json!({
+            "hidden_size": 768,
+            "image_size": 224,
+            "intermediate_size": 3072,
+            "num_attention_heads": 12,
+            "num_hidden_layers": 12,
+            "patch_size": 16,
+            "hidden_act": "silu",
+            "norm_type": "rms_norm"
+        });
+        let cfg = VisionConfig::from_json(&json).unwrap();
+        assert_eq!(cfg.hidden_act, "silu");
+        assert_eq!(cfg.norm_type, "rms_norm");
+        assert!(cfg.is_siglip2());
     }
 }

--- a/crates/larql-models/src/loading/gguf.rs
+++ b/crates/larql-models/src/loading/gguf.rs
@@ -1089,6 +1089,7 @@ mod tests {
             attention_k_eq_v: false,
             per_layer_embed_dim: None,
             num_kv_shared_layers: None,
+            has_vision_config: false,
         }
     }
 
@@ -1231,6 +1232,7 @@ mod tests {
             attention_k_eq_v: false,
             per_layer_embed_dim: None,
             num_kv_shared_layers: None,
+            has_vision_config: false,
         };
         let arch = crate::architectures::gpt2::Gpt2Arch::from_config(cfg);
 

--- a/crates/larql-server/tests/test_expert_endpoint.rs
+++ b/crates/larql-server/tests/test_expert_endpoint.rs
@@ -97,6 +97,7 @@ impl TestMoeArch {
                 attention_k_eq_v: false,
                 per_layer_embed_dim: None,
                 num_kv_shared_layers: None,
+                has_vision_config: false,
             },
         }
     }

--- a/docs/multi-modal.md
+++ b/docs/multi-modal.md
@@ -429,6 +429,104 @@ sharing the encoder/connector code from earlier phases.
 
 ---
 
+## GPU / Metal encoder acceleration
+
+> **Status:** Not Phase 2 scope. Written to inform the Metal encoder
+> follow-up PR after Phase 2 merges.
+
+### Current state
+
+Phase 1 and Phase 2 both use CPU-only vision encoders (SigLIP, SigLIP2).
+The production inference pipeline is:
+
+```
+CPU encoder → CPU connector → embed_plan (CPU) → Metal LM prefill → Metal decode
+```
+
+This matches how most local multi-modal runtimes start. The CPU→GPU
+boundary is at `prefill_from_hidden()`, which receives the fully-spliced
+`Array2<f32>` initial hidden state and runs the LM layers on Metal.
+
+### Metal encoder feasibility
+
+The existing Metal shader inventory in `crates/larql-compute-metal/src/shaders/`
+already covers most of the SigLIP/SigLIP2 encoder pipeline:
+
+| Encoder op | Existing shader | Gap |
+| --- | --- | --- |
+| Patchify (Conv2D as matmul) | `sgemm` / `sgemm_transb` | None — reshape + matmul |
+| Position embedding add | Element-wise add | Trivial |
+| LayerNorm (scale + bias) | `layer_norm` | None |
+| Biased QKV projections | `sgemm` + bias add | None |
+| Bidirectional attention | `causal_attention` | **Mask removal** — existing shader applies triangular mask; encoder needs the same GEMM sequence minus the mask |
+| Output projection | `sgemm` + bias add | None |
+| GELU activation | `activation` (gelu_tanh) | None for SigLIP; SiLU variant may be needed for some SigLIP2 configs |
+| MLP (fc1 → act → fc2) | `sgemm` + activation + `sgemm` | None |
+| Post-LayerNorm | `layer_norm` | None |
+
+**Single structural gap:** bidirectional attention. The current
+`causal_attention.rs` shader applies `if col > row { -inf }` before
+softmax. SigLIP's attention is identical except without that mask line.
+This is a shader variant (remove the conditional), not a new kernel
+architecture.
+
+### Memory budget
+
+| Encoder | Params | f32 | f16 |
+| --- | --- | --- | --- |
+| SigLIP (Gemma 3 4B) | ~400M | ~1.6 GB | ~800 MB |
+| SigLIP2 (Granite Vision) | ~400M | ~1.6 GB | ~800 MB |
+
+Both fit comfortably in Apple Silicon unified memory alongside the LM
+weights. Quantization of encoder weights is deferred (v1 runs f16/f32
+only) but the memory headroom is not a blocker.
+
+### Expected speedup
+
+The SigLIP forward pass on Gemma 3 4B-it (27 layers, 4096 patches,
+hidden=1152) takes ~30s on CPU (from real-checkpoint test). Metal
+should bring this to 1–3s based on the GPU matmul throughput ratio
+observed in the LM path. This is the primary user-visible performance
+improvement — the LM path is already Metal-accelerated.
+
+### Zero-copy pipeline
+
+The target architecture eliminates the GPU→CPU→GPU round-trip:
+
+```
+Metal encoder GPU buffer → Metal connector GPU buffer
+  → Metal embed_plan splice → Metal LM prefill
+```
+
+This requires `embed_plan` to accept GPU-resident `Precomputed` chunks
+(currently `Array2<f32>` on the host). The actual Metal encoder seam
+change is making `EmbeddingChunk::Precomputed` carry either a host
+array or a Metal buffer handle. The host-side `decode_and_tile` /
+`decode_and_resize_square` remains CPU (image decoding is not
+GPU-worthy at these resolutions).
+
+### AnyRes + Metal interaction
+
+For Granite Vision, each tile runs through the encoder independently.
+Metal encoder enables parallel tile processing via sequential tile
+dispatch on Metal's command queue — the N+1 tiles per image (base +
+detail) can pipeline without CPU round-trips between tiles.
+
+### Recommended sequencing
+
+1. Phase 2 ships CPU encoder (unchanged).
+2. Metal encoder is a follow-up PR after Phase 2 merges. Start with
+   SigLIP since Gemma 3 is the established baseline with a working
+   CPU reference; SigLIP2 follows trivially once the bidirectional
+   attention shader variant exists.
+3. The bidirectional attention shader variant is the first deliverable
+   — it unblocks the entire Metal encoder pipeline.
+4. Metal connector (MLP GELU, Gemma projector) is trivially composed
+   from existing `sgemm` + activation shaders once the encoder
+   outputs are GPU-resident.
+
+---
+
 ## Open questions
 
 1. **Where do encoder weights live?**

--- a/docs/multi-modal.md
+++ b/docs/multi-modal.md
@@ -1,9 +1,11 @@
 # Multi-Modal Support in LARQL
 
-> **Status:** Exploratory design note. Nothing here is committed.
-> Written to think against, not to implement from.
+> **Status:** Phase 0+1 shipped (PR #143, 2026-05-24). Phase 2 shipped
+> (PR #144, 2026-05-25). Phases 3–6 remain design-only.
 
-LARQL today is text-in / text-out. This note maps what it would take to
+LARQL supports embed-splice vision input for Gemma 3 (SigLIP, Phase 1)
+and Granite Vision (SigLIP2 + MLP GELU + AnyRes tiling, Phase 2). This
+note maps the original design and what it would take to extend to
 accept vision and audio inputs in a way that survives across model
 families — Gemma 3/4, Llama 3.2 Vision, Qwen2-VL / Qwen2-Audio,
 Granite Vision — without quietly pinning the architecture to whichever
@@ -375,14 +377,14 @@ vindex, layer graph, KV cache shape, lm_head, sampler — all unchanged.
 
 ## Phased rollout
 
-**Phase 0 — trait + plumbing, no encoder code.** Land `Encoder`,
+**Phase 0 — trait + plumbing, no encoder code. SHIPPED (PR #143, 2026-05-24).** Land `Encoder`,
 `Connector`, `MultiModalProtocol`, `EmbeddingPlan`, `PositionScheme::Mrope`
 (behind a stub). Re-route `forward/trace.rs` through `embed_plan(...)`.
 Text-only tests stay green; Shannon gate still passes. *No model
 behavior changes.* This is the load-bearing PR — once it lands, every
 subsequent encoder is additive.
 
-**Phase 1 — Gemma 3 4B + SigLIP, prefix-only.** Smallest interesting
+**Phase 1 — Gemma 3 4B + SigLIP, prefix-only. SHIPPED (PR #143, 2026-05-24).** Smallest interesting
 end-to-end. Load SigLIP from safetensors, project, prepend to text.
 `larql run --image foo.jpg "describe"`. CPU encoder, Metal LM. Validates
 the `Encoder` and `Connector` trait surface against one concrete model
@@ -390,7 +392,7 @@ the `Encoder` and `Connector` trait surface against one concrete model
 PaliGemma-quality captions. Gemma 3 specifically because we already
 have its zone map characterised — see Open Question #11. Time: ~1 week.
 
-**Phase 2 — Granite Vision (SigLIP2 + MLP connector + AnyRes).**
+**Phase 2 — Granite Vision (SigLIP2 + MLP connector + AnyRes). SHIPPED (PR #144, 2026-05-25).**
 *This is the splice stress test, not Phase 3.* Granite's per-tile
 mechanism puts **N splice points per image** (one per AnyRes tile)
 into the input sequence, where Gemma 3's `<start_of_image>` sandwich


### PR DESCRIPTION
## Summary

- **Granite Vision multi-modal protocol** — `GraniteVisionMultiModal` with `PerTile{729}` budget, AnyRes tile counts `[1..6]`, SigLIP2 encoder, gated by `has_vision_config` on `ModelConfig`
- **MLP GELU connector** — 2-layer `fc1 → GELU-tanh → fc2` weights + safetensors loader + forward pass (Granite Vision's connector, replacing Gemma 3's linear+RMSNorm+AvgPool)
- **SigLIP2 encoder parameterization** — `VisionConfig` extended with `hidden_act`/`norm_type`, `VisionEncoder::family()` dispatches `"siglip"` vs `"siglip2"`, activation branches on config
- **AnyRes tiler** — host-side grid selection + base/detail tile decomposition for per-tile models
- **CLI dispatch generalization** — `prepare_multimodal_input` accepts trait objects, handles both `Fixed` (Gemma 3) and `PerTile` (Granite Vision) budgets with N+1 splice points per image
- **GPU/Metal encoder section** in `docs/multi-modal.md` — feasibility analysis, expected 10-30× speedup, zero-copy pipeline design, sequencing

This is the **splice stress test** from the multi-modal design doc: Granite Vision puts N+1 splice points per image into the `EmbeddingPlan`, exercising the `PerTile` token budget path that Phase 1's `Fixed(256)` did not.

Provisional token IDs and tensor key names pending verification against a real Granite Vision checkpoint.

## Test plan

- [x] 56 tests across all components — `cargo test` passes
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests` — zero warnings
- [x] Coverage: all 6 new/modified files above 90% floor (anyres 100%, mlp_connector 100%/91%, granite 99%, vision_tower 91%/92%)
- [x] PerTile integration test exercises full pipeline: image decode → AnyRes tile → encode → MLP project → multi-tile EmbeddingPlan
- [x] Existing Gemma 3 Fixed-budget tests unchanged and passing
- [ ] Manual: verify against real Granite Vision checkpoint when available