### PR TITLE
feat(release): tagged release binaries via CI (ADR-0026) + DEC-0 arm L driver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+# Tagged release binaries (ADR-0026). Cross-builds `larql` (CLI) +
+# `larql-server` for the platforms larql-cli.yml already validates on
+# every push, and attaches one archive per platform to a GitHub Release.
+#
+# Deliberately NOT crates.io publishing — see ADR-0026 for why. These are
+# build artifacts, versioned by tag, with no semver/API-stability
+# commitment attached.
+#
+# Feature flags mirror larql-cli.yml exactly: default features (Metal) on
+# macOS, --no-default-features (CPU-only) on Linux/Windows — a release
+# build should exercise the same configuration CI already proves green.
+
+name: release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: build - ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: aarch64-apple-darwin
+            features: ""
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            features: "--no-default-features"
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            features: "--no-default-features"
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install OpenBLAS (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install OpenBLAS (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      # protoc on PATH satisfies the `cfg(not(windows))` skip in
+      # `larql-router-protocol` / `larql-server`. See those build.rs
+      # files for the rationale.
+      - name: Install protoc (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: choco install protoc -y --no-progress
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-
+
+      - name: Build (release-dist profile)
+        run: cargo build --profile release-dist --target ${{ matrix.target }} -p larql-cli -p larql-server ${{ matrix.features }}
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          out="larql-${{ matrix.target }}"
+          mkdir -p "$out"
+          cp target/${{ matrix.target }}/release-dist/larql "$out/"
+          cp target/${{ matrix.target }}/release-dist/larql-server "$out/"
+          tar czf "${out}.tar.gz" "$out"
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $out = "larql-${{ matrix.target }}"
+          New-Item -ItemType Directory -Force -Path $out
+          Copy-Item "target\${{ matrix.target }}\release-dist\larql.exe" "$out\"
+          Copy-Item "target\${{ matrix.target }}\release-dist\larql-server.exe" "$out\"
+          Compress-Archive -Path $out -DestinationPath "$out.zip"
+
+      - name: Upload artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: larql-${{ matrix.target }}
+          path: |
+            larql-${{ matrix.target }}.tar.gz
+            larql-${{ matrix.target }}.zip
+          if-no-files-found: ignore
+          retention-days: 7
+
+  release:
+    name: publish GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,11 @@ debug = false
 [profile.release]
 debug = "line-tables-only"
 split-debuginfo = "packed"
+
+# Distribution builds only (ADR-0026 release binaries) — full strip, no
+# line tables. Kept separate from [profile.release] so local profiling
+# builds are unaffected; CI's release.yml is the only user.
+[profile.release-dist]
+inherits = "release"
+debug = false
+strip = true

--- a/docs/adr/0026-tagged-release-binaries.md
+++ b/docs/adr/0026-tagged-release-binaries.md
@@ -1,0 +1,159 @@
+# ADR-0026 — Tagged Release Binaries via CI (no crates.io publishing)
+
+**Status:** Accepted 2026-07-24 — implemented same day
+(`.github/workflows/release.yml`, `[profile.release-dist]` in the
+workspace `Cargo.toml`). Crate *names* were separately claimed on
+crates.io the same day as empty placeholders (see addendum below) —
+that is a distinct, narrower action from the publishing this ADR still
+declines.
+**Affects:** `.github/workflows/release.yml` (new), `crates/larql-cli`,
+`crates/larql-server`, workspace `Cargo.toml` (`[profile.release-dist]`).
+**Related:** DEC funnel v0.5 (`docs/dec-funnel.md`), which is the concrete
+pain this would remove; ADR-0019 (backend factory / `BackendKind`, relevant
+to what a release binary actually contains per platform).
+
+---
+
+## Context
+
+larql has no distribution artifact today — no crates.io publish, no GitHub
+Release binaries, nothing `cargo install`-able. The only way to get a
+working `larql`/`larql-server` on a machine is `git clone` + `cargo build
+--release` from source.
+
+This was fine while development happened on one or two long-lived boxes.
+The DEC funnel programme (`docs/dec-funnel.md`) breaks that assumption: it
+runs the same serving code on a sequence of **ephemeral, single-use hosts**
+— Colab notebooks (arm L), Vast x86 boxes (DEC-0.5, DEC-1A, DEC-2 through
+DEC-7, DEC-CV). Every one of them currently starts from zero: install a
+Rust toolchain if missing, `git clone`, then a cold `cargo build --release`
+with no dependency cache. Concretely, from the DEC-0 arm L run this ADR was
+written during: toolchain check → clone → **full cold release build**
+(dozens of dependency crates including `wasmtime` transitively) before the
+expert server can even start. That's 20–40 minutes of pure setup tax, paid
+again on the next box, and the next, for the rest of the programme —
+DEC-0.5, DEC-1A's netem host, DEC-2's N clients + server, DEC-2.5's router +
+2 servers, DEC-3's metrology box, DEC-4/5/6/7's extraction and serving
+hosts. Most of that fleet is architecturally identical (Linux x86_64, CPU
+serving) and would be well served by one prebuilt binary, not N rebuilds.
+
+## Decision
+
+Add a `release.yml` GitHub Actions workflow, triggered on `v*` tags, that
+cross-builds `larql` (the CLI) and `larql-server` for the platforms the
+project's CI already validates — `.github/workflows/larql-cli.yml`'s
+existing test matrix is `[ubuntu-latest, windows-latest, macos-14]` — and
+attaches the binaries to a GitHub Release via `gh release upload` /
+`softprops/action-gh-release`.
+
+Implemented as `.github/workflows/release.yml`: a 3-way matrix
+(`macos-14`/`aarch64-apple-darwin`, `ubuntu-latest`/`x86_64-unknown-linux-gnu`,
+`windows-latest`/`x86_64-pc-windows-msvc`) with the same OpenBLAS/protoc
+setup `larql-cli.yml` already has, building `-p larql-cli -p larql-server`
+under a dedicated `release-dist` cargo profile (see below), packaging each
+platform's binaries into a `.tar.gz`/`.zip`, and publishing them to a
+GitHub Release via `softprops/action-gh-release` once every matrix leg
+succeeds.
+
+Each release gets one archive per platform containing `larql` +
+`larql-server`. A DEC driver script (`dec0-loopback.sh`'s siblings) can
+then do `curl -fsSL .../larql-x86_64-unknown-linux-gnu.tar.gz | tar xz`
+instead of a full `cargo build`, with the `DEC0L_SKIP_BUILD=1`-style env
+already in place (`scripts/dec0-arm-l.sh`) to skip the build step once a
+binary is present — not yet wired to auto-fetch a release archive; that's
+the natural follow-up once the first tag exists to fetch from.
+
+### `release-dist` cargo profile
+
+```toml
+# Distribution builds only — full strip, no line tables. Kept separate
+# from [profile.release] so local profiling builds (samply/flamegraph,
+# which need the release profile's line-tables-only debug info) are
+# unaffected.
+[profile.release-dist]
+inherits = "release"
+debug = false
+strip = true
+```
+
+### Why binaries only, not crates.io
+
+Publishing to crates.io means committing to semver and public API stability
+across ~13 workspace crates that are still churning weekly (DEC funnel, the
+G-ladder backend work, wire codec revisions). A release binary carries no
+such commitment — it's a build artifact, versioned by tag, replaceable at
+will. If/when individual crates (e.g. `larql-vindex-spec`, whose manifest
+schema is already meant to be a stable on-disk contract per ADR-0007)
+stabilize enough to be worth other projects depending on via Cargo, that's
+a separate, much narrower decision to make crate-by-crate — not bundled
+into this one.
+
+### Why the existing CI matrix, not a new one
+
+`larql-cli.yml` already builds and tests on all three platforms with the
+correct per-OS feature flags (`--no-default-features` off macOS's Metal
+default) and system deps (OpenBLAS, protoc). Reusing that matrix means a
+release build exercises a path CI already proves green on every push,
+rather than a parallel, less-tested configuration.
+
+### Scope
+
+**In:** `larql` (CLI) + `larql-server` (default build, no
+`metal-experts` — README already documents that feature must NOT be in the
+CLI's default build; a `metal-experts`-enabled `larql-server` variant is a
+possible second artifact, not required for v1 of this ADR).
+**Out:** crates.io publishing (see above); Docker images (the existing
+`deploy/fly/` Dockerfile already solves that need for fly.io specifically);
+Windows/Linux GPU (CUDA) builds — no CUDA backend exists yet (G-ladder is
+G0-decided, unimplemented).
+
+## Cost
+
+| Change | Status |
+|---|---|
+| `release.yml` workflow (matrix build + package + upload) | Done — copied `larql-cli.yml`'s matrix/OpenBLAS/protoc setup |
+| `[profile.release-dist]` (strip, no line tables) | Done |
+| Update DEC driver scripts to prefer a release binary, falling back to build | Not done — needs a real tag to fetch from first |
+| First tag + verify all 3 platform artifacts actually run | Not done — no `v*` tag pushed yet |
+
+## Open questions
+
+- **Tag cadence.** Every merge to main, or hand-picked stable points? DEC's
+  own driver scripts pin an exact commit today (`workspec.code.ref`); a
+  release tag would need to track commits the DEC programme actually wants
+  to measure against, not just "latest."
+- **Versioning scheme.** `v0.x.y` calendar-ish tags vs. semver tied to
+  something meaningful (no public API to version against yet, since this
+  ADR explicitly excludes crates.io).
+
+The workflow exists but is untested end-to-end — it only runs on a `v*`
+tag push or manual `workflow_dispatch`, neither of which has happened yet.
+First real run will surface whatever the matrix sketch got wrong.
+
+## Addendum: crate-name claiming (2026-07-24, same day)
+
+Separately from the binaries decision above: all 17 workspace crate names
+(`larql`, `larql-models`, `larql-compute`, `larql-compute-metal`,
+`larql-core`, `larql-vindex`, `larql-vindex-spec`, `larql-inference`,
+`larql-kv`, `larql-lql`, `larql-cli`, `larql-server`, `larql-router`,
+`larql-router-protocol`, `larql-python`, `larql-boundary`,
+`model-compute`) were confirmed available on crates.io and claimed as
+**empty placeholder crates** — `version = "0.0.0"`, a description pointing
+back to this repo, no functional code. This is squatting-prevention, not
+the crates.io publishing this ADR declines: the placeholders carry no API
+surface, so there is nothing to hold semver-stable, and swapping a
+placeholder for a real `0.1.0` release later is an ordinary version bump.
+
+Mechanically: minimal `Cargo.toml` + `README.md` + doc-comment-only
+`src/lib.rs` per name, `cargo publish --allow-dirty` from a scratch
+directory (outside the workspace, so `--allow-dirty` just means "no git
+repo here" rather than "ignoring real changes"). crates.io's new-crate
+burst rate limit was hit after 5 publishes in quick succession (resets
+on a rolling window, not a daily cap) — the remaining names went through
+after a short wait.
+
+Irreversibility note for future reference: crates.io publishes can be
+*yanked* (hidden from new dependents) but never deleted — the name stays
+permanently associated with the publishing account's history either way.
+That was accepted knowingly here given the placeholder content is
+inherently disposable (nothing links to it, nothing depends on it).

--- a/docs/adr/0026-tagged-release-binaries.md
+++ b/docs/adr/0026-tagged-release-binaries.md
@@ -37,6 +37,23 @@ DEC-0.5, DEC-1A's netem host, DEC-2's N clients + server, DEC-2.5's router +
 hosts. Most of that fleet is architecturally identical (Linux x86_64, CPU
 serving) and would be well served by one prebuilt binary, not N rebuilds.
 
+Worse than the wall-clock cost: several of these hosts (Colab T4s in
+particular) are GPU allocations, and the build itself is pure CPU
+compilation — the GPU sits idle for the entire 20-40 minutes, burning
+through a scarce/quota-limited session on work that needed no GPU at all.
+A prebuilt binary turns that into near-zero idle GPU time before the
+actual (also GPU-idle, since arm L is CPU-attention pre-G-ladder) serving
+workload starts.
+
+**Hard policy, not just an optimisation: GPU-provisioned hosts never
+build from source.** Any DEC-stage dispatch to a GPU box (Colab, Vast GPU
+tiers) must fetch a prebuilt release artifact and skip `cargo build`
+entirely — if no release artifact exists yet for the commit/platform in
+question, that is a blocker on the dispatch, not something to work around
+by building on the box anyway. CPU-only boxes (metrology, extraction,
+router hosts with no GPU line item) are unaffected and may still build
+from source if no release exists.
+
 ## Decision
 
 Add a `release.yml` GitHub Actions workflow, triggered on `v*` tags, that

--- a/scripts/dec0-arm-l.sh
+++ b/scripts/dec0-arm-l.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# DEC-0 arm L — loopback batch curve, Linux/Colab (docs/dec-funnel.md §3).
+#
+# Sibling of scripts/dec0-loopback.sh (arm M). Differs in three ways:
+#   1. No Metal — this box has no GPU attention path pre-G-ladder, and
+#      dec-bench replay never invokes attention anyway (it replays captured
+#      residuals straight at the expert/FFN server).
+#   2. No capture — arm L's whole point is host-portability: it replays the
+#      *same* 64-prompt pool captured on the Mac (arm M), fetched from
+#      wherever it was staged, not a fresh Linux-side capture.
+#   3. No e2e single-stream anchor by default — that needs the FULL vindex
+#      (attention + embed + FFN weights, ~tens of GB) plus a working CPU
+#      attention decode path. The expert-server-only vindex slice
+#      (`hf://chrishayuk/gemma-4-26b-a4b-it-vindex-expert-server`) is enough
+#      for the replay sweep, which is the claim-bearing measurement (batch
+#      *shape*, not absolute tok/s — dec-funnel.md §3 DEC-0). Set
+#      DEC0L_RUN_ANCHOR=1 with DEC0L_ANCHOR_VINDEX pointing at a full vindex
+#      to also run the anchor arm.
+#
+# Usage:
+#   POOL_DENSE_URL=https://.../residuals-gemma4-26b-a4b-q4k.tar.gz \
+#   POOL_ROUTED_URL=https://.../residuals-gemma4-26b-a4b-q4k-routed.tar.gz \
+#   ./scripts/dec0-arm-l.sh
+#
+# Optional env vars:
+#   DEC0L_VINDEX         — expert-server vindex source (default: the
+#                           published HF expert-server slice; `larql-server`
+#                           auto-downloads hf:// on first launch)
+#   DEC0L_PORT            (default: 8080)
+#   DEC0L_OUT_DIR          (default: bench/dec0)
+#   DEC0L_POOL_DIR         (default: bench/dec0, pools land in
+#                           $DEC0L_POOL_DIR/residuals-gemma4-26b-a4b-q4k[-routed])
+#   POOL_DENSE_URL        — required unless the dense pool dir already exists
+#   POOL_ROUTED_URL       — required unless the routed pool dir already exists
+#   DEC0L_STEPS            (default: 16, must match the captured pool)
+#   DEC0L_REPEATS          (default: 3)
+#   DEC0L_BATCHES           (default: 1,8,16,32,64)
+#   DEC0L_DENSE_WIRES       (default: f32,f16,i8,q8k)
+#   DEC0L_ROUTED_WIRES      (default: f32,q8k — the experts endpoint's only
+#                           supported wires, per `larql dec-bench replay --help`)
+#   DEC0L_RUN_ANCHOR=1     — also run the e2e single-stream anchor arm
+#   DEC0L_ANCHOR_VINDEX    — full vindex for the anchor arm (required if
+#                           DEC0L_RUN_ANCHOR=1)
+#   DEC0L_SKIP_BUILD=1     — skip `cargo build` (reuse an existing binary)
+
+set -euo pipefail
+
+PORT="${DEC0L_PORT:-8080}"
+OUT_DIR="${DEC0L_OUT_DIR:-bench/dec0}"
+POOL_DIR="${DEC0L_POOL_DIR:-bench/dec0}"
+VINDEX="${DEC0L_VINDEX:-hf://chrishayuk/gemma-4-26b-a4b-it-vindex-expert-server}"
+STEPS="${DEC0L_STEPS:-16}"
+REPEATS="${DEC0L_REPEATS:-3}"
+BATCHES="${DEC0L_BATCHES:-1,8,16,32,64}"
+DENSE_WIRES="${DEC0L_DENSE_WIRES:-f32,f16,i8,q8k}"
+ROUTED_WIRES="${DEC0L_ROUTED_WIRES:-f32,q8k}"
+URL="http://127.0.0.1:${PORT}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+
+DENSE_POOL="${POOL_DIR}/residuals-gemma4-26b-a4b-q4k"
+ROUTED_POOL="${POOL_DIR}/residuals-gemma4-26b-a4b-q4k-routed"
+
+mkdir -p "${OUT_DIR}" "${POOL_DIR}"
+
+fetch_pool() {
+    local dir="$1" url_var="$2"
+    if [ -f "${dir}/manifest.json" ]; then
+        echo "[dec0-arm-l] pool already present: ${dir}"
+        return
+    fi
+    local url="${!url_var:-}"
+    if [ -z "${url}" ]; then
+        echo "[dec0-arm-l] ${dir} missing and ${url_var} not set — set it to a" \
+             "fetchable tar.gz of the arm-M pool (dec-funnel.md: pools are" \
+             "host-portable, capture is model-free)." >&2
+        exit 1
+    fi
+    echo "[dec0-arm-l] fetching pool: ${url}"
+    local tmp
+    tmp="$(mktemp)"
+    curl -fsSL "${url}" -o "${tmp}"
+    mkdir -p "${dir}"
+    tar -xzf "${tmp}" -C "${dir}" --strip-components=1
+    rm -f "${tmp}"
+}
+
+fetch_pool "${DENSE_POOL}" POOL_DENSE_URL
+fetch_pool "${ROUTED_POOL}" POOL_ROUTED_URL
+
+if [ "${DEC0L_SKIP_BUILD:-0}" != "1" ]; then
+    echo "[dec0-arm-l] building release binaries…"
+    # --no-default-features mirrors larql-cli.yml's Linux CI job: default
+    # features enable Metal (macOS-only) plus a wider dependency graph
+    # (aws-lc-sys among others) this CPU-only expert-server path doesn't need.
+    cargo build --release -p larql-cli -p larql-server --no-default-features
+fi
+
+echo "[dec0-arm-l] launching expert server (${URL}, --ffn-only, vindex=${VINDEX})…"
+echo "[dec0-arm-l] first launch downloads the vindex from HuggingFace if not cached — allow a few minutes."
+./target/release/larql-server "${VINDEX}" --ffn-only --port "${PORT}" \
+    >"${OUT_DIR}/server-arml-${STAMP}.log" 2>&1 &
+SERVER_PID=$!
+trap 'kill "${SERVER_PID}" 2>/dev/null || true' EXIT
+
+for i in $(seq 1 600); do
+    if curl -sf "${URL}/v1/health" >/dev/null 2>&1; then break; fi
+    if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+        echo "[dec0-arm-l] server died during startup — see ${OUT_DIR}/server-arml-${STAMP}.log" >&2
+        exit 1
+    fi
+    sleep 1
+    if [ "$i" = 600 ]; then
+        echo "[dec0-arm-l] server did not become healthy in 600s (cold HF download can be slow)" >&2
+        exit 1
+    fi
+done
+echo "[dec0-arm-l] server healthy."
+
+# ── Optional anchor arm (off by default — see header) ───────────────────────
+if [ "${DEC0L_RUN_ANCHOR:-0}" = "1" ]; then
+    ANCHOR_VINDEX="${DEC0L_ANCHOR_VINDEX:?set DEC0L_ANCHOR_VINDEX for the anchor arm}"
+    for dispatch in streaming batch; do
+        echo "[dec0-arm-l] anchor arm: --ffn-dispatch ${dispatch}…"
+        ./target/release/larql bench "${ANCHOR_VINDEX}" \
+            --ffn "${URL}" \
+            --ffn-dispatch "${dispatch}" \
+            --wire f32,f16,i8 \
+            --tokens 50 \
+            --warmup 3 \
+            --output json \
+            --output-file "${OUT_DIR}/anchor_arml_${dispatch}_${STAMP}.json"
+    done
+fi
+
+# ── Dense replay: walk-ffn endpoint ──────────────────────────────────────────
+DENSE_PULSE="${OUT_DIR}/dec0_arml_dense_pulse_${STAMP}.jsonl"
+DENSE_RECORD="${OUT_DIR}/dec0_arml_dense_replay_${STAMP}.json"
+echo "[dec0-arm-l] dense replay sweep: batch {${BATCHES}} × wire {${DENSE_WIRES}} × dispatch {streaming,batch}…"
+./target/release/larql dec-bench replay \
+    --ffn "${URL}" \
+    --capture "${DENSE_POOL}" \
+    --endpoint walk-ffn \
+    --batch "${BATCHES}" \
+    --wire "${DENSE_WIRES}" \
+    --dispatch streaming,batch \
+    --repeats "${REPEATS}" \
+    --steps "${STEPS}" \
+    --net-rtt-ms 0.05 \
+    --net-gbps 0 \
+    --output-file "${DENSE_RECORD}" \
+    --pulse-file "${DENSE_PULSE}"
+
+# ── Routed replay: experts endpoint (needs the --routing sidecars) ──────────
+ROUTED_PULSE="${OUT_DIR}/dec0_arml_routed_pulse_${STAMP}.jsonl"
+ROUTED_RECORD="${OUT_DIR}/dec0_arml_routed_replay_${STAMP}.json"
+echo "[dec0-arm-l] routed replay sweep: batch {${BATCHES}} × wire {${ROUTED_WIRES}} × dispatch {streaming,batch}…"
+./target/release/larql dec-bench replay \
+    --ffn "${URL}" \
+    --capture "${ROUTED_POOL}" \
+    --endpoint experts \
+    --batch "${BATCHES}" \
+    --wire "${ROUTED_WIRES}" \
+    --dispatch streaming,batch \
+    --repeats "${REPEATS}" \
+    --steps "${STEPS}" \
+    --net-rtt-ms 0.05 \
+    --net-gbps 0 \
+    --output-file "${ROUTED_RECORD}" \
+    --pulse-file "${ROUTED_PULSE}"
+
+echo
+echo "[dec0-arm-l] done."
+echo "  dense  run record : ${DENSE_RECORD}"
+echo "  dense  pulse       : ${DENSE_PULSE}"
+echo "  routed run record : ${ROUTED_RECORD}"
+echo "  routed pulse       : ${ROUTED_PULSE}"
+echo
+echo "  C1 verdict input: step p50 vs batch, both pools — compare against the"
+echo "  arm-M numbers in docs/dec-funnel.md §3 DEC-0. Kill condition: either"
+echo "  pool saturates below batch 16 on this box while arm M does not."
+echo


### PR DESCRIPTION
## Summary
- New `.github/workflows/release.yml`: cross-platform (macOS-aarch64, Linux-x86_64, Windows-x86_64) release-binary build on `v*` tags, mirroring `larql-cli.yml`'s proven matrix/OpenBLAS/protoc setup, publishing archives to a GitHub Release.
- New `[profile.release-dist]` in the workspace `Cargo.toml` (stripped, no line tables), kept separate from `[profile.release]` so local profiling builds are unaffected.
- `docs/adr/0026-tagged-release-binaries.md`: accepted + implemented, documents the DEC-funnel rebuild-tax motivation (including idle-GPU-quota waste) and the separate crate-name-claiming addendum.
- `scripts/dec0-arm-l.sh`: DEC-0 arm L (Colab/Linux) driver, sibling of `dec0-loopback.sh` — replays the host-portable arm-M residual pools against the HF-published expert-server vindex slice.

## Test plan
- [ ] `release.yml` is untested end-to-end — no `v*` tag pushed yet; first tag will surface any matrix issues
- [x] `docs/adr/0026-tagged-release-binaries.md` reviewed
- [x] `Cargo.toml` diff reviewed — additive only, existing `[profile.release]` untouched
- [ ] `scripts/dec0-arm-l.sh` — first attempt hit a build error (aws-lc-sys), fixed with `--no-default-features`; killed mid-rebuild per new policy (never compile on a GPU box) — will re-run once release.yml produces a fetchable binary