### PR TITLE
feat(dec): shared release-binary acquisition for DEC stage drivers (ADR-0026)

### DIFF
--- a/ROADMAP_STATUS.md
+++ b/ROADMAP_STATUS.md
@@ -72,7 +72,7 @@ after C3; C4 independent; C5 gated on C1+C2 **and** G3; C8 gated on C5.
 | Order | Stage | Status | Exit criterion |
 |---:|---|---|---|
 | 1 | DEC-0 arm M (loopback batch curve, Mac) | **✅ CLOSED 2026-07-23 — C1 holds, both paths** | Step time sub-linear through batch 32. Dense ×1.6–1.8 at B32; routed ×23.6. Registry `dec0-loopback-mac` completed. |
-| 2 | DEC-0 arm L (Colab/Linux) | **blocked** — `scripts/dec0-arm-l.sh` written, but needs a `v*` release artifact; building on a GPU box violates ADR-0026 policy | Same batch *shape* on x86/Linux. Pools are host-portable, so this replays the arm-M capture unchanged. |
+| 2 | DEC-0 arm L (Colab/Linux) | **ready to run** — `v0.1.0` published 2026-07-25 and `scripts/dec0-arm-l.sh` now fetches the Linux archive instead of building (refuses to compile on a GPU host per ADR-0026). Needs only the pool URLs. | Same batch *shape* on x86/Linux. Pools are host-portable, so this replays the arm-M capture unchanged. |
 | 3 | DEC-0.5 x86 kernel gate (~$1) | queued — `scripts/dec0p5-x86.sh` written | x86 within 2× of Apple Silicon per-core → proceed, note the factor in every projection. Worse than 3× → C-ladder blocks the fleet claim (never the demo). |
 | 4 | DEC-1A transport decomposition (~$2–3) | **tooled, not run** — all four instruments landed 2026-07-24 | C2 + C6. Deliverable is the fitted T_codec/T_network model, not just the map. Must reproduce two known field points (~25 tok/s LAN, 2–3 tok/s Fly.io London) or the instrument is wrong, not the field data. |
 | 5 | DEC-1B compiled transport policy (~$2) | gated on 1A flat-codec results | Per-layer sensitivity compiled to a minimum-bytes schedule shipped **in the vindex manifest** — transport policy as a versioned artifact. |
@@ -86,8 +86,11 @@ after C3; C4 independent; C5 gated on C1+C2 **and** G3; C8 gated on C5.
 | G1–G3 | CUDA attention client | not started — the long pole, runs in parallel from week 1 | G3: `larql shannon verify` on the CUDA path ≤0.5% bits/char. **Only DEC-5's headline is gated on this**; every other DEC curve is claim-bearing on CPU attention. |
 | M1 | Model-agnostic verify loop (on Gemma) | queued — any time, pre-weights | `dec/accept_rate`, `dec/tokens_per_step`. Reported per *accepted* token so a low-acceptance draft can't inflate a headline. |
 
-**Immediate next:** cut `v0.1.0` so arm L and DEC-0.5 can run from prebuilt
-binaries in one session, then DEC-1A — the central experiment of the programme.
+**Immediate next:** run arm L + DEC-0.5 in one session — both now fetch the
+`v0.1.0` binaries through the shared `scripts/lib/larql-binaries.sh` helper
+rather than building — then DEC-1A, the central experiment of the programme.
+DEC-0.5 still compiles the criterion kernel bench, which is deliberate: that
+bench is the measurement object, not a shipped artifact.
 At the K3 weight drop (promised 2026-07-27), harvest both models' configs and
 K3's routing statistics immediately: DEC-3 pass 2 costs pennies and converts the
 boundary chart from estimate to prediction while DEC-6 waits.

