### PR TITLE
fix(python): expose up-vector override binding

### DIFF
--- a/crates/larql-python/src/vindex.rs
+++ b/crates/larql-python/src/vindex.rs
@@ -1059,6 +1059,13 @@ impl PyVindex {
         Ok(())
     }
 
+    /// Low-level: set a custom up vector override for a feature.
+    /// During inference, this vector is used instead of the model's up weight row.
+    fn set_up_vector(&mut self, layer: usize, feature: usize, vector: Vec<f32>) -> PyResult<()> {
+        self.index.set_up_vector(layer, feature, vector);
+        Ok(())
+    }
+
     /// Low-level: set feature metadata directly.
     #[pyo3(signature = (layer, feature, top_token, c_score=0.9))]
     fn set_feature_meta(


### PR DESCRIPTION
Title:
fix(python): expose up-vector override binding

Summary:
- Add `Vindex.set_up_vector(layer, feature, vector)` to the Python bindings.
- Keep it symmetric with the existing `set_down_vector` binding.

Why:
`VectorIndex::set_up_vector` already exists in Rust, but Python users can only
set custom down-vector overrides. This exposes the existing up-vector override
without changing Rust index behavior.

Verification:
- cargo check -p larql-python

Branch:
pr/python-set-up-vector-binding

Commit:
8610b14d702de7c929e306f8c05fe104c911a3a6
