### PR TITLE
docs: correct a stale open item in the bandwidth roofline diagnosis

### DIFF
--- a/docs/diagnoses/memory-bandwidth-roofline.md
+++ b/docs/diagnoses/memory-bandwidth-roofline.md
@@ -213,7 +213,11 @@ case), quiet machine on AC:
   the bytes hypothesis, which is at minimum 2× the traffic and grows linearly in
   context. `TurboQuantEngine` exists in larql-kv but is not on the production
   handle.
-- **End-to-end confirmation of the lm_head fix** on the 26B has not been run.
+- **A quiet-machine re-run of `membw_probe`** would be worth having. The numbers
+  above were taken at load 1.5–1.9 with <3% spreads, but a later re-run during a
+  concurrent `llvm-cov` job (load average 98) produced physically impossible
+  figures — a reminder that this probe has no contention guard beyond the spread
+  column, and that the spread column is the thing to read before the GB/s one.
 
 ## Reproducing
 


### PR DESCRIPTION
Markdown-only. The end-to-end confirmation of the spin-pool fix *was* run (10.6 → 34.9 tok/s, four reps on the 26B — recorded in the Fix section of the same document), so listing it as outstanding was wrong.

Replaced with the item genuinely still owed: a quiet-machine re-run of `membw_probe`, plus the note that its **spread** column rather than its GB/s column is what tells you whether a run is trustworthy — a later re-run during a concurrent `llvm-cov` job (load average 98) produced physically impossible figures.