### PR TITLE
test(kv): restore boundary-per-layer walk.rs coverage to ≥90%

### DIFF
--- a/crates/larql-kv/src/engines/boundary_per_layer/walk.rs
+++ b/crates/larql-kv/src/engines/boundary_per_layer/walk.rs
@@ -486,4 +486,36 @@ mod tests {
         assert_eq!(after, 2);
         assert_eq!(rs_after.next_position, 4);
     }
+
+    /// First-overflow cold-tier initialisation. A prefill that fills the
+    /// window exactly leaves `cold_encoded = None`; the first decode
+    /// pushes past the window, so its overflow row must *initialise*
+    /// `cold_encoded` (the `None` match arm) rather than append to an
+    /// existing one.
+    #[test]
+    fn run_decode_initialises_cold_tier_on_first_overflow() {
+        let weights = make_test_weights();
+        let backend = CpuBackend;
+        let ffn = NullFfn;
+        let policy = BoundaryLayerPolicy::bf16_uniform("test", weights.num_layers);
+
+        // window=2, exactly 2 prompt tokens → fills the window, no overflow.
+        let (_, rs) = run_prefill(&weights, &ffn, &backend, &policy, Some(2), &[0, 1]).unwrap();
+        assert!(
+            rs.cold_encoded.is_none(),
+            "a window-filling prefill must not overflow yet"
+        );
+
+        // First decode overflows by one row → initialises cold_encoded.
+        let (_, rs_after) = run_decode(&weights, &ffn, &backend, &policy, rs, 2, None).unwrap();
+        assert!(
+            rs_after.cold_encoded.is_some(),
+            "first decode overflow must initialise the cold tier"
+        );
+        assert_eq!(
+            rs_after.cold_encoded.as_ref().unwrap()[0].n_positions,
+            1,
+            "exactly one row evicted to cold"
+        );
+    }
 }


### PR DESCRIPTION
`larql-kv/src/engines/boundary_per_layer/walk.rs` has been below the 90% per-file coverage floor (88.92%) since the perf-improvements-2 merges, turning the larql-kv coverage CI red on main.

The gap was `run_decode`'s cold-tier **initialise** arm: when a window-filling prefill leaves `cold_encoded = None` and the first decode overflows, that overflow row must *create* the cold tier (the `None` match arm), not append. No test drove that path.

Adds `run_decode_initialises_cold_tier_on_first_overflow` (windowed prefill that exactly fills the window, then one decode that overflows). walk.rs line coverage 88.92% → ~92%.

No production changes.