### PR TITLE
fix(moe-shards): guard empty q4 dense FFN + wire --metal (closes #151)

### DIFF
--- a/crates/larql-cli/src/commands/primary/run_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd.rs
@@ -334,6 +334,7 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
             args.max_tokens,
             &args.moe_dispatch,
             args.moe_predispatch_iters,
+            args.metal,
         );
     }
 
@@ -463,6 +464,7 @@ fn run_with_moe_shards(
     max_tokens: usize,
     dispatch: &str,
     predispatch_iters: usize,
+    metal: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use larql_inference::ffn::moe_remote::{parse_unit_manifest, RemoteMoeBackend, ShardConfig};
     use larql_inference::{generate_with_remote_moe, generate_with_remote_moe_batch};
@@ -510,7 +512,22 @@ fn run_with_moe_shards(
 
     let num_shards = configs.len();
     // Initialise compute backend early so we can report it in the topology banner.
-    let backend = larql_compute::default_backend();
+    // Mirrors the `--metal` wiring in `run_with_remote_ffn` (PR #122): explicit
+    // opt-in via the CLI flag, with Metal-init failure falling back to CPU.
+    let backend: Box<dyn larql_compute::ComputeBackend> = if metal {
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        {
+            larql_compute_metal::metal_backend()
+                .map(|m| Box::new(m) as Box<dyn larql_compute::ComputeBackend>)
+                .unwrap_or_else(larql_compute::cpu_backend)
+        }
+        #[cfg(not(all(feature = "gpu", target_os = "macos")))]
+        {
+            return Err("`--metal` requires the `gpu` feature on macOS".into());
+        }
+    } else {
+        larql_compute::cpu_backend()
+    };
     eprintln!("Connecting to {} MoE shard(s)…", num_shards);
     let remote = RemoteMoeBackend::connect(configs)
         .map_err(|e| format!("failed to connect to MoE shards: {e}"))?;

--- a/crates/larql-compute/src/pipeline_layer.rs
+++ b/crates/larql-compute/src/pipeline_layer.rs
@@ -417,6 +417,22 @@ pub fn resolve_ffn_weights<'a>(
         );
     }
 
+    // Pure MoE vindexes (e.g. Gemma-4 26B A4B) have no dense FFN tensor, so
+    // `interleaved_q4k.bin` is 0 bytes. The interleaved-kquant branch above is
+    // also absent for these (no per-matrix manifest entries), so we fall through
+    // here with an empty `q4_ffn_mmap`. Return empty `QuantWeight` stubs —
+    // `patch_pipeline_layers_for_remote_moe` (below) overwrites the per-layer
+    // dense weights for MoE layers, and `moe_fn` supersedes the dense FFN path
+    // during decode, so the empty slices are never read.
+    if q4_ffn_mmap.is_empty() {
+        let empty = QuantWeight {
+            data: &[],
+            scales: None,
+            format: ffn_format,
+        };
+        return (empty, empty, empty);
+    }
+
     let q4_ffn_per_layer = q4_ffn_per_matrix * 3;
     let fs = layer * q4_ffn_per_layer;
     (
@@ -767,5 +783,31 @@ mod tests {
         for l in &layers {
             assert!(l.ffn_is_remote, "patch should set ffn_is_remote = true");
         }
+    }
+
+    /// Pure-MoE vindexes (e.g. Gemma-4 26B A4B) ship a zero-byte
+    /// `interleaved_q4k.bin` because there is no dense FFN. Before the
+    /// `is_empty()` guard, `resolve_ffn_weights` would panic on the first
+    /// `q4_ffn_mmap[fs..fs + q4_ffn_per_matrix]` slice. The guard returns
+    /// empty `QuantWeight` stubs — `patch_pipeline_layers_for_remote_moe`
+    /// overwrites the per-layer MoE weights afterward and the dense FFN
+    /// path is bypassed entirely by `moe_fn` during decode, so the empty
+    /// slices are never read.
+    #[test]
+    fn resolve_ffn_weights_returns_empty_stubs_when_q4_ffn_mmap_is_empty() {
+        struct EmptyIdx;
+        impl crate::KvIndex for EmptyIdx {}
+        let idx = EmptyIdx;
+        let empty_mmap: &[u8] = &[];
+        // q4_ffn_per_matrix is irrelevant on this path — what we're pinning
+        // is "no slice happens against the empty mmap" (i.e. no panic).
+        let (gate, up, down) =
+            resolve_ffn_weights(&idx, 7, empty_mmap, 1_115_136, QuantFormat::Q4_K);
+        assert!(gate.data.is_empty());
+        assert!(up.data.is_empty());
+        assert!(down.data.is_empty());
+        assert_eq!(gate.format, QuantFormat::Q4_K);
+        assert_eq!(up.format, QuantFormat::Q4_K);
+        assert_eq!(down.format, QuantFormat::Q4_K);
     }
 }


