### PR TITLE
perf(vindex3): run bank experts in parallel, reduce serially

### DIFF
--- a/crates/larql-vindex/src/runtime/execute.rs
+++ b/crates/larql-vindex/src/runtime/execute.rs
@@ -78,13 +78,26 @@ pub fn execute_with<S: TraceSink>(
         // bank's selected experts; quantising per expert would be binding a
         // differently-shaped call than production makes.
         let mut kernel = BankKernel::open(bank, &bank_input)?;
-        for choice in &selected {
-            let expert = bank.expert(choice.expert_id, operation.router.population())?;
-            let out = kernel.run(expert, bank, &bank_input)?;
-            sink.expert_output(choice.expert_id, &out);
+
+        // Experts run in parallel; the reduction stays serial and in
+        // selection order. Splitting it this way is what makes the speed-up
+        // free of numerical consequence: each expert writes only its own
+        // disjoint slot, and the float additions below happen in exactly the
+        // order the serial loop used, so every bit-exactness claim in the
+        // ladder still holds. Summing inside the pool would reorder them.
+        let experts = selected
+            .iter()
+            .map(|c| bank.expert(c.expert_id, operation.router.population()))
+            .collect::<Result<Vec<_>, _>>()?;
+        let hidden = bank.hidden_dim;
+        let mut outs = vec![0.0f32; experts.len() * hidden];
+        kernel.run_many_into(&experts, bank, &bank_input, hidden, &mut outs)?;
+
+        for (choice, out) in selected.iter().zip(outs.chunks(hidden)) {
+            sink.expert_output(choice.expert_id, out);
             operation
                 .reduction
-                .accumulate(&mut reduced, &out, choice.weight)?;
+                .accumulate(&mut reduced, out, choice.weight)?;
         }
     }
     sink.reduced(&reduced);

--- a/crates/larql-vindex/src/runtime/expert_kernel.rs
+++ b/crates/larql-vindex/src/runtime/expert_kernel.rs
@@ -168,40 +168,96 @@ impl BankKernel {
             }
         }
     }
+}
 
