### PR TITLE
fix(inference): clamp dense walk top-k to feature count (rebase of #176)

### DIFF
--- a/crates/larql-inference/src/vindex/walk_ffn/dispatch_tests.rs
+++ b/crates/larql-inference/src/vindex/walk_ffn/dispatch_tests.rs
@@ -97,6 +97,15 @@ fn walk_ffn_new_unlimited() {
 }
 
 #[test]
+fn dense_top_k_for_clamps_to_layer_feature_count() {
+    let weights = shared_weights();
+    let idx = mock_index(weights);
+    let ffn = WalkFfn::new_unlimited(weights, &idx);
+
+    assert_eq!(ffn.top_k_for(0), weights.intermediate_size);
+}
+
+#[test]
 fn walk_ffn_sparse_k() {
     let weights = shared_weights();
     let idx = mock_index(weights);

--- a/crates/larql-inference/src/vindex/walk_ffn/mod.rs
+++ b/crates/larql-inference/src/vindex/walk_ffn/mod.rs
@@ -184,7 +184,9 @@ pub struct WalkFfn<'a> {
 
 impl<'a> WalkFfn<'a> {
     fn top_k_for(&self, layer: usize) -> usize {
-        self.config.k_for(layer).unwrap_or(usize::MAX)
+        self.config
+            .k_for(layer)
+            .unwrap_or_else(|| self.index.num_features(layer))
     }
 
     /// Number of joint-selector calls that degraded to the production


### PR DESCRIPTION
Rebase of #176 by @citizenu03bb onto current `main`. Original authorship preserved on the commit; #176 was 324 commits behind and unmergeable.

Dense walk asked the gate index for `usize::MAX` features instead of the layer's actual feature count.

**What changed in the rebase.** The original patch targeted `walk_ffn/mod.rs` before that module was split. The one-line fix still lands in `mod.rs`; the regression test moves to the extracted `dispatch_tests.rs`. No behavioural change from the original.

**Gates:** `cargo fmt --check` clean, `clippy -p larql-inference --all-targets -D warnings` clean, 158 walk_ffn tests pass including the new `dense_top_k_for_clamps_to_layer_feature_count`.

Closes #176.