### PR TITLE
fix(cli): build_cmd should respect vindex dtype when saving gate vectors

### DIFF
--- a/crates/larql-cli/src/commands/extraction/build_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/build_cmd.rs
@@ -80,7 +80,7 @@ pub fn run(args: BuildArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!("\nSaving to {}...", output_dir.display());
 
-    let layer_infos = result.index.save_gate_vectors(&output_dir)?;
+    let layer_infos = result.index.save_gate_vectors_with_config(&output_dir, &result.config)?;
     let dm_count = result.index.save_down_meta(&output_dir)?;
 
     let mut config = result.config;

--- a/crates/larql-cli/src/commands/extraction/build_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/build_cmd.rs
@@ -80,7 +80,9 @@ pub fn run(args: BuildArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!("\nSaving to {}...", output_dir.display());
 
-    let layer_infos = result.index.save_gate_vectors_with_config(&output_dir, &result.config)?;
+    let layer_infos = result
+        .index
+        .save_gate_vectors_with_config(&output_dir, &result.config)?;
     let dm_count = result.index.save_down_meta(&output_dir)?;
 
     let mut config = result.config;


### PR DESCRIPTION
`larql build` currently calls `save_gate_vectors(&output_dir)`, which hardcodes F32 output regardless of the vindex dtype in the build config.

`save_gate_vectors_with_config()` already exists (and is covered by `save_gate_vectors_with_config_preserves_expert_geometry` in `crates/larql-vindex/src/index/mutate/tests.rs`), but the CLI call site never adopted it — so an f16 vindex silently gets F32 gate vectors, doubling their size on disk and diverging from the declared dtype.

One-line change: route the CLI through the config-aware variant. Rebases cleanly onto current `main`.