### PR TITLE
fix(metal): capability-audit guard batch (F5-F6, F9-F14, F18-F20) + coop kernel parity fix

### DIFF
--- a/crates/larql-compute-metal/src/decode/encode_attn.rs
+++ b/crates/larql-compute-metal/src/decode/encode_attn.rs
@@ -41,6 +41,11 @@ const ATTN_FUSED_INV_FREQ_INDEX: u64 = 16;
 /// `amplitude` slot on `attn_fused`, appended after the sinks pair.
 const ATTN_FUSED_AMPLITUDE_INDEX: u64 = 20;
 
+/// Absolute stream position for RoPE on `attn_fused`. The kernel's cache
+/// row stays occupancy-indexed; only the rotation angle uses this. The
+/// two diverge once a sliding window compacts (audit F11).
+const ATTN_FUSED_ABS_POS_INDEX: u64 = 21;
+
 /// First of the two consecutive `kv_append_attend_fused` slots carrying
 /// attention sinks; the `has_sinks` flag follows in slot 13.
 const KV_APPEND_ATTEND_SINKS_INDEX: u64 = 12;
@@ -253,6 +258,11 @@ impl MetalBackend {
                 layer_rope_plan,
                 layer_head_dim,
                 layer.rotary_dim,
+            );
+            enc.set_bytes(
+                ATTN_FUSED_ABS_POS_INDEX,
+                4,
+                &pos as *const u32 as *const std::ffi::c_void,
             );
             enc.dispatch_thread_groups(
                 MTLSize::new(layer_num_q_heads as u64, 1, 1),
@@ -529,7 +539,7 @@ impl MetalBackend {
             // at buffer index 2.
             larql_compute::QuantFormat::Q8_0 => {
                 let dim_val = layer_q_dim as u32;
-                let blocks = (layer_q_dim / LEGACY_BLOCK_ELEMS) as u32;
+                let blocks = layer_q_dim.div_ceil(LEGACY_BLOCK_ELEMS) as u32;
                 enc.set_compute_pipeline_state(&self.quant.q8_quant_pipeline);
                 enc.set_buffer(0, Some(bufs.attn_out_buf), 0);
                 enc.set_buffer(1, Some(bufs.o_q8_scratch), 0);
@@ -546,6 +556,12 @@ impl MetalBackend {
 
                 let o_rows = hidden as u32;
                 let o_k = layer_q_dim as u32;
+                assert!(
+                    layer_q_dim <= crate::shaders::q8_matvec::MAX_K,
+                    "q8_matvec stages its Q8 input in threadgroup memory capped at \
+                     K = {}; layer_q_dim {layer_q_dim} would corrupt it (audit F13)",
+                    crate::shaders::q8_matvec::MAX_K,
+                );
                 enc.set_compute_pipeline_state(&self.quant.q8_matvec_pipeline.state);
                 enc.set_buffer(0, Some(bufs.wo), 0);
                 enc.set_buffer(1, Some(bufs.o_q8_scratch), 0);
@@ -584,7 +600,13 @@ impl MetalBackend {
             } else {
                 bufs.post_attn_norm.clone()
             };
-            if use_fused_post_attn && ffn_uses_kquant {
+            // The triple-fused kernel has no `b_scale` slot, so a
+            // Granite-style `residual_multiplier != 1.0` must take the
+            // unfused chain below, which binds it. The equivalent guards
+            // in `encode_post_ffn.rs` existed for exactly this reason;
+            // this site lacked one (capability audit F18).
+            let fusable_residual = layer.residual_multiplier == 1.0;
+            if use_fused_post_attn && ffn_uses_kquant && fusable_residual {
                 // Triple-fused: post_attn_norm + residual_norm + h_post_attn
                 // store in ONE dispatch.
                 enc.set_compute_pipeline_state(&self.norms.post_attn_residual_norm_store_pipeline);

--- a/crates/larql-compute-metal/src/decode/encode_ple.rs
+++ b/crates/larql-compute-metal/src/decode/encode_ple.rs
@@ -117,6 +117,19 @@ impl MetalBackend {
         // residual buffer. The shader is single-TG with each thread doing
         // `read h[i]` → `write h[i]` at one index per iteration, so the
         // aliasing has no race.
+        //
+        // The reused kernel has no `b_scale` slot; this reuse bypasses the
+        // `residual_multiplier == 1.0` guard its primary dispatch site in
+        // `encode_post_ffn.rs` applies. No PLE-bearing architecture
+        // carries a residual multiplier today — assert so one arriving
+        // later fails loudly instead of silently dropping the scaling
+        // (capability audit F18).
+        assert!(
+            layer.residual_multiplier == 1.0,
+            "PLE reuses post_ffn_norm_residual_add, which has no b_scale slot; \
+             residual_multiplier {} would be silently dropped",
+            layer.residual_multiplier
+        );
         let post_norm_buf = self.bufs.get_f32(ple.post_norm);
         let hidden_val = hidden as u32;
         let eps = layer.eps;

--- a/crates/larql-compute-metal/src/decode/encode_qkv.rs
+++ b/crates/larql-compute-metal/src/decode/encode_qkv.rs
@@ -392,6 +392,12 @@ impl MetalBackend {
             // same fix class as the decode_hybrid Q4_K geometry bug.
             // q8_qkv_proj is currently 8 rows/TG, 256 threads; if a
             // future bump changes the variant, the dispatch follows.
+            assert!(
+                hidden <= crate::shaders::q8_attn_proj::MAX_K,
+                "q8_qkv_proj stages its input in threadgroup memory capped at \
+                 K = {}; hidden {hidden} would corrupt it (audit F13)",
+                crate::shaders::q8_attn_proj::MAX_K,
+            );
             let kh = &self.attention.q8_qkv_proj_pipeline;
             enc.set_compute_pipeline_state(&kh.state);
             enc.set_buffer(0, Some(bufs.wq), 0);

--- a/crates/larql-compute-metal/src/decode/mod.rs
+++ b/crates/larql-compute-metal/src/decode/mod.rs
@@ -800,7 +800,17 @@ impl MetalBackend {
             // on CPU (direct shared-memory access), then restart for the next layer.
             // layer_scalar is applied AFTER MoE so it scales the combined output
             // (dense + MoE). Applying it before would leave the MoE contribution unscaled.
-            if has_moe {
+            //
+            // Branch on THIS LAYER being a MoE/remote layer, not on the
+            // model-level `has_moe`: with the model-level test, a dense
+            // layer of a hybrid-MoE model entered `handle_moe_interleave`
+            // (which returns immediately for dense layers) and the
+            // `else` arm's layer_scalar was never applied — the same
+            // mis-scaling class as the 14x incident recorded in
+            // `moe_combine.rs`. Capability audit F9. MoE layers get
+            // their scalar inside `moe_combine::apply_outer_combine`.
+            let layer_is_moe = layer.moe.is_some() || layer.ffn_is_remote;
+            if layer_is_moe {
                 self.handle_moe_interleave(
                     layer,
                     moe_interleave::MoeInterleaveCtx {

--- a/crates/larql-compute-metal/src/decode_hybrid.rs
+++ b/crates/larql-compute-metal/src/decode_hybrid.rs
@@ -196,7 +196,9 @@ impl MetalBackend {
         } else {
             // Q8 path
             let q8_buf = self.bufs.output(hidden as u64);
-            let q8s_buf = self.bufs.output((hidden / LEGACY_BLOCK_ELEMS * 4) as u64);
+            let q8s_buf = self
+                .bufs
+                .output((hidden.div_ceil(LEGACY_BLOCK_ELEMS) * 4) as u64);
 
             enc_a.set_compute_pipeline_state(&self.norms.rms_norm_q8_pipeline);
             enc_a.set_buffer(0, Some(&h_buf), 0);
@@ -216,6 +218,12 @@ impl MetalBackend {
             );
 
             let total_rows = (q_dim + kv_dim + kv_dim) as u32;
+            assert!(
+                hidden <= crate::shaders::q8_attn_proj::MAX_K,
+                "q8_qkv_proj stages its input in threadgroup memory capped at K = {}; \
+                 hidden {hidden} would corrupt it (audit F13)",
+                crate::shaders::q8_attn_proj::MAX_K,
+            );
             enc_a.set_compute_pipeline_state(&self.attention.q8_qkv_proj_pipeline.state);
             enc_a.set_buffer(0, Some(&wq_buf), 0);
             enc_a.set_buffer(1, Some(&wk_buf), 0);
@@ -455,11 +463,11 @@ impl MetalBackend {
             let o_q8 = self.bufs.output(layer_q_dim as u64);
             let o_q8s = self
                 .bufs
-                .output((layer_q_dim / LEGACY_BLOCK_ELEMS * 4) as u64);
+                .output((layer_q_dim.div_ceil(LEGACY_BLOCK_ELEMS) * 4) as u64);
             let o_out = self.bufs.output((hidden * 4) as u64);
 
             let dim_val = layer_q_dim as u32;
-            let blocks = (layer_q_dim / LEGACY_BLOCK_ELEMS) as u32;
+            let blocks = layer_q_dim.div_ceil(LEGACY_BLOCK_ELEMS) as u32;
             enc_c.set_compute_pipeline_state(&self.quant.q8_quant_pipeline);
             enc_c.set_buffer(0, Some(&attn_out), 0);
             enc_c.set_buffer(1, Some(&o_q8), 0);
@@ -476,6 +484,12 @@ impl MetalBackend {
 
             let o_rows = hidden as u32;
             let o_k = layer_q_dim as u32;
+            assert!(
+                layer_q_dim <= crate::shaders::q8_matvec::MAX_K,
+                "q8_matvec stages its Q8 input in threadgroup memory capped at K = {}; \
+                 layer_q_dim {layer_q_dim} would corrupt it (audit F13)",
+                crate::shaders::q8_matvec::MAX_K,
+            );
             enc_c.set_compute_pipeline_state(&self.quant.q8_matvec_pipeline.state);
             enc_c.set_buffer(0, Some(&wo_buf), 0);
             enc_c.set_buffer(1, Some(&o_q8), 0);

--- a/crates/larql-compute-metal/src/moe_dispatch.rs
+++ b/crates/larql-compute-metal/src/moe_dispatch.rs
@@ -765,6 +765,17 @@ impl MetalBackend {
         let mut valid_count = 0usize;
 
         for (k, &ei) in expert_indices.iter().enumerate() {
+            // Scratch is sized for `scratch.top_k` experts; without this
+            // guard a caller passing more indices than the scratch was
+            // built for writes past `gate_buf`/`up_buf` (and would only
+            // panic later on the `down_bufs` index). Bound against the
+            // ALLOCATION, not `moe.top_k` — the two are only
+            // debug_assert-ed equal, so in release they can drift. The
+            // sibling staging loop in `run_experts_preselected_metal`
+            // has carried this bound all along. Capability audit F10.
+            if valid_count >= scratch.top_k {
+                break;
+            }
             let Some((gu_bytes, dn_bytes)) = get_expert_bytes(ei) else {
                 continue;
             };
@@ -775,8 +786,10 @@ impl MetalBackend {
             // Q4_K layout: gate || up, each `inter * row_bytes` bytes.
             // SAFETY: gate_ptr / up_ptr are StorageModeShared Metal buffer
             // contents; offsets are bounded by `top_k * gate_half_bytes`
-            // allocated up front (see `MoeScratch::new`). Writes complete
-            // before the encoder dispatches the matvec that reads them.
+            // allocated up front (see `MoeScratch::new`), and the
+            // `valid_count >= top_k` guard above enforces that bound.
+            // Writes complete before the encoder dispatches the matvec
+            // that reads them.
             unsafe {
                 std::ptr::copy_nonoverlapping(
                     gu_bytes.as_ptr(),

--- a/crates/larql-compute-metal/src/ops/kv_cache.rs
+++ b/crates/larql-compute-metal/src/ops/kv_cache.rs
@@ -10,6 +10,11 @@ use crate::buffers::BufferCache;
 
 pub const SHORT_ATTENTION_SPAN: u32 = 1024;
 
+/// `kv_attention_long`'s threadgroup scratch bound — mirrors the MSL
+/// `tg_scores[4096]` in `shaders/kv_attention.rs`. Spans past this
+/// overflow threadgroup memory; the dispatch asserts against it.
+pub const LONG_ATTENTION_SPAN: usize = 4096;
+
 /// Maximum head_dim supported by kernels that dispatch exactly one simdgroup
 /// per head (32 lanes × 8 elements = 256). Layers with head_dim above this
 /// must use the two-simdgroup path or the unfused fallback.
@@ -340,10 +345,27 @@ pub fn encode_kv_attend(
     let num_kv = cache.num_kv_heads as u32;
     let span = attention_span(t_val, window_size);
     let pipeline = if span > SHORT_ATTENTION_SPAN {
-        attend_long_pipeline.unwrap_or(attend_pipeline)
+        // No silent fallback to the short kernel: `kv_attention`'s
+        // tg_scores holds SHORT_ATTENTION_SPAN entries, and a span past
+        // it overflows threadgroup memory. Previously
+        // `unwrap_or(attend_pipeline)` let a caller that supplied no
+        // long pipeline do exactly that (capability audit F20).
+        attend_long_pipeline.expect(
+            "attention span exceeds SHORT_ATTENTION_SPAN and no long-attention \
+             pipeline was supplied; the short kernel's threadgroup scratch \
+             cannot hold this span",
+        )
     } else {
         attend_pipeline
     };
+    // `kv_attention_long`'s own scratch bound. Until now this held only
+    // because the KV cache's default allocation happens to match —
+    // an allocation coincidence, not a checked invariant (F14).
+    assert!(
+        span as usize <= LONG_ATTENTION_SPAN,
+        "attention span {span} exceeds kv_attention_long's threadgroup scratch \
+         bound ({LONG_ATTENTION_SPAN})"
+    );
 
     enc.set_compute_pipeline_state(pipeline);
     enc.set_buffer(0, Some(q), 0);

--- a/crates/larql-compute-metal/src/ops/q4_matvec.rs
+++ b/crates/larql-compute-metal/src/ops/q4_matvec.rs
@@ -75,6 +75,12 @@ pub fn encode(
     k_val: u32,
     num_rows: usize,
 ) {
+    assert!(
+        (k_val as usize) <= crate::shaders::q4_matvec_v4::MAX_K,
+        "q4_matvec stages its Q8 input in threadgroup memory capped at K = {}; \
+         K {k_val} would corrupt threadgroup memory (audit F13)",
+        crate::shaders::q4_matvec_v4::MAX_K,
+    );
     enc.set_compute_pipeline_state(&kernel.state);
     enc.set_buffer(0, Some(buf_q4), 0);
     enc.set_buffer(1, Some(buf_q8), 0);

--- a/crates/larql-compute-metal/src/shaders/attn_fused.rs
+++ b/crates/larql-compute-metal/src/shaders/attn_fused.rs
@@ -59,6 +59,7 @@ kernel void attn_fused(
     constant float*     sinks      [[buffer(18)]],  // per-Q-head attention sink logits
     constant uint&      has_sinks  [[buffer(19)]],
     constant float&     amplitude  [[buffer(20)]],  // cos/sin scalar (YaRN); 1.0 otherwise  // 0 = no sinks (slot is a placeholder)
+    constant uint&      abs_pos    [[buffer(21)]],  // ABSOLUTE stream position for RoPE
     uint tg_id  [[threadgroup_position_in_grid]],
     uint tid    [[thread_index_in_threadgroup]],
     uint tg_sz  [[threads_per_threadgroup]],
@@ -68,6 +69,12 @@ kernel void attn_fused(
     uint head = tg_id;
     if (head >= num_q) return;
     uint kv_head = head / (num_q / num_kv);
+    // Cache ROW is occupancy-indexed (matches kv_cache_append's row
+    // choice); the RoPE ANGLE uses the absolute stream position. They
+    // are equal only until a sliding window evicts — deriving the
+    // angle from T (as `T - 1`) roped at a rewound position after
+    // compaction while every other decode path used abs_position
+    // (capability audit F11).
     uint pos = T - 1u;
 
     threadgroup float tg_q[256];
@@ -124,7 +131,7 @@ kernel void attn_fused(
     // rope passes.
     uint cache_off = pos * num_kv * head_dim + kv_head * head_dim;
     for (uint d = tid; d < hdim; d += tg_sz) {
-        float angle = float(pos) * inv_freq[d];
+        float angle = float(abs_pos) * inv_freq[d];
         float cos_a = cos(angle) * amplitude;
         float sin_a = sin(angle) * amplitude;
 
@@ -150,7 +157,11 @@ kernel void attn_fused(
         V_cache[cache_off + d] = V_in[kv_head * head_dim + d];
     }
 
-    threadgroup_barrier(mem_flags::mem_device);
+    // Orders BOTH memory spaces: phase 5 reads K from device
+    // (K_cache) and Q from threadgroup (tg_q). mem_device alone
+    // synchronised execution but did not fence the tg_q writes
+    // (capability audit F11).
+    threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);
 
     // ── Phase 5: scores. Reads Q from tg_q, K from K_cache. ──
     uint t_start = (window_size > 0u && T > window_size) ? T - window_size : 0u;
@@ -189,6 +200,12 @@ kernel void attn_fused(
     }
 
     {
+        // tg_red still holds the per-simdgroup maxima read above; a
+        // fast simdgroup must not overwrite a slot a slow one has not
+        // read. This is the same read->write reuse race fixed in
+        // kv_attention and kv_append_attend_fused — this kernel never
+        // received that fix (capability audit F11).
+        threadgroup_barrier(mem_flags::mem_threadgroup);
         float sg_sum = simd_sum(local_sum);
         if (lane == 0) tg_red[sg_id] = sg_sum;
         threadgroup_barrier(mem_flags::mem_threadgroup);

--- a/crates/larql-compute-metal/src/shaders/fused_attention.rs
+++ b/crates/larql-compute-metal/src/shaders/fused_attention.rs
@@ -214,6 +214,14 @@ kernel void fused_attention(
 }
 "#;
 
+/// Rust mirror of the MSL `MAX_FUSED_ATTENTION_SEQ_LEN` constant in
+/// [`SHADER`] — the `tg_scores` threadgroup scratch bound. The scratch
+/// is indexed by ABSOLUTE key position (not window-relative), so a
+/// sliding window does not reduce the requirement; seq_len past this
+/// writes out of bounds. Host dispatch asserts against it
+/// (`stages/attention.rs`).
+pub const MAX_FUSED_ATTENTION_SEQ_LEN: usize = 4096;
+
 pub struct Kernel;
 impl crate::kernels::ShaderKernel for Kernel {
     const KERNEL_NAME: &'static str = "fused_attention";

--- a/crates/larql-compute-metal/src/shaders/q4_matvec_v4.rs
+++ b/crates/larql-compute-metal/src/shaders/q4_matvec_v4.rs
@@ -99,6 +99,13 @@ kernel void q4_matvec_v4(
 }
 "#;
 
+/// Hard input-length ceiling from the threadgroup staging arrays
+/// (`tg_x8[8192]` int8 + 256 block scales): the staging loops write
+/// past both for larger K — threadgroup-memory corruption, not a
+/// graceful failure. Host dispatch sites assert against this
+/// (capability audit F13).
+pub const MAX_K: usize = 8192;
+
 pub const ROWS_PER_TG: u64 = 8;
 pub const THREADS_PER_TG: u64 = 256;
 

--- a/crates/larql-compute-metal/src/shaders/q4k_ffn_gate_up_coop.rs
+++ b/crates/larql-compute-metal/src/shaders/q4k_ffn_gate_up_coop.rs
@@ -78,8 +78,14 @@
 pub const SHADER: &str = r#"
 constant uint Q4K_GUC_ROWS_PER_TG = 4;
 constant uint Q4K_GUC_BLOCK_SIZE  = 144;
-// 16 floats per simdgroup (8 scales + 8 mins), ROWS_PER_TG simdgroups.
-constant uint Q4K_GUC_COEFFS_PER_SG = 16u;
+// 32 floats per simdgroup — (8 scales + 8 mins) x 2 superblock
+// parities — ROWS_PER_TG simdgroups. The original 16-slot layout mixed
+// the two parities' scales in one array: writer lane k staged sub-block
+// k of ITS OWN parity's superblock, and a reader whose sub-block index
+// j had the opposite parity to its lane consumed the wrong superblock's
+// scale — cos ~0.52 against the CPU reference (pinned by
+// q4k_ffn_gate_up_coop_parity_even_and_odd_superblocks).
+constant uint Q4K_GUC_COEFFS_PER_SG = 32u;
 
 kernel void q4k_ffn_gate_up_coop(
     device const uchar*  Wg    [[buffer(0)]],
@@ -98,14 +104,17 @@ kernel void q4k_ffn_gate_up_coop(
     uint mat_tg = is_up ? (tg_id - tgs_per_mat) : tg_id;
 
     uint row_idx = mat_tg * Q4K_GUC_ROWS_PER_TG + sg_id;
-    if (row_idx >= N) return;
+    // No early return: this kernel barriers inside its loop, and a
+    // simdgroup that exits while its siblings wait is undefined
+    // behaviour (audit F12). Out-of-range rows stay live but masked.
+    const bool row_live = row_idx < N;
 
     device const uchar* W       = is_up ? Wu : Wg;
     device float*       out_buf = is_up ? U_out : G_out;
 
     const uint superblocks   = K / 256u;
     const uint bytes_per_row = superblocks * Q4K_GUC_BLOCK_SIZE;
-    device const uchar* row_w = W + row_idx * bytes_per_row;
+    device const uchar* row_w = W + min(row_idx, N - 1u) * bytes_per_row;
 
     // Lane partition (matches production):
     //   ix  = lane & 1   → super-block parity
@@ -126,42 +135,58 @@ kernel void q4k_ffn_gate_up_coop(
 
     float acc = 0.0f;
 
-    for (uint sb = ix; sb < superblocks; sb += 2u) {
-        device const uchar* block = row_w + sb * Q4K_GUC_BLOCK_SIZE;
+    // Uniform trip count for every lane and every simdgroup: iterate
+    // superblock PAIRS. The previous `for (sb = ix; sb < superblocks;
+    // sb += 2)` gave ix=0 lanes one more iteration than ix=1 lanes
+    // whenever `superblocks` was odd, so the in-loop barrier was
+    // divergent — undefined behaviour hit by real shapes
+    // (hidden 2816 -> 11 superblocks, 5376 -> 21; audit F12).
+    const uint sb_pairs = (superblocks + 1u) / 2u;
+    for (uint p = 0u; p < sb_pairs; p++) {
+        const uint sb = 2u * p + ix;
+        const bool sb_live = row_live && (sb < superblocks);
+        device const uchar* block = row_w + min(sb, superblocks - 1u) * Q4K_GUC_BLOCK_SIZE;
 
-        // ── Cooperative scale/min decode on lanes 0..7 ──
-        // Each of those lanes also decodes d/dmin themselves (8×
-        // redundant vs production's 32×; negligible cost). Avoids a
-        // `simd_broadcast` round-trip that earlier prototypes found
-        // re-orders the inner FMA chain enough to flip rank-1 on
+        // ── Cooperative scale/min decode on lanes 0..15 ──
+        // Lane w = (w_k, w_par): sub-block w_k of THIS PAIR's parity
+        // w_par superblock, staged into that parity's half of the
+        // per-simdgroup coeffs slice. Writers also decode d/dmin
+        // themselves (redundant vs production's 32x; negligible cost) —
+        // avoids a `simd_broadcast` round-trip that earlier prototypes
+        // found re-orders the inner FMA chain enough to flip rank-1 on
         // close-call tokens at the LM head.
-        if (lane < 8u) {
-            uint k = lane;
+        {
+            const uint w_par = lane & 1u;
+            const uint w_k   = lane >> 1u;
+            const uint w_sb  = 2u * p + w_par;
+            if (lane < 16u && row_live && w_sb < superblocks) {
+                device const uchar* wblock = row_w + w_sb * Q4K_GUC_BLOCK_SIZE;
+                ushort d_bits    = ushort(wblock[0]) | (ushort(wblock[1]) << 8u);
+                ushort dmin_bits = ushort(wblock[2]) | (ushort(wblock[3]) << 8u);
+                float d    = decode_f16_metal(d_bits);
+                float dmin = decode_f16_metal(dmin_bits);
 
-            ushort d_bits    = ushort(block[0]) | (ushort(block[1]) << 8u);
-            ushort dmin_bits = ushort(block[2]) | (ushort(block[3]) << 8u);
-            float d    = decode_f16_metal(d_bits);
-            float dmin = decode_f16_metal(dmin_bits);
-
-            device const uchar* sb_bytes = block + 4u;
-            uint sc, mn;
-            if (k < 4u) {
-                sc = uint(sb_bytes[k])      & 0x3Fu;
-                mn = uint(sb_bytes[k + 4u]) & 0x3Fu;
-            } else {
-                sc = (uint(sb_bytes[k + 4u]) & 0x0Fu) | ((uint(sb_bytes[k - 4u]) >> 6u) << 4u);
-                mn = (uint(sb_bytes[k + 4u]) >> 4u)    | ((uint(sb_bytes[k])      >> 6u) << 4u);
+                device const uchar* sb_bytes = wblock + 4u;
+                uint sc, mn;
+                if (w_k < 4u) {
+                    sc = uint(sb_bytes[w_k])      & 0x3Fu;
+                    mn = uint(sb_bytes[w_k + 4u]) & 0x3Fu;
+                } else {
+                    sc = (uint(sb_bytes[w_k + 4u]) & 0x0Fu) | ((uint(sb_bytes[w_k - 4u]) >> 6u) << 4u);
+                    mn = (uint(sb_bytes[w_k + 4u]) >> 4u)    | ((uint(sb_bytes[w_k])      >> 6u) << 4u);
+                }
+                uint wbase = sg_id * Q4K_GUC_COEFFS_PER_SG + w_par * 16u;
+                coeffs[wbase + w_k]      = d    * float(sc);
+                coeffs[wbase + 8u + w_k] = dmin * float(mn);
             }
-            uint base = sg_id * Q4K_GUC_COEFFS_PER_SG;
-            coeffs[base + k]      = d    * float(sc);
-            coeffs[base + 8u + k] = dmin * float(mn);
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
-        // All lanes read their owned sub-block's scale/mmin.
-        uint base = sg_id * Q4K_GUC_COEFFS_PER_SG;
+        // Each lane reads its own parity's staged scale/mmin.
+        uint base = sg_id * Q4K_GUC_COEFFS_PER_SG + ix * 16u;
         float scale = coeffs[base + j];
         float mmin  = coeffs[base + 8u + j];
+        if (sb_live) {
 
         // ── Inner work: identical to production `q4k_ffn_gate_up` ──
         // Preload 16 X values into registers BEFORE loading weight bytes.
@@ -188,10 +213,14 @@ kernel void q4k_ffn_gate_up_coop(
         }
         // Q4_K deferred form: scale * Σ(nib*x) - dmin_min * Σ(x).
         acc += scale * dot_acc - mmin * sumy;
+        }
+        // Protect the next iteration's staging writes from any thread
+        // still reading this iteration's coeffs.
+        threadgroup_barrier(mem_flags::mem_threadgroup);
     }
 
     acc = simd_sum(acc);
-    if (lane == 0u) out_buf[row_idx] = acc;
+    if (row_live && lane == 0u) out_buf[row_idx] = acc;
 }
 "#;
 

--- a/crates/larql-compute-metal/src/shaders/q8_attn_proj.rs
+++ b/crates/larql-compute-metal/src/shaders/q8_attn_proj.rs
@@ -34,11 +34,15 @@ kernel void q8_qkv_proj(
 {
     uint total_rows = q_rows + k_rows + v_rows;
     uint global_row = tg_id * QKV_ROWS_PER_TG + sg_id;
-    if (global_row >= total_rows) return;
 
     uint blocks = K / 32;
 
-    // Load Q8 input into threadgroup shared memory (once per TG)
+    // Load Q8 input into threadgroup shared memory (once per TG).
+    // ALL threads participate and reach the barrier — the out-of-range
+    // row check comes after it. An early return here was divergent
+    // whenever total_rows % QKV_ROWS_PER_TG != 0: some simdgroups
+    // returned while the rest waited at the barrier, which is
+    // undefined behaviour in MSL (capability audit F13).
     threadgroup int8_t tg_x8[8192];
     threadgroup float tg_xs[256];
     for (uint i = tid_in_tg; i < K; i += 256)
@@ -46,6 +50,7 @@ kernel void q8_qkv_proj(
     for (uint i = tid_in_tg; i < blocks; i += 256)
         tg_xs[i] = X8s[i];
     threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (global_row >= total_rows) return;
 
     // Determine which projection and local row
     device const uchar* W;
@@ -103,10 +108,11 @@ kernel void q8_proj_rope(
     uint sg_id     [[simdgroup_index_in_threadgroup]])
 {
     uint row = tg_id * QKV_ROWS_PER_TG + sg_id;
-    if (row >= num_rows) return;
 
     uint blocks = K / 32;
 
+    // All threads stage and reach the barrier; row masking follows it
+    // (same divergent-barrier fix as q8_qkv_proj above, audit F13).
     threadgroup int8_t tg_x8[8192];
     threadgroup float tg_xs[256];
     for (uint i = tid_in_tg; i < K; i += 256)
@@ -114,6 +120,7 @@ kernel void q8_proj_rope(
     for (uint i = tid_in_tg; i < blocks; i += 256)
         tg_xs[i] = X8s[i];
     threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (row >= num_rows) return;
 
     device const char* row_data = (device const char*)(W8 + row * K);
     device const float* row_scales = W8s + row * blocks;
@@ -135,6 +142,13 @@ kernel void q8_proj_rope(
     if (lane == 0) out[row] = acc;
 }
 "#;
+
+/// Hard input-length ceiling from the threadgroup staging arrays
+/// (`tg_x8[8192]` int8 + 256 block scales): the staging loops write
+/// past both for larger K — threadgroup-memory corruption, not a
+/// graceful failure. Host dispatch sites assert against this
+/// (capability audit F13).
+pub const MAX_K: usize = 8192;
 
 pub const ROWS_PER_TG: u64 = 8;
 pub const THREADS_PER_TG: u64 = 256;

--- a/crates/larql-compute-metal/src/shaders/q8_matvec.rs
+++ b/crates/larql-compute-metal/src/shaders/q8_matvec.rs
@@ -61,6 +61,13 @@ kernel void q8_matvec(
 }
 "#;
 
+/// Hard input-length ceiling from the threadgroup staging arrays
+/// (`tg_x8[8192]` int8 + 256 block scales): the staging loops write
+/// past both for larger K — threadgroup-memory corruption, not a
+/// graceful failure. Host dispatch sites assert against this
+/// (capability audit F13).
+pub const MAX_K: usize = 8192;
+
 pub const ROWS_PER_TG: u64 = 8;
 pub const THREADS_PER_TG: u64 = 256;
 

--- a/crates/larql-compute-metal/src/shaders/quantize_q8.rs
+++ b/crates/larql-compute-metal/src/shaders/quantize_q8.rs
@@ -11,18 +11,24 @@ kernel void quantize_q8(
     uint tid [[thread_position_in_grid]])
 {
     uint block = tid;
-    uint num_blocks = K / 32;
+    // Round UP: several hosts dispatch div_ceil(K, 32) threads, and the
+    // previous truncating K / 32 left the final partial block's scale
+    // slot unwritten — downstream Q8 matvecs then read an uninitialised
+    // scale (capability audit F6). The partial block quantises its
+    // K % 32 real elements only.
+    uint num_blocks = (K + 31u) / 32u;
     if (block >= num_blocks) return;
     uint off = block * 32;
+    uint n = min(32u, K - off);
     float amax = 0.0f;
-    for (uint j = 0; j < 32; j++) {
+    for (uint j = 0; j < n; j++) {
         float v = abs(input[off + j]);
         if (v > amax) amax = v;
     }
     float scale = amax / 127.0f;
     float inv = (scale > 0.0f) ? (1.0f / scale) : 0.0f;
     scales[block] = scale;
-    for (uint j = 0; j < 32; j++) {
+    for (uint j = 0; j < n; j++) {
         float v = input[off + j] * inv;
         v = clamp(v, -128.0f, 127.0f);
         q8_out[off + j] = char(int(round(v)));

--- a/crates/larql-compute-metal/src/stages/attention.rs
+++ b/crates/larql-compute-metal/src/stages/attention.rs
@@ -64,6 +64,28 @@ pub fn encode(
     flags: Flags,
     sinks: Option<&[f32]>,
 ) {
+    // The shader's threadgroup scratch fixes two hard ceilings that
+    // were previously silently assumed (capability audit F14):
+    // `tg_q[512]` caps head_dim, and `tg_scores[4096]` is indexed by
+    // ABSOLUTE key position (not `k - k_start`), so a sliding window
+    // does not shrink the footprint and seq_len past 4096 writes out
+    // of bounds. GQA divisibility is the kernel's head-mapping
+    // assumption (`head / (num_q / num_kv)`), asserted nowhere else.
+    assert!(
+        head_dim <= 512,
+        "fused_attention supports head_dim <= 512 (tg_q scratch); got {head_dim}"
+    );
+    assert!(
+        seq_len <= crate::shaders::fused_attention::MAX_FUSED_ATTENTION_SEQ_LEN,
+        "fused_attention supports seq_len <= {} (tg_scores is indexed by absolute \
+         position, so a window does not reduce this); got {seq_len}",
+        crate::shaders::fused_attention::MAX_FUSED_ATTENTION_SEQ_LEN,
+    );
+    assert!(
+        num_kv_heads > 0 && num_q_heads.is_multiple_of(num_kv_heads),
+        "fused_attention assumes num_q_heads ({num_q_heads}) divisible by \
+         num_kv_heads ({num_kv_heads})"
+    );
     let seq_val = seq_len as u32;
     let hd_val = head_dim as u32;
     let nq_val = num_q_heads as u32;

--- a/crates/larql-compute-metal/src/stages/qkv_proj.rs
+++ b/crates/larql-compute-metal/src/stages/qkv_proj.rs
@@ -217,6 +217,12 @@ pub fn encode_fused_q8(
     kv_rows: usize,
     hidden: usize,
 ) {
+    assert!(
+        hidden <= crate::shaders::q8_attn_proj::MAX_K,
+        "q8_qkv_proj stages its input in threadgroup memory capped at K = {}; \
+         hidden {hidden} would corrupt threadgroup memory (audit F13)",
+        crate::shaders::q8_attn_proj::MAX_K,
+    );
     let q_rows_val = q_rows as u32;
     let k_rows_val = kv_rows as u32;
     let v_rows_val = kv_rows as u32;
@@ -238,7 +244,17 @@ pub fn encode_fused_q8(
     enc.set_bytes(12, 4, &k_rows_val as *const u32 as *const c_void);
     enc.set_bytes(13, 4, &v_rows_val as *const u32 as *const c_void);
     enc.set_bytes(14, 4, &k_val as *const u32 as *const c_void);
-    enc.dispatch_thread_groups(MTLSize::new(total_rows, 1, 1), MTLSize::new(256, 1, 1));
+    // One threadgroup covers ROWS_PER_TG rows (one per simdgroup); the
+    // previous `total_rows` grid over-dispatched 8x, with every excess
+    // TG re-staging the Q8 input into threadgroup memory before its
+    // simdgroups discovered they were all out of range (capability
+    // audit F19). Geometry from the shader module the pipeline was
+    // built from, not a literal.
+    use crate::shaders::q8_attn_proj as q8;
+    enc.dispatch_thread_groups(
+        MTLSize::new(total_rows.div_ceil(q8::ROWS_PER_TG), 1, 1),
+        MTLSize::new(q8::THREADS_PER_TG, 1, 1),
+    );
 }
 
 #[cfg(test)]

--- a/crates/larql-compute-metal/src/trait_impl/quant_matvec.rs
+++ b/crates/larql-compute-metal/src/trait_impl/quant_matvec.rs
@@ -249,17 +249,25 @@ impl QuantMatVec for MetalBackend {
         num_rows: usize,
         hidden: usize,
     ) -> Option<Vec<f32>> {
-        use crate::shaders::q6k_matvec as q6k;
+        // Geometry from the bound `KernelHandle`, never from a shader
+        // module's constants: `q6k_matvec_pipeline` resolves to the 8sg
+        // variant (8 rows/TG, 256 threads) under `LARQL_Q6K_8SG=1`, and
+        // dispatching it with the 4sg module constants launches half
+        // the threadgroups — rows `8t+4..8t+7` are never written and
+        // the output buffer serves stale pool data for them. The q4k
+        // twin above documents the same hazard; this site was left
+        // behind when that one was fixed. Capability audit F5.
+        let kh = &self.quant.q6k_matvec_pipeline;
         let buf_w = self.bufs.get_bytes(q6k_data);
         let buf_x = self.bufs.transient_from_f32(x);
         let buf_out = self.bufs.output((num_rows * 4) as u64);
         let n = num_rows as u32;
         let k = hidden as u32;
-        let num_tgs = (num_rows as u64).div_ceil(q6k::ROWS_PER_TG);
+        let num_tgs = (num_rows as u64).div_ceil(kh.rows_per_tg);
 
         let cmd = self.queue.new_command_buffer();
         let enc = cmd.new_compute_command_encoder();
-        enc.set_compute_pipeline_state(&self.quant.q6k_matvec_pipeline.state);
+        enc.set_compute_pipeline_state(&kh.state);
         enc.set_buffer(0, Some(&buf_w), 0);
         enc.set_buffer(1, Some(&buf_x), 0);
         enc.set_buffer(2, Some(&buf_out), 0);
@@ -267,7 +275,7 @@ impl QuantMatVec for MetalBackend {
         enc.set_bytes(4, 4, &k as *const u32 as *const std::ffi::c_void);
         enc.dispatch_thread_groups(
             metal::MTLSize::new(num_tgs, 1, 1),
-            metal::MTLSize::new(q6k::THREADS_PER_TG, 1, 1),
+            metal::MTLSize::new(kh.threads_per_tg, 1, 1),
         );
         enc.end_encoding();
         cmd.commit();

--- a/crates/larql-compute-metal/tests/test_kernel_q4k_ffn_gate_up.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_q4k_ffn_gate_up.rs
@@ -250,3 +250,75 @@ fn q4k_ffn_gate_up_zero_input() {
         "q4k_ffn_gate_up zero-input: up output contains NaN"
     );
 }
+
+/// Numerical parity for the OPT-IN cooperative variant
+/// (`q4k_ffn_gate_up_coop`, `LARQL_GATE_UP_COOP=1`) against the CPU
+/// reference — written while auditing capability finding F12 (divergent
+/// threadgroup barriers on odd `K/256` and `N % 4 != 0`), because the
+/// kernel had smoke coverage only and its cooperative scale staging
+/// mixes superblock parities in one 8-slot array, which reads as wrong
+/// for every lane whose sub-block parity differs from its superblock
+/// parity. Both geometries matter: even superblock count (barrier-safe
+/// trip counts) isolates pure numerics; odd count adds the divergent
+/// barrier.
+#[test]
+fn q4k_ffn_gate_up_coop_parity_even_and_odd_superblocks() {
+    let metal = get_metal();
+    let cpu = larql_compute::cpu::CpuBackend;
+    use larql_compute_metal::shaders::q4k_ffn_gate_up_coop as guc;
+
+    for (label, inter, hidden) in [
+        ("even superblocks (K=512)", 64usize, 512usize),
+        ("odd superblocks (K=768)", 64usize, 768usize),
+    ] {
+        let gate = synth_matrix(inter, hidden, 0.21);
+        let up = synth_matrix(inter, hidden, 0.83);
+        let x = synth_input(hidden, 0.41);
+        let gate_q4k = larql_compute::cpu::ops::q4_common::quantize_q4_k(&gate);
+        let up_q4k = larql_compute::cpu::ops::q4_common::quantize_q4_k(&up);
+        let gate_cpu = cpu.q4k_matvec(&gate_q4k, &x, inter, hidden).unwrap();
+        let up_cpu = cpu.q4k_matvec(&up_q4k, &x, inter, hidden).unwrap();
+
+        let gate_w_buf = metal.bufs().get_bytes(&gate_q4k);
+        let up_w_buf = metal.bufs().get_bytes(&up_q4k);
+        let x_buf = metal.bufs().transient_from_f32(&x);
+        let gate_out_buf = metal.bufs().output((inter * 4) as u64);
+        let up_out_buf = metal.bufs().output((inter * 4) as u64);
+        let n_val = inter as u32;
+        let k_val = hidden as u32;
+        let n_tgs_per_mat = (inter as u64).div_ceil(guc::ROWS_PER_TG);
+
+        let cmd = metal.queue().new_command_buffer();
+        let enc = cmd.new_compute_command_encoder();
+        enc.set_compute_pipeline_state(&metal.ffn.q4k_ffn_gate_up_coop_pipeline.state);
+        enc.set_buffer(0, Some(&gate_w_buf), 0);
+        enc.set_buffer(1, Some(&up_w_buf), 0);
+        enc.set_buffer(2, Some(&x_buf), 0);
+        enc.set_buffer(3, Some(&gate_out_buf), 0);
+        enc.set_buffer(4, Some(&up_out_buf), 0);
+        enc.set_bytes(5, 4, &n_val as *const u32 as *const std::ffi::c_void);
+        enc.set_bytes(6, 4, &k_val as *const u32 as *const std::ffi::c_void);
+        enc.dispatch_thread_groups(
+            metal::MTLSize::new(n_tgs_per_mat * 2, 1, 1),
+            metal::MTLSize::new(guc::THREADS_PER_TG, 1, 1),
+        );
+        enc.end_encoding();
+        cmd.commit();
+        cmd.wait_until_completed();
+
+        let gate_metal = larql_compute_metal::buffers::read_buffer_f32(&gate_out_buf, inter);
+        let up_metal = larql_compute_metal::buffers::read_buffer_f32(&up_out_buf, inter);
+        let gate_cos = cos_sim(&gate_cpu, &gate_metal);
+        let up_cos = cos_sim(&up_cpu, &up_metal);
+        let gate_diff = max_diff(&gate_cpu, &gate_metal);
+        let up_diff = max_diff(&up_cpu, &up_metal);
+        assert!(
+            gate_cos > 0.999 && gate_diff < 0.5,
+            "coop {label} GATE: cos={gate_cos:.6} max_abs={gate_diff:.3e}"
+        );
+        assert!(
+            up_cos > 0.999 && up_diff < 0.5,
+            "coop {label} UP: cos={up_cos:.6} max_abs={up_diff:.3e}"
+        );
+    }
+}

--- a/crates/larql-compute/ROADMAP.md
+++ b/crates/larql-compute/ROADMAP.md
@@ -61,28 +61,31 @@ built from a six-family audit of every MSL entry point in
       loudly.
 - [x] **F4** (fixed bc2b429f) float weights (BF16/F16/F32) in `quant_matvec::encode` are a
       silent no-op with stale scratch output — panic loudly.
-- [ ] **F5** `q6k_matvec` trait dispatch hardcodes 4sg geometry against a
+- [x] **F5** (fixed 4408d18a) `q6k_matvec` trait dispatch hardcodes 4sg geometry against a
       pipeline alias that can be 8sg — read the `KernelHandle`.
-- [ ] **F6** `quantize_q8` host `div_ceil` vs shader truncating `K/32` —
+- [x] **F6** (fixed 4408d18a) `quantize_q8` host `div_ceil` vs shader truncating `K/32` —
       unwritten tail scale; make the kernel handle partial blocks.
 - [ ] **F7** sinks silently dropped by `kv_attention`/`_long` fallbacks —
       add sink buffers (join max + denominator) so fallback preserves the
       feature set.
 - [ ] **F8** softcap exists only in prefill `fused_attention` — decode
       refuses or supports; no silent cap-drop.
-- [ ] **F9** dense layers of hybrid-MoE models never get `layer_scalar`
+- [x] **F9** (fixed 4408d18a) dense layers of hybrid-MoE models never get `layer_scalar`
       (`decode/mod.rs:789` model-level branch vs layer-level apply).
-- [ ] **F10** `gpu_moe_dispatch_with_scratch` staging loop missing
+- [x] **F10** (fixed 4408d18a) `gpu_moe_dispatch_with_scratch` staging loop missing
       `valid_count >= top_k` guard (sibling has it) — release-mode
       buffer overflow.
-- [ ] **F11** `attn_fused` tg_red max→sum reuse unfenced + `tg_q` handoff
+- [x] **F11** (fixed 4408d18a) `attn_fused` tg_red max→sum reuse unfenced + `tg_q` handoff
       fenced `mem_device`-only + ropes at occupancy not stream position.
-- [ ] **F12** `q4k_ffn_gate_up_coop` divergent threadgroup barriers on odd
-      `K/256` and `N%4 != 0` (both occur in shipped shapes).
-- [ ] **F13** `q8_qkv_proj`/`q8_proj_rope` early-return before barrier;
+- [x] **F12** (fixed 4408d18a) `q4k_ffn_gate_up_coop` divergent threadgroup barriers on odd
+      `K/256` and `N%4 != 0` (both occur in shipped shapes). The fix's
+      new parity test also found the kernel numerically broken outright
+      (16-slot scale staging mixed superblock parities; cos 0.52 vs
+      CPU) — rewritten with parity-indexed staging, pinned even+odd.
+- [x] **F13** (fixed 4408d18a) `q8_qkv_proj`/`q8_proj_rope` early-return before barrier;
       K ≤ 8192 threadgroup-scratch ceiling (shared with `q4_matvec_v4`,
       `q8_matvec`) asserted nowhere.
-- [ ] **F14** `fused_attention` head≤512 / seq≤4096 unasserted;
+- [x] **F14** (fixed 4408d18a) `fused_attention` head≤512 / seq≤4096 unasserted;
       `kv_attention_long` unguarded past its 4096 scratch.
 - [ ] **F15** `Q4_KF_BLOCK_BYTES = 160` (host) vs 144 (both Q4_KF
       shaders) — establish which is real, fix the other.
@@ -91,12 +94,12 @@ built from a six-family audit of every MSL entry point in
       convention across the five down dispatch variants.
 - [ ] **F17** K-alignment asserted in 2 of ~30 quant kernels; GQA
       divisibility asserted nowhere — add dispatch-time checks.
-- [ ] **F18** `residual_multiplier == 1.0` guard missing on
+- [x] **F18** (fixed 4408d18a) `residual_multiplier == 1.0` guard missing on
       `post_attn_residual_norm_store` selection and the PLE reuse of
       `post_ffn_norm_residual_add` (siblings have it).
-- [ ] **F19** `encode_fused_q8` prefill site dispatches `total_rows` TGs
+- [x] **F19** (fixed 4408d18a) `encode_fused_q8` prefill site dispatches `total_rows` TGs
       instead of `div_ceil(total_rows, 8)` — 8× over-dispatch.
-- [ ] **F20** legacy `append_and_attend` passes `None` for the long
+- [x] **F20** (fixed 4408d18a) legacy `append_and_attend` passes `None` for the long
       pipeline → `tg_scores[1024]` overflow past span 1024; hardcodes
       window 0.
 - [ ] **F21** dead-but-compiled inventory (see capability doc §8) — per


### PR DESCRIPTION
Continuation of #231 (merged); replaces #232, which was auto-closed when its base branch was deleted. Lands the guard-level and kernel-local fixes from the capability audit (`docs/metal-kernel-capabilities.md`), leaving F7/F8 (attention feature fallback), F15-F17 remnants, and F21/F22 for the capability-selector slices.

## Highlights

- **`q4k_ffn_gate_up_coop` was numerically broken outright**, beyond the audit's divergent-barrier finding: its 16-slot cooperative scale staging mixed both superblock parities, so half the lanes read the wrong superblock's scales — **cos 0.52 against the CPU reference**. Found by the parity test written for this fix (the kernel had smoke coverage only). Rewritten with parity-indexed staging (32 slots), a uniform pair loop (kills the odd-`K/256` barrier divergence), and row masking instead of the early return. Parity pinned on even and odd superblock geometries.
- **`attn_fused`** gets the tg_red fence its two sibling kernels received, a correct `mem_device | mem_threadgroup` handoff barrier, and RoPE at absolute stream position (new `abs_pos` binding) instead of cache occupancy.
- **`quantize_q8`** now quantises the partial tail block; previously `K % 32 != 0` left the final scale slot unwritten while two hosts dispatched a thread for it.
- Geometry/guard fixes: q6k trait dispatch handle-driven (F5); per-layer `layer_scalar` for dense layers of hybrid-MoE models (F9); MoE staging bound (F10); fused_attention + kv_attention_long scratch ceilings asserted (F14); `residual_multiplier` guards on the fused post-attn kernel and the PLE reuse (F18); prefill fused-Q8 8× over-dispatch (F19); no silent short-kernel fallback past span 1024 (F20); q8 staging barrier order + `MAX_K = 8192` asserted at all production sites (F13).

## Verification

Full `larql-compute-metal` suite green (32 binaries, exit-code checked), `larql-compute` + `larql-inference` green, fmt + clippy clean. One `prefill_q4_seq4_synthetic_smoke` flake observed mid-run with the exact #229 signature (256-of-1024 NaN, one position row) and 6/6 isolated reruns passing — pre-existing, tracked in #229.