### PR TITLE
DEC funnel v0.4 + DEC-readiness review Batch A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,10 @@ experiments/
 vindexes/
 .pids/
 docs/replay/
+
+# DEC-0 loadgen outputs (bench/dec0/prompts.txt stays tracked)
+bench/dec0/residuals-*/
+bench/dec0/*.log
+bench/dec0/*.jsonl
+bench/dec0/anchor_*.json
+bench/dec0/dec0_*.json

--- a/README.md
+++ b/README.md
@@ -805,6 +805,7 @@ The full surface is documented in `crates/larql-inference/ROADMAP.md` §
 | [docs/adr/0012-grid-benchmarking.md](docs/adr/0012-grid-benchmarking.md) | Grid benchmarking infrastructure — criterion + CLI + CI gate |
 | [docs/diagnoses/shannon-cross-engine-divergence.md](docs/diagnoses/shannon-cross-engine-divergence.md) | Forward-pass correctness diagnostic via `larql shannon verify` — three-engine bits/char comparison against HF/PyTorch and MLX, plus the three bugs it surfaced |
 | [scripts/README_shannon_score.md](scripts/README_shannon_score.md) | Cross-engine Shannon scorers — `larql shannon verify` + standalone scripts for MLX and HF |
+| [docs/audits/dec-readiness-review-2026-07-22.md](docs/audits/dec-readiness-review-2026-07-22.md) | DEC-readiness review of the server/router/remote-FFN data plane ahead of the DEC funnel programme — silent-corruption + security findings, remediation tracked in ROADMAP |
 
 ## Platform Support
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -547,6 +547,133 @@ Ordered actions:
     no malformed-message rate limit (`grid/service.rs:121`). [larql-server,
     larql-router]
 
+### DEC-readiness review (2026-07-22)
+
+Targeted review of the **DEC data-plane** ahead of the DEC funnel programme
+([`docs/dec-funnel.md`](docs/dec-funnel.md)) — the code the programme runs on
+rented x86 marketplace hosts, against non-Gemma models, over adversarial
+links. Four parallel readers (security, hardcoding/config, modularity,
+performance), verified findings only. Full record:
+[`docs/audits/dec-readiness-review-2026-07-22.md`](docs/audits/dec-readiness-review-2026-07-22.md).
+Verdict: structurally sound and the wire decoders are mostly hardened, but a
+**silent-corruption cluster** (produces a number, the number is a lie) is the
+dominant risk because the whole programme is a measurement exercise. The B-row
+f32/f16/i8 serving path is well-built; only the Q8K path — the wire DEC prefers
+— does not batch. Work through in the order below (roughly DEC-stage sequencing).
+
+**Batch A — silent corruption + the security HIGH (before any claim-bearing run): ✅ DONE (2026-07-22)**
+
+1. ✅ **Q8K batched compute** (P0, corrupts C1/C6, gates DEC-0) — `walk_ffn/q8k.rs:199`
+   ran B same-layer rows as B independent matvecs, each re-streaming the full
+   layer's weights, so the Q8K batch curve was ~linear by construction. Fixed:
+   the handler now groups request entries by layer; groups of >1 dequantise to
+   f32 and run ONE batched GEMM through `kquant_ffn_forward_layer` (preserving
+   the Q8K upload win, amortising weights across rows); singleton groups keep
+   the existing single-row Q4K×Q8K kernel unchanged (no batching problem there,
+   and it avoids dequantising gate/up on the latency-critical single-token
+   decode path). Numerical equivalence between the two paths is pinned by
+   `walk_ffn_kquant_layer_q8k_batched_gemm_matches_per_row_single_kernel`.
+   [larql-server, larql-inference]
+2. ✅ **Multi-layer decoder allocation bomb** (P0, security) — `Vec::with_capacity(n)`
+   from an attacker u32 → one 16-byte packet aborts the server
+   (`moe_remote/multi_layer_wire.rs:105,146,211,254,292`). Regression from the
+   repo's own `max_possible_entries` guard (PR 104). Fixed: mirrored the guard
+   at every task/result/expert-count allocation site, plus inside the shared
+   `read_f32_slice`/`read_i16_slice` helpers so `hidden`/`nb`-derived lengths
+   are bounded before any allocation, covering both `decode_multi_layer_request`
+   and the client-side `decode_multi_layer_response`. 8 new
+   `rejects_impossible_*_before_allocating` regression tests. [larql-inference]
+3. ✅ **Shard failure zero-fills FFN output** (P0, silent generation corruption) —
+   `sharded.rs:117` returned zeros on a panicked/unowned shard and decode
+   continued on a corrupt hidden state. Fixed: `forward_predispatch_all` now
+   panics loudly on an unowned layer or a shard's transport failure (propagating
+   the worker thread's panic via `resume_unwind` instead of swallowing it),
+   matching `RemoteWalkBackend::forward`'s existing panic-on-error convention.
+   [larql-inference]
+4. ✅ **Down-proj ignores its format tag on the Q8K fast path** (P0, gates
+   DEC-4/6) — `kquant_forward/walk_ffn.rs:135` fed `ffn[2].0` into a Q4_K-only
+   kernel without checking `ffn[2].1`; a non-Q4_K down slab (Inkling/K3) would
+   have decoded garbage. Fixed: the fast path now additionally gates on
+   `ffn[2].1 == "Q4_K"`, falling back to the format-aware `dequantize_matrix`
+   path otherwise. Fixed in both the `larql-inference` copy (the live serving
+   path) and the `larql-compute` twin (same bug, not yet wired to a serving
+   path — see item 4g). Regression:
+   `walk_ffn_kquant_layer_q8k_rejects_down_slab_with_non_q4k_format_tag`.
+   [larql-inference, larql-compute]
+5. ✅ **x86 scalar-fallback is silent** (P0 *observability*, gates DEC-0.5) —
+   `q4k_q8k_gate_up_into` (:1377) and `q6k_q8k_matvec_into` (:2119) have no AVX2
+   branch; the serving-path doc-comments falsely claimed "NEON/AVX2". Building
+   the AVX2 kernels remains **C-ladder** work (not done here). Fixed: added
+   `larql_compute::cpu::ops::q4k_q8k_dot::kernel_class_summary()`, logged once
+   at server startup (`larql-server/bootstrap.rs`), and corrected the false doc
+   comments on `q4k_q8k_gate_up_into` and the `q8k.rs` module doc — so no DEC
+   number is ever recorded on an unlogged scalar path. [larql-compute, larql-server]
+
+**Batch B — fleet/config landmines (before the x86 + Linux arms):**
+
+6. **`127.0.0.1` announce on `--join`** (P1, breaks multi-host grid) — refuse a
+   wildcard host without `--public-url`, or detect the outbound IP
+   (`bootstrap.rs:1222`). [larql-server]
+7. **Backend factory + capability dispatch** (P1, unblocks x86 + pre-work for
+   G-ladder) — replace the 7-site `if metal` cfg copy-paste with one
+   `backend_from_spec` factory and switch dispatch branches to `Capability`
+   probes (`run_cmd.rs:649,924`, `bench/remote_ffn_runtime.rs:77`,
+   `bench/local_runtime.rs:58`, `dec_bench/capture_runtime.rs:43`,
+   `shannon_cmd.rs:971`, `walk_cmd.rs:462`). Make the CPU/x86 capture story
+   explicit (pool is host-portable — capture on Metal, replay anywhere); do NOT
+   rush full CPU fused decode. [larql-cli, larql-compute]
+8. **`--metal` / `--backends metal` hardcoded for x86** (P1) — `DEC0_BACKEND`
+   env in `scripts/dec0-loopback.sh:80,97`, platform-conditional `--backends`
+   default (`bench/args.rs:26`). Couples to #7. [larql-cli]
+9. **`SKIP_MOE` vs `LARQL_SKIP_MOE` name split** (P1, corrupts the anchor's
+   ceiling arm) — one prefixed canonical name, alias the unprefixed one loudly;
+   fix the README/dec-funnel disagreement. Same for `SKIP_OUTER_NORM`,
+   `DECODE_DEBUG`. [larql-inference, larql-compute, docs]
+10. **DEC deployment auth posture** (P1, security) — the data plane is open
+    unless `--api-key` is set (`/v1/shard` streams the whole vindex as a tar);
+    router admin RPCs (`drain_server`/`assign_range`) and the grid port are
+    unauthenticated (`grid/service.rs:386,397,455`; overlaps 2026-06-12 item 1
+    follow-on). Decide: mandatory data-plane auth off-loopback, or private-network
+    binding as a documented DEC deployment rule. Constant-time the gRPC grid-key
+    compare (`service.rs:105`) while here. [larql-server, larql-router]
+11. **Timeout defaults + no-op grid-LAN timeout** (P2) — the 30/60/120s defaults
+    assume 26B+LAN and will 504 on Inkling cold-start (note at DEC-4/5
+    provisioning); `grid_lan_runtime.rs:179` timeout is a `let _ =` no-op (wire
+    it). Arch-tag the grid-regress baselines (`bench-grid-regress.sh:35`).
+    [larql-cli, larql-inference]
+
+**Batch C — structural pre-work (schedule per-ladder, not a DEC-0 blocker):**
+
+12. **Compute admission control** (P1, protects C3/DEC-2) — ~192 concurrent
+    multithreaded-BLAS `spawn_blocking` tasks at 4 clients × 48-layer fan-out
+    look like tier saturation but are oversubscription. Semaphore sized to
+    physical cores + `OPENBLAS_NUM_THREADS=1` for the serving build.
+    [larql-server]
+13. **q8k endpoint drain/heartbeat/latency blindness** (P1, breaks C7 router
+    demo) — add `RifGuard` + `requests_total` + per-layer `record` to the q8k
+    handler (`q8k.rs:41`). [larql-server]
+14. **dec_bench `Endpoint` seam + routing capture** (P1, gates the
+    routed-experts arm that gates the C1-on-MoE verdict) — introduce an
+    `Endpoint` enum (path + frame-builder + decoder + denominator source) and
+    capture per-layer `(expert_ids, weights)`; `/v1/stats` already serves the
+    MoE denominator. [larql-cli, larql-inference]
+15. **Server expert dispatcher** (P2, before G4 cuda-experts) — extract one
+    `run_experts(state, backend, …)` from the per-handler Metal/CPU branches
+    (`q8k.rs:107`, `grpc_expert.rs:178`, `expert/{layer,multi_layer}_batch.rs`).
+    [larql-server]
+16. **Wire consolidation** (P2, at the first new format — DEC-6a MXFP4) — single
+    shared wire module for the dense binary frame (5× CT-string + 2×
+    `BATCH_MARKER` + independent encoder/decoder); fold the dense stack toward
+    the single-sourced MoE/q8k discipline; fix the `call_q8k_layers` byte-counter
+    gap (`remote/http.rs:364`). [larql-inference, larql-server, larql-router]
+17. **MoE parity seams + hot-path cleanups** (P2) — make `build_moe_router_weights`
+    `pub` and share the combine math before the DEC-6b KDA/LatentMoE port
+    (`hidden.rs:93` vs `core.rs:111`); `model.patched` arc-swap so compute
+    doesn't hold the read lock across FFN (C3 shared-tier landmine); drop the
+    4–6 full-buffer request-lifecycle passes (`core.rs:48,235,284`,
+    `binary.rs:88`); gate `--release-mmap-after-request` on `requests_in_flight`;
+    persistent client fan-out pool. [larql-inference, larql-server]
+
 ---
 
 ## Cleanup / consolidation track (added 2026-06-12)

--- a/bench/dec0/prompts.txt
+++ b/bench/dec0/prompts.txt
@@ -1,0 +1,68 @@
+# DEC-0 fixed prompt set — 64 short prompts, one per line (docs/dec-funnel.md §3).
+# Diverse topics so B-row replay batches carry realistic, decorrelated
+# residuals (MoE routing union realism). Do not reorder — prompt index i is
+# row i of every replayed batch; edits invalidate captured pools.
+Explain why the sky appears blue during the day.
+Write a haiku about a mountain river in autumn.
+What is the capital of Australia and why is it often mistaken?
+Summarise the plot of Romeo and Juliet in two sentences.
+How does a refrigerator keep food cold?
+List three uses for a paperclip besides holding paper.
+What causes tides in the ocean?
+Translate the phrase "good morning, my friend" into French.
+Describe the taste of fresh sourdough bread.
+Why do cats purr?
+Explain the difference between speed and velocity.
+Name the planets of the solar system in order from the sun.
+What ingredients go into a classic margherita pizza?
+How do bees communicate the location of flowers?
+Write the opening line of a mystery novel set in Lisbon.
+What is compound interest and why does it matter?
+Describe how a bill becomes a law in the United Kingdom.
+Why is the Mona Lisa considered famous?
+Explain photosynthesis to a ten-year-old.
+What is the tallest mountain on Earth measured from base to peak?
+Give two arguments for and against remote work.
+How does a suspension bridge stay up?
+What is the difference between weather and climate?
+Recommend a book for someone who loved The Martian.
+Why do onions make people cry when chopped?
+Explain what a prime number is with an example.
+Describe the rules of chess castling.
+What happened at the Library of Alexandria?
+How do vaccines train the immune system?
+Write a two-line poem about the sea at night.
+What makes a violin sound different from a cello?
+Explain the water cycle step by step.
+Why did the Roman Empire split in two?
+What is the fastest land animal and how fast can it run?
+Describe how to make a good cup of tea.
+What is machine learning in one paragraph?
+Why do leaves change colour in autumn?
+Explain the offside rule in football simply.
+What is the deepest part of the ocean called?
+Give a short toast for a friend's graduation.
+How does a compass work?
+What are the three states of matter and an example of each?
+Describe the feeling of walking into a quiet library.
+Why is the Dead Sea so salty?
+Explain what inflation does to savings over time.
+What is the difference between a crocodile and an alligator?
+Write a one-sentence summary of the moon landing.
+How do noise-cancelling headphones work?
+What language has the most native speakers worldwide?
+Describe a traditional Japanese tea ceremony briefly.
+Why do we dream during sleep?
+Explain gravity using an everyday example.
+What is the longest river in the world?
+Give three tips for learning a new language quickly.
+How is glass made from sand?
+What causes a rainbow to appear after rain?
+Describe the sound of a thunderstorm approaching.
+Why are flamingos pink?
+Explain what an eclipse is and the two main types.
+What is the smallest country in the world by area?
+Write a friendly reminder note about a dentist appointment.
+How does yeast make bread rise?
+What is the speed of light and why is it important?
+Describe the smell of rain on dry earth and its name.

--- a/bench/oracles/bitnet_2b_capital_of_france.txt
+++ b/bench/oracles/bitnet_2b_capital_of_france.txt
@@ -1,0 +1,1 @@
+ Paris. Paris is a city that is known for its rich history, culture,

--- a/bench/oracles/q4k_qwen3_history_of_computing.txt
+++ b/bench/oracles/q4k_qwen3_history_of_computing.txt
@@ -1,0 +1,2 @@
+<think>
+Okay, the user is asking about the history of computing. Let me start by breaking down the question. They

--- a/crates/larql-cli/coverage-policy.json
+++ b/crates/larql-cli/coverage-policy.json
@@ -1,8 +1,9 @@
 {
-  "policy_note": "CLI is a binary crate with most code under `commands/` doing CLI parsing, dispatch, or I/O against live models/servers. This policy is scoped to the `bench/` subtree: pure helpers are gated at the 90% default; I/O-wrapper runtime files (`*_runtime.rs`) and the top-level orchestrator (`run.rs`) are excluded because they're thin glue around `larql_inference` / `larql_compute` / `LayerShardedBackend` / `RemoteMoeBackend` calls that need live shards and real model weights to exercise. The split keeps every byte of testable post-processing logic under the gate. Baseline measured 2026-05-15.",
+  "policy_note": "CLI is a binary crate with most code under `commands/` doing CLI parsing, dispatch, or I/O against live models/servers. This policy is scoped to the `bench/` and `dec_bench/` subtrees: pure helpers are gated at the 90% default; I/O-wrapper runtime files (`*_runtime.rs`) and the top-level orchestrators (`run.rs`, `mod.rs`, `args.rs`) are excluded because they're thin glue around `larql_inference` / `larql_compute` / `LayerShardedBackend` / `RemoteMoeBackend` / `reqwest` calls that need live shards and real model weights to exercise. The split keeps every byte of testable post-processing logic under the gate. Baseline measured 2026-05-15; dec_bench added 2026-07-22.",
   "include_globs": [
     "crates/larql-cli/src/commands/primary/bench/*.rs",
-    "crates/larql-cli/src/commands/primary/bench/**/*.rs"
+    "crates/larql-cli/src/commands/primary/bench/**/*.rs",
+    "crates/larql-cli/src/commands/primary/dec_bench/*.rs"
   ],
   "exclude_globs": [
     "crates/larql-cli/src/commands/primary/bench/run.rs",
@@ -10,7 +11,12 @@
     "crates/larql-cli/src/commands/primary/bench/grid_lan_runtime.rs",
     "crates/larql-cli/src/commands/primary/bench/local_runtime.rs",
     "crates/larql-cli/src/commands/primary/bench/remote_ffn_runtime.rs",
-    "crates/larql-cli/src/commands/primary/bench/remote_moe_runtime.rs"
+    "crates/larql-cli/src/commands/primary/bench/remote_moe_runtime.rs",
+    "crates/larql-cli/src/commands/primary/bench/local_moe_runtime.rs",
+    "crates/larql-cli/src/commands/primary/dec_bench/mod.rs",
+    "crates/larql-cli/src/commands/primary/dec_bench/args.rs",
+    "crates/larql-cli/src/commands/primary/dec_bench/capture_runtime.rs",
+    "crates/larql-cli/src/commands/primary/dec_bench/replay_runtime.rs"
   ],
   "default_line_min_percent": 90.0,
   "total_line_min_percent": 7.0,

