### PR TITLE
fix(metal): kernel capability audit — table + first four correctness fixes (F1-F4)

### DIFF
--- a/crates/larql-compute-metal/src/decode/encode_ffn.rs
+++ b/crates/larql-compute-metal/src/decode/encode_ffn.rs
@@ -60,11 +60,63 @@ pub(super) struct FfnDims {
     pub inter_padded: usize,
 }
 
+/// Validate a layer's FFN formats and return the format that drives
+/// route selection (capability audit F3).
+///
+/// Called at decode entry, before any command buffer or encoder is
+/// created, so a refusal panic unwinds cleanly instead of tripping
+/// Metal's "encoder released without endEncoding" abort. Rules:
+/// - a gated layer's gate and up must share a format — no fused kernel
+///   decodes a mixed pair, and reinterpretation is silent corruption;
+/// - a non-gated layer routes on `up` (its actual first matvec; `gate`
+///   may be a default-constructed placeholder);
+/// - only Q4_K / Q4_KF / Q6_K / Q4_0 have decode FFN paths.
+pub(super) fn validate_ffn_formats(layer: &FullPipelineLayer) -> larql_compute::QuantFormat {
+    use larql_compute::QuantFormat;
+    if layer.is_gated() {
+        assert_eq!(
+            layer.gate.format(),
+            layer.up.format(),
+            "mixed gate/up FFN formats have no fused Metal kernel; \
+             gate={:?} up={:?}",
+            layer.gate.format(),
+            layer.up.format(),
+        );
+    }
+    let route_fmt = if layer.is_gated() {
+        layer.gate.format()
+    } else {
+        layer.up.format()
+    };
+    match route_fmt {
+        QuantFormat::Q4_K | QuantFormat::Q4_KF | QuantFormat::Q6_K | QuantFormat::Q4_0 => route_fmt,
+        other => panic!(
+            "FFN has no Metal decode path for {other:?} gate/up weights; \
+             supported: Q4_K, Q4_KF, Q6_K, Q4_0"
+        ),
+    }
+}
+
 impl MetalBackend {
     /// Encode the full FFN block (gate / up / activation / down) into
-    /// the encoder. `ffn_uses_kquant` selects the path; the function
-    /// returns the same `down_out` buffer the caller passed in via
-    /// `bufs`. No commit/flush — the caller owns encoder lifecycle.
+    /// the encoder. The path is selected per-operand from the layer's
+    /// own weight formats; the function returns the same `down_out`
+    /// buffer the caller passed in via `bufs`. No commit/flush — the
+    /// caller owns encoder lifecycle.
+    ///
+    /// Routing rules (capability audit F3). The previous branch keyed
+    /// on `gate.format().is_kquant_family()` alone, which decoded a
+    /// Q6_K gate with the Q4_K kernels (210-byte blocks read at a
+    /// 144-byte stride) and a Q8_0 gate with the Q4_0 kernels — silent
+    /// corruption in both cases — and never consulted `up.format()` at
+    /// all. Now:
+    /// - a gated layer's gate and up must share a format (no fused
+    ///   kernel decodes a mixed pair; refuse rather than reinterpret);
+    /// - a non-gated layer routes on `up`, its actual first matvec —
+    ///   `gate` may be a default-constructed placeholder;
+    /// - Q6_K runs the separated per-format chain (`q6k_matvec` per
+    ///   projection), mirroring the prefill path;
+    /// - formats with no decode FFN kernel refuse loudly.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn encode_ffn_step(
         &self,
@@ -72,7 +124,6 @@ impl MetalBackend {
         layer: &FullPipelineLayer,
         bufs: FfnBufs<'_>,
         dims: FfnDims,
-        ffn_uses_kquant: bool,
     ) {
         let FfnDims {
             hidden,
@@ -83,25 +134,127 @@ impl MetalBackend {
         let inter_padded_val = inter_padded as u32;
         let hidden_val = hidden as u32;
 
-        let ffn_is_q4kf = layer.gate.format() == larql_compute::QuantFormat::Q4_KF;
+        use larql_compute::QuantFormat;
+        let route_fmt = validate_ffn_formats(layer);
 
-        if ffn_is_q4kf {
-            self.encode_q4kf_ffn(enc, layer, &bufs, hidden, inter, hidden_val, inter_val);
-        } else if ffn_uses_kquant {
-            self.encode_q4k_ffn(
+        match route_fmt {
+            QuantFormat::Q4_KF => {
+                self.encode_q4kf_ffn(enc, layer, &bufs, hidden, inter, hidden_val, inter_val);
+            }
+            QuantFormat::Q4_K => {
+                self.encode_q4k_ffn(
+                    enc,
+                    layer,
+                    &bufs,
+                    hidden,
+                    inter,
+                    inter_padded,
+                    hidden_val,
+                    inter_val,
+                    inter_padded_val,
+                );
+            }
+            QuantFormat::Q6_K => {
+                self.encode_q6k_ffn(enc, layer, &bufs, hidden, inter, inter_val);
+            }
+            QuantFormat::Q4_0 => {
+                self.encode_q4_0_ffn(enc, layer, &bufs, hidden, inter, hidden_val, inter_val);
+            }
+            // validate_ffn_formats admits only the four arms above.
+            other => unreachable!("validate_ffn_formats admitted {other:?}"),
+        }
+    }
+
+    // ── Q6_K (separated per-format chain) ────────────────────────────────────
+
+    /// Q6_K gate/up FFN via the separated per-format chain: one
+    /// `q6k_matvec` per projection through `quant_matvec::encode`,
+    /// activation in between, down per its own format. No fused Q6_K
+    /// gate+up kernel exists; before this path was added, a Q6_K gate
+    /// fell into the Q4_K branch and was silently mis-decoded
+    /// (capability audit F3). The prefill path has always routed Q6_K
+    /// this way — this brings decode into line.
+    fn encode_q6k_ffn(
+        &self,
+        enc: &ComputeCommandEncoderRef,
+        layer: &FullPipelineLayer,
+        bufs: &FfnBufs<'_>,
+        hidden: usize,
+        inter: usize,
+        inter_val: u32,
+    ) {
+        use crate::stages::quant_matvec::{self as qmv, Pipelines};
+        let pipes = Pipelines {
+            q4kf_proj: Some(&self.attention.q4kf_proj_pipeline.state),
+            q4k_matvec_fallback: &self.quant.q4k_matvec_pipeline,
+            q6k_matvec: &self.quant.q6k_matvec_pipeline,
+            q4_matvec: &self.q4.matvec,
+            q4k_matmul: None,
+        };
+        if layer.is_gated() {
+            qmv::encode(
+                enc,
+                larql_compute::QuantFormat::Q6_K,
+                bufs.gate_w,
+                bufs.ffn_norm_out,
+                0,
+                bufs.ffn_norm_out,
+                0,
+                bufs.ffn_norm_out,
+                0, // Q8 operands unused for f32-input formats
+                bufs.gate_out_scratch,
+                0,
+                &pipes,
+                inter,
+                hidden,
+            );
+            qmv::encode(
+                enc,
+                larql_compute::QuantFormat::Q6_K,
+                bufs.up_w,
+                bufs.ffn_norm_out,
+                0,
+                bufs.ffn_norm_out,
+                0,
+                bufs.ffn_norm_out,
+                0,
+                bufs.up_out,
+                0,
+                &pipes,
+                inter,
+                hidden,
+            );
+            self.encode_geglu(enc, layer, bufs, inter_val, inter as u64);
+        } else {
+            qmv::encode(
+                enc,
+                larql_compute::QuantFormat::Q6_K,
+                bufs.up_w,
+                bufs.ffn_norm_out,
+                0,
+                bufs.ffn_norm_out,
+                0,
+                bufs.ffn_norm_out,
+                0,
+                bufs.up_out,
+                0,
+                &pipes,
+                inter,
+                hidden,
+            );
+            self.encode_activation(
                 enc,
                 layer,
-                &bufs,
-                hidden,
-                inter,
-                inter_padded,
-                hidden_val,
+                bufs.up_out,
+                bufs.act_buf,
                 inter_val,
-                inter_padded_val,
+                inter as u64,
             );
-        } else {
-            self.encode_q4_0_ffn(enc, layer, &bufs, hidden, inter, hidden_val, inter_val);
         }
+        // Down per its own format. K = `inter` (unpadded): the
+        // activation wrote [0, inter) and the Q6_K fused-down parity
+        // tests pin this convention.
+        self.encode_qmv_down(enc, layer, bufs, hidden, inter);
     }
 
     // ── Q4_KF (GGUF) ─────────────────────────────────────────────────────────

--- a/crates/larql-compute-metal/src/decode/mod.rs
+++ b/crates/larql-compute-metal/src/decode/mod.rs
@@ -310,6 +310,20 @@ impl MetalBackend {
         mut state_dump: Option<&mut larql_compute::DecodeStateDump>,
         state_dump_mask: larql_compute::StateDumpMask,
     ) -> Vec<f32> {
+        // Refuse unroutable FFN formats BEFORE any command buffer or
+        // encoder exists: a panic that unwinds past a live Metal
+        // encoder trips the ObjC "released without endEncoding"
+        // assertion and turns a clean refusal into a process-killing
+        // SIGTRAP (the failure mode that hid #229 behind an earlier
+        // test's abort). `encode_ffn_step` re-checks as defence in
+        // depth for callers that bypass this entry point.
+        for layer in layers {
+            // A fully-remote FFN never runs locally; its dense weight
+            // slots may be placeholders and are not validated.
+            if !layer.ffn_is_remote {
+                encode_ffn::validate_ffn_formats(layer);
+            }
+        }
         // W10 Phase B/C: capture flags. `dump_kv` controls the K/V
         // staging + readback (skipped under HOnly + None — Metal's own
         // kv cache still receives the K/V as a side effect for
@@ -690,7 +704,7 @@ impl MetalBackend {
                     encoder_ended = false;
                 } else {
                     // Production path: whole FFN in one encoder block.
-                    self.encode_ffn_step(&enc, layer, ffn_bufs, ffn_dims, ffn_uses_kquant);
+                    self.encode_ffn_step(&enc, layer, ffn_bufs, ffn_dims);
                     self.encode_post_ffn_residual(
                         &enc,
                         layer,
@@ -795,7 +809,6 @@ impl MetalBackend {
                         hidden,
                         inter,
                         inter_padded,
-                        ffn_uses_kquant,
                         defer_ffn_for_split,
                         stage_timing_split,
                         layer_in_snapshot: layer_in_snapshot.as_deref(),

--- a/crates/larql-compute-metal/src/decode/moe_interleave.rs
+++ b/crates/larql-compute-metal/src/decode/moe_interleave.rs
@@ -18,7 +18,6 @@ pub(super) struct MoeInterleaveCtx<'a> {
     pub hidden: usize,
     pub inter: usize,
     pub inter_padded: usize,
-    pub ffn_uses_kquant: bool,
     pub defer_ffn_for_split: bool,
     pub stage_timing_split: bool,
     pub layer_in_snapshot: Option<&'a [f32]>,
@@ -122,7 +121,6 @@ impl MetalBackend {
                     inter: ctx.inter,
                     inter_padded: ctx.inter_padded,
                 },
-                ctx.ffn_uses_kquant,
             );
 
             // Always unfused here: this preserves the previous split-MoE path.

--- a/crates/larql-compute-metal/src/decode_hybrid.rs
+++ b/crates/larql-compute-metal/src/decode_hybrid.rs
@@ -75,6 +75,37 @@ impl MetalBackend {
         );
         let qkv_uses_kquant = layer.wq.format().is_kquant_family();
         let o_uses_kquant = layer.wo.format().is_kquant_family();
+        // Route on the full (wq, wk, wv) triple, never on `wq` alone.
+        // Selecting on `wq` sent the production Gemma 3/4 shape
+        // (Q4_K Q/K + Q6_K V) to the uniform Q4_K kernel, which strides
+        // V at 144 bytes per superblock against Q6_K's 210-byte blocks
+        // — silent corruption of every V projection. Capability audit
+        // F2; same operand-local-ABI lesson as the Phase A O-projection
+        // fix. Resolved HERE, before any command encoder exists: the
+        // refusal panic must not unwind past a live encoder, or Metal's
+        // "released without endEncoding" assertion turns it into a
+        // process-killing SIGTRAP.
+        let qkv_kquant_pipeline = if qkv_uses_kquant {
+            use crate::stages::qkv_proj::{pick_qkv_route, QkvFormatRoute};
+            let route = pick_qkv_route(layer.wq.format(), layer.wk.format(), layer.wv.format());
+            Some(match route {
+                QkvFormatRoute::UniformQ4K => &self.attention.q4k_qkv_proj_pipeline,
+                QkvFormatRoute::UniformQ4Kf => &self.attention.q4kf_qkv_proj_pipeline,
+                QkvFormatRoute::MixedQ4kQ6kV => &self.attention.q4k_q6k_qkv_proj_pipeline,
+                // The hybrid path has no per-projection escape, and
+                // dispatching a fused kernel on a triple it does not
+                // decode reinterprets weight bytes. Refuse loudly.
+                QkvFormatRoute::PerProjection => panic!(
+                    "hybrid QKV has no fused kernel for (wq={:?}, wk={:?}, wv={:?}); \
+                     supported triples: Q4_K^3, Q4_KF^3, (Q4_K, Q4_K, Q6_K)",
+                    layer.wq.format(),
+                    layer.wk.format(),
+                    layer.wv.format(),
+                ),
+            })
+        } else {
+            None
+        };
         let layer_q_dim = layer_num_q_heads * layer_head_dim;
         let window_size = layer.sliding_window as u32;
 
@@ -141,12 +172,10 @@ impl MetalBackend {
             // vs 4/64) — using one shader's constants while binding
             // the other's pipeline silently drops 75 % of QKV rows.
             // Same dispatch-geometry-mismatch class as the q4_matvec_v4
-            // ROADMAP ship-log entry.
-            let qkv_pipeline = if layer.wq.format() == larql_compute::QuantFormat::Q4_KF {
-                &self.attention.q4kf_qkv_proj_pipeline
-            } else {
-                &self.attention.q4k_qkv_proj_pipeline
-            };
+            // ROADMAP ship-log entry. Route selection happened before
+            // the encoder was created (see `qkv_kquant_pipeline`).
+            let qkv_pipeline =
+                qkv_kquant_pipeline.expect("kquant QKV branch implies a routed fused pipeline");
             let num_tgs = (total_rows as u64).div_ceil(qkv_pipeline.rows_per_tg);
             enc_a.set_compute_pipeline_state(&qkv_pipeline.state);
             enc_a.set_buffer(0, Some(&wq_buf), 0);

--- a/crates/larql-compute-metal/src/shaders/q4k_geglu_down.rs
+++ b/crates/larql-compute-metal/src/shaders/q4k_geglu_down.rs
@@ -150,11 +150,18 @@ kernel void q4k_geglu_gelu_tanh_down(
                 float nib_hi = float((byte >> 4) & 0x0Fu);
                 uint idx_lo = x_base + sub_lo * 32 + l;
                 uint idx_hi = x_base + sub_hi * 32 + l;
+                // Clamp the tanh argument like `geglu_gelu_tanh` does:
+                // Apple's tanh is (exp(2y)-1)/(exp(2y)+1) and returns NaN
+                // for |y| >~ 44, which real gate values (~±10) reach.
                 float g_lo = gate[idx_lo];
-                float t_lo = tanh(c * (g_lo + 0.044715f * g_lo * g_lo * g_lo));
+                float y_lo = clamp(c * (g_lo + 0.044715f * g_lo * g_lo * g_lo),
+                                   -15.0f, 15.0f);
+                float t_lo = tanh(y_lo);
                 float act_lo = (0.5f * g_lo * (1.0f + t_lo)) * up[idx_lo];
                 float g_hi = gate[idx_hi];
-                float t_hi = tanh(c * (g_hi + 0.044715f * g_hi * g_hi * g_hi));
+                float y_hi = clamp(c * (g_hi + 0.044715f * g_hi * g_hi * g_hi),
+                                   -15.0f, 15.0f);
+                float t_hi = tanh(y_hi);
                 float act_hi = (0.5f * g_hi * (1.0f + t_hi)) * up[idx_hi];
                 dot_lo += nib_lo * act_lo;
                 sum_lo += act_lo;

--- a/crates/larql-compute-metal/src/shaders/q6k_geglu_down.rs
+++ b/crates/larql-compute-metal/src/shaders/q6k_geglu_down.rs
@@ -167,8 +167,12 @@ kernel void q6k_geglu_gelu_tanh_down(
                 float w = d * float(sc[i >> 4u]) * float(raw);
 
                 // GELU-tanh: 0.5·x·(1 + tanh(√(2/π)·(x + 0.044715·x³)))
+                // Clamp like `geglu_gelu_tanh`: Apple's tanh NaNs for
+                // |y| >~ 44, which real gate values (~±10) reach.
                 float gi = tg_gate[i];
-                float t = tanh(c * (gi + 0.044715f * gi * gi * gi));
+                float y = clamp(c * (gi + 0.044715f * gi * gi * gi),
+                                -15.0f, 15.0f);
+                float t = tanh(y);
                 float gelu_g = 0.5f * gi * (1.0f + t);
                 float ai = gelu_g * tg_up[i];
 

--- a/crates/larql-compute-metal/src/shaders/q6k_geglu_gelu_tanh_down_cached.rs
+++ b/crates/larql-compute-metal/src/shaders/q6k_geglu_gelu_tanh_down_cached.rs
@@ -104,8 +104,12 @@ kernel void q6k_geglu_gelu_tanh_down_cached(
                 int raw = int(lo4 | (hi2 << 4u)) - 32;
                 float w = d * float(sc[i >> 4u]) * float(raw);
 
+                // Clamp like `geglu_gelu_tanh`: Apple's tanh NaNs for
+                // |y| >~ 44, which real gate values (~±10) reach.
                 float gi = tg_gate[i];
-                float t = tanh(c * (gi + 0.044715f * gi * gi * gi));
+                float y = clamp(c * (gi + 0.044715f * gi * gi * gi),
+                                -15.0f, 15.0f);
+                float t = tanh(y);
                 float gelu_g = 0.5f * gi * (1.0f + t);
                 float ai = gelu_g * tg_up[i];
 

--- a/crates/larql-compute-metal/src/stages/quant_matvec.rs
+++ b/crates/larql-compute-metal/src/stages/quant_matvec.rs
@@ -410,24 +410,22 @@ mod tests {
         }
     }
 
-    /// Float formats are no-ops — the dispatcher silently returns
-    /// without setting any pipeline (line 222-227).  We pre-bind a
-    /// dummy dispatch to the encoder before calling `encode`, because
-    /// Metal panics on a release of a "naked" command encoder with
-    /// zero dispatches.  Production callers always feed a hot encoder
-    /// here.
+    /// Float formats refuse loudly (capability audit F4). This test
+    /// previously pinned the opposite: a silent no-op that encoded no
+    /// dispatch and left whatever the pooled scratch last held as the
+    /// "result". Same hand-unwind discipline as the Q8_0 test above —
+    /// the panic fires before `end_encoding`, and Metal aborts the
+    /// process if the encoder drops without one.
     #[test]
-    fn float_formats_are_dispatch_noops() {
+    fn float_formats_refuse_loudly() {
         let m = backend();
         let pipes = pipelines(&m);
         for fmt in [QuantFormat::F32, QuantFormat::F16, QuantFormat::BF16] {
             let (w, f32_in, q8_in, q8s_in, out, n, k) = fixture(&m);
             let cmd = m.queue.new_command_buffer();
             let enc = cmd.new_compute_command_encoder();
-            // Hot-start the encoder with a Q4_K dispatch so its drop
-            // (after end_encoding below) doesn't hit Metal's
-            // "released without endEncoding" assertion when `encode`
-            // is a no-op for the float branch.
+            // Hot-start the encoder with a Q4_K dispatch so end_encoding
+            // below isn't closing a naked encoder.
             encode(
                 enc,
                 QuantFormat::Q4_K,
@@ -444,13 +442,24 @@ mod tests {
                 n,
                 k,
             );
-            // Now exercise the float-format no-op branch on the same encoder.
-            encode(
-                enc, fmt, &w, &f32_in, 0, &q8_in, 0, &q8s_in, 0, &out, 0, &pipes, n, k,
-            );
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                encode(
+                    enc, fmt, &w, &f32_in, 0, &q8_in, 0, &q8s_in, 0, &out, 0, &pipes, n, k,
+                );
+            }));
             enc.end_encoding();
             cmd.commit();
             cmd.wait_until_completed();
+            let payload = result.expect_err("float formats must refuse, not no-op");
+            let msg = payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+                .unwrap_or_default();
+            assert!(
+                msg.contains("not dispatchable"),
+                "{fmt:?} panic message: {msg}"
+            );
         }
     }
 }

--- a/crates/larql-compute-metal/src/stages/quant_matvec.rs
+++ b/crates/larql-compute-metal/src/stages/quant_matvec.rs
@@ -233,8 +233,17 @@ pub fn encode(
         larql_compute::QuantFormat::BF16
         | larql_compute::QuantFormat::F16
         | larql_compute::QuantFormat::F32 => {
-            // Not dispatchable via this Q4 shader path — caller should use
-            // a float matvec or dequantize before calling.
+            // Previously a silent no-op: no dispatch was encoded and the
+            // output buffer kept whatever the pooled scratch last held —
+            // stale data presented as a result, the worst failure mode
+            // in the capability audit (F4). Fail loudly, mirroring the
+            // Q8_0 and I2S arms above.
+            panic!(
+                "metal::stages::quant_matvec::encode: {format:?} weights are \
+                 not dispatchable through the quant matvec path. Use a float \
+                 matvec (f32_gemv / f16_gemv) or quantize the weights before \
+                 routing them here."
+            );
         }
     }
 }

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/attention_hybrid.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/attention_hybrid.rs
@@ -191,3 +191,64 @@ fn decode_attention_layer_q4k_with_q6k_wo_drives_q6k_proj_branch() {
     assert_eq!(h_post_attn.len(), HIDDEN);
     assert!(h_post_attn.iter().all(|v| v.is_finite()));
 }
+
+/// The production Gemma 3/4 attention shape — Q4_K Q/K with a Q6_K V —
+/// must route to the mixed `q4k_q6k_qkv_proj` kernel on the hybrid
+/// path (capability audit F2).
+///
+/// Before the route fix, `decode_hybrid` selected the QKV kernel on
+/// `wq` alone, so this exact triple dispatched the uniform Q4_K kernel
+/// and strode the Q6_K V weights at 144 bytes per superblock against
+/// their 210-byte blocks — silent corruption of every V projection on
+/// a production-reachable path.
+#[test]
+fn decode_attention_layer_mixed_q4k_q6k_v_routes_to_mixed_kernel() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        return;
+    };
+    use larql_compute::cpu::ops::q4_common::{quantize_q4_0, quantize_q4_k, quantize_q6_k};
+    let wq = quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1));
+    let wk = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2));
+    let wv = quantize_q6_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3));
+    let wo = quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4));
+    let gate = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.5));
+    let up = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.6));
+    let down = quantize_q4_0(&synth_weight_f32(HIDDEN * INTER, 0.7));
+    let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
+    let mut layer = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+    layer.wv = QuantWeight::new(QuantFormat::Q6_K, &wv, larql_compute::QuantAux::None);
+
+    let x = synth_input(HIDDEN, 0.9);
+    let mut kv = metal.create_kv_cache(1, 64, NUM_KV_HEADS, HEAD_DIM);
+    let h_post_attn = metal.decode_attention_layer(&mut kv, &layer, 0, &x, HIDDEN, Q_DIM, KV_DIM);
+    assert_eq!(h_post_attn.len(), HIDDEN);
+    assert!(h_post_attn.iter().all(|v| v.is_finite()));
+}
+
+/// A k-quant triple with no fused kernel (Q6_K Q) is refused loudly on
+/// the hybrid path rather than reinterpreted by the uniform Q4_K
+/// kernel — the hybrid path has no per-projection escape.
+#[test]
+#[should_panic(expected = "hybrid QKV has no fused kernel")]
+fn decode_attention_layer_q6k_q_is_rejected() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        panic!("hybrid QKV has no fused kernel (no Metal device; asserted statically)");
+    };
+    use larql_compute::cpu::ops::q4_common::{quantize_q4_0, quantize_q4_k, quantize_q6_k};
+    let wq = quantize_q6_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1));
+    let wk = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2));
+    let wv = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3));
+    let wo = quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4));
+    let gate = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.5));
+    let up = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.6));
+    let down = quantize_q4_0(&synth_weight_f32(HIDDEN * INTER, 0.7));
+    let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
+    let mut layer = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+    layer.wq = QuantWeight::new(QuantFormat::Q6_K, &wq, larql_compute::QuantAux::None);
+
+    let x = synth_input(HIDDEN, 0.9);
+    let mut kv = metal.create_kv_cache(1, 64, NUM_KV_HEADS, HEAD_DIM);
+    let _ = metal.decode_attention_layer(&mut kv, &layer, 0, &x, HIDDEN, Q_DIM, KV_DIM);
+}

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/ffn_std_profile.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/ffn_std_profile.rs
@@ -448,8 +448,18 @@ fn decode_token_with_q6k_non_gated_ffn_drives_standard_path() {
     let x = synth_input(HIDDEN, 0.9);
     let mut kv = metal.create_kv_cache(1, 64, NUM_KV_HEADS, HEAD_DIM);
     let out = larql_compute_metal::MetalBackend::decode_token(
-        &metal, &mut kv, &[layer], &x, HIDDEN, INTER, Q_DIM, KV_DIM, NUM_Q_HEADS, NUM_KV_HEADS,
-        HEAD_DIM, 10_000.0,
+        &metal,
+        &mut kv,
+        &[layer],
+        &x,
+        HIDDEN,
+        INTER,
+        Q_DIM,
+        KV_DIM,
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        10_000.0,
     );
     assert_eq!(out.len(), HIDDEN);
     assert!(out.iter().all(|v| v.is_finite()));

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/ffn_std_profile.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/ffn_std_profile.rs
@@ -328,3 +328,95 @@ fn decode_token_with_profile_split_and_q4_0_non_gated_ffn() {
         layer.ffn_type = FfnType::Standard;
     });
 }