--- a/docs/adr/0026-tagged-release-binaries.md
+++ b/docs/adr/0026-tagged-release-binaries.md
@@ -75,10 +75,30 @@ succeeds.
 Each release gets one archive per platform containing `larql` +
 `larql-server`. A DEC driver script (`dec0-loopback.sh`'s siblings) can
 then do `curl -fsSL .../larql-x86_64-unknown-linux-gnu.tar.gz | tar xz`
-instead of a full `cargo build`, with the `DEC0L_SKIP_BUILD=1`-style env
-already in place (`scripts/dec0-arm-l.sh`) to skip the build step once a
-binary is present — not yet wired to auto-fetch a release archive; that's
-the natural follow-up once the first tag exists to fetch from.
+instead of a full `cargo build`.
+
+**Wired 2026-07-25, once `v0.1.0` existed to fetch from.**
+`scripts/dec0-arm-l.sh` now resolves binaries in four ordered steps:
+operator-supplied (`DEC0L_LARQL_BIN`/`DEC0L_SERVER_BIN`) → reuse an
+already-populated `DEC0L_BIN_DIR` → fetch the release archive for the
+detected platform (`DEC0L_LARQL_VERSION`, default `v0.1.0`) → fall back to
+`cargo build`. That last step is **gated on the policy above**: if
+`nvidia-smi` is present the script refuses and exits non-zero rather than
+compiling on a GPU allocation, and says what to do instead (publish a
+release for the platform, pass the binaries explicitly, or move to a
+CPU-only host). `DEC0L_ALLOW_SOURCE_BUILD=1` overrides for the operator who
+knowingly accepts the cost, and the log line then says the policy was
+*overridden* rather than claiming it was satisfied. The old
+`DEC0L_SKIP_BUILD` knob is gone — "already present" is now detected rather
+than asserted.
+
+The logic lives in `scripts/lib/larql-binaries.sh` and is shared, since every
+remaining DEC stage provisions a fresh host. `scripts/dec0p5-x86.sh` uses it
+too, with one deliberate exemption: DEC-0.5 still compiles the criterion
+kernel bench (`cargo bench -p larql-compute`), because a bench target is not
+a shipped binary and that kernel is precisely what the stage exists to
+measure. Fetching the CLI and server still removes the bulk of the build from
+the lease.
 
 ### `release-dist` cargo profile
 

--- a/scripts/dec0-arm-l.sh
+++ b/scripts/dec0-arm-l.sh
@@ -41,9 +41,21 @@
 #   DEC0L_RUN_ANCHOR=1     — also run the e2e single-stream anchor arm
 #   DEC0L_ANCHOR_VINDEX    — full vindex for the anchor arm (required if
 #                           DEC0L_RUN_ANCHOR=1)
-#   DEC0L_SKIP_BUILD=1     — skip `cargo build` (reuse an existing binary)
+#
+# Binaries (ADR-0026 — GPU hosts never build from source):
+#   DEC0L_LARQL_VERSION    — release tag to fetch (default: v0.1.0)
+#   DEC0L_BIN_DIR          — where fetched binaries land
+#                           (default: $DEC0L_OUT_DIR/bin; reused if present)
+#   DEC0L_LARQL_BIN        — skip acquisition, use this `larql` binary
+#   DEC0L_SERVER_BIN       — skip acquisition, use this `larql-server` binary
+#   DEC0L_ALLOW_SOURCE_BUILD=1
+#                         — permit `cargo build` even on a GPU host. Only if
+#                           you accept burning the GPU allocation on ~20-40
+#                           minutes of CPU-only compilation.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 PORT="${DEC0L_PORT:-8080}"
 OUT_DIR="${DEC0L_OUT_DIR:-bench/dec0}"
@@ -87,17 +99,21 @@ fetch_pool() {
 fetch_pool "${DENSE_POOL}" POOL_DENSE_URL
 fetch_pool "${ROUTED_POOL}" POOL_ROUTED_URL
 
-if [ "${DEC0L_SKIP_BUILD:-0}" != "1" ]; then
-    echo "[dec0-arm-l] building release binaries…"
-    # --no-default-features mirrors larql-cli.yml's Linux CI job: default
-    # features enable Metal (macOS-only) plus a wider dependency graph
-    # (aws-lc-sys among others) this CPU-only expert-server path doesn't need.
-    cargo build --release -p larql-cli -p larql-server --no-default-features
-fi
+# ── Binary acquisition (ADR-0026) — shared with the other DEC drivers ───────
+LARQL_RELEASE_VERSION="${DEC0L_LARQL_VERSION:-v0.1.0}"
+LARQL_BIN_DIR="${DEC0L_BIN_DIR:-${OUT_DIR}/bin}"
+LARQL_BIN="${DEC0L_LARQL_BIN:-}"
+LARQL_SERVER_BIN="${DEC0L_SERVER_BIN:-}"
+LARQL_ALLOW_SOURCE_BUILD="${DEC0L_ALLOW_SOURCE_BUILD:-0}"
+LARQL_LOG_PREFIX="dec0-arm-l"
+# shellcheck source=lib/larql-binaries.sh
+. "${SCRIPT_DIR}/lib/larql-binaries.sh"
+larql_acquire_binaries
+SERVER_BIN="${LARQL_SERVER_BIN}"
 
 echo "[dec0-arm-l] launching expert server (${URL}, --ffn-only, vindex=${VINDEX})…"
 echo "[dec0-arm-l] first launch downloads the vindex from HuggingFace if not cached — allow a few minutes."
-./target/release/larql-server "${VINDEX}" --ffn-only --port "${PORT}" \
+"${SERVER_BIN}" "${VINDEX}" --ffn-only --port "${PORT}" \
     >"${OUT_DIR}/server-arml-${STAMP}.log" 2>&1 &
 SERVER_PID=$!
 trap 'kill "${SERVER_PID}" 2>/dev/null || true' EXIT
@@ -121,7 +137,7 @@ if [ "${DEC0L_RUN_ANCHOR:-0}" = "1" ]; then
     ANCHOR_VINDEX="${DEC0L_ANCHOR_VINDEX:?set DEC0L_ANCHOR_VINDEX for the anchor arm}"
     for dispatch in streaming batch; do
         echo "[dec0-arm-l] anchor arm: --ffn-dispatch ${dispatch}…"
-        ./target/release/larql bench "${ANCHOR_VINDEX}" \
+        "${LARQL_BIN}" bench "${ANCHOR_VINDEX}" \
             --ffn "${URL}" \
             --ffn-dispatch "${dispatch}" \
             --wire f32,f16,i8 \
@@ -136,7 +152,7 @@ fi
 DENSE_PULSE="${OUT_DIR}/dec0_arml_dense_pulse_${STAMP}.jsonl"
 DENSE_RECORD="${OUT_DIR}/dec0_arml_dense_replay_${STAMP}.json"
 echo "[dec0-arm-l] dense replay sweep: batch {${BATCHES}} × wire {${DENSE_WIRES}} × dispatch {streaming,batch}…"
-./target/release/larql dec-bench replay \
+"${LARQL_BIN}" dec-bench replay \
     --ffn "${URL}" \
     --capture "${DENSE_POOL}" \
     --endpoint walk-ffn \
@@ -154,7 +170,7 @@ echo "[dec0-arm-l] dense replay sweep: batch {${BATCHES}} × wire {${DENSE_WIRES
 ROUTED_PULSE="${OUT_DIR}/dec0_arml_routed_pulse_${STAMP}.jsonl"
 ROUTED_RECORD="${OUT_DIR}/dec0_arml_routed_replay_${STAMP}.json"
 echo "[dec0-arm-l] routed replay sweep: batch {${BATCHES}} × wire {${ROUTED_WIRES}} × dispatch {streaming,batch}…"
-./target/release/larql dec-bench replay \
+"${LARQL_BIN}" dec-bench replay \
     --ffn "${URL}" \
     --capture "${ROUTED_POOL}" \
     --endpoint experts \

--- a/scripts/dec0p5-x86.sh
+++ b/scripts/dec0p5-x86.sh
@@ -1,16 +1,31 @@
 #!/usr/bin/env bash
 # DEC-0.5 — x86 expert-tier kernel gate (docs/dec-funnel.md v0.5 §3).
 #
-# Runs ON the rented x86 box (Ubuntu, ≥128GB RAM). Turnkey: clone/build,
-# fetch the expert-server vindex slice + replay pools from HF, run the
-# per-core kernel bench + the serving-level replay points, print the
-# gate inputs. Designed to fit inside a ≤3h lease with time to spare.
+# Runs ON the rented x86 box (Ubuntu, ≥128GB RAM). Turnkey: clone, fetch
+# the expert-server vindex slice + replay pools from HF, run the per-core
+# kernel bench + the serving-level replay points, print the gate inputs.
+# Designed to fit inside a ≤3h lease with time to spare.
+#
+# Binaries: `larql`/`larql-server` are FETCHED from the tagged release
+# (ADR-0026), not built. The criterion kernel bench is the one thing still
+# compiled here — it is the measurement object, not a shipped artifact —
+# and it builds `larql-compute` alone, a much smaller graph than the CLI
+# and server the fetch removed from the critical path.
 #
 # Prereqs on the box: git, curl, build-essential, pkg-config, libssl-dev,
-# python3-pip (for huggingface_hub). Rust installed by this script.
+# python3-pip (for huggingface_hub). Rust installed by this script (still
+# needed for the bench).
 #
 # Usage:
 #   HF_TOKEN=hf_... ./scripts/dec0p5-x86.sh [COMMIT]
+#
+# Optional env vars:
+#   DEC0P5_LARQL_VERSION   — release tag to fetch (default: v0.1.0)
+#   DEC0P5_BIN_DIR         — where fetched binaries land (default: $OUT/bin)
+#   DEC0P5_LARQL_BIN / DEC0P5_SERVER_BIN
+#                          — use these binaries, skip acquisition
+#   DEC0P5_ALLOW_SOURCE_BUILD=1
+#                          — permit building larql itself on a GPU host
 #
 # Outputs under ./dec0p5-out/: kernel bench log, replay run records +
 # pulses (dense q8k B8 + routed experts-ml-q8k B8), kernel_class line,
@@ -44,16 +59,34 @@ snapshot_download("chrishayuk/dec0-residual-pools", repo_type="dataset",
                   local_dir="pools")
 PYEOF
 
-echo "[dec0p5] building release…"
-cargo build --release -p larql-cli -p larql-server 2>&1 | tail -1
+# ── Serving binaries (ADR-0026) ─────────────────────────────────────────
+# Fetched, not built: `larql` + `larql-server` are shipped artifacts, and
+# this box may carry an incidental GPU (the funnel's infra table provisions
+# "cheapest attached" for DEC-0.5 because some marketplace tiers require
+# one). The kernel bench below is the exception — see its note.
+LARQL_RELEASE_VERSION="${DEC0P5_LARQL_VERSION:-v0.1.0}"
+LARQL_BIN_DIR="${DEC0P5_BIN_DIR:-$OUT/bin}"
+LARQL_BIN="${DEC0P5_LARQL_BIN:-}"
+LARQL_SERVER_BIN="${DEC0P5_SERVER_BIN:-}"
+LARQL_ALLOW_SOURCE_BUILD="${DEC0P5_ALLOW_SOURCE_BUILD:-0}"
+LARQL_LOG_PREFIX="dec0p5"
+# cwd is the cloned repo root at this point, so the helper resolves here.
+# shellcheck source=lib/larql-binaries.sh
+. scripts/lib/larql-binaries.sh
+larql_acquire_binaries
 
 # ── 1. Per-core kernel bench (single-thread GiB/s; AVX2-or-scalar on x86,
 #      the startup kernel_class line pins which) ─────────────────────────
-echo "[dec0p5] kernel bench (single-thread)…"
+# This one MUST compile from source and is deliberately exempt from the
+# fetch-don't-build rule: a criterion bench target is not a shipped binary,
+# and the kernel it times is the object DEC-0.5 exists to measure. It builds
+# `larql-compute` only — a far smaller graph than larql-cli + larql-server,
+# which is precisely what the fetch above removed from the critical path.
+echo "[dec0p5] kernel bench (single-thread, compiled from source — the measurement object)…"
 cargo bench -p larql-compute --bench q4k_q8k_matvec 2>&1 | tee "$OUT/kernel-bench.log" | grep -E "GiB|time:|thrpt" | head -20
 
 # ── 2. Serving-level points (loopback on this box) ──────────────────────
-./target/release/larql-server vindex-expert-server --ffn-only --port 8080 \
+"${LARQL_SERVER_BIN}" vindex-expert-server --ffn-only --port 8080 \
     > "$OUT/server.log" 2>&1 &
 SRV=$!
 trap 'kill "$SRV" 2>/dev/null || true' EXIT
@@ -65,13 +98,13 @@ done
 grep -E "kernel class|decode options" "$OUT/server.log" | tee "$OUT/kernel-class.txt"
 
 echo "[dec0p5] dense q8k replay point (B ∈ {1,8}, batch dispatch)…"
-./target/release/larql dec-bench replay --ffn $URL --capture pools/dense \
+"${LARQL_BIN}" dec-bench replay --ffn $URL --capture pools/dense \
     --endpoint walk-ffn --wire q8k --batch 1,8 --dispatch batch --repeats 3 \
     --net-rtt-ms 0.05 --net-gbps 0 \
     --output-file "$OUT/dense-q8k.json" --pulse-file "$OUT/dense-q8k.jsonl"
 
 echo "[dec0p5] routed experts-ml-q8k replay point (B ∈ {1,8}, batch dispatch)…"
-./target/release/larql dec-bench replay --ffn $URL --capture pools/routed \
+"${LARQL_BIN}" dec-bench replay --ffn $URL --capture pools/routed \
     --endpoint experts --wire q8k --batch 1,8 --dispatch batch --repeats 3 \
     --net-rtt-ms 0.05 --net-gbps 0 \
     --output-file "$OUT/routed-q8k.json" --pulse-file "$OUT/routed-q8k.jsonl"

--- a/scripts/lib/larql-binaries.sh
+++ b/scripts/lib/larql-binaries.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Shared binary acquisition for DEC stage drivers (docs/adr/0026-tagged-release-binaries.md).
+#
+# Hard policy, not an optimisation: GPU-provisioned hosts NEVER build larql
+# from source. A cold `cargo build --release` is 20-40 minutes of pure CPU
+# work (dozens of dependency crates, wasmtime transitively) during which the
+# GPU allocation sits idle. If no release artifact exists for the platform,
+# that is a blocker on the dispatch, not something to work around by building
+# on the box anyway.
+#
+# Usage — set any of the inputs below, then source and call:
+#
+#     LARQL_LOG_PREFIX=dec0-arm-l
+#     . "${SCRIPT_DIR}/lib/larql-binaries.sh"
+#     larql_acquire_binaries
+#
+# Afterwards LARQL_BIN and LARQL_SERVER_BIN hold usable paths.
+#
+# Inputs (all optional):
+#   LARQL_RELEASE_VERSION       release tag to fetch        (default: v0.1.0)
+#   LARQL_BIN_DIR               where fetched binaries land (default: ./larql-bin)
+#   LARQL_BIN                   use this `larql`, skip acquisition
+#   LARQL_SERVER_BIN            use this `larql-server`, skip acquisition
+#   LARQL_ALLOW_SOURCE_BUILD=1  permit `cargo build` even on a GPU host
+#   LARQL_LOG_PREFIX            log tag                     (default: larql)
+#
+# Resolution order: operator-supplied → reuse populated BIN_DIR → fetch the
+# release archive → build from source (GPU-gated).
+
+LARQL_RELEASE_VERSION="${LARQL_RELEASE_VERSION:-v0.1.0}"
+LARQL_BIN_DIR="${LARQL_BIN_DIR:-./larql-bin}"
+LARQL_BIN="${LARQL_BIN:-}"
+LARQL_SERVER_BIN="${LARQL_SERVER_BIN:-}"
+LARQL_ALLOW_SOURCE_BUILD="${LARQL_ALLOW_SOURCE_BUILD:-0}"
+LARQL_LOG_PREFIX="${LARQL_LOG_PREFIX:-larql}"
+
+_larql_log() { echo "[${LARQL_LOG_PREFIX}] $*"; }
+
+larql_detect_target() {
+    case "$(uname -s)/$(uname -m)" in
+        Linux/x86_64)  echo "x86_64-unknown-linux-gnu" ;;
+        Darwin/arm64)  echo "aarch64-apple-darwin" ;;
+        *)             echo "" ;;
+    esac
+}
+
+larql_fetch_binaries() {
+    local target="$1"
+    local url="https://github.com/chrishayuk/larql/releases/download/${LARQL_RELEASE_VERSION}/larql-${target}.tar.gz"
+    local tmp
+    _larql_log "fetching prebuilt binaries: ${url}"
+    tmp="$(mktemp)"
+    if ! curl -fsSL "${url}" -o "${tmp}"; then
+        rm -f "${tmp}"
+        return 1
+    fi
+    mkdir -p "${LARQL_BIN_DIR}"
+    tar -xzf "${tmp}" -C "${LARQL_BIN_DIR}" --strip-components=1
+    rm -f "${tmp}"
+    chmod +x "${LARQL_BIN_DIR}/larql" "${LARQL_BIN_DIR}/larql-server"
+}
+
+larql_acquire_binaries() {
+    local target
+
+    if [ -n "${LARQL_BIN}" ] && [ -n "${LARQL_SERVER_BIN}" ]; then
+        _larql_log "using operator-supplied binaries."
+    elif [ -x "${LARQL_BIN_DIR}/larql" ] && [ -x "${LARQL_BIN_DIR}/larql-server" ]; then
+        LARQL_BIN="${LARQL_BIN_DIR}/larql"
+        LARQL_SERVER_BIN="${LARQL_BIN_DIR}/larql-server"
+        _larql_log "reusing binaries already in ${LARQL_BIN_DIR}."
+    else
+        target="$(larql_detect_target)"
+        if [ -n "${target}" ] && larql_fetch_binaries "${target}"; then
+            LARQL_BIN="${LARQL_BIN_DIR}/larql"
+            LARQL_SERVER_BIN="${LARQL_BIN_DIR}/larql-server"
+        elif command -v nvidia-smi >/dev/null 2>&1 && [ "${LARQL_ALLOW_SOURCE_BUILD}" != "1" ]; then
+            echo "[${LARQL_LOG_PREFIX}] no release artifact for '${target:-unsupported platform}'" \
+                 "at ${LARQL_RELEASE_VERSION}, and this host has a GPU (nvidia-smi present)." >&2
+            echo "[${LARQL_LOG_PREFIX}] REFUSING to build larql from source on a GPU box —" \
+                 "ADR-0026 policy. Publish a release for this platform, pass LARQL_BIN/" \
+                 "LARQL_SERVER_BIN, or re-run on a CPU-only host. Override with" \
+                 "LARQL_ALLOW_SOURCE_BUILD=1 only if you accept burning the GPU" \
+                 "allocation on compilation." >&2
+            exit 1
+        else
+            # Two ways to land here, and they are NOT the same event — say which.
+            if command -v nvidia-smi >/dev/null 2>&1; then
+                _larql_log "no release artifact for '${target:-unsupported platform}' at ${LARQL_RELEASE_VERSION};" \
+                           "building from source on a host WITH a GPU because" \
+                           "LARQL_ALLOW_SOURCE_BUILD=1 was set — the ADR-0026 policy was" \
+                           "deliberately overridden, and the GPU is idle for this build."
+            else
+                _larql_log "no release artifact for '${target:-unsupported platform}' at ${LARQL_RELEASE_VERSION};" \
+                           "building from source (no GPU detected, so ADR-0026 permits it)…"
+            fi
+            # --no-default-features mirrors larql-cli.yml's Linux CI job: default
+            # features enable Metal (an empty crate off-macOS, but it still drags
+            # larql-{inference,kv,vindex}/gpu and a wider dependency graph —
+            # aws-lc-sys among others) that the CPU-only expert-server path never uses.
+            cargo build --release -p larql-cli -p larql-server --no-default-features
+            LARQL_BIN="./target/release/larql"
+            LARQL_SERVER_BIN="./target/release/larql-server"
+        fi
+    fi
+
+    _larql_log "larql: $("${LARQL_BIN}" --version 2>&1 | head -1)"
+}