--- a/crates/larql-cli/src/commands/primary/dec_bench/args.rs
+++ b/crates/larql-cli/src/commands/primary/dec_bench/args.rs
@@ -1,0 +1,132 @@
+//! Clap args for `larql dec-bench` — the DEC residual-replay loadgen
+//! (docs/dec-funnel.md §3, DEC-0). Two sub-modes:
+//!
+//!   * `capture` — run single-stream decode over N prompts against a live
+//!     expert server, recording each step's pre-normed per-layer residuals
+//!     into a portable pool.
+//!   * `replay`  — sweep batch × wire × dispatch against the server using
+//!     B-row frames built from the pool; emit the `dec/*` schema.
+
+use clap::{Args, Subcommand};
+
+#[derive(Args, Clone)]
+pub struct DecBenchArgs {
+    #[command(subcommand)]
+    pub cmd: DecBenchCmd,
+}
+
+#[derive(Subcommand, Clone)]
+pub enum DecBenchCmd {
+    /// Capture a residual pool from live decode over N prompts.
+    Capture(CaptureArgs),
+    /// Replay the pool as B-row requests, sweeping batch × wire × dispatch.
+    Replay(ReplayArgs),
+}
+
+#[derive(Args, Clone)]
+pub struct CaptureArgs {
+    /// Vindex directory, `hf://owner/name`, or cache shorthand.
+    pub model: String,
+
+    /// Expert-server URL (loopback for DEC-0 arm M).
+    #[arg(long)]
+    pub ffn: String,
+
+    /// Prompts file, one prompt per line (fixed set, checked in).
+    #[arg(long)]
+    pub prompts_file: std::path::PathBuf,
+
+    /// Number of prompts to capture (= max replay batch size).
+    #[arg(long, default_value = "64")]
+    pub num_prompts: usize,
+
+    /// Decode steps to capture per prompt.
+    #[arg(long, default_value = "16")]
+    pub steps: usize,
+
+    /// Use the Metal GPU attention backend (required on macOS for the
+    /// remote-FFN decode path).
+    #[arg(long)]
+    pub metal: bool,
+
+    /// Output pool directory (`manifest.json` + `residuals.bin`).
+    #[arg(long)]
+    pub out: std::path::PathBuf,
+
+    /// Per-request timeout for the expert server.
+    #[arg(long, default_value = "60")]
+    pub ffn_timeout_secs: u64,
+
+    #[arg(short, long)]
+    pub verbose: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct ReplayArgs {
+    /// Expert-server URL.
+    #[arg(long)]
+    pub ffn: String,
+
+    /// Capture pool directory (from `dec-bench capture`).
+    #[arg(long)]
+    pub capture: std::path::PathBuf,
+
+    /// Comma-separated batch sizes (rows per request).
+    #[arg(long, default_value = "1,8,16,32,64")]
+    pub batch: String,
+
+    /// Comma-separated wire arms: f32, f16, i8, q8k.
+    #[arg(long, default_value = "f32,f16,i8,q8k")]
+    pub wire: String,
+
+    /// Comma-separated dispatch modes: streaming (sequential per-layer),
+    /// batch (all layers fired in parallel, mirrors predispatch).
+    #[arg(long, default_value = "streaming,batch")]
+    pub dispatch: String,
+
+    /// Inclusive layer range `A-B` to replay (default: all layers).
+    #[arg(long)]
+    pub layers: Option<String>,
+
+    /// Steps to replay per repeat (default: all captured steps).
+    #[arg(long)]
+    pub steps: Option<usize>,
+
+    /// Repeats per sweep point.
+    #[arg(long, default_value = "3")]
+    pub repeats: usize,
+
+    /// Warmup passes over all replayed layers per sweep point (discarded).
+    /// Full passes, not single requests — mmap-backed layer weights pay
+    /// first-touch page faults per layer.
+    #[arg(long, default_value = "1")]
+    pub warmup_passes: usize,
+
+    /// Per-request timeout.
+    #[arg(long, default_value = "60")]
+    pub timeout_secs: u64,
+
+    /// Write the full JSON run record here.
+    #[arg(long)]
+    pub output_file: Option<std::path::PathBuf>,
+
+    /// Write `dec/*` pulse JSONL here (rig `$CHUK_METRICS` format).
+    #[arg(long)]
+    pub pulse_file: Option<std::path::PathBuf>,
+
+    /// Include per-layer p50/p99 keys in the pulse lines (always present in
+    /// the JSON run record).
+    #[arg(long)]
+    pub pulse_per_layer: bool,
+
+    /// Measured link RTT to record alongside the run (spec §6 gate).
+    #[arg(long)]
+    pub net_rtt_ms: Option<f64>,
+
+    /// Measured link bandwidth to record alongside the run (spec §6 gate).
+    #[arg(long)]
+    pub net_gbps: Option<f64>,
+
+    #[arg(short, long)]
+    pub verbose: bool,
+}

--- a/crates/larql-cli/src/commands/primary/dec_bench/capture_format.rs
+++ b/crates/larql-cli/src/commands/primary/dec_bench/capture_format.rs
@@ -1,0 +1,365 @@
+//! On-disk residual capture pool for the DEC replay loadgen.
+//!
+//! A capture directory holds two files:
+//!   * `manifest.json` — [`CaptureManifest`]: model identity, shape, and
+//!     per-prompt step counts.
+//!   * `residuals.bin` — f32 LE, layout `[prompt][step][layer][hidden]`,
+//!     `steps` = the minimum step count across prompts (ragged tails are
+//!     truncated at write time so every `(step, layer)` cell has a row from
+//!     every prompt).
+//!
+//! Rows are captured **pre-normed** (see `ResidualCaptureSink`), i.e. exactly
+//! the bytes the f32 wire carries and exactly the input Q8K quantisation
+//! consumes — so replay needs no model weights and the pool is portable
+//! across hosts (Mac capture → x86 replay).
+
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::Path;
+
+/// Bump when the binary layout changes. `open` rejects other versions.
+pub const CAPTURE_VERSION: u32 = 1;
+
+const MANIFEST_FILE: &str = "manifest.json";
+const RESIDUALS_FILE: &str = "residuals.bin";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptMeta {
+    pub id: usize,
+    pub text: String,
+    /// Steps this prompt actually produced before truncation to `steps`.
+    pub steps_captured: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaptureManifest {
+    pub version: u32,
+    /// Model path / id the pool was captured from.
+    pub model: String,
+    pub hidden_size: usize,
+    pub num_layers: usize,
+    /// Replayable steps: min over prompts of steps captured.
+    pub steps: usize,
+    /// Always `"f32-le"` at version 1.
+    pub dtype: String,
+    pub prompts: Vec<PromptMeta>,
+    pub created_unix: u64,
+}
+
+impl CaptureManifest {
+    /// Expected `residuals.bin` byte length for this manifest.
+    pub fn expected_bytes(&self) -> u64 {
+        self.prompts.len() as u64
+            * self.steps as u64
+            * self.num_layers as u64
+            * self.hidden_size as u64
+            * 4
+    }
+}
+
+/// An open, validated capture pool.
+pub struct CapturePool {
+    pub manifest: CaptureManifest,
+    /// Raw `residuals.bin` contents; decoded to f32 on demand in [`Self::rows`].
+    data: Vec<u8>,
+}
+
+impl CapturePool {
+    /// Write a pool from per-prompt captured steps.
+    ///
+    /// `per_prompt[p][step][layer]` is the pre-normed residual for prompt `p`.
+    /// Prompts with more steps than the shortest are truncated so the binary
+    /// layout is rectangular; the pre-truncation count is kept in
+    /// [`PromptMeta::steps_captured`].
+    pub fn write(
+        dir: &Path,
+        model: &str,
+        hidden_size: usize,
+        num_layers: usize,
+        prompt_texts: &[String],
+        per_prompt: &[Vec<Vec<Vec<f32>>>],
+        created_unix: u64,
+    ) -> Result<CaptureManifest, String> {
+        if per_prompt.is_empty() {
+            return Err("capture pool: no prompts captured".into());
+        }
+        if per_prompt.len() != prompt_texts.len() {
+            return Err(format!(
+                "capture pool: {} prompt texts but {} capture sinks",
+                prompt_texts.len(),
+                per_prompt.len()
+            ));
+        }
+        let steps = per_prompt.iter().map(|s| s.len()).min().unwrap_or(0);
+        if steps == 0 {
+            return Err("capture pool: a prompt produced zero decode steps".into());
+        }
+        for (p, prompt_steps) in per_prompt.iter().enumerate() {
+            for (s, layers) in prompt_steps.iter().take(steps).enumerate() {
+                if layers.len() != num_layers {
+                    return Err(format!(
+                        "capture pool: prompt {p} step {s} has {} layers, expected {num_layers}",
+                        layers.len()
+                    ));
+                }
+                for (l, row) in layers.iter().enumerate() {
+                    if row.len() != hidden_size {
+                        return Err(format!(
+                            "capture pool: prompt {p} step {s} layer {l} has {} floats, \
+                             expected hidden {hidden_size}",
+                            row.len()
+                        ));
+                    }
+                }
+            }
+        }
+
+        let manifest = CaptureManifest {
+            version: CAPTURE_VERSION,
+            model: model.to_string(),
+            hidden_size,
+            num_layers,
+            steps,
+            dtype: "f32-le".into(),
+            prompts: prompt_texts
+                .iter()
+                .enumerate()
+                .map(|(id, text)| PromptMeta {
+                    id,
+                    text: text.clone(),
+                    steps_captured: per_prompt[id].len(),
+                })
+                .collect(),
+            created_unix,
+        };
+
+        std::fs::create_dir_all(dir).map_err(|e| format!("capture pool: mkdir: {e}"))?;
+        let bin_path = dir.join(RESIDUALS_FILE);
+        let f = std::fs::File::create(&bin_path)
+            .map_err(|e| format!("capture pool: create {}: {e}", bin_path.display()))?;
+        let mut w = std::io::BufWriter::new(f);
+        for prompt_steps in per_prompt {
+            for layers in prompt_steps.iter().take(steps) {
+                for row in layers {
+                    for &v in row {
+                        w.write_all(&v.to_le_bytes())
+                            .map_err(|e| format!("capture pool: write: {e}"))?;
+                    }
+                }
+            }
+        }
+        w.flush().map_err(|e| format!("capture pool: flush: {e}"))?;
+
+        let manifest_json = serde_json::to_string_pretty(&manifest)
+            .map_err(|e| format!("capture pool: manifest serialize: {e}"))?;
+        std::fs::write(dir.join(MANIFEST_FILE), manifest_json)
+            .map_err(|e| format!("capture pool: write manifest: {e}"))?;
+        Ok(manifest)
+    }
+
+    /// Open and validate a pool directory.
+    pub fn open(dir: &Path) -> Result<Self, String> {
+        let manifest_path = dir.join(MANIFEST_FILE);
+        let manifest_json = std::fs::read_to_string(&manifest_path)
+            .map_err(|e| format!("capture pool: read {}: {e}", manifest_path.display()))?;
+        let manifest: CaptureManifest = serde_json::from_str(&manifest_json)
+            .map_err(|e| format!("capture pool: parse manifest: {e}"))?;
+        if manifest.version != CAPTURE_VERSION {
+            return Err(format!(
+                "capture pool: version {} unsupported (expected {CAPTURE_VERSION})",
+                manifest.version
+            ));
+        }
+        let bin_path = dir.join(RESIDUALS_FILE);
+        let data = std::fs::read(&bin_path)
+            .map_err(|e| format!("capture pool: read {}: {e}", bin_path.display()))?;
+        if data.len() as u64 != manifest.expected_bytes() {
+            return Err(format!(
+                "capture pool: residuals.bin is {} bytes, manifest expects {}",
+                data.len(),
+                manifest.expected_bytes()
+            ));
+        }
+        Ok(Self { manifest, data })
+    }
+
+    /// Number of prompts in the pool — the maximum replay batch size.
+    pub fn num_prompts(&self) -> usize {
+        self.manifest.prompts.len()
+    }
+
+    /// Build a `batch × hidden` contiguous row block for `(step, layer)`:
+    /// row `i` is prompt `i`'s pre-normed residual at that step and layer.
+    /// Distinct prompts per row keep MoE routing union realistic.
+    pub fn rows(&self, batch: usize, step: usize, layer: usize) -> Result<Vec<f32>, String> {
+        let m = &self.manifest;
+        if batch == 0 || batch > m.prompts.len() {
+            return Err(format!(
+                "capture pool: batch {batch} out of range (pool has {} prompts)",
+                m.prompts.len()
+            ));
+        }
+        if step >= m.steps {
+            return Err(format!(
+                "capture pool: step {step} out of range (pool has {} steps)",
+                m.steps
+            ));
+        }
+        if layer >= m.num_layers {
+            return Err(format!(
+                "capture pool: layer {layer} out of range (pool has {} layers)",
+                m.num_layers
+            ));
+        }
+        let row_bytes = m.hidden_size * 4;
+        let mut out = Vec::with_capacity(batch * m.hidden_size);
+        for prompt in 0..batch {
+            let row_idx = (prompt * m.steps + step) * m.num_layers + layer;
+            let start = row_idx * row_bytes;
+            out.extend(
+                self.data[start..start + row_bytes]
+                    .chunks_exact(4)
+                    .map(|c| f32::from_le_bytes(c.try_into().unwrap())),
+            );
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthetic_capture(
+        prompts: usize,
+        steps: usize,
+        layers: usize,
+        hidden: usize,
+    ) -> Vec<Vec<Vec<Vec<f32>>>> {
+        (0..prompts)
+            .map(|p| {
+                (0..steps)
+                    .map(|s| {
+                        (0..layers)
+                            .map(|l| {
+                                (0..hidden)
+                                    .map(|h| (p * 1000 + s * 100 + l * 10 + h) as f32)
+                                    .collect()
+                            })
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn write_synthetic(dir: &Path, prompts: usize, steps: usize, layers: usize, hidden: usize) {
+        let cap = synthetic_capture(prompts, steps, layers, hidden);
+        let texts: Vec<String> = (0..prompts).map(|i| format!("prompt {i}")).collect();
+        CapturePool::write(dir, "test-model", hidden, layers, &texts, &cap, 12345).unwrap();
+    }
+
+    #[test]
+    fn manifest_round_trips_through_serde() {
+        let m = CaptureManifest {
+            version: CAPTURE_VERSION,
+            model: "m".into(),
+            hidden_size: 8,
+            num_layers: 2,
+            steps: 3,
+            dtype: "f32-le".into(),
+            prompts: vec![PromptMeta {
+                id: 0,
+                text: "p".into(),
+                steps_captured: 3,
+            }],
+            created_unix: 99,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let back: CaptureManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.version, m.version);
+        assert_eq!(back.hidden_size, 8);
+        assert_eq!(back.expected_bytes(), 3 * 2 * 8 * 4);
+    }
+
+    #[test]
+    fn write_open_rows_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        write_synthetic(dir.path(), 2, 2, 2, 4);
+        let pool = CapturePool::open(dir.path()).unwrap();
+        assert_eq!(pool.num_prompts(), 2);
+
+        // Row i of a batch must be prompt i at the same (step, layer).
+        let rows = pool.rows(2, 1, 1).unwrap();
+        assert_eq!(rows.len(), 2 * 4);
+        let expect_p0: Vec<f32> = (0..4).map(|h| (100 + 10 + h) as f32).collect();
+        let expect_p1: Vec<f32> = (0..4).map(|h| (1000 + 100 + 10 + h) as f32).collect();
+        assert_eq!(&rows[..4], &expect_p0[..]);
+        assert_eq!(&rows[4..], &expect_p1[..]);
+    }
+
+    #[test]
+    fn write_truncates_ragged_prompts_to_min_steps() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cap = synthetic_capture(2, 3, 1, 2);
+        cap[1].truncate(1); // prompt 1 stopped early (EOS)
+        let texts = vec!["a".into(), "b".into()];
+        let m = CapturePool::write(dir.path(), "m", 2, 1, &texts, &cap, 0).unwrap();
+        assert_eq!(m.steps, 1);
+        assert_eq!(m.prompts[0].steps_captured, 3);
+        assert_eq!(m.prompts[1].steps_captured, 1);
+        let pool = CapturePool::open(dir.path()).unwrap();
+        assert!(pool.rows(2, 0, 0).is_ok());
+        assert!(pool.rows(2, 1, 0).is_err(), "step beyond min must fail");
+    }
+
+    #[test]
+    fn write_rejects_empty_and_mismatched_inputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let texts = vec!["a".into()];
+        assert!(CapturePool::write(dir.path(), "m", 2, 1, &texts, &[], 0).is_err());
+
+        // Wrong layer count.
+        let cap = synthetic_capture(1, 1, 2, 2);
+        assert!(CapturePool::write(dir.path(), "m", 2, 1, &texts, &cap, 0).is_err());
+
+        // Wrong hidden size.
+        let cap = synthetic_capture(1, 1, 1, 3);
+        assert!(CapturePool::write(dir.path(), "m", 2, 1, &texts, &cap, 0).is_err());
+
+        // Zero steps.
+        let cap: Vec<Vec<Vec<Vec<f32>>>> = vec![vec![]];
+        assert!(CapturePool::write(dir.path(), "m", 2, 1, &texts, &cap, 0).is_err());
+    }
+
+    #[test]
+    fn open_rejects_truncated_bin_and_bad_version() {
+        let dir = tempfile::tempdir().unwrap();
+        write_synthetic(dir.path(), 1, 1, 1, 4);
+
+        // Truncate residuals.bin → open must fail on size mismatch.
+        let bin = dir.path().join("residuals.bin");
+        let data = std::fs::read(&bin).unwrap();
+        std::fs::write(&bin, &data[..data.len() - 4]).unwrap();
+        assert!(CapturePool::open(dir.path()).is_err());
+        std::fs::write(&bin, &data).unwrap();
+        assert!(CapturePool::open(dir.path()).is_ok());
+
+        // Corrupt the version → open must fail.
+        let mf = dir.path().join("manifest.json");
+        let json = std::fs::read_to_string(&mf).unwrap();
+        std::fs::write(&mf, json.replace("\"version\": 1", "\"version\": 999")).unwrap();
+        assert!(CapturePool::open(dir.path()).is_err());
+    }
+
+    #[test]
+    fn rows_bounds_checks() {
+        let dir = tempfile::tempdir().unwrap();
+        write_synthetic(dir.path(), 2, 2, 2, 2);
+        let pool = CapturePool::open(dir.path()).unwrap();
+        assert!(pool.rows(0, 0, 0).is_err());
+        assert!(pool.rows(3, 0, 0).is_err(), "batch > prompts");
+        assert!(pool.rows(1, 2, 0).is_err(), "step out of range");
+        assert!(pool.rows(1, 0, 2).is_err(), "layer out of range");
+    }
+}

--- a/crates/larql-cli/src/commands/primary/dec_bench/capture_runtime.rs
+++ b/crates/larql-cli/src/commands/primary/dec_bench/capture_runtime.rs
@@ -1,0 +1,150 @@
+//! I/O-bound capture driver: loads the model exactly like the bench
+//! remote-FFN runtime, runs single-stream decode per prompt against the live
+//! expert server with the residual-capture sink attached, and writes the
+//! pool. Coverage-excluded (needs live model weights + a running server);
+//! all validation and formatting logic lives in `capture_format.rs`.
+
+use super::args::CaptureArgs;
+use super::capture_format::CapturePool;
+
+pub(super) fn run_capture(args: &CaptureArgs) -> Result<(), Box<dyn std::error::Error>> {
+    use larql_inference::{
+        generate_with_remote_ffn_batch_captured, LayerShardedBackend, ResidualCaptureSink,
+    };
+    use std::time::Duration;
+
+    let vindex_path = crate::commands::primary::cache::resolve_model(&args.model)?;
+    if !vindex_path.is_dir() {
+        return Err(format!(
+            "resolved model path is not a directory: {}",
+            vindex_path.display(),
+        )
+        .into());
+    }
+
+    let prompts_raw = std::fs::read_to_string(&args.prompts_file)
+        .map_err(|e| format!("read prompts file {}: {e}", args.prompts_file.display()))?;
+    let prompts: Vec<String> = prompts_raw
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .take(args.num_prompts)
+        .map(String::from)
+        .collect();
+    if prompts.len() < args.num_prompts {
+        return Err(format!(
+            "prompts file has {} usable prompts, --num-prompts asked for {}",
+            prompts.len(),
+            args.num_prompts
+        )
+        .into());
+    }
+
+    let backend: Box<dyn larql_compute::ComputeBackend> = if args.metal {
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        {
+            larql_compute_metal::metal_backend()
+                .map(|m| Box::new(m) as Box<dyn larql_compute::ComputeBackend>)
+                .unwrap_or_else(larql_compute::cpu_backend)
+        }
+        #[cfg(not(all(feature = "gpu", target_os = "macos")))]
+        {
+            return Err("`--metal` requires the `gpu` feature on macOS".into());
+        }
+    } else {
+        larql_compute::default_backend()
+    };
+
+    let mut cb = larql_vindex::SilentLoadCallbacks;
+    let weights = larql_vindex::load_model_weights_kquant(&vindex_path, &mut cb)
+        .map_err(|e| format!("failed to load client weights: {e}"))?;
+    let tokenizer = larql_vindex::load_vindex_tokenizer(&vindex_path)
+        .map_err(|e| format!("failed to load tokenizer: {e}"))?;
+    let mut index = larql_vindex::VectorIndex::load_vindex(&vindex_path, &mut cb)
+        .map_err(|e| format!("failed to load vindex: {e}"))?;
+    index.load_attn_kquant(&vindex_path)?;
+    index.load_interleaved_kquant(&vindex_path)?;
+    let _ = index.load_lm_head_kquant(&vindex_path);
+
+    let timeout = Duration::from_secs(args.ffn_timeout_secs);
+    eprintln!("Connecting to remote FFN at {}…", args.ffn);
+    let remote = LayerShardedBackend::connect(&args.ffn, timeout)
+        .map_err(|e| format!("failed to connect to remote FFN: {e}"))?;
+    eprintln!("  Attention:  {} (local)", backend.name());
+    eprintln!("  FFN:        remote  ({})", args.ffn);
+
+    let eos = larql_inference::layer_graph::generate::eos::EosConfig::from_vindex_dir(&vindex_path);
+    // The sink records one entry per decode-loop step; the first generated
+    // token comes straight from prefill logits (no captured step), so ask
+    // for steps+1 tokens to get `steps` captured entries (EOS may still cut
+    // a prompt short — the pool truncates to the min across prompts).
+    let max_tokens = args.steps + 1;
+
+    let mut sinks: Vec<Vec<Vec<Vec<f32>>>> = Vec::with_capacity(prompts.len());
+    for (i, prompt) in prompts.iter().enumerate() {
+        let wrapped =
+            larql_inference::chat::render_user_prompt(&vindex_path, weights.arch.family(), prompt)
+                .unwrap_or_else(|_| prompt.clone());
+        let prompt_ids = larql_inference::encode_prompt(&tokenizer, &*weights.arch, &wrapped)
+            .map_err(|e| format!("tokenise prompt {i}: {e}"))?;
+
+        let mut sink = ResidualCaptureSink::default();
+        generate_with_remote_ffn_batch_captured(
+            &weights,
+            &tokenizer,
+            prompt_ids,
+            max_tokens,
+            &index,
+            &*backend,
+            &remote,
+            &eos,
+            1,
+            Some(&mut sink),
+        )
+        .map_err(|e| format!("capture decode failed on prompt {i}: {e}"))?;
+
+        if args.verbose {
+            eprintln!(
+                "[capture] prompt {}/{}: {} steps",
+                i + 1,
+                prompts.len(),
+                sink.steps.len()
+            );
+        }
+        if sink.steps.is_empty() {
+            return Err(format!(
+                "prompt {i} ({prompt:?}) produced no decode steps (immediate EOS) — \
+                 replace it in the prompts file"
+            )
+            .into());
+        }
+        sinks.push(sink.steps);
+    }
+
+    let created_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let hidden = weights.hidden_size;
+    let num_layers = weights.num_layers;
+    let manifest = CapturePool::write(
+        &args.out,
+        &args.model,
+        hidden,
+        num_layers,
+        &prompts,
+        &sinks,
+        created_unix,
+    )?;
+
+    eprintln!(
+        "Captured pool: {} prompts × {} steps × {} layers × hidden {} → {} ({} MB)",
+        manifest.prompts.len(),
+        manifest.steps,
+        manifest.num_layers,
+        manifest.hidden_size,
+        args.out.display(),
+        manifest.expected_bytes() / (1024 * 1024),
+    );
+    Ok(())
+}

--- a/crates/larql-cli/src/commands/primary/dec_bench/mod.rs
+++ b/crates/larql-cli/src/commands/primary/dec_bench/mod.rs
@@ -1,0 +1,30 @@
+//! `larql dec-bench` — DEC residual-replay loadgen (docs/dec-funnel.md).
+//!
+//! Measures the expert tier's batch behaviour (claim C1/C2) by replaying
+//! real captured residuals as B-row requests, without client-side batched
+//! decode. Module map:
+//!
+//!   args           — clap surface (`capture` / `replay` sub-modes).
+//!   capture_format — pool on-disk format (pure, coverage-gated).
+//!   capture_runtime— model load + live decode capture (I/O, excluded).
+//!   replay         — sweep plan, frame builders, summaries (pure, gated).
+//!   replay_runtime — HTTP driver (I/O, excluded).
+//!   pulse          — `dec/*` JSONL emission (pure, gated).
+//!   output         — full JSON run record (pure, gated).
+
+pub mod args;
+pub mod capture_format;
+mod capture_runtime;
+pub mod output;
+pub mod pulse;
+pub mod replay;
+mod replay_runtime;
+
+pub use args::DecBenchArgs;
+
+pub fn run(args: DecBenchArgs) -> Result<(), Box<dyn std::error::Error>> {
+    match args.cmd {
+        args::DecBenchCmd::Capture(a) => capture_runtime::run_capture(&a),
+        args::DecBenchCmd::Replay(a) => replay_runtime::run_replay(&a),
+    }
+}

--- a/crates/larql-cli/src/commands/primary/dec_bench/output.rs
+++ b/crates/larql-cli/src/commands/primary/dec_bench/output.rs
@@ -1,0 +1,140 @@
+//! DEC replay run record — the full-fidelity JSON sidecar written by
+//! `--output-file` (the pulse JSONL is the compact rig-facing view).
+
+use serde::Serialize;
+
+use super::capture_format::CaptureManifest;
+use super::replay::DecPointSummary;
+
+#[derive(Serialize)]
+pub struct DecBenchJsonResult {
+    /// Unix seconds, as a string (matches ADR-0012 bench JSON).
+    pub timestamp: String,
+    /// Which server endpoint the sweep measured. `walk-ffn` exercises the
+    /// dense/shared-expert FFN path; routed experts are a separate arm.
+    pub endpoint: String,
+    pub ffn_url: String,
+    pub capture: CaptureSummary,
+    /// `/v1/stats` echo taken before the sweep.
+    pub stats_before: serde_json::Value,
+    /// `/v1/stats` echo taken after the sweep (includes the server's own
+    /// `layer_latency` EMA/p99 accumulated over the run).
+    pub stats_after: serde_json::Value,
+    /// Layers replayed.
+    pub layers: Vec<usize>,
+    pub steps: usize,
+    pub repeats: usize,
+    pub warmup_passes: usize,
+    /// Dense FFN weight bytes per token over `layers` (movement-ratio
+    /// denominator for the measured endpoint); `None` when the server
+    /// doesn't expose `ffn_weights`.
+    pub weight_bytes_tok: Option<f64>,
+    /// Layers whose dense byte count was unavailable in `/v1/stats` — a
+    /// non-zero value flags a partial denominator.
+    pub weight_bytes_missing_layers: usize,
+    pub net_rtt_ms: Option<f64>,
+    pub net_gbps: Option<f64>,
+    pub points: Vec<DecPointSummary>,
+}
+
+/// Capture-pool identity embedded in the run record (not the full manifest —
+/// prompt texts stay in the pool directory).
+#[derive(Serialize)]
+pub struct CaptureSummary {
+    pub model: String,
+    pub hidden_size: usize,
+    pub num_layers: usize,
+    pub steps: usize,
+    pub num_prompts: usize,
+    pub created_unix: u64,
+}
+
+impl From<&CaptureManifest> for CaptureSummary {
+    fn from(m: &CaptureManifest) -> Self {
+        Self {
+            model: m.model.clone(),
+            hidden_size: m.hidden_size,
+            num_layers: m.num_layers,
+            steps: m.steps,
+            num_prompts: m.prompts.len(),
+            created_unix: m.created_unix,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::capture_format::{CaptureManifest, PromptMeta, CAPTURE_VERSION};
+    use super::*;
+
+    #[test]
+    fn capture_summary_from_manifest_drops_prompt_texts() {
+        let m = CaptureManifest {
+            version: CAPTURE_VERSION,
+            model: "gemma4-26b-a4b-q4k".into(),
+            hidden_size: 5376,
+            num_layers: 48,
+            steps: 16,
+            dtype: "f32-le".into(),
+            prompts: vec![
+                PromptMeta {
+                    id: 0,
+                    text: "secret-ish prompt text".into(),
+                    steps_captured: 16,
+                },
+                PromptMeta {
+                    id: 1,
+                    text: "another".into(),
+                    steps_captured: 20,
+                },
+            ],
+            created_unix: 42,
+        };
+        let s = CaptureSummary::from(&m);
+        assert_eq!(s.num_prompts, 2);
+        assert_eq!(s.steps, 16);
+        let json = serde_json::to_value(&s).unwrap();
+        assert!(json.get("prompts").is_none());
+        assert_eq!(json["hidden_size"], 5376);
+    }
+
+    #[test]
+    fn run_record_serializes_with_schema_fields() {
+        let m = CaptureManifest {
+            version: CAPTURE_VERSION,
+            model: "m".into(),
+            hidden_size: 4,
+            num_layers: 2,
+            steps: 1,
+            dtype: "f32-le".into(),
+            prompts: vec![PromptMeta {
+                id: 0,
+                text: "p".into(),
+                steps_captured: 1,
+            }],
+            created_unix: 0,
+        };
+        let r = DecBenchJsonResult {
+            timestamp: "123".into(),
+            endpoint: "walk-ffn".into(),
+            ffn_url: "http://127.0.0.1:8080".into(),
+            capture: CaptureSummary::from(&m),
+            stats_before: serde_json::json!({"layers": 2}),
+            stats_after: serde_json::json!({"layers": 2}),
+            layers: vec![0, 1],
+            steps: 1,
+            repeats: 3,
+            warmup_passes: 1,
+            weight_bytes_tok: Some(1000.0),
+            weight_bytes_missing_layers: 0,
+            net_rtt_ms: None,
+            net_gbps: None,
+            points: vec![],
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["endpoint"], "walk-ffn");
+        assert_eq!(v["capture"]["num_prompts"], 1);
+        assert_eq!(v["weight_bytes_tok"], 1000.0);
+        assert!(v["points"].as_array().unwrap().is_empty());
+    }
+}

--- a/crates/larql-cli/src/commands/primary/dec_bench/pulse.rs
+++ b/crates/larql-cli/src/commands/primary/dec_bench/pulse.rs
@@ -1,0 +1,174 @@
+//! `dec/*` pulse emission — JSONL lines consumable by the chuk-train rig.
+//!
+//! Contract (rig side): each line is one JSON object with a numeric `step`;
+//! every other numeric field becomes a metric sample, non-numeric fields are
+//! dropped. String axes (`dec/wire_format`, `dec/dispatch_mode`) are part of
+//! the spec §7 schema and included for humans, with numeric `_code` twins so
+//! the axes survive a numeric-only ingester.
+
+use super::replay::DecPointSummary;
+
+/// Build one pulse line for a sweep point. `step` is the sweep-point index.
+#[allow(clippy::too_many_arguments)]
+pub fn pulse_line(
+    step: usize,
+    s: &DecPointSummary,
+    weight_bytes_tok: Option<f64>,
+    movement_ratio: Option<f64>,
+    net_rtt_ms: Option<f64>,
+    net_gbps: Option<f64>,
+    per_layer: bool,
+) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("step".into(), step.into());
+    obj.insert("dec/batch".into(), s.batch.into());
+    obj.insert("dec/wire_format".into(), s.wire_format.clone().into());
+    obj.insert("dec/wire_format_code".into(), s.wire_format_code.into());
+    obj.insert("dec/dispatch_mode".into(), s.dispatch_mode.clone().into());
+    obj.insert(
+        "dec/dispatch_mode_code".into(),
+        s.dispatch_mode_code.into(),
+    );
+    obj.insert("dec/step_ms_mean".into(), num(s.step_ms_mean));
+    obj.insert("dec/step_ms_p50".into(), num(s.step_ms_p50));
+    obj.insert("dec/step_ms_p99".into(), num(s.step_ms_p99));
+    obj.insert("dec/tok_s".into(), num(s.tok_s));
+    obj.insert("dec/payload_bytes_tok".into(), num(s.payload_bytes_tok));
+    if let Some(w) = weight_bytes_tok {
+        obj.insert("dec/weight_bytes_tok".into(), num(w));
+    }
+    if let Some(r) = movement_ratio {
+        obj.insert("dec/movement_ratio".into(), num(r));
+    }
+    if let Some(p50) = s.server_ms_p50 {
+        obj.insert("dec/server_ms_p50".into(), num(p50));
+    }
+    if let Some(p99) = s.server_ms_p99 {
+        obj.insert("dec/server_ms_p99".into(), num(p99));
+    }
+    if let Some(rtt) = net_rtt_ms {
+        obj.insert("net/rtt_ms".into(), num(rtt));
+    }
+    if let Some(gbps) = net_gbps {
+        obj.insert("net/gbps".into(), num(gbps));
+    }
+    if per_layer {
+        for l in &s.per_layer {
+            obj.insert(
+                format!("dec/layer{}_ms_p50", l.layer),
+                num(l.client_ms_p50),
+            );
+            obj.insert(
+                format!("dec/layer{}_ms_p99", l.layer),
+                num(l.client_ms_p99),
+            );
+        }
+    }
+    serde_json::Value::Object(obj)
+}
+
+fn num(v: f64) -> serde_json::Value {
+    serde_json::Number::from_f64(v)
+        .map(serde_json::Value::Number)
+        .unwrap_or(serde_json::Value::Null)
+}
+
+/// Serialise pulse lines as JSONL (one compact object per line, trailing
+/// newline).
+pub fn to_jsonl(lines: &[serde_json::Value]) -> String {
+    let mut out = String::new();
+    for l in lines {
+        out.push_str(&l.to_string());
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::replay::{DecPointSummary, LayerSummary};
+    use super::*;
+
+    fn summary() -> DecPointSummary {
+        DecPointSummary {
+            batch: 8,
+            wire_format: "f16".into(),
+            wire_format_code: 1,
+            served_wire: vec!["f16".into()],
+            dispatch_mode: "batch".into(),
+            dispatch_mode_code: 1,
+            steps: 16,
+            step_ms_mean: 12.5,
+            step_ms_p50: 12.0,
+            step_ms_p99: 20.0,
+            tok_s: 640.0,
+            payload_bytes_tok: 21504.0,
+            server_ms_p50: Some(9.0),
+            server_ms_p99: Some(15.0),
+            per_layer: vec![LayerSummary {
+                layer: 3,
+                client_ms_p50: 0.4,
+                client_ms_p99: 0.9,
+            }],
+        }
+    }
+
+    #[test]
+    fn pulse_line_has_numeric_step_and_schema_keys() {
+        let line = pulse_line(
+            7,
+            &summary(),
+            Some(2.0e9),
+            Some(1.1e-5),
+            Some(0.05),
+            Some(10.0),
+            false,
+        );
+        assert_eq!(line["step"], 7);
+        assert_eq!(line["dec/batch"], 8);
+        assert_eq!(line["dec/wire_format"], "f16");
+        assert_eq!(line["dec/wire_format_code"], 1);
+        assert_eq!(line["dec/dispatch_mode_code"], 1);
+        assert!(line["dec/step_ms_p50"].is_number());
+        assert!(line["dec/step_ms_p99"].is_number());
+        assert!(line["dec/tok_s"].is_number());
+        assert!(line["dec/payload_bytes_tok"].is_number());
+        assert!(line["dec/weight_bytes_tok"].is_number());
+        assert!(line["dec/movement_ratio"].is_number());
+        assert!(line["dec/server_ms_p50"].is_number());
+        assert!(line["net/rtt_ms"].is_number());
+        assert!(line["net/gbps"].is_number());
+        // Per-layer keys only under the flag.
+        assert!(line.get("dec/layer3_ms_p50").is_none());
+    }
+
+    #[test]
+    fn pulse_line_optional_fields_omitted_and_per_layer_gated() {
+        let mut s = summary();
+        s.server_ms_p50 = None;
+        s.server_ms_p99 = None;
+        let line = pulse_line(0, &s, None, None, None, None, true);
+        assert!(line.get("dec/weight_bytes_tok").is_none());
+        assert!(line.get("dec/movement_ratio").is_none());
+        assert!(line.get("dec/server_ms_p50").is_none());
+        assert!(line.get("net/rtt_ms").is_none());
+        assert!(line["dec/layer3_ms_p50"].is_number());
+        assert!(line["dec/layer3_ms_p99"].is_number());
+    }
+
+    #[test]
+    fn to_jsonl_one_compact_line_each() {
+        let lines = vec![
+            pulse_line(0, &summary(), None, None, None, None, false),
+            pulse_line(1, &summary(), None, None, None, None, false),
+        ];
+        let jsonl = to_jsonl(&lines);
+        let rows: Vec<&str> = jsonl.trim_end().split('\n').collect();
+        assert_eq!(rows.len(), 2);
+        for (i, row) in rows.iter().enumerate() {
+            let v: serde_json::Value = serde_json::from_str(row).unwrap();
+            assert_eq!(v["step"], i);
+        }
+        assert!(jsonl.ends_with('\n'));
+    }
+}

--- a/crates/larql-cli/src/commands/primary/dec_bench/replay.rs
+++ b/crates/larql-cli/src/commands/primary/dec_bench/replay.rs
@@ -1,0 +1,620 @@
+//! Pure replay logic for the DEC loadgen: sweep-plan expansion, wire-frame
+//! construction, and per-point statistics. Everything transport-shaped lives
+//! in `replay_runtime.rs`; every byte on the wire goes through the SAME codec
+//! functions the production client uses (parity discipline).
+
+use larql_compute::cpu::ops::q4k_q8k_dot::quantize_x_to_q8k;
+use larql_inference::{encode_binary_request, encode_q8k_batch_request};
+
+use super::super::bench::row::compute_percentiles;
+
+// ── Sweep plan ────────────────────────────────────────────────────────────────
+
+/// One wire-format arm of the sweep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WireArm {
+    F32,
+    F16,
+    I8,
+    Q8k,
+}
+
+impl WireArm {
+    pub fn parse_list(s: &str) -> Result<Vec<WireArm>, String> {
+        s.split(',')
+            .map(|w| match w.trim() {
+                "f32" => Ok(WireArm::F32),
+                "f16" => Ok(WireArm::F16),
+                "i8" => Ok(WireArm::I8),
+                "q8k" => Ok(WireArm::Q8k),
+                other => Err(format!(
+                    "unknown wire format {other:?} (expected f32, f16, i8, q8k)"
+                )),
+            })
+            .collect()
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            WireArm::F32 => "f32",
+            WireArm::F16 => "f16",
+            WireArm::I8 => "i8",
+            WireArm::Q8k => "q8k",
+        }
+    }
+
+    /// Numeric twin of [`Self::label`] for numeric-only metric ingesters.
+    pub fn code(self) -> u32 {
+        match self {
+            WireArm::F32 => 0,
+            WireArm::F16 => 1,
+            WireArm::I8 => 2,
+            WireArm::Q8k => 3,
+        }
+    }
+
+    /// `Accept` header for the strict arm (no fallback formats offered).
+    /// `None` for Q8K, which is its own endpoint rather than a negotiated CT.
+    pub fn accept(self) -> Option<&'static str> {
+        match self {
+            WireArm::F32 => Some(larql_inference::BINARY_CT),
+            WireArm::F16 => Some(larql_inference::F16_CT),
+            WireArm::I8 => Some(larql_inference::I8_CT),
+            WireArm::Q8k => None,
+        }
+    }
+}
+
+/// How the per-layer requests of one step are dispatched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchMode {
+    /// Sequential per-layer round trips; step time = Σ layer RTTs.
+    Streaming,
+    /// All layers fired in parallel (mirrors `forward_predispatch_all`);
+    /// step time = fan-out wall time.
+    Batch,
+}
+
+impl DispatchMode {
+    pub fn parse_list(s: &str) -> Result<Vec<DispatchMode>, String> {
+        s.split(',')
+            .map(|d| match d.trim() {
+                "streaming" => Ok(DispatchMode::Streaming),
+                "batch" => Ok(DispatchMode::Batch),
+                other => Err(format!(
+                    "unknown dispatch mode {other:?} (expected streaming, batch)"
+                )),
+            })
+            .collect()
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            DispatchMode::Streaming => "streaming",
+            DispatchMode::Batch => "batch",
+        }
+    }
+
+    pub fn code(self) -> u32 {
+        match self {
+            DispatchMode::Streaming => 0,
+            DispatchMode::Batch => 1,
+        }
+    }
+}
+
+/// One point of the sweep: (batch, wire, dispatch).
+#[derive(Debug, Clone, Copy)]
+pub struct SweepPoint {
+    pub batch: usize,
+    pub wire: WireArm,
+    pub dispatch: DispatchMode,
+}
+
+pub fn parse_batch_list(s: &str) -> Result<Vec<usize>, String> {
+    s.split(',')
+        .map(|b| {
+            b.trim()
+                .parse::<usize>()
+                .map_err(|_| format!("invalid batch size {b:?}"))
+                .and_then(|n| {
+                    if n == 0 {
+                        Err("batch size 0 is invalid".into())
+                    } else {
+                        Ok(n)
+                    }
+                })
+        })
+        .collect()
+}
+
+/// Full cross product, ordered batch-major so all wire/dispatch arms of one
+/// batch size run adjacently (comparable thermal window).
+pub fn expand_sweep(
+    batches: &[usize],
+    wires: &[WireArm],
+    dispatches: &[DispatchMode],
+) -> Vec<SweepPoint> {
+    let mut out = Vec::with_capacity(batches.len() * wires.len() * dispatches.len());
+    for &batch in batches {
+        for &wire in wires {
+            for &dispatch in dispatches {
+                out.push(SweepPoint {
+                    batch,
+                    wire,
+                    dispatch,
+                });
+            }
+        }
+    }
+    out
+}
+
+// ── Frame construction ────────────────────────────────────────────────────────
+
+/// Build a B-row `/v1/walk-ffn` request frame for one layer.
+///
+/// `rows` is `batch × hidden` contiguous f32s. `top_k` is hard-wired to 0:
+/// the server's L2 FFN cache engages when `seq_len == 1 && top_k > 0`, which
+/// would falsify repeated B=1 measurements with cache hits.
+pub fn build_walk_ffn_frame(layer: usize, rows: &[f32], batch: usize) -> Vec<u8> {
+    encode_binary_request(Some(layer), None, rows, batch, true, 0)
+}
+
+/// Build a B-row `/v1/walk-ffn-q8k` request frame for one layer: B entries
+/// sharing `layer`, each one row quantised through the production
+/// `quantize_x_to_q8k` path.
+pub fn build_q8k_frame(layer: usize, rows: &[f32], batch: usize, hidden: usize) -> Vec<u8> {
+    let q8ks: Vec<_> = (0..batch)
+        .map(|i| quantize_x_to_q8k(&rows[i * hidden..(i + 1) * hidden]))
+        .collect();
+    let entries: Vec<(usize, &_)> = q8ks.iter().map(|q| (layer, q)).collect();
+    encode_q8k_batch_request(&entries)
+}
+
+/// Short wire label for a response content-type (unknown CTs pass through
+/// verbatim so the run record never hides what the server sent).
+pub fn wire_label_for_content_type(ct: &str) -> String {
+    match ct {
+        larql_inference::BINARY_CT => "f32".into(),
+        larql_inference::F16_CT => "f16".into(),
+        larql_inference::I8_CT => "i8".into(),
+        larql_inference::Q8K_BATCH_CT => "q8k".into(),
+        other => other.to_string(),
+    }
+}
+
+// ── Per-point statistics ──────────────────────────────────────────────────────
+
+/// One request's measurements (one layer of one step of one repeat).
+#[derive(Debug, Clone)]
+pub struct RequestSample {
+    pub layer: usize,
+    pub client_ms: f64,
+    /// Server compute ms from the embedded response header; `None` on the
+    /// Q8K endpoint (its response carries no latency field).
+    pub server_ms: Option<f64>,
+    pub bytes_sent: u64,
+    pub bytes_recv: u64,
+    /// Wire format the server actually served (from the response
+    /// content-type). Accept negotiation may fall back — e.g. an i8 arm
+    /// served as f32 — and the run record must say so.
+    pub served_wire: String,
+}
+
+/// Accumulated raw measurements for one sweep point.
+#[derive(Debug, Default)]
+pub struct SweepPointStats {
+    /// One entry per (repeat × step): full-pass step time in ms.
+    pub step_ms: Vec<f64>,
+    pub samples: Vec<RequestSample>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LayerSummary {
+    pub layer: usize,
+    pub client_ms_p50: f64,
+    pub client_ms_p99: f64,
+}
+
+/// Summarised sweep point, ready for the run record and pulse file.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DecPointSummary {
+    pub batch: usize,
+    pub wire_format: String,
+    pub wire_format_code: u32,
+    /// Wire format(s) the server actually served this point (sorted,
+    /// deduped). Differs from `wire_format` when Accept negotiation fell
+    /// back — the arm's bandwidth number then belongs to the served format.
+    pub served_wire: Vec<String>,
+    pub dispatch_mode: String,
+    pub dispatch_mode_code: u32,
+    pub steps: usize,
+    pub step_ms_mean: f64,
+    pub step_ms_p50: f64,
+    pub step_ms_p99: f64,
+    /// Rows served per second: `batch × 1000 / step_ms_mean`.
+    pub tok_s: f64,
+    /// (bytes sent + received) ÷ (steps × batch) — wire cost per token row.
+    pub payload_bytes_tok: f64,
+    pub server_ms_p50: Option<f64>,
+    pub server_ms_p99: Option<f64>,
+    pub per_layer: Vec<LayerSummary>,
+}
+
+pub fn summarize(point: &SweepPoint, stats: &SweepPointStats) -> DecPointSummary {
+    let (mean, p50, p99) = compute_percentiles(&stats.step_ms);
+    let tok_s = if mean > 0.0 {
+        point.batch as f64 * 1000.0 / mean
+    } else {
+        0.0
+    };
+    let total_bytes: u64 = stats
+        .samples
+        .iter()
+        .map(|s| s.bytes_sent + s.bytes_recv)
+        .sum();
+    let token_rows = (stats.step_ms.len() * point.batch) as f64;
+    let payload_bytes_tok = if token_rows > 0.0 {
+        total_bytes as f64 / token_rows
+    } else {
+        0.0
+    };
+
+    let server_samples: Vec<f64> = stats.samples.iter().filter_map(|s| s.server_ms).collect();
+    let (server_ms_p50, server_ms_p99) = if server_samples.is_empty() {
+        (None, None)
+    } else {
+        let (_, p50, p99) = compute_percentiles(&server_samples);
+        (Some(p50), Some(p99))
+    };
+
+    let mut served_wire: Vec<String> = stats
+        .samples
+        .iter()
+        .map(|s| s.served_wire.clone())
+        .collect();
+    served_wire.sort();
+    served_wire.dedup();
+
+    let mut layers: Vec<usize> = stats.samples.iter().map(|s| s.layer).collect();
+    layers.sort_unstable();
+    layers.dedup();
+    let per_layer = layers
+        .into_iter()
+        .map(|layer| {
+            let vals: Vec<f64> = stats
+                .samples
+                .iter()
+                .filter(|s| s.layer == layer)
+                .map(|s| s.client_ms)
+                .collect();
+            let (_, p50, p99) = compute_percentiles(&vals);
+            LayerSummary {
+                layer,
+                client_ms_p50: p50,
+                client_ms_p99: p99,
+            }
+        })
+        .collect();
+
+    DecPointSummary {
+        batch: point.batch,
+        wire_format: point.wire.label().into(),
+        wire_format_code: point.wire.code(),
+        served_wire,
+        dispatch_mode: point.dispatch.label().into(),
+        dispatch_mode_code: point.dispatch.code(),
+        steps: stats.step_ms.len(),
+        step_ms_mean: mean,
+        step_ms_p50: p50,
+        step_ms_p99: p99,
+        tok_s,
+        payload_bytes_tok,
+        server_ms_p50,
+        server_ms_p99,
+        per_layer,
+    }
+}
+
+// ── Movement ratio ────────────────────────────────────────────────────────────
+
+/// `dec/movement_ratio` = wire bytes crossing the attention↔weights boundary
+/// per token ÷ weight bytes the measured endpoint touches per token
+/// (docs/dec-funnel.md §1). Offload ≈ 1.0 by construction; this architecture
+/// targets 1e-3–1e-4.
+pub fn movement_ratio(payload_bytes_tok: f64, weight_bytes_tok: f64) -> Option<f64> {
+    if weight_bytes_tok > 0.0 && payload_bytes_tok >= 0.0 {
+        Some(payload_bytes_tok / weight_bytes_tok)
+    } else {
+        None
+    }
+}
+
+/// Sum the dense FFN weight bytes per token over `layers` from a `/v1/stats`
+/// response (`ffn_weights.per_layer_dense_bytes`). This is the exact byte
+/// count `/v1/walk-ffn` touches per token on those layers — the movement-
+/// ratio denominator for the measured endpoint. Layers with `null` entries
+/// (no interleaved k-quant data) contribute nothing and are reported back so
+/// the caller can flag partial coverage.
+///
+/// Returns `(dense_bytes, missing_layer_count)`, or `None` when the stats
+/// response has no `ffn_weights` block at all.
+pub fn weight_bytes_per_token(
+    stats: &serde_json::Value,
+    layers: &[usize],
+) -> Option<(f64, usize)> {
+    let per_layer = stats
+        .get("ffn_weights")?
+        .get("per_layer_dense_bytes")?
+        .as_array()?;
+    let mut total = 0.0f64;
+    let mut missing = 0usize;
+    for &l in layers {
+        match per_layer.get(l).and_then(|v| v.as_u64()) {
+            Some(b) => total += b as f64,
+            None => missing += 1,
+        }
+    }
+    Some((total, missing))
+}
+
+/// Parse an inclusive `"A-B"` layer range into a layer list, defaulting to
+/// `0..num_layers` when absent.
+pub fn parse_layer_range(spec: Option<&str>, num_layers: usize) -> Result<Vec<usize>, String> {
+    match spec {
+        None => Ok((0..num_layers).collect()),
+        Some(s) => {
+            let (a, b) = s
+                .split_once('-')
+                .ok_or_else(|| format!("invalid layer range {s:?} (expected A-B)"))?;
+            let a: usize = a
+                .trim()
+                .parse()
+                .map_err(|_| format!("invalid layer range start {a:?}"))?;
+            let b: usize = b
+                .trim()
+                .parse()
+                .map_err(|_| format!("invalid layer range end {b:?}"))?;
+            if a > b || b >= num_layers {
+                return Err(format!(
+                    "layer range {a}-{b} out of bounds (model has {num_layers} layers)"
+                ));
+            }
+            Ok((a..=b).collect())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parsing ────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_wire_list_all_arms() {
+        let arms = WireArm::parse_list("f32, f16,i8,q8k").unwrap();
+        assert_eq!(
+            arms,
+            vec![WireArm::F32, WireArm::F16, WireArm::I8, WireArm::Q8k]
+        );
+        assert!(WireArm::parse_list("f64").is_err());
+    }
+
+    #[test]
+    fn wire_arm_labels_codes_accepts() {
+        assert_eq!(WireArm::F32.label(), "f32");
+        assert_eq!(WireArm::Q8k.code(), 3);
+        assert_eq!(WireArm::F32.accept(), Some("application/x-larql-ffn"));
+        assert_eq!(WireArm::F16.accept(), Some("application/x-larql-ffn-f16"));
+        assert_eq!(WireArm::I8.accept(), Some("application/x-larql-ffn-i8"));
+        assert_eq!(WireArm::Q8k.accept(), None, "q8k is its own endpoint");
+    }
+
+    #[test]
+    fn parse_dispatch_and_batch_lists() {
+        let d = DispatchMode::parse_list("streaming,batch").unwrap();
+        assert_eq!(d, vec![DispatchMode::Streaming, DispatchMode::Batch]);
+        assert!(DispatchMode::parse_list("parallel").is_err());
+
+        assert_eq!(parse_batch_list("1,8,16").unwrap(), vec![1, 8, 16]);
+        assert!(parse_batch_list("0").is_err());
+        assert!(parse_batch_list("x").is_err());
+    }
+
+    #[test]
+    fn expand_sweep_is_batch_major_cross_product() {
+        let points = expand_sweep(
+            &[1, 8],
+            &[WireArm::F32, WireArm::F16],
+            &[DispatchMode::Streaming],
+        );
+        assert_eq!(points.len(), 4);
+        assert_eq!(points[0].batch, 1);
+        assert_eq!(points[1].batch, 1);
+        assert_eq!(points[2].batch, 8);
+        assert_eq!(points[1].wire, WireArm::F16);
+    }
+
+    // ── frames ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn walk_ffn_frame_encodes_batch_rows_and_zero_top_k() {
+        let hidden = 4;
+        let batch = 3;
+        let rows: Vec<f32> = (0..batch * hidden).map(|i| i as f32 * 0.5).collect();
+        let frame = build_walk_ffn_frame(7, &rows, batch);
+        // Header: layer, seq_len, flags, top_k — then batch×hidden f32s.
+        assert_eq!(frame.len(), 16 + batch * hidden * 4);
+        assert_eq!(u32::from_le_bytes(frame[0..4].try_into().unwrap()), 7);
+        assert_eq!(
+            u32::from_le_bytes(frame[4..8].try_into().unwrap()) as usize,
+            batch
+        );
+        assert_eq!(
+            u32::from_le_bytes(frame[12..16].try_into().unwrap()),
+            0,
+            "top_k must be 0 — non-zero engages the server L2 cache at seq_len==1"
+        );
+        // Row 1's first float lands after row 0.
+        let v = f32::from_le_bytes(frame[16 + hidden * 4..20 + hidden * 4].try_into().unwrap());
+        assert_eq!(v, hidden as f32 * 0.5);
+    }
+
+    #[test]
+    fn q8k_frame_carries_one_entry_per_row_same_layer() {
+        let hidden = 256; // one Q8K superblock
+        let batch = 3;
+        let rows: Vec<f32> = (0..batch * hidden).map(|i| (i as f32 * 0.01).sin()).collect();
+        let frame = build_q8k_frame(9, &rows, batch, hidden);
+        let entries = larql_inference::ffn::remote::decode_q8k_batch_request(&frame).unwrap();
+        assert_eq!(entries.len(), batch);
+        assert!(entries.iter().all(|e| e.layer_idx == 9));
+        // Each entry must be that row's quantisation, not row 0 repeated.
+        let q1 = quantize_x_to_q8k(&rows[hidden..2 * hidden]);
+        assert_eq!(entries[1].q8k.qs, q1.qs);
+        assert_eq!(entries[1].q8k.d, q1.d);
+    }
+
+    // ── summaries ──────────────────────────────────────────────────────
+
+    fn sample(layer: usize, client_ms: f64, server_ms: Option<f64>) -> RequestSample {
+        RequestSample {
+            layer,
+            client_ms,
+            server_ms,
+            bytes_sent: 100,
+            bytes_recv: 60,
+            served_wire: "f16".into(),
+        }
+    }
+
+    #[test]
+    fn summarize_computes_throughput_payload_and_per_layer() {
+        let point = SweepPoint {
+            batch: 8,
+            wire: WireArm::F16,
+            dispatch: DispatchMode::Batch,
+        };
+        let stats = SweepPointStats {
+            step_ms: vec![10.0, 20.0],
+            samples: vec![
+                sample(0, 4.0, Some(3.0)),
+                sample(1, 6.0, Some(5.0)),
+                sample(0, 8.0, Some(6.0)),
+                sample(1, 12.0, Some(9.0)),
+            ],
+        };
+        let s = summarize(&point, &stats);
+        assert_eq!(s.batch, 8);
+        assert_eq!(s.wire_format, "f16");
+        assert_eq!(s.dispatch_mode, "batch");
+        assert_eq!(s.steps, 2);
+        assert!((s.step_ms_mean - 15.0).abs() < 1e-9);
+        // tok_s = 8 rows × 1000 / 15 ms
+        assert!((s.tok_s - 8.0 * 1000.0 / 15.0).abs() < 1e-6);
+        // payload = 4 samples × 160 bytes / (2 steps × 8 rows)
+        assert!((s.payload_bytes_tok - (4.0 * 160.0) / 16.0).abs() < 1e-9);
+        assert!(s.server_ms_p50.is_some());
+        assert_eq!(s.per_layer.len(), 2);
+        assert_eq!(s.per_layer[0].layer, 0);
+        assert!(s.per_layer[1].client_ms_p99 >= s.per_layer[1].client_ms_p50);
+    }
+
+    #[test]
+    fn summarize_handles_empty_and_no_server_ms() {
+        let point = SweepPoint {
+            batch: 1,
+            wire: WireArm::Q8k,
+            dispatch: DispatchMode::Streaming,
+        };
+        let s = summarize(&point, &SweepPointStats::default());
+        assert_eq!(s.tok_s, 0.0);
+        assert_eq!(s.payload_bytes_tok, 0.0);
+        assert!(s.server_ms_p50.is_none());
+
+        let stats = SweepPointStats {
+            step_ms: vec![5.0],
+            samples: vec![sample(0, 5.0, None)],
+        };
+        let s = summarize(&point, &stats);
+        assert!(s.server_ms_p50.is_none(), "q8k has no embedded latency");
+    }
+
+    // ── movement ratio + weight bytes ──────────────────────────────────
+
+    #[test]
+    fn summarize_reports_served_wire_including_fallback() {
+        // An i8-requested arm that the server served as f32 must say so —
+        // the bandwidth number belongs to what was actually on the wire.
+        let point = SweepPoint {
+            batch: 1,
+            wire: WireArm::I8,
+            dispatch: DispatchMode::Streaming,
+        };
+        let mut s0 = sample(0, 1.0, Some(0.5));
+        s0.served_wire = "f32".into();
+        let mut s1 = sample(1, 1.0, Some(0.5));
+        s1.served_wire = "f32".into();
+        let stats = SweepPointStats {
+            step_ms: vec![2.0],
+            samples: vec![s0, s1],
+        };
+        let s = summarize(&point, &stats);
+        assert_eq!(s.wire_format, "i8");
+        assert_eq!(s.served_wire, vec!["f32".to_string()]);
+    }
+
+    #[test]
+    fn wire_label_maps_known_cts_and_passes_through_unknown() {
+        assert_eq!(wire_label_for_content_type("application/x-larql-ffn"), "f32");
+        assert_eq!(
+            wire_label_for_content_type("application/x-larql-ffn-f16"),
+            "f16"
+        );
+        assert_eq!(
+            wire_label_for_content_type("application/x-larql-ffn-i8"),
+            "i8"
+        );
+        assert_eq!(
+            wire_label_for_content_type("application/x-larql-ffn-q8k-batch"),
+            "q8k"
+        );
+        assert_eq!(wire_label_for_content_type("text/plain"), "text/plain");
+    }
+
+    #[test]
+    fn movement_ratio_basic_and_guards() {
+        assert_eq!(movement_ratio(1.0, 1000.0), Some(0.001));
+        assert_eq!(movement_ratio(1.0, 0.0), None);
+        assert_eq!(movement_ratio(-1.0, 10.0), None);
+    }
+
+    #[test]
+    fn weight_bytes_per_token_sums_selected_layers() {
+        let stats = serde_json::json!({
+            "ffn_weights": {
+                "per_layer_dense_bytes": [100, 200, null, 400],
+            }
+        });
+        let (bytes, missing) = weight_bytes_per_token(&stats, &[0, 1, 2, 3]).unwrap();
+        assert_eq!(bytes, 700.0);
+        assert_eq!(missing, 1);
+
+        let (bytes, missing) = weight_bytes_per_token(&stats, &[1]).unwrap();
+        assert_eq!(bytes, 200.0);
+        assert_eq!(missing, 0);
+
+        assert!(weight_bytes_per_token(&serde_json::json!({}), &[0]).is_none());
+    }
+
+    #[test]
+    fn parse_layer_range_default_and_bounds() {
+        assert_eq!(parse_layer_range(None, 3).unwrap(), vec![0, 1, 2]);
+        assert_eq!(parse_layer_range(Some("1-2"), 4).unwrap(), vec![1, 2]);
+        assert!(parse_layer_range(Some("2-1"), 4).is_err());
+        assert!(parse_layer_range(Some("0-4"), 4).is_err());
+        assert!(parse_layer_range(Some("x"), 4).is_err());
+    }
+}

--- a/crates/larql-cli/src/commands/primary/dec_bench/replay_runtime.rs
+++ b/crates/larql-cli/src/commands/primary/dec_bench/replay_runtime.rs
@@ -1,0 +1,374 @@
+//! I/O-bound replay driver: sweeps batch × wire × dispatch against a live
+//! expert server using frames built from a capture pool. Coverage-excluded
+//! (needs a running server); every pure decision lives in `replay.rs`.
+//!
+//! Dispatch parity: `streaming` = sequential per-layer POSTs (step time =
+//! Σ layer RTTs, mirroring `generate_with_remote_ffn`'s per-layer round
+//! trips); `batch` = all layers fired in parallel via `std::thread::scope`
+//! (mirroring `LayerShardedBackend::forward_predispatch_all`). The
+//! multi-layer wire frame is deliberately NOT used — the production client
+//! never sends per-layer-distinct residuals through it.
+
+use super::args::ReplayArgs;
+use super::capture_format::CapturePool;
+use super::output::{CaptureSummary, DecBenchJsonResult};
+use super::pulse;
+use super::replay::{
+    build_q8k_frame, build_walk_ffn_frame, expand_sweep, movement_ratio, parse_batch_list,
+    parse_layer_range, summarize, DispatchMode, RequestSample, SweepPoint, SweepPointStats,
+    WireArm, weight_bytes_per_token,
+};
+
+use larql_inference::ffn::remote::{STATS_PATH, WALK_FFN_PATH, WALK_FFN_Q8K_PATH};
+
+pub(super) fn run_replay(args: &ReplayArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let pool = CapturePool::open(&args.capture)?;
+
+    let batches = parse_batch_list(&args.batch)?;
+    if let Some(&max_b) = batches.iter().max() {
+        if max_b > pool.num_prompts() {
+            return Err(format!(
+                "max batch {max_b} exceeds pool prompt count {} — capture more prompts",
+                pool.num_prompts()
+            )
+            .into());
+        }
+    }
+    let wires = WireArm::parse_list(&args.wire)?;
+    let dispatches = DispatchMode::parse_list(&args.dispatch)?;
+    let steps = match args.steps {
+        Some(s) => {
+            if s == 0 || s > pool.manifest.steps {
+                return Err(format!(
+                    "--steps {s} out of range (pool has {} steps)",
+                    pool.manifest.steps
+                )
+                .into());
+            }
+            s
+        }
+        None => pool.manifest.steps,
+    };
+
+    let base_url = args.ffn.trim_end_matches('/').to_string();
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(args.timeout_secs))
+        .build()?;
+
+    let stats_before = fetch_stats(&client, &base_url)?;
+    let server_layers = stats_before
+        .get("layers")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(pool.manifest.num_layers as u64) as usize;
+    if server_layers != pool.manifest.num_layers {
+        eprintln!(
+            "[dec-bench] WARNING: server reports {server_layers} layers, pool captured {} — \
+             replaying the pool's layer space",
+            pool.manifest.num_layers
+        );
+    }
+    let layers = parse_layer_range(args.layers.as_deref(), pool.manifest.num_layers)?;
+
+    let (weight_bytes_tok, weight_missing) =
+        match weight_bytes_per_token(&stats_before, &layers) {
+            Some((bytes, missing)) => (Some(bytes), missing),
+            None => {
+                eprintln!(
+                    "[dec-bench] server /v1/stats has no ffn_weights block — \
+                     dec/movement_ratio will be omitted"
+                );
+                (None, 0)
+            }
+        };
+
+    let sweep = expand_sweep(&batches, &wires, &dispatches);
+    eprintln!(
+        "[dec-bench] replaying {} points: batch {:?} × wire {:?} × dispatch {:?}, \
+         {} layers × {} steps × {} repeats",
+        sweep.len(),
+        batches,
+        wires.iter().map(|w| w.label()).collect::<Vec<_>>(),
+        dispatches.iter().map(|d| d.label()).collect::<Vec<_>>(),
+        layers.len(),
+        steps,
+        args.repeats,
+    );
+
+    let mut points = Vec::with_capacity(sweep.len());
+    let mut pulse_lines = Vec::with_capacity(sweep.len());
+    for (idx, point) in sweep.iter().enumerate() {
+        let stats = run_point(&client, &base_url, &pool, point, &layers, steps, args)?;
+        let summary = summarize(point, &stats);
+        if summary.served_wire != vec![summary.wire_format.clone()] {
+            eprintln!(
+                "[dec-bench] NOTE: {} arm was served as {:?} (Accept fallback) — \
+                 bandwidth numbers belong to the served format",
+                summary.wire_format, summary.served_wire
+            );
+        }
+        let ratio = weight_bytes_tok
+            .and_then(|w| movement_ratio(summary.payload_bytes_tok, w));
+        eprintln!(
+            "[dec-bench] point {}/{}: batch={} wire={} dispatch={} → \
+             step p50 {:.2} ms, p99 {:.2} ms, {:.1} tok/s, {:.0} B/tok{}",
+            idx + 1,
+            sweep.len(),
+            summary.batch,
+            summary.wire_format,
+            summary.dispatch_mode,
+            summary.step_ms_p50,
+            summary.step_ms_p99,
+            summary.tok_s,
+            summary.payload_bytes_tok,
+            ratio
+                .map(|r| format!(", movement {r:.2e}"))
+                .unwrap_or_default(),
+        );
+        pulse_lines.push(pulse::pulse_line(
+            idx,
+            &summary,
+            weight_bytes_tok,
+            ratio,
+            args.net_rtt_ms,
+            args.net_gbps,
+            args.pulse_per_layer,
+        ));
+        points.push(summary);
+    }
+
+    let stats_after = fetch_stats(&client, &base_url)?;
+
+    if let Some(path) = &args.pulse_file {
+        std::fs::write(path, pulse::to_jsonl(&pulse_lines))
+            .map_err(|e| format!("write pulse file {}: {e}", path.display()))?;
+        eprintln!("[dec-bench] pulse → {}", path.display());
+    }
+
+    let record = DecBenchJsonResult {
+        timestamp: {
+            let secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            format!("{secs}")
+        },
+        endpoint: "walk-ffn".into(),
+        ffn_url: base_url.clone(),
+        capture: CaptureSummary::from(&pool.manifest),
+        stats_before,
+        stats_after,
+        layers,
+        steps,
+        repeats: args.repeats,
+        warmup_passes: args.warmup_passes,
+        weight_bytes_tok,
+        weight_bytes_missing_layers: weight_missing,
+        net_rtt_ms: args.net_rtt_ms,
+        net_gbps: args.net_gbps,
+        points,
+    };
+    let json = serde_json::to_string_pretty(&record)?;
+    match &args.output_file {
+        Some(path) => {
+            std::fs::write(path, &json)
+                .map_err(|e| format!("write output file {}: {e}", path.display()))?;
+            eprintln!("[dec-bench] run record → {}", path.display());
+        }
+        None => println!("{json}"),
+    }
+    Ok(())
+}
+
+fn fetch_stats(
+    client: &reqwest::blocking::Client,
+    base_url: &str,
+) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let resp = client.get(format!("{base_url}{STATS_PATH}")).send()?;
+    if !resp.status().is_success() {
+        return Err(format!("/v1/stats returned {}", resp.status()).into());
+    }
+    Ok(resp.json()?)
+}
+
+/// Run one sweep point: warmup, then `repeats × steps` full passes over
+/// `layers`.
+fn run_point(
+    client: &reqwest::blocking::Client,
+    base_url: &str,
+    pool: &CapturePool,
+    point: &SweepPoint,
+    layers: &[usize],
+    steps: usize,
+    args: &ReplayArgs,
+) -> Result<SweepPointStats, Box<dyn std::error::Error>> {
+    // Warmup: full passes over ALL replayed layers, discarded. Per-layer
+    // warming matters — the server's FFN weights are mmap-backed, and a
+    // cold layer's first touch pays page-fault cost that would otherwise
+    // land in the first measured step's p99 (observed: 4s p99 on an
+    // otherwise ~120ms point).
+    for _ in 0..args.warmup_passes {
+        for &layer in layers {
+            let rows = pool.rows(point.batch, 0, layer)?;
+            let _ = send_one(client, base_url, point, layer, &rows, pool)?;
+        }
+    }
+
+    let mut stats = SweepPointStats::default();
+    for _repeat in 0..args.repeats.max(1) {
+        for step in 0..steps {
+            match point.dispatch {
+                DispatchMode::Streaming => {
+                    let mut step_ms = 0.0f64;
+                    for &layer in layers {
+                        let rows = pool.rows(point.batch, step, layer)?;
+                        let s = send_one(client, base_url, point, layer, &rows, pool)?;
+                        step_ms += s.client_ms;
+                        stats.samples.push(s);
+                    }
+                    stats.step_ms.push(step_ms);
+                }
+                DispatchMode::Batch => {
+                    // Pre-build all frames outside the timed window so the
+                    // fan-out wall time measures transport + server, not
+                    // frame encoding (mirrors predispatch, which reuses
+                    // already-materialised residuals).
+                    let mut frames = Vec::with_capacity(layers.len());
+                    for &layer in layers {
+                        let rows = pool.rows(point.batch, step, layer)?;
+                        frames.push((layer, rows));
+                    }
+                    let t0 = std::time::Instant::now();
+                    let results: Vec<Result<RequestSample, String>> =
+                        std::thread::scope(|scope| {
+                            let handles: Vec<_> = frames
+                                .iter()
+                                .map(|(layer, rows)| {
+                                    scope.spawn(move || {
+                                        send_one(client, base_url, point, *layer, rows, pool)
+                                            .map_err(|e| e.to_string())
+                                    })
+                                })
+                                .collect();
+                            handles
+                                .into_iter()
+                                .map(|h| {
+                                    h.join().unwrap_or_else(|_| {
+                                        Err("replay worker panicked".into())
+                                    })
+                                })
+                                .collect()
+                        });
+                    let wall_ms = t0.elapsed().as_secs_f64() * 1000.0;
+                    for r in results {
+                        stats.samples.push(r.map_err(|e| -> Box<dyn std::error::Error> {
+                            e.into()
+                        })?);
+                    }
+                    stats.step_ms.push(wall_ms);
+                }
+            }
+        }
+    }
+    Ok(stats)
+}
+
+/// Send one B-row request for one layer; validate the decoded shape through
+/// the same codecs the production client uses.
+fn send_one(
+    client: &reqwest::blocking::Client,
+    base_url: &str,
+    point: &SweepPoint,
+    layer: usize,
+    rows: &[f32],
+    pool: &CapturePool,
+) -> Result<RequestSample, Box<dyn std::error::Error>> {
+    let hidden = pool.manifest.hidden_size;
+    let batch = point.batch;
+
+    match point.wire {
+        WireArm::Q8k => {
+            let body = build_q8k_frame(layer, rows, batch, hidden);
+            let bytes_sent = body.len() as u64;
+            let t0 = std::time::Instant::now();
+            let resp = client
+                .post(format!("{base_url}{WALK_FFN_Q8K_PATH}"))
+                .header(reqwest::header::CONTENT_TYPE, larql_inference::Q8K_BATCH_CT)
+                .body(body)
+                .send()?;
+            let status = resp.status();
+            let resp_body = resp.bytes()?;
+            let client_ms = t0.elapsed().as_secs_f64() * 1000.0;
+            if !status.is_success() {
+                return Err(format!(
+                    "q8k replay layer {layer} batch {batch}: server returned {status}"
+                )
+                .into());
+            }
+            let entries =
+                larql_inference::decode_q8k_batch_response_entries(&resp_body)?;
+            if entries.len() != batch
+                || entries.iter().any(|(l, v)| *l != layer || v.len() != hidden)
+            {
+                return Err(format!(
+                    "q8k replay layer {layer}: expected {batch} entries × hidden {hidden}, \
+                     got {} entries",
+                    entries.len()
+                )
+                .into());
+            }
+            Ok(RequestSample {
+                layer,
+                client_ms,
+                server_ms: None,
+                bytes_sent,
+                bytes_recv: resp_body.len() as u64,
+                served_wire: "q8k".into(),
+            })
+        }
+        arm => {
+            let body = build_walk_ffn_frame(layer, rows, batch);
+            let bytes_sent = body.len() as u64;
+            let accept = arm.accept().expect("non-q8k arm has an accept CT");
+            let t0 = std::time::Instant::now();
+            let resp = client
+                .post(format!("{base_url}{WALK_FFN_PATH}"))
+                .header(reqwest::header::CONTENT_TYPE, larql_inference::BINARY_CT)
+                .header(reqwest::header::ACCEPT, accept)
+                .body(body)
+                .send()?;
+            let status = resp.status();
+            let resp_ct = resp
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or(larql_inference::BINARY_CT)
+                .to_string();
+            let resp_body = resp.bytes()?;
+            let client_ms = t0.elapsed().as_secs_f64() * 1000.0;
+            if !status.is_success() {
+                return Err(format!(
+                    "walk-ffn replay layer {layer} batch {batch}: server returned {status}"
+                )
+                .into());
+            }
+            let (resp_layer, server_ms, floats) =
+                larql_inference::decode_single_response(&resp_ct, &resp_body, hidden)?;
+            if resp_layer != layer || floats.len() != batch * hidden {
+                return Err(format!(
+                    "walk-ffn replay layer {layer}: expected {batch}×{hidden} floats for \
+                     layer {layer}, got {} floats for layer {resp_layer}",
+                    floats.len()
+                )
+                .into());
+            }
+            Ok(RequestSample {
+                layer,
+                client_ms,
+                server_ms: Some(server_ms),
+                bytes_sent,
+                bytes_recv: resp_body.len() as u64,
+                served_wire: super::replay::wire_label_for_content_type(&resp_ct),
+            })
+        }
+    }
+}

--- a/crates/larql-cli/src/commands/primary/mod.rs
+++ b/crates/larql-cli/src/commands/primary/mod.rs
@@ -7,6 +7,7 @@
 pub mod accuracy_cmd;
 pub mod bench;
 pub mod cache;
+pub mod dec_bench;
 pub mod diag_cmd;
 pub mod link_cmd;
 pub mod list_cmd;

--- a/crates/larql-cli/src/main.rs
+++ b/crates/larql-cli/src/main.rs
@@ -92,6 +92,11 @@ enum Commands {
     /// Benchmark decode throughput on a real vindex (Metal / CPU / Ollama).
     Bench(bench::BenchArgs),
 
+    /// DEC residual-replay loadgen — capture real per-layer residuals, then
+    /// replay batch × wire × dispatch sweeps against an expert server
+    /// (docs/dec-funnel.md).
+    DecBench(dec_bench::DecBenchArgs),
+
     /// Split-axis accuracy suite — parametric vs in-context vs conflict,
     /// scored with top-1 match and Shannon bits-per-token.
     Accuracy(accuracy_cmd::AccuracyArgs),
@@ -547,6 +552,7 @@ fn real_main() -> i32 {
         Commands::Run(args) => run_cmd::run(args),
         Commands::Chat(args) => run_cmd::run(args.into()),
         Commands::Bench(args) => bench::run(args),
+        Commands::DecBench(args) => dec_bench::run(args),
         Commands::Accuracy(args) => accuracy_cmd::run(args),
         Commands::Shannon(cmd) => shannon_cmd::run(cmd),
         Commands::Pull(args) => pull_cmd::run(args),

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot.rs
@@ -61,6 +61,45 @@ fn q8k_shape_ok(out_len: usize, rows: usize, q8k_qs_len: usize, cols: usize) -> 
     out_len == rows && q8k_qs_len == cols && cols % ELEMS_PER_BLOCK == 0
 }
 
+/// One-line summary of which SIMD kernel class each Q4_K/Q6_K×Q8_K matvec
+/// kernel selects **on this machine, right now** — not what the doc
+/// comments claim.
+///
+/// The three kernels on the serving path don't all have the same SIMD
+/// coverage: [`q4k_q8k_matvec_into`] has a runtime-detected AVX2 branch on
+/// x86_64, but [`q4k_q8k_gate_up_into`] (the dense `/v1/walk-ffn-q8k` gate+up
+/// kernel) and `q6k_q8k_matvec_into` (every Q6_K projection — attention V,
+/// lm_head on typical Q4K vindexes) do not; both silently fall back to the
+/// ~12–16× slower scalar reference on x86_64. A DEC run must never record a
+/// number produced by an unlogged scalar fallback — call this once at
+/// server startup. See docs/audits/dec-readiness-review-2026-07-22.md §1b.
+pub fn kernel_class_summary() -> String {
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    {
+        let variant = if use_asm_kernel() { "neon-asm" } else { "neon" };
+        format!("q4k_matvec={variant} q6k_matvec={variant} q4k_gate_up={variant}")
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        let q4k_matvec = if is_x86_feature_detected!("avx2") {
+            "avx2"
+        } else {
+            "scalar"
+        };
+        // q6k_q8k_matvec_into and q4k_q8k_gate_up_into have no AVX2 branch
+        // yet (2026-07-22 review) — always scalar on x86_64 regardless of
+        // AVX2 availability.
+        format!("q4k_matvec={q4k_matvec} q6k_matvec=scalar q4k_gate_up=scalar")
+    }
+    #[cfg(not(any(
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_arch = "x86_64"
+    )))]
+    {
+        "q4k_matvec=scalar q6k_matvec=scalar q4k_gate_up=scalar".to_string()
+    }
+}
+
 /// Quantised activation in Q8_K layout, one entry per super-block of `x`.
 ///
 /// `qs` packs all super-blocks contiguously: `qs[sb * 256 .. (sb+1) * 256]`
