### PR TITLE
fix(kv): clear both gates #204 broke — clippy and the 90% coverage floor

### DIFF
--- a/crates/larql-kv/src/engines/semantic_promotion/authority_regime.rs
+++ b/crates/larql-kv/src/engines/semantic_promotion/authority_regime.rs
@@ -113,7 +113,7 @@ impl UnaidedTrial {
     /// excluded. There is deliberately no path that derives it from a
     /// qualification metric: EXP-36's contrast was a decision flip, not
     /// a divergence, and a KL threshold would not have detected it.
-    pub(crate) fn observe(record: RecordId, record_won: bool) -> Self {
+    pub fn observe(record: RecordId, record_won: bool) -> Self {
         Self { record, record_won }
     }
 

--- a/crates/larql-kv/src/engines/semantic_promotion/tests/engine_delegation.rs
+++ b/crates/larql-kv/src/engines/semantic_promotion/tests/engine_delegation.rs
@@ -1,0 +1,518 @@
+//! The wrapper's `KvEngine` surface.
+//!
+//! `SemanticPromotionEngine` implements every entry point on `KvEngine`,
+//! but the promotion suites only ever drive the two the fixtures use.
+//! The rest are the ones that matter for a wrapper: each must reach the
+//! base engine, and each *prefill* must additionally restart the session
+//! epoch and re-read the architecture's layer classification while each
+//! *decode* advances the token position by one.
+//!
+//! Getting that wrong is not a crash. A prefill variant that skipped
+//! `on_prefill` would leave the wrapper describing the previous prompt —
+//! stale authority references, a token position that never moved, and a
+//! `layer_attention` read off whichever model was prefilled last. All of
+//! that reads as a working engine right up until a promotion consults it.
+//!
+//! So each variant is asserted on the *observable consequence* of the
+//! bookkeeping, not merely on the call being forwarded.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use larql_inference::ffn::{FfnBackend, NullFfn};
+use larql_inference::kv_engine::{EngineError, EngineInfo};
+use larql_inference::model::ModelWeights;
+use larql_inference::test_utils::{make_test_q4k_vindex, make_test_q4k_weights};
+use ndarray::Array2;
+
+use crate::engines::semantic_promotion::config::SemanticPromotionConfig;
+use crate::engines::semantic_promotion::engine::SemanticPromotionEngine;
+use crate::KvEngine;
+
+const HIDDEN: usize = 4;
+
+/// A prefill invocation that returns its hidden state, so the variant
+/// loop can assert on the result as well as the bookkeeping.
+type Call = Box<dyn Fn(&mut SemanticPromotionEngine) -> Result<Array2<f32>, EngineError>>;
+/// A prefill invocation whose borrows are built inside the closure.
+type Drive = Box<dyn Fn(&mut SemanticPromotionEngine)>;
+
+/// Records which entry points were reached, so delegation can be
+/// asserted without the base engine doing any real work.
+#[derive(Default)]
+struct Calls {
+    prefill: AtomicUsize,
+    decode: AtomicUsize,
+    names: std::sync::Mutex<Vec<&'static str>>,
+}
+
+impl Calls {
+    fn note(&self, what: &'static str, is_prefill: bool) {
+        if is_prefill {
+            self.prefill.fetch_add(1, Ordering::SeqCst);
+        } else {
+            self.decode.fetch_add(1, Ordering::SeqCst);
+        }
+        self.names.lock().unwrap().push(what);
+    }
+    fn last(&self) -> Option<&'static str> {
+        self.names.lock().unwrap().last().copied()
+    }
+}
+
+/// A base engine that reaches none of the real machinery. Returns a
+/// well-shaped hidden state so the wrapper's success path runs.
+struct RecordingEngine {
+    calls: Arc<Calls>,
+    rows: usize,
+    fail: bool,
+}
+
+impl RecordingEngine {
+    fn out(&self) -> Result<Array2<f32>, EngineError> {
+        if self.fail {
+            return Err(EngineError::BackendFailure {
+                details: "test stub: fail set".into(),
+            });
+        }
+        Ok(Array2::zeros((self.rows, HIDDEN)))
+    }
+}
+
+impl KvEngine for RecordingEngine {
+    fn name(&self) -> &str {
+        "recording"
+    }
+    fn info(&self) -> EngineInfo {
+        EngineInfo {
+            name: "recording".into(),
+            description: "test fixture".into(),
+            backend: "cpu".into(),
+            config: "base-config".into(),
+        }
+    }
+    fn prefill(
+        &mut self,
+        _w: &ModelWeights,
+        _f: &dyn FfnBackend,
+        ids: &[u32],
+    ) -> Result<Array2<f32>, EngineError> {
+        self.rows = ids.len();
+        self.calls.note("prefill", true);
+        self.out()
+    }
+    fn decode_step(
+        &mut self,
+        _w: &ModelWeights,
+        _f: &dyn FfnBackend,
+        _t: u32,
+    ) -> Result<Array2<f32>, EngineError> {
+        self.calls.note("decode_step", false);
+        self.out()
+    }
+    fn supports_multimodal(&self) -> bool {
+        true
+    }
+    fn prefill_from_hidden(
+        &mut self,
+        _w: &ModelWeights,
+        _f: &dyn FfnBackend,
+        h: &Array2<f32>,
+    ) -> Result<Array2<f32>, EngineError> {
+        self.rows = h.nrows();
+        self.calls.note("prefill_from_hidden", true);
+        self.out()
+    }
+    fn memory_bytes(&self) -> usize {
+        1234
+    }
+    fn window_tokens(&self) -> usize {
+        77
+    }
+    fn cold_bytes(&self) -> usize {
+        99
+    }
+    fn prefill_quant(
+        &mut self,
+        _w: &ModelWeights,
+        _f: &dyn FfnBackend,
+        _i: &larql_vindex::VectorIndex,
+        ids: &[u32],
+        _b: &dyn larql_compute::ComputeBackend,
+    ) -> Result<Array2<f32>, EngineError> {
+        self.rows = ids.len();
+        self.calls.note("prefill_quant", true);
+        self.out()
+    }
+    fn decode_step_quant(
+        &mut self,
+        _w: &ModelWeights,
+        _f: &dyn FfnBackend,
+        _i: &larql_vindex::VectorIndex,
+        _t: u32,
+        _b: &dyn larql_compute::ComputeBackend,
+    ) -> Result<Array2<f32>, EngineError> {
+        self.calls.note("decode_step_quant", false);
+        self.out()
+    }
+    fn prefill_resident(
+        &mut self,
+        _w: &ModelWeights,
+        _f: &dyn FfnBackend,
+        _i: &larql_vindex::VectorIndex,
+        ids: &[u32],
+    ) -> Result<Array2<f32>, EngineError> {
+        self.rows = ids.len();
+        self.calls.note("prefill_resident", true);
+        self.out()
+    }
+    fn decode_step_resident(
+        &mut self,
+        _w: &ModelWeights,
+        _f: &dyn FfnBackend,
+        _i: &larql_vindex::VectorIndex,
+        _t: u32,
+    ) -> Result<Array2<f32>, EngineError> {
+        self.calls.note("decode_step_resident", false);
+        self.out()
+    }
+    fn prefill_via_executor(
+        &mut self,
+        _w: &ModelWeights,
+        _e: &dyn larql_inference::layer_executor::LayerExecutor,
+        _f: &dyn FfnBackend,
+        ids: &[u32],
+    ) -> Result<Array2<f32>, EngineError> {
+        self.rows = ids.len();
+        self.calls.note("prefill_via_executor", true);
+        self.out()
+    }
+    fn decode_step_via_executor(
+        &mut self,
+        _w: &ModelWeights,
+        _e: &dyn larql_inference::layer_executor::LayerExecutor,
+        _f: &dyn FfnBackend,
+        _t: u32,
+    ) -> Result<Array2<f32>, EngineError> {
+        self.calls.note("decode_step_via_executor", false);
+        self.out()
+    }
+    fn prefill_quant_via_executor(
+        &mut self,
+        _w: &ModelWeights,
+        _e: &dyn larql_inference::layer_executor::LayerExecutor,
+        _f: &dyn FfnBackend,
+        _i: &larql_vindex::VectorIndex,
+        ids: &[u32],
+    ) -> Result<Array2<f32>, EngineError> {
+        self.rows = ids.len();
+        self.calls.note("prefill_quant_via_executor", true);
+        self.out()
+    }
+    fn decode_step_quant_via_executor(
+        &mut self,
+        _w: &ModelWeights,
+        _e: &dyn larql_inference::layer_executor::LayerExecutor,
+        _f: &dyn FfnBackend,
+        _i: &larql_vindex::VectorIndex,
+        _t: u32,
+    ) -> Result<Array2<f32>, EngineError> {
+        self.calls.note("decode_step_quant_via_executor", false);
+        self.out()
+    }
+}
+
+/// A `LayerExecutor` that is only ever passed through — the recording
+/// base engine never calls back into it.
+struct PassthroughExecutor(Box<dyn larql_compute::ComputeBackend>);
+
+impl larql_inference::layer_executor::LayerExecutor for PassthroughExecutor {
+    fn backend(&self) -> &dyn larql_compute::ComputeBackend {
+        self.0.as_ref()
+    }
+    fn dispatch_kind(&self) -> larql_inference::layer_executor::ExecutorDispatchKind {
+        larql_inference::layer_executor::ExecutorDispatchKind::Fused
+    }
+    fn name(&self) -> &str {
+        "passthrough"
+    }
+}
+
+fn wrap(calls: Arc<Calls>, fail: bool) -> SemanticPromotionEngine {
+    SemanticPromotionEngine::new(
+        Box::new(RecordingEngine {
+            calls,
+            rows: 1,
+            fail,
+        }),
+        SemanticPromotionConfig::default(),
+    )
+    .expect("observe mode is admissible with ffn-only capabilities")
+}
+
+fn engine() -> (SemanticPromotionEngine, Arc<Calls>) {
+    let calls = Arc::new(Calls::default());
+    (wrap(Arc::clone(&calls), false), calls)
+}
+
+// ── identity and reporting ───────────────────────────────────────────────
+
+/// The wrapper names itself in terms of what it wraps, and its `info`
+/// carries the base engine's own config alongside its own.
+#[test]
+fn name_and_info_are_composed_from_the_base_engine() {
+    let (e, _) = engine();
+    assert_eq!(e.name(), "semantic-promotion(recording)");
+
+    let info = e.info();
+    assert_eq!(info.name, "semantic-promotion(recording)");
+    assert_eq!(info.backend, "cpu");
+    assert!(
+        info.description.contains("recording"),
+        "info should name the wrapped engine: {}",
+        info.description
+    );
+    assert!(
+        info.config.contains("base[base-config]"),
+        "info should carry the base config: {}",
+        info.config
+    );
+}
+
+/// Observe mode advertises bit-identical decode. That string is the
+/// wrapper's own claim about itself, and the promotion suites rely on
+/// it, so it must track the mode rather than being fixed text.
+#[test]
+fn info_describes_observe_mode_as_bit_identical() {
+    let (e, _) = engine();
+    assert!(
+        e.info().description.contains("bit-identical"),
+        "observe mode must say decode is unchanged: {}",
+        e.info().description
+    );
+    assert!(e.session().is_passthrough());
+}
+
+/// Pure reporting is forwarded rather than answered by the wrapper —
+/// the wrapper holds no cache of its own.
+#[test]
+fn size_and_capability_reporting_is_forwarded() {
+    let (e, _) = engine();
+    assert_eq!(e.memory_bytes(), 1234);
+    assert_eq!(e.window_tokens(), 77);
+    assert_eq!(e.cold_bytes(), 99);
+    assert!(e.supports_multimodal());
+    // `stage_summary` has no stub value; it must still reach the base.
+    assert!(e.stage_summary().is_none());
+}
+
+#[test]
+fn debug_reports_the_wrappers_own_policy_state() {
+    let (e, _) = engine();
+    let rendered = format!("{e:?}");
+    assert!(rendered.contains("SemanticPromotionEngine"), "{rendered}");
+    assert!(
+        rendered.contains("semantic-promotion(recording)"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("session_epoch"), "{rendered}");
+}
+
+#[test]
+fn accessors_expose_the_wrapped_engine_and_its_own_config() {
+    let (mut e, _) = engine();
+    assert_eq!(e.base().name(), "recording");
+    assert_eq!(e.base_mut().name(), "recording");
+    assert_eq!(e.config().mode, SemanticPromotionConfig::default().mode);
+    assert!(e.capabilities().caller_supplied_ffn_backend);
+    assert_eq!(e.metrics().promotions_committed, 0);
+    assert!(e.journal().is_none());
+    assert!(e.layer_attention().is_none(), "nothing prefilled yet");
+    // `session_mut` is the planner's handle onto the same session.
+    assert_eq!(e.session_mut().token_position(), 0);
+}
+
+// ── prefill variants ─────────────────────────────────────────────────────
+
+/// Every prefill entry point must restart the session epoch, mirror the
+/// prompt length into the token position, and read the architecture's
+/// layer classification. A variant that skipped this would leave the
+/// wrapper describing the previous prompt.
+#[test]
+fn every_prefill_variant_restarts_the_session_and_reads_the_architecture() {
+    let weights = make_test_q4k_weights();
+    let index = make_test_q4k_vindex(&weights);
+    let backend = larql_compute::cpu_backend();
+    let executor = PassthroughExecutor(larql_compute::cpu_backend());
+    let ids = [1u32, 2, 3];
+
+    // (label, invocation)
+    let variants: Vec<(&str, Call)> = vec![
+        (
+            "prefill",
+            Box::new(|e: &mut SemanticPromotionEngine| {
+                let w = make_test_q4k_weights();
+                e.prefill(&w, &NullFfn, &[1, 2, 3])
+            }),
+        ),
+        (
+            "prefill_from_hidden",
+            Box::new(|e: &mut SemanticPromotionEngine| {
+                let w = make_test_q4k_weights();
+                let h = Array2::zeros((3, w.hidden_size));
+                e.prefill_from_hidden(&w, &NullFfn, &h)
+            }),
+        ),
+    ];
+
+    for (label, call) in variants {
+        let (mut e, calls) = engine();
+        let epoch_before = e.session_epoch();
+        call(&mut e).unwrap_or_else(|err| panic!("{label} should succeed: {err:?}"));
+
+        assert_eq!(calls.prefill.load(Ordering::SeqCst), 1, "{label} delegated");
+        assert_eq!(calls.last(), Some(label), "{label} reached its own entry");
+        assert_eq!(
+            e.session_epoch(),
+            epoch_before + 1,
+            "{label} must start a new session epoch"
+        );
+        assert_eq!(
+            e.session().token_position(),
+            ids.len() as u64,
+            "{label} must mirror the prompt length"
+        );
+        assert!(
+            e.layer_attention().is_some(),
+            "{label} must read the layer classification"
+        );
+    }
+
+    // The index/backend/executor-bearing variants, driven directly so
+    // their borrows stay simple.
+    let cases: Vec<(&str, Drive)> = vec![
+        (
+            "prefill_quant",
+            Box::new(|e: &mut SemanticPromotionEngine| {
+                let w = make_test_q4k_weights();
+                let i = make_test_q4k_vindex(&w);
+                let b = larql_compute::cpu_backend();
+                e.prefill_quant(&w, &NullFfn, &i, &[1, 2, 3], &*b)
+                    .expect("prefill_quant");
+            }),
+        ),
+        (
+            "prefill_resident",
+            Box::new(|e: &mut SemanticPromotionEngine| {
+                let w = make_test_q4k_weights();
+                let i = make_test_q4k_vindex(&w);
+                e.prefill_resident(&w, &NullFfn, &i, &[1, 2, 3])
+                    .expect("prefill_resident");
+            }),
+        ),
+    ];
+    for (label, call) in cases {
+        let (mut e, calls) = engine();
+        call(&mut e);
+        assert_eq!(calls.last(), Some(label));
+        assert_eq!(e.session_epoch(), 2, "{label} must start a new epoch");
+        assert_eq!(e.session().token_position(), 3, "{label} mirrors length");
+        assert!(e.layer_attention().is_some(), "{label} reads architecture");
+    }
+
+    // Executor-bearing prefills.
+    for label in ["prefill_via_executor", "prefill_quant_via_executor"] {
+        let (mut e, calls) = engine();
+        let out = if label == "prefill_via_executor" {
+            e.prefill_via_executor(&weights, &executor, &NullFfn, &ids)
+        } else {
+            e.prefill_quant_via_executor(&weights, &executor, &NullFfn, &index, &ids)
+        };
+        out.unwrap_or_else(|err| panic!("{label}: {err:?}"));
+        assert_eq!(calls.last(), Some(label));
+        assert_eq!(e.session_epoch(), 2, "{label} must start a new epoch");
+        assert_eq!(e.session().token_position(), 3, "{label} mirrors length");
+        assert!(e.layer_attention().is_some(), "{label} reads architecture");
+    }
+    let _ = backend;
+}
+
+// ── decode variants ──────────────────────────────────────────────────────
+
+/// Every decode entry point advances the token position by exactly one.
+/// The position is what scopes an answer boundary, so a variant that
+/// forgot to advance would let a scope outlive the answer it was
+/// qualified for.
+#[test]
+fn every_decode_variant_advances_the_token_position_by_one() {
+    let weights = make_test_q4k_weights();
+    let index = make_test_q4k_vindex(&weights);
+    let backend = larql_compute::cpu_backend();
+    let executor = PassthroughExecutor(larql_compute::cpu_backend());
+
+    for label in [
+        "decode_step",
+        "decode_step_quant",
+        "decode_step_resident",
+        "decode_step_via_executor",
+        "decode_step_quant_via_executor",
+    ] {
+        let (mut e, calls) = engine();
+        e.prefill(&weights, &NullFfn, &[1, 2, 3]).expect("prefill");
+        let before = e.session().token_position();
+
+        let out = match label {
+            "decode_step" => e.decode_step(&weights, &NullFfn, 9),
+            "decode_step_quant" => e.decode_step_quant(&weights, &NullFfn, &index, 9, &*backend),
+            "decode_step_resident" => e.decode_step_resident(&weights, &NullFfn, &index, 9),
+            "decode_step_via_executor" => {
+                e.decode_step_via_executor(&weights, &executor, &NullFfn, 9)
+            }
+            _ => e.decode_step_quant_via_executor(&weights, &executor, &NullFfn, &index, 9),
+        };
+        out.unwrap_or_else(|err| panic!("{label}: {err:?}"));
+
+        assert_eq!(calls.last(), Some(label), "{label} reached its own entry");
+        assert_eq!(calls.decode.load(Ordering::SeqCst), 1, "{label} delegated");
+        assert_eq!(
+            e.session().token_position(),
+            before + 1,
+            "{label} must advance the position by exactly one"
+        );
+    }
+}
+
+// ── failure ──────────────────────────────────────────────────────────────
+
+/// A failed prefill must not restart the session. Bookkeeping runs only
+/// on success, so a base engine that refused leaves the wrapper
+/// describing the state that is actually still resident.
+#[test]
+fn a_failed_prefill_does_not_restart_the_session() {
+    let calls = Arc::new(Calls::default());
+    let mut e = wrap(Arc::clone(&calls), true);
+    let weights = make_test_q4k_weights();
+
+    let epoch_before = e.session_epoch();
+    assert!(e.prefill(&weights, &NullFfn, &[1, 2, 3]).is_err());
+
+    assert_eq!(e.session_epoch(), epoch_before, "epoch must not advance");
+    assert_eq!(e.session().token_position(), 0, "position must not move");
+    assert!(
+        e.layer_attention().is_none(),
+        "a refused prefill must not publish a layer classification"
+    );
+}
+
+/// Likewise a failed decode leaves the position where it was — an
+/// advanced position after a refused step would misplace every
+/// subsequent boundary.
+#[test]
+fn a_failed_decode_does_not_advance_the_position() {
+    let calls = Arc::new(Calls::default());
+    let mut e = wrap(Arc::clone(&calls), true);
+    let weights = make_test_q4k_weights();
+
+    assert!(e.decode_step(&weights, &NullFfn, 9).is_err());
+    assert_eq!(e.session().token_position(), 0);
+}

--- a/crates/larql-kv/src/engines/semantic_promotion/tests/mod.rs
+++ b/crates/larql-kv/src/engines/semantic_promotion/tests/mod.rs
@@ -4,6 +4,7 @@
 //! cross-module ones: G0 parity, the FFN-dispatch gate, the lifecycle
 //! refusals, and the EXP-25 qualification matrix expressed as policy.
 
+mod engine_delegation;
 mod fixtures;
 mod lifecycle;
 mod parity;
@@ -11,3 +12,4 @@ mod position_seam;
 mod qualification_gate;
 mod row_position_storage;
 mod window_policy_gates;
+mod window_policy_refusals;

--- a/crates/larql-kv/src/engines/semantic_promotion/tests/window_policy_refusals.rs
+++ b/crates/larql-kv/src/engines/semantic_promotion/tests/window_policy_refusals.rs
@@ -1,0 +1,236 @@
+//! **R8-policy — refusals and reporting.**
+//!
+//! `window_policy_gates` drives the policy over a real `StandardEngine`,
+//! so it only reaches caches that already satisfy every precondition.
+//! These cover the other direction: the refusals the policy owes a
+//! caller whose cache cannot express the question, and the reporting
+//! helpers on the outcome.
+//!
+//! Every refusal here fires *before* a row is touched. That ordering is
+//! the point — a policy that clipped some layers and then discovered it
+//! could not clip the rest would leave the cache in a state no caller
+//! asked for, and `WindowPolicyOutcome` would describe a cache that no
+//! longer exists.
+
+use larql_inference::kv_engine::{ExcisedKvRows, PerLayerKvAccess};
+use larql_inference::kv_row_positions::KvRowPositions;
+use ndarray::Array2;
+
+use crate::engines::semantic_promotion::error::PromotionError;
+use crate::engines::semantic_promotion::exclusion::LayerAttention;
+use crate::engines::semantic_promotion::window_policy::{apply_window_policy, WindowPolicyOutcome};
+
+/// A cache whose capabilities are dialled in directly, so each
+/// precondition can be withdrawn on its own. Only the methods the policy
+/// actually consults do anything.
+struct StubCache {
+    layer_count: Option<usize>,
+    positions: Option<KvRowPositions>,
+    /// What `clip_layer_to_logical_window` returns; `None` models a
+    /// layer that refused the clip.
+    clip_result: Option<usize>,
+    clip_calls: std::cell::Cell<usize>,
+}
+
+impl StubCache {
+    fn new(layers: usize) -> Self {
+        Self {
+            layer_count: Some(layers),
+            positions: Some(KvRowPositions::contiguous(layers, 0)),
+            clip_result: Some(0),
+            clip_calls: std::cell::Cell::new(0),
+        }
+    }
+}
+
+impl PerLayerKvAccess for StubCache {
+    fn layer_count(&self) -> Option<usize> {
+        self.layer_count
+    }
+    fn logical_next_position(&self) -> usize {
+        0
+    }
+    fn resident_rows(&self, _layer: usize) -> Option<usize> {
+        Some(0)
+    }
+    fn read_layer_kv(&self, _layer: usize) -> Option<(Array2<f32>, Array2<f32>)> {
+        None
+    }
+    fn excise_kv_rows(
+        &mut self,
+        _layer: usize,
+        _rows: std::ops::Range<usize>,
+    ) -> Option<ExcisedKvRows> {
+        None
+    }
+    fn splice_kv_rows(&mut self, _layer: usize, _at: usize, _rows: &ExcisedKvRows) -> bool {
+        false
+    }
+    fn replace_layer_kv(
+        &mut self,
+        _layer: usize,
+        _k: &Array2<f32>,
+        _v: &Array2<f32>,
+        _positions: &[u64],
+    ) -> bool {
+        false
+    }
+    fn row_positions(&self) -> Option<&KvRowPositions> {
+        self.positions.as_ref()
+    }
+    fn set_logical_next_position(&mut self, _position: usize) -> bool {
+        false
+    }
+    fn clip_layer_to_logical_window(&mut self, _layer: usize, _window: u64) -> Option<usize> {
+        self.clip_calls.set(self.clip_calls.get() + 1);
+        self.clip_result
+    }
+}
+
+/// `n` layers, the first `sliding` of them sliding, with `window`
+/// declared.
+fn attention(n: usize, sliding: usize, window: Option<usize>) -> LayerAttention {
+    LayerAttention {
+        is_sliding: (0..n).map(|i| i < sliding).collect(),
+        sliding_window: window,
+    }
+}
+
+// ── outcome reporting ────────────────────────────────────────────────────
+
+/// `total_rows_dropped` sums across layers; `is_no_op` is that total
+/// being zero. A cache already inside every window it declares is not a
+/// failure, and must not read as one.
+#[test]
+fn outcome_totals_and_no_op_reporting() {
+    let empty = WindowPolicyOutcome::default();
+    assert_eq!(empty.total_rows_dropped(), 0);
+    assert!(empty.is_no_op());
+
+    let untouched = WindowPolicyOutcome {
+        rows_dropped: vec![0, 0, 0],
+        sliding_layers: 2,
+        global_layers: 1,
+    };
+    assert_eq!(untouched.total_rows_dropped(), 0);
+    assert!(untouched.is_no_op(), "no row moved, so this is a no-op");
+
+    let clipped = WindowPolicyOutcome {
+        rows_dropped: vec![3, 0, 4],
+        sliding_layers: 2,
+        global_layers: 1,
+    };
+    assert_eq!(clipped.total_rows_dropped(), 7);
+    assert!(!clipped.is_no_op());
+}
+
+// ── refusals ─────────────────────────────────────────────────────────────
+
+/// No per-layer access at all — a coarse whole-model handle has no
+/// granularity to apply a per-layer policy to.
+#[test]
+fn a_cache_with_no_layer_count_is_refused() {
+    let mut kv = StubCache::new(2);
+    kv.layer_count = None;
+
+    let err = apply_window_policy(&mut kv, &attention(2, 1, Some(4)))
+        .expect_err("no per-layer access should refuse");
+    assert!(matches!(err, PromotionError::UnsupportedCapability(_)));
+    assert_eq!(kv.clip_calls.get(), 0, "refused before touching a layer");
+}
+
+/// The architecture and the cache disagreeing about layer count means
+/// `is_sliding[layer]` would be indexing a different model than the one
+/// resident — an out-of-bounds read at best, the wrong classification at
+/// worst.
+#[test]
+fn a_layer_count_disagreement_is_refused() {
+    let mut kv = StubCache::new(2);
+
+    let err = apply_window_policy(&mut kv, &attention(6, 5, Some(4)))
+        .expect_err("layer-count disagreement should refuse");
+    assert!(matches!(err, PromotionError::InvariantViolation(_)));
+    assert_eq!(kv.clip_calls.get(), 0, "refused before touching a layer");
+}
+
+/// Without a row-position map, logical age is unknowable: row count and
+/// next position stop determining which positions are resident the
+/// moment the cache has a hole.
+#[test]
+fn a_cache_with_no_row_position_map_is_refused() {
+    let mut kv = StubCache::new(2);
+    kv.positions = None;
+
+    let err = apply_window_policy(&mut kv, &attention(2, 1, Some(4)))
+        .expect_err("missing row positions should refuse");
+    assert!(matches!(err, PromotionError::UnsupportedCapability(_)));
+    assert_eq!(kv.clip_calls.get(), 0, "refused before touching a layer");
+}
+
+/// Sliding layers with no declared window have no bound to apply.
+/// Silently keeping everything would report as a clip that did nothing,
+/// which is indistinguishable from a cache already inside its window.
+#[test]
+fn sliding_layers_without_a_declared_window_are_refused() {
+    let mut kv = StubCache::new(2);
+
+    let err = apply_window_policy(&mut kv, &attention(2, 1, None))
+        .expect_err("sliding layers with no window should refuse");
+    assert!(matches!(err, PromotionError::UnsupportedCapability(_)));
+    assert_eq!(kv.clip_calls.get(), 0, "refused before touching a layer");
+}
+
+/// An all-global architecture with no declared window is *not* a
+/// refusal: there is no sliding layer for the missing window to bound,
+/// so the policy is well defined and drops nothing.
+#[test]
+fn an_all_global_architecture_needs_no_window() {
+    let mut kv = StubCache::new(3);
+
+    let outcome = apply_window_policy(&mut kv, &attention(3, 0, None))
+        .expect("no sliding layer means no window is needed");
+    assert_eq!(outcome.rows_dropped, vec![0, 0, 0]);
+    assert_eq!(outcome.sliding_layers, 0);
+    assert_eq!(outcome.global_layers, 3);
+    assert!(outcome.is_no_op());
+    assert_eq!(
+        kv.clip_calls.get(),
+        0,
+        "a global layer is not clipped, not clipped-with-a-large-window"
+    );
+}
+
+/// A layer that refuses its clip surfaces as a failure rather than being
+/// recorded as "dropped nothing" — the distinction between a correct
+/// no-op and a failed clip is the entire content of the outcome.
+#[test]
+fn a_layer_that_refuses_its_clip_fails_the_policy() {
+    let mut kv = StubCache::new(2);
+    kv.clip_result = None;
+
+    let err = apply_window_policy(&mut kv, &attention(2, 1, Some(4)))
+        .expect_err("a refused clip should not be reported as zero rows");
+    assert!(matches!(err, PromotionError::SourceMaskFailed));
+}
+
+// ── the accepting path ───────────────────────────────────────────────────
+
+/// Sliding layers are clipped, global layers are left whole, and the
+/// split is reported rather than summarised.
+#[test]
+fn only_sliding_layers_are_clipped_and_the_split_is_reported() {
+    let mut kv = StubCache::new(4);
+    kv.clip_result = Some(2);
+
+    let outcome = apply_window_policy(&mut kv, &attention(4, 2, Some(4))).expect("policy applies");
+    assert_eq!(
+        outcome.rows_dropped,
+        vec![2, 2, 0, 0],
+        "global layers must report 0, not a clip that happened to drop nothing"
+    );
+    assert_eq!(outcome.sliding_layers, 2);
+    assert_eq!(outcome.global_layers, 2);
+    assert_eq!(outcome.total_rows_dropped(), 4);
+    assert!(!outcome.is_no_op());
+    assert_eq!(kv.clip_calls.get(), 2, "one clip per sliding layer only");
+}

--- a/crates/larql-kv/src/model_walk/tests/mod.rs
+++ b/crates/larql-kv/src/model_walk/tests/mod.rs
@@ -11,5 +11,7 @@ mod enforce_gates;
 mod exclusion_oracle;
 mod exp25;
 mod heterogeneous_gates;
+mod rendering;
 mod replay_gates;
+mod validation_refusals;
 mod walk_gates;

--- a/crates/larql-kv/src/model_walk/tests/rendering.rs
+++ b/crates/larql-kv/src/model_walk/tests/rendering.rs
@@ -1,0 +1,458 @@
+//! Rendering and graph-traversal units.
+//!
+//! The gate suites drive whole walks, so they only ever render the node,
+//! edge and step shapes their fixtures happen to contain. These pin the
+//! rest directly.
+//!
+//! Renderings are load-bearing: `ModelWalkPlan::fingerprint` is the W0
+//! determinism gate and is built by concatenating `WalkStep::render`,
+//! which in turn embeds `render_boundary` and `render_scope`. A rendering
+//! that varies between runs, or that collides between two distinct
+//! shapes, would silently weaken that gate rather than fail it.
+
+use crate::model_walk::graph::{render_boundary, ModelEdge, ModelGraph, ModelNode};
+use crate::model_walk::plan::{ExpertPrefetchHint, ModelWalkPlan, WalkPlanId, WalkStep};
+use crate::semantic_promotion::{
+    AnswerBoundary, AuthorityId, CheckpointId, OperationId, QualificationId, RecordId,
+    RetirementScope,
+};
+
+fn authority(n: u128) -> AuthorityId {
+    AuthorityId::from_counter(n)
+}
+fn record(n: u128) -> RecordId {
+    RecordId::from_counter(n)
+}
+fn operation(n: u128) -> OperationId {
+    OperationId::from_counter(n)
+}
+fn qualification(n: u128) -> QualificationId {
+    QualificationId::from_counter(n)
+}
+fn checkpoint(n: u128) -> CheckpointId {
+    CheckpointId::from_counter(n)
+}
+
+// ── ModelNode ────────────────────────────────────────────────────────────
+
+/// Every node variant renders, and no two variants collide — a walk
+/// trace has to stay readable, and the W0 fingerprint has to stay
+/// injective over node shapes.
+#[test]
+fn every_node_variant_renders_distinctly() {
+    let nodes = [
+        ModelNode::SourceAuthority(authority(1)),
+        ModelNode::CanonicalFact(record(1)),
+        ModelNode::DerivedClaim(record(1)),
+        ModelNode::Operation(operation(1)),
+        ModelNode::AnswerBoundary(AnswerBoundary::FirstTermination),
+        ModelNode::ReplayCheckpoint(checkpoint(1)),
+    ];
+    let rendered: Vec<String> = nodes.iter().map(|n| n.render()).collect();
+
+    // Ids carry a type tag in their raw value, so the expectation is
+    // built from the same accessor the rendering uses — this pins the
+    // *prefix* and the id round-trip, not a literal counter.
+    assert_eq!(
+        rendered,
+        vec![
+            format!("source({})", authority(1).raw()),
+            format!("canonical({})", record(1).raw()),
+            format!("derived({})", record(1).raw()),
+            format!("operation({})", operation(1).raw()),
+            "boundary(first_termination)".to_string(),
+            format!("checkpoint({})", checkpoint(1).raw()),
+        ]
+    );
+
+    // The same raw id under different variants must not render alike:
+    // `canonical(1)` and `derived(1)` are different nodes.
+    let unique: std::collections::BTreeSet<&String> = rendered.iter().collect();
+    assert_eq!(unique.len(), rendered.len(), "renderings collide");
+}
+
+#[test]
+fn record_and_authority_projections_only_answer_for_their_own_variants() {
+    assert_eq!(
+        ModelNode::CanonicalFact(record(7)).record(),
+        Some(record(7))
+    );
+    assert_eq!(ModelNode::DerivedClaim(record(7)).record(), Some(record(7)));
+    assert_eq!(ModelNode::Operation(operation(7)).record(), None);
+
+    assert_eq!(
+        ModelNode::SourceAuthority(authority(3)).authority(),
+        Some(authority(3))
+    );
+    assert_eq!(ModelNode::CanonicalFact(record(3)).authority(), None);
+
+    assert!(ModelNode::DerivedClaim(record(1)).is_derived_claim());
+    assert!(!ModelNode::CanonicalFact(record(1)).is_derived_claim());
+}
+
+// ── boundaries and edges ─────────────────────────────────────────────────
+
+/// `ExactPayloadLength` carries its length into the rendering — two
+/// different payload lengths are two different boundaries, and the
+/// fingerprint must be able to tell them apart.
+#[test]
+fn every_boundary_renders_and_payload_length_is_carried() {
+    assert_eq!(
+        render_boundary(AnswerBoundary::FirstTermination),
+        "first_termination"
+    );
+    assert_eq!(
+        render_boundary(AnswerBoundary::ExactPayloadLength(4)),
+        "payload(4)"
+    );
+    assert_eq!(
+        render_boundary(AnswerBoundary::ExactPayloadLength(9)),
+        "payload(9)"
+    );
+    assert_eq!(
+        render_boundary(AnswerBoundary::ExternalCommit),
+        "external_commit"
+    );
+}
+
+#[test]
+fn every_edge_variant_renders_distinctly() {
+    let edges = [
+        ModelEdge::Asserts,
+        ModelEdge::DerivedFrom,
+        ModelEdge::OperandOf,
+        ModelEdge::Produces,
+        ModelEdge::ReplacesFor {
+            qualification: qualification(1),
+            scope: RetirementScope::AnswerScoped {
+                operation: operation(1),
+                through: AnswerBoundary::FirstTermination,
+            },
+        },
+        ModelEdge::Discharges,
+        ModelEdge::ReplaysFrom,
+    ];
+    let rendered: Vec<&str> = edges.iter().map(|e| e.render()).collect();
+    assert_eq!(
+        rendered,
+        vec![
+            "asserts",
+            "derived_from",
+            "operand_of",
+            "produces",
+            "replaces_for",
+            "discharges",
+            "replays_from",
+        ]
+    );
+    let unique: std::collections::BTreeSet<&&str> = rendered.iter().collect();
+    assert_eq!(unique.len(), rendered.len(), "edge renderings collide");
+}
+
+// ── provenance traversal ─────────────────────────────────────────────────
+
+/// `provenance_of` walks back through intermediate *records*, not just
+/// direct source edges — a derived claim built on another derived claim
+/// still reaches the underlying authority.
+#[test]
+fn provenance_walks_through_intermediate_records() {
+    let src = authority(1);
+    let mut g = ModelGraph::new();
+    g.relate(
+        ModelNode::DerivedClaim(record(2)),
+        ModelEdge::DerivedFrom,
+        ModelNode::CanonicalFact(record(1)),
+    );
+    g.relate(
+        ModelNode::CanonicalFact(record(1)),
+        ModelEdge::Asserts,
+        ModelNode::SourceAuthority(src),
+    );
+
+    // Two hops away, through a record that is not itself a source.
+    assert_eq!(
+        g.provenance_of(ModelNode::DerivedClaim(record(2))),
+        vec![src]
+    );
+}
+
+/// A provenance cycle must terminate rather than spin. Records that cite
+/// each other are a graph a caller can build, so the traversal owns the
+/// termination guarantee.
+#[test]
+fn provenance_terminates_on_a_cycle() {
+    let src = authority(1);
+    let mut g = ModelGraph::new();
+    let a = ModelNode::DerivedClaim(record(1));
+    let b = ModelNode::DerivedClaim(record(2));
+    g.relate(a, ModelEdge::DerivedFrom, b);
+    g.relate(b, ModelEdge::DerivedFrom, a);
+    g.relate(b, ModelEdge::Asserts, ModelNode::SourceAuthority(src));
+
+    assert_eq!(g.provenance_of(a), vec![src]);
+}
+
+#[test]
+fn provenance_of_an_unconnected_record_is_empty() {
+    let mut g = ModelGraph::new();
+    g.add_node(ModelNode::CanonicalFact(record(1)));
+    assert!(g
+        .provenance_of(ModelNode::CanonicalFact(record(1)))
+        .is_empty());
+}
+
+/// A `ReplaysFrom` edge that does not land on a checkpoint node is not a
+/// replay route. Returning the malformed target instead would hand the
+/// validator a route it cannot execute.
+#[test]
+fn replay_route_ignores_a_replays_from_edge_to_a_non_checkpoint() {
+    let a = authority(1);
+    let mut g = ModelGraph::new();
+    g.relate(
+        ModelNode::SourceAuthority(a),
+        ModelEdge::ReplaysFrom,
+        ModelNode::CanonicalFact(record(1)),
+    );
+    assert_eq!(g.replay_route_for(a), None);
+
+    let mut ok = ModelGraph::new();
+    ok.relate(
+        ModelNode::SourceAuthority(a),
+        ModelEdge::ReplaysFrom,
+        ModelNode::ReplayCheckpoint(checkpoint(5)),
+    );
+    assert_eq!(ok.replay_route_for(a), Some(checkpoint(5)));
+}
+
+// ── WalkStep ─────────────────────────────────────────────────────────────
+
+/// Exactly the steps that change what attention reads report as
+/// mutating. Observe mode records these rather than performing them, so
+/// a step wrongly classified as inert would be silently executed.
+#[test]
+fn only_visibility_changing_steps_report_as_mutating() {
+    let mutating = [
+        WalkStep::PreparePromotion {
+            source: authority(1),
+            record: record(1),
+        },
+        WalkStep::CommitPromotion,
+        WalkStep::RestoreAuthority,
+        WalkStep::ReplayAuthority {
+            authority: authority(1),
+        },
+    ];
+    for step in mutating {
+        assert!(step.mutates_visibility(), "{step:?} should mutate");
+    }
+
+    let inert = [
+        WalkStep::ResolveAuthority {
+            authority: authority(1),
+        },
+        WalkStep::SelectRecord { record: record(1) },
+        WalkStep::BeginOperation {
+            operation: operation(1),
+        },
+        WalkStep::QualifyPromotion {
+            qualification: qualification(1),
+            requested_scope: RetirementScope::GeneralState {
+                certificate: qualification(1),
+            },
+        },
+        WalkStep::Generate {
+            boundary: AnswerBoundary::FirstTermination,
+        },
+        WalkStep::FinishOperation,
+    ];
+    for step in inert {
+        assert!(!step.mutates_visibility(), "{step:?} should not mutate");
+    }
+}
+
+/// Both scope forms render, including `GeneralState` — the scope goes
+/// into the step rendering and therefore into the W0 fingerprint.
+#[test]
+fn every_step_variant_renders_distinctly() {
+    let steps = [
+        WalkStep::ResolveAuthority {
+            authority: authority(1),
+        },
+        WalkStep::SelectRecord { record: record(2) },
+        WalkStep::BeginOperation {
+            operation: operation(3),
+        },
+        WalkStep::PreparePromotion {
+            source: authority(1),
+            record: record(2),
+        },
+        WalkStep::QualifyPromotion {
+            qualification: qualification(4),
+            requested_scope: RetirementScope::AnswerScoped {
+                operation: operation(3),
+                through: AnswerBoundary::ExactPayloadLength(2),
+            },
+        },
+        WalkStep::QualifyPromotion {
+            qualification: qualification(4),
+            requested_scope: RetirementScope::GeneralState {
+                certificate: qualification(4),
+            },
+        },
+        WalkStep::CommitPromotion,
+        WalkStep::Generate {
+            boundary: AnswerBoundary::FirstTermination,
+        },
+        WalkStep::FinishOperation,
+        WalkStep::RestoreAuthority,
+        WalkStep::ReplayAuthority {
+            authority: authority(5),
+        },
+    ];
+    let rendered: Vec<String> = steps.iter().map(|s| s.render()).collect();
+    let (a1, r2, o3, q4, a5) = (
+        authority(1).raw(),
+        record(2).raw(),
+        operation(3).raw(),
+        qualification(4).raw(),
+        authority(5).raw(),
+    );
+    assert_eq!(
+        rendered,
+        vec![
+            format!("resolve_authority({a1})"),
+            format!("select_record({r2})"),
+            format!("begin_operation({o3})"),
+            format!("prepare_promotion({a1},{r2})"),
+            format!("qualify_promotion({q4},answer_scoped({o3},payload(2)))"),
+            format!("qualify_promotion({q4},general_state({q4}))"),
+            "commit_promotion".to_string(),
+            "generate(first_termination)".to_string(),
+            "finish_operation".to_string(),
+            "restore_authority".to_string(),
+            format!("replay_authority({a5})"),
+        ]
+    );
+    let unique: std::collections::BTreeSet<&String> = rendered.iter().collect();
+    assert_eq!(unique.len(), rendered.len(), "step renderings collide");
+}
+
+// ── ModelWalkPlan accessors ──────────────────────────────────────────────
+
+fn plan_with(steps: Vec<WalkStep>) -> ModelWalkPlan {
+    ModelWalkPlan {
+        id: WalkPlanId::derived(operation(3), record(2)),
+        operation: operation(3),
+        steps,
+        fallback: None,
+        expert_hints: Vec::new(),
+    }
+}
+
+/// `retired_source` and `promoted_record` both read the same
+/// `PreparePromotion` step but must report its two different fields —
+/// swapping them would retire the wrong authority.
+#[test]
+fn promotion_accessors_report_their_own_field() {
+    let p = plan_with(vec![
+        WalkStep::BeginOperation {
+            operation: operation(3),
+        },
+        WalkStep::PreparePromotion {
+            source: authority(9),
+            record: record(4),
+        },
+        WalkStep::RestoreAuthority,
+    ]);
+    assert_eq!(p.retired_source(), Some(authority(9)));
+    assert_eq!(p.promoted_record(), Some(record(4)));
+    assert!(p.has_recovery_step());
+}
+
+/// A walk that does not promote retires nothing and excludes nothing.
+#[test]
+fn a_non_promoting_plan_retires_nothing() {
+    let p = plan_with(vec![
+        WalkStep::BeginOperation {
+            operation: operation(3),
+        },
+        WalkStep::Generate {
+            boundary: AnswerBoundary::FirstTermination,
+        },
+        WalkStep::FinishOperation,
+    ]);
+    assert_eq!(p.retired_source(), None);
+    assert_eq!(p.promoted_record(), None);
+    assert_eq!(p.requested_scope(), None);
+    assert_eq!(p.exclusion_token_count(), 0);
+    assert!(!p.has_recovery_step());
+    assert_eq!(
+        p.generated_boundary(),
+        Some(AnswerBoundary::FirstTermination)
+    );
+}
+
+#[test]
+fn exclusion_token_count_is_reported_once_for_a_promoting_plan() {
+    let p = plan_with(vec![WalkStep::PreparePromotion {
+        source: authority(9),
+        record: record(4),
+    }]);
+    assert_eq!(p.exclusion_token_count(), 1);
+}
+
+/// A replay step counts as recovery just as a restore does — both are
+/// routes back to source authority.
+#[test]
+fn replay_counts_as_a_recovery_step() {
+    let p = plan_with(vec![WalkStep::ReplayAuthority {
+        authority: authority(9),
+    }]);
+    assert!(p.has_recovery_step());
+}
+
+/// Two plans differing only in their fallback are different plans, so
+/// the fingerprint must include the fallback chain.
+#[test]
+fn fingerprint_includes_the_fallback_chain() {
+    let bare = plan_with(vec![WalkStep::FinishOperation]);
+    let mut with_fallback = bare.clone();
+    with_fallback.fallback = Some(Box::new(plan_with(vec![WalkStep::RestoreAuthority])));
+
+    assert_ne!(bare.fingerprint(), with_fallback.fingerprint());
+    assert!(with_fallback.fingerprint().contains("fallback:"));
+    assert!(with_fallback.fingerprint().contains("restore_authority"));
+    // Deterministic across calls (gate W0).
+    assert_eq!(with_fallback.fingerprint(), with_fallback.fingerprint());
+}
+
+/// The id packs operation and record into fixed-width fields, so two
+/// different operands over the same operation stay distinguishable.
+#[test]
+fn plan_id_is_derived_from_operation_and_record() {
+    assert_eq!(
+        WalkPlanId::derived(operation(3), record(2)),
+        WalkPlanId::derived(operation(3), record(2))
+    );
+    assert_ne!(
+        WalkPlanId::derived(operation(3), record(2)),
+        WalkPlanId::derived(operation(3), record(5))
+    );
+    assert_ne!(
+        WalkPlanId::derived(operation(3), record(2)),
+        WalkPlanId::derived(operation(4), record(2))
+    );
+    assert_eq!(WalkPlanId::derived(operation(3), record(2)).raw() >> 32, 3);
+}
+
+#[test]
+fn expert_hints_are_carried_on_the_plan_unmodified() {
+    let mut p = plan_with(vec![WalkStep::FinishOperation]);
+    p.expert_hints.push(ExpertPrefetchHint {
+        owners: vec!["bank-a".into()],
+        predicted_ttl_tokens: 12,
+    });
+    assert_eq!(p.expert_hints.len(), 1);
+    assert_eq!(p.expert_hints[0].owners, vec!["bank-a".to_string()]);
+    assert_eq!(p.expert_hints[0].predicted_ttl_tokens, 12);
+}

--- a/crates/larql-kv/src/model_walk/tests/validation_refusals.rs
+++ b/crates/larql-kv/src/model_walk/tests/validation_refusals.rs
@@ -1,0 +1,397 @@
+//! Every refusal `DefaultWalkValidator` owns.
+//!
+//! The gate suites validate plans the planner *built*, so they exercise
+//! the accepting path. These build plans by hand — which is exactly the
+//! threat model, since `ModelWalkPlan`'s fields are public and only
+//! `ValidatedWalkPlan`'s are private. A hand-built plan is the thing the
+//! validator exists to stop, and gate W8 is only worth as much as the
+//! refusal it rests on.
+//!
+//! One assertion per refusal, on the error *value* rather than just
+//! `is_err()`: two different bugs that both refuse are not the same bug,
+//! and a validator that refuses everything would pass a weaker suite.
+
+use crate::model_walk::graph::{ModelEdge, ModelGraph, ModelNode};
+use crate::model_walk::plan::{ModelWalkPlan, WalkPlanId, WalkStep};
+use crate::model_walk::validate::{DefaultWalkValidator, WalkValidationError, WalkValidator};
+use crate::semantic_promotion::{
+    AnswerBoundary, AuthorityId, OperationId, QualificationId, RecordId, RetirementScope,
+};
+
+use super::exp25::certificate_from_measurement;
+use crate::semantic_promotion::qualification::ConsumptionMode;
+
+const OP: u128 = 3;
+const REC: u128 = 2;
+const SRC: u128 = 1;
+
+fn authority(n: u128) -> AuthorityId {
+    AuthorityId::from_counter(n)
+}
+fn record(n: u128) -> RecordId {
+    RecordId::from_counter(n)
+}
+fn operation(n: u128) -> OperationId {
+    OperationId::from_counter(n)
+}
+fn qualification(n: u128) -> QualificationId {
+    QualificationId::from_counter(n)
+}
+
+fn plan(steps: Vec<WalkStep>) -> ModelWalkPlan {
+    ModelWalkPlan {
+        id: WalkPlanId::derived(operation(OP), record(REC)),
+        operation: operation(OP),
+        steps,
+        fallback: None,
+        expert_hints: Vec::new(),
+    }
+}
+
+/// A graph with the operation registered and one canonical fact that is
+/// a properly-attributed operand of it. The minimum a plan needs to get
+/// past the structural checks.
+fn base_graph() -> ModelGraph {
+    let mut g = ModelGraph::new();
+    let op = ModelNode::Operation(operation(OP));
+    let rec = ModelNode::CanonicalFact(record(REC));
+    g.add_node(op);
+    g.relate(rec, ModelEdge::OperandOf, op);
+    g.relate(
+        rec,
+        ModelEdge::Asserts,
+        ModelNode::SourceAuthority(authority(SRC)),
+    );
+    g
+}
+
+/// A certificate that qualifies on a zero-KL measurement. Built through
+/// the shared EXP-25 helper so it carries a real `CapabilityKey` rather
+/// than a hand-assembled one. Never carries general-state evidence.
+fn cert() -> crate::semantic_promotion::QualificationCertificate {
+    certificate_from_measurement(
+        qualification(31),
+        record(REC),
+        [0u8; 32],
+        "increment",
+        &[0.0; 5],
+        ConsumptionMode::AnswerWithoutReapplication,
+    )
+    .expect("zero-KL measurement should qualify")
+}
+
+fn validate(g: &ModelGraph, p: &ModelWalkPlan) -> Result<(), WalkValidationError> {
+    DefaultWalkValidator.validate(g, p).map(|_| ())
+}
+
+fn expect_err(g: &ModelGraph, p: &ModelWalkPlan) -> WalkValidationError {
+    validate(g, p).expect_err("plan should have been refused")
+}
+
+// ── structural presence ──────────────────────────────────────────────────
+
+/// A plan for an operation the graph has never heard of cannot be
+/// validated against it — there is nothing to check the operands against.
+#[test]
+fn an_operation_absent_from_the_graph_is_refused() {
+    let g = ModelGraph::new();
+    let p = plan(vec![WalkStep::FinishOperation]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::MissingNode(format!("operation({})", operation(OP).raw()))
+    );
+}
+
+#[test]
+fn resolving_an_authority_absent_from_the_graph_is_refused() {
+    let g = base_graph();
+    let p = plan(vec![WalkStep::ResolveAuthority {
+        authority: authority(99),
+    }]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::MissingNode(format!("source({})", authority(99).raw()))
+    );
+}
+
+#[test]
+fn selecting_a_record_absent_from_the_graph_is_refused() {
+    let g = base_graph();
+    let p = plan(vec![WalkStep::SelectRecord { record: record(77) }]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::MissingNode(format!("record({})", record(77).raw()))
+    );
+}
+
+/// The record exists, but is not an operand of *this* operation. A plan
+/// may not import an unrelated record into an operation it was never
+/// attributed to.
+#[test]
+fn selecting_a_record_that_is_not_an_operand_of_this_operation_is_refused() {
+    let mut g = base_graph();
+    g.add_node(ModelNode::CanonicalFact(record(42)));
+    let p = plan(vec![WalkStep::SelectRecord { record: record(42) }]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::MissingEdge(format!(
+            "canonical({}) -operand_of-> operation({})",
+            record(42).raw(),
+            operation(OP).raw()
+        ))
+    );
+}
+
+/// A derived claim must additionally discharge the operation. Being an
+/// operand is not enough: a derived result that discharges nothing is a
+/// claim the walk cannot stand behind.
+#[test]
+fn a_derived_claim_that_discharges_nothing_is_refused() {
+    let mut g = base_graph();
+    let derived = ModelNode::DerivedClaim(record(8));
+    let op = ModelNode::Operation(operation(OP));
+    g.relate(derived, ModelEdge::OperandOf, op);
+
+    let p = plan(vec![WalkStep::SelectRecord { record: record(8) }]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::DerivedClaimNotDischarged
+    );
+
+    // With the discharge edge present the same plan validates.
+    g.relate(derived, ModelEdge::Discharges, op);
+    assert!(validate(&g, &p).is_ok());
+}
+
+#[test]
+fn beginning_a_different_operation_than_the_plan_declares_is_refused() {
+    let g = base_graph();
+    let p = plan(vec![WalkStep::BeginOperation {
+        operation: operation(999),
+    }]);
+    assert_eq!(expect_err(&g, &p), WalkValidationError::OperationMismatch);
+}
+
+// ── promotion provenance ─────────────────────────────────────────────────
+
+#[test]
+fn promoting_a_record_absent_from_the_graph_is_refused() {
+    let g = base_graph();
+    let p = plan(vec![WalkStep::PreparePromotion {
+        source: authority(SRC),
+        record: record(77),
+    }]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::MissingNode(format!("record({})", record(77).raw()))
+    );
+}
+
+/// A record with no route to any durable source cannot replace one —
+/// there would be nothing to restore or replay from.
+#[test]
+fn promoting_a_record_with_no_provenance_is_refused() {
+    let mut g = ModelGraph::new();
+    let op = ModelNode::Operation(operation(OP));
+    let rec = ModelNode::CanonicalFact(record(REC));
+    g.add_node(op);
+    g.relate(rec, ModelEdge::OperandOf, op);
+
+    let p = plan(vec![WalkStep::PreparePromotion {
+        source: authority(SRC),
+        record: record(REC),
+    }]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::NoProvenance(format!("canonical({})", record(REC).raw()))
+    );
+}
+
+/// The record has provenance, but not to the source this step claims to
+/// retire. Retiring an authority the record never asserted would remove
+/// evidence the record does not stand in for.
+#[test]
+fn promoting_against_a_source_outside_the_records_provenance_is_refused() {
+    let g = base_graph();
+    let p = plan(vec![WalkStep::PreparePromotion {
+        source: authority(55),
+        record: record(REC),
+    }]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::MissingEdge(format!(
+            "canonical({}) -asserts/derived_from-> source({})",
+            record(REC).raw(),
+            authority(55).raw()
+        ))
+    );
+}
+
+// ── qualification ────────────────────────────────────────────────────────
+
+fn answer_scoped() -> RetirementScope {
+    RetirementScope::AnswerScoped {
+        operation: operation(OP),
+        through: AnswerBoundary::FirstTermination,
+    }
+}
+
+#[test]
+fn qualifying_against_a_certificate_the_graph_does_not_hold_is_refused() {
+    let g = base_graph();
+    let p = plan(vec![WalkStep::QualifyPromotion {
+        qualification: qualification(31),
+        requested_scope: answer_scoped(),
+    }]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::UnknownCertificate(qualification(31).raw().to_string())
+    );
+}
+
+/// An answer-scoped request naming a *different* operation than the plan
+/// runs is a scope the walk cannot honour — the certificate would expire
+/// at a boundary this walk never reaches.
+#[test]
+fn an_answer_scope_naming_another_operation_is_refused() {
+    let mut g = base_graph();
+    g.add_certificate(cert());
+
+    let p = plan(vec![WalkStep::QualifyPromotion {
+        qualification: qualification(31),
+        requested_scope: RetirementScope::AnswerScoped {
+            operation: operation(888),
+            through: AnswerBoundary::FirstTermination,
+        },
+    }]);
+    assert_eq!(expect_err(&g, &p), WalkValidationError::OperationMismatch);
+}
+
+/// General state needs explicit general-state evidence. A certificate
+/// that only scored one answer does not license authority beyond it —
+/// this is the check the whole design exists for.
+#[test]
+fn general_state_without_general_state_evidence_is_refused() {
+    let mut g = base_graph();
+    g.add_certificate(cert());
+
+    let p = plan(vec![WalkStep::QualifyPromotion {
+        qualification: qualification(31),
+        requested_scope: RetirementScope::GeneralState {
+            certificate: qualification(31),
+        },
+    }]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::UnevidencedGeneralState
+    );
+}
+
+// ── recovery and generation ──────────────────────────────────────────────
+
+#[test]
+fn replaying_an_authority_with_no_replay_route_is_refused() {
+    let g = base_graph();
+    let p = plan(vec![WalkStep::ReplayAuthority {
+        authority: authority(SRC),
+    }]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::MissingEdge(format!(
+            "source({}) -replays_from-> checkpoint",
+            authority(SRC).raw()
+        ))
+    );
+}
+
+/// `ExternalCommit` is not a boundary a walk may generate through: it is
+/// outside the system, so nothing downstream could observe the
+/// expiry.
+#[test]
+fn generating_through_an_external_commit_boundary_is_refused() {
+    let g = base_graph();
+    let p = plan(vec![WalkStep::Generate {
+        boundary: AnswerBoundary::ExternalCommit,
+    }]);
+    assert_eq!(expect_err(&g, &p), WalkValidationError::BoundaryNotCovered);
+}
+
+// ── whole-plan obligations ───────────────────────────────────────────────
+
+/// Promoting without qualifying is the unqualified-promotion hole: a
+/// record would replace a source with nothing having scored it.
+#[test]
+fn promoting_without_a_qualification_step_is_refused() {
+    let g = base_graph();
+    let p = plan(vec![
+        WalkStep::PreparePromotion {
+            source: authority(SRC),
+            record: record(REC),
+        },
+        WalkStep::RestoreAuthority,
+    ]);
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::UnqualifiedPromotion
+    );
+}
+
+/// A promoting walk must carry a route back to source authority, so the
+/// exclusion is reversible.
+#[test]
+fn promoting_without_a_recovery_step_is_refused() {
+    let mut g = base_graph();
+    g.add_certificate(cert());
+
+    let p = plan(vec![
+        WalkStep::PreparePromotion {
+            source: authority(SRC),
+            record: record(REC),
+        },
+        WalkStep::QualifyPromotion {
+            qualification: qualification(31),
+            requested_scope: answer_scoped(),
+        },
+    ]);
+    assert_eq!(expect_err(&g, &p), WalkValidationError::NoRecoveryStep);
+}
+
+/// The fallback is validated too. A plan whose primary path is legal but
+/// whose fallback is not would otherwise smuggle an illegal walk in
+/// behind a legal one.
+#[test]
+fn an_illegal_fallback_is_refused_even_when_the_primary_path_is_legal() {
+    let g = base_graph();
+    let mut p = plan(vec![WalkStep::FinishOperation]);
+    assert!(validate(&g, &p).is_ok(), "primary path should be legal");
+
+    p.fallback = Some(Box::new(plan(vec![WalkStep::ResolveAuthority {
+        authority: authority(99),
+    }])));
+    assert_eq!(
+        expect_err(&g, &p),
+        WalkValidationError::MissingNode(format!("source({})", authority(99).raw()))
+    );
+}
+
+/// The accepting path: a validated plan exposes the steps it was built
+/// from, unchanged.
+#[test]
+fn a_validated_plan_exposes_its_own_steps() {
+    let g = base_graph();
+    let steps = vec![
+        WalkStep::BeginOperation {
+            operation: operation(OP),
+        },
+        WalkStep::SelectRecord {
+            record: record(REC),
+        },
+        WalkStep::FinishOperation,
+    ];
+    let p = plan(steps.clone());
+    let validated = DefaultWalkValidator
+        .validate(&g, &p)
+        .expect("plan should validate");
+    assert_eq!(validated.steps(), steps.as_slice());
+    assert_eq!(validated.plan(), &p);
+}


### PR DESCRIPTION
Fixes both `larql-kv` gates that #204 broke on `main`. Two commits, one per gate.

Originally split as #205 + this; merged into one PR because they cannot be verified apart — the coverage job runs after the clippy job in the same workflow, so the clippy fix alone can never show a green run.

## 1. Clippy — `fix(kv): make UnaidedTrial::observe public`

`larql-kv.yml` runs `cargo clippy -p larql-kv --all-targets --no-deps -- -D warnings`, and on `2a7c4083` that fails on all three OSes:

```
error: associated function `observe` is never used
  --> crates/larql-kv/src/engines/semantic_promotion/authority_regime.rs:116:19
```

`UnaidedTrial` is re-exported from `semantic_promotion` and `record()` / `record_won()` are both `pub`, but its only constructor was `pub(crate)` — so nothing outside its own tests could construct one, and the lib build sees it as dead. Widening the constructor to `pub` matches the rest of the type's surface and makes the re-export usable, rather than silencing the lint over a type callers cannot construct.

## 2. Coverage — `test(kv): cover the files below the 90% floor`

The policy holds every file to 90% lines. Five files from the two subsystems that landed with #204 were under it:

| file | before | after |
|---|---:|---:|
| `semantic_promotion/engine.rs` | 48.56% | **99.59%** |
| `model_walk/validate.rs` | 74.78% | **99.13%** |
| `model_walk/plan.rs` | 76.53% | **100%** |
| `semantic_promotion/window_policy.rs` | 82.00% | **100%** |
| `model_walk/graph.rs` | 83.80% | **100%** |

Crate total 95.68% → 96.38% lines. Verified with the workflow's own `check_coverage_policy.py` invocation, not just a summary number.

The existing suites drive whole walks over planner-built plans and real engines, so they reach the accepting paths and the shapes their fixtures contain. The gap was the complement — refusals, renderings, and the wrapper's delegation surface. Four new files:

- **`model_walk/tests/rendering.rs`** — node/edge/step/scope renderings and graph traversals. These feed `ModelWalkPlan::fingerprint`, which *is* the W0 determinism gate, so they are pinned for distinctness rather than just output: a collision between two shapes weakens W0 silently instead of failing it. Also covers the two traversal branches no fixture reaches — provenance through an intermediate record, and provenance over a cycle, which must terminate rather than spin.

- **`model_walk/tests/validation_refusals.rs`** — one test per `WalkValidationError`, asserting the error *value*, not `is_err()` (two different bugs that both refuse are not the same bug). Plans are hand-built, which is the real threat model: `ModelWalkPlan` has public fields and only `ValidatedWalkPlan` is sealed, so a hand-built plan is exactly what the validator exists to stop.

- **`semantic_promotion/tests/window_policy_refusals.rs`** — the four refusals plus the all-global case that must *not* refuse, over a stub cache whose capabilities can be withdrawn one at a time. Each asserts the refusal fired before any layer was clipped.

- **`semantic_promotion/tests/engine_delegation.rs`** — every `KvEngine` entry point on the wrapper, asserted on the observable consequence rather than the call being forwarded: each prefill must restart the session epoch, mirror the prompt length and publish a layer classification; each decode must advance the position by exactly one. A variant skipping that bookkeeping would describe the previous prompt and still look like a working engine.

Only the one-line visibility change touches production code; the rest is tests, so the floor is raised by adding tests rather than lowering it — what the policy note asks for.

**Gates:** fmt clean, `clippy -p larql-kv --all-targets --no-deps -D warnings` clean, full suite green (1238 lib tests).