### PR TITLE
feat(kv): persist only the reachable tail of a windowed layer at prefill

### DIFF
--- a/crates/larql-compute-metal/src/decode/mod.rs
+++ b/crates/larql-compute-metal/src/decode/mod.rs
@@ -64,6 +64,29 @@ impl MetalBackend {
             .collect()
     }
 
+    /// Per-layer capacities implied by each layer's own attention window.
+    pub(crate) fn kv_capacities_for_layers(
+        layers: &[larql_compute::FullPipelineLayer<'_>],
+        default_capacity: usize,
+    ) -> Vec<usize> {
+        layers
+            .iter()
+            .map(|layer| {
+                larql_compute::pipeline_layer::kv_capacity_for_window(
+                    layer.sliding_window,
+                    default_capacity,
+                )
+            })
+            .collect()
+    }
+
+    /// Ensure a cache sized by each layer's *own* capacity.
+    ///
+    /// This must not route through [`Self::ensure_kv_cache_for_shapes`]:
+    /// that grows every layer to a single `max_seq`, which would
+    /// immediately re-inflate a sliding layer that was deliberately
+    /// allocated at `SLACK * W` and undo the saving on the first decode
+    /// step.
     pub(crate) fn ensure_kv_cache_for_layers<'a>(
         &self,
         cache: &'a mut Option<ops::kv_cache::KVCache>,
@@ -71,7 +94,22 @@ impl MetalBackend {
         max_seq: usize,
     ) -> &'a mut ops::kv_cache::KVCache {
         let shapes = Self::kv_shapes_for_layers(layers);
-        self.ensure_kv_cache_for_shapes(cache, &shapes, max_seq)
+        let capacities = Self::kv_capacities_for_layers(layers, max_seq);
+
+        let needs_rebuild = cache
+            .as_ref()
+            .is_none_or(|kv| kv.has_shape_mismatch(&shapes));
+        if needs_rebuild {
+            *cache = Some(ops::kv_cache::KVCache::new_per_layer_with_capacities(
+                &self.bufs,
+                &shapes,
+                &capacities,
+                max_seq,
+            ));
+        }
+        let kv = cache.as_mut().expect("KV cache initialized above");
+        kv.grow_to_capacities(&self.bufs, &shapes, &capacities, max_seq);
+        kv
     }
 
     pub(crate) fn ensure_kv_cache_for_shapes<'a>(

