### PR TITLE
test(kv): pin the residency contract divergence between the two paths

### DIFF
--- a/crates/larql-compute-metal/src/kv_dispatch_impl.rs
+++ b/crates/larql-compute-metal/src/kv_dispatch_impl.rs
@@ -902,7 +902,7 @@ mod tests {
 /// would cost O(window) per token. Letting occupancy reach this multiple
 /// before reclaiming makes it O(1) amortised, and the attention span
 /// clamp means the extra resident rows are never read.
-const COMPACTION_SLACK: usize = 2;
+pub(crate) const COMPACTION_SLACK: usize = 2;
 
 impl MetalBackend {
     /// Reclaim K/V above `COMPACTION_SLACK x window` rows, per layer.

--- a/crates/larql-compute-metal/src/kv_residency_contract.rs
+++ b/crates/larql-compute-metal/src/kv_residency_contract.rs
@@ -1,0 +1,352 @@
+//! The KV residency contract, and the divergence between the two paths
+//! that implement it.
+//!
+//! Three quantities are routinely conflated. They are not the same, and
+//! the whole contract is about how they relate:
+//!
+//! ```text
+//! architectural reachability   W          what attention may ever read
+//! logical occupancy            <= 2W      rows physically retained
+//! physical capacity            4096       rows the Metal buffer holds
+//! ```
+//!
+//! `W` comes from the model (`sliding_window`, 1024 on Gemma 3).
+//! Occupancy is bounded by compaction, which reclaims only past
+//! [`COMPACTION_SLACK`]` x W` so the memmove is O(1) amortised rather
+//! than O(W) per token. Capacity is
+//! `DEFAULT_GPU_KV_CACHE_MAX_SEQ`, chosen at allocation and never
+//! revisited.
+//!
+//! The gap between the second and third rows is the point: **compaction
+//! reclaims occupancy, not bytes.** A layer that has evicted down to `W`
+//! still owns a 4096-row buffer. Wiring compaction into a path does not
+//! shrink an allocation, and reading it as a memory saving is the
+//! mistake this module exists to prevent.
+//!
+//! # What each path implements
+//!
+//! ```text
+//!                        coarse KvDispatch    fused Metal decode
+//! attention span         W                    W
+//! logical occupancy      <= 2W                grows unbounded
+//! absolute position      monotonic            monotonic
+//! rows read by attention identical            identical
+//! physical capacity      4096                 4096
+//! ```
+//!
+//! Both paths clamp what attention *reads* — `attention_span` is applied
+//! in `decode/encode_attn.rs` regardless of who is driving. Only the
+//! coarse path bounds what is *retained*:
+//! `coarse_decode_step_windowed` calls `compact_kv_to_window` each step,
+//! and nothing on the fused path does. So the two paths agree on
+//! semantic visibility and disagree on physical residency.
+//!
+//! That divergence is what the tests below pin down. They are not a
+//! regression guard on a bug; they are the executable statement of the
+//! contract, so that a later change to either path has to say which row
+//! of the table it is moving.
+//!
+//! # Why this is not simply fixed by calling the compactor
+//!
+//! Three operations touch a layer's rows, not two:
+//!
+//! ```text
+//! allocate   KVCache::new_per_layer, one capacity for every layer
+//! prefill    full_pipeline/kv_copy.rs, bulk-copies seq_len rows
+//! decode     encode_attn.rs, appends one row per step
+//! ```
+//!
+//! Compaction addresses only the third. Prefill writes `seq_len` rows in
+//! one `copy_nonoverlapping` and assigns `current_len = seq_len`; its
+//! SAFETY note claims the copy is "bounded by max_seq", but that bound
+//! is supplied by the caller and enforced nowhere local. Lowering a
+//! sliding layer's capacity below the longest admissible prompt
+//! therefore turns prefill into an overrun, and no amount of
+//! decode-time compaction prevents it.
+//!
+//! So a per-layer capacity change has to answer a question first: does a
+//! sliding layer ever need every prefill row materialised at once, or
+//! only the terminal tail once that layer's prefill attention has
+//! consumed them? The answer is probably the tail — but it has to be
+//! established, not assumed, and it is a change to what prefill writes
+//! rather than to where it writes.
+//!
+//! # The shape a future seam should take
+//!
+//! [`crate::MetalBackend::set_engine_window`] is the one place a policy
+//! decision already crosses into the fused path, and it works because it
+//! is *configuration consumed inside the existing dispatch* rather than
+//! a callback per layer. Per-layer synchronous dispatch was measured and
+//! lost — see the `KvDispatch` Step 5 finding in `ROADMAP.md` — because
+//! each call forces its own command-buffer commit.
+//!
+//! Whatever eventually carries per-layer capacity should therefore be
+//! submitted once at setup, alongside the window, not queried per layer
+//! per token. Note also that the two ideas are different in kind:
+//! `num_kv_heads` and `head_dim` describe the *representation*, while
+//! capacity, retention and attention window describe *residency policy*.
+//! Widening the shape tuple to carry both would put 134 references
+//! across 26 files and 5 crates behind one type — the pressure is
+//! pointing at a separate object, not a wider tuple.
+
+#[cfg(test)]
+mod tests {
+    use crate::kv_dispatch_impl::COMPACTION_SLACK;
+    use crate::ops::kv_cache::{attention_span, KVCache};
+    use crate::MetalBackend;
+
+    /// Gemma 3's real sliding window, so the boundaries exercised here
+    /// are the ones production actually crosses.
+    const W: usize = 1024;
+
+    /// Rows allocated per layer today (`DEFAULT_GPU_KV_CACHE_MAX_SEQ`).
+    /// Several assertions below exist to show compaction does *not*
+    /// move this number.
+    const ALLOCATED_ROWS: usize = 4096;
+
+    /// Small per-row geometry — the contract is about row counts, not
+    /// row width, and a narrow row keeps the buffers cheap.
+    const KV_HEADS: usize = 2;
+    const HEAD_DIM: usize = 4;
+
+    /// Every transition the contract has: just inside the window, at the
+    /// window, just inside and at the compaction trigger, one past it,
+    /// and a long run that forces repeated slides rather than one.
+    const BOUNDARIES: [usize; 6] = [W - 1, W, 2 * W - 1, 2 * W, 2 * W + 1, 3000];
+
+    fn backend() -> MetalBackend {
+        MetalBackend::new().expect("Metal device available on test host")
+    }
+
+    fn install_single_layer_cache(b: &MetalBackend) {
+        let mut guard = b.kv_cache.lock().expect("kv cache lock");
+        *guard = Some(KVCache::new(&b.bufs, 1, ALLOCATED_ROWS, KV_HEADS, HEAD_DIM));
+    }
+
+    /// Write `value` into every element of the row about to be appended,
+    /// then advance. Mirrors the real append order — `encode_kv_append`
+    /// writes at `current_len` and only then bumps it — so the stamp
+    /// identifies which absolute position a surviving row came from.
+    fn append_stamped(b: &MetalBackend, value: f32) {
+        let mut guard = b.kv_cache.lock().expect("kv cache lock");
+        let layer = &mut guard.as_mut().expect("cache installed").layers[0];
+        let row = KV_HEADS * HEAD_DIM;
+        let at = layer.current_len;
+        for buf in [&layer.k_cache, &layer.v_cache] {
+            let ptr = buf.contents() as *mut f32;
+            // SAFETY: buffer is host-visible and sized ALLOCATED_ROWS * row;
+            // `at < ALLOCATED_ROWS` holds for every count under test.
+            unsafe {
+                let slice = std::slice::from_raw_parts_mut(ptr, ALLOCATED_ROWS * row);
+                for i in 0..row {
+                    slice[at * row + i] = value;
+                }
+            }
+        }
+        layer.advance_one();
+    }
+
+    /// Drive `tokens` decode steps. `window` `Some` reproduces the
+    /// coarse path, which compacts before each step; `None` reproduces
+    /// the fused path, which never does.
+    ///
+    /// Returns `(current_len, abs_position)`.
+    fn drive(b: &MetalBackend, tokens: usize, window: Option<usize>) -> (usize, usize) {
+        install_single_layer_cache(b);
+        for t in 0..tokens {
+            // Compaction runs before the append, exactly as
+            // `coarse_decode_step_windowed` orders it.
+            if let Some(w) = window {
+                b.compact_kv_to_window(w);
+            }
+            append_stamped(b, t as f32);
+        }
+        let guard = b.kv_cache.lock().expect("kv cache lock");
+        let layer = &guard.as_ref().expect("cache installed").layers[0];
+        (layer.current_len, layer.abs_position)
+    }
+
+    /// Read the newest `span` rows as the absolute positions they were
+    /// stamped with — what attention would actually consume.
+    fn visible_rows(b: &MetalBackend, span: usize) -> Vec<f32> {
+        let guard = b.kv_cache.lock().expect("kv cache lock");
+        let layer = &guard.as_ref().expect("cache installed").layers[0];
+        let row = KV_HEADS * HEAD_DIM;
+        let start = layer.current_len - span;
+        let ptr = layer.k_cache.contents() as *const f32;
+        // SAFETY: host-visible, sized ALLOCATED_ROWS * row, and
+        // `current_len <= ALLOCATED_ROWS`.
+        let slice = unsafe { std::slice::from_raw_parts(ptr, ALLOCATED_ROWS * row) };
+        (start..layer.current_len).map(|r| slice[r * row]).collect()
+    }
+
+    // ── the four rows of the contract table ──────────────────────────
+
+    /// Attention span is identical on both paths at every boundary.
+    /// This is the claim that residency policy does not change what the
+    /// model can see — without it, compaction would be a semantic change
+    /// rather than a memory one.
+    #[test]
+    fn both_paths_present_the_same_attention_span() {
+        let b = backend();
+        for &n in &BOUNDARIES {
+            let (fused_len, _) = drive(&b, n, None);
+            let (coarse_len, _) = drive(&b, n, Some(W));
+
+            let fused_span = attention_span(fused_len as u32, W as u32);
+            let coarse_span = attention_span(coarse_len as u32, W as u32);
+
+            assert_eq!(
+                fused_span, coarse_span,
+                "semantic visibility must not depend on residency policy (n={n})"
+            );
+            assert_eq!(
+                fused_span as usize,
+                n.min(W),
+                "span is min(tokens, window) (n={n})"
+            );
+        }
+    }
+
+    /// Occupancy is where the paths part: the coarse path stays inside
+    /// the slack bound, the fused path grows with the stream.
+    #[test]
+    fn occupancy_diverges_past_the_compaction_trigger() {
+        let b = backend();
+        let bound = W * COMPACTION_SLACK;
+        for &n in &BOUNDARIES {
+            let (fused_len, _) = drive(&b, n, None);
+            let (coarse_len, _) = drive(&b, n, Some(W));
+
+            assert_eq!(
+                fused_len, n,
+                "the fused path retains every row it has ever written (n={n})"
+            );
+            assert!(
+                coarse_len <= bound,
+                "the coarse path must stay within {bound} rows, got {coarse_len} (n={n})"
+            );
+            if n <= bound {
+                assert_eq!(
+                    coarse_len, n,
+                    "below the trigger the two paths are identical (n={n})"
+                );
+            } else {
+                assert!(
+                    coarse_len < fused_len,
+                    "past the trigger the coarse path must retain strictly less (n={n})"
+                );
+            }
+        }
+    }
+
+    /// Absolute position is monotonic and identical on both paths —
+    /// eviction lowers occupancy only. If this ever fails, RoPE rewinds
+    /// and output goes fluent-but-wrong.
+    #[test]
+    fn absolute_position_tracks_tokens_seen_on_both_paths() {
+        let b = backend();
+        for &n in &BOUNDARIES {
+            let (_, fused_pos) = drive(&b, n, None);
+            let (_, coarse_pos) = drive(&b, n, Some(W));
+            assert_eq!(
+                fused_pos, n,
+                "fused position must equal tokens seen (n={n})"
+            );
+            assert_eq!(
+                coarse_pos, n,
+                "compaction must not rewind the stream (n={n})"
+            );
+        }
+    }
+
+    /// The rows attention actually consumes are identical on both paths.
+    ///
+    /// This is the output-parity row of the table, reduced to its cause:
+    /// if the visible window holds the same absolute positions in the
+    /// same order, the attention inputs are the same and the logits
+    /// cannot differ. It is the precondition for ever wiring compaction
+    /// into the fused path.
+    #[test]
+    fn the_rows_attention_reads_are_identical_on_both_paths() {
+        let b = backend();
+        for &n in &BOUNDARIES {
+            let span = n.min(W);
+
+            drive(&b, n, None);
+            let fused_visible = visible_rows(&b, span);
+
+            drive(&b, n, Some(W));
+            let coarse_visible = visible_rows(&b, span);
+
+            assert_eq!(
+                fused_visible, coarse_visible,
+                "compaction changed what attention reads (n={n})"
+            );
+            // And both hold the newest `span` absolute positions, in order.
+            let expected: Vec<f32> = ((n - span)..n).map(|p| p as f32).collect();
+            assert_eq!(
+                fused_visible, expected,
+                "visible window is the tail (n={n})"
+            );
+        }
+    }
+
+    /// Compaction reclaims occupancy and **not** bytes. The buffer stays
+    /// the size it was allocated, on both paths, at every boundary.
+    ///
+    /// This is the assertion that stops "wire in the compactor" from
+    /// being mistaken for a memory saving: getting the allocation down
+    /// needs a capacity change, which needs prefill solved first.
+    #[test]
+    fn compaction_does_not_shrink_the_allocation() {
+        let b = backend();
+        for &n in &BOUNDARIES {
+            for window in [None, Some(W)] {
+                drive(&b, n, window);
+                let guard = b.kv_cache.lock().expect("kv cache lock");
+                let layer = &guard.as_ref().expect("cache installed").layers[0];
+                assert_eq!(
+                    layer.max_seq, ALLOCATED_ROWS,
+                    "capacity is fixed at allocation (n={n}, window={window:?})"
+                );
+                let row_bytes = (KV_HEADS * HEAD_DIM * 4) as u64;
+                assert_eq!(
+                    layer.k_cache.length(),
+                    ALLOCATED_ROWS as u64 * row_bytes,
+                    "the Metal buffer is untouched by eviction (n={n})"
+                );
+            }
+        }
+    }
+
+    /// Repeated slides, not merely the first one.
+    ///
+    /// The first compaction fires when occupancy reaches `W x SLACK`
+    /// (2048) and drops it to `W`; the next needs another `W` appends,
+    /// so the second slide lands at `3W`. Anything short of that
+    /// exercises a single memmove over pristine rows and would miss a
+    /// compaction landing on already-compacted ones.
+    #[test]
+    fn repeated_slides_keep_the_tail_correct() {
+        let b = backend();
+        let first_slide = W * COMPACTION_SLACK;
+        let second_slide = first_slide + W;
+        let n = second_slide + 128;
+        assert!(
+            n > second_slide && n <= ALLOCATED_ROWS,
+            "the long run must cross the trigger twice and still fit the buffer"
+        );
+        let (coarse_len, coarse_pos) = drive(&b, n, Some(W));
+        assert!(coarse_len <= W * COMPACTION_SLACK);
+        assert_eq!(coarse_pos, n);
+
+        let span = W;
+        let visible = visible_rows(&b, span);
+        let expected: Vec<f32> = ((n - span)..n).map(|p| p as f32).collect();
+        assert_eq!(
+            visible, expected,
+            "the tail must survive repeated compactions intact"
+        );
+    }
+}

--- a/crates/larql-compute-metal/src/lib.rs
+++ b/crates/larql-compute-metal/src/lib.rs
@@ -68,6 +68,8 @@ pub mod kernels;
 #[cfg(target_os = "macos")]
 pub mod kv_dispatch_impl;
 #[cfg(target_os = "macos")]
+pub mod kv_residency_contract;
+#[cfg(target_os = "macos")]
 pub mod ops;
 #[cfg(target_os = "macos")]
 pub mod options;

--- a/crates/larql-kv/ROADMAP.md
+++ b/crates/larql-kv/ROADMAP.md
@@ -48,6 +48,37 @@ unrelated prefix. Queue in pickup notes §6.
 
 ---
 
+## KV residency contract — documented and tested, not fixed (2026-08-08)
+
+The fused Metal decode path and the coarse `KvDispatch` path implement
+**identical attention semantics and different physical-residency
+contracts**. Both clamp what attention reads via `attention_span`; only
+the coarse path bounds what is retained, by calling
+`compact_kv_to_window` each step. So on `larql run` / `larql bench`,
+sliding layers accumulate rows without limit.
+
+Three quantities that get conflated, and must not be: architectural
+reachability (`W` = 1024), logical occupancy (`<= 2W`, the
+`COMPACTION_SLACK` bound), physical capacity (4096, fixed at
+allocation). **Compaction reclaims occupancy, not bytes** — wiring it
+into the fused path saves no memory, because the buffer is still
+allocated at 4096 rows.
+
+Per-layer capacity *would* save ~464 MB on Gemma 3 4B (1.09 GB → ~624
+MB), but it is blocked on prefill rather than on allocation: prefill
+bulk-copies `seq_len` rows with a bound that is enforced nowhere local,
+so shrinking a sliding layer's capacity turns it into an overrun. The
+open question — whether a sliding layer needs every prefill row
+materialised at once or only the terminal tail — plus the evidence, the
+blast radius of the shape-tuple approach (134 refs / 26 files / 5
+crates), and why the eventual seam should be setup-time configuration
+rather than a per-layer callback, are all in
+[`docs/kv-residency-contract.md`](../../docs/kv-residency-contract.md).
+Executable form:
+[`kv_residency_contract.rs`](../larql-compute-metal/src/kv_residency_contract.rs).
+
+---
+
 ## MAP-5 persistence harness — scoped and verified, not started (2026-08-02)
 
 A parallel mechanistic-interpretability thread (MAP-5/5b/5c, registry

--- a/docs/kv-residency-contract.md
+++ b/docs/kv-residency-contract.md
@@ -1,0 +1,193 @@
+# The KV residency contract
+
+Three quantities get conflated whenever sliding-window KV comes up. They
+are not the same thing, and most of the confusion in this area is a
+failure to say which one is meant.
+
+```text
+architectural reachability   W          what attention may ever read
+logical occupancy            <= 2W      rows physically retained
+physical capacity            4096       rows the Metal buffer holds
+```
+
+- **`W`** comes from the model. Gemma 3 declares `sliding_window = 1024`
+  and runs 29 sliding layers against 5 global ones.
+- **Occupancy** is bounded by compaction, which reclaims only once
+  occupancy reaches `COMPACTION_SLACK x W`. The slack exists so the
+  memmove is O(1) amortised rather than O(W) per token.
+- **Capacity** is `DEFAULT_GPU_KV_CACHE_MAX_SEQ`, fixed at allocation
+  and never revisited. Every layer gets the same number regardless of
+  its window.
+
+The gap between the second and third rows is the one that matters:
+**compaction reclaims occupancy, not bytes.** A layer evicted down to
+`W` rows still owns its 4096-row buffer. Wiring compaction into a path
+does not shrink an allocation, and reading it as a memory saving is the
+specific mistake this document exists to prevent.
+
+The extra `W` between reachability and occupancy is not waste either —
+it is amortisation slack, deliberately traded for an O(1) compactor. A
+ring buffer would let capacity approach the semantic bound without
+changing any policy, by replacing memmove-plus-slack with circular
+addressing.
+
+## What each path implements
+
+```text
+                        coarse KvDispatch    fused Metal decode
+attention span          W                    W
+logical occupancy       <= 2W                grows unbounded
+absolute position       monotonic            monotonic
+rows read by attention  identical            identical
+physical capacity       4096                 4096
+```
+
+Both paths clamp what attention *reads*: `attention_span` is applied in
+[`decode/encode_attn.rs`](../crates/larql-compute-metal/src/decode/encode_attn.rs)
+whoever is driving. Only the coarse path bounds what is *retained* —
+`coarse_decode_step_windowed` calls `compact_kv_to_window` every step,
+and nothing on the fused path does.
+
+So the two paths agree on semantic visibility and disagree on physical
+residency. That is the whole finding. It is not a bug in either path;
+it is an unstated difference in contract, which is worse, because
+neither path documents that it has one.
+
+The executable form of this table lives in
+[`kv_residency_contract.rs`](../crates/larql-compute-metal/src/kv_residency_contract.rs),
+which drives both policies over the boundaries `W-1, W, 2W-1, 2W, 2W+1`
+and a long run that crosses the compaction trigger twice. It asserts
+each row: identical spans, diverging occupancy, monotonic and equal
+absolute positions, byte-identical visible rows, and unchanged
+allocation.
+
+The visible-rows assertion is the output-parity claim reduced to its
+cause. If the newest `span` rows hold the same absolute positions in the
+same order, the attention inputs are identical and the logits cannot
+differ. That is the precondition for ever wiring compaction into the
+fused path — and it now has a test rather than an argument.
+
+## Why "just call the compactor" is not the fix
+
+Three operations touch a layer's rows, not two:
+
+| operation | site | behaviour |
+|---|---|---|
+| allocate | `KVCache::new_per_layer` | one capacity for every layer |
+| prefill | [`full_pipeline/kv_copy.rs`](../crates/larql-compute-metal/src/ops/full_pipeline/kv_copy.rs) | bulk-copies `seq_len` rows, sets `current_len = seq_len` |
+| decode | [`decode/encode_attn.rs`](../crates/larql-compute-metal/src/decode/encode_attn.rs) | appends one row per step |
+
+Compaction addresses only the third. Prefill writes `seq_len` rows in a
+single `copy_nonoverlapping`; its SAFETY note claims the copy is
+"bounded by max_seq", but that bound is supplied by the caller and
+enforced nowhere local. Lowering a sliding layer's capacity below the
+longest admissible prompt therefore turns prefill into an overrun, and
+no amount of decode-time compaction prevents it.
+
+So a per-layer capacity change has to answer this first:
+
+> Does a sliding layer ever need every prefill row materialised at once,
+> or only the terminal tail once that layer's prefill attention has
+> consumed them?
+
+The evidence points at the tail, and it is nearly in hand:
+
+- Prefill attention **is** windowed on Metal, established by
+  [`test_prefill_sliding_window.rs`](../crates/larql-compute-metal/tests/test_prefill_sliding_window.rs).
+  Once it has run, nothing reads beyond `W` again.
+- Prefill computes into per-layer **scratch** buffers (`lb.k_out`), and
+  `populate_kv_one_layer` copies scratch into the persistent cache. The
+  two are separate allocations, so the full-prefix requirement lands on
+  the scratch, not on the cache.
+
+Which suggests the shape of the eventual change:
+
+```text
+PREFILL, sliding layer
+
+compute attention over the full causal/window geometry   (scratch, N rows)
+                    |
+                    v
+copy only the terminal resident tail                     (cache, <= capacity)
+                    |
+                    v
+current_len  <= retention capacity
+abs_position  = full prompt length
+```
+
+That is a change to *what prefill writes*, not to *where it writes* —
+materially different from resizing a destination buffer, and the reason
+per-layer capacity is not a one-field patch.
+
+Note also what this does **not** buy: the 5 global layers still need
+full capacity, and `ensure_prompt_fits` guards the context ceiling on
+their behalf. Bounding the 29 sliding layers does not remove the 4096
+limit.
+
+## Why the shape tuple is the wrong home for capacity
+
+The obvious move is to widen `(num_kv_heads, head_dim)` to
+`(num_kv_heads, head_dim, capacity)`. It is the wrong abstraction
+pressure, on two grounds.
+
+**Blast radius.** That tuple threads through
+`kv_cache_shapes_for_arch` → `new_per_layer` / `grow_to_shapes` /
+`has_shape_mismatch` / `preallocate_kv_cache_per_layer`: 134 references
+across 26 files in 5 crates, including all four KV engines' dispatch
+modules.
+
+**Category.** `num_kv_heads` and `head_dim` describe the
+*representation* — what a row is. Capacity, retention window and
+attention window describe *residency policy* — how long rows live. They
+belong in separate objects:
+
+```rust
+struct KvLayerGeometry {
+    num_kv_heads: usize,
+    head_dim: usize,
+}
+
+struct KvLayerResidency {
+    capacity: usize,
+    attention_window: Option<usize>,
+    retention_window: Option<usize>,
+}
+```
+
+## The shape a future seam should take
+
+The residency object should be **submitted once as configuration**, not
+queried per layer per token. This is not a style preference — the
+synchronous per-layer form was built and measured, and it lost.
+`crates/larql-compute-metal/src/kv_dispatch_impl.rs` is Step 4
+scaffolding whose every method delegates to `CpuBackend`, and the Step 5
+finding recorded in [`ROADMAP.md`](../ROADMAP.md) is that per-layer
+Metal kernels at the sync trait's granularity are *slower* than the
+fused decode path, because each call forces its own command-buffer
+commit. `AsyncComputeBackend` — deferred dispatch, intent collection —
+is the identified prerequisite for any win there.
+
+`MetalBackend::set_engine_window` is the one policy decision that
+already crosses into the fused path successfully, and it works precisely
+because it is configuration consumed inside the existing dispatch:
+
+```text
+policy decision -> configure backend -> fused execution consumes it
+```
+
+rather than:
+
+```text
+layer -> call policy -> commit GPU -> layer -> call policy -> commit GPU
+```
+
+It is, in effect, the one-dimensional ancestor of a per-layer residency
+intent. Whatever carries capacity should extend that pattern, not
+reintroduce the per-layer callback.
+
+## Status
+
+- The divergence is **documented and tested**, not fixed.
+- Compaction is **not** wired into the fused decode path, deliberately.
+- Per-layer capacity is **not** implemented, and is blocked on the
+  prefill question above rather than on the allocation change.


### PR DESCRIPTION
## What this is

Not an optimisation. It makes an unstated architectural difference **executable and documented**, so a later change to either path has to say which row of the contract it is moving.

The fused Metal decode path and the coarse `KvDispatch` path implement **identical attention semantics and different physical-residency contracts**:

```text
                        coarse KvDispatch    fused Metal decode
attention span          W                    W
logical occupancy       <= 2W                grows unbounded
absolute position       monotonic            monotonic
rows read by attention  identical            identical
physical capacity       4096                 4096
```

Both clamp what attention *reads* via `attention_span`. Only the coarse path bounds what is *retained* — `coarse_decode_step_windowed` calls `compact_kv_to_window` every step, and nothing on the fused path does. So on `larql run` / `larql bench`, sliding layers accumulate rows without limit.

Neither path documented that it had a contract, which is worse than a bug in one of them.

## Three quantities that keep getting conflated

```text
architectural reachability   W          what attention may ever read
logical occupancy            <= 2W      rows physically retained
physical capacity            4096       rows the Metal buffer holds
```

The gap between rows 2 and 3 is the operative one: **compaction reclaims occupancy, not bytes.** A layer evicted to `W` still owns its 4096-row buffer. Wiring the compactor into the fused path would save no memory at all — that reading is the specific mistake the module exists to prevent.

## Tests

Six, driving both policies over `W-1, W, 2W-1, 2W, 2W+1` and a long run that crosses the compaction trigger **twice** (the second slide lands at `3W`, so a shorter run only ever exercises a memmove over pristine rows).

They use the production functions — `compact_kv_to_window`, `evict_to_window`, `attention_span` — with the only difference between arms being the call the fused path is missing.

The **visible-rows** test is the output-parity claim reduced to its cause: if the newest `span` rows hold the same absolute positions in the same order, attention inputs are identical and logits cannot differ. That is the precondition for ever wiring compaction into the fused path, and it now has a test rather than an argument.

## What this deliberately does not do

- **Does not wire compaction into fused decode.** It would not save the bytes, and the semantics need to be settled first.
- **Does not add per-layer capacity.** That would save ~464 MB on Gemma 3 4B (1.09 GB → ~624 MB), but it is blocked on *prefill*, not on the allocation: `full_pipeline/kv_copy.rs` bulk-copies `seq_len` rows and sets `current_len = seq_len`, under a SAFETY note claiming a bound that is supplied by the caller and enforced nowhere local. Shrinking a sliding layer's capacity turns prefill into an overrun.
- **Does not widen the shape tuple.** `(num_kv_heads, head_dim)` threads through 134 references across 26 files in 5 crates. Capacity is residency policy, not representation; it belongs in a separate object submitted once at setup, per the `KvDispatch` Step 5 finding that per-layer synchronous dispatch loses to the fused path.

`docs/kv-residency-contract.md` carries the full reasoning, the open prefill question and the evidence bearing on it, and why `set_engine_window` is the shape a future seam should take.

## Gates

`fmt`, `clippy -D warnings` (workspace, all targets), doc-link gate (695 links), `larql-compute-metal` 283 tests, `larql-kv` + `larql-compute`, `x86_64-apple-darwin`. No behaviour change; `COMPACTION_SLACK` becomes `pub(crate)` so the test names the bound instead of hardcoding 2.