-    /// Run one expert, returning its unweighted output.
+impl BankKernel {
+    /// Run `experts` into `out`, one `hidden`-wide slot each, in parallel when
+    /// the incumbent kernel and the spin pool are both available.
     ///
-    /// Returns an owned vector for both kernels. The reference allocates one
-    /// anyway, and the copy out of the incumbent's scratch keeps the two
-    /// arms' cost comparable without making the caller reason about a borrow
-    /// that lives across the reduction.
-    pub(crate) fn run(
+    /// **Why this replaced a serial per-expert `run`.** Profiling a composed
+    /// run showed the bound path and the incumbent calling the *identical*
+    /// `run_single_expert_q4k_q8k_into` on identical bytes — but the incumbent
+    /// dispatching it through `spin_pool::par_chunks_mut` while the bound path
+    /// ran top-8 experts on the calling thread. 9293 samples against 1151 in
+    /// one window, and +992 ms/token on a 26B MoE. Nothing about the container
+    /// was slow; the expert loop simply was not parallel. Parallelising it took
+    /// the measured container tax to +7 ms/token.
+    ///
+    /// **Determinism holds by construction.** Each expert writes only its own
+    /// disjoint slot and *nothing is summed here* — the caller accumulates the
+    /// slots afterwards in selection order, so float additions happen in the
+    /// same order the serial loop used. Every bit-exactness claim in the
+    /// VINDEX3 ladder still holds. Summing inside the pool would reorder them,
+    /// which is exactly what this avoids.
+    pub(crate) fn run_many_into(
         &mut self,
-        expert: &BoundExpert<'_>,
+        experts: &[&BoundExpert<'_>],
         bank: &BoundBankOperation<'_>,
         bank_input: &[f32],
-    ) -> Result<Vec<f32>, ExecutionError> {
-        match self {
+        hidden: usize,
+        out: &mut [f32],
+    ) -> Result<(), ExecutionError> {
+        debug_assert_eq!(out.len(), experts.len() * hidden);
+
+        let session = match self {
+            // The reference kernel is a differential instrument, not a
+            // production path; keep it serial and obviously correct.
             Self::Reference => {
-                expert::forward(expert, bank_input, bank.intermediate_dim, bank.activation)
+                for (slot, expert) in out.chunks_mut(hidden).zip(experts) {
+                    let v = expert::forward(
+                        expert,
+                        bank_input,
+                        bank.intermediate_dim,
+                        bank.activation,
+                    )?;
+                    slot.copy_from_slice(&v);
+                }
+                return Ok(());
             }
-            Self::IncumbentQ4kQ8k(session) => {
-                let operands = incumbent_operands(expert, bank.intermediate_dim, bank.hidden_dim)?;
-                // The incumbent's own function, over the region's own bytes.
-                // Its internal short-slab guard — which would zero the output
-                // and return successfully — is unreachable from here: the
-                // operand checks above pin exactly the byte count it measures.
-                let out = run_single_expert_q4k_q8k_into(
-                    &mut session.scratch,
-                    &session.input,
-                    operands.gate_up.bytes,
-                    operands.down.bytes,
-                    bank.intermediate_dim,
-                    bank.activation,
+            Self::IncumbentQ4kQ8k(session) => session,
+        };
+
+        // Operand resolution can fail, and a failure inside a pool closure
+        // cannot propagate — resolve everything first, and only enter the
+        // parallel section once every operand is known good.
+        let operands = experts
+            .iter()
+            .map(|e| incumbent_operands(e, bank.intermediate_dim, bank.hidden_dim))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let padded = padded_intermediate(bank.intermediate_dim, block_elements());
+        let input = &session.input;
+        let intermediate = bank.intermediate_dim;
+        let activation = bank.activation;
+        let ops = &operands[..];
+
+        if larql_compute::cpu::spin_pool::enabled() && experts.len() > 1 {
+            larql_compute::cpu::spin_pool::par_chunks_mut(out, hidden, |ci, slot| {
+                let mut scratch = ExpertScratch::new(hidden, intermediate, padded);
+                let v = run_single_expert_q4k_q8k_into(
+                    &mut scratch,
+                    input,
+                    ops[ci].gate_up.bytes,
+                    ops[ci].down.bytes,
+                    intermediate,
+                    activation,
                 );
-                Ok(out.to_vec())
+                slot.copy_from_slice(v);
+            });
+        } else {
+            for (ci, slot) in out.chunks_mut(hidden).enumerate() {
+                let v = run_single_expert_q4k_q8k_into(
+                    &mut session.scratch,
+                    input,
+                    ops[ci].gate_up.bytes,
+                    ops[ci].down.bytes,
+                    intermediate,
+                    activation,
+                );
+                slot.copy_from_slice(v);
             }
         }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Profiling a composed run found the whole measured "container tax", and it wasn't the container.

Both arms call the **identical** `run_single_expert_q4k_q8k_into` on identical bytes — but the incumbent dispatches it through `spin_pool::par_chunks_mut` while the bound path ran top-8 experts on the calling thread:

```
in-process (1151 samples)          bound (9293 samples)
 └ cpu_moe_forward                  └ BoundMoeBackend::run_layer
   └ spin_pool::par_chunks_mut  ←     └ execute::execute
     └ run_single_expert...             └ BankKernel::run
                                          └ run_single_expert...   ← no pool
```

**No `lyrw2`, `resolve` or `region` frame appears anywhere in the profile.** The example's own hypothesis was that 7680 `region_bytes` lookups per token cost real time. The lookups are real — `moe_container` resolves all 128 experts per layer rather than the selected 8, which is its own waste — but resolve is a handful of arithmetic ops and 7680 of them don't register.

## Measured — gemma4-26b-a4b, M3 Max

| | before | after |
|---|---|---|
| container tax (expert stage) | +992 ms/token | **+7 ms/token** |
| expert stage (bound vs incumbent) | 1261 vs 269 ms | 278 vs 271 ms |
| wall ratio | 1.561× | **1.025×** |

Reproduced across runs (+953 / 1.553× before, +7 / 1.025× after).

## Determinism holds by construction

This is the part that matters. Each expert writes only its own disjoint slot and **nothing is summed inside the pool** — the caller accumulates slots afterwards in selection order, so float additions happen in exactly the order the serial loop used. Summing in parallel would reorder them, and every bit-exactness claim in the VINDEX3 ladder would have paid for it.

- `vindex3_container_parity` still passes bit-identical
- real-model decode parity on gemma4-26b-a4b still exact under teacher-forcing **and** free-running, with top-8 experts — so the parallel branch is genuinely exercised, not skipped by a small fixture

Operands are resolved before the parallel section, because a failure inside a pool closure can't propagate. Each worker takes its own `ExpertScratch`; the Q8_K bank input is quantised once by `open` and shared read-only.

The serial per-expert `run` is removed — `run_many_into` subsumes it and is the only shape production takes.