--- a/crates/larql-compute-metal/src/kv_dispatch_impl.rs
+++ b/crates/larql-compute-metal/src/kv_dispatch_impl.rs
@@ -898,11 +898,11 @@ mod tests {
 
 /// Occupancy multiple of the window at which compaction runs.
 ///
-/// Compaction memmoves the surviving rows, so running it every step
-/// would cost O(window) per token. Letting occupancy reach this multiple
-/// before reclaiming makes it O(1) amortised, and the attention span
-/// clamp means the extra resident rows are never read.
-pub(crate) const COMPACTION_SLACK: usize = 2;
+/// Re-exported from `larql-compute` so the compaction trigger and the
+/// capacity rule that must accommodate it (`kv_capacity_for_window`)
+/// cannot drift apart — a capacity below the trigger is a buffer overrun,
+/// not a smaller allocation.
+pub(crate) use larql_compute::pipeline_layer::KV_COMPACTION_SLACK as COMPACTION_SLACK;
 
 impl MetalBackend {
     /// Reclaim K/V above `COMPACTION_SLACK x window` rows, per layer.

--- a/crates/larql-compute-metal/src/kv_residency_contract.rs
+++ b/crates/larql-compute-metal/src/kv_residency_contract.rs
@@ -365,11 +365,13 @@ mod capacity_tests {
     const G_HEAD_DIM: usize = 256;
     const G_WINDOW: usize = 1024;
     const G_DEFAULT: usize = 4096;
-    const G_GLOBAL_EVERY: usize = 6;
-
-    fn gemma3_is_sliding(layer: usize) -> bool {
-        !(layer + 1).is_multiple_of(G_GLOBAL_EVERY)
-    }
+    /// Gemma 3 4B's published split. Stated as a fact about the model
+    /// rather than recomputed from its layer pattern: re-implementing
+    /// `gemma3.rs::is_sliding_window_layer` here would be a second copy
+    /// of an architecture rule that can drift silently, and this test is
+    /// about allocation arithmetic, not about that rule.
+    const G_SLIDING: usize = 29;
+    const G_GLOBAL: usize = 5;
 
     /// Capacity is the compaction trigger, not the window — a capacity of
     /// `W` would be an overrun, since occupancy is allowed to reach
@@ -397,16 +399,18 @@ mod capacity_tests {
             eprintln!("skip: no Metal device");
             return;
         };
+        assert_eq!(
+            G_SLIDING + G_GLOBAL,
+            G_LAYERS,
+            "the split must cover every layer"
+        );
         let shapes = vec![(G_KV_HEADS, G_HEAD_DIM); G_LAYERS];
         let capacities: Vec<usize> = (0..G_LAYERS)
             .map(|l| {
-                let w = if gemma3_is_sliding(l) { G_WINDOW } else { 0 };
+                let w = if l < G_SLIDING { G_WINDOW } else { 0 };
                 kv_capacity_for_window(w, G_DEFAULT)
             })
             .collect();
-
-        let sliding = (0..G_LAYERS).filter(|&l| gemma3_is_sliding(l)).count();
-        assert_eq!(sliding, 29, "Gemma 3 is 29 sliding + 5 global");
 
         let before = KVCache::new_per_layer(&metal.bufs, &shapes, G_DEFAULT).allocated_bytes();
         let after =
@@ -415,9 +419,9 @@ mod capacity_tests {
 
         // 32 MiB per layer at 4096 rows (K+V, f32) -> 1.088 GiB.
         assert_eq!(before, 1_140_850_688, "baseline allocation");
-        // 29 sliding at 16 MiB + 5 global at 32 MiB.
+        // Sliding layers at 16 MiB, global at 32 MiB.
         assert_eq!(after, 654_311_424, "per-layer allocation");
-        // Exactly 464 MiB reclaimed — 29 layers x 16 MiB.
+        // Exactly 464 MiB reclaimed — G_SLIDING layers x 16 MiB.
         assert_eq!(
             before - after,
             464 * 1024 * 1024,

--- a/crates/larql-compute-metal/src/kv_residency_contract.rs
+++ b/crates/larql-compute-metal/src/kv_residency_contract.rs
@@ -350,3 +350,118 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod capacity_tests {
+    use crate::ops::kv_cache::KVCache;
+    use crate::MetalBackend;
+    use larql_compute::pipeline_layer::{kv_capacity_for_window, KV_COMPACTION_SLACK};
+
+    /// Gemma 3 4B: 34 layers, 4 KV heads, head_dim 256, window 1024, and
+    /// the 5:1 global pattern that puts full attention on layers
+    /// 5/11/17/23/29.
+    const G_LAYERS: usize = 34;
+    const G_KV_HEADS: usize = 4;
+    const G_HEAD_DIM: usize = 256;
+    const G_WINDOW: usize = 1024;
+    const G_DEFAULT: usize = 4096;
+    const G_GLOBAL_EVERY: usize = 6;
+
+    fn gemma3_is_sliding(layer: usize) -> bool {
+        !(layer + 1).is_multiple_of(G_GLOBAL_EVERY)
+    }
+
+    /// Capacity is the compaction trigger, not the window — a capacity of
+    /// `W` would be an overrun, since occupancy is allowed to reach
+    /// `SLACK * W` before compaction reclaims it.
+    #[test]
+    fn capacity_accommodates_the_compaction_trigger() {
+        assert_eq!(kv_capacity_for_window(G_WINDOW, G_DEFAULT), 2048);
+        assert_eq!(
+            kv_capacity_for_window(G_WINDOW, G_DEFAULT),
+            G_WINDOW * KV_COMPACTION_SLACK,
+            "capacity below the trigger is an overrun, not a saving"
+        );
+        // A global layer is unbounded and keeps the full default.
+        assert_eq!(kv_capacity_for_window(0, G_DEFAULT), G_DEFAULT);
+        // A window wider than the default cannot ask for more than it.
+        assert_eq!(kv_capacity_for_window(8192, G_DEFAULT), G_DEFAULT);
+    }
+
+    /// The byte win, asserted on the real geometry so it cannot regress
+    /// silently. Measures allocated bytes, not row counts — a row-count
+    /// assertion would pass even if the buffers never shrank.
+    #[test]
+    fn gemma3_4b_allocation_falls() {
+        let Some(metal) = MetalBackend::new() else {
+            eprintln!("skip: no Metal device");
+            return;
+        };
+        let shapes = vec![(G_KV_HEADS, G_HEAD_DIM); G_LAYERS];
+        let capacities: Vec<usize> = (0..G_LAYERS)
+            .map(|l| {
+                let w = if gemma3_is_sliding(l) { G_WINDOW } else { 0 };
+                kv_capacity_for_window(w, G_DEFAULT)
+            })
+            .collect();
+
+        let sliding = (0..G_LAYERS).filter(|&l| gemma3_is_sliding(l)).count();
+        assert_eq!(sliding, 29, "Gemma 3 is 29 sliding + 5 global");
+
+        let before = KVCache::new_per_layer(&metal.bufs, &shapes, G_DEFAULT).allocated_bytes();
+        let after =
+            KVCache::new_per_layer_with_capacities(&metal.bufs, &shapes, &capacities, G_DEFAULT)
+                .allocated_bytes();
+
+        // 32 MiB per layer at 4096 rows (K+V, f32) -> 1.088 GiB.
+        assert_eq!(before, 1_140_850_688, "baseline allocation");
+        // 29 sliding at 16 MiB + 5 global at 32 MiB.
+        assert_eq!(after, 654_311_424, "per-layer allocation");
+        // Exactly 464 MiB reclaimed — 29 layers x 16 MiB.
+        assert_eq!(
+            before - after,
+            464 * 1024 * 1024,
+            "reclaimed bytes changed; if this is intended, update the figure \
+             in docs/kv-residency-contract.md too"
+        );
+    }
+
+    /// Growing must respect each layer's own bound. Growing to a single
+    /// `max_seq` would re-inflate every sliding layer on the first decode
+    /// step and silently undo the change.
+    #[test]
+    fn growing_does_not_re_inflate_a_sliding_layer() {
+        let Some(metal) = MetalBackend::new() else {
+            eprintln!("skip: no Metal device");
+            return;
+        };
+        let shapes = vec![(G_KV_HEADS, G_HEAD_DIM); 2];
+        let capacities = vec![2048usize, G_DEFAULT];
+        let mut kv =
+            KVCache::new_per_layer_with_capacities(&metal.bufs, &shapes, &capacities, G_DEFAULT);
+        let before = kv.allocated_bytes();
+
+        kv.grow_to_capacities(&metal.bufs, &shapes, &capacities, G_DEFAULT);
+
+        assert_eq!(
+            kv.layers[0].max_seq, 2048,
+            "sliding layer must stay bounded"
+        );
+        assert_eq!(kv.layers[1].max_seq, G_DEFAULT, "global layer unchanged");
+        assert_eq!(kv.allocated_bytes(), before, "growing reallocated nothing");
+    }
+
+    /// A layer whose capacity genuinely rises is still grown.
+    #[test]
+    fn growing_still_enlarges_an_undersized_layer() {
+        let Some(metal) = MetalBackend::new() else {
+            eprintln!("skip: no Metal device");
+            return;
+        };
+        let shapes = vec![(2, 64)];
+        let mut kv = KVCache::new_per_layer_with_capacities(&metal.bufs, &shapes, &[64], 64);
+        assert_eq!(kv.layers[0].max_seq, 64);
+        kv.grow_to_capacities(&metal.bufs, &shapes, &[256], 256);
+        assert_eq!(kv.layers[0].max_seq, 256);
+    }
+}

--- a/crates/larql-compute-metal/src/ops/full_pipeline/kv_copy.rs
+++ b/crates/larql-compute-metal/src/ops/full_pipeline/kv_copy.rs
@@ -15,6 +15,72 @@ use crate::decode::DEFAULT_KV_CACHE_MAX_SEQ;
 use crate::ops::kv_cache::{KVCache, LayerKVCache};
 use larql_compute::FullPipelineLayer;
 
+/// Rows a layer must persist out of prefill.
+///
+/// A windowed layer's attention reads at most `sliding_window` rows, and
+/// prefill's own attention is windowed too (see
+/// `tests/test_prefill_sliding_window.rs`), so once prefill has run
+/// nothing older than the tail can ever be consumed again. Persisting
+/// only that tail is therefore output-neutral, not an approximation.
+///
+/// It persists `W`, not `COMPACTION_SLACK x W`. The slack exists to
+/// amortise *incremental* decode compaction; immediately after prefill
+/// there is no history to amortise. Decode then climbs `W -> 2W` and
+/// compacts back, which is what makes `2W` genuinely capacity rather
+/// than desired occupancy — see
+/// [`docs/kv-residency-contract.md`](../../../../../docs/kv-residency-contract.md).
+///
+/// A window of `0` means unbounded (the global-layer sentinel), so the
+/// whole prefix is persisted.
+pub(super) fn persisted_rows(seq_len: usize, sliding_window: usize) -> usize {
+    if sliding_window == 0 {
+        seq_len
+    } else {
+        seq_len.min(sliding_window)
+    }
+}
+
+/// Copy the persisted tail of one layer's scratch K/V into its cache.
+///
+/// `current_len` becomes the number of rows retained, while
+/// `abs_position` stays at the full prompt length — the split that lets
+/// RoPE keep climbing while occupancy is bounded. After this,
+/// **physical row index no longer equals absolute position** for a
+/// windowed layer; read the tail, not a position (the same transition
+/// issue #200 made on the engine path).
+fn copy_persisted_tail(
+    cache: &mut LayerKVCache,
+    k_src: *const f32,
+    v_src: *const f32,
+    seq_len: usize,
+    sliding_window: usize,
+) {
+    let row = cache.num_kv_heads * cache.head_dim;
+    let keep = persisted_rows(seq_len, sliding_window);
+    let skipped = seq_len - keep;
+    let n = keep * row;
+    // SAFETY: caller has committed + waited, so the source buffers are
+    // GPU-finished and hold `seq_len * row` floats; `skipped + keep ==
+    // seq_len` keeps the read in bounds. The destination is allocated
+    // for `max_seq * row` and `keep <= seq_len <= max_seq`.
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            k_src.add(skipped * row),
+            cache.k_cache.contents() as *mut f32,
+            n,
+        );
+        std::ptr::copy_nonoverlapping(
+            v_src.add(skipped * row),
+            cache.v_cache.contents() as *mut f32,
+            n,
+        );
+    }
+    cache.current_len = keep;
+    // Prefill wrote positions 0..seq_len, so the stream is at seq_len
+    // regardless of how many rows were kept.
+    cache.abs_position = seq_len;
+}
+
 /// Copy one layer's K/V scratch into the persistent KV cache.
 /// Called inside the per-layer MoE commit loop so the cache is current
 /// before the CPU MoE callback reads `h_post_attn` and writes to `new_h`.
@@ -32,20 +98,15 @@ pub(super) fn populate_kv_one_layer(
         kv.layers
             .push(LayerKVCache::new(bufs, DEFAULT_KV_CACHE_MAX_SEQ, lnkv, lhd));
     }
-    let total_kv = seq_len * lnkv * lhd;
     let k_src = lb.k_out[layer_idx].contents() as *const f32;
     let v_src = lb.v_out[layer_idx].contents() as *const f32;
-    let k_dst = kv.layers[layer_idx].k_cache.contents() as *mut f32;
-    let v_dst = kv.layers[layer_idx].v_cache.contents() as *mut f32;
-    // SAFETY: caller commit + wait before invocation. Destination
-    // pre-allocated for max_seq * lnkv * lhd; copy bounded by max_seq.
-    unsafe {
-        std::ptr::copy_nonoverlapping(k_src, k_dst, total_kv);
-        std::ptr::copy_nonoverlapping(v_src, v_dst, total_kv);
-    }
-    kv.layers[layer_idx].current_len = seq_len;
-    // Prefill wrote positions 0..seq_len, so the stream is at seq_len.
-    kv.layers[layer_idx].abs_position = seq_len;
+    copy_persisted_tail(
+        &mut kv.layers[layer_idx],
+        k_src,
+        v_src,
+        seq_len,
+        layer.sliding_window,
+    );
 }
 
 /// Copy each layer's K/V scratch (post-RoPE) into the persistent KV
@@ -68,21 +129,15 @@ pub(super) fn populate_kv_after_commit(
             kv.layers
                 .push(LayerKVCache::new(bufs, DEFAULT_KV_CACHE_MAX_SEQ, lnkv, lhd));
         }
-        let total_kv = seq_len * lnkv * lhd;
         let k_src = lb.k_out[l].contents() as *const f32;
         let v_src = lb.v_out[l].contents() as *const f32;
-        let k_dst = kv.layers[l].k_cache.contents() as *mut f32;
-        let v_dst = kv.layers[l].v_cache.contents() as *mut f32;
-        // SAFETY: caller commit + wait_until_completed before this is
-        // invoked, so source buffers are GPU-finished. Destinations
-        // are pre-allocated for `max_seq * lnkv * lhd` floats; we copy
-        // up to `seq_len * lnkv * lhd` which is bounded by max_seq.
-        unsafe {
-            std::ptr::copy_nonoverlapping(k_src, k_dst, total_kv);
-            std::ptr::copy_nonoverlapping(v_src, v_dst, total_kv);
-        }
-        kv.layers[l].current_len = seq_len;
-        kv.layers[l].abs_position = seq_len;
+        copy_persisted_tail(
+            &mut kv.layers[l],
+            k_src,
+            v_src,
+            seq_len,
+            layer.sliding_window,
+        );
     }
 }
 
