### PR TITLE
fix(inference): clamp dense walk top-k to feature count

### DIFF
--- a/crates/larql-inference/src/vindex/walk_ffn/mod.rs
+++ b/crates/larql-inference/src/vindex/walk_ffn/mod.rs
@@ -212,7 +212,9 @@ fn walk_trace_env_enabled() -> bool {
 
 impl<'a> WalkFfn<'a> {
     fn top_k_for(&self, layer: usize) -> usize {
-        self.config.k_for(layer).unwrap_or(usize::MAX)
+        self.config
+            .k_for(layer)
+            .unwrap_or_else(|| self.index.num_features(layer))
     }
 
     // ── Legacy constructors (stable public API) ──
@@ -784,6 +786,15 @@ mod dispatch_tests {
         let x = input(1, weights.hidden_size);
         let out = ffn.forward(0, &x);
         assert_eq!(out.shape(), &[1, weights.hidden_size]);
+    }
+
+    #[test]
+    fn dense_top_k_for_clamps_to_layer_feature_count() {
+        let weights = shared_weights();
+        let idx = mock_index(weights);
+        let ffn = WalkFfn::new_unlimited(weights, &idx);
+
+        assert_eq!(ffn.top_k_for(0), weights.intermediate_size);
     }
 
     /// Variant of `MockGateIndex` that yields a `FeatureMeta` for every


### PR DESCRIPTION
Title:
fix(inference): clamp dense walk top-k to feature count

Summary:
- Clamp unlimited dense WalkFfn top-k to the layer feature count.
- Add a regression test covering `WalkFfn::new_unlimited`.

Why:
`WalkFfn::new_unlimited` previously returned `usize::MAX` from `top_k_for`
when no explicit per-layer k was configured. Dense paths that used this value
as a selection bound could request more features than exist. The unlimited
dense case should mean "all features in this layer", not an unbounded sentinel
escaping into execution.

Verification:
- cargo test -p larql-inference dense_top_k_for_clamps_to_layer_feature_count --lib
- cargo test -p larql-inference --lib

Branch:
pr/walk-ffn-dense-topk-clamp

Commit:
d75cd5d76fab898474d75fcede6ea8e04ce5578b