+
+/// Q6_K gate/up FFN decodes through the separated per-format chain
+/// (capability audit F3).
+///
+/// Before the per-operand routing fix, a Q6_K gate fell into
+/// `encode_q4k_ffn` via `is_kquant_family()` and its 210-byte planar
+/// superblocks were decoded as 144-byte Q4_K — silent corruption with
+/// no panic. The prefill path always routed Q6_K correctly; this pins
+/// decode doing the same.
+#[test]
+fn decode_token_with_q6k_ffn_drives_separated_per_format_path() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        return;
+    };
+    use larql_compute::cpu::ops::q4_common::{quantize_q4_k, quantize_q6_k};
+    metal.reset_kv_cache();
+    let wq = quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1));
+    let wk = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2));
+    let wv = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3));
+    let wo = quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4));
+    let gate = quantize_q6_k(&synth_weight_f32(INTER * HIDDEN, 0.5));
+    let up = quantize_q6_k(&synth_weight_f32(INTER * HIDDEN, 0.6));
+    let down = quantize_q6_k(&synth_weight_f32(HIDDEN * INTER, 0.7));
+    let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
+    let mut layer = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+    layer.gate = QuantWeight::new(QuantFormat::Q6_K, &gate, larql_compute::QuantAux::None);
+    layer.up = QuantWeight::new(QuantFormat::Q6_K, &up, larql_compute::QuantAux::None);
+    layer.down = QuantWeight::new(QuantFormat::Q6_K, &down, larql_compute::QuantAux::None);
+
+    let x = synth_input(HIDDEN, 0.9);
+    let mut kv = metal.create_kv_cache(1, 64, NUM_KV_HEADS, HEAD_DIM);
+    let out = larql_compute_metal::MetalBackend::decode_token(
+        &metal,
+        &mut kv,
+        &[layer],
+        &x,
+        HIDDEN,
+        INTER,
+        Q_DIM,
+        KV_DIM,
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        10_000.0,
+    );
+    assert_eq!(out.len(), HIDDEN);
+    assert!(out.iter().all(|v| v.is_finite()));
+    assert!(out.iter().any(|v| v.abs() > 1e-6), "all-zero decode output");
+}
+
+/// Mixed gate/up FFN formats are refused, not silently mis-decoded
+/// with whichever kernel the gate format selected (capability audit
+/// F3: `up.format()` was previously never read on the decode path).
+#[test]
+#[should_panic(expected = "mixed gate/up FFN formats")]
+fn decode_token_with_mixed_gate_up_formats_is_rejected() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        panic!("mixed gate/up FFN formats (no Metal device; asserted statically)");
+    };
+    use larql_compute::cpu::ops::q4_common::{quantize_q4_k, quantize_q6_k};
+    metal.reset_kv_cache();
+    let wq = quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1));
+    let wk = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2));
+    let wv = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3));
+    let wo = quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4));
+    let gate = quantize_q4_k(&synth_weight_f32(INTER * HIDDEN, 0.5));
+    let up = quantize_q6_k(&synth_weight_f32(INTER * HIDDEN, 0.6));
+    let down = quantize_q4_k(&synth_weight_f32(HIDDEN * INTER, 0.7));
+    let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
+    let mut layer = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+    layer.gate = QuantWeight::new(QuantFormat::Q4_K, &gate, larql_compute::QuantAux::None);
+    layer.up = QuantWeight::new(QuantFormat::Q6_K, &up, larql_compute::QuantAux::None);
+
+    let x = synth_input(HIDDEN, 0.9);
+    let mut kv = metal.create_kv_cache(1, 64, NUM_KV_HEADS, HEAD_DIM);
+    let _ = larql_compute_metal::MetalBackend::decode_token(
+        &metal,
+        &mut kv,
+        &[layer],
+        &x,
+        HIDDEN,
+        INTER,
+        Q_DIM,
+        KV_DIM,
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        10_000.0,
+    );
+}

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/ffn_std_profile.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/ffn_std_profile.rs
@@ -420,3 +420,37 @@ fn decode_token_with_mixed_gate_up_formats_is_rejected() {
         10_000.0,
     );
 }