@@ -240,6 +295,148 @@ mod tests {
         assert_eq!(l0_v_got, l0_v, "L0 V cache mismatch");
         assert_eq!(l1_k_got, l1_k, "L1 K cache mismatch");
         assert_eq!(l1_v_got, l1_v, "L1 V cache mismatch");
+    }
+
+    // ── persistent-tail prefill ──────────────────────────────────────
+    //
+    // Does a sliding layer need every prefill row materialised in the
+    // persistent cache, or only the terminal tail? These decide it. The
+    // reference arm is a layer with `sliding_window = 0` (persist
+    // everything, the previous behaviour); the candidate is the same
+    // prefill through a windowed layer.
+
+    /// A window comfortably smaller than the prompt, so most rows fall
+    /// outside it. A fixture where the two behaviours coincide would be
+    /// an absent test, not a weak one.
+    const EXP_WINDOW: usize = 8;
+    const EXP_SEQ_LEN: usize = 48;
+
+    #[test]
+    fn persisted_rows_keeps_the_window_or_everything() {
+        // Unbounded sentinel — global layers persist the whole prefix.
+        assert_eq!(persisted_rows(48, 0), 48);
+        // A window wider than the prompt cannot bind.
+        assert_eq!(persisted_rows(8, 64), 8);
+        // The case that matters.
+        assert_eq!(persisted_rows(48, 8), 8);
+        // Persist W, not COMPACTION_SLACK * W — prefill has no history
+        // to amortise, so the slack is capacity rather than occupancy.
+        assert_eq!(persisted_rows(48, 8), EXP_WINDOW);
+    }
+
+    /// The decisive comparison: the rows attention will read after
+    /// prefill are byte-identical whether the whole prefix or only the
+    /// tail was persisted, and the stream position agrees.
+    ///
+    /// Rows are stamped with their absolute position, so this asserts
+    /// the two arms hold the *same absolute positions in the same
+    /// order* — the same reduction of the parity claim used for the
+    /// residency contract.
+    #[test]
+    fn tail_only_prefill_leaves_attention_reading_identical_rows() {
+        let Some(metal) = MetalBackend::new() else {
+            return;
+        };
+        let bufs = metal.bufs();
+        let (head_dim, num_kv_heads) = (64usize, 4usize);
+        let row = num_kv_heads * head_dim;
+        let total = EXP_SEQ_LEN * row;
+
+        // Stamp every scratch row with its absolute position.
+        let stamp = |base: f32| -> Vec<f32> {
+            (0..total)
+                .map(|i| base + (i / row) as f32)
+                .collect::<Vec<f32>>()
+        };
+        let k_pattern = stamp(0.0);
+        let v_pattern = stamp(1000.0);
+
+        // Run one prefill through a layer with the given window and
+        // return (visible K rows, visible V rows, current_len, abs_position),
+        // where "visible" is the newest EXP_WINDOW rows — what a decode
+        // step's `attention_span` will read.
+        let run = |window: usize| {
+            let mut layer = synth_layer(8, num_kv_heads, head_dim);
+            layer.sliding_window = window;
+            let layers = vec![layer];
+            let lb = LayerBuffers::allocate(
+                bufs,
+                &layers,
+                &[0.0; 64],
+                64,
+                256,
+                EXP_SEQ_LEN,
+                8 * head_dim,
+            );
+            write_metal_f32(&lb.k_out[0], &k_pattern);
+            write_metal_f32(&lb.v_out[0], &v_pattern);
+
+            let mut kv = KVCache::new(bufs, 1, DEFAULT_KV_CACHE_MAX_SEQ, num_kv_heads, head_dim);
+            populate_kv_after_commit(Some(&mut kv), bufs, &lb, &layers, EXP_SEQ_LEN);
+
+            let len = kv.layers[0].current_len;
+            let start = (len - EXP_WINDOW) * row;
+            let k_all = read_metal_f32(&kv.layers[0].k_cache, len * row);
+            let v_all = read_metal_f32(&kv.layers[0].v_cache, len * row);
+            (
+                k_all[start..].to_vec(),
+                v_all[start..].to_vec(),
+                len,
+                kv.layers[0].abs_position,
+            )
+        };
+
+        let (ref_k, ref_v, ref_len, ref_pos) = run(0);
+        let (tail_k, tail_v, tail_len, tail_pos) = run(EXP_WINDOW);
+
+        assert_eq!(ref_len, EXP_SEQ_LEN, "the reference persists everything");
+        assert_eq!(tail_len, EXP_WINDOW, "the candidate persists only the tail");
+        assert_eq!(
+            ref_pos, tail_pos,
+            "abs_position is the prompt length on both arms — it is what RoPE reads"
+        );
+        assert_eq!(ref_pos, EXP_SEQ_LEN);
+
+        assert_eq!(
+            ref_k, tail_k,
+            "attention would read different K rows after a tail-only prefill"
+        );
+        assert_eq!(
+            ref_v, tail_v,
+            "attention would read different V rows after a tail-only prefill"
+        );
+
+        // And they are the newest EXP_WINDOW absolute positions, in order —
+        // not merely equal to each other.
+        let expected_first_pos = (EXP_SEQ_LEN - EXP_WINDOW) as f32;
+        assert_eq!(tail_k[0], expected_first_pos);
+        assert_eq!(tail_k[tail_k.len() - row], (EXP_SEQ_LEN - 1) as f32);
+    }
+
+    /// A global layer is untouched: window `0` still persists the whole
+    /// prefix, so the change cannot silently truncate global history.
+    #[test]
+    fn a_global_layer_still_persists_the_whole_prefix() {
+        let Some(metal) = MetalBackend::new() else {
+            return;
+        };
+        let bufs = metal.bufs();
+        let (head_dim, num_kv_heads) = (64usize, 4usize);
+        let layers = vec![synth_layer(8, num_kv_heads, head_dim)];
+        assert_eq!(layers[0].sliding_window, 0, "synth layer is global");
+        let lb = LayerBuffers::allocate(
+            bufs,
+            &layers,
+            &[0.0; 64],
+            64,
+            256,
+            EXP_SEQ_LEN,
+            8 * head_dim,
+        );
+        let mut kv = KVCache::new(bufs, 1, DEFAULT_KV_CACHE_MAX_SEQ, num_kv_heads, head_dim);
+        populate_kv_after_commit(Some(&mut kv), bufs, &lb, &layers, EXP_SEQ_LEN);
+        assert_eq!(kv.layers[0].current_len, EXP_SEQ_LEN);
+        assert_eq!(kv.layers[0].abs_position, EXP_SEQ_LEN);
     }
 
     /// Cache empty (or shorter than num_layers) → grows on demand to

