### PR TITLE
fix(publish): prune stale remote files, retry transient uploads

### DIFF
--- a/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
@@ -125,6 +125,32 @@ fn parse_quant(s: &str) -> Result<larql_vindex::QuantFormat, String> {
     }
 }
 
+/// Resolve the effective extract level from the flags that can raise it.
+///
+/// Two things upgrade to `All`:
+///   * `--include-weights` — the pre-`--level` spelling, kept for compat.
+///   * `--quant q4k` — its help has always said it implies `--level all`,
+///     but until 2026-08-07 nothing acted on that, so the level fell through
+///     to the `inference` default and got written into `index.json`. The
+///     claim was right about the *bytes*: `write_kquant` runs the
+///     norms → ple → lm_head trio unconditionally, so a q4k vindex already
+///     contains everything an `all` vindex would. Only the recorded metadata
+///     was wrong — and it under-reported the vindex's contents to every
+///     consumer that reads `extract_level`.
+///
+/// Never *lowers* an explicitly requested level.
+fn resolve_extract_level(
+    include_weights: bool,
+    quant: larql_vindex::QuantFormat,
+    requested: larql_vindex::ExtractLevel,
+) -> larql_vindex::ExtractLevel {
+    if include_weights || quant == larql_vindex::QuantFormat::Q4K {
+        larql_vindex::ExtractLevel::All
+    } else {
+        requested
+    }
+}
+
 fn parse_extract_level(s: &str) -> Result<larql_vindex::ExtractLevel, String> {
     match s.to_lowercase().as_str() {
         "browse" => Ok(larql_vindex::ExtractLevel::Browse),
@@ -202,12 +228,7 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
     let mut callbacks = CliBuildCallbacks::new();
     let build_start = Instant::now();
 
-    // Resolve extract level: --include-weights upgrades to All (backwards compat)
-    let level = if args.include_weights {
-        larql_vindex::ExtractLevel::All
-    } else {
-        args.level
-    };
+    let level = resolve_extract_level(args.include_weights, args.quant, args.level);
 
     // Dtype resolution:
     //   --f16                → F16
@@ -541,4 +562,50 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod level_resolution_tests {
+    use super::resolve_extract_level;
+    use larql_vindex::{ExtractLevel, QuantFormat};
+
+    #[test]
+    fn quant_q4k_implies_all_as_its_help_has_always_claimed() {
+        // The regression this pins: `--quant q4k` with the default level
+        // recorded `inference` while the writer had emitted an `all` vindex.
+        assert_eq!(
+            resolve_extract_level(false, QuantFormat::Q4K, ExtractLevel::Inference),
+            ExtractLevel::All
+        );
+        // Also from the lowest level — the writer's output does not depend
+        // on what was asked for, so neither should the recorded level.
+        assert_eq!(
+            resolve_extract_level(false, QuantFormat::Q4K, ExtractLevel::Browse),
+            ExtractLevel::All
+        );
+    }
+
+    #[test]
+    fn include_weights_still_upgrades() {
+        assert_eq!(
+            resolve_extract_level(true, QuantFormat::None, ExtractLevel::Browse),
+            ExtractLevel::All
+        );
+    }
+
+    #[test]
+    fn without_either_flag_the_requested_level_is_untouched() {
+        for lvl in [
+            ExtractLevel::Browse,
+            ExtractLevel::Attention,
+            ExtractLevel::Inference,
+            ExtractLevel::All,
+        ] {
+            assert_eq!(
+                resolve_extract_level(false, QuantFormat::None, lvl),
+                lvl,
+                "unquantised extract must record exactly the level asked for"
+            );
+        }
+    }
 }

--- a/crates/larql-cli/src/commands/primary/publish_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/publish_cmd.rs
@@ -118,6 +118,21 @@ pub struct PublishArgs {
     #[arg(long)]
     pub force_upload: bool,
 
+    /// Keep remote files that no longer exist in the source vindex.
+    ///
+    /// By default `publish` mirrors the source: after uploading, any file
+    /// on the Hub that the vindex no longer contains is deleted (except
+    /// `README.md` and dot-files, which are authored separately). This
+    /// matters when a weight file is renamed — leaving both generations in
+    /// the repo lets the loader pick the stale one by name, which is how
+    /// `gemma-3-4b-it-vindex` ended up serving a pre-ggml-layout weight
+    /// after a republish on 2026-08-07.
+    ///
+    /// Pass this to keep extra files, e.g. when a repo intentionally
+    /// carries hand-added assets alongside the vindex.
+    #[arg(long)]
+    pub no_prune: bool,
+
     /// HuggingFace repo type: `model` (default) or `dataset`.
     #[arg(long, default_value = "model")]
     pub repo_type: String,
@@ -226,6 +241,7 @@ pub fn run(args: PublishArgs) -> Result<(), Box<dyn std::error::Error>> {
             args.force_upload,
             &args.repo_type,
             args.private,
+            !args.no_prune,
         )?;
         results.push(StepOutcome {
             label: step.label,
@@ -526,12 +542,20 @@ fn execute_step(
     force_upload: bool,
     repo_type: &str,
     private: bool,
+    prune_remote: bool,
 ) -> Result<String, Box<dyn std::error::Error>> {
     match (&step.preset, &step.staging) {
         // Full vindex — upload the source directory directly, no slicing.
         (None, _) => {
             println!("\n→ Uploading full vindex to {}", step.repo);
-            upload_dir(src, &step.repo, force_upload, repo_type, private)
+            upload_dir(
+                src,
+                &step.repo,
+                force_upload,
+                repo_type,
+                private,
+                prune_remote,
+            )
         }
         // Sliced upload — carve into staging, upload, clean up.
         (Some(preset), Some(staging)) => {
@@ -548,7 +572,14 @@ fn execute_step(
                 staging.display()
             );
             println!("→ Uploading slice `{preset}` to {}", step.repo);
-            let result = upload_dir(staging, &step.repo, force_upload, repo_type, private);
+            let result = upload_dir(
+                staging,
+                &step.repo,
+                force_upload,
+                repo_type,
+                private,
+                prune_remote,
+            );
             // Always try to clean up the staging dir, regardless of outcome.
             let _ = std::fs::remove_dir_all(staging);
             result
@@ -563,12 +594,14 @@ fn upload_dir(
     force_upload: bool,
     repo_type: &str,
     private: bool,
+    prune_remote: bool,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let mut callbacks = CliPublishCallbacks::new();
     let opts = larql_vindex::PublishOptions {
         skip_unchanged: !force_upload,
         repo_type: repo_type.to_string(),
         private,
+        prune_remote,
     };
     let url = larql_vindex::publish_vindex_with_opts(dir, repo, &opts, &mut callbacks)?;
     Ok(url)
@@ -653,6 +686,29 @@ impl larql_vindex::PublishCallbacks for CliPublishCallbacks {
             truncate_msg(filename, 28),
             short_sha
         ));
+    }
+
+    fn on_retry(
+        &mut self,
+        filename: &str,
+        attempt: u32,
+        max_attempts: u32,
+        reason: &str,
+        wait: std::time::Duration,
+    ) {
+        // Say it out loud: a silent multi-second sleep inside a stalled
+        // progress bar is indistinguishable from a hung upload.
+        let _ = self.mp.println(format!(
+            "    ⟳ {} — {reason}, retrying in {:.0}s (attempt {attempt}/{max_attempts})",
+            truncate_msg(filename, 40),
+            wait.as_secs_f32(),
+        ));
+    }
+
+    fn on_file_deleted(&mut self, filename: &str) {
+        let _ = self
+            .mp
+            .println(format!("    ✗ {filename} [pruned — not in source vindex]"));
     }
 
     fn on_complete(&mut self, url: &str) {

--- a/crates/larql-vindex/src/format/huggingface/publish/lfs/mod.rs
+++ b/crates/larql-vindex/src/format/huggingface/publish/lfs/mod.rs
@@ -14,6 +14,7 @@
 mod batch;
 mod finalize;
 mod multipart;
+mod retry;
 mod stream;
 #[cfg(test)]
 mod test_support;

--- a/crates/larql-vindex/src/format/huggingface/publish/lfs/multipart.rs
+++ b/crates/larql-vindex/src/format/huggingface/publish/lfs/multipart.rs
@@ -24,6 +24,7 @@ use crate::error::VindexError;
 
 use super::super::protocol::{CONTENT_TYPE_LFS_JSON, LFS_PUT_TIMEOUT};
 use super::super::PublishCallbacks;
+use super::retry::{backoff_for, is_transient_status, retry_after_secs, TRANSIENT_MAX_ATTEMPTS};
 
 /// Streamed multipart LFS upload. Returns successfully once HF's
 /// completion endpoint has accepted the assembled parts.
@@ -102,21 +103,56 @@ pub(super) fn upload_multipart(
             ))
         })?;
 
-        let resp = client.put(part_url).body(buf).send().map_err(|e| {
-            VindexError::Parse(format!(
-                "multipart upload {remote_filename} part {part_number}/{}: PUT failed: {e}",
-                parts.len()
-            ))
-        })?;
+        // Retry transient failures rather than aborting the publish. HF's S3
+        // backend rate-limits a long upload with `503 SlowDown`, and losing
+        // the run at part N leaves the repo holding stale files with no
+        // replacement — a partially-published repo still serves, so it is
+        // worse than a clean failure. The body is re-sent from `buf`, which
+        // is already in memory, so a retry costs no extra read.
+        let mut attempt: u32 = 1;
+        let resp = loop {
+            let outcome = client.put(part_url).body(buf.clone()).send();
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().unwrap_or_default();
-            return Err(VindexError::Parse(format!(
-                "multipart upload {remote_filename} part {part_number}/{} ({status}): {body}",
-                parts.len()
-            )));
-        }
+            let (retryable, detail, resp) = match outcome {
+                Ok(r) if r.status().is_success() => break r,
+                Ok(r) => {
+                    let status = r.status();
+                    let wait = retry_after_secs(r.headers());
+                    let transient = is_transient_status(status.as_u16());
+                    (transient, format!("{status}"), Some((r, wait)))
+                }
+                // A transport error (reset, timeout, DNS blip) is always
+                // worth one more go — nothing was necessarily rejected.
+                Err(e) => (true, format!("transport error: {e}"), None),
+            };
+
+            if !retryable || attempt >= TRANSIENT_MAX_ATTEMPTS {
+                let body = match resp {
+                    Some((r, _)) => r.text().unwrap_or_default(),
+                    None => String::new(),
+                };
+                let give_up = if retryable {
+                    format!(" after {TRANSIENT_MAX_ATTEMPTS} attempts")
+                } else {
+                    String::new()
+                };
+                return Err(VindexError::Parse(format!(
+                    "multipart upload {remote_filename} part {part_number}/{} ({detail}){give_up}: {body}",
+                    parts.len()
+                )));
+            }
+
+            let wait = backoff_for(attempt, resp.and_then(|(_, w)| w));
+            callbacks.on_retry(
+                &format!("{remote_filename} part {part_number}/{}", parts.len()),
+                attempt + 1,
+                TRANSIENT_MAX_ATTEMPTS,
+                &detail,
+                wait,
+            );
+            std::thread::sleep(wait);
+            attempt += 1;
+        };
 
         // S3 returns the part's ETag in the response header. The
         // completion POST must reference these ETags in order.

--- a/crates/larql-vindex/src/format/huggingface/publish/lfs/retry.rs
+++ b/crates/larql-vindex/src/format/huggingface/publish/lfs/retry.rs
@@ -1,0 +1,113 @@
+//! Bounded retry for transient upload failures.
+//!
+//! A large publish issues hundreds of PUTs against HF's S3 backend, and
+//! that backend rate-limits. Without a retry, one `503 SlowDown` on part
+//! 35 of 109 aborts the whole publish — which is exactly what happened on
+//! 2026-08-07 and left `gemma-3-4b-it-vindex-server` holding a stale weight
+//! file with no replacement. A partially-uploaded repo is worse than a
+//! failed one, because it still serves.
+//!
+//! Scope: transport errors and the transient HTTP statuses below. A 4xx
+//! that is not 408/429 is a real rejection (bad signature, expired URL) and
+//! is returned immediately — retrying it would just burn the backoff budget
+//! and delay the error the caller needs to see.
+
+use std::time::Duration;
+
+/// Attempts per operation, including the first. Five attempts with the
+/// backoff below spans ~15 s, comfortably past the short shaping windows
+/// S3 applies while still failing fast on a genuine outage.
+pub(super) const TRANSIENT_MAX_ATTEMPTS: u32 = 5;
+
+/// First backoff step; doubles per attempt (1s, 2s, 4s, 8s).
+pub(super) const TRANSIENT_BACKOFF_BASE: Duration = Duration::from_secs(1);
+
+/// Upper bound on a single sleep, including a server-supplied
+/// `Retry-After`. Stops a hostile or mistaken header from parking the
+/// upload for minutes.
+pub(super) const TRANSIENT_BACKOFF_CAP: Duration = Duration::from_secs(30);
+
+/// HTTP statuses worth retrying: request timeout, explicit rate limit, and
+/// the 5xx family S3 uses for shaping and transient unavailability.
+pub(super) fn is_transient_status(status: u16) -> bool {
+    matches!(status, 408 | 429 | 500 | 502 | 503 | 504)
+}
+
+/// Backoff for `attempt` (1-based), honouring a server `Retry-After` in
+/// seconds when it is present and shorter than the cap.
+pub(super) fn backoff_for(attempt: u32, retry_after_secs: Option<u64>) -> Duration {
+    let exponential = TRANSIENT_BACKOFF_BASE
+        .saturating_mul(1u32 << attempt.saturating_sub(1).min(16))
+        .min(TRANSIENT_BACKOFF_CAP);
+    match retry_after_secs {
+        Some(s) => Duration::from_secs(s).clamp(exponential, TRANSIENT_BACKOFF_CAP),
+        None => exponential,
+    }
+}
+
+/// Read `Retry-After` as whole seconds. The HTTP-date form is not parsed —
+/// S3 and HF both send the delta-seconds form, and guessing wrong on a
+/// date is worse than falling back to the exponential schedule.
+pub(super) fn retry_after_secs(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_statuses_are_exactly_the_retryable_family() {
+        for s in [408, 429, 500, 502, 503, 504] {
+            assert!(is_transient_status(s), "{s} should be transient");
+        }
+        // 403 is an expired/incorrect pre-signed URL and 404 a missing
+        // target: retrying either just delays a real error.
+        for s in [200, 400, 401, 403, 404, 409, 422, 501] {
+            assert!(!is_transient_status(s), "{s} should not be transient");
+        }
+    }
+
+    #[test]
+    fn backoff_doubles_and_is_capped() {
+        assert_eq!(backoff_for(1, None), Duration::from_secs(1));
+        assert_eq!(backoff_for(2, None), Duration::from_secs(2));
+        assert_eq!(backoff_for(3, None), Duration::from_secs(4));
+        assert_eq!(backoff_for(4, None), Duration::from_secs(8));
+        // Far past the schedule, the cap holds rather than overflowing.
+        assert_eq!(backoff_for(30, None), TRANSIENT_BACKOFF_CAP);
+    }
+
+    #[test]
+    fn retry_after_raises_but_never_exceeds_the_cap() {
+        // Server asks for longer than the exponential step — honour it.
+        assert_eq!(backoff_for(1, Some(5)), Duration::from_secs(5));
+        // Server asks for less than we already intended — keep our own
+        // floor, so a "Retry-After: 0" cannot spin the loop.
+        assert_eq!(backoff_for(4, Some(0)), Duration::from_secs(8));
+        // Absurd value is clamped.
+        assert_eq!(backoff_for(1, Some(86_400)), TRANSIENT_BACKOFF_CAP);
+    }
+
+    #[test]
+    fn retry_after_parses_only_delta_seconds() {
+        let mut h = reqwest::header::HeaderMap::new();
+        h.insert(reqwest::header::RETRY_AFTER, "12".parse().unwrap());
+        assert_eq!(retry_after_secs(&h), Some(12));
+
+        // HTTP-date form is deliberately ignored.
+        h.insert(
+            reqwest::header::RETRY_AFTER,
+            "Wed, 21 Oct 2026 07:28:00 GMT".parse().unwrap(),
+        );
+        assert_eq!(retry_after_secs(&h), None);
+
+        assert_eq!(retry_after_secs(&reqwest::header::HeaderMap::new()), None);
+    }
+}

--- a/crates/larql-vindex/src/format/huggingface/publish/mod.rs
+++ b/crates/larql-vindex/src/format/huggingface/publish/mod.rs
@@ -811,4 +811,129 @@ mod tests {
             rec.uploaded
         );
     }
+
+    #[test]
+    #[serial]
+    fn publish_prunes_remote_files_absent_from_the_vindex() {
+        // The defect this pins: publish only ever added files, so a renamed
+        // weight file left both generations in the repo and the loader chose
+        // between them by name.
+        let mut server = mockito::Server::new();
+        let _base = EnvGuard::set(protocol::TEST_BASE_ENV, &server.url());
+        let _tok = EnvGuard::set("HF_TOKEN", "tok");
+
+        let tmp = tempfile::tempdir().unwrap();
+        make_minimal_vindex(tmp.path());
+
+        let _create = server
+            .mock("POST", "/api/repos/create")
+            .with_status(200)
+            .with_body("{}")
+            .expect_at_least(1)
+            .create();
+        // Remote carries the local file plus a superseded weight file, its
+        // manifest sibling, and two entries that must survive.
+        let _tree = server
+            .mock("GET", "/api/models/org/repo/tree/main?recursive=true")
+            .with_status(200)
+            .with_body(
+                serde_json::json!([
+                    {"type":"file","path":"index.json"},
+                    {"type":"file","path":"interleaved_q4k.bin","lfs":{"oid":"stale"}},
+                    {"type":"file","path":"interleaved_q4k_manifest.json"},
+                    {"type":"file","path":"README.md"},
+                    {"type":"file","path":".gitattributes"}
+                ])
+                .to_string(),
+            )
+            .expect_at_least(1)
+            .create();
+        // Upload of index.json, then the prune commit. Both POST the same
+        // path, so one mock serves both and the callback records the split.
+        let _preupload = server
+            .mock("POST", "/api/models/org/repo/preupload/main")
+            .with_status(200)
+            .with_body(r#"{"files":[{"path":"index.json","uploadMode":"regular"}]}"#)
+            .expect_at_least(1)
+            .create();
+        let _commit = server
+            .mock("POST", "/api/models/org/repo/commit/main")
+            .with_status(200)
+            .with_body("{}")
+            .expect_at_least(1)
+            .create();
+
+        #[derive(Default)]
+        struct Recorder {
+            deleted: Vec<String>,
+        }
+        impl PublishCallbacks for Recorder {
+            fn on_file_deleted(&mut self, f: &str) {
+                self.deleted.push(f.into());
+            }
+        }
+        let mut rec = Recorder::default();
+
+        publish_vindex_with_opts(tmp.path(), "org/repo", &PublishOptions::default(), &mut rec)
+            .expect("publish with prune must return Ok");
+
+        rec.deleted.sort();
+        assert_eq!(
+            rec.deleted,
+            vec![
+                "interleaved_q4k.bin".to_string(),
+                "interleaved_q4k_manifest.json".to_string()
+            ],
+            "only files absent from the vindex, and never README/dot-files"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn publish_with_prune_disabled_deletes_nothing() {
+        let mut server = mockito::Server::new();
+        let _base = EnvGuard::set(protocol::TEST_BASE_ENV, &server.url());
+        let _tok = EnvGuard::set("HF_TOKEN", "tok");
+
+        let tmp = tempfile::tempdir().unwrap();
+        make_minimal_vindex(tmp.path());
+
+        let _create = server
+            .mock("POST", "/api/repos/create")
+            .with_status(200)
+            .with_body("{}")
+            .expect_at_least(1)
+            .create();
+        let _preupload = server
+            .mock("POST", "/api/models/org/repo/preupload/main")
+            .with_status(200)
+            .with_body(r#"{"files":[{"path":"index.json","uploadMode":"regular"}]}"#)
+            .expect_at_least(1)
+            .create();
+        let _commit = server
+            .mock("POST", "/api/models/org/repo/commit/main")
+            .with_status(200)
+            .with_body("{}")
+            .expect_at_least(1)
+            .create();
+
+        #[derive(Default)]
+        struct Recorder {
+            deleted: Vec<String>,
+        }
+        impl PublishCallbacks for Recorder {
+            fn on_file_deleted(&mut self, f: &str) {
+                self.deleted.push(f.into());
+            }
+        }
+        let mut rec = Recorder::default();
+
+        let opts = PublishOptions {
+            prune_remote: false,
+            ..PublishOptions::default()
+        };
+        publish_vindex_with_opts(tmp.path(), "org/repo", &opts, &mut rec)
+            .expect("publish must return Ok");
+        assert!(rec.deleted.is_empty(), "--no-prune must delete nothing");
+    }
 }

--- a/crates/larql-vindex/src/format/huggingface/publish/mod.rs
+++ b/crates/larql-vindex/src/format/huggingface/publish/mod.rs
@@ -23,7 +23,10 @@ use crate::error::VindexError;
 use crate::format::filenames::*;
 
 use protocol::{hf_base, repo_type_plural, REPO_TYPE_DATASET, REPO_TYPE_MODEL};
-use remote::{create_hf_repo, fetch_remote_lfs_oids, update_repo_visibility};
+use remote::{
+    create_hf_repo, delete_remote_files, fetch_remote_file_paths, fetch_remote_lfs_oids,
+    is_prune_exempt, update_repo_visibility,
+};
 use upload::upload_file_to_hf;
 
 /// Options controlling [`publish_vindex_with_opts`]. Kept as a struct so
@@ -45,6 +48,17 @@ pub struct PublishOptions {
     /// existing caller's behaviour (`larql publish`/`larql hf publish`
     /// have always created public repos).
     pub private: bool,
+    /// Delete remote files that no longer exist in the source vindex.
+    ///
+    /// Publishing only ever *added* files until 2026-08-07. When the Q6_K
+    /// weight files were renamed (`interleaved_q4k.bin` →
+    /// `interleaved_kquant.bin`) a republish left both generations in the
+    /// repo, and `pick_bin` chose between them by name — so a repo could
+    /// silently serve a stale weight file that the source vindex no longer
+    /// contained. Mirroring the source is the intended meaning of "publish
+    /// this vindex", so this defaults to `true`; see [`is_prune_exempt`]
+    /// for what is never removed.
+    pub prune_remote: bool,
 }
 
 impl Default for PublishOptions {
@@ -53,6 +67,7 @@ impl Default for PublishOptions {
             skip_unchanged: false,
             repo_type: REPO_TYPE_MODEL.into(),
             private: false,
+            prune_remote: true,
         }
     }
 }
@@ -174,6 +189,29 @@ pub fn publish_vindex_with_opts(
         callbacks.on_file_done(filename);
     }
 
+    // Mirror the source: anything on the Hub that the vindex no longer
+    // contains is removed. Runs *after* the uploads so a failed upload
+    // never leaves the repo with neither the old file nor the new one.
+    if opts.prune_remote {
+        let local: std::collections::HashSet<&str> =
+            files.iter().map(|(_, name)| name.as_str()).collect();
+        // A listing failure is not fatal — the upload already succeeded and
+        // stale files are a tidiness problem, not a correctness one now that
+        // the current generation is present.
+        if let Ok(remote) = fetch_remote_file_paths(repo_id, &token, repo_type) {
+            let stale: Vec<String> = remote
+                .into_iter()
+                .filter(|p| !local.contains(p.as_str()) && !is_prune_exempt(p))
+                .collect();
+            if !stale.is_empty() {
+                delete_remote_files(repo_id, &token, repo_type, &stale)?;
+                for p in &stale {
+                    callbacks.on_file_deleted(p);
+                }
+            }
+        }
+    }
+
     let url = hf_repo_url(repo_type, repo_id);
     callbacks.on_complete(&url);
     Ok(url)
@@ -235,6 +273,22 @@ pub trait PublishCallbacks {
     /// `lfs.oid` and the upload is skipped. Default no-op so existing
     /// callbacks don't need to change.
     fn on_file_skipped(&mut self, _filename: &str, _size: u64, _sha256: &str) {}
+    /// Fired before sleeping to retry a transient upload failure —
+    /// `attempt` is the one about to be made, `reason` the status or
+    /// transport error that triggered it. Default no-op; surface it, because
+    /// a silent multi-minute backoff looks identical to a hung upload.
+    fn on_retry(
+        &mut self,
+        _filename: &str,
+        _attempt: u32,
+        _max_attempts: u32,
+        _reason: &str,
+        _wait: std::time::Duration,
+    ) {
+    }
+    /// Fired for each remote file deleted because it no longer exists in
+    /// the source vindex. Default no-op.
+    fn on_file_deleted(&mut self, _filename: &str) {}
     fn on_complete(&mut self, _url: &str) {}
 }
 

--- a/crates/larql-vindex/src/format/huggingface/publish/remote.rs
+++ b/crates/larql-vindex/src/format/huggingface/publish/remote.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use crate::error::VindexError;
 
-use super::protocol::{hf_base, repo_type_plural, HTTP_STATUS_CONFLICT};
+use super::protocol::{hf_base, repo_type_plural, CONTENT_TYPE_NDJSON, HTTP_STATUS_CONFLICT};
 
 /// List remote files and return `filename → lfs.oid` for every LFS-tracked
 /// file at the repo root. Files without an `lfs.oid` (git-tracked small
@@ -131,6 +131,104 @@ pub(super) fn update_repo_visibility(
             "HF repo visibility update failed ({status}): {body}"
         )))
     }
+}
+
+/// Every file path in the repo, whether LFS-tracked or not.
+///
+/// [`fetch_remote_lfs_oids`] deliberately drops non-LFS entries because it
+/// only answers "can I skip this upload". Pruning needs the full set: the
+/// small `*_manifest.json` siblings of a renamed weight file are git-tracked,
+/// not LFS, and leaving them behind is what makes a half-renamed vindex load
+/// the wrong pair.
+pub(super) fn fetch_remote_file_paths(
+    repo_id: &str,
+    token: &str,
+    repo_type: &str,
+) -> Result<Vec<String>, VindexError> {
+    let plural = repo_type_plural(repo_type);
+    let url = format!(
+        "{}/api/{plural}/{repo_id}/tree/main?recursive=true",
+        hf_base()
+    );
+    let resp = reqwest::blocking::Client::new()
+        .get(&url)
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .map_err(|e| VindexError::Parse(format!("HF tree fetch failed: {e}")))?;
+    if !resp.status().is_success() {
+        // Fresh repo → nothing to prune.
+        return Ok(Vec::new());
+    }
+    let body: serde_json::Value = resp
+        .json()
+        .map_err(|e| VindexError::Parse(format!("HF tree JSON: {e}")))?;
+    Ok(parse_file_paths(&body))
+}
+
+/// Pull `path` from every `type == "file"` entry of a tree listing.
+fn parse_file_paths(body: &serde_json::Value) -> Vec<String> {
+    let arr = match body.as_array() {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+    arr.iter()
+        .filter(|e| e.get("type").and_then(|v| v.as_str()) == Some("file"))
+        .filter_map(|e| e.get("path").and_then(|v| v.as_str()).map(str::to_string))
+        .collect()
+}
+
+/// Delete `paths` from the repo in one commit.
+pub(super) fn delete_remote_files(
+    repo_id: &str,
+    token: &str,
+    repo_type: &str,
+    paths: &[String],
+) -> Result<(), VindexError> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+    let plural = repo_type_plural(repo_type);
+    let url = format!("{}/api/{plural}/{repo_id}/commit/main", hf_base());
+
+    let mut ndjson = serde_json::to_string(&serde_json::json!({
+        "key": "header",
+        "value": { "summary": format!("Prune {} file(s) not in the source vindex", paths.len()) },
+    }))
+    .unwrap();
+    ndjson.push('\n');
+    for p in paths {
+        ndjson.push_str(
+            &serde_json::to_string(&serde_json::json!({
+                "key": "deletedFile",
+                "value": { "path": p },
+            }))
+            .unwrap(),
+        );
+        ndjson.push('\n');
+    }
+
+    let resp = reqwest::blocking::Client::new()
+        .post(&url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", CONTENT_TYPE_NDJSON)
+        .body(ndjson)
+        .send()
+        .map_err(|e| VindexError::Parse(format!("prune commit failed: {e}")))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().unwrap_or_default();
+        return Err(VindexError::Parse(format!(
+            "prune commit ({status}): {body}"
+        )));
+    }
+    Ok(())
+}
+
+/// Repo files that `publish` never writes and must therefore never prune:
+/// git plumbing and the model card, which is authored separately
+/// (`larql card`) and lives only on the Hub.
+pub(super) fn is_prune_exempt(path: &str) -> bool {
+    path.starts_with('.') || path == "README.md" || path.ends_with("/README.md")
 }
 
 #[cfg(test)]

--- a/crates/larql-vindex/src/format/huggingface/publish/remote.rs
+++ b/crates/larql-vindex/src/format/huggingface/publish/remote.rs
@@ -339,6 +339,163 @@ mod tests {
     }
 
     #[test]
+    fn parse_file_paths_takes_every_file_regardless_of_lfs() {
+        // The contrast with `parse_lfs_oid_index`: pruning must see the
+        // small git-tracked manifests too, because a renamed weight file
+        // leaves its `*_manifest.json` sibling behind as well.
+        let body = serde_json::json!([
+            {"type": "file", "path": "interleaved_kquant.bin", "lfs": {"oid": "a"}},
+            {"type": "file", "path": "interleaved_kquant_manifest.json"},
+            {"type": "directory", "path": "layers"},
+            {"type": "file", "path": "layers/layer_00.weights", "lfs": {"oid": "b"}}
+        ]);
+        let paths = parse_file_paths(&body);
+        assert_eq!(
+            paths,
+            vec![
+                "interleaved_kquant.bin",
+                "interleaved_kquant_manifest.json",
+                "layers/layer_00.weights"
+            ],
+            "directories must be dropped, non-LFS files kept"
+        );
+    }
+
+    #[test]
+    fn parse_file_paths_tolerates_a_non_array_body() {
+        assert!(parse_file_paths(&serde_json::json!({"error": "nope"})).is_empty());
+    }
+
+    #[test]
+    fn prune_exempts_git_plumbing_and_the_model_card() {
+        // These are authored outside the vindex (`larql card`, repo
+        // creation) so publishing must never treat them as stale.
+        for p in [".gitattributes", ".gitignore", "README.md", "sub/README.md"] {
+            assert!(is_prune_exempt(p), "{p} must be exempt");
+        }
+        // Everything the build emits is fair game.
+        for p in [
+            "interleaved_q4k.bin",
+            "attn_weights_q4k_manifest.json",
+            "layers/layer_00.weights",
+            "index.json",
+        ] {
+            assert!(!is_prune_exempt(p), "{p} must be prunable");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn fetch_remote_file_paths_lists_files_and_skips_directories() {
+        let mut server = mockito::Server::new();
+        let _guard = EnvBaseGuard::new(&server.url());
+        let mock = server
+            .mock("GET", "/api/models/org/repo/tree/main?recursive=true")
+            .match_header("authorization", "Bearer t")
+            .with_status(200)
+            .with_body(
+                serde_json::json!([
+                    {"type": "file", "path": "index.json"},
+                    {"type": "directory", "path": "layers"},
+                    {"type": "file", "path": "layers/layer_00.weights", "lfs": {"oid": "x"}}
+                ])
+                .to_string(),
+            )
+            .create();
+        let paths = fetch_remote_file_paths("org/repo", "t", "model").unwrap();
+        mock.assert();
+        assert_eq!(paths, vec!["index.json", "layers/layer_00.weights"]);
+    }
+
+    #[test]
+    #[serial]
+    fn fetch_remote_file_paths_dataset_uses_datasets_path_segment() {
+        let mut server = mockito::Server::new();
+        let _guard = EnvBaseGuard::new(&server.url());
+        let mock = server
+            .mock("GET", "/api/datasets/org/repo/tree/main?recursive=true")
+            .with_status(200)
+            .with_body("[]")
+            .create();
+        assert!(fetch_remote_file_paths("org/repo", "t", "dataset")
+            .unwrap()
+            .is_empty());
+        mock.assert();
+    }
+
+    #[test]
+    #[serial]
+    fn fetch_remote_file_paths_returns_empty_on_a_missing_repo() {
+        // A fresh repo 404s on the tree API; that means "nothing to prune",
+        // not an error that should abort a successful publish.
+        let mut server = mockito::Server::new();
+        let _guard = EnvBaseGuard::new(&server.url());
+        let mock = server
+            .mock("GET", "/api/models/org/new/tree/main?recursive=true")
+            .with_status(404)
+            .create();
+        assert!(fetch_remote_file_paths("org/new", "t", "model")
+            .unwrap()
+            .is_empty());
+        mock.assert();
+    }
+
+    #[test]
+    #[serial]
+    fn delete_remote_files_posts_one_commit_with_a_deleted_entry_per_path() {
+        let mut server = mockito::Server::new();
+        let _guard = EnvBaseGuard::new(&server.url());
+        let mock = server
+            .mock("POST", "/api/models/org/repo/commit/main")
+            .match_header("authorization", "Bearer t")
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::Regex(r#""key":"header""#.into()),
+                mockito::Matcher::Regex(r#""path":"interleaved_q4k\.bin""#.into()),
+                mockito::Matcher::Regex(r#""path":"attn_weights_q4k\.bin""#.into()),
+            ]))
+            .with_status(200)
+            .create();
+
+        delete_remote_files(
+            "org/repo",
+            "t",
+            "model",
+            &[
+                "interleaved_q4k.bin".to_string(),
+                "attn_weights_q4k.bin".to_string(),
+            ],
+        )
+        .unwrap();
+        mock.assert();
+    }
+
+    #[test]
+    #[serial]
+    fn delete_remote_files_is_a_no_op_for_an_empty_list() {
+        // No mock is registered: if this issued a request it would fail to
+        // connect, so passing proves no commit was attempted.
+        let server = mockito::Server::new();
+        let _guard = EnvBaseGuard::new(&server.url());
+        delete_remote_files("org/repo", "t", "model", &[]).unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn delete_remote_files_surfaces_a_rejected_commit() {
+        let mut server = mockito::Server::new();
+        let _guard = EnvBaseGuard::new(&server.url());
+        let _mock = server
+            .mock("POST", "/api/models/org/repo/commit/main")
+            .with_status(403)
+            .with_body("forbidden")
+            .create();
+        let err = delete_remote_files("org/repo", "t", "model", &["a.bin".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("403"), "error should name the status: {err}");
+    }
+
+    #[test]
     #[serial]
     fn fetch_remote_lfs_oids_parses_tree_response() {
         let mut server = mockito::Server::new();


### PR DESCRIPTION
Three defects, all surfaced by republishing the vindexes after #212's Q6_K layout fix.

## 1. Publish never deleted anything

It only ever *added* files. So when the weight files were renamed (`interleaved_q4k.bin` → `interleaved_kquant.bin`), a republish left **both generations** in the repo — and `pick_bin` chooses between them by name. A repo could silently serve a stale weight file the source vindex no longer contained, while carrying 2.0 GB of dead bytes to do it.

Publish now mirrors the source: after the uploads, remote files absent from the vindex are deleted in one commit. `README.md` and dot-files are exempt — they're authored separately (`larql card`), not emitted by the build. `--no-prune` opts out.

**The prune runs *after* the uploads, deliberately.** A failed upload must never leave the repo holding neither the old file nor the new one.

## 2. One 503 aborted the whole publish

HF's S3 backend rate-limits long uploads and the multipart part-PUT had no retry:

```
multipart upload interleaved_kquant.bin part 35/109 (503): Code: SlowDown
```

That killed the run and left `gemma-3-4b-it-vindex-server` holding a stale weight file with **no replacement**. A partially-published repo still serves, so it is worse than a clean failure.

Part PUTs now retry up to 5 times with exponential backoff (1/2/4/8s, capped at 30s), honouring `Retry-After` when present but never below our own floor — so a `Retry-After: 0` cannot spin the loop. Only transport errors and `408/429/500/502/503/504` retry; a `403` is an expired pre-signed URL and surfaces immediately rather than burning the backoff budget.

Retries and prunes both report through new `PublishCallbacks` methods — a silent multi-second backoff inside a stalled progress bar is indistinguishable from a hung upload.

## 3. `--quant q4k` did not imply `--level all`

Its help has claimed this since it was written, but nothing acted on it: the level fell through to the `inference` default and got recorded in `index.json`.

The claim was right about the **bytes** — `write_kquant` runs the norms/ple/lm_head trio unconditionally, so a q4k vindex already contains everything an `all` vindex would. What was wrong was only the recorded metadata, which under-reported the vindex's own contents to every consumer reading `extract_level`.

Pulled the rule out of `run()` into `resolve_extract_level` so it is testable, and pinned all three branches.

## Verification

- 4 tests for retry policy: transient classification (403/404 explicitly *not* retryable), backoff doubling and cap, `Retry-After` clamping in both directions, delta-seconds-only parsing
- 3 tests for level resolution
- `larql-vindex` 2173 pass, `larql-cli` 602 pass, clippy clean at `-D warnings`

Applied by hand to the already-published repos while this lands: **4.4 GB of stale files removed** across the six gemma-3-4b repos, all now correct with zero stale entries.