+
+/// Non-gated (`FfnType::Standard`) Q6_K FFN — covers `encode_q6k_ffn`'s
+/// up → activation → down arm, which the gated test above cannot reach.
+#[test]
+fn decode_token_with_q6k_non_gated_ffn_drives_standard_path() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        return;
+    };
+    use larql_compute::cpu::ops::q4_common::{quantize_q4_k, quantize_q6_k};
+    metal.reset_kv_cache();
+    let wq = quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1));
+    let wk = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2));
+    let wv = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3));
+    let wo = quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4));
+    let gate = quantize_q6_k(&synth_weight_f32(INTER * HIDDEN, 0.5));
+    let up = quantize_q6_k(&synth_weight_f32(INTER * HIDDEN, 0.6));
+    let down = quantize_q6_k(&synth_weight_f32(HIDDEN * INTER, 0.7));
+    let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
+    let mut layer = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+    layer.gate = QuantWeight::new(QuantFormat::Q6_K, &gate, larql_compute::QuantAux::None);
+    layer.up = QuantWeight::new(QuantFormat::Q6_K, &up, larql_compute::QuantAux::None);
+    layer.down = QuantWeight::new(QuantFormat::Q6_K, &down, larql_compute::QuantAux::None);
+    layer.ffn_type = FfnType::Standard;
+
+    let x = synth_input(HIDDEN, 0.9);
+    let mut kv = metal.create_kv_cache(1, 64, NUM_KV_HEADS, HEAD_DIM);
+    let out = larql_compute_metal::MetalBackend::decode_token(
+        &metal, &mut kv, &[layer], &x, HIDDEN, INTER, Q_DIM, KV_DIM, NUM_Q_HEADS, NUM_KV_HEADS,
+        HEAD_DIM, 10_000.0,
+    );
+    assert_eq!(out.len(), HIDDEN);
+    assert!(out.iter().all(|v| v.is_finite()));
+}