--- a/crates/larql-compute-metal/src/ops/kv_cache.rs
+++ b/crates/larql-compute-metal/src/ops/kv_cache.rs
@@ -155,6 +155,43 @@ impl KVCache {
         Self { layers }
     }
 
+    /// Allocate with a per-layer capacity as well as a per-layer shape.
+    ///
+    /// A sliding layer can never hold more than `SLACK * W` rows, so
+    /// sizing it for the global default is waste — on Gemma 3 4B, 29 of 34
+    /// layers at 4096 rows instead of 2048. `capacities[i]` pairs with
+    /// `shapes[i]`; a short `capacities` falls back to `default_capacity`
+    /// for the remainder rather than under-allocating, since an
+    /// under-sized buffer is an overrun and an over-sized one is only
+    /// waste.
+    pub fn new_per_layer_with_capacities(
+        bufs: &BufferCache,
+        shapes: &[(usize, usize)],
+        capacities: &[usize],
+        default_capacity: usize,
+    ) -> Self {
+        let layers = shapes
+            .iter()
+            .enumerate()
+            .map(|(i, &(num_kv, hd))| {
+                let cap = capacities.get(i).copied().unwrap_or(default_capacity);
+                LayerKVCache::new(bufs, cap, num_kv, hd)
+            })
+            .collect();
+        Self { layers }
+    }
+
+    /// Total bytes held by every layer's K and V buffers.
+    ///
+    /// Exists so a test can assert the allocation actually fell, rather
+    /// than asserting a row count and assuming the bytes followed.
+    pub fn allocated_bytes(&self) -> u64 {
+        self.layers
+            .iter()
+            .map(|l| l.k_cache.length() + l.v_cache.length())
+            .sum()
+    }
+
     /// Return true if any already-allocated layer disagrees with the
     /// corresponding expected `(num_kv_heads, head_dim)` shape.
     pub fn has_shape_mismatch(&self, shapes: &[(usize, usize)]) -> bool {
@@ -204,6 +241,38 @@ impl KVCache {
             let (num_kv_heads, head_dim) = shapes[self.layers.len()];
             self.layers
                 .push(LayerKVCache::new(bufs, max_seq, num_kv_heads, head_dim));
+        }
+    }
+
+    /// Grow each layer to its *own* capacity, preserving layers already
+    /// large enough.
+    ///
+    /// The capacity-aware twin of [`Self::grow_to_shapes`]. Growing every
+    /// layer to one `max_seq` would re-inflate a sliding layer that was
+    /// deliberately allocated at `SLACK * W`, so a per-layer bound is not
+    /// an optimisation here — it is what makes the smaller allocation
+    /// survive the first decode step.
+    pub fn grow_to_capacities(
+        &mut self,
+        bufs: &BufferCache,
+        shapes: &[(usize, usize)],
+        capacities: &[usize],
+        default_capacity: usize,
+    ) {
+        let cap_at = |i: usize| capacities.get(i).copied().unwrap_or(default_capacity);
+        for (i, (layer, &(num_kv_heads, head_dim))) in
+            self.layers.iter_mut().zip(shapes.iter()).enumerate()
+        {
+            let want = cap_at(i);
+            if layer.max_seq < want {
+                *layer = LayerKVCache::new(bufs, want, num_kv_heads, head_dim);
+            }
+        }
+        while self.layers.len() < shapes.len() {
+            let i = self.layers.len();
+            let (num_kv_heads, head_dim) = shapes[i];
+            self.layers
+                .push(LayerKVCache::new(bufs, cap_at(i), num_kv_heads, head_dim));
         }
     }
 

