### PR TITLE
DEC funnel v0.4/v0.5: release binaries, wire instruments, arm-L driver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,12 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             features: ""
-          - os: ubuntu-latest
+          # Pinned to 22.04, NOT ubuntu-latest: the runner's glibc sets the
+          # binary's minimum. 24.04 (glibc 2.39) emitted a GLIBC_2.38
+          # requirement, which will not load on Colab or any 22.04-class rented
+          # box — i.e. exactly the hosts ADR-0026 exists to serve. Raise this
+          # only when every DEC target host has moved past it.
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             features: "--no-default-features"
           - os: windows-latest

--- a/scripts/lib/larql-binaries.sh
+++ b/scripts/lib/larql-binaries.sh
@@ -104,5 +104,25 @@ larql_acquire_binaries() {
         fi
     fi
 
-    _larql_log "larql: $("${LARQL_BIN}" --version 2>&1 | head -1)"
+    # Gate on the binary actually EXECUTING, not just existing. A fetched
+    # archive can be intact and still unloadable on this host — a
+    # `GLIBC_2.38 not found` on Colab was logged as if it were a version
+    # string, and the driver went on to launch a server that could never
+    # start, costing a full session to diagnose. No measurement may be taken
+    # on a path whose binary was never proven to run.
+    # NB: capture the binary's own status, NOT a pipeline's — `… | head -1`
+    # would report head's success and silently defeat this gate.
+    local version_out version_rc=0
+    version_out="$("${LARQL_BIN}" --version 2>&1)" || version_rc=$?
+    version_out="$(printf '%s\n' "${version_out}" | head -1)"
+    if [ "${version_rc}" -ne 0 ]; then
+        _larql_log "larql: FATAL — fetched binary will not execute on this host:" >&2
+        _larql_log "  ${version_out}" >&2
+        _larql_log "  binary: ${LARQL_BIN}" >&2
+        _larql_log "  If this is a glibc mismatch, the release was built against a" >&2
+        _larql_log "  newer glibc than this host provides — rebuild the release on an" >&2
+        _larql_log "  older runner rather than working around it here (ADR-0026)." >&2
+        exit 1
+    fi
+    _larql_log "larql: ${version_out}"
 }


### PR DESCRIPTION
Brings the DEC funnel branch up to main. Seven commits, spanning the DEC-1A
instrument set, the ADR-0026 release-binary policy, and a Windows mmap fix.

Headline items:

- **Tagged release binaries (ADR-0026)** — `release.yml` cross-builds `larql` +
  `larql-server` for macOS-aarch64 / Linux-x86_64 / Windows-x86_64 under a
  `release-dist` profile. Motivation is policy, not optimisation: GPU-provisioned
  hosts never build from source.
- **Linux binaries pinned to ubuntu-22.04** — v0.1.0 was built on `ubuntu-latest`
  (24.04, glibc 2.39) and required GLIBC_2.38, so it would not load on Colab or
  any 22.04-class rented box. Caught running DEC-0 arm L.
- **Binary acquisition now gates on execution** — the helper logged `--version`
  output without checking status, so a loader error was recorded as if it were a
  version string and the driver launched a server that could never start.
- **DEC-1A instruments** — consolidated dense frame codec, `serve_us` timing
  trailer, asymmetric direction codecs, and `dec-bench drift` (the C6
  wire-fidelity gate). Protocol spec in ADR-0025; G0 decided in ADR-0024.
- **Windows mmap fix** — non-zero anon mmap length so `make_read_only` works,
  unbreaking `larql-vindex` on `windows-latest` after 44 consecutive red runs.

A `v0.1.1` tag follows this merge so the release rebuilds with the glibc fix.