@@ -1353,6 +1392,12 @@ unsafe fn hsum_i32x8(v: std::arch::x86_64::__m256i) -> i32 {
 ///
 /// Caller layouts: `gate_w.len() == up_w.len() == rows * (cols / 256) * 144`,
 /// `gate_out.len() == up_out.len() == rows`.
+///
+/// **x86_64 has no AVX2 branch here** (unlike [`q4k_q8k_matvec_into`], which
+/// does) — this always falls through to the scalar reference on x86_64,
+/// ~12–16× slower than AVX2/NEON. This is the dense `/v1/walk-ffn-q8k`
+/// serving kernel; see `kernel_class_summary` (logged once at server
+/// startup) and docs/audits/dec-readiness-review-2026-07-22.md §1b.
 pub fn q4k_q8k_gate_up_into(
     gate_out: &mut [f32],
     up_out: &mut [f32],
@@ -2135,6 +2180,18 @@ pub fn q6k_q8k_matvec_into(
 mod tests {
     use super::*;
     use crate::cpu::ops::q4_common::{q4k_matvec_into, quantize_q4_k, quantize_q6_k};
+
+    /// Regression for docs/audits/dec-readiness-review-2026-07-22.md §1b:
+    /// the DEC serving path must be able to log which kernel class it
+    /// selected. Pins the format (three `key=value` fields) rather than
+    /// specific values, since those are host-dependent.
+    #[test]
+    fn kernel_class_summary_reports_all_three_kernels() {
+        let summary = kernel_class_summary();
+        assert!(summary.contains("q4k_matvec="), "{summary}");
+        assert!(summary.contains("q6k_matvec="), "{summary}");
+        assert!(summary.contains("q4k_gate_up="), "{summary}");
+    }
 
     /// Q8_K round-trip should reconstruct within 0.5% of absmax (1 LSB on
     /// the 127-step scale).  Sums must equal the literal i32 sums of the

--- a/crates/larql-compute/src/kquant_forward/mod.rs
+++ b/crates/larql-compute/src/kquant_forward/mod.rs
@@ -161,6 +161,116 @@ mod tests {
         assert_eq!(out.shape(), &[1, weights.hidden_size]);
     }
 
+    /// Regression for docs/audits/dec-readiness-review-2026-07-22.md §1a:
+    /// pins the numerical equivalence the server's batched-GEMM Q8K
+    /// handler (`larql-server/routes/walk_ffn/q8k.rs`) depends on. Same-
+    /// layer entries dequantised to f32 and run through
+    /// `kquant_ffn_forward_layer` as ONE multi-row GEMM must reproduce
+    /// (within f32 rounding) what the single-row `q4k_q8k_matvec_into`
+    /// kernel produces per entry — otherwise batching same-layer rows to
+    /// fix the ~linear-in-B batch curve would silently change the numbers.
+    #[test]
+    fn walk_ffn_kquant_layer_q8k_batched_gemm_matches_per_row_single_kernel() {
+        use crate::cpu::ops::q4k_q8k_dot::quantize_x_to_q8k;
+        let weights = make_test_q4k_weights();
+        let idx = make_q4k_fixture_index(&weights);
+        let hidden = weights.hidden_size;
+
+        let rows: Vec<Vec<f32>> = (0..3)
+            .map(|i| {
+                (0..hidden)
+                    .map(|j| ((i * hidden + j) as f32 * 0.001).sin() * 0.05)
+                    .collect()
+            })
+            .collect();
+
+        // Reference: each row through the single-row Q8K fast kernel,
+        // exactly as a batch-1 request (or the pre-fix code) would.
+        let single_row_outputs: Vec<Vec<f32>> = rows
+            .iter()
+            .map(|r| {
+                let h_q8k = quantize_x_to_q8k(r);
+                kquant_ffn_forward_layer_q8k(&*weights.arch, &idx, 0, &h_q8k)
+                    .into_raw_vec_and_offset()
+                    .0
+            })
+            .collect();
+
+        // Batched: dequantise each row's Q8K activation back to f32 and
+        // run all 3 rows through ONE GEMM, mirroring the server's grouped
+        // handler.
+        let mut dequantised: Vec<f32> = Vec::with_capacity(3 * hidden);
+        for r in &rows {
+            let h_q8k = quantize_x_to_q8k(r);
+            for b in 0..h_q8k.n_blocks() {
+                let d = h_q8k.d[b];
+                for i in 0..256 {
+                    dequantised.push(d * (h_q8k.qs[b * 256 + i] as f32));
+                }
+            }
+        }
+        let x = ndarray::Array2::from_shape_vec((3, hidden), dequantised).unwrap();
+        let batched = kquant_ffn_forward_layer(&*weights.arch, &idx, 0, &x);
+
+        for (row_idx, single) in single_row_outputs.iter().enumerate() {
+            let batched_row = batched.row(row_idx);
+            for (a, &b) in single.iter().zip(batched_row.iter()) {
+                assert!(
+                    (a - b).abs() < 1e-3,
+                    "row {row_idx}: single-kernel {a} vs batched-GEMM {b} diverge"
+                );
+            }
+        }
+    }
+
+    /// Regression for docs/audits/dec-readiness-review-2026-07-22.md §1d:
+    /// the down-projection fast path must consult the down slab's own
+    /// format tag (`ffn[2].1`), not just the block-alignment guard.
+    /// Before the fix, any down slab — regardless of its declared format —
+    /// went straight into the Q4_K-only `q4k_q8k_matvec_into` kernel
+    /// whenever `intermediate` was 256-aligned, silently misreading any
+    /// non-Q4_K byte layout. Here the down component is (still
+    /// Q4_K-encoded bytes, but) tagged with an unsupported format string;
+    /// with the fix, that tag mismatch routes to the format-aware
+    /// `dequantize_matrix` fallback, which loudly rejects an unknown tag
+    /// instead of the fast path silently "succeeding" on the wrong
+    /// assumption.
+    #[test]
+    #[should_panic(expected = "unsupported quant format")]
+    fn walk_ffn_kquant_layer_q8k_rejects_down_slab_with_non_q4k_format_tag() {
+        struct BogusDownFormat<'a> {
+            inner: &'a crate::test_fixtures::Q4kFixtureIndex,
+        }
+        impl crate::KvIndex for BogusDownFormat<'_> {
+            fn num_features(&self, l: usize) -> usize {
+                self.inner.num_features(l)
+            }
+            fn attn_kquant_layer_data(&self, l: usize) -> Option<[(&[u8], &str); 4]> {
+                self.inner.attn_kquant_layer_data(l)
+            }
+            fn interleaved_kquant_layer_data(
+                &self,
+                l: usize,
+            ) -> Option<[(&[u8], &str); crate::FFN_COMPONENTS_PER_LAYER]> {
+                let mut ffn = self.inner.interleaved_kquant_layer_data(l)?;
+                ffn[2].1 = "BOGUS_FORMAT";
+                Some(ffn)
+            }
+            fn interleaved_kquant_mmap_ref(&self) -> Option<&[u8]> {
+                self.inner.interleaved_kquant_mmap_ref()
+            }
+            // No `kquant_ffn_layer_once` — forces the dequant fallback,
+            // which is the only branch that consults the format tag.
+        }
+        use crate::cpu::ops::q4k_q8k_dot::quantize_x_to_q8k;
+        let weights = make_test_q4k_weights();
+        let inner = make_q4k_fixture_index(&weights);
+        let idx = BogusDownFormat { inner: &inner };
+        let h_in: Vec<f32> = vec![0.01; weights.hidden_size];
+        let h_q8k = quantize_x_to_q8k(&h_in);
+        let _ = kquant_ffn_forward_layer_q8k(&*weights.arch, &idx, 0, &h_q8k);
+    }
+
     // ── tensors.rs ───────────────────────────────────────────────────
 
     #[test]

--- a/crates/larql-compute/src/kquant_forward/walk_ffn.rs
+++ b/crates/larql-compute/src/kquant_forward/walk_ffn.rs
@@ -73,8 +73,12 @@ pub fn kquant_ffn_forward_layer(
 
 /// Q4_K × Q8_K variant: accepts a pre-quantised Q8_K activation vector
 /// (already RMS-normed by the client) and skips the dequant of gate/up by
-/// using the NEON/AVX2 `q4k_q8k_gate_up_into` kernel.  Down projection
-/// still goes through the f32 dequant path (no Q6K×Q8K kernel yet).
+/// using the `q4k_q8k_gate_up_into` kernel (NEON/hand-asm on aarch64;
+/// scalar-only on x86_64 today — see `q4k_q8k_gate_up_into`'s doc comment).
+/// Down projection takes the matching Q4_K×Q8_K matvec kernel only when the
+/// down slab's own format tag is `"Q4_K"`; any other format (a non-Q4_K
+/// down slab, e.g. from a model with a different quant mix) falls back to
+/// the f32 dequant path, which consults the tag correctly.
 ///
 /// `h_q8k.qs.len()` must equal `hidden` (= `x.ncols()`), which is a
 /// multiple of 256 (Q8_K block size).
@@ -128,17 +132,21 @@ pub fn kquant_ffn_forward_layer_q8k(
     // Down projection: Q4K×Q8K NEON — quantise the f32 activation once,
     // then call the NEON matvec directly on the mmap Q4K bytes.
     // No dequant, no large f32 allocation, no BLAS thread-pool collision.
-    // Guard: intermediate must be Q8K-block-aligned (multiple of the
-    // Q4_K/Q8_K super-block size).
-    // For non-aligned sizes (rare, non-production) fall back to OnceLock cache.
-    if intermediate.is_multiple_of(crate::ffn::Q4K_Q8K_SUPERBLOCK_ELEMS) {
+    // Guard: down's own format tag must be "Q4_K" (this kernel reads the
+    // Q4_K block layout only — feeding it Q6_K/Q5_K/… bytes decodes silent
+    // garbage, see docs/audits/dec-readiness-review-2026-07-22.md §1d) AND
+    // intermediate must be Q8K-block-aligned (multiple of the Q4_K/Q8_K
+    // super-block size). Either condition failing falls back to the
+    // format-aware dequant path below.
+    if ffn[2].1 == "Q4_K" && intermediate.is_multiple_of(crate::ffn::Q4K_Q8K_SUPERBLOCK_ELEMS) {
         let activation_flat = activation.as_slice().expect("activation contiguous");
         let act_q8k = quantize_x_to_q8k(activation_flat);
         let mut out = vec![0.0f32; hidden];
         q4k_q8k_matvec_into(&mut out, &act_q8k, ffn[2].0, hidden, intermediate);
         Array2::from_shape_vec((1, hidden), out).expect("down output shape")
     } else {
-        // Fallback: OnceLock cache + ndarray dot for non-256-aligned intermediate.
+        // Fallback: OnceLock cache + ndarray dot; consults `ffn[2].1` via
+        // `dequantize_matrix`, so any down format is handled correctly.
         let n = intermediate * hidden;
         if let Some(arc) = index.kquant_ffn_layer_once(layer, 2) {
             let w_down_t = ndarray::ArrayView2::from_shape((intermediate, hidden), &arc[..n])

--- a/crates/larql-inference/src/ffn/mod.rs
+++ b/crates/larql-inference/src/ffn/mod.rs
@@ -34,8 +34,9 @@ pub use moe_remote::{
     MoeRouterWeights, RemoteMoeBackend, RemoteMoeError, RemoteMoeFfn, ShardConfig,
 };
 pub use remote::{
-    LayerShardedBackend, RemoteFfnConfig, RemoteFfnError, RemoteLatencyStats, RemoteWalkBackend,
-    WirePreference,
+    decode_q8k_batch_response_entries, decode_single_response, encode_binary_request,
+    encode_q8k_batch_request, LayerShardedBackend, RemoteFfnConfig, RemoteFfnError,
+    RemoteLatencyStats, RemoteWalkBackend, WirePreference, BINARY_CT, F16_CT, I8_CT, Q8K_BATCH_CT,
 };
 pub use sparse::SparseFfn;
 pub use sparse_compute::{

--- a/crates/larql-inference/src/ffn/moe_remote/multi_layer_wire.rs
+++ b/crates/larql-inference/src/ffn/moe_remote/multi_layer_wire.rs
@@ -102,12 +102,23 @@ pub fn encode_multi_layer_request(tasks: &[MultiLayerTask]) -> Vec<u8> {
 pub fn decode_multi_layer_request(bytes: &[u8]) -> Option<Vec<MultiLayerTask>> {
     let mut pos = 0;
     let n = read_u32(bytes, &mut pos)? as usize;
+    // Bound against the minimal 12-byte-per-task header (layer + hidden +
+    // num_experts) before reserving — an attacker-controlled `n` must not
+    // reach `Vec::with_capacity` directly. Mirrors q8k_wire.rs's
+    // `max_possible_entries` guard (PR 104 CI).
+    if n > bytes.len().saturating_sub(pos) / 12 {
+        return None;
+    }
     let mut tasks = Vec::with_capacity(n);
     for _ in 0..n {
         let layer = read_u32(bytes, &mut pos)? as usize;
         let hidden = read_u32(bytes, &mut pos)? as usize;
         let ne = read_u32(bytes, &mut pos)? as usize;
         let residual = read_f32_slice(bytes, &mut pos, hidden)?;
+        // Each expert entry needs 4 bytes now (id) + 4 bytes later (weight).
+        if ne > bytes.len().saturating_sub(pos) / 8 {
+            return None;
+        }
         let mut expert_ids = Vec::with_capacity(ne);
         for _ in 0..ne {
             expert_ids.push(read_u32(bytes, &mut pos)?);
@@ -143,6 +154,13 @@ pub fn encode_multi_layer_response(results: &[MultiLayerResult]) -> Vec<u8> {
 pub fn decode_multi_layer_response(bytes: &[u8]) -> Option<Vec<MultiLayerResult>> {
     let mut pos = 0;
     let n = read_u32(bytes, &mut pos)? as usize;
+    // Each result needs at least 8 bytes (layer + hidden) before its
+    // payload; guard the allocation against an attacker-controlled `n`
+    // (a malicious shard can send this response too — see
+    // docs/audits/dec-readiness-review-2026-07-22.md §2a).
+    if n > bytes.len().saturating_sub(pos) / 8 {
+        return None;
+    }
     let mut results = Vec::with_capacity(n);
     for _ in 0..n {
         let layer = read_u32(bytes, &mut pos)? as usize;
@@ -208,6 +226,11 @@ pub fn encode_multi_layer_request_q8k(tasks: &[MultiLayerTaskQ8K]) -> Vec<u8> {
 pub fn decode_multi_layer_request_q8k(bytes: &[u8]) -> Option<Vec<MultiLayerTaskQ8K>> {
     let mut pos = 0;
     let n = read_u32(bytes, &mut pos)? as usize;
+    // Bound against the minimal 12-byte-per-task header before reserving
+    // — same rationale as `decode_multi_layer_request` above.
+    if n > bytes.len().saturating_sub(pos) / 12 {
+        return None;
+    }
     let mut tasks = Vec::with_capacity(n);
     for _ in 0..n {
         let layer = read_u32(bytes, &mut pos)? as usize;
@@ -219,6 +242,9 @@ pub fn decode_multi_layer_request_q8k(bytes: &[u8]) -> Option<Vec<MultiLayerTask
         let d = read_f32_slice(bytes, &mut pos, nb)?;
         let sums = read_i16_slice(bytes, &mut pos, nb * SUMS_PER_Q8K_BLOCK)?;
         // Expert routing
+        if ne > bytes.len().saturating_sub(pos) / 8 {
+            return None;
+        }
         let mut expert_ids = Vec::with_capacity(ne);
         for _ in 0..ne {
             expert_ids.push(read_u32(bytes, &mut pos)?);
@@ -251,6 +277,11 @@ fn read_i8_slice(bytes: &[u8], pos: &mut usize, n: usize) -> Option<Vec<i8>> {
 }
 
 fn read_i16_slice(bytes: &[u8], pos: &mut usize, n: usize) -> Option<Vec<i16>> {
+    // `n` (e.g. `nb * SUMS_PER_Q8K_BLOCK`, derived from a wire `hidden`)
+    // must not reach `Vec::with_capacity` unbounded — see PR 104 CI.
+    if n > bytes.len().saturating_sub(*pos) / 2 {
+        return None;
+    }
     let mut v = Vec::with_capacity(n);
     for _ in 0..n {
         let end = pos.checked_add(2)?;
@@ -289,6 +320,13 @@ fn read_f32(bytes: &[u8], pos: &mut usize) -> Option<f32> {
 }
 
 fn read_f32_slice(bytes: &[u8], pos: &mut usize, n: usize) -> Option<Vec<f32>> {
+    // `n` is wire-controlled (e.g. `hidden` straight off the wire): a
+    // `[n=1][layer=0][hidden=0xFFFFFFFF]` request must not reach
+    // `Vec::with_capacity` unbounded (~17 GB reservation → SIGABRT).
+    // See docs/audits/dec-readiness-review-2026-07-22.md §2a / PR 104 CI.
+    if n > bytes.len().saturating_sub(*pos) / 4 {
+        return None;
+    }
     let mut v = Vec::with_capacity(n);
     for _ in 0..n {
         v.push(read_f32(bytes, pos)?);
@@ -369,6 +407,83 @@ mod tests {
         assert_eq!(encoded.len(), 4);
         let decoded = decode_multi_layer_response(&encoded).unwrap();
         assert!(decoded.is_empty());
+    }
+
+    // ── Allocation-bomb regressions (docs/audits/dec-readiness-review-2026-07-22.md §2a) ──
+
+    #[test]
+    fn decode_multi_layer_request_rejects_impossible_task_count_before_allocating() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&u32::MAX.to_le_bytes()); // num_tasks
+        assert!(decode_multi_layer_request(&body).is_none());
+    }
+
+    #[test]
+    fn decode_multi_layer_request_rejects_impossible_hidden_before_allocating() {
+        // [n=1][layer=0][hidden=0xFFFFFFFF][num_experts=0] — 16 bytes total.
+        // Before the fix, `hidden` reached `read_f32_slice`'s
+        // `Vec::with_capacity` unbounded (~17 GB reservation → SIGABRT).
+        let mut body = Vec::new();
+        body.extend_from_slice(&1u32.to_le_bytes()); // num_tasks
+        body.extend_from_slice(&0u32.to_le_bytes()); // layer
+        body.extend_from_slice(&u32::MAX.to_le_bytes()); // hidden
+        body.extend_from_slice(&0u32.to_le_bytes()); // num_experts
+        assert!(decode_multi_layer_request(&body).is_none());
+    }
+
+    #[test]
+    fn decode_multi_layer_request_rejects_impossible_expert_count_before_allocating() {
+        // A well-formed zero-length residual, then an attacker-controlled
+        // `num_experts` far beyond what the remaining body could hold.
+        let mut body = Vec::new();
+        body.extend_from_slice(&1u32.to_le_bytes()); // num_tasks
+        body.extend_from_slice(&0u32.to_le_bytes()); // layer
+        body.extend_from_slice(&0u32.to_le_bytes()); // hidden
+        body.extend_from_slice(&u32::MAX.to_le_bytes()); // num_experts
+        assert!(decode_multi_layer_request(&body).is_none());
+    }
+
+    #[test]
+    fn decode_multi_layer_response_rejects_impossible_result_count_before_allocating() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&u32::MAX.to_le_bytes()); // num_results
+        assert!(decode_multi_layer_response(&body).is_none());
+    }
+
+    #[test]
+    fn decode_multi_layer_response_rejects_impossible_hidden_before_allocating() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&1u32.to_le_bytes()); // num_results
+        body.extend_from_slice(&0u32.to_le_bytes()); // layer
+        body.extend_from_slice(&u32::MAX.to_le_bytes()); // hidden
+        assert!(decode_multi_layer_response(&body).is_none());
+    }
+
+    #[test]
+    fn decode_multi_layer_request_q8k_rejects_impossible_task_count_before_allocating() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&u32::MAX.to_le_bytes()); // num_tasks
+        assert!(decode_multi_layer_request_q8k(&body).is_none());
+    }
+
+    #[test]
+    fn decode_multi_layer_request_q8k_rejects_impossible_hidden_before_allocating() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&1u32.to_le_bytes()); // num_tasks
+        body.extend_from_slice(&0u32.to_le_bytes()); // layer
+        body.extend_from_slice(&u32::MAX.to_le_bytes()); // hidden
+        body.extend_from_slice(&0u32.to_le_bytes()); // num_experts
+        assert!(decode_multi_layer_request_q8k(&body).is_none());
+    }
+
+    #[test]
+    fn decode_multi_layer_request_q8k_rejects_impossible_expert_count_before_allocating() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&1u32.to_le_bytes()); // num_tasks
+        body.extend_from_slice(&0u32.to_le_bytes()); // layer
+        body.extend_from_slice(&0u32.to_le_bytes()); // hidden (0 blocks)
+        body.extend_from_slice(&u32::MAX.to_le_bytes()); // num_experts
+        assert!(decode_multi_layer_request_q8k(&body).is_none());
     }
 
     #[test]

--- a/crates/larql-inference/src/ffn/remote/codec.rs
+++ b/crates/larql-inference/src/ffn/remote/codec.rs
@@ -5,7 +5,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-pub(super) const BINARY_CT: &str = "application/x-larql-ffn";
+/// f32 content-type constant.
+pub const BINARY_CT: &str = "application/x-larql-ffn";
 pub(super) const BATCH_MARKER: u32 = 0xFFFF_FFFF;
 
 fn checked_mul(a: usize, b: usize, what: &str) -> Result<usize, String> {
@@ -192,7 +193,7 @@ pub fn decode_binary_batch(body: &[u8]) -> Result<HashMap<usize, Vec<f32>>, Stri
 }
 
 /// f16 content-type constant (ADR-0009).
-pub(crate) const F16_CT: &str = "application/x-larql-ffn-f16";
+pub const F16_CT: &str = "application/x-larql-ffn-f16";
 
 /// Decode a binary single-layer f16 response into f32 output.
 pub fn decode_binary_single_f16(body: &[u8]) -> Result<(usize, Vec<f32>), String> {
@@ -256,7 +257,7 @@ pub fn decode_binary_batch_f16(body: &[u8]) -> Result<HashMap<usize, Vec<f32>>, 
 }
 
 /// i8 content-type constant (ADR-0009).
-pub(crate) const I8_CT: &str = "application/x-larql-ffn-i8";
+pub const I8_CT: &str = "application/x-larql-ffn-i8";
 
 /// Decode one position from an i8 per-position block.
 /// Format: `[scale f32 LE][zero_point f32 LE (ignored)][data i8[hidden_size]]`
@@ -348,6 +349,26 @@ pub(crate) fn decode_binary_batch_i8(
         out.insert(layer, all_floats);
     }
     Ok(out)
+}
+
+/// Decode any single-layer binary walk-ffn response by content type.
+///
+/// Dispatches to the f32/f16/i8 decoder based on `content_type` and also
+/// extracts the server-side `latency_ms` embedded at bytes 8-11.
+/// Returns `(layer, server_latency_ms, output_f32)`.
+pub fn decode_single_response(
+    content_type: &str,
+    body: &[u8],
+    hidden_size: usize,
+) -> Result<(usize, f64, Vec<f32>), String> {
+    let server_ms = extract_response_latency_ms(body);
+    let (layer, floats) = match content_type {
+        I8_CT => decode_binary_single_i8(body, hidden_size)?,
+        F16_CT => decode_binary_single_f16(body)?,
+        BINARY_CT => decode_binary_single(body)?,
+        other => return Err(format!("unsupported walk-ffn response content-type: {other}")),
+    };
+    Ok((layer, server_ms, floats))
 }
 
 /// Extract the `latency_ms` f32 embedded at bytes 8-11 of a binary response.
@@ -856,6 +877,73 @@ mod tests {
         assert_eq!(F16_CT, "application/x-larql-ffn-f16");
         assert_eq!(I8_CT, "application/x-larql-ffn-i8");
         assert_eq!(BATCH_MARKER, 0xFFFF_FFFFu32);
+    }
+
+    // ── decode_single_response (content-type dispatch) ─────────────────
+
+    #[test]
+    fn decode_single_response_dispatches_f32() {
+        let output = vec![1.0f32, -2.0, 3.5, 0.25];
+        let body = make_single_response(3, 2, 4.5, &output);
+        let (layer, server_ms, floats) = decode_single_response(BINARY_CT, &body, 2).unwrap();
+        assert_eq!(layer, 3);
+        assert!((server_ms - 4.5).abs() < 1e-6);
+        assert_eq!(floats, output);
+    }
+
+    #[test]
+    fn decode_single_response_dispatches_f16() {
+        let body = make_single_response_f16(7, 2, 2.25, &[0.5, -0.25, 1.5, -2.5]);
+        let (layer, server_ms, floats) = decode_single_response(F16_CT, &body, 2).unwrap();
+        assert_eq!(layer, 7);
+        assert!((server_ms - 2.25).abs() < 1e-6);
+        assert_eq!(floats, vec![0.5, -0.25, 1.5, -2.5]);
+    }
+
+    #[test]
+    fn decode_single_response_dispatches_i8_multi_row() {
+        // seq_len = 3 rows of hidden = 2: the B>1 replay shape.
+        let body = make_single_response_i8(
+            0,
+            3,
+            1.5,
+            &[(1.0, &[10i8, 20]), (0.25, &[-4i8, 8]), (2.0, &[1i8, -1])],
+        );
+        let (layer, server_ms, floats) = decode_single_response(I8_CT, &body, 2).unwrap();
+        assert_eq!(layer, 0);
+        assert!((server_ms - 1.5).abs() < 1e-6);
+        assert_eq!(floats, vec![10.0, 20.0, -1.0, 2.0, 2.0, -2.0]);
+    }
+
+    #[test]
+    fn decode_single_response_rejects_unknown_content_type() {
+        let body = make_single_response(0, 1, 0.0, &[1.0]);
+        assert!(decode_single_response("application/json", &body, 1).is_err());
+    }
+
+    #[test]
+    fn encode_binary_request_top_k_zero_pins_l2_cache_bypass() {
+        // The server's FfnL2Cache only engages when seq_len==1 && top_k>0.
+        // Replay frames encode top_k=0 so repeated B=1 requests measure
+        // real FFN compute, not cache hits. Pin the byte position.
+        let residual = vec![0.5f32; 4];
+        let body = encode_binary_request(Some(3), None, &residual, 1, true, 0);
+        let top_k = u32::from_le_bytes(body[12..16].try_into().unwrap());
+        assert_eq!(top_k, 0);
+        let seq_len = u32::from_le_bytes(body[4..8].try_into().unwrap());
+        assert_eq!(seq_len, 1);
+    }
+
+    #[test]
+    fn encode_binary_request_multi_row_seq_len() {
+        // B-row replay frame: residual = B × hidden floats, seq_len = B.
+        let hidden = 4;
+        let batch = 8;
+        let rows: Vec<f32> = (0..batch * hidden).map(|i| i as f32 * 0.1).collect();
+        let body = encode_binary_request(Some(0), None, &rows, batch, true, 0);
+        let seq_len = u32::from_le_bytes(body[4..8].try_into().unwrap());
+        assert_eq!(seq_len as usize, batch);
+        assert_eq!(body.len(), 16 + batch * hidden * 4);
     }
 
     #[test]

--- a/crates/larql-inference/src/ffn/remote/http.rs
+++ b/crates/larql-inference/src/ffn/remote/http.rs
@@ -21,9 +21,12 @@ use super::q8k_wire::{decode_q8k_batch_response, encode_q8k_batch_request, Q8K_B
 use crate::ffn::FfnBackend;
 use larql_compute::cpu::ops::q4k_q8k_dot::Q8KActivation;
 
-const STATS_PATH: &str = "/v1/stats";
-const WALK_FFN_PATH: &str = "/v1/walk-ffn";
-const WALK_FFN_Q8K_PATH: &str = "/v1/walk-ffn-q8k";
+/// Server stats endpoint (shared by the DEC loadgen driver).
+pub const STATS_PATH: &str = "/v1/stats";
+/// Dense-FFN endpoint (shared by the DEC loadgen driver).
+pub const WALK_FFN_PATH: &str = "/v1/walk-ffn";
+/// Q8K dense-FFN batch endpoint (shared by the DEC loadgen driver).
+pub const WALK_FFN_Q8K_PATH: &str = "/v1/walk-ffn-q8k";
 const HIDDEN_SIZE_KEY: &str = "hidden_size";
 
 // ── Config ───────────────────────────────────────────────────────────────────

--- a/crates/larql-inference/src/ffn/remote/mod.rs
+++ b/crates/larql-inference/src/ffn/remote/mod.rs
@@ -60,10 +60,15 @@ mod http;
 pub mod q8k_wire;
 pub mod sharded;
 
-pub use codec::RemoteLatencyStats;
-pub use http::{RemoteFfnConfig, RemoteFfnError, RemoteWalkBackend, WirePreference};
+pub use codec::{
+    decode_single_response, encode_binary_request, RemoteLatencyStats, BINARY_CT, F16_CT, I8_CT,
+};
+pub use http::{
+    RemoteFfnConfig, RemoteFfnError, RemoteWalkBackend, WirePreference, STATS_PATH, WALK_FFN_PATH,
+    WALK_FFN_Q8K_PATH,
+};
 pub use q8k_wire::{
-    decode_q8k_batch_request, decode_q8k_batch_response, encode_q8k_batch_request,
-    encode_q8k_batch_response, Q8KRequestEntry, Q8K_BATCH_CT,
+    decode_q8k_batch_request, decode_q8k_batch_response, decode_q8k_batch_response_entries,
+    encode_q8k_batch_request, encode_q8k_batch_response, Q8KRequestEntry, Q8K_BATCH_CT,
 };
 pub use sharded::LayerShardedBackend;

--- a/crates/larql-inference/src/ffn/remote/q8k_wire.rs
+++ b/crates/larql-inference/src/ffn/remote/q8k_wire.rs
@@ -75,7 +75,19 @@ pub fn encode_q8k_batch_request(layers: &[(usize, &Q8KActivation)]) -> Vec<u8> {
 // ── Decode (client ← server) ─────────────────────────────────────────────────
 
 /// Decode a Q8K batch response body into a `HashMap<layer_idx → output_floats>`.
+///
+/// Entries with a duplicate `layer_idx` collapse (last wins) — use
+/// [`decode_q8k_batch_response_entries`] when the request carried several rows
+/// for the same layer.
 pub fn decode_q8k_batch_response(body: &[u8]) -> Result<HashMap<usize, Vec<f32>>, String> {
+    Ok(decode_q8k_batch_response_entries(body)?
+        .into_iter()
+        .collect())
+}
+
+/// Decode a Q8K batch response body into ordered `(layer_idx, output_floats)`
+/// entries, preserving duplicates and wire order.
+pub fn decode_q8k_batch_response_entries(body: &[u8]) -> Result<Vec<(usize, Vec<f32>)>, String> {
     if body.len() < 4 {
         return Err(format!(
             "q8k batch response too short: {} bytes",
@@ -94,7 +106,7 @@ pub fn decode_q8k_batch_response(body: &[u8]) -> Result<HashMap<usize, Vec<f32>>
         ));
     }
     let mut offset = 4usize;
-    let mut out = HashMap::with_capacity(num_entries);
+    let mut out = Vec::with_capacity(num_entries);
     for i in 0..num_entries {
         if body.len() < offset + 8 {
             return Err(format!("q8k batch response: truncated entry header {i}"));
@@ -115,7 +127,7 @@ pub fn decode_q8k_batch_response(body: &[u8]) -> Result<HashMap<usize, Vec<f32>>
             .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
             .collect();
         offset += floats_bytes;
-        out.insert(layer_idx, floats);
+        out.push((layer_idx, floats));
     }
     Ok(out)
 }
@@ -274,6 +286,44 @@ mod tests {
         assert_eq!(map.len(), 2);
         assert_eq!(map[&5], out0);
         assert_eq!(map[&10], out1);
+    }
+
+    #[test]
+    fn response_entries_preserve_duplicate_layers_in_wire_order() {
+        // B-row replay sends B entries for the SAME layer; the ordered
+        // decode must keep all of them, in order. The HashMap variant
+        // collapses to one — that asymmetry is the reason this exists.
+        let out0 = vec![1.0f32, 2.0];
+        let out1 = vec![3.0f32, 4.0];
+        let out2 = vec![5.0f32, 6.0];
+        let entries: Vec<(usize, &[f32])> = vec![(7usize, &out0), (7usize, &out1), (7usize, &out2)];
+        let body = encode_q8k_batch_response(&entries);
+
+        let ordered = decode_q8k_batch_response_entries(&body).unwrap();
+        assert_eq!(ordered.len(), 3);
+        assert_eq!(ordered[0], (7, out0.clone()));
+        assert_eq!(ordered[1], (7, out1.clone()));
+        assert_eq!(ordered[2], (7, out2.clone()));
+
+        let collapsed = decode_q8k_batch_response(&body).unwrap();
+        assert_eq!(collapsed.len(), 1, "map variant collapses duplicates");
+        assert_eq!(collapsed[&7], out2, "last entry wins in the map variant");
+    }
+
+    #[test]
+    fn response_entries_truncated_returns_error() {
+        let out = vec![1.0f32, 2.0];
+        let entries: Vec<(usize, &[f32])> = vec![(0usize, &out)];
+        let mut body = encode_q8k_batch_response(&entries);
+        body.truncate(body.len() - 4);
+        assert!(decode_q8k_batch_response_entries(&body).is_err());
+    }
+
+    #[test]
+    fn response_entries_reject_impossible_entry_count() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&u32::MAX.to_le_bytes());
+        assert!(decode_q8k_batch_response_entries(&body).is_err());
     }
 
     #[test]

--- a/crates/larql-inference/src/ffn/remote/sharded.rs
+++ b/crates/larql-inference/src/ffn/remote/sharded.rs
@@ -111,6 +111,14 @@ impl LayerShardedBackend {
     /// Returns one FFN output vector per layer, in layer order.
     ///
     /// Uses `std::thread::scope` so shards can be borrowed without `Arc`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a layer has no owning shard, or if a shard's request fails
+    /// (mirrors `RemoteWalkBackend::forward`'s own panic-on-transport-error
+    /// convention). A silent zero-fill here would let decode continue on a
+    /// corrupted hidden state — see
+    /// docs/audits/dec-readiness-review-2026-07-22.md §1c.
     pub fn forward_predispatch_all(&self, h_per_layer: &[Vec<f32>]) -> Vec<Vec<f32>> {
         let hidden = self.hidden_size();
         let num_layers = h_per_layer.len();
@@ -126,14 +134,20 @@ impl LayerShardedBackend {
                             .expect("h_per_layer shape must match hidden");
                         match self.shard_for(layer) {
                             Some(shard) => shard.forward(layer, &x).row(0).to_vec(),
-                            None => vec![0.0f32; hidden],
+                            None => panic!(
+                                "forward_predispatch_all: layer {layer} has no owning shard \
+                                 (check --ffn shard-map coverage)"
+                            ),
                         }
                     })
                 })
                 .collect();
 
             for (result, handle) in results.iter_mut().zip(handles) {
-                *result = handle.join().unwrap_or_else(|_| vec![0.0f32; hidden]);
+                *result = match handle.join() {
+                    Ok(v) => v,
+                    Err(e) => std::panic::resume_unwind(e),
+                };
             }
         });
 

--- a/crates/larql-inference/src/layer_graph/grid.rs
+++ b/crates/larql-inference/src/layer_graph/grid.rs
@@ -19,7 +19,10 @@ mod remote_moe;
 mod setup;
 mod timing;
 
-pub use remote_ffn::{generate_with_remote_ffn, generate_with_remote_ffn_batch};
+pub use remote_ffn::{
+    generate_with_remote_ffn, generate_with_remote_ffn_batch,
+    generate_with_remote_ffn_batch_captured, ResidualCaptureSink,
+};
 pub use remote_moe::{generate_with_remote_moe, generate_with_remote_moe_batch};
 
 // ── Bottleneck diagnostic ────────────────────────────────────────────────────

--- a/crates/larql-inference/src/layer_graph/grid/remote_ffn.rs
+++ b/crates/larql-inference/src/layer_graph/grid/remote_ffn.rs
@@ -279,6 +279,17 @@ fn dispatch_ffn_with_q8k_fallback(
     postnorm_layers(weights, raw_results)
 }
 
+/// Per-prompt residual capture written by
+/// [`generate_with_remote_ffn_batch_captured`]: `steps[step][layer]` is the
+/// pre-normed post-attention residual (length = hidden) exactly as the final
+/// FFN dispatch of that decode step sent it over the wire. Pre-normed capture
+/// makes replay model-free — a replay driver needs no weights or norms to
+/// reproduce the bytes the server saw.
+#[derive(Debug, Default)]
+pub struct ResidualCaptureSink {
+    pub steps: Vec<Vec<Vec<f32>>>,
+}
+
 /// Batch pre-dispatch variant of [`generate_with_remote_ffn`].
 #[allow(clippy::too_many_arguments)]
 pub fn generate_with_remote_ffn_batch(
@@ -291,6 +302,39 @@ pub fn generate_with_remote_ffn_batch(
     remote: &LayerShardedBackend,
     eos: &EosConfig,
     predispatch_iters: usize,
+) -> Result<GridGenerateResult, RemoteMoeError> {
+    generate_with_remote_ffn_batch_captured(
+        weights,
+        tokenizer,
+        prompt_ids,
+        max_tokens,
+        index,
+        backend,
+        remote,
+        eos,
+        predispatch_iters,
+        None,
+    )
+}
+
+/// [`generate_with_remote_ffn_batch`] with an optional residual-capture sink.
+///
+/// When `sink` is `Some`, each decode step appends the pre-normed per-layer
+/// residuals that the final predispatch iteration dispatched to the remote —
+/// the DEC loadgen's capture hook. `None` is byte-identical to the plain
+/// batch path.
+#[allow(clippy::too_many_arguments)]
+pub fn generate_with_remote_ffn_batch_captured(
+    weights: &ModelWeights,
+    tokenizer: &tokenizers::Tokenizer,
+    prompt_ids: Vec<u32>,
+    max_tokens: usize,
+    index: &VectorIndex,
+    backend: &dyn larql_compute::ComputeBackend,
+    remote: &LayerShardedBackend,
+    eos: &EosConfig,
+    predispatch_iters: usize,
+    mut sink: Option<&mut ResidualCaptureSink>,
 ) -> Result<GridGenerateResult, RemoteMoeError> {
     let runtime = GridRuntimeConfig::from_env();
     let predispatch_iters = predispatch_iters.max(1);
@@ -418,6 +462,11 @@ pub fn generate_with_remote_ffn_batch(
 
         for iter in 0..predispatch_iters {
             let is_final = iter + 1 == predispatch_iters;
+            if is_final {
+                if let Some(s) = sink.as_deref_mut() {
+                    s.steps.push(prenorm_layers(weights, &h_capture));
+                }
+            }
             let t_ffn = std::time::Instant::now();
             let h2 = dispatch_ffn_with_q8k_fallback(remote, weights, &h_capture);
             step_ffn_ms += t_ffn.elapsed().as_secs_f64() * 1000.0;

--- a/crates/larql-inference/src/lib.rs
+++ b/crates/larql-inference/src/lib.rs
@@ -183,9 +183,11 @@ pub use chat::{wrap_chat_prompt, wrap_prompt_raw, wrap_with_vindex_template, Cha
 pub use error::InferenceError;
 pub use ffn::graph_backend::{GateIndex, IndexBuildCallbacks, SilentIndexCallbacks};
 pub use ffn::{
-    BackendFfn, FfnBackend, LayerFfnRouter, LayerShardedBackend, MoeRouterWeights, RemoteFfnConfig,
-    RemoteFfnError, RemoteLatencyStats, RemoteMoeBackend, RemoteMoeError, RemoteWalkBackend,
-    ShardConfig, SparseFfn, WeightFfn, WirePreference,
+    decode_q8k_batch_response_entries, decode_single_response, encode_binary_request,
+    encode_q8k_batch_request, BackendFfn, FfnBackend, LayerFfnRouter, LayerShardedBackend,
+    MoeRouterWeights, RemoteFfnConfig, RemoteFfnError, RemoteLatencyStats, RemoteMoeBackend,
+    RemoteMoeError, RemoteWalkBackend, ShardConfig, SparseFfn, WeightFfn, WirePreference,
+    BINARY_CT, F16_CT, I8_CT, Q8K_BATCH_CT,
 };
 pub use kv_dispatch::{
     CompressionCodec, EngineBackend, KvDispatch, KvHandle, KvHandleInner, PerLayerDecodeState,
@@ -229,8 +231,9 @@ pub use layer_graph::{
     generate_with_sampling,
     // Expert grid generation
     grid::{
-        generate_with_remote_ffn, generate_with_remote_ffn_batch, generate_with_remote_moe,
-        generate_with_remote_moe_batch,
+        generate_with_remote_ffn, generate_with_remote_ffn_batch,
+        generate_with_remote_ffn_batch_captured, generate_with_remote_moe,
+        generate_with_remote_moe_batch, ResidualCaptureSink,
     },
     hybrid::predict_hybrid,
     predict_honest,

--- a/crates/larql-inference/src/vindex/kquant_forward/walk_ffn.rs
+++ b/crates/larql-inference/src/vindex/kquant_forward/walk_ffn.rs
@@ -74,8 +74,12 @@ pub fn kquant_ffn_forward_layer(
 
 /// Q4_K × Q8_K variant: accepts a pre-quantised Q8_K activation vector
 /// (already RMS-normed by the client) and skips the dequant of gate/up by
-/// using the NEON/AVX2 `q4k_q8k_gate_up_into` kernel.  Down projection
-/// still goes through the f32 dequant path (no Q6K×Q8K kernel yet).
+/// using the `q4k_q8k_gate_up_into` kernel (NEON/hand-asm on aarch64;
+/// scalar-only on x86_64 today — see `q4k_q8k_gate_up_into`'s doc comment).
+/// Down projection takes the matching Q4_K×Q8_K matvec kernel only when the
+/// down slab's own format tag is `"Q4_K"`; any other format (a non-Q4_K
+/// down slab, e.g. from a model with a different quant mix) falls back to
+/// the f32 dequant path, which consults the tag correctly.
 ///
 /// `h_q8k.qs.len()` must equal `hidden` (= `x.ncols()`), which is a
 /// multiple of 256 (Q8_K block size).
@@ -129,17 +133,21 @@ pub fn kquant_ffn_forward_layer_q8k(
     // Down projection: Q4K×Q8K NEON — quantise the f32 activation once,
     // then call the NEON matvec directly on the mmap Q4K bytes.
     // No dequant, no large f32 allocation, no BLAS thread-pool collision.
-    // Guard: intermediate must be Q8K-block-aligned (multiple of the
-    // Q4_K/Q8_K super-block size).
-    // For non-aligned sizes (rare, non-production) fall back to OnceLock cache.
-    if intermediate.is_multiple_of(crate::ffn::Q4K_Q8K_SUPERBLOCK_ELEMS) {
+    // Guard: down's own format tag must be "Q4_K" (this kernel reads the
+    // Q4_K block layout only — feeding it Q6_K/Q5_K/… bytes decodes silent
+    // garbage, see docs/audits/dec-readiness-review-2026-07-22.md §1d) AND
+    // intermediate must be Q8K-block-aligned (multiple of the Q4_K/Q8_K
+    // super-block size). Either condition failing falls back to the
+    // format-aware dequant path below.
+    if ffn[2].1 == "Q4_K" && intermediate.is_multiple_of(crate::ffn::Q4K_Q8K_SUPERBLOCK_ELEMS) {
         let activation_flat = activation.as_slice().expect("activation contiguous");
         let act_q8k = quantize_x_to_q8k(activation_flat);
         let mut out = vec![0.0f32; hidden];
         q4k_q8k_matvec_into(&mut out, &act_q8k, ffn[2].0, hidden, intermediate);
         Array2::from_shape_vec((1, hidden), out).expect("down output shape")
     } else {
-        // Fallback: OnceLock cache + ndarray dot for non-256-aligned intermediate.
+        // Fallback: OnceLock cache + ndarray dot; consults `ffn[2].1` via
+        // `dequantize_matrix`, so any down format is handled correctly.
         let n = intermediate * hidden;
         if let Some(arc) = index.kquant_ffn_layer_once(layer, 2) {
             let w_down_t = ndarray::ArrayView2::from_shape((intermediate, hidden), &arc[..n])

--- a/crates/larql-server/src/bootstrap.rs
+++ b/crates/larql-server/src/bootstrap.rs
@@ -802,6 +802,12 @@ async fn spawn_http3_listener_if_configured(cli: &Cli, app: axum::Router) -> Res
 /// through `clap::Parser::parse_from`.
 pub async fn serve(cli: Cli) -> Result<(), BoxError> {
     info!("larql-server v{}", env!("CARGO_PKG_VERSION"));
+    // No DEC number should ever be recorded on an unlogged scalar
+    // fallback — see docs/audits/dec-readiness-review-2026-07-22.md §1b.
+    info!(
+        "  Q4K/Q6K×Q8K kernel class: {}",
+        larql_compute::cpu::ops::q4k_q8k_dot::kernel_class_summary()
+    );
 
     let mut models: Vec<Arc<LoadedModel>> = Vec::new();
 

--- a/crates/larql-server/src/metrics.rs
+++ b/crates/larql-server/src/metrics.rs
@@ -83,6 +83,18 @@ impl LayerLatencyTracker {
         }
     }
 
+    /// Number of samples currently held in `layer`'s ring buffer (caps at
+    /// the ring capacity). Instrumentation/test hook — lets a caller assert
+    /// that a request actually recorded compute (e.g. the DEC replay
+    /// `top_k=0` L2-cache bypass) without depending on timing values.
+    pub fn recorded_count(&self, layer: u32) -> usize {
+        self.inner
+            .lock()
+            .ok()
+            .and_then(|g| g.get(&layer).map(|s| s.ring.len()))
+            .unwrap_or(0)
+    }
+
     /// Snapshot current stats as proto `LayerLatency` values, sorted by layer.
     /// Returns an empty vec when no requests have been recorded yet.
     pub fn snapshot(&self) -> Vec<LayerLatency> {

--- a/crates/larql-server/src/routes/stats.rs
+++ b/crates/larql-server/src/routes/stats.rs
@@ -37,6 +37,19 @@ fn build_stats(model: &LoadedModel) -> serde_json::Value {
         "full"
     };
 
+    let layer_latency: Vec<serde_json::Value> = model
+        .layer_latency_tracker
+        .snapshot()
+        .iter()
+        .map(|l| {
+            serde_json::json!({
+                "layer": l.layer,
+                "avg_ms": l.avg_ms,
+                "p99_ms": l.p99_ms,
+            })
+        })
+        .collect();
+
     serde_json::json!({
         "model": config.model,
         "family": config.family,
@@ -49,6 +62,7 @@ fn build_stats(model: &LoadedModel) -> serde_json::Value {
         "extract_level": config.extract_level.to_string(),
         "dtype": config.dtype.to_string(),
         "layer_bands": layer_bands,
+        "layer_latency": layer_latency,
         "loaded": {
             "browse": !model.embed_only,
             "inference": has_inference && !model.infer_disabled,
@@ -56,6 +70,62 @@ fn build_stats(model: &LoadedModel) -> serde_json::Value {
             "embed_service": true,
         },
     })
+}
+
+/// Per-layer FFN weight byte accounting for the DEC movement-ratio
+/// denominator (`dec/movement_ratio`, docs/dec-funnel.md §1).
+///
+/// `per_layer_dense_bytes[l]` is the exact mmap byte length of layer `l`'s
+/// interleaved k-quant gate+up+down weights — the bytes `/v1/walk-ffn`
+/// touches for one token on that layer — or `null` where the vindex has no
+/// interleaved k-quant data. The `moe` block echoes routing metadata from
+/// the vindex config; `per_expert_bytes` is probed from already-loaded model
+/// weights (never forces a weight load) and omitted when unavailable.
+fn ffn_weights_json(
+    model: &LoadedModel,
+    base: &larql_vindex::VectorIndex,
+) -> Option<serde_json::Value> {
+    let config = &model.config;
+    let per_layer: Vec<Option<u64>> = (0..config.num_layers)
+        .map(|layer| {
+            base.interleaved_kquant_layer_data(layer)
+                .map(|slices| slices.iter().map(|(bytes, _)| bytes.len() as u64).sum())
+        })
+        .collect();
+    let has_any_dense = per_layer.iter().any(|b| b.is_some());
+
+    let moe = model
+        .weights
+        .get()
+        .and_then(|rw| rw.read().ok())
+        .and_then(|w| {
+            let arch = &*w.arch;
+            if !arch.is_moe() {
+                return None;
+            }
+            let per_expert_bytes: Option<u64> = if w.has_per_layer_ffn() {
+                (0..config.num_layers).find_map(|l| {
+                    w.get_layer_entry_bytes(l, 0)
+                        .map(|(gu, dn)| (gu.len() + dn.len()) as u64)
+                })
+            } else {
+                None
+            };
+            Some(serde_json::json!({
+                "num_experts": arch.num_experts(),
+                "top_k": arch.num_experts_per_token(),
+                "moe_intermediate_size": arch.moe_intermediate_size(),
+                "per_expert_bytes": per_expert_bytes,
+            }))
+        });
+
+    if !has_any_dense && moe.is_none() {
+        return None;
+    }
+    Some(serde_json::json!({
+        "per_layer_dense_bytes": per_layer,
+        "moe": moe,
+    }))
 }
 
 /// Async wrapper for the Q4K cache + W2 surface. The base
@@ -66,6 +136,7 @@ async fn add_q4k_ffn(model: &LoadedModel, mut stats: serde_json::Value) -> serde
     let p = model.patched.read().await;
     let (slots, bytes) = p.base.kquant_ffn_cache_stats();
     let has_fm = p.base.has_down_features_kquant();
+    let ffn_weights = ffn_weights_json(model, &p.base);
     if let Some(obj) = stats.as_object_mut() {
         obj.insert(
             "q4k_ffn".into(),
@@ -75,6 +146,9 @@ async fn add_q4k_ffn(model: &LoadedModel, mut stats: serde_json::Value) -> serde
                 "feature_major_down": has_fm,
             }),
         );
+        if let Some(w) = ffn_weights {
+            obj.insert("ffn_weights".into(), w);
+        }
     }
     stats
 }

--- a/crates/larql-server/src/routes/walk_ffn/q8k.rs
+++ b/crates/larql-server/src/routes/walk_ffn/q8k.rs
@@ -2,8 +2,10 @@
 //!
 //! The client has already applied the FFN input norm and quantised
 //! the activation to Q8_K. The server decodes each entry, runs the
-//! NEON/AVX2 Q4K×Q8K gate+up kernel (or the Metal backend when
-//! available), and returns the FFN delta per layer as f32.
+//! Q4K×Q8K gate+up kernel (NEON/hand-asm on aarch64, scalar on x86_64
+//! today — see `larql_compute::cpu::ops::q4k_q8k_dot::kernel_class_summary`,
+//! logged once at server startup) or the Metal backend when available,
+//! and returns the FFN delta per layer as f32.
 //!
 //! Returns 404 if the vindex doesn't have interleaved Q4K data
 //! (ffn-only servers without Q4K weights can't serve this endpoint).
@@ -17,7 +19,22 @@
 use axum::extract::State;
 use axum::http::{header, StatusCode};
 use axum::response::Response;
+use larql_compute::cpu::ops::q4k_q8k_dot::Q8KActivation;
 use larql_vindex::QuantizedFfnAccess;
+
+/// Dequantise a Q8_K-quantised activation back to f32:
+/// `h[b*256 + i] = d[b] * qs[b*256 + i]`. Shared by the Metal per-entry
+/// dispatch and the CPU batched-GEMM path below.
+fn q8k_activation_to_f32(q8k: &Q8KActivation, hidden: usize) -> Vec<f32> {
+    let mut out = vec![0.0f32; hidden];
+    for (b, &d) in q8k.d.iter().enumerate() {
+        let base = b * 256;
+        for i in 0..256 {
+            out[base + i] = d * (q8k.qs[base + i] as f32);
+        }
+    }
+    out
+}
 
 /// Content-type for the Q8K dense-FFN batch protocol.
 pub(crate) const Q8K_BATCH_CT: &str = "application/x-larql-ffn-q8k-batch";
@@ -50,7 +67,7 @@ pub async fn handle_walk_ffn_q8k(
 
     let result = tokio::task::spawn_blocking(move || {
         use larql_inference::ffn::remote::{decode_q8k_batch_request, encode_q8k_batch_response};
-        use larql_inference::vindex::kquant_ffn_forward_layer_q8k;
+        use larql_inference::vindex::{kquant_ffn_forward_layer, kquant_ffn_forward_layer_q8k};
 
         let model = state
             .model(None)
@@ -151,16 +168,7 @@ pub async fn handle_walk_ffn_q8k(
                         }
 
                         let bufs = &layer_bufs[layer];
-                        // Decode Q8K → f32: h_norm[b*256 + i] = d[b] * qs[b*256 + i]
-                        let n_blocks = entry.q8k.d.len();
-                        let mut h_norm = vec![0.0f32; hidden];
-                        for b in 0..n_blocks {
-                            let d = entry.q8k.d[b];
-                            let base = b * 256;
-                            for i in 0..256 {
-                                h_norm[base + i] = d * (entry.q8k.qs[base + i] as f32);
-                            }
-                        }
+                        let h_norm = q8k_activation_to_f32(&entry.q8k, hidden);
 
                         let out = backend.run_dense_ffn_q4k(
                             &h_norm,
@@ -188,38 +196,90 @@ pub async fn handle_walk_ffn_q8k(
             }
         }
 
-        // ── CPU fallback (NEON Q4K×Q8K) ──────────────────────────────────
+        // ── CPU fallback (Q4K×Q8K) ────────────────────────────────────────
         let weights = model
             .get_or_load_weights()
             .map_err(crate::error::ServerError::InferenceUnavailable)?;
 
         let arch = &*weights.arch;
+        let hidden = model.config.hidden_size;
+
+        // Validate every entry's layer bounds/ownership up front, before
+        // any compute — matches the previous per-entry checks.
+        for entry in &entries {
+            let layer = entry.layer_idx;
+            if layer >= model.config.num_layers {
+                return Err(crate::error::ServerError::BadRequest(format!(
+                    "layer {layer} out of range (num_layers = {})",
+                    model.config.num_layers
+                )));
+            }
+            if !patched.base().is_layer_owned(layer) {
+                let range_desc = match patched.base().owned_layer_range() {
+                    Some((s, e)) => format!("{s}–{}", e - 1),
+                    None => "all".into(),
+                };
+                return Err(crate::error::ServerError::BadRequest(format!(
+                    "layer {layer} not served by this shard (owned: {range_desc})"
+                )));
+            }
+        }
+
+        // Group entries by layer: a batch-B request from the replay/predispatch
+        // client sends B entries that share one layer, and firing B independent
+        // single-row matvecs re-streams that layer's full Q4K gate/up/down
+        // bytes B times (the DEC-0/DEC-1 batch curve becomes ~linear in B by
+        // construction — see docs/audits/dec-readiness-review-2026-07-22.md
+        // §1a). Same-layer groups of >1 dequantise to f32 and run ONE batched
+        // GEMM through `kquant_ffn_forward_layer` (amortising weights across
+        // all rows, same as the f32/f16/i8 arm); a singleton group keeps the
+        // existing single-row Q4K×Q8K kernel (no batching to fix, and it
+        // avoids dequantising gate/up for the common single-token decode
+        // case). Different layers still parallelise across groups.
+        let mut by_layer: std::collections::BTreeMap<usize, Vec<usize>> =
+            std::collections::BTreeMap::new();
+        for (i, entry) in entries.iter().enumerate() {
+            by_layer.entry(entry.layer_idx).or_default().push(i);
+        }
 
         use rayon::prelude::*;
-        let response_entries: Result<Vec<(usize, Vec<f32>)>, crate::error::ServerError> = entries
-            .par_iter()
-            .map(|entry| {
-                let layer = entry.layer_idx;
-                if layer >= model.config.num_layers {
-                    return Err(crate::error::ServerError::BadRequest(format!(
-                        "layer {layer} out of range (num_layers = {})",
-                        model.config.num_layers
-                    )));
+        let mut outputs: Vec<Option<Vec<f32>>> = vec![None; entries.len()];
+        let group_results: Vec<(Vec<usize>, Vec<Vec<f32>>)> = by_layer
+            .into_par_iter()
+            .map(|(layer, idxs)| {
+                if idxs.len() == 1 {
+                    let out =
+                        kquant_ffn_forward_layer_q8k(arch, patched.base(), layer, &entries[idxs[0]].q8k);
+                    (idxs, vec![out.into_raw_vec_and_offset().0])
+                } else {
+                    let mut flat = Vec::with_capacity(idxs.len() * hidden);
+                    for &i in &idxs {
+                        flat.extend_from_slice(&q8k_activation_to_f32(&entries[i].q8k, hidden));
+                    }
+                    let x = larql_vindex::ndarray::Array2::from_shape_vec((idxs.len(), hidden), flat)
+                        .expect("q8k batch shape");
+                    let out = kquant_ffn_forward_layer(arch, patched.base(), layer, &x);
+                    let rows = out.rows().into_iter().map(|r| r.to_vec()).collect();
+                    (idxs, rows)
                 }
-                if !patched.base().is_layer_owned(layer) {
-                    let range_desc = match patched.base().owned_layer_range() {
-                        Some((s, e)) => format!("{s}–{}", e - 1),
-                        None => "all".into(),
-                    };
-                    return Err(crate::error::ServerError::BadRequest(format!(
-                        "layer {layer} not served by this shard (owned: {range_desc})"
-                    )));
-                }
-                let out = kquant_ffn_forward_layer_q8k(arch, patched.base(), layer, &entry.q8k);
-                Ok((layer, out.into_raw_vec_and_offset().0))
             })
             .collect();
-        let response_entries = response_entries?;
+        for (idxs, rows) in group_results {
+            for (i, row) in idxs.into_iter().zip(rows) {
+                outputs[i] = Some(row);
+            }
+        }
+
+        let response_entries: Vec<(usize, Vec<f32>)> = entries
+            .iter()
+            .zip(outputs)
+            .map(|(entry, out)| {
+                (
+                    entry.layer_idx,
+                    out.expect("every entry index is assigned exactly once by its layer group"),
+                )
+            })
+            .collect();
 
         let _latency_ms = start.elapsed().as_secs_f64() * 1000.0;
 

--- a/crates/larql-server/src/routes/walk_ffn/q8k.rs
+++ b/crates/larql-server/src/routes/walk_ffn/q8k.rs
@@ -72,6 +72,34 @@ pub async fn handle_walk_ffn_q8k(
         let entries =
             decode_q8k_batch_request(&body).map_err(crate::error::ServerError::BadRequest)?;
 
+        // Shape validation before any kernel touches the activations: Q8K
+        // activations quantise in 256-element super-blocks, so the model's
+        // hidden size must be block-aligned (production clients only pick
+        // the Q8K wire when it is) and every entry must carry exactly
+        // hidden/256 blocks. Without this gate a shape-mismatched frame
+        // panics inside the FFN kernels (slice out of range) → 500.
+        {
+            let hidden = model.config.hidden_size;
+            let block = larql_inference::ffn::Q4K_Q8K_SUPERBLOCK_ELEMS;
+            if hidden % block != 0 {
+                return Err(crate::error::ServerError::BadRequest(format!(
+                    "hidden_size {hidden} is not a multiple of {block} — \
+                     Q8K wire not supported for this model; use /v1/walk-ffn"
+                )));
+            }
+            let expected_blocks = hidden / block;
+            for (i, entry) in entries.iter().enumerate() {
+                let n_blocks = entry.q8k.d.len();
+                if n_blocks != expected_blocks {
+                    return Err(crate::error::ServerError::BadRequest(format!(
+                        "entry {i} (layer {}): {n_blocks} Q8K blocks, expected \
+                         {expected_blocks} for hidden_size {hidden}",
+                        entry.layer_idx
+                    )));
+                }
+            }
+        }
+
         let patched = model.patched.blocking_read();
         let start = std::time::Instant::now();
 

--- a/crates/larql-server/tests/test_walk_ffn_dec_replay.rs
+++ b/crates/larql-server/tests/test_walk_ffn_dec_replay.rs
@@ -1,0 +1,332 @@
+//! DEC replay-shape coverage (docs/dec-funnel.md, DEC-0 loadgen).
+//!
+//! The `larql dec-bench replay` driver sends B-row single-layer frames with
+//! `top_k = 0` and decodes responses through the shared codecs. These tests
+//! pin the server side of that contract:
+//!
+//!   * B-row (`seq_len = B`) binary requests return `B × hidden` outputs for
+//!     every negotiated wire format (f32 / f16 / i8);
+//!   * `top_k = 0` requests bypass the FfnL2Cache — repeated identical
+//!     requests re-run compute (asserted via the layer-latency tracker, not
+//!     timing values);
+//!   * `/v1/stats` exposes the `layer_latency` snapshot and the
+//!     `ffn_weights.per_layer_dense_bytes` movement-ratio denominator;
+//!   * Q8K batch entries with a duplicate layer id round-trip in wire order.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use tower::ServiceExt;
+
+const SYN_HIDDEN: usize = 8;
+
+fn residual_rows(batch: usize) -> Vec<f32> {
+    let mut v = vec![0.0_f32; batch * SYN_HIDDEN];
+    for (i, slot) in v.iter_mut().enumerate() {
+        *slot = (i as f32) * 0.01 + 0.5;
+    }
+    v
+}
+
+/// Production replay frame: single layer, `seq_len = batch`, full_output,
+/// `top_k = 0` — built through the same encoder `larql dec-bench` uses.
+fn replay_frame(layer: usize, batch: usize) -> Vec<u8> {
+    larql_inference::encode_binary_request(
+        Some(layer),
+        None,
+        &residual_rows(batch),
+        batch,
+        true,
+        0,
+    )
+}
+
+async fn post_walk_ffn_binary(
+    app: axum::Router,
+    body: Vec<u8>,
+    accept: &str,
+) -> axum::http::Response<Body> {
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri("/v1/walk-ffn")
+            .header(header::CONTENT_TYPE, larql_inference::BINARY_CT)
+            .header(header::ACCEPT, accept)
+            .body(Body::from(body))
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+}
+
+async fn assert_b_row_response(accept: &str, batch: usize) {
+    let (model, _fixture) = common::model_with_real_weights("synthetic");
+    let state = common::state(vec![model]);
+    let app = larql_server::routes::single_model_router(state);
+
+    let resp = post_walk_ffn_binary(app, replay_frame(0, batch), accept).await;
+    assert_eq!(resp.status(), StatusCode::OK, "accept={accept}");
+    let ct = resp
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(larql_inference::BINARY_CT)
+        .to_owned();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+
+    // Decode through the SAME dispatcher the replay driver uses.
+    let (layer, server_ms, floats) =
+        larql_inference::decode_single_response(&ct, &bytes, SYN_HIDDEN)
+            .unwrap_or_else(|e| panic!("decode ({accept}): {e}"));
+    assert_eq!(layer, 0);
+    assert!(server_ms >= 0.0);
+    assert_eq!(
+        floats.len(),
+        batch * SYN_HIDDEN,
+        "B-row response must carry batch × hidden floats (accept={accept})"
+    );
+}
+
+#[tokio::test]
+async fn walk_ffn_b_row_f32_returns_batch_by_hidden() {
+    assert_b_row_response(larql_inference::BINARY_CT, 8).await;
+}
+
+#[tokio::test]
+async fn walk_ffn_b_row_f16_returns_batch_by_hidden() {
+    assert_b_row_response(larql_inference::F16_CT, 8).await;
+}
+
+#[tokio::test]
+async fn walk_ffn_b_row_i8_returns_batch_by_hidden() {
+    assert_b_row_response(larql_inference::I8_CT, 8).await;
+}
+
+#[tokio::test]
+async fn walk_ffn_top_k_zero_recomputes_on_repeat() {
+    // The FfnL2Cache serves cached output when `seq_len == 1 && top_k > 0`
+    // (routes/walk_ffn/core.rs) — a replayed B=1 point with a non-zero
+    // top_k would measure cache hits from the second request on. `top_k=0`
+    // must re-run compute every time; each compute records into the
+    // layer-latency tracker, so the sample count is the timing-free proof.
+    let (model, _fixture) = common::model_with_real_weights("synthetic");
+    let tracker = model.layer_latency_tracker.clone();
+    let state = common::state(vec![model]);
+
+    assert_eq!(tracker.recorded_count(0), 0);
+    for expected in 1..=2 {
+        let app = larql_server::routes::single_model_router(state.clone());
+        let resp = post_walk_ffn_binary(app, replay_frame(0, 1), larql_inference::BINARY_CT).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            tracker.recorded_count(0),
+            expected,
+            "request {expected} with top_k=0 must run compute, not hit the L2 cache"
+        );
+    }
+}
+
+#[tokio::test]
+async fn stats_exposes_layer_latency_and_ffn_weights() {
+    // Q4K fixture: interleaved k-quant data present, so /v1/stats must
+    // report per-layer dense weight bytes (the movement-ratio denominator)
+    // and, after a walk-ffn request, a non-empty layer_latency snapshot.
+    let (model, _fixture) = common::model_with_q4k_weights("synthetic");
+    let num_layers = model.config.num_layers;
+    let state = common::state(vec![model]);
+
+    let app = larql_server::routes::single_model_router(state.clone());
+    let resp = post_walk_ffn_binary(app, replay_frame(0, 1), larql_inference::BINARY_CT).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let app = larql_server::routes::single_model_router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+    let latency = v["layer_latency"]
+        .as_array()
+        .expect("stats must expose layer_latency");
+    assert!(
+        !latency.is_empty(),
+        "layer_latency must be non-empty after a walk-ffn request"
+    );
+    assert!(latency[0]["avg_ms"].is_number());
+    assert!(latency[0]["p99_ms"].is_number());
+
+    let per_layer = v["ffn_weights"]["per_layer_dense_bytes"]
+        .as_array()
+        .expect("q4k vindex must expose ffn_weights.per_layer_dense_bytes");
+    assert_eq!(per_layer.len(), num_layers);
+    assert!(
+        per_layer[0].as_u64().unwrap_or(0) > 0,
+        "layer 0 dense bytes must be a positive byte count"
+    );
+}
+
+#[tokio::test]
+async fn stats_ffn_weights_moe_block_from_loaded_weights() {
+    // With MoE model weights already loaded, /v1/stats must expose the moe
+    // routing metadata (num_experts / top_k) used for the full-MoE
+    // movement-ratio accounting; the fixture has no per-layer expert
+    // entries, so per_expert_bytes must be null, not fabricated.
+    let (model, _fixture) = common::model_with_q4k_weights("synthetic");
+    model
+        .weights
+        .set(std::sync::RwLock::new(
+            larql_models::test_fixtures::make_test_gemma4_moe_weights(),
+        ))
+        .unwrap_or_else(|_| panic!("weights OnceLock already set"));
+    let state = common::state(vec![model]);
+    let app = larql_server::routes::single_model_router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let moe = &v["ffn_weights"]["moe"];
+    assert!(moe["num_experts"].as_u64().unwrap() > 0);
+    assert!(moe["top_k"].as_u64().unwrap() > 0);
+    assert!(moe["per_expert_bytes"].is_null());
+}
+
+#[tokio::test]
+async fn stats_ffn_weights_dense_arch_omits_moe_block() {
+    // Loaded weights with a non-MoE arch: the ffn_weights block stays (the
+    // q4k vindex has dense byte data) but moe must be null.
+    let (model, _fixture) = common::model_with_q4k_weights("synthetic");
+    model
+        .weights
+        .set(std::sync::RwLock::new(
+            larql_models::test_fixtures::make_test_weights(),
+        ))
+        .unwrap_or_else(|_| panic!("weights OnceLock already set"));
+    let state = common::state(vec![model]);
+    let app = larql_server::routes::single_model_router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(v["ffn_weights"]["per_layer_dense_bytes"].is_array());
+    assert!(v["ffn_weights"]["moe"].is_null());
+}
+
+#[tokio::test]
+async fn stats_f32_vindex_omits_ffn_weights() {
+    // The plain f32 synthetic has no interleaved k-quant data and no MoE —
+    // the ffn_weights block must be absent, not zero-filled, so the replay
+    // driver knows the denominator is unavailable.
+    let (model, _fixture) = common::model_with_real_weights("synthetic");
+    let state = common::state(vec![model]);
+    let app = larql_server::routes::single_model_router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(v.get("ffn_weights").is_none());
+    assert!(v["layer_latency"].as_array().is_some());
+}
+
+#[tokio::test]
+async fn walk_ffn_q8k_duplicate_layer_entries_preserved_in_order() {
+    // B-row Q8K replay = B entries sharing one layer id. When the server
+    // accepts the frame, the response must echo one entry per request entry
+    // in wire order (the client-side ordered decoder is unit-tested in
+    // larql-inference; this pins the server's pass-through shape).
+    use larql_compute::cpu::ops::q4k_q8k_dot::quantize_x_to_q8k;
+
+    let (model, _fixture) = common::model_with_q4k_weights("synthetic");
+    let state = common::state(vec![model]);
+    let app = larql_server::routes::single_model_router(state);
+
+    // Q8K activations quantise in 256-element super-blocks; pad each row.
+    let rows: Vec<Vec<f32>> = (0..3)
+        .map(|i| {
+            let mut r = vec![0.0f32; 256];
+            for (j, slot) in r.iter_mut().enumerate().take(SYN_HIDDEN) {
+                *slot = (i * SYN_HIDDEN + j) as f32 * 0.01 + 0.1;
+            }
+            r
+        })
+        .collect();
+    let q8ks: Vec<_> = rows.iter().map(|r| quantize_x_to_q8k(r)).collect();
+    let entries: Vec<(usize, &_)> = q8ks.iter().map(|q| (0usize, q)).collect();
+    let body = larql_inference::encode_q8k_batch_request(&entries);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/walk-ffn-q8k")
+                .header(header::CONTENT_TYPE, larql_inference::Q8K_BATCH_CT)
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    if status == StatusCode::OK {
+        let decoded = larql_inference::decode_q8k_batch_response_entries(&bytes).unwrap();
+        assert_eq!(decoded.len(), 3, "one response entry per request entry");
+        assert!(decoded.iter().all(|(l, _)| *l == 0));
+    } else {
+        // The tiny synthetic (hidden=8) may not satisfy the Q8K kernel's
+        // block-shape preconditions; a clean 4xx is acceptable — the
+        // duplicate-order contract is pinned client-side. A 5xx is not.
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "q8k duplicate-layer frame must be served or cleanly rejected"
+        );
+    }
+}

--- a/docs/audits/dec-readiness-review-2026-07-22.md
+++ b/docs/audits/dec-readiness-review-2026-07-22.md
@@ -1,0 +1,493 @@
+# DEC-readiness review — 2026-07-22
+
+> **Remediation status (2026-07-22):** Batch A (§1a–§1d, §2a first item) is
+> fixed — see [`ROADMAP.md`](../../ROADMAP.md) §"Codebase hardening" →
+> "DEC-readiness review (2026-07-22)" for the per-item summary and the
+> commit that landed it. Batches B and C (fleet/config landmines, structural
+> pre-work) remain open, tracked in the same ROADMAP section.
+
+Targeted review of the **DEC data-plane** (`larql-server`, `larql-router`,
+`larql-inference` remote-FFN/MoE paths, `larql-cli` bench/dec_bench, the DEC
+scripts) ahead of the DEC funnel programme ([`docs/dec-funnel.md`](../dec-funnel.md)).
+Scope was deliberately narrow — the code the programme actually exercises when
+it runs `larql-server` expert tiers, `larql-router`, and the new `dec-bench`
+loadgen on **rented marketplace hosts** (Vast.ai x86 EPYC, not the M3 Max the
+stack was developed on), against **models other than Gemma** (Inkling ~975B,
+Kimi K3), over **network links with adversarial peers**.
+
+Four parallel readers (security, hardcoding/config, modularity, performance),
+each returning only findings verified against the code with `file:line`
+evidence. This document is the canonical record; prioritized actions are
+tracked in [`ROADMAP.md`](../../ROADMAP.md) §"Codebase hardening" under
+"DEC-readiness review (2026-07-22)".
+
+## Verdict
+
+The stack is structurally sound and the wire decoders are mostly hardened —
+but the review surfaced a **cluster of silent-corruption defects** that
+matter more than usual here because the entire programme is a measurement
+exercise: each produces plausible-looking output that is actually wrong, with
+no error. The single dominant theme is *"produces a number, the number is a
+lie"*, and it intersects the DEC-0 batch curve, the DEC-0.5 x86 tier, and the
+Inkling/K3 extraction stages directly. Security exposure is one genuine
+remote-abort bug (a regression from the codebase's own established guard
+pattern) plus deployment-posture items that are real under the stated
+threat model. Structural debt is real but lower-urgency — it's pre-work for
+the G/C ladders and the K3 port, not a DEC-0 blocker.
+
+The B-row **f32/f16/i8** serving path is genuinely well-built (one BLAS GEMM
+over all rows, lock-free per-layer weight cache); it is specifically the
+**Q8K** path — the wire DEC prefers — that does not batch.
+
+---
+
+## 1. Silent corruption — wrong numbers, no crash
+
+The highest-priority cluster. None of these throw; all of them corrupt a DEC
+measurement or a generation.
+
+### 1a. Q8K has no batched compute on the server [perf + modularity, HIGH] — ✅ FIXED
+
+`crates/larql-server/src/routes/walk_ffn/q8k.rs:199` maps each request entry
+through `kquant_ffn_forward_layer_q8k`
+(`crates/larql-inference/src/vindex/kquant_forward/walk_ffn.rs:84`), which is
+strictly single-row (`Array2::from_shape_vec((1, …))`, matvec kernels). The
+replay client sends B entries that all share one layer
+(`dec_bench/replay.rs` `build_q8k_frame`), so a batch-64 Q8K request runs 64
+independent matvecs, **re-streaming the layer's full Q4K gate/up/down bytes 64
+times** while rayon workers contend for DRAM bandwidth.
+
+Contrast the f32/f16/i8 arm: one frame with `seq_len=B` hits
+`kquant_ffn_forward_layer` (`walk_ffn.rs:32`), which is `x.dot(w.t())` — a real
+GEMM over the once-dequantised f32 cache, amortising weights across all rows.
+
+**DEC impact:** the DEC-0/DEC-1 batch-64 curve on the Q8K arm is ~linear in B
+by construction. C1 ("step time sub-linear in batch") fails on Q8K for a
+serving-code reason, not physics; the C6 wire comparison is corrupted (Q8K
+looks worse than its bandwidth advantage deserves).
+
+**Fix direction:** on the Q8K handler, group same-layer entries and either
+(a) dequantise each activation to f32 and run them as one batched GEMM through
+the existing `kquant_ffn_forward_layer` path (preserves the Q8K *upload*
+compression that is the C6 claim, fixes compute scaling), or (b) add a
+multi-row Q4K×Q8K kernel that keeps a weight super-block resident across the B
+rows. The wire already carries duplicate-layer entries in order
+(`decode_q8k_batch_response_entries` exists for exactly this shape).
+
+### 1b. x86 silently falls to scalar on two serving kernels [hardcoding, HIGH] — ✅ FIXED (observability)
+
+`crates/larql-compute/src/cpu/ops/q4k_q8k_dot.rs`:
+- `q4k_q8k_gate_up_into` (:1377) has **no x86 branch** — non-aarch64 runs
+  `q4k_q8k_matvec_scalar` twice. This is the dense `/v1/walk-ffn-q8k` serving
+  kernel (`kquant_forward/walk_ffn.rs:108`), whose doc-comment (:77) falsely
+  claims "NEON/AVX2". The code's own comment (:1253) says AVX2 is ~12–16×
+  faster than scalar.
+- `q6k_q8k_matvec_into` (:2119) is NEON-or-scalar, no AVX2 — and
+  `q4k_q8k_matvec_parallel` ("the single source for every quantized
+  projection on the decode path") routes every Q6_K projection (attention V,
+  lm_head on typical Q4K vindexes) through it.
+
+**DEC impact:** DEC-0.5 (x86 kernel gate) is *defined* as measuring the x86
+tier. It would produce numbers on a 10–16× handicapped kernel with no warning,
+and sub-linearity conclusions would be drawn on it. Building the AVX2 kernels
+is C-ladder work; the **silence** is the bug this review flags — the serving
+path must log the selected kernel class once at startup and the false doc
+comments must be corrected, so no DEC number is ever recorded on an unlogged
+scalar fallback.
+
+### 1c. Shard failure silently zero-fills the FFN output [hardcoding, HIGH] — ✅ FIXED
+
+`crates/larql-inference/src/ffn/remote/sharded.rs:117` `forward_predispatch_all`:
+an unowned layer (:129) or a panicked shard thread
+(:136 `handle.join().unwrap_or_else(|_| vec![0.0; hidden])`) returns a zero
+vector, and decode continues on a corrupted hidden state.
+
+**DEC impact:** multi-hour rented session, one shard OOMs/restarts →
+generation quality silently collapses while the bench harness keeps recording
+tok/s. The MoE path already returns `Result`; the dense predispatch path
+swallows it. Fix: propagate the error.
+
+### 1d. Down-projection ignores its format tag on the Q8K fast path [hardcoding, HIGH] — ✅ FIXED
+
+`crates/larql-inference/src/vindex/kquant_forward/walk_ffn.rs:135` feeds
+`ffn[2].0` straight into the Q4_K-only `q4k_q8k_matvec_into` without consulting
+the format tag `ffn[2].1` (the f32 fallback at :153 *does* use it via
+`dequantize_matrix`); the doc comment at :78 staleley claims down goes through
+the f32 dequant path.
+
+**DEC impact:** a model whose down slab is not Q4_K (DEC-4 Inkling / DEC-6 Kimi
+extraction with a different quant mix) decodes silent garbage rather than
+erroring. Fix: gate on `ffn[2].1 == "Q4_K"`, fall back otherwise.
+
+---
+
+## 2. Security
+
+### 2a. Allocation bomb in the multi-layer decoders [security, HIGH] — ✅ FIXED
+
+`crates/larql-inference/src/ffn/moe_remote/multi_layer_wire.rs:105,146,211,254,292`
+call `Vec::with_capacity(n)` directly from attacker-controlled `u32` length
+fields with no bound against the actual body size. A 16-byte request
+(`[n=1][layer=0][hidden=0xFFFFFFFF][ne=0]`) triggers a ~17 GB reservation →
+`handle_alloc_error` process abort (uncatchable `SIGABRT`, kills the whole
+server, all in-flight work dies).
+
+Reachable **unauthenticated by default** at `POST /v1/experts/multi-layer-batch`
+and `…-batch-q8k` (`routes/expert/multi_layer_batch.rs:55,126`). The 64 MB
+`DefaultBodyLimit` does not help — the size comes from a header field, not the
+body length. Client-side `decode_multi_layer_response` (:146) has the same bug:
+a malicious shard can crash the router/inference client identically.
+
+This is a **regression from the codebase's own guard pattern**: `codec.rs`,
+`q8k_wire.rs`, and the expert `wire.rs` decoders all compute a
+`max_possible_entries` / `want` bound before allocating, explicitly citing
+"aborting the process — see PR 104 CI". The three multi-layer decoders never
+got that treatment.
+
+**Fix:** before each `Vec::with_capacity(n)`, bound `n` by
+`remaining_bytes / min_element_size` (or compute a total `want` and reject
+`bytes.len() < want`), mirroring `decode_expert_request`. Same for
+`read_f32_slice`/`read_i16_slice`.
+
+### 2b. Data-plane HTTP is unauthenticated unless `--api-key` is set [security, MED]
+
+`bootstrap.rs:1145` attaches `auth::auth_middleware` only `if
+cli.api_key.is_some()`. The `--grid-key`/`LARQL_GRID_KEY` guards **only** the
+server→router announce bearer and the router's `join` check — it never guards
+the server's own FFN/expert HTTP surface. On a Vast host with adversarial
+peers, `/v1/walk-ffn`, `/v1/experts/*`, `/v1/expert/*` are open. In particular
+`GET /v1/shard/{model_id}/{range}` (`routes/shard.rs:50`) **streams the entire
+on-disk vindex directory as a tar to any caller** — full model-weight
+exfiltration — with `model_id` discoverable via unauthenticated `/v1/models`
+and `/v1/stats`.
+
+**Fix direction:** make auth mandatory for the data plane in DEC deployments,
+or bind these hosts to a private network; at minimum require the grid/api key
+on `/v1/shard` and the expert endpoints.
+
+### 2c. Router admin gRPC RPCs are unauthenticated [security, MED]
+
+`crates/larql-router/src/grid/service.rs:386,397,455` — `status`,
+`drain_server`, `assign_range` are unauthenticated even when `grid_key` is set
+(only `join` checks it, :99; the module doc at :17 admits this). An adversarial
+peer reaching the router's gRPC port can enumerate every replica (`status`),
+force-drain/unassign shards (`drain_server`, grid-disruption DoS), or
+manipulate topology (`assign_range`). `server_id` is guessable —
+`alloc_server_id` is `srv-<unix_secs>-<n>` with a small monotonic `n` (:78).
+Fix: apply the bearer check to the admin RPCs, or enforce that the gRPC port is
+never network-exposed.
+
+### 2d. Grid-key comparison is non-constant-time [security, LOW]
+
+`crates/larql-router/src/grid/service.rs:105` uses `token != expected` — a
+bytewise-timing side channel on the grid key. The HTTP path was deliberately
+hardened for exactly this (`auth.rs` uses SHA-256 + `subtle::ConstantTimeEq`);
+the gRPC grid path did not get it. Fix: hash-then-`ct_eq`.
+
+### 2e. BF16-monolith expert stride overflow [security, LOW]
+
+`crates/larql-server/src/routes/expert/single.rs:93` and `expert/cpu.rs:115` —
+`expert_id * gu_stride` can wrap in release builds, reading a different
+expert's weights (correctness/info) or panicking on a slice index (caught by
+`spawn_blocking` → 500, no process crash). Only the legacy non-`per_layer_ffn`
+BF16 path; the Q4K per-layer path DEC uses takes the bounds-checked
+`get_layer_entry_bytes` branch. Fix: `checked_mul`/`checked_add`.
+
+---
+
+## 3. Fleet / config landmines (block the x86 + Linux arms)
+
+### 3a. Grid join advertises `127.0.0.1` on the fleet [hardcoding, HIGH]
+
+`crates/larql-server/src/bootstrap.rs:1222` — with default `--host 0.0.0.0`
+and no `--public-url`, a `--join`'d server announces `listen_url =
+http://127.0.0.1:<port>`. On a multi-host grid (DEC-1 grid arms, any x86
+fleet) every shard advertises loopback and the router routes traffic to
+itself. Fix: refuse `--join` with a wildcard host unless `--public-url` is set,
+or detect the outbound-interface IP.
+
+### 3b. CPU backend cannot run the remote-FFN decode loop [modularity, MED]
+
+`generate_with_remote_ffn*` hard-fails when `decode_token_with_moe` returns
+`None` (`grid/remote_ffn.rs:64,134,408,502`); `CpuBackend` implements
+`DecodeBackend` with all defaults (`cpu/mod.rs:167`), so it returns `None`.
+The remote-**MoE** CPU path dodges this via a completely different decode stack
+(larql-kv engine + `RemoteMoeFfn`, `run_cmd.rs:751`) selected by an `if metal`
+CLI branch — two divergent decode stacks chosen by a flag, not by capability.
+
+**DEC impact:** `larql bench --ffn` (the DEC-0/DEC-1 single-stream *anchor*)
+and `larql dec-bench capture` (`capture_runtime.rs:43`) only work on
+macOS+Metal. The spec's "CPU attention until G-ladder" is true for *replay*
+(model-free, portable pool) but **false for the anchor and capture** on Linux.
+Near-term fix: make the Metal requirement explicit + documented (capture the
+pool on a Mac, ship it — it is host-portable). Full fix (CPU fused decode) is
+G-ladder-adjacent and larger; do not rush it.
+
+### 3c. Backend construction is a 7-site copy-pasted `--metal: bool` + cfg block [modularity, MED]
+
+Identical `if metal { #[cfg(all(feature="gpu", target_os="macos"))] … } else {
+cpu }` at `run_cmd.rs:649,924`, `bench/remote_ffn_runtime.rs:77`,
+`bench/local_runtime.rs:58`, `dec_bench/capture_runtime.rs:43`,
+`shannon_cmd.rs:971`, `walk_cmd.rs:462`, plus behavioural branching on the same
+bool (`run_cmd.rs:723,1289`). Adding `--cuda`/G3 today means touching every
+site and every `metal: bool` arg struct. The `Capability` enum
+(`larql-compute/src/backend/capability.rs:40`) already exists for exactly this.
+Fix: one `backend_from_spec(&str) -> Box<dyn ComputeBackend>` factory + switch
+`if metal` dispatch to capability probes — **before G1 lands**.
+
+### 3d. `--metal` hardcoded in the DEC-0 script [hardcoding, HIGH]
+
+`scripts/dec0-loopback.sh:80,97` hardcode `--metal` in the anchor and capture
+arms; `dec-bench capture` hard-errors without the gpu feature on macOS
+(`capture_runtime.rs:52`), so the script cannot run on the DEC-0.5 x86 box
+without editing. Fix: a `DEC0_BACKEND` env defaulting per-platform (couples to
+3c).
+
+### 3e. `SKIP_MOE` vs `LARQL_SKIP_MOE` — two names, docs disagree [hardcoding, HIGH]
+
+Grid path reads unprefixed `SKIP_MOE` (`moe_remote/runtime.rs:64` →
+`grid/config.rs:25`); local compute path reads `LARQL_SKIP_MOE`
+(`compute/options.rs:70`). `README.md:649` documents `LARQL_SKIP_MOE`;
+`docs/dec-funnel.md` DEC-0 says `SKIP_MOE`. The "SKIP_MOE ceiling 56.8" anchor
+measures a different thing depending on which name the operator types, and
+unprefixed `SKIP_MOE` can collide with a rented host's ambient env.
+`SKIP_OUTER_NORM` and `DECODE_DEBUG` are also unprefixed. Fix: one prefixed
+name, alias the old one with a loud warning.
+
+### 3f. `--backends metal` default fails on Linux [hardcoding, MED]
+
+`bench/args.rs:26` defaults `--backends` to `"metal"`; plain `larql bench
+<model>` hard-errors on Linux (`bench/local_runtime.rs:66`). Fails loudly, but
+every DEC runbook command needs `--backends cpu` appended on x86. Fix:
+platform-conditional default (couples to 3c).
+
+### 3g. `--default-timeout` values assume 26B-class latency + LAN [hardcoding, MED]
+
+Shard HTTP 30s (`moe_remote/config.rs:47`), remote-FFN 60s (`remote/http.rs:101`),
+server `--infer-timeout-secs` 60 (`bootstrap.rs:477`), router shard 120s
+(`main.rs:196`). Inkling ~975B prefill or first-touch mmap page-fault storms on
+a cold rented box can exceed these → spurious 504s/aborts mid-session. All
+configurable; the *defaults* are the landmine. Note at DEC-4/5 provisioning.
+
+### 3h. `grid_lan_runtime` run timeout is a no-op [hardcoding, MED]
+
+`bench/grid_lan_runtime.rs:179` — `let _ = opts.timeout_secs; // future` while
+`command.output()` blocks forever. A hung shard wedges the whole grid-LAN
+matrix in an unattended multi-hour session.
+
+### 3i. Grid auth optional = open grid port [security/hardcoding, MED]
+
+`--grid-key` unset → "grid port is open to any server (development only)"
+(`larql-router/src/main.rs:206`, `bootstrap.rs:695`). On rented boxes with
+public IPs anyone can join/poison the shard map. Make the key mandatory
+off-loopback. (Overlaps 2c.)
+
+### 3j. Grid-LAN baselines keyed by model only [hardcoding, MED]
+
+`scripts/bench-grid-regress.sh:35` — `bench/baselines/grid-<model>.json` has no
+host/arch dimension; an EPYC run compared against an M3 Max baseline yields a
+meaningless verdict, or silently seeds an EPYC baseline that later gates a Mac
+run. Fix: add an arch/host tag to the baseline key.
+
+---
+
+## 4. Structural pre-work (schedule per-ladder, not a DEC-0 blocker)
+
+### 4a. Dense-FFN vs MoE wire stacks are parallel implementations [modularity, MED-LARGE]
+
+`ffn/remote/*` (dense) and `ffn/moe_remote/*` (MoE) share no transport, codec,
+negotiation, or byte accounting. Dense is HTTP-only with Accept-header
+negotiation; MoE has HTTP + UDS + gRPC with endpoint-per-format. Adding one
+new activation wire format (the DEC-6a MXFP4/bf16 question) currently touches
+~7 places. The UDS transport the DEC-0 loopback arms would benefit from exists
+only on the MoE side. `call_q8k_layers` (`remote/http.rs:364`) never increments
+the wire-byte atomics, so `bench --ffn` `wire_bytes_per_tok` undercounts on the
+default Q8K predispatch path (dec-bench does its own counting, unaffected).
+Consolidate at the first new wire format (DEC-6a decision point).
+
+### 4b. Server-side expert dispatch is per-handler, three shapes [modularity, MED]
+
+`q8k.rs:107` inline Metal-vs-CPU cfg block; `grpc_expert.rs:178` a second,
+differently-shaped one; `expert/layer_batch.rs:105` + `expert/multi_layer_batch.rs:70`
+hard-wire `run_experts_cpu_batch` with **no GPU path at all**. A CUDA expert
+backend (G4, "mirroring metal-experts") would be spliced into each handler.
+Extract one `run_experts(state, backend, …)` dispatcher — before G4.
+
+### 4c. dec_bench `Endpoint` seam for the routed-experts arm [modularity, SMALL-MED]
+
+Endpoint is conflated with wire format (`WireArm::Q8k.accept() → None` "is its
+own endpoint"); `send_one` hard-branches on the two walk-ffn paths; the run
+record hardcodes `endpoint: "walk-ffn"`. The capture pool stores only
+pre-normed residuals — routed replay needs per-step per-layer `(expert_ids,
+weights)`, which breaks the "replay is model-free" property. The
+movement-ratio denominator is dense-only in the driver (the server side is
+already ready — `/v1/stats` publishes `moe.per_expert_bytes`). Introduce an
+`Endpoint` enum (path + frame-builder + response-decoder + denominator source)
+before the routed-experts fast-follow (which gates the C1-on-MoE verdict).
+
+### 4d. Walk-ffn binary frame re-declared per crate [modularity, SMALL]
+
+Client encoder (`ffn/remote/codec.rs`) and server decoder
+(`routes/walk_ffn/binary.rs`) are independent hand-maintained implementations
+of one layout; the CT string `application/x-larql-ffn` is declared in **5**
+places (`codec.rs`, server `types.rs`/`wire.rs`/`http.rs`, `larql-router/http.rs`);
+`BATCH_MARKER` twice. Contrast: q8k and all MoE codecs are single-sourced in
+larql-inference and imported by the server. Any DEC header extension must be
+hand-synced across encoder/decoder + router. Consolidate opportunistically
+with 4a.
+
+### 4e. Duplicated MoE router-weight construction + combine math [modularity, SMALL]
+
+`build_moe_router_weights` is a **private** helper (`kquant_forward/hidden.rs:93`);
+the server hand-rolls the identical 10-field construction at
+`routes/walk_ffn/core.rs:111`, plus 3 more sites in a server example. The
+outer-norm + residual combine is duplicated inline (`core.rs:153` vs
+`hidden.rs:121`) with no shared function or cross-test. K3's Stable LatentMoE
+routing changes this structure — make the helper `pub` and share the combine
+before the DEC-6b KDA/LatentMoE port.
+
+### 4f. Vestigial / asymmetric bits [modularity, SMALL each]
+
+- `/v1/expert/batch` labelled "pre-2026-05-01 legacy" (`routes/expert/mod.rs:12`)
+  but still the only path used by `forward_moe_seq` prefill
+  (`moe_remote/backend.rs:248`) and still mounted — a replay/CUDA implementer
+  can target the wrong wire.
+- `RemoteWalkBackend::forward_moe_full_layer` is the last JSON-float-array hot
+  path (`remote/http.rs:535`); the server binary decoder can't express
+  `moe_layer` (`binary.rs:76` hardcodes `false`).
+- i8 wire is server-side **default-off** behind `LARQL_I8_WIRE` (`wire.rs:37`),
+  while dec-bench's default sweep includes the i8 arm — a default DEC-1 run
+  measures f32 on the i8 arm unless the rig sets the env var (`served_wire`
+  records the fallback, so it is visible, but it is a plan-level footgun for
+  the netem harness scripts).
+- Q8K responses carry no server-latency field, so the Q8K arm loses the
+  server/network decomposition all other DEC-1 arms have.
+- `forward_predispatch_all_q8k` signals failure by inserting all-zero vectors
+  and the caller heuristically re-dispatches on "any all-zero row"
+  (`sharded.rs:199`, `grid/remote_ffn.rs:271`) — a legitimately all-zero FFN
+  output silently switches wire paths.
+
+### 4g. Twin-file duplication [hardcoding/modularity, LOW]
+
+`larql-compute/src/kquant_forward/walk_ffn.rs` and
+`larql-inference/src/vindex/kquant_forward/walk_ffn.rs` are ~160-line
+near-identical copies (diff is only the index type) — the bug-fix-twice hazard
+that produced the historical q4_common subnormal bug. `LayerLatencyTracker`
+global `Mutex<HashMap>` is fine at DEC scale (tiny critical section).
+
+---
+
+## 5. Env-var inventory (serving path)
+
+**Change numerical output:** `SKIP_MOE` (unprefixed), `LARQL_SKIP_MOE`,
+`LARQL_MOE_TOP_K`, `LARQL_MOE_WIRE_F16`, `LARQL_I8_WIRE`,
+`LARQL_F16_WIRE_DISABLE`, `LARQL_DISABLE_Q8K_WIRE`, `LARQL_DISABLE_Q4K_DIRECT` /
+`LARQL_Q4K_DIRECT` / `LARQL_Q4K_DIRECT_FFN`, `LARQL_Q4K_ASM`,
+`LARQL_USE_METAL_EXPERTS` / `LARQL_DISABLE_METAL_EXPERTS` /
+`LARQL_USE_LEGACY_CPU`, `SKIP_OUTER_NORM` (unprefixed).
+
+**Dispatch/perf:** `LARQL_MOE_BATCH_MODE`, `LARQL_COMPUTE_CONCURRENCY`
+(**load-bearing, undocumented** — `layer_batch.rs:48`), `LARQL_MOE_NO_SPLIT`,
+`LARQL_SPIN_POOL`, `RAYON_NUM_THREADS`, `LARQL_MOE_CACHE_ENTRIES`,
+`LARQL_NO_WARMUP`.
+
+**Diagnostics (stderr):** `LARQL_MOE_TIMING`, `LARQL_MOE_BYTES`,
+`LARQL_MOE_SHARD_TIMING`, `LARQL_HTTP_TIMING`, `LARQL_KERNEL_TIMING`,
+`LARQL_MOE_FWD_TIMING`, `LARQL_VERBOSE`, `LARQL_DECODE_STAGES`,
+`LARQL_PROFILE_SPLIT`, `LARQL_METAL_VS_CPU_DEBUG`.
+
+**Auth/scripts:** `LARQL_GRID_KEY`; `LARQL_BENCH_VINDEX`, `LARQL_BENCH_FFN_URL`,
+`LARQL_TOK_PER_S_THRESHOLD`, `LARQL_P99_THRESHOLD`.
+
+Undocumented-but-load-bearing: `LARQL_COMPUTE_CONCURRENCY`, `SKIP_MOE` under its
+real (unprefixed) name, `LARQL_DISABLE_Q8K_WIRE`. (This overlaps the
+2026-06-12 review's item-7 env-flag-registry action, which remains open.)
+
+---
+
+## Performance findings not already covered
+
+- **No admission control on compute [perf, HIGH]:** every request is one
+  `spawn_blocking` (`handler.rs:79,115`, `q8k.rs:51`) on the stock 512-thread
+  blocking pool; 4 clients × 48-layer fan-out = ~192 simultaneous
+  multithreaded-BLAS tasks on 8–16 cores. **DEC-2's "≥80% linear at N=4"
+  (C3) is exactly where this shows, and the failure looks like tier
+  saturation when it is scheduler oversubscription.** Fix: a
+  `tokio::sync::Semaphore` sized ~physical cores gating the spawn_blocking
+  bodies, and pin BLAS to 1 thread per call for the serving build
+  (`OPENBLAS_NUM_THREADS=1`).
+- **`--release-mmap-after-request` thrashes concurrent requests [perf, HIGH
+  when set]:** `handler.rs:88`, `q8k.rs:183` call `release_mmap_pages()` after
+  every request; with 4 clients each completing request evicts pages the other
+  three are streaming → re-fault storm (the known madvise-churn class,
+  per-request now), and in the q8k Metal path releases pages still referenced
+  by zero-copy Metal buffers. Never release while `requests_in_flight > 1`;
+  any DEC point run with this flag is measuring page faults — flag in run-record
+  hygiene.
+- **q8k endpoint invisible to drain / heartbeat / latency tracking [perf,
+  MED]:** `q8k.rs:41` bumps only `bump_requests()` — no `RifGuard`,
+  `requests_total`, or `layer_latency_tracker.record`. GT6 drain can conclude
+  "no in-flight" during a q8k burst, and the C7 latency-EMA router
+  (`HeartbeatMsg.layer_stats`) is blind to exactly the traffic DEC generates.
+  Add the guard + counters + per-layer record.
+- **Client fan-out spawns 30–48 OS threads per token, every token [perf,
+  MED]:** `sharded.rs:119` (and mirrored `dec_bench/replay_runtime.rs`) use
+  `std::thread::scope`/`s.spawn` per layer per step. Persistent worker pool or
+  async `buffer_unordered`. The q8k grouping path already reduces spawns to one
+  per shard — the f32 path should follow.
+- **`model.patched` fair RwLock held across FFN compute [perf, MED]:** a
+  queued patch/insert write (`patches.rs:155`) blocks all new readers across
+  all clients until every in-flight batch-64 compute drains — correlated p99
+  spikes; a landmine for the shared-tier demo (C3 is precisely concurrent
+  patch + serve). Arc-swap/epoch snapshot of the overlay.
+- **4–6 full-buffer passes per request [perf, MED]:** `req.residual.clone()`
+  into Array2 (`core.rs:48,235`), `out.into_iter().collect()` (:284, vs the free
+  `into_raw_vec_and_offset` used two lines away), per-element byte-push encode
+  loops (`binary.rs:88,102,123,157`; f16 scalar per element), encode running on
+  the async worker after `spawn_blocking` returns. Scales with B while the warm
+  GEMM amortises — grows as a fraction of step time exactly where C1 is
+  measured, and biases the f16/i8 arms of C6. Take residual by value, bulk
+  `bytemuck::cast_slice` copies, chunked f16.
+
+---
+
+## What is already solid (verified)
+
+- B-row **f32/f16/i8** path is genuinely vectorised: one reshape → one BLAS
+  GEMM per projection over a lock-free per-layer f32 cache (single atomic load
+  + `Arc::clone`), no per-row re-setup, no per-row locks, norm-free.
+- Wire decoders (except the three multi-layer ones) are hardened:
+  overflow-checked lengths, `num_entries` allocation bombs rejected, dedicated
+  `reject_impossible_*` tests; `q8k.rs` validates block shape before any kernel
+  touch.
+- Compute is correctly off the async runtime; body reads bounded at 64 MB;
+  `ConcurrencyLimitLayer` + `compute_semaphore` present.
+- `auth.rs` HTTP bearer is constant-time SHA-256; no secrets committed; grid
+  key never logged; scripts are `set -euo pipefail` and fully quoted; no
+  request-derived filesystem paths or shell injection.
+- The gRPC **proto is the single source of truth** (`tonic::include_proto!`);
+  no re-declared proto shapes.
+- MoE/q8k HTTP codecs are single-sourced and the loadgen reuses production
+  codecs down to the truncation guards — the parity discipline is real.
+- `/v1/stats` already publishes the routed-replay movement-ratio denominator
+  (`ffn_weights.moe.per_expert_bytes` + `num_experts`/`top_k`).
+- `DecodeBackend`/`Capability` is a workable CUDA seam; `metal-experts` server
+  feature is a ready template for `cuda-experts` (G4).
+- dec_bench pure/IO split with served-wire fallback recording — honest
+  metrology baked into the structure.
+- Weights lazy-load is single-flighted with a lock-free fast path; `RifGuard`
+  is drop-based and saturating (on the f32 endpoint).
+
+---
+
+## Refuted / non-issues checked
+
+- No request-derived value builds a filesystem path or shell command anywhere
+  in the reviewed surface (the 2026-06-12 `model_id` traversal item was already
+  fixed; `/v1/shard` streams the server-controlled `model.path`).
+- `gate_knn` clamps `top_k` from the wire (`gate_knn/mod.rs:94`,
+  `dispatch.rs:283`) — no unbounded-heap DoS.
+- Client response validation checks every shard output length against expected
+  `hidden` — a malicious server can't corrupt shapes silently (aside from 2a).
+- `LayerLatencyTracker` / `FfnL2Cache` locking is not a DEC-scale contention
+  issue; replay's `top_k=0` bypasses the L2 cache entirely.

--- a/docs/dec-funnel-v0.2.md
+++ b/docs/dec-funnel-v0.2.md
@@ -1,0 +1,248 @@
+# DEC Funnel v0.2 — Decoupled-FFN Serving at Batch and at Frontier Scale
+
+> **Archived reference.** Superseded by `dec-funnel.md` (v0.4.1). Kept because the current funnel inherits this document's control plane (§4.1), procurement filters (§4.3), iperf3 network-verification gate (§4.4), and budget rate basis (§7) by reference.
+
+**Programme:** DEC-0 … DEC-5 (pre-registered)
+**Estate:** chuk-mcp-training (rig) · chuk-experiments-server (registry, system of record) · Cloudflare R2 (artifacts/shards) · LARQL vindex (serving stack)
+**Status:** draft v0.2 — gates and kill criteria pre-registered before any run executes; infra spec + topologies added
+**Date:** 2026-07-22
+
+---
+
+## 1. Objective
+
+Convert the single-stream decoupled-inference result (Gemma 4 26B A4B: attention local, experts served remotely over HTTP via vindex, ~25 tok/s LAN) into **measured curves at batch and at frontier scale**, sufficient to support two claims:
+
+1. **Fleet claim** — a decoupled Granite/Inkling-class serving fleet costs O(commodity GPUs + DRAM), not O(Hopper nodes), because the knowledge tier is a shared service scaling with aggregate token throughput rather than replica count.
+2. **Public claim (video)** — Inkling (975B / 41B active, Apache 2.0) runs live on ~$2–3/hr of rented hardware with all expert weights resident in CPU DRAM.
+
+Everything below is **pure inference — exact function, relocated weights.** No approximation, no store-fidelity dependency, no E4. The walk/sparse-fidelity research track is explicitly out of scope for DEC.
+
+## 2. Claims under test
+
+| ID | Claim | Falsifier |
+|----|-------|-----------|
+| C1 | vindex serving compute survives batched decode (gate lookup + expert stream at batch 64 within the per-step budget) | step time grows super-linearly with batch on loopback |
+| C2 | transport survives batch: payload × batch × steps fits a real NIC; latency amortises to one round trip per step | throughput at batch 32+ NIC-bound below useful tok/s on LAN-class links |
+| C3 | one expert tier serves N attention clients with near-linear aggregate throughput (shared knowledge tier) | aggregate tok/s flattens before N=4 while tier CPU/NIC has headroom |
+| C4 | DRAM streaming amortises for ultra-sparse MoE only up to a batch-union bound (honest limit, measured) | n/a — metrology; deliverable is the curve itself |
+| C5 | Inkling runs end-to-end decoupled: attention on one ≤48GB card, experts on 2–3 DRAM boxes, ≥5 tok/s single-stream | fails to produce coherent output, or <1 tok/s sustained |
+
+Gate rule: **C1 → C2 → C3 are sequential gates.** C4 runs any time (independent). C5 (Inkling) does not start until C1 and C2 pass on Gemma 26B — extractor bugs must be distinguishable from architecture failures.
+
+## 3. Experiment ladder
+
+### DEC-0 — Loopback batch curve (Gemma 26B, Colab, ~£0)
+
+*Tests C1. No network.*
+
+- **Infra:** one Colab high-RAM instance. Attention client (2.43GB slice) on T4; vindex server on same VM, CPU, experts ~14GB Q4 in RAM; localhost transport.
+- **Method:** synthetic decode load, batch ∈ {1, 8, 16, 32, 64}; fixed prompt set from the registry; 3 repeats per point, fixed seeds.
+- **Metrics (pulse channel):** `dec/tok_s`, `dec/step_ms_p50`, `dec/step_ms_p99`, `dec/ffn_ms_per_layer`, `sys/cpu_util`, `sys/mem_bw_est`, `dec/gate_lookups_s`.
+- **Pass:** step time sub-linear in batch through 32; tok/s at batch 32 ≥ 8× batch-1 tok/s.
+- **Kill:** serving compute saturates below batch 16 → the shared-tier economics fail regardless of transport; stop and profile before any spend.
+- **Deliverable:** Chart 1 — tok/s and step-time vs batch, loopback.
+
+### DEC-1 — Split-tier batch curve (Colab/Vast, ~$3)
+
+*Tests C2. Doubles as rig proving run E2 (live Vast).*
+
+- **Infra:** arm A — attention on Colab T4, vindex server on Vast high-RAM CPU box (WAN, latency-hostile, cheap). Arm B — attention on Vast 3060/4090 + vindex server on Vast CPU box, same datacenter (LAN-class; the number that matters).
+- **Method:** same batch sweep as DEC-0. Record per-token payload bytes explicitly (compressed and uncompressed) — resolves whether the 660KB/token from the 26B demo is irreducible.
+- **Metrics:** DEC-0 set + `dec/payload_bytes_tok`, `dec/rtt_ms`, `sys/nic_mbps` (both sides).
+- **Pass:** arm B batch-32 throughput ≥ 70% of DEC-0 loopback at same batch; payload × batch × steps ≤ 60% of measured NIC capacity.
+- **Kill:** LAN-class arm is NIC-bound below batch 16 with no payload-compression path identified.
+- **Budget hard wall:** 4 GPU-hours + 6 CPU-box-hours; workers auto-destroyed at wall per rig policy.
+- **Deliverable:** Chart 2 — batch curve loopback vs LAN vs WAN, with NIC utilisation overlay.
+
+### DEC-2 — Shared tier (Vast multi-worker, ~$5)
+
+*Tests C3. The fleet-economics chart.*
+
+- **Infra:** one vindex expert server (Vast CPU box); N attention clients for N ∈ {1, 2, 3, 4}: mix of cheap Vast GPUs, the Colab session, and the Mac as BYO/persistent worker (long-lived token class; never destroyed by control plane).
+- **Method:** each client runs the DEC-1 arm-B workload at fixed batch (choose the knee from DEC-1, likely 16–32). Measure per-client and aggregate throughput as N grows; expert-server CPU, memory bandwidth, NIC alongside.
+- **Pass:** aggregate tok/s at N=4 ≥ 3.2× N=1 (≥80% linear) with tier headroom visible.
+- **Kill:** flattening caused by tier compute/NIC saturation at N≤2 → per-replica duplication assumption survives; fleet claim reverts to single-box KTransformers-class only.
+- **Deliverable:** Chart 3 — aggregate tok/s vs client count, tier utilisation overlay. This is the slide.
+
+### DEC-3 — Sparse batch-union metrology (Vast, ~$2, independent)
+
+*Tests C4. Synthetic; no real weights.*
+
+- **Infra:** one big-RAM Vast EPYC box.
+- **Method:** allocate synthetic expert tensors; per token per layer sample top-16-of-896 under (a) uniform and (b) skewed (Zipf) routing; stream the batch-union per step; measure step time vs batch ∈ {1 … 256}. Repeat at top-6-of-~256-class config (Inkling-shaped) and top-8-of-128 (Gemma-shaped).
+- **Deliverable:** Chart 4 — effective GB streamed per step and step time vs batch, per sparsity config. Defines where DRAM amortisation dies for K3-class models; quoted as the honest boundary in both the video and the internal pitch.
+
+### DEC-4 — Inkling extraction (Vast, ~$5–10)
+
+*Prereq for C5. Gate: DEC-0 and DEC-1 passed.*
+
+- **Infra:** one Vast box with ≥2TB NVMe and fat downlink.
+- **Method:** pull Inkling weights from HF; parse architecture from config + tml-renderer reference; drop multimodal weights (text path only, v1); quantise experts to Q4/MXFP-class; cut vindex shards by layer range; extract client slice (attention/router/embeddings/norms — measure its actual size, est. 15–30GB, decides DEC-5 GPU class); push shards to R2.
+- **Verification before any serving:** logit-match a short prompt set against a reference implementation of the same quantisation, token-level agreement threshold set before the run.
+- **Kill:** architecture quirks (controllable-thinking tokens, from-scratch layout) exceed a time-boxed effort wall → park, publish Gemma-scale results, revisit.
+- **Artifacts:** Inkling vindex shard set in R2 (zero-egress; reusable asset independent of the video), extractor crate, verification report in registry.
+
+### DEC-5 — Inkling live demo + hero video (~$10–15 total runtime)
+
+*Tests C5.*
+
+- **Infra:** attention client on one Vast 48GB card (A6000/L40S class, ~$0.50–0.80/hr); expert tier on 2–3 Vast EPYC boxes (256–512GB DRAM each), same datacenter; shards pulled from R2 (free egress). Total topology ~$2–3/hr.
+- **Method:** single-stream live inference; then re-run the DEC-1/DEC-2 sweeps at Inkling scale as far as budget allows (even N=2 shared-tier at 975B is a headline).
+- **Pass:** ≥5 tok/s sustained single-stream, coherent output; stretch: ≥10 tok/s.
+- **Deliverable:** the frame — split terminal: `nvidia-smi` (one modest card) · `htop` on expert boxes (~500GB resident) · live streaming answer. Plus Charts 1–4 as the "yes it scales" companion material.
+
+## 4. Infrastructure specification & topology
+
+### 4.1 Control plane (all stages)
+
+Unchanged from the current estate — DEC adds workloads, not infrastructure:
+
+```mermaid
+flowchart LR
+  MAC[Mac / mcp-cli client]
+  subgraph fly["Fly.io control plane"]
+    MCP["chuk-train-mcp.fly.dev\n(dispatch, budgets, pulse)"]
+    REG["chuk-experiments-server.fly.dev\n(registry — system of record)"]
+  end
+  R2[("Cloudflare R2\nshards · checkpoints · charts")]
+  subgraph workers["Leased workers (Colab / Vast)"]
+    AC["attention-client\nworkload"]
+    VS["vindex-server\nworkload"]
+  end
+  MAC --> MCP
+  MCP <--> REG
+  MCP -- "submit_run_from_experiment\n+ single-use cj_ token" --> AC
+  MCP -- "cj_ token" --> VS
+  AC -- "HTTP /infer (batched decode)" --> VS
+  VS -- "shard pull (zero egress)" --> R2
+  AC -- "dec/* pulse metrics" --> MCP
+  VS -- "sys/* pulse metrics" --> MCP
+  REG --> R2
+```
+
+Budget hard-walls, single-use join tokens for leased workers, Mac as BYO/persistent class only — all per existing rig policy. The vindex server carries its existing auth + TLS; join token doubles as the client credential for the demo runs.
+
+### 4.2 Per-stage instance specification
+
+| Stage | Node role | Count | GPU | RAM | Disk | NIC (min) | Rental class |
+|---|---|---|---|---|---|---|---|
+| DEC-0 | combined (loopback) | 1 | Colab T4 16GB | high-RAM (~50GB) | default | n/a | Colab (paid) |
+| DEC-1a | attention client | 1 | Colab T4 | std | default | n/a | Colab |
+| DEC-1a | expert server (WAN) | 1 | cheapest attached | ≥64GB | 50GB | 1Gbps | interruptible |
+| DEC-1b | attention client (LAN) | 1 | 4090 24GB | ≥32GB | 50GB | 10Gbps pref | interruptible |
+| DEC-1b | expert server (LAN) | 1 | cheapest attached | ≥64GB | 50GB | 10Gbps pref | interruptible |
+| DEC-2 | expert server | 1 | cheapest attached | ≥64GB | 50GB | 10Gbps | on-demand |
+| DEC-2 | attention clients | 4 | 3060/4090 mix (+Mac BYO, +Colab) | ≥16GB | 30GB | 1Gbps | interruptible |
+| DEC-3 | metrology box | 1 | cheapest attached | ≥384GB (512 pref) | 50GB | n/a | interruptible |
+| DEC-4 | extraction box | 1 | any ≥24GB (dequant/verify) | ≥128GB | **≥2.5TB NVMe** | fat downlink, **unmetered** | on-demand |
+| DEC-5 | attention client | 1 | A6000/L40S 48GB | ≥64GB | 100GB | 10Gbps | on-demand, reliability ≥0.95 |
+| DEC-5 | expert tier | 2–3 | cheapest attached | 256–512GB each | 250GB each | 10Gbps | on-demand, reliability ≥0.95 |
+
+Vast has no pure-CPU rentals: "expert server" and "metrology box" mean *filter by RAM/cores, sort by price, ignore the attached card* (it can idle, or handle dequant scratch).
+
+### 4.3 Procurement filters (Vast)
+
+- **Reliability:** ≥0.90 for sweeps, ≥0.95 for DEC-4/DEC-5.
+- **Placement:** DEC-1b/2/5 require LAN-class inter-node paths — filter by geolocation; strongly prefer a single host exposing multiple rentable slots (same physical machine). Never assume; verify (§4.4).
+- **Bandwidth metering:** DEC-4 host must be unmetered or high-included-transfer — a metered 2TB HF pull can exceed the compute cost.
+- **Interruptible vs on-demand:** interruptible for restartable sweeps (DEC-1/2 arms, DEC-3); on-demand wherever eviction is expensive in hours (DEC-4 download, DEC-5 filming).
+
+### 4.4 Network verification gate (mandatory pre-benchmark)
+
+Before any claim-bearing run on a multi-node topology:
+
+1. `iperf3` between every attention-client ↔ expert-server pair; record Gbps + RTT.
+2. Thresholds: DEC-1b/DEC-2 ≥ 2Gbps and ≤ 2ms RTT to count as LAN-class; DEC-5 ≥ 5Gbps aggregate into the expert tier.
+3. Measured values written to the registry run record as metadata (`net/gbps`, `net/rtt_ms`) — a curve without its link measurement is not admissible as a result.
+
+Failing the gate = re-provision, not re-interpret.
+
+### 4.5 Stage topologies
+
+**DEC-1b — split tier, LAN-class (the claim-bearing arm):**
+
+```mermaid
+flowchart LR
+  subgraph dc["Same Vast datacenter (iperf3-verified)"]
+    A["attention client\n4090 · 2.43GB slice + KV"]
+    E["expert server\n≥64GB RAM · vindex shards (Gemma 26B Q4)"]
+  end
+  A -- "per step: batched residuals →\n← expert contributions\n(payload_bytes_tok × batch)" --> E
+  E -. "shard pull at start" .-> R2[(R2)]
+```
+
+**DEC-2 — shared knowledge tier:**
+
+```mermaid
+flowchart TB
+  E["expert server (×1)\n≥64GB RAM · one shard set\nconstant cost"]
+  C1["client 1\nVast 3060"] --> E
+  C2["client 2\nVast 4090"] --> E
+  C3["client 3\nColab T4"] --> E
+  C4["client 4\nMac (BYO)"] --> E
+  E -.-> M["measure: aggregate tok/s vs N\n+ tier CPU / mem-BW / NIC"]
+```
+
+**DEC-5 — Inkling live demo:**
+
+```mermaid
+flowchart LR
+  subgraph dc["Same Vast datacenter · on-demand · reliability ≥0.95"]
+    A["attention client\nA6000/L40S 48GB\nclient slice 15–30GB + KV"]
+    E1["expert box 1\n512GB DRAM\nlayers 0–19"]
+    E2["expert box 2\n512GB DRAM\nlayers 20–39"]
+    E3["expert box 3\n512GB DRAM\nlayers 40–59"]
+  end
+  A --> E1
+  A --> E2
+  A --> E3
+  R2[("R2: Inkling vindex\n~500GB · zero egress")] -.-> E1
+  R2 -.-> E2
+  R2 -.-> E3
+```
+
+Shard-by-layer-range mirrors the Gemma/Fly.io demo; exact split set after DEC-4 measures the true client-slice and per-layer expert sizes.
+
+## 5. New build (only these)
+
+1. **Workload packaging:** `vindex-server` and `attention-client` as rig workload units — agent-launchable, join-token in, pulse metrics out, R2 shard pull on start, clean shutdown at budget wall. (Benchmark workload type already on rig roadmap.)
+2. **Loadgen:** batched-decode driver with fixed prompt sets + seeds, emitting the `dec/*` metric schema. wrk-class HTTP loadgen against the infer endpoint as a secondary check.
+3. **Inkling extractor:** new-architecture safetensors → vindex cutter (DEC-4). The only genuinely novel code in the programme.
+
+## 6. Registry & artifact conventions
+
+- One registry experiment per DEC stage: `dec0-loopback-gemma26b`, `dec1-splittier`, `dec2-sharedtier`, `dec3-sparseunion`, `dec4-inkling-extract`, `dec5-inkling-live`; dispatched via `submit_run_from_experiment`.
+- Experiments server is system of record for results, lineage, and shard pins; harness mirrors per the artifact-ownership ruling.
+- Charts 1–4 + verification report stored as registry artifacts; shard sets pinned in R2.
+- All runs carry budget hard walls; leased workers single-use tokens; Mac only ever BYO class.
+
+## 7. Budget (Vast marketplace rates, Jul 2026)
+
+Reference rates: 4090 ~$0.29–0.39/hr on-demand (interruptible from ~$0.14); 3060-class <$0.12/hr; L40S from ~$0.39/hr; A6000 48GB ~$0.40–0.60/hr; high-RAM hosts ~$0.25–0.50/hr depending on attached card. Marketplace prices float — treat as ±30%.
+
+| Stage | Topology | ~Rate (all-in) | Hours | Est. spend |
+|-------|----------|----------------|-------|-----------|
+| DEC-0 | Colab only | — | — | £0 (already paid) |
+| DEC-1 | 4090 + RAM box same-DC, + WAN arm | ~$0.60/hr | 4–6 | $3–4 |
+| DEC-2 | 1 expert box + 4 clients | ~$0.90/hr | 4 | $4–5 |
+| DEC-3 | 1× EPYC 512GB host | ~$0.35/hr | 4 | $2 |
+| DEC-4 | 2.5TB-NVMe box, unmetered | ~$0.50–0.80/hr | 6–10 | $5–8 |
+| DEC-5 | 48GB card + 3× 512GB boxes | ~$2–2.50/hr | 5–8 | $12–18 |
+| **Total** | | | | **≈ $26–37** one-off |
+
+Recurring: R2 shard storage ~$7–8/month for the ~500GB Inkling vindex (zero egress on every rerun). Largest cost risk is not compute: it is re-running DEC-4 on an extractor bug — mitigated by the logit-match verification gate before DEC-5 provisions.
+
+## 8. Risks (pre-registered)
+
+- **Extractor is real work** — Inkling is a from-scratch architecture; time-box it (DEC-4 kill wall).
+- **Released precision may be BF16** (~2TB download) — budget NVMe and hours accordingly; quantise at extraction.
+- **Payload at Inkling scale** — per-token activation payload scales with hidden dim; if DEC-1 shows the Gemma payload is mostly irreducible, DEC-5 needs same-rack placement and possibly host-local sharding; decision point at DEC-1 exit.
+- **Colab↔Vast is WAN** — arm A is expected to look like the Fly.io result at batch 1; arm B is the claim-bearing arm. Do not let arm A numbers leak into the headline.
+- **Batch-union limit (C4)** — quote it proactively; the credibility of the 20× fleet claim depends on stating where it doesn't hold (K3-class ultra-sparse at high batch).
+
+- **Marketplace networking** — inter-host bandwidth on Vast varies wildly; every multi-node result is gated on the §4.4 iperf3 record, and a run that fails the gate is re-provisioned, never re-interpreted.
+
+## 9. Sequencing
+
+DEC-0 tonight-sized (nothing required beyond current estate + workload packaging). DEC-1/DEC-2 same week once packaging exists. DEC-3 any idle evening. DEC-4/DEC-5 gated, targeted while Inkling is still news.

--- a/docs/dec-funnel.md
+++ b/docs/dec-funnel.md
@@ -1,0 +1,252 @@
+# DEC Funnel v0.4.1 — Decoupled Attention/Weights Serving at Batch and at Frontier Scale
+
+**Programme:** DEC-0 … DEC-7 + G-ladder (GPU engineering) + C-ladder (CPU kernels)
+**Estate:** larql (grid stack, wire codecs, router, bench infra) · chuk-mcp-training (rig, `gpu-training-harness` repo) · chuk-experiments-server (registry) · Cloudflare R2 (shards) · Vast/Colab (compute)
+**Status:** draft v0.4.2 — instruments built: DEC-0/DEC-1's batch axis is measured by the `larql dec-bench` residual-replay loadgen (capture + replay, `dec/*` pulse emission, movement-ratio accounting via the `/v1/stats` `ffn_weights` extension); e2e tok/s stays single-stream via `larql bench --ffn`; client batched decode explicitly deferred. v0.4.1 made the spec repo-resident: v0.2 archived alongside as [`dec-funnel-v0.2.md`](dec-funnel-v0.2.md) with carry-overs resolved; K3 registry slugs added; DEC-0 anchor configuration pinned. v0.4 added the Kimi K3 track (DEC-6/7): KDA client port, MXFP4 expert path, batch-union positioning; DEC-3 upgraded to re-parameterise on K3's real routing statistics.
+**Date:** 2026-07-22
+
+---
+
+## 1. Thesis & objective
+
+The claim under test is **not** host offload for MoE. It is the decoupling of the transformer along its stateful/stateless boundary:
+
+- **Attention** is the stateful half — KV/continuation state, per-user session, sequence position, latency budget. It stays GPU-side and sizes the GPU fleet.
+- **The FFN/expert contribution** is a stateless pure function of the residual. Stateless pure functions become shared, durable, horizontally-scaled service tiers — with sharing, replication, versioning, hot-swap, and independent scaling inherited from the cut, not bolted on.
+
+Direction of movement is the category difference: offload moves **weights to the compute** (GB across PCIe, one box, no sharing); this architecture moves **compute to the weights** (KB of activations across a negotiated wire, N clients, durable tier).
+
+Consequently the interconnect is not a deployment constraint to survive — it is **the resource the architecture schedules**, and larql already engineers it three layers deep: wire codec ladder (f32/f16/i8/Q8K, per-request negotiated), dispatch batching (streaming 0.6 → batch 6.5 tok/s on 31B dense remote-FFN), and latency-EMA/p99 per-layer routing (`HeartbeatMsg.layer_stats` → larql-router steers replicated layers to the fastest server).
+
+**DEC's job:** characterise the scheduler's operating envelope — the feasible region in (RTT × bandwidth × batch × wire format × dispatch mode) — and demonstrate the two artifacts no offload or AFD lineage can produce: a **shared multi-client knowledge tier** and **adaptive routing under degraded links**; then land both at frontier scale on Inkling.
+
+Everything is pure inference — exact function, relocated weights. The walk/sparse-fidelity research track (E4) is out of scope.
+
+### Cross-cutting metric: movement ratio
+
+`dec/movement_ratio` = bytes crossing the attention↔weights boundary per token ÷ expert/FFN weight bytes touched per token. Offload ≈ 1.0 by construction; this architecture targets 10⁻³–10⁻⁴. Reported on every run; it is the one number that makes the categorical difference legible.
+
+## 2. Claims under test
+
+| ID | Claim | Falsifier |
+|----|-------|-----------|
+| C1 | Serving compute survives batched decode (gate/expert path at batch 64 within step budget) | step time super-linear in batch on loopback |
+| C2 | The feasible region is large: at batch ≥16 with batch dispatch + f16 wire, LAN-class links (≤2ms, ≥2Gbps) reach ≥70% of loopback throughput | region collapses to loopback-only |
+| C3 | One expert tier serves N clients near-linearly (≥80% linear at N=4) with tier headroom | saturation at N≤2 from tier compute/NIC |
+| C4 | DRAM streaming amortisation for ultra-sparse MoE has a measurable batch-union bound (metrology; deliverable is the curve) | n/a |
+| C5 | Inkling runs end-to-end decoupled: ≤48GB-VRAM attention client, experts in DRAM, ≥5 tok/s single-stream, shannon-verified | incoherent output or <1 tok/s |
+| C6 | Wire codec ladder trades bandwidth for bounded fidelity: i8/Q8K paths stay within a pre-set bits/char drift vs f32 wire | drift exceeds gate on standard corpus |
+| C7 | The latency-EMA router arbitrages heterogeneous links: traffic migrates off a degraded replica within a bounded window and recovers ≥90% of pre-degradation throughput | router fails to migrate or oscillates |
+| C8 | K3 (2.8T, 16/896, MXFP4, KDA) runs decoupled as a **capability tier**: ≥3 tok/s single-stream from DRAM-resident experts, shannon-verified, with its batch ceiling pre-predicted by the DEC-3 boundary chart | incoherent output, <1 tok/s, or measured ceiling contradicting the DEC-3 prediction by >2× (instrument failure) |
+
+Gate order: C1 → C2 → C3 sequential; C6 measured inside DEC-1; C7 = DEC-2.5 after C3; C4 independent; C5 gated on C1+C2 **and** G3 (CUDA correctness); C8 gated on C5 (Inkling proven first) + DEC-3 re-parameterised on K3's real routing statistics.
+
+## 3. Experiment ladder
+
+### DEC-0 — Loopback batch curve, dual-arm (£0)
+
+*Tests C1.*
+
+- **Arm M (reference):** M3 Max, Metal attention + local expert server over loopback — anchors against known numbers (26B A4B: local 18.9 / 1-shard grid 18.3 / 2-shard 17.3 tok/s; SKIP_MOE ceiling 56.8). **Anchor configuration note:** those numbers predate the KV append-in-place and spin-pool landings (CPU-path 26B is now 27.9 tok/s short-ctx flags-off, ~34.9 with `LARQL_SPIN_POOL=1`); DEC-0 re-baselines with the flag set recorded in the run record, and a first-run result *above* the anchor is expected, not an instrument error. Regression-checking is against the re-baseline, not the historical anchor.
+- **Arm L (Linux):** Colab high-RAM — T4 present but attention on **CPU until G-ladder lands**; expert server on same VM. Absolute tok/s is non-hero; the batch *shape* (sub-linearity of step time) is the claim-bearing measurement.
+- **Method — two instruments, pre-registered (v0.4.2):** larql's decode loop is single-sequence (`--ffn-dispatch batch` batches *layer dispatches* within one token step, not sequences), so the batch axis is measured by the **residual-replay loadgen** (`larql dec-bench`): capture real pre-normed per-layer residuals from single-stream decode over 64 distinct prompts (`dec-bench capture`, prompts pinned in `bench/dec0/prompts.txt`), then replay them as B-row `/v1/walk-ffn[-q8k]` requests (`dec-bench replay`), batch ∈ {1, 8, 16, 32, 64} × wire {f32, f16, i8, q8k} × dispatch {streaming, batch}, 3 repeats. Distinct prompts per row keep the MoE routing union realistic; replay frames send `top_k=0` (defuses the server's L2 FFN cache); replay is model-free, so a Mac-captured pool runs unchanged on the x86 arms. E2e tok/s remains the **single-stream anchor** via the existing `larql bench --ffn` path. C1's step-time-vs-batch claim is about the expert tier, which the loadgen measures directly; client-side batched decode is NOT built — revisit at DEC-2 if aggregate-throughput claims need it. Scope note: `/v1/walk-ffn` exercises the dense/shared-expert FFN path; a routed-experts replay arm (`/v1/expert/*`) is a pre-registered fast-follow **required before declaring C1 pass on the 26B MoE layers**. Driver: `scripts/dec0-loopback.sh`.
+- **Metrics:** `dec/tok_s`, `dec/step_ms_p50/p99`, per-layer stats from `HeartbeatMsg.layer_stats`, `dec/movement_ratio`, `sys/*`.
+- **Pass:** step time sub-linear through batch 32 on both arms.
+- **Kill:** serving compute saturates below batch 16 → profile before any spend.
+
+### DEC-0.5 — x86 expert-tier kernel gate (~$1)
+
+The hot CPU path (Q4K inner dot) is hand-written **aarch64 NEON**, tuned on M3 Max; Linux/x86 falls back to the generic/OpenBLAS route. Before any fleet-wide projection:
+
+- **Method:** identical expert-server bench (per-layer expert/FFN latency, gate KNN, dequant-stream throughput) on the Mac vs one cheap Vast x86 EPYC box.
+- **Gate:** x86 within 2× of Apple Silicon per-core → proceed, note the factor in all projections. Worse than 3× → **C-ladder (AVX-512/AMX Q4K inner dot) becomes a blocker for the fleet claim** (not for the demo — the demo can eat the factor) and gets scheduled before DEC-5's throughput arm.
+- Rationale: every DEC-2/3/5 curve runs on x86 DRAM boxes; projecting from M3 numbers without this factor is the most likely way the 20× claim quietly becomes 6×.
+
+### DEC-1 — The feasibility surface (netem, single box, ~$2–3)
+
+*Tests C2 + C6. Replaces v0.2's two-arm design.*
+
+- **Infra:** one Vast host, 4090 + ≥256GB RAM. Attention client and expert server in separate network namespaces; `tc netem` shapes the veth.
+- **Sweep:** RTT ∈ {0.05, 0.2, 1, 5, 20ms} × bandwidth ∈ {1, 2.5, 10, 25, ∞ Gbps} × batch ∈ {1, 8, 16, 32, 64} × **wire ∈ {f32, f16, i8, Q8K}** × **dispatch ∈ {streaming, batch}**. Prune with a coarse pass, densify around the knee.
+- **Instrument:** the DEC-0 pair — `larql dec-bench replay` for the batch×wire surface (same Mac-captured pool; replay is model-free) + `larql bench --ffn URL` for the single-stream anchor + `make bench-wire` for codec throughput — run as a rig workload emitting the `dec/*` schema. Record `dec/payload_bytes_tok` per wire format.
+- **Model check:** the surface must reproduce the two known field points — ~25 tok/s LAN and 2–3 tok/s Fly.io London on 26B (30 crossings × RTT accounting). If it doesn't, the instrument is wrong, not the field data.
+- **C6 gate:** i8/Q8K arms run `larql shannon verify`-style bits/char scoring vs the f32-wire baseline; drift gate pre-set at 0.5% (matching the repo's existing CI threshold).
+- **Pass (C2):** as stated in claims table.
+- **Deliverable:** Chart 2 — the feasibility map: for each (RTT, BW), max tok/s over wire×dispatch at batch 32, annotated with the colocation classes (loopback / rack / DC / metro) each configuration can inhabit. This is the central chart of the programme.
+
+### DEC-2 — Shared knowledge tier (~$5)
+
+*Tests C3. Unchanged pass criterion; upgraded framing: this is the experiment structurally impossible for offload — it has no N-client story at any price.*
+
+- One expert server; N ∈ {1,2,3,4} attention clients (cheap Vast GPUs — CPU attention acceptable pre-G-ladder — + Colab + Mac BYO). Fixed batch at the DEC-1 knee. Aggregate tok/s vs N; tier CPU/mem-BW/NIC overlay; `dec/movement_ratio` per client.
+- **Pass:** ≥80% linear at N=4 with tier headroom. **Kill:** saturation at N≤2.
+- **Deliverable:** Chart 3 — the category chart.
+
+### DEC-2.5 — Router arbitrage under degradation (~$2)
+
+*Tests C7. The adaptive-grid demonstration; no offload/AFD lineage can draw this chart.*
+
+- **Infra:** one client; a layer range replicated across two expert servers behind larql-router.
+- **Method:** steady state at fixed batch → netem-degrade server A (inject 10ms RTT, then throttle bandwidth) → observe `layer_stats` EMA/p99 and route-share migration → remove degradation → observe recovery. Repeat with degradation flapping to probe oscillation.
+- **Pass:** ≥90% of pre-degradation throughput recovered within a bounded migration window; no sustained oscillation under flap.
+- **Deliverable:** Chart 4 — route share + tok/s over time with degradation window shaded. Also the strongest 30 seconds of video B-roll in the programme.
+
+### DEC-3 — Sparse batch-union metrology (~$2–4, independent, two passes)
+
+*Tests C4 and pre-draws C8's ceiling.*
+
+- **Pass 1 (synthetic, any time):** synthetic experts on a big-RAM x86 box; top-16-of-896 (K3-shaped), top-6 (Inkling-shaped), top-8-of-128 (Gemma-shaped) under uniform and Zipf routing; effective GB/step and step time vs batch ∈ {1…256}.
+- **Pass 2 (K3-real, at weight drop):** re-parameterise with K3's **actual expert-selection distribution** — harvested from the published config + a routing-statistics run over a standard corpus as soon as weights land (2026-07-27 promised), even if DEC-6 itself waits. Upgrades the boundary chart from estimate to prediction; DEC-7's measured ceiling must land within 2× of it (C8's instrument-check clause).
+- **Deliverable:** Chart 5 — where DRAM amortisation dies per sparsity class, synthetic and K3-real overlaid; quoted proactively as the honest boundary of the claim.
+
+### DEC-4 — Inkling extraction (~$5–10; gate: DEC-0 + DEC-1 passed)
+
+- 2.5TB-NVMe unmetered Vast box; `larql extract` extended with the Inkling architecture (tml-renderer + config as reference); drop multimodal weights (text-only v1); Q4K experts; `larql slice --preset client` / `expert-server`; `larql publish` → R2 mirror.
+- **Verification gate:** `larql shannon verify` against the HF reference on a fixed corpus, ≤0.5% bits/char — the repo's existing cross-engine harness is the logit-match gate, no new verifier needed.
+- **Kill:** time-boxed effort wall on architecture quirks → park, ship Gemma-scale results, revisit.
+- **Artifacts:** Inkling vindex (full + client + expert-server slices) in R2 — the reusable asset independent of the video.
+
+### DEC-5 — Inkling live demo (~$8–14; gate: DEC-4 verified **and** G3 passed)
+
+- **Primary arm — single fat host:** one Vast box, 48GB card + 512GB–1TB RAM; experts in host DRAM, zero network. Best tok/s, least filming risk. Expected 5–15 tok/s single-stream (41B active ≈ ~20GB/token Q4 vs 200–400GB/s real-world DRAM BW, minus dequant/orchestration).
+- **Secondary arm — networked tier:** 2-box expert split via `--moe-shards`, same DC, for the distributed frame and a small-N shared-tier point at 975B.
+- **Pass (C5):** ≥5 tok/s sustained, coherent, shannon-verified extraction. Stretch ≥10.
+- **Deliverable:** the frame — `nvidia-smi` (one modest card) · `htop` (hundreds of GB resident) · live stream — plus the movement-ratio line: "~20GB of weights participated in that token; kilobytes moved."
+
+### DEC-6 — K3 extraction + KDA client port (gate: DEC-5 passed; weights published)
+
+The serving topology transfers wholesale from Inkling; what's new is model-side:
+
+- **6a — expert path (moderate, partly solved):** MXFP4 expert extraction reuses the GPT-OSS-120B lineage (128-expert MXFP4 already in the support table); 896 experts is a bigger bank for existing range-sharding. New: MXFP4 dequant-or-native decision on the x86 tier (AMX speaks INT8/BF16 — dequant pass in the streaming loop vs a native FP4 gather kernel; benchmark both, pick per DEC-0.5 methodology).
+- **6b — KDA attention client (the real port):** Kimi Delta Attention is hybrid linear attention, not vanilla SDPA — new attention math in the client slice, plus faithful Stable LatentMoE routing (latent-space routing, quantile balancing) for router-side expert selection. This is to K3 what the whole extractor was to Inkling: expect 3–6 weekends. `shannon verify` ≤0.5% bits/char against the reference implementation is the gate, unchanged.
+- **Compensating factor to measure:** KDA's design goal is cheap decode state at long context → *lower* KV pressure on the client GPU. K3 is harder on the expert tier and kinder on the attention tier; record client-side KV bytes/token alongside the usual schema.
+- **Infra:** extraction box upgraded to ≥3TB NVMe; ~1.4TB native download.
+- **Kill:** KDA port exceeds its time-box → park with Inkling shipped; the programme's claims stand without K3.
+
+### DEC-7 — K3 live: the capability-tier demo (gate: DEC-6 verified)
+
+- **Infra:** one or two 1.5–2TB-DRAM hosts (single fat host preferred, per DEC-5 lesson) + the DEC-5 attention client class.
+- **Positioning (pre-registered, load-bearing):** K3-decoupled is a **single-digit-batch capability tier** — hard queries, interactive agent sessions — *not* a throughput tier. The batch-union bound from DEC-3 pass 2 is quoted up front; DEC-7 measures against it (C8's 2× instrument clause).
+- **Pass:** ≥3 tok/s single-stream sustained, coherent, shannon-verified; measured batch ceiling within 2× of the DEC-3 prediction.
+- **Narrative:** the escalation act — largest open model ever (2.8T) on the same architecture, *with its honest limit measured and stated* — the chart that separates a research programme from a stunt.
+
+## 4. G-ladder — GPU engineering (CUDA attention client)
+
+larql's GPU path is Metal-only today ("Vulkan/CUDA later"); on Linux the attention client falls back to CPU. The hero demo and any NVIDIA fleet claim need a CUDA attention path. Scoped as its own gated ladder, off DEC's critical path for everything except DEC-5:
+
+- **G0 — backend decision (time-boxed).** CUDA-native (cudarc/PTX, Metal shaders as the reference implementation, maximum kernel control) vs wgpu/Vulkan (portability, one shader dialect for Metal+Vulkan+CUDA-via-Vulkan, likely perf tax on Q4K inner loops). Default recommendation: CUDA-native for the bounded client-slice kernel set; revisit wgpu when portability matters more than the hero number.
+- **G1 — quantised GEMV/GEMM:** Q4K/Q6K matvec + matmul kernels (QKV/O projections, LM head). The MSL shaders (`q4k_matvec`, defused norm+QKV per ADR-016) define the semantics to port.
+- **G2 — attention path:** RMSNorm, RoPE, SDPA with KV cache through the `KvEngine` trait, GEGLU (client-side dense layers where present). Client slice only — no expert kernels needed for DEC-5's primary arm.
+- **G3 — correctness gate:** `larql shannon verify` on the CUDA path vs HF/PyTorch, ≤0.5% bits/char, wired into the existing shannon-verify CI workflow. **DEC-5 hero is gated on G3**, not on G-ladder completion.
+- **G4 (post-DEC-5, optional):** `cuda-experts` — GPU-backed expert servers, mirroring `metal-experts` (with its known build-separation constraint: server binary only).
+
+**Interim validity note:** DEC-0…2.5 curves are claim-bearing with CPU attention — they characterise the expert tier, the wire, and the router, and the crossing-tax accounting is attention-implementation-independent. Only absolute end-to-end tok/s waits on G3, and only DEC-5 headline numbers require it.
+
+## 5. C-ladder — x86 CPU kernels (conditional)
+
+Triggered by DEC-0.5: AVX-512/AMX Q4K inner dot for the x86 expert tier, acceptance = closing to ≤2× Apple Silicon per-core on the expert-server bench. Blocker for fleet-cost projections if DEC-0.5 shows >3×; never a blocker for the demo.
+
+## 6. Infrastructure specification & topology
+
+Control plane unchanged from v0.2 §4.1 (archived alongside this doc as [`dec-funnel-v0.2.md`](dec-funnel-v0.2.md)): Fly control plane (`chuk-train-mcp.fly.dev` dispatch/budgets/pulse + `chuk-experiments-server.fly.dev` registry as system of record) + Cloudflare R2; budget hard-walls; single-use cj_ join tokens for leased workers (token doubles as the vindex client credential); Mac BYO/persistent class only. Workload units: `vindex-server`, `attention-client`, `netem-harness` (namespace + tc setup + sweep driver), each agent-launchable with pulse metrics.
+
+| Stage | Node role | Count | GPU | RAM | Disk | NIC | Rental |
+|---|---|---|---|---|---|---|---|
+| DEC-0 M | Mac (BYO) | 1 | Metal | 128GB | — | — | — |
+| DEC-0 L | Colab combined | 1 | T4 (idle pre-G3) | high-RAM | default | — | Colab |
+| DEC-0.5 | x86 bench box | 1 | cheapest attached | ≥128GB | 50GB | — | interruptible |
+| DEC-1 | netem host | 1 | 4090 | ≥256GB | 100GB | n/a (namespaces) | interruptible |
+| DEC-2 | expert server | 1 | cheapest | ≥64GB | 50GB | 10Gbps | on-demand |
+| DEC-2 | clients | 4 | 3060/4090 mix + Mac + Colab | ≥16GB | 30GB | 1Gbps | interruptible |
+| DEC-2.5 | router + 2 servers + client | 4 | cheapest | ≥64GB ea | 50GB | 10Gbps | on-demand |
+| DEC-3 | metrology box | 1 | cheapest | ≥384GB | 50GB | — | interruptible |
+| DEC-4 | extraction box | 1 | ≥24GB | ≥128GB | ≥2.5TB NVMe | unmetered fat downlink | on-demand |
+| DEC-5 primary | fat host | 1 | 48GB (A6000/L40S) | 512GB–1TB | 250GB | — | on-demand, rel ≥0.95 |
+| DEC-5 secondary | expert boxes | 2 | cheapest | 512GB ea | 250GB | 10Gbps | on-demand, rel ≥0.95 |
+| DEC-6 | extraction box | 1 | ≥24GB | ≥256GB | **≥3TB NVMe** | unmetered fat downlink | on-demand |
+| DEC-7 | fat host | 1–2 | 48GB (client) + cheapest (tier) | 1.5–2TB total | 500GB | 10Gbps if split | on-demand, rel ≥0.95 |
+
+### Procurement filters (v0.2 §4.3, restated for the v0.4 ladder)
+
+- **Reliability:** ≥0.90 for interruptible sweep boxes; ≥0.95 for DEC-4/5/6/7 (downloads and filming — eviction is expensive in hours).
+- **Placement:** multi-box stages (DEC-2, DEC-2.5, DEC-5 secondary, DEC-7 split) require LAN-class inter-node paths — filter by geolocation; strongly prefer a single host exposing multiple rentable slots. Never assume; verify with the iperf3 gate below.
+- **Bandwidth metering:** extraction boxes (DEC-4/6) must be unmetered or high-included-transfer — a metered 1.4–2TB HF pull can exceed the compute cost.
+- Vast has no pure-CPU rentals: "expert server" / "metrology box" means filter by RAM/cores, sort by price, ignore the attached card.
+
+### Network verification gate (v0.2 §4.4, retained verbatim in substance)
+
+Before any claim-bearing run on a multi-node topology:
+
+1. `iperf3` between every attention-client ↔ expert-server pair; record Gbps + RTT.
+2. Thresholds: DEC-2/DEC-2.5 ≥ 2Gbps and ≤ 2ms RTT to count as LAN-class; DEC-5/DEC-7 ≥ 5Gbps aggregate into the expert tier.
+3. Measured values written to the registry run record (`net/gbps`, `net/rtt_ms`) — a curve without its link measurement is not admissible as a result.
+
+Failing the gate = **re-provision, never re-interpret**. Single-host netem stages (DEC-1) are exempt — the shaping is the instrument.
+
+### Stage topologies
+
+Two diagrams changed from v0.2 and are shown below: DEC-1 is now the single-host netem namespace pair, and DEC-2.5 (router arbitrage) is new. DEC-2's shared-tier fan-in and the networked expert-tier split (DEC-5 secondary / DEC-7 split arm) carry over from [`dec-funnel-v0.2.md`](dec-funnel-v0.2.md) §4.5 unchanged in shape — with the one v0.4 amendment that DEC-5/7 *lead* with the single-fat-host arm, relegating the multi-box tier to the secondary arm.
+
+```mermaid
+flowchart LR
+  subgraph host["DEC-1: one Vast host (4090 + 256GB)"]
+    subgraph nsA["netns: client"]
+      A["attention client\n(CPU pre-G3 / CUDA post-G3)"]
+    end
+    subgraph nsB["netns: expert"]
+      E["vindex expert server\n(mmap shards in RAM)"]
+    end
+    A -- "veth + tc netem\nRTT × BW shaped\nwire: f32/f16/i8/Q8K\ndispatch: stream/batch" --> E
+  end
+```
+
+```mermaid
+flowchart LR
+  subgraph dc["DEC-2.5: router arbitrage"]
+    C["client"] --> R["larql-router\n(layer_stats EMA/p99)"]
+    R --> S1["server A (replica L0-14)\n← netem degradation injected"]
+    R --> S2["server B (replica L0-14)"]
+  end
+```
+
+## 7. Registry & artifact conventions
+
+Registry experiments: `dec0-loopback-{mac,colab}`, `dec0p5-x86-kernel-gate`, `dec1-feasibility-surface`, `dec2-sharedtier`, `dec2p5-router-arbitrage`, `dec3-sparseunion` (pass 2 lands as a run under the same experiment, tagged `k3-real`), `dec4-inkling-extract`, `dec5-inkling-live`, `dec6-k3-extract`, `dec7-k3-live`, plus `g3-cuda-shannon`. Experiments server is system of record; harness mirrors; charts + shannon reports + surface data as registry artifacts; shard sets pinned in R2. Metric schema adds: `dec/movement_ratio`, `dec/payload_bytes_tok`, `dec/wire_format`, `dec/dispatch_mode`, `net/gbps`, `net/rtt_ms`, per-layer p50/p99 via `layer_stats`.
+
+## 8. Budget
+
+| Stage | Est. spend |
+|-------|-----------|
+| DEC-0 (both arms) | £0 |
+| DEC-0.5 | ~$1 |
+| DEC-1 | ~$2–3 |
+| DEC-2 | ~$4–5 |
+| DEC-2.5 | ~$2 |
+| DEC-3 | ~$2 |
+| DEC-4 | ~$5–8 |
+| DEC-5 | ~$8–14 |
+| DEC-6 | ~$10–15 (download-dominated) |
+| DEC-7 | ~$10–20 (2TB-host premium) |
+| G-ladder dev GPU time (4090 sessions) | ~$10–20 |
+| **Total (through DEC-5)** | **≈ $35–55** |
+| **Total (through DEC-7)** | **≈ $55–90** one-off |
+
+Recurring: R2 rises to ~$25–30/month with the K3 shard set (~1.4TB) alongside Inkling's (zero egress on both). Rate basis: Vast marketplace rates, Jul 2026, per [`dec-funnel-v0.2.md`](dec-funnel-v0.2.md) §7 (4090 ~$0.29–0.39/hr on-demand, high-RAM hosts ~$0.25–0.50/hr, A6000 48GB ~$0.40–0.60/hr); marketplace prices float — treat as ±30%.
+
+## 9. Risks (pre-registered)
+
+- **CUDA port slippage (G-ladder)** — mitigated: only DEC-5 headline gated on G3; all Gemma-scale content and every curve except hero tok/s proceeds on CPU attention; Metal shaders + shannon-verify CI bound the port's scope and acceptance.
+- **x86 kernel gap (DEC-0.5)** — the most likely silent deflator of the fleet claim; measured first, factored into every projection, C-ladder on standby.
+- **Wire fidelity (C6)** — i8/Q8K bandwidth wins are conditional on the 0.5% bits/char gate; a failed gate removes those arms from the feasibility map, it does not sink the map.
+- **Extractor is real work** — new-architecture code against a week-old model; time-boxed; shannon verify is the tripwire.
+- **Released precision may be BF16 (~2TB)** — budget NVMe + hours; quantise at extraction.
+- **Marketplace networking** — iperf3 gate retained; netem consolidation means no claim-bearing curve depends on marketplace link quality.
+- **Router oscillation under flap (DEC-2.5)** — if observed, damping is an engineering fix in larql-router, and the experiment has done its job; pre-registering it as a possible finding, not a failure.
+- **KDA port complexity (DEC-6b)** — hybrid linear attention + LatentMoE routing is the largest single unknown in the programme after G-ladder; time-boxed, gated behind a shipped Inkling result, and the programme's claims stand if it parks.
+- **K3 positioning discipline (DEC-7)** — the capability-tier framing (single-digit batch) is pre-registered *before* results exist so a modest batch ceiling reads as the predicted boundary, not a walk-back; DEC-3 pass 2 must publish before DEC-7 runs.
+- **MXFP4 on x86** — dequant-in-loop vs native FP4 gather is an unmeasured 1.5–2× on the K3 tier; benchmarked inside DEC-6a before any DEC-7 projection.
+- **Batch-union limit (C4)** — quoted proactively as the boundary of the claim for ultra-sparse MoE at high batch.
+
+## 10. Sequencing
+
+DEC-0 arm M immediately (known numbers, workload packaging shake-out) → DEC-0 arm L + DEC-0.5 same session → DEC-1 surface (the central experiment) → DEC-2 → DEC-2.5 → DEC-3 pass 1 any idle evening. G0–G3 in parallel from week 1 (the long pole). **At weight drop (promised 2026-07-27): immediately harvest both models' configs and K3's routing statistics** — DEC-3 pass 2 costs pennies and converts the boundary chart into a prediction while DEC-6 waits. DEC-4 → DEC-5 while Inkling is news; DEC-6/7 as the escalation act, gated on a shipped DEC-5 and a passed KDA time-box.

--- a/scripts/dec0-loopback.sh
+++ b/scripts/dec0-loopback.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# DEC-0 arm M — loopback batch curve (docs/dec-funnel.md §3).
+#
+# Runs the full DEC-0 measurement on one machine:
+#   1. launches a loopback expert server (larql-server --ffn-only),
+#   2. anchor arm: e2e single-stream `larql bench --ffn` (streaming + batch
+#      dispatch, wire sweep) — the re-baseline against the known numbers,
+#   3. capture arm: 64-prompt residual pool via `larql dec-bench capture`,
+#   4. replay arm: batch × wire × dispatch sweep via `larql dec-bench replay`,
+#      emitting the dec/* pulse JSONL + full JSON run record,
+#   5. prints the C1 verdict input (step p50 vs batch sub-linearity).
+#
+# Usage:
+#   LARQL_BENCH_VINDEX=output/gemma4-26b-a4b-q4k.vindex ./scripts/dec0-loopback.sh
+#
+# Optional env vars:
+#   DEC0_PORT       — expert server port            (default: 8080)
+#   DEC0_OUT_DIR    — output directory              (default: bench/dec0)
+#   DEC0_PROMPTS    — prompts file                  (default: bench/dec0/prompts.txt)
+#   DEC0_STEPS      — capture/replay steps          (default: 16)
+#   DEC0_PROMPT_N   — prompts to capture            (default: 64)
+#   DEC0_REPEATS    — replay repeats per point      (default: 3)
+#   DEC0_BATCHES    — replay batch list             (default: 1,8,16,32,64)
+#   DEC0_WIRES      — replay wire list              (default: f32,f16,i8,q8k)
+#   DEC0_SKIP_ANCHOR / DEC0_SKIP_CAPTURE — set to 1 to skip a phase (reuse
+#      an existing pool with DEC0_SKIP_CAPTURE=1).
+#
+# Bench discipline (thermal-artifacts memory): run on AC power with
+# indexers quiet; suspect any regression measured on a hot machine.
+
+set -euo pipefail
+
+VINDEX="${LARQL_BENCH_VINDEX:?set LARQL_BENCH_VINDEX to the vindex directory}"
+PORT="${DEC0_PORT:-8080}"
+OUT_DIR="${DEC0_OUT_DIR:-bench/dec0}"
+PROMPTS="${DEC0_PROMPTS:-bench/dec0/prompts.txt}"
+STEPS="${DEC0_STEPS:-16}"
+PROMPT_N="${DEC0_PROMPT_N:-64}"
+REPEATS="${DEC0_REPEATS:-3}"
+BATCHES="${DEC0_BATCHES:-1,8,16,32,64}"
+WIRES="${DEC0_WIRES:-f32,f16,i8,q8k}"
+URL="http://127.0.0.1:${PORT}"
+MODEL_KEY="$(basename "${VINDEX}" .vindex)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+
+mkdir -p "${OUT_DIR}"
+
+echo "[dec0] building release binaries…"
+cargo build --release -p larql-cli -p larql-server
+
+echo "[dec0] launching expert server (${URL}, --ffn-only)…"
+./target/release/larql-server "${VINDEX}" --ffn-only --port "${PORT}" \
+    >"${OUT_DIR}/server-${STAMP}.log" 2>&1 &
+SERVER_PID=$!
+trap 'kill "${SERVER_PID}" 2>/dev/null || true' EXIT
+
+for i in $(seq 1 120); do
+    if curl -sf "${URL}/v1/health" >/dev/null 2>&1; then break; fi
+    if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+        echo "[dec0] server died during startup — see ${OUT_DIR}/server-${STAMP}.log" >&2
+        exit 1
+    fi
+    sleep 1
+    if [ "$i" = 120 ]; then
+        echo "[dec0] server did not become healthy in 120s" >&2
+        exit 1
+    fi
+done
+echo "[dec0] server healthy."
+
+# ── 1. Anchor arm: e2e single-stream (existing bench path, unchanged) ────────
+if [ "${DEC0_SKIP_ANCHOR:-0}" != "1" ]; then
+    for dispatch in streaming batch; do
+        echo "[dec0] anchor arm: --ffn-dispatch ${dispatch}…"
+        ./target/release/larql bench "${VINDEX}" \
+            --ffn "${URL}" \
+            --ffn-dispatch "${dispatch}" \
+            --metal \
+            --wire f32,f16,i8 \
+            --tokens 50 \
+            --warmup 3 \
+            --output json \
+            --output-file "${OUT_DIR}/anchor_${MODEL_KEY}_${dispatch}_${STAMP}.json"
+    done
+fi
+
+# ── 2. Capture arm: residual pool ────────────────────────────────────────────
+POOL="${OUT_DIR}/residuals-${MODEL_KEY}"
+if [ "${DEC0_SKIP_CAPTURE:-0}" != "1" ]; then
+    echo "[dec0] capturing ${PROMPT_N}-prompt residual pool (${STEPS} steps)…"
+    ./target/release/larql dec-bench capture "${VINDEX}" \
+        --ffn "${URL}" \
+        --prompts-file "${PROMPTS}" \
+        --num-prompts "${PROMPT_N}" \
+        --steps "${STEPS}" \
+        --metal \
+        --out "${POOL}"
+fi
+
+# ── 3. Replay arm: the batch curve ───────────────────────────────────────────
+PULSE="${OUT_DIR}/dec0_${MODEL_KEY}_pulse_${STAMP}.jsonl"
+RECORD="${OUT_DIR}/dec0_${MODEL_KEY}_replay_${STAMP}.json"
+echo "[dec0] replay sweep: batch {${BATCHES}} × wire {${WIRES}} × dispatch {streaming,batch}…"
+./target/release/larql dec-bench replay \
+    --ffn "${URL}" \
+    --capture "${POOL}" \
+    --batch "${BATCHES}" \
+    --wire "${WIRES}" \
+    --dispatch streaming,batch \
+    --repeats "${REPEATS}" \
+    --net-rtt-ms 0.05 \
+    --net-gbps 0 \
+    --output-file "${RECORD}" \
+    --pulse-file "${PULSE}"
+
+echo
+echo "[dec0] done."
+echo "  run record : ${RECORD}"
+echo "  pulse      : ${PULSE}"
+echo
+echo "[dec0] C1 check — dec/step_ms_p50 vs batch (sub-linear through 32 = pass):"
+python3 - "$PULSE" <<'EOF'
+import json, sys
+from collections import defaultdict
+
+rows = [json.loads(l) for l in open(sys.argv[1])]
+by_arm = defaultdict(list)
+for r in rows:
+    by_arm[(r["dec/wire_format"], r["dec/dispatch_mode"])].append(r)
+for (wire, dispatch), pts in sorted(by_arm.items()):
+    pts.sort(key=lambda r: r["dec/batch"])
+    base = next((p for p in pts if p["dec/batch"] == 1), None)
+    print(f"  {wire:>4} / {dispatch:<9}", end="")
+    for p in pts:
+        b, ms = p["dec/batch"], p["dec/step_ms_p50"]
+        scale = f" (×{ms / base['dec/step_ms_p50']:.1f} @ B{b})" if base and b > 1 else ""
+        print(f"  B{b}: {ms:.1f}ms{scale}", end="")
+    print()
+print("  sub-linear = ×factor at B32 well below 32 (bandwidth amortising).")
+EOF


### PR DESCRIPTION
## Summary

- Brings `main` up to the DEC funnel v0.4 programme work already on this branch (loadgen, `dec-bench`, `dec/*` pulse, `stats.ffn_weights`, DEC funnel v0.4.2 docs).
- Implements **Batch A** of [`docs/audits/dec-readiness-review-2026-07-22.md`](docs/audits/dec-readiness-review-2026-07-22.md) — the silent-corruption + allocation-bomb findings that block any claim-bearing DEC run:
  - Q8K walk-ffn batch handler batches same-layer entries into one GEMM instead of B independent matvecs (§1a).
  - Multi-layer wire decoders bound every allocation against body size before reserving (§2a, allocation-bomb).
  - `forward_predispatch_all` fails loudly instead of silently zero-filling a corrupted hidden state on shard failure (§1c).
  - Q8K down-projection fast path checks the down slab's format tag before using the Q4_K-only kernel (§1d).
  - Server logs the selected Q4K/Q6K×Q8K kernel class at startup; false "NEON/AVX2" doc comments corrected (§1b).

Batches B (fleet/config landmines) and C (structural pre-work) remain open, tracked in `ROADMAP.md`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p larql-server` (332 + suite, all passing)
- [x] `cargo test -p larql-inference` (1257+ passing)
- [x] `cargo test -p larql-compute` (749+ passing, incl. new allocation-bomb and format-tag regressions)
- [x] `cargo clippy -p larql-server -p larql-inference -p larql-compute --tests -- -D warnings` (no new warnings introduced)