### PR TITLE
fix(quant): Q4_KF is a kernel-route tag, not a 160-byte layout (F15, F16, F22)

### DIFF
--- a/crates/larql-compute-metal/examples/compare_ollama.rs
+++ b/crates/larql-compute-metal/examples/compare_ollama.rs
@@ -17,7 +17,7 @@ fn main() {
 
     #[cfg(target_os = "macos")]
     {
-        use larql_compute::cpu::ops::q4_common::{quantize_q4_k, quantize_q4_kf, quantize_to_q8};
+        use larql_compute::cpu::ops::q4_common::{quantize_q4_k, quantize_to_q8};
         use larql_compute::prelude::*;
         use std::time::Instant;
 
@@ -96,12 +96,16 @@ fn main() {
                         wk: quantize_q4_k(&pad(&wk_f)),
                         wv: quantize_q4_k(&pad(&wv_f)),
                         wo: quantize_q4_k(&pad(&wo_f)),
-                        // Q4_KF byte layout (160B/256 — pre-baked half scales)
-                        // for the all-Q4_KF attention variant.
-                        wq_kf: quantize_q4_kf(&pad(&wq_f)),
-                        wk_kf: quantize_q4_kf(&pad(&wk_f)),
-                        wv_kf: quantize_q4_kf(&pad(&wv_f)),
-                        wo_kf: quantize_q4_kf(&pad(&wo_f)),
+                        // The Q4_KF kernels read standard 144-byte GGUF
+                        // Q4_K blocks (the tag selects the llama.cpp-exact
+                        // inner loop, not a layout — audit F15). This
+                        // example previously fed them the experimental
+                        // 160-byte pre-baked layout, so its Q4_KF arm
+                        // measured garbage numerics.
+                        wq_kf: quantize_q4_k(&pad(&wq_f)),
+                        wk_kf: quantize_q4_k(&pad(&wk_f)),
+                        wv_kf: quantize_q4_k(&pad(&wv_f)),
+                        wo_kf: quantize_q4_k(&pad(&wo_f)),
                         wq8: q8q.iter().map(|&x| x as u8).collect(),
                         wk8: q8k.iter().map(|&x| x as u8).collect(),
                         wv8: q8v.iter().map(|&x| x as u8).collect(),

--- a/crates/larql-compute-metal/src/decode/setup.rs
+++ b/crates/larql-compute-metal/src/decode/setup.rs
@@ -166,23 +166,33 @@ impl DecodeScratch {
         let h_post_attn = bufs.output((hidden * 4) as u64);
         let ffn_norm_out = bufs.output((hidden * 4) as u64);
         let ffn_q8 = bufs.output(hidden as u64);
-        let ffn_q8s = bufs.output((hidden / LEGACY_BLOCK_ELEMS * 4) as u64);
-        let up_out = bufs.output((inter * 4) as u64);
-        let act_buf = bufs.output((inter_padded * 4) as u64);
-        {
-            let ptr = act_buf.contents() as *mut f32;
-            // SAFETY: `act_buf` is a freshly-allocated shared-storage
-            // Metal buffer with `inter_padded * 4` bytes. We zero its
-            // entire f32 capacity before any layer writes the live
-            // `inter` columns; the trailing `inter_padded - inter`
-            // columns stay zero for the remainder of the decode.
+        let ffn_q8s = bufs.output((hidden.div_ceil(LEGACY_BLOCK_ELEMS) * 4) as u64);
+        // `up_out`, `act_buf` and `gate_out_scratch` are all sized (and
+        // tail-zeroed) at `inter_padded`, not `inter`: the fused Q4_K
+        // GEGLU+down kernel reads gate/up over K = inter_padded, so
+        // `inter`-sized buffers were an out-of-bounds read for any
+        // model with inter % 256 != 0 (capability audit F16 — latent,
+        // since all shipped shapes are 256-aligned). The zeroed tail is
+        // mathematically inert: gelu(0) (or silu(0)) × 0 contributes
+        // nothing to the down matvec.
+        let zeroed_padded = |buf: &metal::Buffer| {
+            let ptr = buf.contents() as *mut f32;
+            // SAFETY: freshly-allocated shared-storage Metal buffer with
+            // `inter_padded * 4` bytes; zeroed before any layer writes
+            // the live `inter` columns, so the trailing columns stay
+            // zero for the remainder of the decode.
             unsafe { std::ptr::write_bytes(ptr, 0, inter_padded) };
-        }
+        };
+        let up_out = bufs.output((inter_padded * 4) as u64);
+        zeroed_padded(&up_out);
+        let act_buf = bufs.output((inter_padded * 4) as u64);
+        zeroed_padded(&act_buf);
         let down_out = bufs.output((hidden * 4) as u64);
-        let gate_out_scratch = bufs.output((inter * 4) as u64);
+        let gate_out_scratch = bufs.output((inter_padded * 4) as u64);
+        zeroed_padded(&gate_out_scratch);
         let normed_scratch = bufs.output((hidden * 4) as u64);
         let o_q8_scratch = bufs.output(max_q_dim as u64);
-        let o_q8s_scratch = bufs.output((max_q_dim / LEGACY_BLOCK_ELEMS * 4) as u64);
+        let o_q8s_scratch = bufs.output((max_q_dim.div_ceil(LEGACY_BLOCK_ELEMS) * 4) as u64);
         let scaled_scratch = bufs.output((hidden * 4) as u64);
 
         let has_moe = layers.iter().any(|l| l.moe.is_some() || l.ffn_is_remote);

--- a/crates/larql-compute-metal/src/kernels/ffn.rs
+++ b/crates/larql-compute-metal/src/kernels/ffn.rs
@@ -37,8 +37,9 @@ pub struct FfnKernels {
 
     // Q4_K gate+up (production + three opt-in variants).
     pub q4k_ffn_gate_up_pipeline: KernelHandle,
-    /// `LARQL_F16_ACC=1` opt-in. f16 inner accumulator on the legacy
-    /// 4sg gate+up.
+    /// `LARQL_F16_ACC=1` opt-in (requires `LARQL_GATE_UP_8SG=0` too —
+    /// the 8sg default discards it). f16 inner accumulator on the
+    /// legacy 4sg gate+up.
     pub q4k_ffn_gate_up_f16acc_pipeline: KernelHandle,
     /// `LARQL_GATE_UP_8SG=0` opts back to 4sg; this is the 8sg variant
     /// that the production alias resolves to today.
@@ -54,8 +55,11 @@ pub struct FfnKernels {
     pub q4k_geglu_gelu_tanh_down_pipeline: KernelHandle,
     pub q6k_geglu_silu_down_pipeline: KernelHandle,
     pub q6k_geglu_gelu_tanh_down_pipeline: KernelHandle,
-    /// Cached-activation Q6_K + GELU-tanh — `LARQL_FUSED_Q6K_DOWN=1`
-    /// opt-in. Currently no-op until kernel-level parity work lands.
+    /// "Cached-activation" Q6_K + GELU-tanh — **never dispatched**:
+    /// `LARQL_FUSED_Q6K_DOWN=1` binds the non-cached pipeline above,
+    /// and this kernel's body is a verbatim copy of it (it caches
+    /// nothing, contradicting its module doc; audit F21/F22).
+    /// Retire-or-implement is tracked on the larql-compute roadmap.
     pub q6k_geglu_gelu_tanh_down_cached_pipeline: KernelHandle,
 
     /// Per-Layer Embeddings gate-apply (Gemma 4 E2B): fused

--- a/crates/larql-compute-metal/src/options/mod.rs
+++ b/crates/larql-compute-metal/src/options/mod.rs
@@ -50,11 +50,16 @@ pub struct DecodeFlags {
     /// reading site doesn't have to re-invert.
     pub gate_up_use_4sg: bool,
     /// `LARQL_F16_ACC=1` — f16 accumulator on the legacy 4sg gate+up.
-    /// Opt-in (default false).
+    /// Opt-in (default false). **Requires `LARQL_GATE_UP_8SG=0` as
+    /// well**: the default 8sg branch discards this flag
+    /// (`encode_ffn.rs` selection chain), so `LARQL_F16_ACC=1` alone is
+    /// a no-op (capability audit F22).
     pub f16_acc: bool,
-    /// `LARQL_FUSED_Q6K_DOWN=1` — opt into the cached-activation Q6_K
-    /// fused down. Currently no-op pending kernel parity (see
-    /// `encode_ffn.rs` block doc).
+    /// `LARQL_FUSED_Q6K_DOWN=1` — opt into the fused Q6_K GELU-tanh
+    /// down. Dispatches `q6k_geglu_gelu_tanh_down` (the NON-cached
+    /// kernel — the `_cached` variant is never dispatched and its body
+    /// is a verbatim copy anyway; audit F22). Recorded broken on the
+    /// current interleaved layout (see `encode_ffn.rs` block doc).
     pub fused_q6k_down: bool,
     /// `LARQL_FUSED_DOWN` — fused Q4_K GEGLU+down on the decode hot
     /// path. Default true; opt out with `=0`. (The prefill path in

--- a/crates/larql-compute-metal/src/shaders/q4k_matvec_stride32.rs
+++ b/crates/larql-compute-metal/src/shaders/q4k_matvec_stride32.rs
@@ -24,7 +24,11 @@
 //!
 //! ## Retention rationale (ADR-017)
 //!
-//! **Status**: opt-in, not wired into production decode.
+//! **Status**: not in the decode hot path, but LIVE in production —
+//! the vindex lm-head KNN path (`larql-vindex/.../lm_head/knn.rs`)
+//! dispatches it via `MetalBackend` when a Q4_K lm_head mmap is
+//! present (a prior revision of this note said "not wired"; audit
+//! F22).
 //!
 //! **Empirical result (2026-05-09, `project_f16_gemv_wiring_todo.md`)**:
 //! the broader f16-on-Q4_K wiring story is dead — direct f16 LM head is

--- a/crates/larql-compute-metal/tests/test_kernel_q4k_ffn_gate_up.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_q4k_ffn_gate_up.rs
@@ -159,9 +159,12 @@ fn q4k_ffn_gate_up_gemma4_26b_a4b_moe_shape() {
 
 #[test]
 fn q4k_ffn_gate_up_max_k_boundary_4096() {
-    // Right at the shader's Q4K_GU_MAX_K=4096 shared-memory cap. Should
-    // pass — the threadgroup tile fits exactly. Anything past this is
-    // out-of-bounds shared-memory access (Metal UB).
+    // Historical boundary: the shader once staged X in a shared-memory
+    // tile capped by Q4K_GU_MAX_K = 4096. That tile (and the constant)
+    // are gone — the kernel now streams X from device memory — but the
+    // geometry stays pinned as a regression guard for any future
+    // reintroduction of a K cap (audit F22: the old comment described
+    // a constant that no longer exists).
     assert_q4k_ffn_gate_up_matches_per_matrix("at MAX_K (4096)", 32, 4096);
 }
 

--- a/crates/larql-compute/ROADMAP.md
+++ b/crates/larql-compute/ROADMAP.md
@@ -87,9 +87,9 @@ built from a six-family audit of every MSL entry point in
       `q8_matvec`) asserted nowhere.
 - [x] **F14** (fixed 4408d18a) `fused_attention` head≤512 / seq≤4096 unasserted;
       `kv_attention_long` unguarded past its 4096 scratch.
-- [ ] **F15** `Q4_KF_BLOCK_BYTES = 160` (host) vs 144 (both Q4_KF
+- [x] **F15** (fixed on fix/metal-audit-f15-f16-f22) `Q4_KF_BLOCK_BYTES = 160` (host) vs 144 (both Q4_KF
       shaders) — establish which is real, fix the other.
-- [ ] **F16** `gate_out`/`up_out` sized `inter` while fused Q4_K down
+- [x] **F16** (fixed on fix/metal-audit-f15-f16-f22) `gate_out`/`up_out` sized `inter` while fused Q4_K down
       reads `inter_padded`; unify the `inter` vs `inter_padded` K
       convention across the five down dispatch variants.
 - [ ] **F17** K-alignment asserted in 2 of ~30 quant kernels; GQA
@@ -106,7 +106,7 @@ built from a six-family audit of every MSL entry point in
       the shader-retention policy each needs a revival-story check before
       deletion, not a bulk purge; `q6k_..._cached` additionally caches
       nothing despite its module doc.
-- [ ] **F22** doc/code mismatches: `LARQL_FUSED_Q6K_DOWN` names the wrong
+- [x] **F22** (fixed on fix/metal-audit-f15-f16-f22) doc/code mismatches: `LARQL_FUSED_Q6K_DOWN` names the wrong
       kernel, `LARQL_F16_ACC` co-requirement undocumented, stride32
       "not wired" doc stale, `Q4K_GU_MAX_K` test comment references a
       removed constant.

--- a/crates/larql-compute/src/cpu/ops/q4_common/quantize.rs
+++ b/crates/larql-compute/src/cpu/ops/q4_common/quantize.rs
@@ -283,6 +283,10 @@ pub fn quantize_q6_k(data: &[f32]) -> Vec<u8> {
 ///   [0..15]    8 × f16 pre-computed d*scale_j (16 bytes)
 ///   [16..31]   8 × f16 pre-computed dmin*min_j (16 bytes)
 ///   [32..159]  128 bytes nibbles (unchanged)
+/// **No Metal kernel consumes this 160-byte layout** (capability audit
+/// F15): the live `Q4_KF`-tagged shaders read standard 144-byte GGUF
+/// Q4_K blocks. This conversion survives as the CPU-side pre-baked
+/// experiment only — do not feed its output to the Metal Q4_KF path.
 pub fn q4k_to_q4kf(q4k_data: &[u8], num_rows: usize, hidden: usize) -> Vec<u8> {
     let superblocks_per_row = hidden / 256;
     let q4k_bytes_per_row = superblocks_per_row * 144;

--- a/crates/larql-compute/src/pipeline/quant_format.rs
+++ b/crates/larql-compute/src/pipeline/quant_format.rs
@@ -1,5 +1,15 @@
-/// Bytes per Q4_KF pre-baked super-block. Q4_KF keeps the 256-element
-/// Q4_K block shape but expands packed scale/min metadata for faster decode.
+/// Bytes per super-block of the EXPERIMENTAL 160-byte "pre-baked"
+/// layout that `cpu::ops::q4_common::quantize_q4_kf` produces.
+///
+/// **No Metal kernel reads this layout.** Every live `Q4_KF`-tagged
+/// kernel (`q4kf_qkv_proj`, `q4kf_proj`, `q4kf_ffn_gate_up`) hardcodes
+/// the standard 144-byte GGUF Q4_K block and differs from the `Q4_K`
+/// kernels only in its llama.cpp-exact inner loop. The capability audit
+/// (F15) found this constant feeding `packed_block_layout`, so any
+/// caller sizing a Q4_KF buffer through it disagreed with the shaders'
+/// row stride by 16 bytes per super-block. `packed_block_layout` now
+/// answers 144; this constant remains only for the CPU-side pre-baked
+/// experiment and its tests.
 pub const Q4_KF_BLOCK_BYTES: usize = 160;
 
 /// Quantization format for a weight tensor.
@@ -9,7 +19,7 @@ pub const Q4_KF_BLOCK_BYTES: usize = 160;
 pub enum QuantFormat {
     Q4_0,  // 18 bytes per 32 values (one f16 scale)
     Q4_K,  // 144 bytes per 256 values (GGUF-canonical, Ollama-compatible)
-    Q4_KF, // 160 bytes per 256 values (pre-baked half scales — fast decode)
+    Q4_KF, // 144-byte GGUF Q4_K bytes decoded by the llama.cpp-exact kernels
     Q6_K,  // 210 bytes per 256 values (6-bit with sub-block scales)
     Q8_0,  // int8 values + separate f32 scales
     BF16,  // raw bfloat16 (2 bytes per value, no quantization scales)
@@ -37,7 +47,13 @@ impl QuantFormat {
         match self {
             Self::Q4_0 => Some((ggml::Q4_0_BLOCK_ELEMS, ggml::Q4_0_BLOCK_BYTES)),
             Self::Q4_K => Some((ggml::Q4_K_BLOCK_ELEMS, ggml::Q4_K_BLOCK_BYTES)),
-            Self::Q4_KF => Some((ggml::Q4_K_BLOCK_ELEMS, Q4_KF_BLOCK_BYTES)),
+            // Q4_KF is a KERNEL-ROUTE tag over standard 144-byte GGUF
+            // Q4_K bytes, not a distinct storage layout: all three live
+            // Q4_KF shaders hardcode 144 (audit F15). The 160-byte
+            // pre-baked layout (`Q4_KF_BLOCK_BYTES`) has no kernel
+            // consumer; answering 160 here mis-sized every buffer
+            // derived through this method by 16 bytes per super-block.
+            Self::Q4_KF => Some((ggml::Q4_K_BLOCK_ELEMS, ggml::Q4_K_BLOCK_BYTES)),
             Self::Q6_K => Some((ggml::Q6_K_BLOCK_ELEMS, ggml::Q6_K_BLOCK_BYTES)),
             _ => None,
         }
@@ -331,6 +347,24 @@ mod scale_storage_tests {
         for (f, expected) in table {
             assert_eq!(f.scale_storage(), expected, "{f:?}");
         }
+    }
+
+    /// Q4_KF's packed layout is the standard 144-byte GGUF Q4_K block —
+    /// the tag selects the llama.cpp-exact kernels, not a storage
+    /// format. The 160-byte pre-baked layout (`Q4_KF_BLOCK_BYTES`) has
+    /// no kernel consumer; answering it here mis-sized every derived
+    /// buffer by 16 bytes per super-block (capability audit F15).
+    #[test]
+    fn q4_kf_packed_layout_is_gguf_q4_k() {
+        use larql_models::quant::ggml;
+        assert_eq!(
+            QuantFormat::Q4_KF.packed_block_layout(),
+            Some((ggml::Q4_K_BLOCK_ELEMS, ggml::Q4_K_BLOCK_BYTES)),
+        );
+        assert_eq!(
+            QuantFormat::Q4_KF.packed_block_layout(),
+            QuantFormat::Q4_K.packed_block_layout(),
+        );
     }
 
     /// Inline formats are exactly the block-packed ones *today*. Asserted

--- a/crates/larql-compute/src/pipeline/tests.rs
+++ b/crates/larql-compute/src/pipeline/tests.rs
@@ -146,7 +146,11 @@ fn quant_format_classifiers() {
 fn quant_format_reports_packed_matrix_bytes() {
     assert_eq!(QuantFormat::Q4_0.packed_matrix_bytes(2, 32), Some(36));
     assert_eq!(QuantFormat::Q4_K.packed_matrix_bytes(2, 256), Some(288));
-    assert_eq!(QuantFormat::Q4_KF.packed_matrix_bytes(2, 256), Some(320));
+    // Q4_KF packs identically to Q4_K (144 B/super-block): the tag
+    // selects the llama.cpp-exact kernels, not a storage layout. The
+    // previous pinned value (320 = 2 x 160) described the experimental
+    // pre-baked layout no kernel reads — capability audit F15.
+    assert_eq!(QuantFormat::Q4_KF.packed_matrix_bytes(2, 256), Some(288));
     assert_eq!(QuantFormat::Q6_K.packed_matrix_bytes(2, 256), Some(420));
     assert_eq!(QuantFormat::F16.packed_matrix_bytes(2, 256), None);
 }


### PR DESCRIPTION
Batch D of the capability-audit findings (`docs/metal-kernel-capabilities.md`).

**F15 resolved with a verdict:** the 160-byte "pre-baked" Q4_KF layout has no kernel consumer anywhere — every live Q4_KF shader reads standard 144-byte GGUF Q4_K blocks and differs only in its llama.cpp-exact inner loop. `packed_block_layout` now answers 144 (it was mis-sizing every derived buffer by 16 B/super-block), the `compare_ollama` example stops feeding 160-byte data to 144-byte kernels (its Q4_KF arm was measuring garbage), and the CPU-side pre-baked experiment carries a do-not-feed-to-Metal warning.

**F16:** `up_out`/`gate_out_scratch` sized and tail-zeroed at `inter_padded` like `act_buf` — closes the latent OOB read for `inter % 256 != 0`.

**F22:** four doc/code mismatches corrected (F16_ACC co-requirement, FUSED_Q6K_DOWN kernel identity, the never-dispatched `_cached` pipeline, stride32's live caller, the removed `Q4K_GU_MAX_K` constant).

Verification: `larql-compute-metal` (exit-code checked), `larql-compute`, `larql-inference` all green; fmt + clippy clean. One stale pinned test corrected with rationale in-line.

With this, **18 of the audit's 22 findings are fixed**; F7/F8 land with the attention feature-fallback slice, F17's blanket checks with the selectors, F21 stays a retention-gated roadmap item.