### PR TITLE
fix(kv): make UnaidedTrial::observe public, clearing the larql-kv clippy gate

### DIFF
--- a/crates/larql-kv/src/engines/semantic_promotion/authority_regime.rs
+++ b/crates/larql-kv/src/engines/semantic_promotion/authority_regime.rs
@@ -113,7 +113,7 @@ impl UnaidedTrial {
     /// excluded. There is deliberately no path that derives it from a
     /// qualification metric: EXP-36's contrast was a decision flip, not
     /// a divergence, and a KL threshold would not have detected it.
-    pub(crate) fn observe(record: RecordId, record_won: bool) -> Self {
+    pub fn observe(record: RecordId, record_won: bool) -> Self {
         Self { record, record_won }
     }
 


### PR DESCRIPTION
main is currently red. `larql-kv.yml` runs `cargo clippy -p larql-kv --all-targets --no-deps -- -D warnings`, and on `2a7c4083` that fails:

```
error: associated function `observe` is never used
  --> crates/larql-kv/src/engines/semantic_promotion/authority_regime.rs:116:19
```

`UnaidedTrial` is re-exported from `semantic_promotion`, and `record()` / `record_won()` are both `pub`, but its only constructor was `pub(crate)` — so nothing outside the type's own tests could call it, and the lib build sees it as dead.

Widening the constructor to `pub` matches the rest of the type's surface and makes the re-export actually usable, rather than silencing the lint over a type callers cannot construct.

Verified locally with the exact CI invocation: clean.