### PR TITLE
fix(vindex): unbreak Windows CI — non-zero anon mmap length for make_read_only

### DIFF
--- a/crates/larql-vindex/src/format/load.rs
+++ b/crates/larql-vindex/src/format/load.rs
@@ -122,7 +122,7 @@ impl VectorIndex {
                 "gate_vectors (absent — client-only slice)",
                 &dir.display().to_string(),
             );
-            let empty = memmap2::MmapMut::map_anon(0)?.make_read_only()?;
+            let empty = crate::mmap_util::map_anon_min_one(0)?.make_read_only()?;
             let gate_slices: Vec<crate::index::core::GateLayerSlice> = vec![
                 crate::index::core::GateLayerSlice { float_offset: 0, num_features: 0 };
                 num_layers
@@ -299,7 +299,10 @@ fn synthesize_gate_from_q4k(
     }
     let total_bytes = byte_offset as usize;
 
-    let mut anon = memmap2::MmapMut::map_anon(total_bytes)
+    // `map_anon_min_one`, not `map_anon`: a layer range that owns no features
+    // leaves `total_bytes` at 0, and the `make_read_only()` below then fails
+    // on Windows only (os error 87). Same class as the client-slice buffer.
+    let mut anon = crate::mmap_util::map_anon_min_one(total_bytes)
         .map_err(|e| VindexError::Parse(format!("anon mmap: {e}")))?;
 
     for info in &config.layers {

--- a/crates/larql-vindex/src/mmap_util.rs
+++ b/crates/larql-vindex/src/mmap_util.rs
@@ -68,6 +68,32 @@ pub fn advise_willneed(ptr: *const u8, len: usize) {
     }
 }
 
+/// Anonymous read-write mapping of `len` bytes whose result survives the
+/// `make_read_only()` conversion on every platform, including `len == 0`.
+///
+/// A zero-length `MmapMut::map_anon(0)` is portable on its own — memmap2
+/// clamps the *underlying* Windows mapping to one byte. What is **not**
+/// portable is what the vindex load path does next. memmap2 records the
+/// requested `len` (0), not the clamped one, so a later `make_read_only()`
+/// reaches `VirtualProtect(ptr, 0, PAGE_READONLY, …)`; Windows rejects a
+/// zero `dwSize` with `ERROR_INVALID_PARAMETER` — os error 87, "The
+/// parameter is incorrect." Unix has no equivalent step, so the same code
+/// passes on macOS and Linux and fails only on Windows.
+///
+/// (The early-out in memmap2's `virtual_protect` does not help here: it
+/// triggers on the sentinel pointer used by *file-backed* empty maps, which
+/// an anonymous mapping never has.)
+///
+/// Empty is a legitimate state for several vindex buffers — an attention-only
+/// client slice (`larql slice --preset client`) carries no gate data at all,
+/// and a layer range can own no features. Requesting one byte keeps `len`
+/// non-zero so the protection change is valid; every consumer bounds-checks
+/// against the mapping length before reading, and the buffer is described as
+/// empty by its slices, so the extra byte is never addressed.
+pub fn map_anon_min_one(len: usize) -> Result<memmap2::MmapMut, std::io::Error> {
+    memmap2::MmapMut::map_anon(len.max(1))
+}
+
 /// Apply sequential + willneed hints to an existing mmap. Unix-only;
 /// on Windows the function is a no-op (the OS handles readahead).
 #[cfg_attr(not(unix), allow(unused_variables))]
@@ -82,5 +108,39 @@ pub fn advise_sequential(mmap: &memmap2::Mmap) {
             // Willneed: prefault pages into cache (background page-in)
             libc::madvise(ptr, len, libc::MADV_WILLNEED);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pinned on every platform so the non-zero-length contract can't be
+    /// quietly dropped by a refactor that "simplifies" back to a bare
+    /// `map_anon`. The Windows failure this guards is in
+    /// `make_read_only` (see below), not here — this case only asserts
+    /// the length that keeps that conversion legal.
+    #[test]
+    fn map_anon_min_one_accepts_zero_length() {
+        let m = map_anon_min_one(0).expect("zero-length anon mapping must succeed");
+        assert!(!m.is_empty(), "must map at least one addressable byte");
+    }
+
+    #[test]
+    fn map_anon_min_one_preserves_requested_length() {
+        let m = map_anon_min_one(4096).expect("anon mapping");
+        assert_eq!(m.len(), 4096, "non-zero lengths pass through unchanged");
+    }
+
+    /// A dense-only / client-slice gate buffer is read-only downstream —
+    /// the `make_read_only` conversion the load path performs must work on
+    /// the rounded-up mapping too.
+    #[test]
+    fn map_anon_min_one_zero_length_converts_to_read_only() {
+        let ro = map_anon_min_one(0)
+            .expect("anon mapping")
+            .make_read_only()
+            .expect("read-only conversion");
+        assert!(!ro.is_empty());
     }
 }

--- a/docs/adr/0026-tagged-release-binaries.md
+++ b/docs/adr/0026-tagged-release-binaries.md
@@ -3,9 +3,9 @@
 **Status:** Accepted 2026-07-24 — implemented same day
 (`.github/workflows/release.yml`, `[profile.release-dist]` in the
 workspace `Cargo.toml`). Crate *names* were separately claimed on
-crates.io the same day as empty placeholders (see addendum below) —
-that is a distinct, narrower action from the publishing this ADR still
-declines.
+crates.io as empty placeholders — 12 on 2026-07-24, the remaining 6
+after the rate-limit window reopened (see addendum below) — that is a
+distinct, narrower action from the publishing this ADR still declines.
 **Affects:** `.github/workflows/release.yml` (new), `crates/larql-cli`,
 `crates/larql-server`, workspace `Cargo.toml` (`[profile.release-dist]`).
 **Related:** DEC funnel v0.5 (`docs/dec-funnel.md`), which is the concrete
@@ -149,25 +149,44 @@ First real run will surface whatever the matrix sketch got wrong.
 
 ## Addendum: crate-name claiming (2026-07-24, same day)
 
-Separately from the binaries decision above: all 17 workspace crate names
+Separately from the binaries decision above: the 17 workspace crate names
 (`larql`, `larql-models`, `larql-compute`, `larql-compute-metal`,
 `larql-core`, `larql-vindex`, `larql-vindex-spec`, `larql-inference`,
 `larql-kv`, `larql-lql`, `larql-cli`, `larql-server`, `larql-router`,
 `larql-router-protocol`, `larql-python`, `larql-boundary`,
-`model-compute`) were confirmed available on crates.io and claimed as
-**empty placeholder crates** — `version = "0.0.0"`, a description pointing
-back to this repo, no functional code. This is squatting-prevention, not
-the crates.io publishing this ADR declines: the placeholders carry no API
-surface, so there is nothing to hold semver-stable, and swapping a
-placeholder for a real `0.1.0` release later is an ordinary version bump.
+`model-compute`) plus `larql-experts` (the nested expert workspace at
+`crates/larql-experts/`, excluded from the root `[workspace] members` and
+so missed by the first sweep — 18 names total) were confirmed available on
+crates.io and claimed as **empty placeholder crates** — `version = "0.0.0"`,
+a description pointing back to this repo, no functional code. This is
+squatting-prevention, not the crates.io publishing this ADR declines: the
+placeholders carry no API surface, so there is nothing to hold
+semver-stable, and swapping a placeholder for a real `0.1.0` release later
+is an ordinary version bump.
+
+Scope note: only the top-level `larql-experts` name is held. The ~17
+*sub*-crate names inside that workspace (`expert-interface`,
+`arithmetic`, `date`, `unit`, …) are generic, are not namespaced to this
+project, and were deliberately left unclaimed — holding them would be a
+much wider land-grab than squatting-prevention warrants.
 
 Mechanically: minimal `Cargo.toml` + `README.md` + doc-comment-only
 `src/lib.rs` per name, `cargo publish --allow-dirty` from a scratch
 directory (outside the workspace, so `--allow-dirty` just means "no git
 repo here" rather than "ignoring real changes"). crates.io's new-crate
-burst rate limit was hit after 5 publishes in quick succession (resets
-on a rolling window, not a daily cap) — the remaining names went through
-after a short wait.
+rate limit is a **burst of 5, refilling ~1 per 10 minutes** (a rolling
+window, not a daily cap), and it shaped the rollout: the first session
+landed 12 names and stopped mid-sweep at the burst wall, leaving
+`larql-router`, `larql-router-protocol`, `larql-python`, `larql-boundary`
+and `model-compute` unclaimed until a follow-up session — a gap this
+addendum originally, and wrongly, recorded as complete. Verify the real
+state against the registry (`GET https://crates.io/api/v1/crates/<name>`,
+404 = unclaimed) rather than against this document.
+
+Retry-parsing gotcha for anyone automating this: the 429 body gives its
+retry time as an **HTTP-date** (`Fri, 24 Jul 2026 22:52:09 GMT`), not
+RFC3339 — a scraper matching only `\d{4}-\d{2}-\d{2}T…Z` silently
+misclassifies a plain rate-limit as a hard failure.
 
 Irreversibility note for future reference: crates.io publishes can be
 *yanked* (hidden from new dependents) but never deleted — the name stays


### PR DESCRIPTION
Clears the last red workflow. `larql-vindex` has failed on `test - windows-latest` for 44 consecutive runs since 2026-06-19 (last green `f647b0aa`); macOS, Linux and the ubuntu coverage leg were green throughout.

## The bug

`extract::build::tests::dense_only_vindex_loads_without_gate_vectors` failed with:

```
Io(Os { code: 87, kind: InvalidInput, message: "The parameter is incorrect." })
```

The failing call is **not** `map_anon(0)`, which the error line makes it look like. memmap2 0.9.11 already clamps the underlying Windows mapping to one byte (`windows.rs:365`), so that call succeeds — but it records the *requested* length of 0. The `make_read_only()` chained onto the same line is what fails: `virtual_protect` computes `aligned_len = self.len + alignment = 0` and calls `VirtualProtect(ptr, 0, PAGE_READONLY, …)`, which Windows rejects. memmap2's early-out for empty maps keys on a sentinel pointer used only by *file-backed* zero-length maps, which an anonymous mapping never has. Unix performs no protection change at all, hence green everywhere else.

## The fix

`mmap_util::map_anon_min_one(len)` maps `len.max(1)`, keeping the recorded length non-zero so the conversion stays legal. Two call sites:

- `format/load.rs:125` — the attention-only client slice (`larql slice --preset client`), which the failing test builds.
- `format/load.rs:302` — `synthesize_gate_from_q4k`, carrying the **identical latent bug**: it also ends in `make_read_only()`, and `total_bytes` is 0 whenever the layer range owns no features. Not currently hit by CI, but it sits on the range-restricted-vindex path the DEC funnel uses.

Safe because every consumer bounds-checks against the mapping length before reading, and the buffer is described as empty by its all-zero `GateLayerSlice`s — the extra byte is unreachable. Other `map_anon` sites in the tree were audited: all are `#[cfg(test)]` helpers or non-empty payloads.

Three unit tests pin the contract on every platform (zero-length accepted, non-zero lengths pass through unchanged, zero-length survives `make_read_only`).

## Also included

ADR-0026 addendum correction. It recorded all 17 crate names as claimed on crates.io; the first session actually stopped at 12 on the registry's burst limit (5 new crates, ~1 per 10 min refill), leaving `larql-router`, `larql-router-protocol`, `larql-python`, `larql-boundary` and `model-compute` unclaimed. All are now published, plus `larql-experts` — a nested workspace excluded from the root `[workspace] members` and so invisible to the original sweep — bringing it to 18/18, verified against the registry API. Its ~17 sub-crate names are deliberately left unclaimed, now written down as a decision.

## Verification

`larql-vindex` 1106 tests pass, `-inference` 1309, `-kv` 766; `larql-cli`/`larql-server` build; clippy clean at `-D warnings`. **The Windows leg is the actual proof and can only run here** — the mechanism is confirmed from vendored memmap2 source rather than reproduced locally.