### PR DESCRIPTION
## Summary

Two fixes for `larql run --moe-shards` on pure-MoE models (e.g. Gemma-4 26B A4B), reported in #151:

1. **Empty `interleaved_q4k.bin` panic guard.** `resolve_ffn_weights` panicked with `range end index 3345408 out of range for slice of length 0` when the dense FFN mmap was 0 bytes. Pure-MoE vindexes ship no dense FFN tensor, so the fallback branch sliced into an empty mmap. Now guarded with `q4_ffn_mmap.is_empty()`: returns empty `QuantWeight` stubs — `patch_pipeline_layers_for_remote_moe` overwrites them downstream and `moe_fn` supersedes the dense FFN path during decode, so the stubs are never read.

2. **`--metal` not wired into `run_with_moe_shards`.** Always used `default_backend()` instead of honouring the CLI flag. Mirrors the pattern PR #122 already applied to `run_with_remote_ffn`: explicit `metal_backend()` with CPU fallback on init failure, and a clear error when the `gpu` feature isn't compiled in.

Both fixes were needed to get Gemma-4 26B A4B running with `--moe-shards`.

## Files changed

- `crates/larql-compute/src/pipeline_layer.rs` — `is_empty()` guard + regression test
- `crates/larql-cli/src/commands/primary/run_cmd.rs` — new `metal: bool` param on `run_with_moe_shards`, mirroring `run_with_remote_ffn`'s backend init, threaded from `args.metal` at the call site

Net diff: 2 files, +60 / -1.

## Test plan

Local verification on macOS, branched off current `chrishayuk/larql:main` (post-#145):

- [x] `cargo check -p larql-compute -p larql-cli --lib --tests` — clean
- [x] `cargo clippy -p larql-compute -p larql-cli --lib --tests --no-deps -- -D warnings` — clean
- [x] `cargo fmt -p larql-compute -p larql-cli -- --check` — clean
- [x] `cargo test -p larql-compute --lib` — **657 passed** (includes new `resolve_ffn_weights_returns_empty_stubs_when_q4_ffn_mmap_is_empty` regression)
- [x] `cargo test -p larql-cli --tests` — 3 passed (1 ignored, model-heavy)

## CI verification (all green — 15/15)

- [x] `test - ubuntu-latest` (inference + cli) — pass (1m27s, 8m17s)
- [x] `test - macos-14` (inference + cli) — pass (5m18s, 2m49s)
- [x] `test - windows-latest` (inference + cli) — pass (12m23s, 12m26s)
- [x] `test · ubuntu-latest` (compute) — pass (3m20s)
- [x] `test · macos-14` (compute) — pass (6m28s, 1m1s)
- [x] `test · windows-latest` (compute) — pass (10m50s)
- [x] `coverage - ubuntu` × 2 — pass (6m46s, 6m29s)
- [x] `coverage · ubuntu` — pass (51s)
- [x] `bench` — pass (9m27s)
- [x] `verify` — pass (3m48s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)