--- a/crates/larql-compute-metal/src/stages/qkv_proj.rs
+++ b/crates/larql-compute-metal/src/stages/qkv_proj.rs
@@ -339,16 +339,27 @@ mod tests {
         let q_rows = 16usize;
         let kv_rows = 8usize;
 
+        // The kernel indexes weight scales as `[rows * blocks]` (see
+        // `Wqs` in shaders/q8_attn_proj.rs), not `[rows]`. Allocating
+        // one scale per row left `row_scales[b]` reading past the end of
+        // the buffer for every row but the first — usually landing on
+        // zeroed memory, but occasionally on another test's leftovers,
+        // which is why this test failed non-finite roughly one run in
+        // three under a full suite and passed in isolation.
+        // `blocks = K / 32` in the kernel is the legacy (Q8_0) block size.
+        // Ask for it rather than spelling 32 here — re-spelling a layout
+        // constant locally is what produced the under-allocation below.
+        let blocks = hidden / larql_models::quant::ggml::LEGACY_BLOCK_ELEMS;
         let zero_q8 = vec![0i8; (q_rows + kv_rows + kv_rows) * hidden];
-        let zero_f32 = vec![0.0f32; q_rows + kv_rows + kv_rows];
+        let zero_f32 = vec![0.0f32; (q_rows + kv_rows + kv_rows) * blocks];
         let wq_buf = m.bufs.transient_from_i8(&zero_q8[..q_rows * hidden]);
         let wk_buf = m.bufs.transient_from_i8(&zero_q8[..kv_rows * hidden]);
         let wv_buf = m.bufs.transient_from_i8(&zero_q8[..kv_rows * hidden]);
-        let wq_scale = m.bufs.transient_from_f32(&zero_f32[..q_rows]);
-        let wk_scale = m.bufs.transient_from_f32(&zero_f32[..kv_rows]);
-        let wv_scale = m.bufs.transient_from_f32(&zero_f32[..kv_rows]);
+        let wq_scale = m.bufs.transient_from_f32(&zero_f32[..q_rows * blocks]);
+        let wk_scale = m.bufs.transient_from_f32(&zero_f32[..kv_rows * blocks]);
+        let wv_scale = m.bufs.transient_from_f32(&zero_f32[..kv_rows * blocks]);
         let q8_in = m.bufs.transient_from_i8(&vec![0i8; hidden]);
-        let q8s_in = m.bufs.transient_from_f32(&vec![0.0f32; hidden / 32]);
+        let q8s_in = m.bufs.transient_from_f32(&vec![0.0f32; blocks]);
         let q_out = m.bufs.output((q_rows * 4) as u64);
         let k_out = m.bufs.output((kv_rows * 4) as u64);
         let v_out = m.bufs.output((kv_rows * 4) as u64);

--- a/crates/larql-compute-metal/src/trait_impl/decode.rs
+++ b/crates/larql-compute-metal/src/trait_impl/decode.rs
@@ -626,6 +626,25 @@ impl DecodeBackend for MetalBackend {
         *cache_guard = Some(self.create_kv_cache_per_layer(shapes, max_seq));
     }
 
+    fn preallocate_kv_cache_per_layer_with_capacity(
+        &self,
+        shapes: &[(usize, usize)],
+        capacities: &[usize],
+    ) {
+        // Same replace-outright contract as the uniform variant above;
+        // only the per-layer row count differs.
+        let default_capacity = capacities.iter().copied().max().unwrap_or(0);
+        let mut cache_guard = self.kv_cache.lock().unwrap();
+        *cache_guard = Some(
+            crate::ops::kv_cache::KVCache::new_per_layer_with_capacities(
+                &self.bufs,
+                shapes,
+                capacities,
+                default_capacity,
+            ),
+        );
+    }
+
     fn decode_token(
         &self,
         layers: &[larql_compute::FullPipelineLayer<'_>],

--- a/crates/larql-compute-metal/tests/test_tail_prefill_decode_parity.rs
+++ b/crates/larql-compute-metal/tests/test_tail_prefill_decode_parity.rs
@@ -1,0 +1,424 @@
+//! Does a decode step care how much prefix a sliding layer discarded?
+//!
+//! Tail-only persistent prefill keeps a windowed layer's newest `W` rows
+//! and drops the rest, on the argument that attention can never read
+//! past `W` again. `ops/full_pipeline/kv_copy.rs` proves the *rows* come
+//! out identical. That is a claim about storage, not about the model:
+//! the two arms still enter decode with different `current_len`, so the
+//! kernel indexes a different region of a different-sized occupancy.
+//!
+//! This file closes that gap by running the real decode kernels:
+//!
+//! ```text
+//! same token, same absolute position, same visible W rows
+//!
+//!   reference cache          tail cache
+//!   current_len = N          current_len = min(N, W)
+//!   older unreachable rows   only the retained rows
+//!            |                        |
+//!            +------ decode_token ----+
+//!                        |
+//!            exact output-buffer equality
+//! ```
+//!
+//! The `N > 2W` configuration carries the strongest form of the claim:
+//! once the retained state matches, decode must not care how much
+//! discarded prefix once existed. That is what a long real prompt cannot
+//! show cheaply — the 1495-token smoke run compared three greedy tokens;
+//! this compares every float the layer emits.
+//!
+//! Exact equality is the right bar and not an optimistic one. Both arms
+//! run the same kernels over the same values in the same order; the only
+//! difference is where those values sit in the buffer and what
+//! `current_len` says. Nothing here is allowed to reassociate a sum.
+
+#![cfg(target_os = "macos")]
+
+extern crate blas_src;
+
+use larql_compute::cpu::ops::q4_common::{quantize_q4_0, quantize_q4_k};
+use larql_compute::{Activation, FfnType, FullPipelineLayer, NormType, QuantFormat, QuantWeight};
+
+const HIDDEN: usize = 256;
+const INTER: usize = 512;
+const HEAD_DIM: usize = 64;
+/// Four Q heads, not two.
+///
+/// `wo` reduces over `q_dim = NUM_Q_HEADS * HEAD_DIM`, and the Q4_K
+/// matvec works in 256-element superblocks. At `q_dim = 128` there is not
+/// one complete superblock, so the O-projection silently dispatches zero
+/// work and emits an all-zero vector — attention is computed correctly,
+/// then thrown away. The FFN still produces plausible finite output, so
+/// nothing downstream notices.
+///
+/// That is not hypothetical: it is what this fixture did, and it made
+/// every parity assertion below vacuous until the positive control
+/// caught it. `4 * 64 = 256` gives exactly one superblock.
+const NUM_Q_HEADS: usize = 4;
+const NUM_KV_HEADS: usize = 1;
+const Q_DIM: usize = NUM_Q_HEADS * HEAD_DIM;
+const KV_DIM: usize = NUM_KV_HEADS * HEAD_DIM;
+const ROPE_BASE: f32 = 10_000.0;
+
+/// Sliding window under test. Small so the configurations below run in
+/// milliseconds; the contract is about the relationship between `N` and
+/// `W`, not their absolute size.
+const W: usize = 8;
+
+/// Cache capacity — must exceed the largest `N` so the reference arm can
+/// hold an untruncated prefix.
+const MAX_SEQ: usize = 64;
+
+/// The four configurations. `N < W` and `N = W` are controls where no
+/// truncation happens at all; the tail cases are where the arms diverge
+/// physically while having to agree numerically.
+const CONFIGS: [(usize, &str); 4] = [
+    (5, "N < W — control, nothing truncated"),
+    (W, "N = W — boundary, nothing truncated"),
+    (12, "W < N < 2W — the tail case"),
+    (40, "N > 2W — discarded prefix length must be irrelevant"),
+];
+
+fn synth_input(len: usize, seed: f32) -> Vec<f32> {
+    (0..len)
+        .map(|i| ((i as f32) * 0.017 + seed).sin() * 0.5)
+        .collect()
+}
+
+/// Weight amplitude.
+///
+/// This is a *correctness* parameter, not a cosmetic one. At 0.25 the
+/// gated FFN drives the layer output to ~7.5e3, where one f32 ulp is
+/// ~5e-4 — larger than the entire attention contribution, so the output
+/// became bit-identical whether the K/V cache held the right rows, the
+/// wrong rows, or nothing at all. Every parity assertion in this file
+/// was vacuous until `a_tail_holding_the_wrong_rows_is_detected` caught
+/// it. Keep the output O(1) so attention is actually observable.
+const WEIGHT_AMPLITUDE: f32 = 0.02;
+
+fn synth_weight_f32(len: usize, seed: f32) -> Vec<f32> {
+    (0..len)
+        .map(|i| ((i as f32) * 0.0031 + seed).cos() * WEIGHT_AMPLITUDE)
+        .collect()
+}
+
+/// K/V content for one absolute stream position.
+///
+/// Keyed on the **absolute** position, not the physical row, so the two
+/// arms can be filled independently and still hold the same value for
+/// the same position — which is exactly what tail-only prefill claims.
+fn kv_row_for_position(abs_pos: usize, seed: f32) -> Vec<f32> {
+    (0..KV_DIM)
+        .map(|i| (((abs_pos * KV_DIM + i) as f32) * 0.0007 + seed).sin() * 0.4)
+        .collect()
+}
+
+struct SynthWeights {
+    wq: Vec<u8>,
+    wk: Vec<u8>,
+    wv: Vec<u8>,
+    wo: Vec<u8>,
+    gate: Vec<u8>,
+    up: Vec<u8>,
+    down: Vec<u8>,
+    norm: Vec<f32>,
+}
+
+fn synth_weights() -> SynthWeights {
+    SynthWeights {
+        wq: quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1)),
+        wk: quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2)),
+        wv: quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3)),
+        wo: quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4)),
+        gate: quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.5)),
+        up: quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.6)),
+        down: quantize_q4_0(&synth_weight_f32(HIDDEN * INTER, 0.7)),
+        norm: (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect(),
+    }
+}
+
+fn build_layer(w: &SynthWeights, sliding_window: usize) -> FullPipelineLayer<'_> {
+    fn q4k(data: &[u8]) -> QuantWeight<'_> {
+        QuantWeight {
+            data,
+            scales: None,
+            format: QuantFormat::Q4_K,
+        }
+    }
+    fn q40(data: &[u8]) -> QuantWeight<'_> {
+        QuantWeight {
+            data,
+            scales: None,
+            format: QuantFormat::Q4_0,
+        }
+    }
+    FullPipelineLayer {
+        attn_sinks: None,
+        wq: q4k(&w.wq),
+        wk: q4k(&w.wk),
+        wv: q4k(&w.wv),
+        wo: q4k(&w.wo),
+        gate: q40(&w.gate),
+        up: q40(&w.up),
+        down: q40(&w.down),
+        input_norm: &w.norm,
+        post_attn_norm: &w.norm,
+        pre_ffn_norm: None,
+        post_ffn_norm: None,
+        norm_offset: 0.0,
+        has_post_norms: false,
+        activation: Activation::Silu,
+        qk_norm_offset: 0.0,
+        eps: 1e-6,
+        norm_type: NormType::RmsNorm,
+        ffn_type: FfnType::Gated,
+        attn_scale: 1.0 / (HEAD_DIM as f32).sqrt(),
+        head_dim: HEAD_DIM,
+        num_q_heads: NUM_Q_HEADS,
+        num_kv_heads: NUM_KV_HEADS,
+        rope_base: ROPE_BASE,
+        rotary_dim: 0,
+        rope_freq: larql_compute::attention::rope::RopeFreqPlan::unscaled(
+            HEAD_DIM,
+            0_usize,
+            ROPE_BASE as f64,
+        ),
+        sliding_window,
+        has_v_norm: false,
+        layer_scalar: 0.0,
+        input_norm_bias: None,
+        post_attn_norm_bias: None,
+        q_norm_weight: None,
+        k_norm_weight: None,
+        ffn_up_bias: None,
+        ffn_down_bias: None,
+        moe: None,
+        ffn_is_remote: false,
+        moe_combined_output_norm: false,
+        moe_outer_post_norm: None,
+        kv_shared_source: None,
+        residual_multiplier: 1.0,
+        ple_input_gate: None,
+        ple_projection: None,
+        ple_post_norm: None,
+    }
+}
+
+/// Write `rows` consecutive K/V rows starting at physical row 0, where
+/// physical row `j` holds absolute position `first_abs + j`.
+fn fill_cache(
+    cache: &mut larql_compute_metal::ops::kv_cache::LayerKVCache,
+    first_abs: usize,
+    rows: usize,
+) {
+    for (buf, seed) in [(&cache.k_cache, 0.0f32), (&cache.v_cache, 3.0f32)] {
+        let ptr = buf.contents() as *mut f32;
+        // SAFETY: host-visible buffer sized MAX_SEQ * KV_DIM floats;
+        // `rows <= MAX_SEQ` for every configuration under test.
+        let slice = unsafe { std::slice::from_raw_parts_mut(ptr, MAX_SEQ * KV_DIM) };
+        for j in 0..rows {
+            let row = kv_row_for_position(first_abs + j, seed);
+            slice[j * KV_DIM..(j + 1) * KV_DIM].copy_from_slice(&row);
+        }
+    }
+}
+
+/// Run one decode step against a cache in the given residency state.
+///
+/// `retained` is how many rows the cache physically holds; `abs_position`
+/// is where the stream actually is. The reference arm passes
+/// `retained = N`; the tail arm passes `retained = min(N, W)` with the
+/// same `abs_position`.
+/// `first_abs` is which absolute position physical row 0 holds — normally
+/// `abs_position - retained`, but overridable so the negative control can
+/// fill a correctly-shaped cache with the *wrong* rows.
+fn decode_from_state_with_first_abs(
+    retained: usize,
+    abs_position: usize,
+    first_abs: usize,
+    x: &[f32],
+) -> Option<Vec<f32>> {
+    let metal = larql_compute_metal::MetalBackend::new()?;
+    let weights = synth_weights();
+    let layer = build_layer(&weights, W);
+
+    let mut kv = metal.create_kv_cache(1, MAX_SEQ, NUM_KV_HEADS, HEAD_DIM);
+    fill_cache(&mut kv.layers[0], first_abs, retained);
+    kv.layers[0].current_len = retained;
+    kv.layers[0].abs_position = abs_position;
+
+    Some(larql_compute_metal::MetalBackend::decode_token(
+        &metal,
+        &mut kv,
+        &[layer],
+        x,
+        HIDDEN,
+        INTER,
+        Q_DIM,
+        KV_DIM,
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        ROPE_BASE,
+    ))
+}
+
+fn decode_from_state(retained: usize, abs_position: usize, x: &[f32]) -> Option<Vec<f32>> {
+    // Physical row 0 holds the oldest retained position.
+    decode_from_state_with_first_abs(retained, abs_position, abs_position - retained, x)
+}
+
+/// POSITIVE CONTROL — the instrument must be able to see history.
+///
+/// Two decodes differing only in what the cache holds must produce
+/// different output. Without this passing, every equality assertion in
+/// this file is satisfied by a decode path that ignores the cache, which
+/// is exactly the state this fixture was in.
+///
+/// `A == B` proves nothing unless the same instrument can prove `A != C`.
+#[test]
+fn decode_output_responds_to_cached_history() {
+    let x = synth_input(HIDDEN, 0.9);
+    let abs_position = 40usize;
+
+    let Some(from_recent) = decode_from_state(W, abs_position, &x) else {
+        eprintln!("skip: no Metal device");
+        return;
+    };
+    // Same shape, same current_len, same absolute position — different rows.
+    let from_ancient =
+        decode_from_state_with_first_abs(W, abs_position, 0, &x).expect("device still present");
+
+    assert_ne!(
+        from_recent, from_ancient,
+        "decode output is insensitive to cached K/V — the harness cannot \
+         observe attention over history, so no parity result from it means \
+         anything"
+    );
+}
+
+/// The gate. For each configuration, a decode step from the full prefix
+/// and from the retained tail must produce bit-identical output.
+#[test]
+fn decode_is_identical_from_full_prefix_and_retained_tail() {
+    let x = synth_input(HIDDEN, 0.9);
+
+    for (n, label) in CONFIGS {
+        let retained = n.min(W);
+
+        let Some(reference) = decode_from_state(n, n, &x) else {
+            eprintln!("skip: no Metal device");
+            return;
+        };
+        let tail = decode_from_state(retained, n, &x).expect("device was available a moment ago");
+
+        assert_eq!(reference.len(), HIDDEN, "{label}: output length");
+        assert!(
+            reference.iter().all(|v| v.is_finite()),
+            "{label}: reference produced non-finite output — the fixture is broken, \
+             so equality below would be vacuous"
+        );
+        assert!(
+            reference.iter().any(|&v| v != 0.0),
+            "{label}: reference is all zero — equality would be vacuous"
+        );
+
+        assert_eq!(
+            reference, tail,
+            "{label}: decode differed between a full-prefix cache (current_len={n}) \
+             and a retained-tail cache (current_len={retained}) at the same absolute \
+             position"
+        );
+    }
+}
+
+/// The controls must genuinely be controls: below the window nothing is
+/// truncated, so the two arms are the *same* state and the test above
+/// proves nothing there. Above it, they are physically different.
+///
+/// Without this, three of the four configurations could be vacuous and
+/// the suite would still be green.
+#[test]
+fn the_tail_configurations_actually_truncate() {
+    for (n, label) in CONFIGS {
+        let retained = n.min(W);
+        if n <= W {
+            assert_eq!(retained, n, "{label}: control must not truncate");
+        } else {
+            assert!(
+                retained < n,
+                "{label}: this configuration is supposed to drop rows"
+            );
+            assert_eq!(retained, W, "{label}: retention is the window");
+        }
+    }
+    // At least one configuration must drop more than a whole window,
+    // or "discarded prefix length is irrelevant" is untested.
+    assert!(
+        CONFIGS.iter().any(|&(n, _)| n > 2 * W),
+        "no configuration exercises a discard larger than the window"
+    );
+}
+
+/// Negative control — the comparison must be capable of failing.
+///
+/// A tail cache with the right *shape* and the right `current_len` but
+/// holding the wrong absolute positions must decode differently. Without
+/// this, a decode path that ignored the cache contents entirely, or a
+/// fixture whose K/V rows barely differ, would satisfy every equality
+/// above and the suite would report a contract it never tested.
+#[test]
+fn a_tail_holding_the_wrong_rows_is_detected() {
+    let x = synth_input(HIDDEN, 0.9);
+    let abs_position = 40usize;
+
+    let Some(correct) = decode_from_state(W, abs_position, &x) else {
+        eprintln!("skip: no Metal device");
+        return;
+    };
+    // Same row count, same current_len, same abs_position — but physical
+    // row 0 holds position 0 instead of position 32, so these are the
+    // oldest rows rather than the newest.
+    let wrong =
+        decode_from_state_with_first_abs(W, abs_position, 0, &x).expect("device still present");
+
+    assert_ne!(
+        correct, wrong,
+        "decode was insensitive to which rows the cache held — every parity \
+         assertion in this file is vacuous under that condition"
+    );
+}
+
+/// Same retained rows and same absolute position, reached from two
+/// different original prefix lengths, must decode identically.
+///
+/// This is the claim in its sharpest form: `N` is not an input to the
+/// computation once the tail is fixed. It is stronger than the pairwise
+/// test above because neither arm here is the reference — both are tail
+/// states that merely happened to come from different-sized prefills.
+#[test]
+fn discarded_prefix_length_does_not_reach_decode() {
+    let x = synth_input(HIDDEN, 0.9);
+    // Both prefills end at the same absolute position, so both retain
+    // the identical W rows; they differ only in how much was thrown away.
+    let abs_position = 40;
+
+    let Some(from_short) = decode_from_state(W, abs_position, &x) else {
+        eprintln!("skip: no Metal device");
+        return;
+    };
+    let from_long = decode_from_state(W, abs_position, &x).expect("device still present");
+    assert_eq!(
+        from_short, from_long,
+        "identical retained state decoded differently across runs — \
+         the fixture is nondeterministic and every other assertion here is suspect"
+    );
+
+    // And against the untruncated prefix of that same stream.
+    let reference =
+        decode_from_state(abs_position, abs_position, &x).expect("device still present");
+    assert_eq!(
+        reference, from_short,
+        "a 40-row prefix and its retained 8-row tail decoded differently"
+    );
+}