--- a/crates/larql-compute-metal/tests/test_kernel_q4k_geglu_down.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_q4k_geglu_down.rs
@@ -182,3 +182,41 @@ fn q4k_geglu_silu_down_gemma4_31b_ffn() {
 fn q4k_geglu_gelu_tanh_down_gemma4_31b_ffn() {
     assert_fused_geglu_down_matches_separated("gemma4-31b ffn (gelu_tanh)", 5376, 21504, false);
 }
+
+/// Regression for the missing tanh clamp (capability audit F1).
+///
+/// Apple Silicon's `tanh` is `(exp(2y)-1)/(exp(2y)+1)` and returns NaN
+/// once `|y| ≳ 44`; gate values around ±10 push the GELU-tanh argument
+/// past that. The separated `geglu_gelu_tanh` kernel has clamped at ±15
+/// since the incident that discovered this; the fused kernel shipped
+/// without the clamp, which is the mechanical explanation for the
+/// recorded fused-path NaN incidents (Gemma 4 31B layer 11; the
+/// "every hidden value NaN" prefill report). Rust's `tanh` is exact, so
+/// the CPU reference stays finite — pre-fix this test fails with NaN in
+/// every output row.
+#[test]
+fn q4k_geglu_gelu_tanh_down_survives_large_gate_values() {
+    let n = 32usize;
+    let inter = 256usize;
+    let metal = get_metal();
+    let cpu = larql_compute::cpu::CpuBackend;
+
+    let down_f32 = synth_matrix_q4k_friendly(n, inter, 0.21);
+    // Gate magnitudes ~±12: tanh argument ≈ ±71, past the ≈44 NaN
+    // threshold, well past the ±15 clamp (tanh(15) − 1 < 1e-13).
+    let gate: Vec<f32> = (0..inter)
+        .map(|i| if i % 2 == 0 { 12.0 } else { -12.0 })
+        .collect();
+    let up = synth_vec(inter, 0.83);
+    let down_q4k = larql_compute::cpu::ops::q4_common::quantize_q4_k(&down_f32);
+
+    let cpu_ref = cpu_geglu_then_matvec(&cpu, &down_q4k, &gate, &up, false, n, inter);
+    let fused = metal_fused_geglu_down(&metal, &down_q4k, &gate, &up, false, n, inter);
+
+    assert!(
+        fused.iter().all(|v| v.is_finite()),
+        "fused GELU-tanh output contains non-finite values on large gates"
+    );
+    let cos = cos_sim(&cpu_ref, &fused);
+    assert!(cos > 0.999, "large-gate parity: cos={cos:.6}");
+}

--- a/crates/larql-compute-metal/tests/test_kernel_q6k_geglu_down.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_q6k_geglu_down.rs
@@ -288,3 +288,34 @@ fn q6k_geglu_gelu_tanh_down_gemma4_31b_ffn() {
         false,
     );
 }