### PR DESCRIPTION
Follows #187 and the `v0.1.0` release. Turns ADR-0026's "GPU hosts never build from source" from a documented policy into an enforced one, and unblocks DEC-0 arm L.

## `scripts/lib/larql-binaries.sh` (new)

Factored out rather than duplicated, because every remaining DEC stage (0.5, 1A, 1B, 2, 2.5, 3, CV, 4–7) provisions a fresh host and needs the same thing. Resolution order:

1. Operator-supplied `LARQL_BIN` / `LARQL_SERVER_BIN`
2. Reuse an already-populated `LARQL_BIN_DIR`
3. Fetch the release archive for the detected platform (`LARQL_RELEASE_VERSION`, default `v0.1.0`)
4. `cargo build` — **GPU-gated**

Step 4 refuses and exits non-zero when `nvidia-smi` is present, naming the three legitimate ways forward (publish a release for the platform, pass the binaries, move to a CPU-only host). ADR-0026 says a missing artifact "is a blocker on the dispatch, not something to work around by building on the box anyway" — this enforces that instead of trusting the operator to remember it. `LARQL_ALLOW_SOURCE_BUILD=1` overrides.

## Drivers

- **`dec0-arm-l.sh`** — the acquisition block moved to the helper; `DEC0L_SKIP_BUILD` is gone, since "binaries already present" is now detected rather than asserted by the caller.
- **`dec0p5-x86.sh`** — fetches the CLI and server, with **one deliberate exemption**: it still runs `cargo bench -p larql-compute`. A criterion bench target is not a shipped binary, and that kernel is precisely what DEC-0.5 exists to measure — you cannot fetch your own measurement object. It now compiles `larql-compute` alone instead of the full CLI + server graph. Documented in the script and the ADR so it doesn't read as an oversight.

Also fixes a latent wart in `dec0p5-x86.sh`: its build had no `--no-default-features`, so on Linux it pulled `larql-{inference,kv,vindex}/gpu` and the wider dependency graph the Linux CI job deliberately avoids. Not a breakage — `larql-compute-metal` compiles to an empty crate off-macOS — just slower and inconsistent. The shared fallback matches CI.

## Verification

Every acquisition path exercised for real against the published `v0.1.0`, by truncating a copy of the driver just before the server launch (a full run pulls a ~26 GB vindex):

| Path | Result |
|---|---|
| Fresh fetch | downloads, extracts, chmods, reports `larql 0.1.0` |
| Reuse populated `BIN_DIR` | skips the fetch |
| GPU host + no artifact | refuses, **exit 1** |
| GPU host + override | proceeds to build |
| Operator-supplied | bypasses acquisition, exit 0 |

Re-run against arm-L after the refactor, since collapsing it onto the helper could have broken what was already verified.

**One defect found and fixed during that verification:** the override path logged *"no GPU detected, so ADR-0026 permits it"* — but a GPU **was** detected; the build proceeded only because of the override. A log line that misreports why a policy was bypassed makes the audit trail worse than having none. Both branches now state what actually happened.