### PR TITLE
perf(bench): surface the GPU/wall split and cmd buffers in bench output

### DIFF
--- a/crates/larql-cli/src/commands/primary/bench/output.rs
+++ b/crates/larql-cli/src/commands/primary/bench/output.rs
@@ -112,6 +112,39 @@ pub(super) fn format_stage_breakdown(rows: &[BenchRow]) -> Vec<String> {
             s.gpu_ms_total,
             pct(s.gpu_ms_total)
         ));
+        // "GPU fwd" is wall time *around* the GPU call, not GPU time, so
+        // show what the profile actually measured on the GPU. Read the CPU
+        // share as instrument-relative: profiling costs ~2.5× end to end and
+        // nearly all of that lands on this line, so it is useful for ranking
+        // stages within a profiled run and misleading as a production
+        // CPU/GPU ratio. `gpu_ms` is the number that holds across both.
+        if s.gpu_only_ms_total > 0.0 {
+            let cpu_side = (s.gpu_ms_total - s.gpu_only_ms_total).max(0.0);
+            let cpu_pct = cpu_side / s.gpu_ms_total * 100.0;
+            out.push(format!(
+                "      on GPU  {:>6.3}ms  ({:>4.1}% of GPU fwd)",
+                s.gpu_only_ms_total,
+                100.0 - cpu_pct
+            ));
+            out.push(format!(
+                "      on CPU  {:>6.3}ms  ({cpu_pct:>4.1}% of GPU fwd — encode, \
+                 readback, host-side experts)",
+                cpu_side
+            ));
+            if s.attn_ms_total > 0.0 {
+                out.push(format!(
+                    "      attn    {:>6.3}ms  ({:>4.1}% of on-GPU)",
+                    s.attn_ms_total,
+                    s.attn_ms_total / s.gpu_only_ms_total * 100.0
+                ));
+            }
+            if s.cmd_buffers_total > 0 {
+                out.push(format!(
+                    "      cmd bufs {:>5}  per token",
+                    s.cmd_buffers_total
+                ));
+            }
+        }
     }
     if s.gate_up_ms_total > 0.0 {
         out.push(format!(
@@ -336,6 +369,79 @@ mod tests {
         assert!(lines.iter().any(|l| l.contains("CPU fwd")));
         assert!(!lines.iter().any(|l| l.contains("GPU fwd")));
         assert!(lines.iter().any(|l| l.contains("lm_head")));
+    }
+
+    #[test]
+    fn stage_breakdown_splits_gpu_wall_into_gpu_and_cpu() {
+        let mut r = empty_row("metal", 1.0);
+        let stages = larql_inference::layer_graph::generate::StageTimings {
+            gpu_ms_total: 10.0,
+            gpu_only_ms_total: 2.0,
+            attn_ms_total: 0.5,
+            cmd_buffers_total: 34,
+            lm_head_ms_total: 1.0,
+            ..Default::default()
+        };
+        r.stages = Some(stages);
+        let lines = format_stage_breakdown(&[r]);
+        let on_gpu = lines
+            .iter()
+            .find(|l| l.contains("on GPU"))
+            .expect("split must render");
+        let on_cpu = lines
+            .iter()
+            .find(|l| l.contains("on CPU"))
+            .expect("split must render");
+        // 2 of 10ms on the GPU; the other 8 are host-side.
+        assert!(on_gpu.contains("20.0%"), "{on_gpu}");
+        assert!(on_cpu.contains("80.0%"), "{on_cpu}");
+        assert!(on_cpu.contains("8.000ms"), "{on_cpu}");
+        // attn is scored against on-GPU time, not the wall: 0.5 of 2.0.
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("attn") && l.contains("25.0%")),
+            "{lines:?}"
+        );
+        assert!(lines
+            .iter()
+            .any(|l| l.contains("cmd bufs") && l.contains("34")));
+    }
+
+    #[test]
+    fn stage_breakdown_omits_split_when_unprofiled() {
+        // No split recorded → report GPU fwd alone rather than claiming the
+        // GPU did zero work.
+        let mut r = empty_row("metal", 1.0);
+        let stages = larql_inference::layer_graph::generate::StageTimings {
+            gpu_ms_total: 10.0,
+            lm_head_ms_total: 1.0,
+            ..Default::default()
+        };
+        r.stages = Some(stages);
+        let lines = format_stage_breakdown(&[r]);
+        assert!(lines.iter().any(|l| l.contains("GPU fwd")));
+        assert!(!lines.iter().any(|l| l.contains("on GPU")));
+        assert!(!lines.iter().any(|l| l.contains("on CPU")));
+    }
+
+    #[test]
+    fn stage_breakdown_clamps_gpu_exceeding_its_own_wall() {
+        // Command-buffer windows can overlap, so the summed GPU time can
+        // exceed the wall around the call. Report 100% on GPU rather than a
+        // negative CPU share.
+        let mut r = empty_row("metal", 1.0);
+        let stages = larql_inference::layer_graph::generate::StageTimings {
+            gpu_ms_total: 10.0,
+            gpu_only_ms_total: 12.0,
+            lm_head_ms_total: 1.0,
+            ..Default::default()
+        };
+        r.stages = Some(stages);
+        let lines = format_stage_breakdown(&[r]);
+        let on_cpu = lines.iter().find(|l| l.contains("on CPU")).unwrap();
+        assert!(on_cpu.contains("0.000ms"), "{on_cpu}");
+        assert!(on_cpu.contains(" 0.0%"), "{on_cpu}");
     }
 
     #[test]

--- a/crates/larql-cli/src/commands/primary/bench/row.rs
+++ b/crates/larql-cli/src/commands/primary/bench/row.rs
@@ -61,10 +61,24 @@ pub(crate) struct BenchJsonLatency {
     pub p99: f64,
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Default)]
 pub(crate) struct BenchJsonStages {
     pub embed_ms: f64,
     pub gpu_fwd_ms: f64,
+    /// Of `gpu_fwd_ms`, the part the GPU was actually executing. `gpu_fwd_ms`
+    /// alone is wall time *around* the GPU call, so a consumer that reads it
+    /// as GPU time overstates the GPU on any hybrid path. Emitted only when
+    /// the profile measured it (`LARQL_PROFILE_SPLIT=1`) — a fabricated zero
+    /// would read as "no GPU time", which is the opposite error.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub gpu_only_ms: f64,
+    /// Attention share of the GPU split. Same gating as `gpu_only_ms`.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub attn_ms: f64,
+    /// Command buffers submitted per token — dispatch overhead the per-stage
+    /// durations do not show.
+    #[serde(skip_serializing_if = "is_zero_count")]
+    pub cmd_buffers: u64,
     pub cpu_fwd_ms: f64,
     pub gate_up_ms: f64,
     pub down_ms: f64,
@@ -79,11 +93,18 @@ fn is_zero(v: &f64) -> bool {
     *v == 0.0
 }
 
+fn is_zero_count(v: &u64) -> bool {
+    *v == 0
+}
+
 impl From<larql_inference::layer_graph::generate::StageTimings> for BenchJsonStages {
     fn from(s: larql_inference::layer_graph::generate::StageTimings) -> Self {
         Self {
             embed_ms: s.embed_ms_total,
             gpu_fwd_ms: s.gpu_ms_total,
+            gpu_only_ms: s.gpu_only_ms_total,
+            attn_ms: s.attn_ms_total,
+            cmd_buffers: s.cmd_buffers_total,
             cpu_fwd_ms: s.cpu_fwd_ms_total,
             gate_up_ms: s.gate_up_ms_total,
             down_ms: s.down_ms_total,
@@ -164,6 +185,7 @@ mod tests {
             lm_head_ms_total: 1.75,
             detok_ms_total: 0.012,
             dequant_ms_total: 0.0,
+            ..Default::default()
         };
         let j: BenchJsonStages = s.into();
         assert!((j.embed_ms - 1.0).abs() < 1e-9);
@@ -187,6 +209,7 @@ mod tests {
             lm_head_ms: 1.75,
             detok_ms: 0.012,
             dequant_ms: 0.0,
+            ..Default::default()
         };
         let json = serde_json::to_string(&j).unwrap();
         assert!(!json.contains("dequant_ms"));
@@ -194,21 +217,58 @@ mod tests {
 
     #[test]
     fn bench_json_stages_serialisation_emits_nonzero_dequant() {
-        let mut j = BenchJsonStages {
-            embed_ms: 0.0,
-            gpu_fwd_ms: 0.0,
-            cpu_fwd_ms: 0.0,
-            gate_up_ms: 0.0,
-            down_ms: 0.0,
-            final_norm_ms: 0.0,
-            lm_head_ms: 0.0,
-            detok_ms: 0.0,
-            dequant_ms: 0.0,
+        let j = BenchJsonStages {
+            dequant_ms: 2.5,
+            ..Default::default()
         };
-        j.dequant_ms = 2.5;
         let json = serde_json::to_string(&j).unwrap();
         assert!(json.contains("dequant_ms"));
         assert!(json.contains("2.5"));
+    }
+
+    #[test]
+    fn is_zero_count_matches_only_exact_zero() {
+        assert!(is_zero_count(&0));
+        assert!(!is_zero_count(&1));
+    }
+
+    #[test]
+    fn bench_json_stages_carries_the_gpu_split() {
+        // The whole point of the split: a JSON consumer must be able to tell
+        // GPU time from wall time around the GPU call. `gpu_fwd_ms` alone
+        // cannot, so the split fields have to survive the conversion.
+        let s = larql_inference::layer_graph::generate::StageTimings {
+            gpu_ms_total: 11.6,
+            gpu_only_ms_total: 1.9,
+            attn_ms_total: 0.7,
+            cmd_buffers_total: 34,
+            ..Default::default()
+        };
+        let j: BenchJsonStages = s.into();
+        assert!((j.gpu_only_ms - 1.9).abs() < 1e-9);
+        assert!((j.attn_ms - 0.7).abs() < 1e-9);
+        assert_eq!(j.cmd_buffers, 34);
+
+        let json = serde_json::to_string(&j).unwrap();
+        assert!(json.contains("gpu_only_ms"), "{json}");
+        assert!(json.contains("attn_ms"), "{json}");
+        assert!(json.contains("cmd_buffers"), "{json}");
+    }
+
+    #[test]
+    fn bench_json_stages_omits_the_split_when_unprofiled() {
+        // Without `LARQL_PROFILE_SPLIT=1` nothing measured the GPU window.
+        // Emitting `gpu_only_ms: 0` would assert the GPU did no work, which
+        // is a stronger and wronger claim than saying nothing.
+        let s = larql_inference::layer_graph::generate::StageTimings {
+            gpu_ms_total: 11.6,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&BenchJsonStages::from(s)).unwrap();
+        assert!(json.contains("gpu_fwd_ms"), "{json}");
+        assert!(!json.contains("gpu_only_ms"), "{json}");
+        assert!(!json.contains("attn_ms"), "{json}");
+        assert!(!json.contains("cmd_buffers"), "{json}");
     }
 
     #[test]

--- a/crates/larql-compute-metal/src/decode/mod.rs
+++ b/crates/larql-compute-metal/src/decode/mod.rs
@@ -1001,6 +1001,15 @@ impl MetalBackend {
                 attn_ms: gpu_time.attn_ms,
                 gate_up_ms: gpu_time.gate_up_ms,
                 down_ms: gpu_time.down_ms,
+                // The GPU/wall pair travels with the stage split so a caller
+                // can report how much of the token was on the GPU at all.
+                // The numbers were already measured here; they only ever
+                // reached stderr via `print_if_enabled`, so every structured
+                // consumer — the bench table, `--json` — attributed the whole
+                // wall to "GPU fwd".
+                gpu_ms: gpu_time.total_gpu_ms,
+                wall_ms,
+                cmd_buffers: gpu_time.n_cmd_buffers as u32,
             });
         }
 

--- a/crates/larql-compute-metal/src/decode/profile.rs
+++ b/crates/larql-compute-metal/src/decode/profile.rs
@@ -77,6 +77,7 @@ mod tests {
             attn_ms: 4.0,
             gate_up_ms: 2.0,
             down_ms: 0.5,
+            ..Default::default()
         };
         store_last_split_timings(written);
         let read = take_last_split_timings().expect("stored timing should be present");

--- a/crates/larql-compute-metal/src/trait_impl/decode.rs
+++ b/crates/larql-compute-metal/src/trait_impl/decode.rs
@@ -843,6 +843,13 @@ impl DecodeBackend for MetalBackend {
                 attn_ms: wall_ms,
                 gate_up_ms: 0.0,
                 down_ms: 0.0,
+                // No split was recorded, so nothing is known about how much
+                // of this wall was GPU. Report zero rather than guessing —
+                // a fabricated `gpu_ms` here would be the same mistake the
+                // "GPU fwd" counter made.
+                gpu_ms: 0.0,
+                wall_ms,
+                cmd_buffers: 0,
             }
         });
         (result, timings.attn_ms, timings.gate_up_ms, timings.down_ms)

--- a/crates/larql-compute-metal/src/trait_impl/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/mod.rs
@@ -199,6 +199,7 @@ mod tests {
             attn_ms: 3.0,
             gate_up_ms: 1.5,
             down_ms: 0.5,
+            ..Default::default()
         };
         crate::decode::profile::store_last_split_timings(written);
         let read = ComputeBackend::take_split_timings(&m).expect("must surface stored timing");

--- a/crates/larql-compute/src/backend/decode.rs
+++ b/crates/larql-compute/src/backend/decode.rs
@@ -123,6 +123,26 @@ pub struct ProfileTimings {
     pub gate_up_ms: f64,
     /// Wall time for the FFN down projection + post-FFN residual + scalar.
     pub down_ms: f64,
+    /// Total time the GPU was actually executing, summed from
+    /// `MTLCommandBuffer` start/end windows. Zero on CPU backends.
+    ///
+    /// Reported alongside [`Self::wall_ms`] so a reader can see that "GPU
+    /// fwd" is wall time *around* the dispatch rather than GPU time.
+    ///
+    /// **The split is only valid against itself.** Turning profiling on
+    /// costs 2.5× — qwen3-0.6b runs 94.8 tok/s unprofiled and 38.2 tok/s
+    /// with `LARQL_PROFILE_SPLIT=1`, with `gpu_ms` steady near 2.8ms while
+    /// the wall around it goes 4.3ms → 20ms. Almost all of the CPU-side
+    /// share this reports is the instrument's own per-command-buffer
+    /// synchronisation, not production cost. Use it to compare stages within
+    /// one profiled run; do not quote the CPU/GPU ratio as a property of the
+    /// unprofiled path.
+    pub gpu_ms: f64,
+    /// Wall time around the whole token, CPU encoding and readback included.
+    pub wall_ms: f64,
+    /// Command buffers submitted for this token. A large count is dispatch
+    /// overhead the per-stage numbers do not show.
+    pub cmd_buffers: u32,
 }
 
 impl ProfileTimings {
@@ -461,6 +481,7 @@ mod tests {
             attn_ms: 1.5,
             gate_up_ms: 2.5,
             down_ms: 1.0,
+            ..Default::default()
         };
         assert!((p.total_ms() - 5.0).abs() < 1e-9);
     }
@@ -480,6 +501,7 @@ mod tests {
             attn_ms: 6.0,
             gate_up_ms: 3.0,
             down_ms: 1.0,
+            ..Default::default()
         };
         let s = p.format_summary(10);
         assert!(s.contains("total=10.00ms"));
@@ -493,6 +515,7 @@ mod tests {
             attn_ms: 1.0,
             gate_up_ms: 1.0,
             down_ms: 1.0,
+            ..Default::default()
         };
         let s = p.format_summary(0);
         assert!(s.contains("0 layers"));

--- a/crates/larql-inference/src/layer_graph/generate/cpu.rs
+++ b/crates/larql-inference/src/layer_graph/generate/cpu.rs
@@ -212,6 +212,9 @@ fn generate_via_cpu_q4k_cached(
         stage_timings: StageTimings {
             embed_ms_total: 0.0,
             gpu_ms_total: 0.0,
+            gpu_only_ms_total: 0.0,
+            attn_ms_total: 0.0,
+            cmd_buffers_total: 0,
             cpu_fwd_ms_total: t_cpu_fwd,
             gate_up_ms_total: 0.0,
             down_ms_total: 0.0,
@@ -303,6 +306,9 @@ fn generate_via_cpu_q4k_uncached(
         stage_timings: StageTimings {
             embed_ms_total: 0.0,
             gpu_ms_total: 0.0,
+            gpu_only_ms_total: 0.0,
+            attn_ms_total: 0.0,
+            cmd_buffers_total: 0,
             cpu_fwd_ms_total: t_cpu_fwd,
             gate_up_ms_total: 0.0,
             down_ms_total: 0.0,

--- a/crates/larql-inference/src/layer_graph/generate/gpu/decode_loop.rs
+++ b/crates/larql-inference/src/layer_graph/generate/gpu/decode_loop.rs
@@ -24,7 +24,14 @@ pub(super) struct DecodeLoopOutcome {
     /// Per-step wall time in ms.
     pub decode_ms: Vec<f64>,
     pub t_embed: f64,
+    /// Wall time around the GPU call, CPU encode and readback included.
     pub t_gpu: f64,
+    /// Time the GPU was actually executing. Only populated under
+    /// `profile_split`; the gap against `t_gpu` is CPU-side cost.
+    pub t_gpu_only: f64,
+    /// Command buffers submitted across the run.
+    pub n_cmd_buffers: u64,
+    pub t_attn: f64,
     pub t_gate_up: f64,
     pub t_down: f64,
     pub t_norm: f64,
@@ -72,6 +79,10 @@ where
     let profile_split = runtime.profile_split;
     let mut t_embed = 0.0f64;
     let mut t_gpu = 0.0f64;
+    // Split detail, populated only when `profile_split` is on.
+    let mut t_attn = 0.0f64;
+    let mut t_gpu_only = 0.0f64;
+    let mut n_cmd_buffers = 0u64;
     let mut t_gate_up = 0.0f64;
     let mut t_down = 0.0f64;
     let mut t_norm = 0.0f64;
@@ -185,8 +196,17 @@ where
         t_gpu += gpu_ms;
         if profile_split {
             if let Some(pt) = backend.take_split_timings() {
+                // `attn_ms` was previously dropped here: the backend measured
+                // it, the loop discarded it, and a third of the GPU split
+                // never reached any report.
+                t_attn += pt.attn_ms;
                 t_gate_up += pt.gate_up_ms;
                 t_down += pt.down_ms;
+                // How much of the token was on the GPU at all. Without this
+                // the caller can only see wall time and will attribute all of
+                // it to the GPU.
+                t_gpu_only += pt.gpu_ms;
+                n_cmd_buffers += u64::from(pt.cmd_buffers);
             }
         }
         t_norm += norm_ms;
@@ -215,6 +235,9 @@ where
         decode_ms,
         t_embed,
         t_gpu,
+        t_gpu_only,
+        n_cmd_buffers,
+        t_attn,
         t_gate_up,
         t_down,
         t_norm,

--- a/crates/larql-inference/src/layer_graph/generate/gpu/mod.rs
+++ b/crates/larql-inference/src/layer_graph/generate/gpu/mod.rs
@@ -399,6 +399,9 @@ where
         stage_timings: StageTimings {
             embed_ms_total: outcome.t_embed,
             gpu_ms_total: outcome.t_gpu,
+            gpu_only_ms_total: outcome.t_gpu_only,
+            attn_ms_total: outcome.t_attn,
+            cmd_buffers_total: outcome.n_cmd_buffers,
             cpu_fwd_ms_total: 0.0,
             gate_up_ms_total: outcome.t_gate_up,
             down_ms_total: outcome.t_down,

--- a/crates/larql-inference/src/layer_graph/generate/types.rs
+++ b/crates/larql-inference/src/layer_graph/generate/types.rs
@@ -8,6 +8,16 @@
 pub struct StageTimings {
     pub embed_ms_total: f64,
     pub gpu_ms_total: f64,
+    /// Of `gpu_ms_total`, the part the GPU was actually executing. The
+    /// remainder is CPU encode, submission and readback — but note that
+    /// profiling itself inflates that remainder several-fold, so the ratio
+    /// describes the profiled run and not production. Zero unless
+    /// `LARQL_PROFILE_SPLIT=1`.
+    pub gpu_only_ms_total: f64,
+    /// Attention share of the GPU split. Zero unless profiling is on.
+    pub attn_ms_total: f64,
+    /// Command buffers submitted across the measured run.
+    pub cmd_buffers_total: u64,
     /// CPU fallback forward time when the backend lacks fused Q4 decode.
     pub cpu_fwd_ms_total: f64,
     /// Gate+up dispatch time within GPU fwd (populated when LARQL_PROFILE_SPLIT=1).
@@ -129,6 +139,10 @@ impl StageTimings {
         StageTimings {
             embed_ms_total: self.embed_ms_total / nf,
             gpu_ms_total: self.gpu_ms_total / nf,
+            gpu_only_ms_total: self.gpu_only_ms_total / nf,
+            attn_ms_total: self.attn_ms_total / nf,
+            // A count, not a duration: per-token average, rounded down.
+            cmd_buffers_total: (self.cmd_buffers_total as f64 / nf) as u64,
             cpu_fwd_ms_total: self.cpu_fwd_ms_total / nf,
             gate_up_ms_total: self.gate_up_ms_total / nf,
             down_ms_total: self.down_ms_total / nf,
@@ -315,6 +329,7 @@ mod tests {
             lm_head_ms_total: 70.0,
             detok_ms_total: 80.0,
             dequant_ms_total: 90.0,
+            ..Default::default()
         };
         let avg = t.avg_per_step(10);
         assert_eq!(avg.embed_ms_total, 1.0);


### PR DESCRIPTION
## What

`larql bench` reported a single `GPU fwd` figure that is **wall time around the dispatch**, not GPU time. The Metal backend already measured the real GPU window per command buffer, but it only ever reached stderr via `print_if_enabled` — so both the bench table and `--json` attributed the whole wall to the GPU.

This carries `gpu_ms` / `wall_ms` / `cmd_buffers` through `ProfileTimings` → `StageTimings` → both outputs, and stops the decode loop dropping `attn_ms` (the backend measured it, the loop discarded it, so a third of the split never reached any report).

## Read the split as instrument-relative

Enabling `LARQL_PROFILE_SPLIT=1` costs ~2.5× end to end, and almost all of it lands on the CPU side of this split:

| qwen3-0.6b, n=40 | tok/s | GPU fwd | on GPU |
|---|---|---|---|
| unprofiled | 94.8 | 4.28ms | — |
| `LARQL_PROFILE_SPLIT=1` | 38.2 | 19.97ms | 2.77ms |

`gpu_ms` holds steady while the wall around it goes 4.3 → 20ms — that gap is the instrument's own per-command-buffer synchronisation. So the split ranks stages *within* a profiled run; the CPU/GPU ratio is not a property of the unprofiled path. The doc comments say so at each site, and `gpu_ms` is called out as the one number that carries across.

Sample output (gemma3-4b, profiled):

```
    GPU fwd   31.371ms  (94.4%)
      on GPU   9.416ms  (30.0% of GPU fwd)
      on CPU  21.955ms  (70.0% of GPU fwd — encode, readback, host-side experts)
      attn     3.365ms  (35.7% of on-GPU)
      cmd bufs    98  per token
```

## Notes

- JSON fields are **omitted rather than zeroed** when unprofiled — emitting `gpu_only_ms: 0` would assert the GPU did no work, a stronger and wronger claim than saying nothing.
- Removed a dead `gpu_ms_total > 0.0` guard nested inside the identical outer check.
- 6 new tests: split arithmetic, unprofiled path, JSON round-trip both directions, and the clamp for GPU windows that overlap past their own wall.

## Gates

`fmt`, `clippy -D warnings` (workspace, all targets), tests, plus `--no-default-features` and `x86_64-apple-darwin` for the non-GPU shape.