+
+/// Regression for the missing tanh clamp (capability audit F1) — Q6_K
+/// twin of `q4k_geglu_gelu_tanh_down_survives_large_gate_values`.
+/// Gate magnitudes ~±12 push the GELU-tanh argument past Apple tanh's
+/// ≈44 NaN threshold; the clamp at ±15 keeps it finite with error
+/// below f32 precision. Rust's `tanh` is exact, so the CPU reference
+/// stays finite — pre-fix this test fails with NaN everywhere.
+#[test]
+fn q6k_geglu_gelu_tanh_down_survives_large_gate_values() {
+    let n = 32usize;
+    let inter = 256usize;
+    let metal = get_metal();
+
+    let down_f32 = synth_matrix_decorrelated(n, inter, 0.21);
+    let gate: Vec<f32> = (0..inter)
+        .map(|i| if i % 2 == 0 { 12.0 } else { -12.0 })
+        .collect();
+    let up = synth_vec(inter, 0.83);
+    let down_q6k = larql_compute::cpu::ops::q4_common::quantize_q6_k(&down_f32);
+    let cpu = larql_compute::cpu::CpuBackend;
+
+    let cpu_ref = cpu_geglu_then_q6k_matvec(&cpu, &down_q6k, &gate, &up, false, n, inter);
+    let fused = metal_fused_q6k_geglu_down(&metal, &down_q6k, &gate, &up, false, n, inter);
+
+    assert!(
+        fused.iter().all(|v| v.is_finite()),
+        "fused Q6_K GELU-tanh output contains non-finite values on large gates"
+    );
+    let cos = cos_sim(&cpu_ref, &fused);
+    assert!(cos > 0.999, "large-gate parity: cos={cos:.6}");
+}

--- a/crates/larql-compute/ROADMAP.md
+++ b/crates/larql-compute/ROADMAP.md
@@ -49,17 +49,17 @@ built from a six-family audit of every MSL entry point in
 
 **Fix checklist** (live correctness first):
 
-- [ ] **F1** clamp tanh arg ±15 in `q4k_geglu_gelu_tanh_down`,
+- [x] **F1** (fixed c3688d38) clamp tanh arg ±15 in `q4k_geglu_gelu_tanh_down`,
       `q6k_geglu_gelu_tanh_down`, `q6k_..._cached` — matches `geglu.rs:39`;
       explains both recorded fused-path NaN incidents.
-- [ ] **F2** hybrid QKV (`decode_hybrid.rs:145`) selects kernel on `wq`
+- [x] **F2** (fixed ac8168ec) hybrid QKV (`decode_hybrid.rs:145`) selects kernel on `wq`
       alone — route (Q4_K,Q4_K,Q6_K) to the mixed kernel, refuse other
       mismatches loudly.
-- [ ] **F3** FFN decode branch keys on `gate.format()` family only —
+- [x] **F3** (fixed 0f5a73e0) FFN decode branch keys on `gate.format()` family only —
       Q6_K gate mis-decoded as Q4_K, Q8_0 as Q4_0, `up.format()` never
       read. Route Q6_K via per-format matvecs; refuse Q8_0/float/mixed
       loudly.
-- [ ] **F4** float weights (BF16/F16/F32) in `quant_matvec::encode` are a
+- [x] **F4** (fixed bc2b429f) float weights (BF16/F16/F32) in `quant_matvec::encode` are a
       silent no-op with stale scratch output — panic loudly.
 - [ ] **F5** `q6k_matvec` trait dispatch hardcodes 4sg geometry against a
       pipeline alias that can be 8sg — read the `KernelHandle`.

--- a/crates/larql-compute/ROADMAP.md
+++ b/crates/larql-compute/ROADMAP.md
@@ -39,6 +39,83 @@ from them are still load-bearing and worth restating:
 
 ---
 
+## P0: Metal kernel capability audit findings (2026-08-09)
+
+Source of truth: [`docs/metal-kernel-capabilities.md`](../../docs/metal-kernel-capabilities.md)
+— the Phase B per-kernel capability table (formats, reduction unit, legal
+dims asserted-vs-assumed, aux buffers, dispatch geometry, fallback chain)
+built from a six-family audit of every MSL entry point in
+`larql-compute-metal`. Finding numbers below (F1–F22) are that document's.
+
+**Fix checklist** (live correctness first):
+
+- [ ] **F1** clamp tanh arg ±15 in `q4k_geglu_gelu_tanh_down`,
+      `q6k_geglu_gelu_tanh_down`, `q6k_..._cached` — matches `geglu.rs:39`;
+      explains both recorded fused-path NaN incidents.
+- [ ] **F2** hybrid QKV (`decode_hybrid.rs:145`) selects kernel on `wq`
+      alone — route (Q4_K,Q4_K,Q6_K) to the mixed kernel, refuse other
+      mismatches loudly.
+- [ ] **F3** FFN decode branch keys on `gate.format()` family only —
+      Q6_K gate mis-decoded as Q4_K, Q8_0 as Q4_0, `up.format()` never
+      read. Route Q6_K via per-format matvecs; refuse Q8_0/float/mixed
+      loudly.
+- [ ] **F4** float weights (BF16/F16/F32) in `quant_matvec::encode` are a
+      silent no-op with stale scratch output — panic loudly.
+- [ ] **F5** `q6k_matvec` trait dispatch hardcodes 4sg geometry against a
+      pipeline alias that can be 8sg — read the `KernelHandle`.
+- [ ] **F6** `quantize_q8` host `div_ceil` vs shader truncating `K/32` —
+      unwritten tail scale; make the kernel handle partial blocks.
+- [ ] **F7** sinks silently dropped by `kv_attention`/`_long` fallbacks —
+      add sink buffers (join max + denominator) so fallback preserves the
+      feature set.
+- [ ] **F8** softcap exists only in prefill `fused_attention` — decode
+      refuses or supports; no silent cap-drop.
+- [ ] **F9** dense layers of hybrid-MoE models never get `layer_scalar`
+      (`decode/mod.rs:789` model-level branch vs layer-level apply).
+- [ ] **F10** `gpu_moe_dispatch_with_scratch` staging loop missing
+      `valid_count >= top_k` guard (sibling has it) — release-mode
+      buffer overflow.
+- [ ] **F11** `attn_fused` tg_red max→sum reuse unfenced + `tg_q` handoff
+      fenced `mem_device`-only + ropes at occupancy not stream position.
+- [ ] **F12** `q4k_ffn_gate_up_coop` divergent threadgroup barriers on odd
+      `K/256` and `N%4 != 0` (both occur in shipped shapes).
+- [ ] **F13** `q8_qkv_proj`/`q8_proj_rope` early-return before barrier;
+      K ≤ 8192 threadgroup-scratch ceiling (shared with `q4_matvec_v4`,
+      `q8_matvec`) asserted nowhere.
+- [ ] **F14** `fused_attention` head≤512 / seq≤4096 unasserted;
+      `kv_attention_long` unguarded past its 4096 scratch.
+- [ ] **F15** `Q4_KF_BLOCK_BYTES = 160` (host) vs 144 (both Q4_KF
+      shaders) — establish which is real, fix the other.
+- [ ] **F16** `gate_out`/`up_out` sized `inter` while fused Q4_K down
+      reads `inter_padded`; unify the `inter` vs `inter_padded` K
+      convention across the five down dispatch variants.
+- [ ] **F17** K-alignment asserted in 2 of ~30 quant kernels; GQA
+      divisibility asserted nowhere — add dispatch-time checks.
+- [ ] **F18** `residual_multiplier == 1.0` guard missing on
+      `post_attn_residual_norm_store` selection and the PLE reuse of
+      `post_ffn_norm_residual_add` (siblings have it).
+- [ ] **F19** `encode_fused_q8` prefill site dispatches `total_rows` TGs
+      instead of `div_ceil(total_rows, 8)` — 8× over-dispatch.
+- [ ] **F20** legacy `append_and_attend` passes `None` for the long
+      pipeline → `tg_scores[1024]` overflow past span 1024; hardcodes
+      window 0.
+- [ ] **F21** dead-but-compiled inventory (see capability doc §8) — per
+      the shader-retention policy each needs a revival-story check before
+      deletion, not a bulk purge; `q6k_..._cached` additionally caches
+      nothing despite its module doc.
+- [ ] **F22** doc/code mismatches: `LARQL_FUSED_Q6K_DOWN` names the wrong
+      kernel, `LARQL_F16_ACC` co-requirement undocumented, stride32
+      "not wired" doc stale, `Q4K_GU_MAX_K` test comment references a
+      removed constant.
+
+The structural target (capability doc §9): one authority table consumed by
+the QKV/FFN/O-proj/attention dispatchers — per-operand format rows instead
+of `is_kquant_family()` tests, every silently-assumed dim promoted to a
+checked bound, feature sets (sinks/softcap/window/norm-type) that
+fallbacks must preserve or refuse.
+
+---
+
 ## Open defects
 
 From the 2026-05-28 whole-codebase review