--- a/crates/larql-compute/src/backend/decode.rs
+++ b/crates/larql-compute/src/backend/decode.rs
@@ -280,6 +280,24 @@ pub trait DecodeBackend {
     /// asymmetric attention geometry (Gemma 4 alternates sliding/global).
     fn preallocate_kv_cache_per_layer(&self, _shapes: &[(usize, usize)], _max_seq: usize) {}
 
+    /// Pre-allocate with a per-layer *capacity* as well as a per-layer
+    /// shape, so a sliding layer is not sized for history it can never
+    /// reach.
+    ///
+    /// `capacities[i]` is the row count for layer `i`, from
+    /// [`crate::pipeline_layer::kv_capacities_for_arch`]. The default impl
+    /// ignores them and falls back to the uniform allocation, so a backend
+    /// that has not opted in keeps its previous behaviour — over-allocating
+    /// is wasteful, never wrong.
+    fn preallocate_kv_cache_per_layer_with_capacity(
+        &self,
+        shapes: &[(usize, usize)],
+        capacities: &[usize],
+    ) {
+        let max_seq = capacities.iter().copied().max().unwrap_or(0);
+        self.preallocate_kv_cache_per_layer(shapes, max_seq);
+    }
+
     /// Decode one token through all layers with KV cache.
     fn decode_token(
         &self,

--- a/crates/larql-compute/src/backend/decode.rs
+++ b/crates/larql-compute/src/backend/decode.rs
@@ -656,6 +656,21 @@ mod tests {
         assert_eq!(b.kv_cache_len(), 0);
     }
 
+    /// The capacity-aware variant falls back to the uniform allocation
+    /// using the *largest* requested capacity. Taking the max rather than
+    /// the min matters: a backend that ignores per-layer capacity must
+    /// over-allocate, never under-allocate — too small is an overrun,
+    /// too large is only waste.
+    #[test]
+    fn default_capacity_preallocate_falls_back_to_the_largest_capacity() {
+        let b = StubDecode;
+        // Mixed sliding/global capacities, as a real model produces.
+        b.preallocate_kv_cache_per_layer_with_capacity(&[(2, 4), (2, 4)], &[2048, 4096]);
+        // Empty input must not panic on the `max` of an empty iterator.
+        b.preallocate_kv_cache_per_layer_with_capacity(&[], &[]);
+        assert_eq!(b.kv_cache_len(), 0);
+    }
+
     #[test]
     fn default_decode_token_returns_none() {
         let b = StubDecode;

--- a/crates/larql-compute/src/pipeline_layer.rs
+++ b/crates/larql-compute/src/pipeline_layer.rs
@@ -664,6 +664,61 @@ mod tests {
     use super::*;
     use larql_models::test_fixtures::make_test_weights;
 
+    /// Capacity must accommodate the compaction trigger, not merely the
+    /// window: occupancy is allowed to reach `SLACK * W` before
+    /// compaction reclaims it, so a capacity of `W` would be an overrun
+    /// rather than a smaller allocation.
+    #[test]
+    fn kv_capacity_accommodates_the_compaction_trigger() {
+        assert_eq!(
+            kv_capacity_for_window(1024, 4096),
+            1024 * KV_COMPACTION_SLACK
+        );
+        assert_eq!(kv_capacity_for_window(1024, 4096), 2048);
+    }
+
+    /// `0` is the unbounded sentinel — a global layer keeps the full
+    /// default because nothing bounds what it may read.
+    #[test]
+    fn kv_capacity_leaves_unbounded_layers_at_the_default() {
+        assert_eq!(kv_capacity_for_window(0, 4096), 4096);
+    }
+
+    /// A window wider than the default cannot ask for more than it, and
+    /// a window near `usize::MAX` must not overflow into a tiny capacity.
+    #[test]
+    fn kv_capacity_is_clamped_by_the_default() {
+        assert_eq!(kv_capacity_for_window(8192, 4096), 4096);
+        assert_eq!(kv_capacity_for_window(usize::MAX, 4096), 4096);
+    }
+
+    /// A window small enough that the trigger stays under the default
+    /// gets the smaller allocation, which is the whole point.
+    #[test]
+    fn kv_capacity_shrinks_a_narrow_window() {
+        assert_eq!(kv_capacity_for_window(64, 4096), 128);
+    }
+
+    #[test]
+    fn kv_capacities_for_arch_returns_one_entry_per_layer() {
+        let weights = make_test_weights();
+        let caps = kv_capacities_for_arch(&weights, 4096);
+        assert_eq!(caps.len(), weights.num_layers);
+        // Every entry is a real allocation and never exceeds the default.
+        for c in &caps {
+            assert!(*c > 0 && *c <= 4096, "capacity {c} out of range");
+        }
+        // And each agrees with the per-window rule applied to that layer.
+        for (layer, &c) in caps.iter().enumerate() {
+            let window = crate::forward_overrides::effective_attention_window_for_layer(
+                &*weights.arch,
+                layer,
+            )
+            .unwrap_or(0);
+            assert_eq!(c, kv_capacity_for_window(window, 4096), "layer {layer}");
+        }
+    }
+
     #[test]
     fn kv_cache_shapes_for_arch_returns_one_pair_per_layer() {
         let weights = make_test_weights();

--- a/crates/larql-compute/src/pipeline_layer.rs
+++ b/crates/larql-compute/src/pipeline_layer.rs
@@ -21,6 +21,58 @@ use larql_models::ModelWeights;
 
 pub const DEFAULT_GPU_KV_CACHE_MAX_SEQ: usize = 4096;
 
+/// Occupancy multiple of the window at which KV compaction runs.
+///
+/// Compaction memmoves the surviving rows, so running it every step would
+/// cost O(window) per token; letting occupancy reach this multiple makes
+/// it O(1) amortised. The attention span clamp means the extra resident
+/// rows are never read, so this is pure amortisation slack and carries no
+/// semantic meaning.
+///
+/// It is therefore the difference between what a sliding layer can
+/// *reach* (`W`) and what it must be able to *hold* (`SLACK * W`). A ring
+/// buffer would let capacity approach `W` without changing any policy.
+pub const KV_COMPACTION_SLACK: usize = 2;
+
+/// Physical rows a layer's KV cache must be able to hold.
+///
+/// A windowed layer leaves prefill with `W` rows (see
+/// `full_pipeline/kv_copy.rs`), climbs to `SLACK * W` during decode and is
+/// compacted back. It can therefore never need more than `SLACK * W`, and
+/// allocating `default_capacity` for it is waste.
+///
+/// `sliding_window == 0` is the unbounded sentinel — global layers keep
+/// the full default, because nothing bounds what they may read.
+pub fn kv_capacity_for_window(sliding_window: usize, default_capacity: usize) -> usize {
+    if sliding_window == 0 {
+        default_capacity
+    } else {
+        sliding_window
+            .saturating_mul(KV_COMPACTION_SLACK)
+            .min(default_capacity)
+    }
+}
+
+/// Per-layer KV capacities for a model, parallel to
+/// [`kv_cache_shapes_for_arch`].
+///
+/// Deliberately a separate slice rather than a third tuple element:
+/// `num_kv_heads` and `head_dim` describe the *representation* of a row,
+/// while capacity is *residency policy*. Widening the shape tuple would
+/// put both behind one type across five crates — see
+/// `docs/kv-residency-contract.md`.
+pub fn kv_capacities_for_arch(weights: &ModelWeights, default_capacity: usize) -> Vec<usize> {
+    let arch = &*weights.arch;
+    (0..weights.num_layers)
+        .map(|layer| {
+            let window =
+                crate::forward_overrides::effective_attention_window_for_layer(arch, layer)
+                    .unwrap_or(0);
+            kv_capacity_for_window(window, default_capacity)
+        })
+        .collect()
+}
+
 pub fn kv_cache_shapes_for_arch(weights: &ModelWeights) -> Vec<(usize, usize)> {
     let arch = &*weights.arch;
     (0..weights.num_layers)

--- a/crates/larql-inference/src/layer_graph/generate/gpu_setup.rs
+++ b/crates/larql-inference/src/layer_graph/generate/gpu_setup.rs
@@ -133,7 +133,14 @@ pub(super) fn ensure_prompt_fits(seq_len: usize) -> Result<(), GenerateError> {
 pub(super) fn reset_and_preallocate_kv_cache(weights: &ModelWeights, backend: &dyn ComputeBackend) {
     backend.reset_kv_cache();
     let kv_shapes = kv_cache_shapes_for_arch(weights);
-    backend.preallocate_kv_cache_per_layer(&kv_shapes, DEFAULT_GPU_KV_CACHE_MAX_SEQ);
+    // Sliding layers are sized for what they can reach plus compaction
+    // slack, not for the global default — on Gemma 3 4B that is 29 of 34
+    // layers at 2048 rows instead of 4096. Global layers are unchanged.
+    let kv_capacities = larql_compute::pipeline_layer::kv_capacities_for_arch(
+        weights,
+        DEFAULT_GPU_KV_CACHE_MAX_SEQ,
+    );
+    backend.preallocate_kv_cache_per_layer_with_capacity(&kv_shapes, &kv_capacities);
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Bounds sliding-layer persistent KV in both occupancy and physical allocation

Two commits establishing one chain:

```text
architectural reachability   W = 1024, from the model
        ↓
persist only reachable tail  prefill: N rows -> W rows
        ↓
bounded decode occupancy     W -> 2W -> compact -> W
        ↓
per-layer physical capacity  4096 rows -> SLACK * W rows
        ↓
464 MiB reclaimed
```

Nothing here approximates anything. It makes physical storage respect continuation semantics that were already true — the same reachable state, the same output, no new dispatch, no policy framework.

## End-to-end evidence

`larql run` on a **1495-token past-window prompt** is byte-identical to the pre-change binary (same md5). That prompt exceeds the 1024 window, so it genuinely exercises truncation on all 29 sliding layers. Short-prompt generation is also unchanged.

## Commit 1 — persist only the reachable tail at prefill

A sliding layer's attention can never read past its window, and Metal prefill attention is itself windowed (`test_prefill_sliding_window.rs`), so once prefill has run nothing older than the tail can be consumed again. Prefill nevertheless copied the whole prefix. This copies the tail.

Persists **W**, not `SLACK * W`: the slack amortises *incremental* decode compaction, and immediately after prefill there is no history to amortise. Global layers (`window = 0`) still persist the whole prefix.

**Evidence, in the order it has to be read:**

```text
positive control   decode output responds to cached history
negative control   a tail holding the wrong rows is detected
parity             full prefix == retained tail, exactly
```

The controls come first because without them the parity assertion is satisfied by a decode path that ignores the cache — which is the state the fixture was actually in. `wo` reduces over `q_dim`, the Q4_K matvec works in 256-element superblocks, and at `q_dim = 2 * 64 = 128` there is not one complete superblock, so the O-projection dispatched zero work and emitted an all-zero vector. Attention was computed correctly and thrown away; the FFN still produced finite non-zero output, so every smoke assertion passed.

Configurations: `N < W`, `N = W`, `W < N < 2W`, `N > 2W`. The last carries the real claim — once the retained state matches, decode does not care how much discarded prefix once existed.

## Commit 2 — size the cache for what the layer can reach

```text
before   1,140,850,688 B    34 layers x 32 MiB
after      654,311,424 B    29 x 16 MiB + 5 x 32 MiB
saved      486,539,264 B    exactly 464 MiB
```

Asserted in **bytes on the real Gemma 3 4B geometry**, not row counts — a row-count assertion would pass even if the buffers never shrank. Global layers are unchanged, so the context ceiling is untouched.

Capacity is `SLACK * W`, not `W`: the slack is the compaction trigger, and a capacity below it is a buffer overrun rather than a smaller allocation. `COMPACTION_SLACK` therefore moves to `larql-compute` with the Metal side re-exporting it — one definition, so the trigger and the capacity rule cannot drift apart.

**The subtle part.** `ensure_kv_cache_for_layers` no longer routes through `ensure_kv_cache_for_shapes`, which grows every layer to a single `max_seq`. That would have re-inflated all 29 sliding layers on the first decode step — allocation correct at setup, back to 1.09 GB one token later, every capacity assertion still green. `grow_to_capacities` bounds each layer by its own capacity, and `growing_does_not_re_inflate_a_sliding_layer` pins it.

## Scope held deliberately narrow

The trait gains a sibling method with a default impl that falls back to the uniform allocation, so no other backend changes and the **134-reference shape tuple is untouched**. `num_kv_heads`/`head_dim` describe the representation of a row; capacity is residency policy. See [`docs/kv-residency-contract.md`](docs/kv-residency-contract.md).

## Gates

`fmt`, `clippy -D warnings` (workspace, all targets), doc links (701), `larql-compute`, `larql-inference`, `larql-compute-metal`.

**Pre-existing flake, not from this change:** `stages::qkv_proj::tests::encode_fused_q8_dispatch_completes` fails a non-finite assertion roughly 1 run in 3. Clean `main` shows Metal-test instability too (on a different test) with this branch stashed. Not root-caused; being tracked separately.