### PR TITLE
perf(run): use the resident KV-cached route for CPU MoE decode

### DIFF
--- a/crates/larql-cli/src/commands/extraction/walk_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/walk_cmd.rs
@@ -557,7 +557,18 @@ fn run_predict_q4k(
         // once, up front, instead of on every token. `larql bench --cpu` has
         // always taken this route, which is why its numbers and `larql run`'s
         // disagreed by a factor nobody could place.
-        if !arch_needs_per_layer_embeddings(weights) && weights.arch.is_hybrid_moe() {
+        // `LARQL_CPU_RESIDENT=0` forces the uncached route so the two can be
+        // A/B'd in one binary under identical conditions. Without it the old
+        // path becomes unreachable on MoE models the moment this lands, and a
+        // before/after measured on two different builds — or, worse, two
+        // different prompts — is not a comparison.
+        let resident_allowed = std::env::var("LARQL_CPU_RESIDENT")
+            .map(|v| v != "0")
+            .unwrap_or(true);
+        if resident_allowed
+            && !arch_needs_per_layer_embeddings(weights)
+            && weights.arch.is_hybrid_moe()
+        {
             return run_q4k_generate_cpu_resident(weights, tokenizer, &token_ids, args, &index);
         }
 

--- a/crates/larql-cli/src/commands/extraction/walk_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/walk_cmd.rs
@@ -546,6 +546,25 @@ fn run_predict_q4k(
         // something else under the caller's chosen label: silently dropping
         // the flag is what made every engine look identical through
         // `larql run` (issue #199), since they were all the same path.
+        // Fast path first: a non-PLE hybrid-MoE model can run the resident,
+        // KV-cached route instead of the O(N^2) re-dequantising loop below.
+        //
+        // Measured on gemma4-26b-a4b (M3 Max, 2026-08-08): 1745 ms/token on
+        // the uncached path against 26.8 ms/token here — 65x — for 2.1 GB
+        // more RSS (15.5 -> 17.6 GB). The two compute the same model: same
+        // layers, same experts (which stay Q4_K in both), same lm_head. All
+        // that differs is *when* attention and the dense FFN are dequantised:
+        // once, up front, instead of on every token. `larql bench --cpu` has
+        // always taken this route, which is why its numbers and `larql run`'s
+        // disagreed by a factor nobody could place.
+        if !arch_needs_per_layer_embeddings(weights) && weights.arch.is_hybrid_moe() {
+            return run_q4k_generate_cpu_resident(weights, tokenizer, &token_ids, args, &index);
+        }
+
+        // Uncached fallback: PLE architectures and dense models. This path has
+        // no KV cache and therefore no engine to select, so a named `--engine`
+        // cannot be honoured — say so instead of running something else under
+        // the caller's chosen label (issue #199).
         if let Some(spec) = requested_engine_spec(args) {
             return Err(engine_unsupported_on_uncached_path(&spec).into());
         }
@@ -711,6 +730,89 @@ fn run_predict_q4k_remote(
         );
     }
 
+    Ok(())
+}
+
+/// Whether this architecture applies Per-Layer Embeddings.
+///
+/// The resident engine path does not apply PLE, so those architectures
+/// (Gemma 4 E-series) must keep the full-recompute route — the same guard
+/// `bench`'s in-process MoE runner enforces, kept in both places because a
+/// silent mismatch here is a wrong answer rather than a slow one.
+fn arch_needs_per_layer_embeddings(weights: &ModelWeights) -> bool {
+    weights.arch.per_layer_input_gate_key(0).is_some()
+}
+
+/// CPU Q4K generation over resident attention + dense FFN, with a KV cache.
+///
+/// Dequantises attention and the dense FFN slab to f32 once and keeps them
+/// resident for the whole run; experts stay Q4_K and are read directly by
+/// `LocalMoeFfn`. Identical in what it computes to
+/// [`run_q4k_generate_cpu`] — the difference is that the uncached loop redoes
+/// that dequantisation, and re-runs the entire growing sequence, on every
+/// token.
+fn run_q4k_generate_cpu_resident(
+    weights: &mut ModelWeights,
+    tokenizer: &tokenizers::Tokenizer,
+    initial_ids: &[u32],
+    args: &WalkArgs,
+    index: &VectorIndex,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write;
+    let start = Instant::now();
+
+    for layer in 0..weights.num_layers {
+        larql_inference::vindex::insert_q4k_layer_tensors_resident(weights, index, layer)
+            .map_err(|e| format!("failed to dequantise layer {layer} to f32: {e}"))?;
+    }
+    let resident_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    // `--engine` is honoured here, unlike on the uncached path: this route
+    // has a real KV engine to select.
+    let engine_spec = requested_engine_spec(args);
+    let spec = engine_spec.as_deref().unwrap_or("standard");
+    let kind = larql_kv::EngineKind::from_name(spec)
+        .ok_or_else(|| format!("--engine {spec:?}: unknown engine"))?;
+    let engine_label = kind.display_name().to_string();
+    let mut engine = kind.build(larql_inference::cpu_engine_backend());
+
+    let weights_ref: &ModelWeights = weights;
+    let moe_ffn = larql_inference::ffn::LocalMoeFfn {
+        weights: weights_ref,
+        index: Some(index),
+    };
+
+    let decode_start = Instant::now();
+    let mut stdout = std::io::stdout();
+    let mut emitted = 0usize;
+    let ids = larql_kv::generation::generate_with_engine_resident(
+        &mut engine,
+        weights_ref,
+        tokenizer,
+        &moe_ffn,
+        index,
+        initial_ids,
+        args.max_tokens,
+        |_id, tok| {
+            print!("{tok}");
+            let _ = stdout.flush();
+            emitted += 1;
+        },
+    );
+    println!();
+
+    if args.verbose {
+        let decode_ms = decode_start.elapsed().as_secs_f64() * 1000.0;
+        let n = ids.len().saturating_sub(initial_ids.len()).max(emitted);
+        eprintln!(
+            "  Q4K CPU generate (resident, {}): {:.2}s  ({} tokens, {:.1} ms/token)",
+            engine_label,
+            decode_ms / 1000.0,
+            n,
+            if n == 0 { 0.0 } else { decode_ms / n as f64 },
+        );
+        eprintln!("  f32-resident dequantisation: {resident_ms:.0} ms (once)");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
`larql run` on a Q4_K hybrid-MoE vindex decoded at ~1700 ms/token while `larql bench --cpu` reported 26.8 ms/token — same vindex, same machine, same hour. Both numbers were right. They measured different routes, and nothing said so.

## What differed

`run_q4k_generate_cpu` calls `predict_kquant` once per step, which re-dequantises every layer's attention and dense-FFN weights **and** re-runs the whole growing sequence — O(N²) with redundant dequantisation on top. Its own doc comment said as much.

`bench` has always taken the resident route: dequantise attention + dense FFN to f32 once, keep them resident, decode through a KV engine. Experts stay Q4_K in both.

## Measured — apples to apples

`LARQL_CPU_RESIDENT=0` forces the uncached route, so both paths are reachable from one binary. Same binary, same prompt, same 32 tokens, arms alternating, gemma4-26b-a4b on M3 Max:

| round | OLD uncached | NEW resident | speedup |
|---|---|---|---|
| 1 | 54.09 s → 1690 ms/tok | 1.96 s → 61.3 ms/tok | 27.6× |
| 2 | 54.74 s → 1711 ms/tok | 1.76 s → 55.1 ms/tok | 31.0× |
| **mean** | **1700 ms/tok (0.59 tok/s)** | **58 ms/tok (17.2 tok/s)** | **29×** |

Old-arm spread 1.2%, new-arm 10% — the new arm is under two seconds so noise is visible, but not at this effect size.

**Including the one-off resident build (~1.0 s):** a 32-token run is 2.9 s against 54.4 s wall, i.e. **19×**. It amortises with length — 53.1 ms/token end-to-end at 128 tokens.

Output unchanged: `"The capital of France is"` → `"Paris."` on the new path, and independently on `--metal`.

> The first version of this PR quoted 1745 → 61.0 ms/token. Those came from two different prompts at two different lengths — the effect was real, the numbers weren't commensurable. The escape hatch exists so this stays measurable rather than needing two builds.

## The routes compute the same model

Same layers, same experts, same lm_head — only the dequantisation *schedule* differs. The guard keeping that true is Per-Layer Embeddings: the resident engine path doesn't apply them, so PLE architectures (Gemma 4 E-series) stay on the uncached route. `bench` enforces the same condition, duplicated deliberately — a mismatch there is a wrong answer, not a slow one.

`--engine` is now honoured here, because this route finally has a KV engine to select. The uncached fallback still refuses it rather than silently running something else under the caller's label (#199).

## The cost, stated plainly

**RSS 15.5 → 24.1 GB.** Larger than the 2.1 GB a bench-to-bench comparison suggested, because `run` also holds gate vectors. Callers who can't afford it have `--metal` (21.5 tok/s), the uncached path, or `LARQL_CPU_RESIDENT=0`.

## Not fixed here

`bench` discards its generated ids (`let _ids = ...`) and never checks them — it would report a throughput number just as happily if the resident path emitted garbage. Worth fixing on its own.