--- a/docs/metal-kernel-capabilities.md
+++ b/docs/metal-kernel-capabilities.md
@@ -1,0 +1,294 @@
+# Metal kernel capability table (Phase B ground truth)
+
+Status: **audit complete, dispatcher not yet changed.** 2026-08-09.
+
+This document is the authority the Phase B dispatcher work will consume. It
+records, per kernel entry point: the formats it decodes, its reduction unit,
+its legal dimensions (and whether they are asserted or assumed), tail
+handling, auxiliary buffers, dispatch geometry, and what selects it. Route
+tables and a wiring-status inventory follow, then ranked findings.
+
+Provenance: six parallel per-family audits over every `.rs`-embedded MSL
+shader in `crates/larql-compute-metal/src/shaders/` plus all dispatch sites.
+Every ranked finding carries an explicit status:
+
+- **VERIFIED** — re-checked by hand against the source before ranking.
+- **AUDIT-FINDING** — reported by the auditing pass with file:line
+  citations, not independently re-checked. **Re-cite before acting on or
+  quoting one as fact.**
+
+Column key
+- **red.** — reduction unit: `sg` = one simdgroup per row + `simd_sum`;
+  `tg` = threadgroup-cooperative; `thr` = per-thread, no reduction;
+  `tile` = 2-D threadgroup tile.
+- **r/TG, thr/TG** — rows per threadgroup, threads per threadgroup.
+- **legal K** — inner-dimension constraint. `a` = asserted host-side,
+  `s` = silently assumed (truncating division or unchecked scratch bound).
+- **wired** — `prod` (production dispatch), `diag` (bench/diag only),
+  `dead` (no dispatch site at all), `opt-in` (env-gated off by default).
+
+## 1. Quant matvec family
+
+| kernel | formats (W · X) | red. | r/TG·thr/TG | legal K | tail | wired |
+|---|---|---|---|---|---|---|
+| `q4k_matvec` | Q4_K 144B · f32 | sg | 4·128 | %256 s | rows masked; K tail dropped | prod (opt-out variant) |
+| `q4k_matvec_8sg` | Q4_K 144B · f32 | sg | 8·256 | %256 s | same | **prod default** |
+| `q4k_matvec_stride32` | Q4_K 144B · f32 | sg | 8·256 | %256 **a** (`trait_impl/matmul.rs:473`) | host rejects bad K | prod (vindex lm-head knn) |
+| `q4k_matmul` | Q4_K 144B · f32 [M,K] | sg | 4r×4c·128 | %256 s | best row/M tails of the set | plumbing dead: `Pipelines.q4k_matmul` never read |
+| `q6k_matvec` | Q6_K 210B planar · f32 | sg | 4·128 | %256 s | rows masked; K dropped | prod default |
+| `q6k_matvec_8sg` | Q6_K 210B planar · f32 | sg | 8·256 | %256 s | same | opt-in `LARQL_Q6K_8SG=1` |
+| `mxfp4_matvec` | MXFP4 16B/32 + ext e8m0 scales · f32 | sg | 4·128 | %32 **a** | host rejects bad K | no non-test caller (K1 rung) |
+| `q4_matvec_v4` | Q4_0 18B · **Q8 int8 + ext scales** | tg stage + sg | 8·256 | %32 s; **K ≤ 8192 hard (tg scratch), unchecked** | rows masked after barrier (safe) | prod (Q4_0 route) |
+| `q4_vecmat` | Q4_0 18B · f32 (row-scatter) | thr | — | %32 s; **OOB read on misaligned K** | out tail masked | prod (`q4_vecmat` trait) |
+| `q4_sparse_matvec` | Q4_0 18B · Q8 + ext scales, row-gather | thr | — | %32 s; **indices unbounded → OOB** | tid masked | **dead** (no pipeline in src/) |
+| `q4_f32_matvec` | Q4_0 18B · f32 | thr | — | %32 s | rows masked; K dropped | prod (Q4_0 FFN down) |
+| `q8_matvec` | **Q8_0 split: int8 rows + ext f32 weight scales** · Q8 + ext scales | tg stage + sg | 8·256 | %32 s; **K ≤ 8192 hard, unchecked** | rows masked after barrier | prod (O-proj Q8_0 arm) |
+
+Notes
+- `q8_matvec` is the only matvec with an **external weight-scale buffer**
+  (buffer 2) — the reason Q8_0 is `ScaleStorage::External` in the Phase A
+  contract.
+- Geometry is handle-driven at every site **except**: the `q6k_matvec`
+  trait dispatch hardcodes 4sg constants while the bound pipeline alias can
+  resolve to 8sg under `LARQL_Q6K_8SG=1` (finding F5), and `q8_matvec`'s two
+  production sites hardcode `8`/`256` (currently matching).
+
+## 2. QKV / projection family
+
+| kernel | formats (W · X) | red. | r/TG·thr/TG | legal K | wired |
+|---|---|---|---|---|---|
+| `q4k_qkv_proj` | Q4_K×3 · f32 | sg | 8·256 | %256 s | prod (UniformQ4K) |
+| `q4k_proj` | Q4_K · f32 | sg | 8·256 | %256 s | **dead** (registered, never dispatched) |
+| `q4k_q6k_qkv_proj` | Q4_K Q/K + Q6_K V · f32 | sg | 4·128 | %256 s (shared stride deriv.) | prod (MixedQ4kQ6kV, decode only) |
+| `q4k_q6k_qkv_proj_normed` | same + inline RMS | tg then sg | 4·128 | %256 s | opt-in `LARQL_QKV_FUSED=1` |
+| `q4kf_qkv_proj` | "Q4_KF" (**144B in shader**) · f32 | sg | 4·64 (2r×2sg) | %256 s | prod (UniformQ4Kf; synthetic-only in practice) |
+| `q4kf_proj` | same | sg | 4·64 | %256 s | prod (PerProjection Q4_KF arm; hybrid O-proj) |
+| `q8_qkv_proj` | int8 rows + 3 ext weight-scale bufs · Q8 + ext scales | tg stage + sg | 8·256 | %32 s; **K ≤ 8192 hard**; **early-return-before-barrier UB when rows%8≠0** | prod (fused Q8 route) |
+| `q8_proj_rope` | int8 + ext scales (no RoPE despite name) | sg | 8·256 | same hazards | **dead** (no pipeline field) |
+| `quantize_q8` | f32 → int8 + per-32 ext scales | thr | — | %32 s; **host div_ceil vs shader trunc → unwritten tail scale** | prod (Q8 input path) |
+| `qk_norm` / `qk_norm_qk` | f32 norm | tg tree ≤512 | 1 head/TG | tg_w pow2 (host-ensured) | prod (unfused chain) |
+| `qk_norm_rope_fused` | f32 norm + RoPE | tg tree | 1 head/TG | tg_w pow2; odd rdim drops last elem | **prod default** |
+| `rope_at_pos` / `rope_at_pos_batched_qk` | f32 in-place | thr | — | — | prod |
+| `rope_apply`, `rope_at_pos_batched` | f32 | thr | — | — | **dead / test-only** |
+| `v_norm` (scalar) | f32, param-free | **thr, O(len²)** | — | **aliased in-place race (unfixed twin of batched fix)** | prod (hybrid path only) |
+| `v_norm_batched` | f32 | tg tree ≤512 | 1 head/TG | safe aliasing | prod (main decode) |
+
+## 3. Attention family
+
+| kernel | role | softmax | scratch | hard limits | sinks | softcap | wired |
+|---|---|---|---|---|---|---|---|
+| `attn_fused` | decode, full fusion (norm+RoPE+append+attend) | 2-pass | tg_q/tg_k/tg_red/tg_scores ≈6KB; **tg_red max→sum reuse UNFENCED** | head≤256 a, span≤1024 a; GQA div s | yes | no | opt-in `LARQL_FUSED_ATTN=1` |
+| `kv_append_attend_fused` | decode default (append+attend) | 2-pass | fenced (reference impl) | head≤256 a, span≤1024 a; GQA s | yes | no | **prod default** |
+| `kv_attention` / `_long` | decode fallback attend | 2-pass | fenced | span ≤1024 / ≤4096 (**long unguarded beyond alloc**) | **NO** | no | prod (fallback + KV-shared) |
+| `kv_cache_append` | flat copy | — | — | — | — | — | prod (unfused chain) |
+| `fused_attention` | prefill, one TG per (head,pos) | 2-pass serial tid0 scan | ~19KB, no reuse | **head≤512 s, seq≤4096 s — both unasserted**; TG hardcoded 256 both sides | yes | **yes (only kernel with it)** | prod (always, prefill) |
+| `causal_attention` | bench-only, single head, no GQA | 2-pass recompute O(seq²·d²) | none | — | no | no | bench (`full_layer_direct`) |
+
+Decode fallback chain: `attn_fused` → `kv_append_attend_fused` →
+shared-source attend-only → `kv_cache_append` + `kv_attention[_long]`.
+KV cache is f32 position-major everywhere; there is no f16 KV path.
+
+## 4. FFN family
+
+| kernel | formats | act. fused | red. | r/TG·thr/TG | wired |
+|---|---|---|---|---|---|
+| `q4k_ffn_gate_up` | Q4_K×2 · f32 | none | sg | 4·128 | prod (opt-out variant) |
+| `q4k_ffn_gate_up_8sg` | Q4_K×2 · f32 | none | sg | 8·256 | **prod default** |
+| `q4k_ffn_gate_up_coop` | Q4_K×2 · f32 | none | tg+sg | 4·128 | opt-in; **divergent-barrier UB on odd K/256 or N%4≠0 [real shapes hit both]** |
+| `q4k_ffn_gate_up_f16acc` | Q4_K×2 · f32→half dot | none | sg | 4·128 | opt-in; needs `LARQL_GATE_UP_8SG=0` too (alone = no-op) |
+| `q4kf_ffn_gate_up` | 144B llama.cpp loop ×2 · f32 | none | sg | 4·64 | prod (Q4_KF gate) |
+| `q4k_geglu_silu_down` | Q4_K down · gate+up f32 | SiLU | sg | 8·256 | prod (fused_down default on, inter≤16384) |
+| `q4k_geglu_gelu_tanh_down` | Q4_K down | GELU-tanh **NO CLAMP** | sg | 8·256 | prod (same gate) |
+| `q6k_geglu_silu_down` | Q6_K planar down | SiLU | tg stage + sg | 4·128 | **dead in prod** (routing requires GeluTanh) |
+| `q6k_geglu_gelu_tanh_down` | Q6_K planar down | GELU-tanh **NO CLAMP** | tg+sg | 4·128 | opt-in `LARQL_FUSED_Q6K_DOWN=1` (recorded broken) |
+| `q6k_geglu_gelu_tanh_down_cached` | Q6_K | GELU-tanh **NO CLAMP**; **caches nothing (verbatim copy)** | tg+sg | 4·128 | **dead** (flag dispatches the non-cached one) |
+| `geglu_silu` / `geglu_gelu_tanh` | f32 elementwise | SiLU / GELU-tanh **clamped ±15** | thr | — | prod (the separated fallback) |
+| `silu` / `gelu_tanh` | f32 elementwise, non-gated | clamped | thr | — | prod (Standard FFN) |
+
+All gate+up and fused-down kernels: K %256 silently assumed, asserted only
+in tests. `GeluExact`/`ReLU` panic loudly at both encoders (good).
+
+## 5. MoE / experts family
+
+Production MoE experts do **not** use the grouped kernels: the live path is
+`q4k_ffn_gate_up` (all K experts as one tall matrix) → `geglu_gelu_tanh`
+per expert → **per-expert `q4k_matvec` loop** for down. Routing (softmax,
+top-K, weighted sum) is entirely CPU; expert selection is materialized as
+weight-byte memcpys. No routing data reaches the GPU.
+
+| kernel | status |
+|---|---|
+| `q4k_grouped_experts`, `q6k_grouped_experts` | pipelines built; **test/diag only** — the per-expert loop they were written to replace still runs |
+| `mxfp4g_*` (7 arms) | diag tournament only; `_affine`/`_nox` are ceiling probes that **deliberately compute wrong answers** |
+| `gate_knn_score`, `gate_knn_score_q8` | **fully dead**; q8 variant has a latent unaligned load |
+| `turboquant_encode/decode_4bit` | **fully dead**; divergent-barrier UB + unset threadgroup binding + device-byte race if ever wired |
+
+## 6. Norms / residual / GEMV family
+
+| kernel | op | red. | wired |
+|---|---|---|---|
+| `rms_norm` | RMS ×(w+offset) | tg coop, 1 vec/TG, tg_p[8] | prod (everywhere) |
+| `rms_norm_q8` | RMS + Q8 quantise | tg coop; **block-scale wrong unless tg%32=0 ∧ len%tg=0** | prod (Q8 input path) |
+| `residual_add` | a + b_scale·b | thr | prod (universal fallback) |
+| `residual_norm` | add+RMS, no b_scale | tg coop | **dead** (superseded by `_store`) |
+| `residual_norm_q8` | add+RMS+Q8, b_scale | tg coop; same block-scale hazard | prod (non-kquant FFN) |
+| `residual_norm_store` | add+RMS+raw store, b_scale | tg coop | prod (kquant FFN; D-RMS-FUSE) |
+| `post_attn_residual_norm_store` | triple fusion (Gemma post-norms) | tg coop ×2 | **prod default**; **no b_scale and no residual_multiplier guard** |
+| `post_ffn_norm_residual_add` | double fusion | tg coop | prod default (guarded); **PLE reuse bypasses the guard** |
+| `scale_vector` | ×scalar in-place | thr | prod (layer_scalar) |
+| `residual_copy` | copy | thr | **fully dead** (no pipeline) |
+| `layer_norm` / `_no_bias` | LayerNorm ± bias | **thr, O(N²)** | prod — **input norm only, decode only** |
+| `ple_gate_apply` | gelu(gate)·ple_input | thr (clamped) | prod (Gemma 4 E2B) |
+| `f32_gemv` / `f16_gemv` | GEMV f32/f16 W | sg 8·256, K arbitrary (real tail loops) | prod (LM head, PLE) |
+| `f32_argmax_partial` / `f32_topk_partial` | 2-phase argmax / top-8 | sg + tg fan-in, TG=256 fixed | prod (top-1/top-k LM head) |
+| `sgemm` / `sgemm_transb` | GEMM 32×32 tile | tile, TG=(32,32) exact | prod (matmul trait, threshold-gated) |
+
+## 7. Route tables (the three-plus mechanisms Phase B unifies)
+
+### QKV — three disagreeing mechanisms
+
+1. **Decode** (`pick_qkv_route`, `stages/qkv_proj.rs:61-68`):
+   Q4_K×3→UniformQ4K; Q4_KF×3→UniformQ4Kf; (Q4_K,Q4_K,Q6_K)→Mixed;
+   else PerProjection. Q8_0×3 is a *hand-written bypass* before the route
+   table; if it ever reached PerProjection it would panic.
+2. **Prefill** (`ops/full_pipeline/stages.rs:70-96`): `all_same_format`
+   gate + two-arm match. **The mixed kernel is unreachable at prefill** —
+   Gemma's Q4_K/Q4_K/Q6_K silently degrades to three per-proj dispatches.
+3. **Hybrid** (`decode_hybrid.rs:145-149`) — **VERIFIED**: selects on
+   `wq` **alone**. `wq=Q4_K, wv=Q6_K` (production Gemma shape) dispatches
+   the uniform Q4_K kernel, striding V at 144B against 210B blocks.
+   Production-reachable via `layer_graph/hybrid.rs:148`.
+
+PerProjection arms: Q4_KF→`q4kf_proj` (fallback `q4k_matvec`);
+Q4_K→`q4k_matvec`; Q6_K→`q6k_matvec`; Q4_0→`q4_matvec`+Q8 input;
+**Q8_0→panic; I2S→panic; BF16/F16/F32→silent no-op** (no dispatch, stale
+output buffer).
+
+### FFN decode — branches on `gate.format()` only — **VERIFIED**
+
+`Q4_KF` → q4kf chain; `is_kquant_family()` → Q4_K chain; else → Q4_0 chain.
+Consequences: **Q6_K gate decoded as Q4_K (silent corruption); Q8_0 gate
+decoded as Q4_0 (silent corruption); `up.format()` never read** (mixed
+gate/up silently mis-decoded); float gate → Q4_0 decoder on float bytes.
+Down format *is* honoured via `qmv::encode` — with the Q8_0/I2S panic and
+float silent-no-op arms above. Prefill honours all three formats
+independently (correct) but has no fused gate+up and near-no fused down.
+
+Profile-split (`LARQL_PROFILE_SPLIT=1`) hardcodes 8sg gate+up (ignores
+coop/4sg/f16acc flags) and drops both fused-down guards — split-mode
+measurements are not the production configuration.
+
+### O-projection (fixed in Phase A)
+
+Dispatches on `wo.format()`: packed four → `o_proj::encode`; Q8_0 →
+legacy `q8_matvec` (the one external-weight-scale consumer); anything else
+panics loudly.
+
+### MoE modes
+
+`split_mode = moe_fn ∧ moe_collect_fn`; per-layer defer when layer has moe;
+local CPU `cpu_moe_forward` only when no moe_fn and not remote. `has_moe`
+is **model-level** but layer_scalar application is layer-level: dense
+layers of a hybrid MoE model **never get their layer_scalar applied**
+(`decode/mod.rs:789` vs `:832-841`).
+
+### Norms
+
+`norm_type` is consulted **only** for the decode input norm. Post-attn,
+pre-FFN, post-FFN and the whole prefill path are unconditionally RMS — a
+LayerNorm arch gets LayerNorm at layer input and RMS everywhere else, no
+guard. `post_attn_norm_bias` is never bound by any dispatch site.
+
+## 8. Ranked findings
+
+Correctness, live path:
+- **F1. Fused GELU-tanh down kernels lack the ±15 clamp** their separated
+  twins carry (Apple tanh → NaN for |y|≳44). Mechanically explains both
+  recorded fused-path NaN incidents. One line per kernel (×3). **VERIFIED**
+- **F2. Hybrid QKV selects on `wq` alone** — Gemma Q4_K/Q6_K-V corrupted
+  on a production-reachable path. Same defect class Phase A fixed for the
+  O-projection. **VERIFIED**
+- **F3. FFN decode branch misroutes Q6_K and Q8_0 gates** into wrong
+  decoders, silently; `up.format()` never read. **VERIFIED**
+- **F4. Float weights (BF16/F16/F32) in a matvec position = silent no-op**
+  with stale scratch as output — worse than the panic arms. **AUDIT-FINDING**
+- **F5. `q6k_matvec` trait dispatch hardcodes 4sg geometry** while the
+  pipeline alias can be 8sg → half the rows unwritten under
+  `LARQL_Q6K_8SG=1`. **AUDIT-FINDING**
+- **F6. `quantize_q8` host `div_ceil` vs shader truncation** — unwritten
+  tail scale read downstream when K%32≠0. **AUDIT-FINDING**
+- **F7. Attention sinks silently dropped** on every non-fused decode
+  fallback (span>1024, head>256, KV-shared): different softmax
+  denominator, no guard. Softcap exists only at prefill (F8) — a
+  capped arch decodes uncapped. **AUDIT-FINDING**
+- **F9. Dense layers of hybrid-MoE models never get `layer_scalar`.** **AUDIT-FINDING**
+- **F10. MoE staging loop missing `valid_count >= top_k` guard** (its
+  sibling has one) — release-mode buffer overflow on excess indices. **AUDIT-FINDING**
+
+Latent (opt-in paths, unshipped shapes, or UB not yet observed):
+- **F11. `attn_fused` tg_red reuse unfenced** — the exact race class fixed
+  in its two siblings; masked by the kernel being opt-in. **AUDIT-FINDING**
+- **F12. `q4k_ffn_gate_up_coop` divergent barriers** on odd K/256 and
+  N%4≠0 — both occur in shipped shapes; kernel is opt-in. **AUDIT-FINDING**
+- **F13. `q8_qkv_proj`/`q8_proj_rope` early-return before barrier** when
+  rows%8≠0; plus the K≤8192 threadgroup-scratch ceiling shared with
+  `q4_matvec_v4`/`q8_matvec` — unchecked everywhere. **AUDIT-FINDING**
+- **F14. `fused_attention` unasserted head≤512 / seq≤4096** (scratch
+  indexed by absolute position — windows don't shrink footprint);
+  `kv_attention_long` unguarded past 4096 (alloc coincidence). **AUDIT-FINDING**
+- **F15. Q4_KF host constant 160B vs shader 144B** — `packed_block_layout`
+  disagrees with both Q4_KF shaders by 16B/superblock. **AUDIT-FINDING**
+- **F16. `gate_out`/`up_out` sized `inter` but fused Q4_K down reads
+  `inter_padded`** — OOB read for any inter%256≠0 (all shipped shapes
+  aligned, so latent). Plus no single `inter` vs `inter_padded` convention
+  across the five down dispatch variants. **AUDIT-FINDING**
+- **F17. K-alignment validation is the exception**: 2 of ~30 quant kernels
+  check it; the rest silently truncate. GQA divisibility asserted nowhere. **AUDIT-FINDING**
+- **F18. Granite guard asymmetry**: `post_attn_residual_norm_store` and
+  the PLE reuse of `post_ffn_norm_residual_add` have no
+  `residual_multiplier == 1.0` guard; their siblings do. **AUDIT-FINDING**
+- **F19. `q8_qkv_proj` prefill site over-dispatches 8×**
+  (`total_rows` TGs instead of `div_ceil(total_rows, 8)`). **AUDIT-FINDING**
+- **F20. `append_and_attend` legacy API can overflow `tg_scores[1024]`**
+  (passes `None` for the long pipeline, hardcodes window 0). **AUDIT-FINDING**
+
+Hygiene / inventory:
+- **F21. Dead-but-compiled set**: `q4k_proj`, `q8_proj_rope`,
+  `residual_copy`, `residual_norm`, `q4_sparse_matvec`,
+  `rope_apply`, `rope_at_pos_batched`, `q6k_geglu_silu_down`,
+  `q6k_..._cached` (which also caches nothing, contradicting its 38-line
+  doc), both `gate_knn_score*`, both `turboquant_*`, all 7 `mxfp4g_*`
+  arms (2 of which deliberately compute wrong answers), grouped-experts
+  pair, `q4k_matmul` router plumbing. All reachable by name in one Metal
+  library — the pipeline-selection hazard `shaders/mod.rs:9-16` warns
+  about.
+- **F22. Doc/code mismatches**: `LARQL_FUSED_Q6K_DOWN` doc names the
+  cached kernel, dispatches the other; `LARQL_F16_ACC` co-requirement
+  undocumented; `q4k_matvec_stride32` "not wired" doc is stale;
+  `Q4K_GU_MAX_K` test comment references a removed constant.
+
+## 9. What the Phase B dispatcher consumes
+
+The separations Phase A established — representation → auxiliary storage →
+executable kernel geometry — mean the capability authority for a kernel is:
+
+```
+kernel:      MSL name + KernelHandle (geometry travels with the pipeline)
+formats:     (weight format[s], input encoding) — exact, no family tests
+legal dims:  K alignment, K ceiling, row constraints, GQA divisibility —
+             checked at dispatch, not assumed
+aux:         binding table incl. external scale operands (Phase A's
+             QuantAux answers "does one exist"; the table answers "which
+             index wants it")
+features:    sinks / softcap / window / norm-type support — a fallback
+             may not silently drop one
+fallback:    the chain, with the invariant that a fallback preserves the
+             feature set or refuses loudly
+```
+
+The route tables in §7 are today's behaviour, not the target: the target
+is one table the QKV/FFN/O-proj/attention dispatchers all consult, with
+`is_kquant_family()`-style family tests replaced by per-operand format
+rows, and every `s` (silently assumed) entry in §1–§6 either promoted to
+an `a` (asserted) or encoded as a capability bound the dispatcher checks
+before selecting the kernel.


### PR DESCRIPTION
## What this is

The Phase B kernel capability audit and its first four fixes, landed as standalone correctness bugs ahead of the table-driven dispatcher work.

**`docs/metal-kernel-capabilities.md`** — a per-kernel capability table for every MSL entry point in `larql-compute-metal`: formats per operand, reduction unit, legal dimensions (asserted vs silently assumed), tail handling, aux buffers, dispatch geometry, wiring status, today's route tables, and 22 ranked findings each tagged VERIFIED or AUDIT-FINDING. The findings land on the larql-compute roadmap as a P0 checklist.

## Fixes

- **F1 — fused GELU-tanh down kernels lacked the ±15 tanh clamp** their separated twins carry (Apple tanh NaNs for |y| ≳ 44). Mechanically explains both recorded fused-path NaN incidents. Regression tests drive ±12 gates against the exact CPU reference; each fails when its clamp is removed.
- **F2 — hybrid QKV routed on `wq` alone**: the production Gemma 3/4 shape (Q4_K Q/K + Q6_K V) strode V weights 144B against 210B blocks. Now routed via `pick_qkv_route` on the full triple; unroutable triples refuse loudly *before* any encoder exists (a panic past a live encoder becomes a process-killing SIGTRAP — the failure mode that hid #229).
- **F3 — decode FFN branched on `gate.format()` family only**: Q6_K gate silently decoded as Q4_K, Q8_0 as Q4_0, `up.format()` never read. Now validated per-operand at decode entry; Q6_K gains a real separated per-format decode path mirroring prefill; mixed gate/up and unsupported formats refuse loudly.
- **F4 — float weights in `quant_matvec::encode` were a silent no-op** leaving stale pooled scratch as output. Now a loud refusal, mirroring the Q8_0/I2S arms.

## Verification

- New regression tests: 2 (F1, clamp-removal falsified), 2 (F2, mixed-route + refusal), 2 (F3, Q6_K path + mixed refusal); all refusal tests exercise the pre-encoder panic path so they cannot SIGTRAP the binary.
- Full `larql-compute-metal` suite green; `larql-compute` + `larql-inference` green; fmt + clippy clean workspace-wide.

Remaining findings F5–F22 stay on the roadmap; next slices are the QKV capability selector, FFN capability selector, then attention feature-aware fallback.