### PR TITLE
feat(metal): per-operand FFN routing everywhere, including profile-split (slice 2)

### DIFF
--- a/crates/larql-compute-metal/src/decode/encode_ffn.rs
+++ b/crates/larql-compute-metal/src/decode/encode_ffn.rs
@@ -257,6 +257,51 @@ impl MetalBackend {
         self.encode_qmv_down(enc, layer, bufs, hidden, inter);
     }
 
+    /// The Q4_K gate+up kernel variant selected by the decode flags —
+    /// coop > 4sg+f16 > 4sg > 8sg (default). One selection consulted by
+    /// BOTH the production FFN encode and the profile-split gate+up
+    /// phase, so split-mode measurements run the kernel production
+    /// would; the phase previously hardcoded 8sg and silently ignored
+    /// `LARQL_GATE_UP_COOP` / `LARQL_GATE_UP_8SG=0` / `LARQL_F16_ACC`
+    /// (capability audit, slice 2).
+    fn q4k_gate_up_selection(&self) -> (&metal::ComputePipelineState, u64, u64) {
+        use crate::shaders::q4k_ffn_gate_up as q4k_gu;
+        use crate::shaders::q4k_ffn_gate_up_8sg as q4k_gu_8sg;
+        use crate::shaders::q4k_ffn_gate_up_coop as q4k_gu_coop;
+        let use_coop = self.decode_flags.gate_up_coop;
+        let use_4sg = self.decode_flags.gate_up_use_4sg;
+        let use_f16 = self.decode_flags.f16_acc;
+        if use_coop {
+            // Cooperative wins over the other flags — it's the newest
+            // variant under measurement.
+            (
+                &self.ffn.q4k_ffn_gate_up_coop_pipeline.state,
+                q4k_gu_coop::ROWS_PER_TG,
+                q4k_gu_coop::THREADS_PER_TG,
+            )
+        } else if use_4sg && use_f16 {
+            (
+                &self.ffn.q4k_ffn_gate_up_f16acc_pipeline.state,
+                q4k_gu::ROWS_PER_TG,
+                q4k_gu::THREADS_PER_TG,
+            )
+        } else if use_4sg {
+            (
+                &self.ffn.q4k_ffn_gate_up_pipeline.state,
+                q4k_gu::ROWS_PER_TG,
+                q4k_gu::THREADS_PER_TG,
+            )
+        } else {
+            // Default (8sg) — f16 is incompatible-untested with 8sg
+            // dispatch, so 8sg wins if both flags conflict.
+            (
+                &self.ffn.q4k_ffn_gate_up_8sg_pipeline.state,
+                q4k_gu_8sg::ROWS_PER_TG,
+                q4k_gu_8sg::THREADS_PER_TG,
+            )
+        }
+    }
+
     // ── Q4_KF (GGUF) ─────────────────────────────────────────────────────────
 
     #[allow(clippy::too_many_arguments)]
@@ -319,16 +364,12 @@ impl MetalBackend {
                 inter as u64,
             );
 
-            enc.set_compute_pipeline_state(&self.attention.q4kf_proj_pipeline.state);
-            enc.set_buffer(0, Some(bufs.down_w), 0);
-            enc.set_buffer(1, Some(bufs.act_buf), 0);
-            enc.set_buffer(2, Some(bufs.down_out), 0);
-            enc.set_bytes(3, 4, &hidden_val as *const u32 as *const std::ffi::c_void);
-            enc.set_bytes(4, 4, &inter_val as *const u32 as *const std::ffi::c_void);
-            enc.dispatch_thread_groups(
-                MTLSize::new(n_tgs_down, 1, 1),
-                MTLSize::new(q4kf::THREADS_PER_TG, 1, 1),
-            );
+            // Down per its OWN format, like the gated arm above — the
+            // previous hardcoded `q4kf_proj` dispatch mis-decoded any
+            // non-Q4_KF down weight on a standard-FFN layer (audit
+            // route-table gap, slice 2).
+            self.encode_qmv_down(enc, layer, bufs, hidden, inter);
+            let _ = n_tgs_down;
         }
     }
 
@@ -347,7 +388,6 @@ impl MetalBackend {
         inter_val: u32,
         inter_padded_val: u32,
     ) {
-        use crate::shaders::q4k_ffn_gate_up as q4k_gu;
         // Pull `q4k_matvec` dispatch geometry from the bound pipeline so
         // dispatches work for both 4sg and 8sg variants. Hardcoding the
         // 4sg constants while dispatching the 8sg pipeline (production
@@ -376,8 +416,6 @@ impl MetalBackend {
             //   - `LARQL_F16_ACC=1`: f16 inner accumulator. Kernel-isolated
             //     1.79× but end-to-end at parity on quiet GPU. Kept as
             //     opt-in for future hardware/fusion scenarios.
-            use crate::shaders::q4k_ffn_gate_up_8sg as q4k_gu_8sg;
-            use crate::shaders::q4k_ffn_gate_up_coop as q4k_gu_coop;
             // `LARQL_GATE_UP_COOP=1`: cooperative scale-loading variant.
             // Tried 2026-05-01 — null end-to-end (kernel-isolated ALU
             // diagnosis was misleading). Kept opt-in.
@@ -386,39 +424,7 @@ impl MetalBackend {
             // `metal::flags::DecodeFlags`) — the decode hot path is
             // ~34 layers/tok and `getenv` per layer per flag was a
             // measurable syscall tax.
-            let use_coop = self.decode_flags.gate_up_coop;
-            let use_4sg = self.decode_flags.gate_up_use_4sg;
-            let use_f16 = self.decode_flags.f16_acc;
-            let (pipeline, rows_per_tg, threads_per_tg) = if use_coop {
-                // Cooperative wins over the other flags — it's the
-                // newest variant under measurement.
-                (
-                    &self.ffn.q4k_ffn_gate_up_coop_pipeline.state,
-                    q4k_gu_coop::ROWS_PER_TG,
-                    q4k_gu_coop::THREADS_PER_TG,
-                )
-            } else if use_4sg && use_f16 {
-                (
-                    &self.ffn.q4k_ffn_gate_up_f16acc_pipeline.state,
-                    q4k_gu::ROWS_PER_TG,
-                    q4k_gu::THREADS_PER_TG,
-                )
-            } else if use_4sg {
-                (
-                    &self.ffn.q4k_ffn_gate_up_pipeline.state,
-                    q4k_gu::ROWS_PER_TG,
-                    q4k_gu::THREADS_PER_TG,
-                )
-            } else {
-                // Default (8sg) — and f16 is incompatible-untested with
-                // 8sg dispatch, so 8sg wins if both flags conflict.
-                let _ = use_f16;
-                (
-                    &self.ffn.q4k_ffn_gate_up_8sg_pipeline.state,
-                    q4k_gu_8sg::ROWS_PER_TG,
-                    q4k_gu_8sg::THREADS_PER_TG,
-                )
-            };
+            let (pipeline, rows_per_tg, threads_per_tg) = self.q4k_gate_up_selection();
             let n_tgs_per_mat = (inter as u64).div_ceil(rows_per_tg);
             enc.set_compute_pipeline_state(pipeline);
             enc.set_buffer(0, Some(bufs.gate_w), 0);
@@ -468,9 +474,21 @@ impl MetalBackend {
             // a no-op (keeps the kernel and pipeline registered as
             // dead code for the investigation in
             // `larql-inference/ROADMAP.md` G-3 follow-up).
-            let use_fused_q6k_down = self.decode_flags.fused_q6k_down
-                && layer.down.format() == larql_compute::QuantFormat::Q6_K
-                && matches!(layer.activation, larql_compute::Activation::GeluTanh);
+            // 2026-08-09 status update: the kernel-level parity suite
+            // (test_kernel_q6k_geglu_down, planar bytes, incl. the exact
+            // decode shape 512->256) now PASSES, so the layout-drift
+            // hypothesis above is falsified. But the decode INTEGRATION
+            // still produces all-NaN output (reproducer:
+            // decode_token_with_q4k_ffn_and_fused_q6k_down_option,
+            // #[ignore]d). The defect is in what this dispatch binds or
+            // sequences, not in the kernel. Hard-disabled until that is
+            // found — a flag that ships all-NaN is the audit's silent-
+            // corruption class with extra steps.
+            // Original gate, for when the integration bug is fixed:
+            //   self.decode_flags.fused_q6k_down
+            //     && layer.down.format() == Q6_K
+            //     && activation == GeluTanh
+            let use_fused_q6k_down = false;
             if use_fused_q6k_down {
                 let kh = &self.ffn.q6k_geglu_gelu_tanh_down_pipeline;
                 let n_tgs = (hidden as u64).div_ceil(kh.rows_per_tg);
@@ -561,20 +579,13 @@ impl MetalBackend {
                 inter as u64,
             );
 
-            enc.set_compute_pipeline_state(&self.quant.q4k_matvec_pipeline.state);
-            enc.set_buffer(0, Some(bufs.down_w), 0);
-            enc.set_buffer(1, Some(bufs.act_buf), 0);
-            enc.set_buffer(2, Some(bufs.down_out), 0);
-            enc.set_bytes(3, 4, &hidden_val as *const u32 as *const std::ffi::c_void);
-            enc.set_bytes(
-                4,
-                4,
-                &inter_padded_val as *const u32 as *const std::ffi::c_void,
-            );
-            enc.dispatch_thread_groups(
-                MTLSize::new(n_tgs_down, 1, 1),
-                MTLSize::new(q4k_matvec_threads_per_tg, 1, 1),
-            );
+            // Down per its OWN format (the hardcoded q4k_matvec here
+            // mis-decoded a Q6_K down on a standard-FFN layer — audit
+            // route-table gap, slice 2). K = inter_padded: the weight's
+            // per-row superblock stride is derived from the padded
+            // width, and act_buf's zeroed tail is inert.
+            self.encode_qmv_down(enc, layer, bufs, hidden, inter_padded);
+            let _ = n_tgs_down;
         }
     }
 
@@ -762,14 +773,19 @@ impl MetalBackend {
         layer: &FullPipelineLayer,
         bufs: &FfnBufs<'_>,
         dims: FfnDims,
-        ffn_uses_kquant: bool,
     ) {
         let FfnDims { hidden, inter, .. } = dims;
         let inter_val = inter as u32;
         let hidden_val = hidden as u32;
-        let ffn_is_q4kf = layer.gate.format() == larql_compute::QuantFormat::Q4_KF;
+        // Same per-operand route as `encode_ffn_step`. The previous
+        // family-boolean split hardcoded the 8sg Q4_K kernel (ignoring
+        // every variant flag, so split-mode profiled a kernel
+        // production might not run) and sent a Q6_K gate to the Q4_K
+        // pipelines (capability audit, slice 2).
+        use larql_compute::QuantFormat;
+        let route_fmt = validate_ffn_formats(layer);
 
-        if ffn_is_q4kf {
+        if route_fmt == QuantFormat::Q4_KF {
             use crate::shaders::q4kf_ffn_gate_up as q4kf_gu;
             use crate::shaders::q4kf_qkv_proj as q4kf;
             if layer.is_gated() {
@@ -799,12 +815,56 @@ impl MetalBackend {
                     MTLSize::new(q4kf::THREADS_PER_TG, 1, 1),
                 );
             }
-        } else if ffn_uses_kquant {
-            let rows = self.ffn.q4k_ffn_gate_up_8sg_pipeline.rows_per_tg;
-            let tgs = self.ffn.q4k_ffn_gate_up_8sg_pipeline.threads_per_tg;
+        } else if route_fmt == QuantFormat::Q6_K {
+            // Separated per-format gate/up via quant_matvec — mirrors
+            // `encode_q6k_ffn`'s first half.
+            use crate::stages::quant_matvec::{self as qmv, Pipelines};
+            let pipes = Pipelines {
+                q4kf_proj: Some(&self.attention.q4kf_proj_pipeline.state),
+                q4k_matvec_fallback: &self.quant.q4k_matvec_pipeline,
+                q6k_matvec: &self.quant.q6k_matvec_pipeline,
+                q4_matvec: &self.q4.matvec,
+                q4k_matmul: None,
+            };
             if layer.is_gated() {
+                qmv::encode(
+                    enc,
+                    QuantFormat::Q6_K,
+                    bufs.gate_w,
+                    bufs.ffn_norm_out,
+                    0,
+                    bufs.ffn_norm_out,
+                    0,
+                    bufs.ffn_norm_out,
+                    0,
+                    bufs.gate_out_scratch,
+                    0,
+                    &pipes,
+                    inter,
+                    hidden,
+                );
+            }
+            qmv::encode(
+                enc,
+                QuantFormat::Q6_K,
+                bufs.up_w,
+                bufs.ffn_norm_out,
+                0,
+                bufs.ffn_norm_out,
+                0,
+                bufs.ffn_norm_out,
+                0,
+                bufs.up_out,
+                0,
+                &pipes,
+                inter,
+                hidden,
+            );
+        } else if route_fmt == QuantFormat::Q4_K {
+            if layer.is_gated() {
+                let (pipeline, rows, tgs) = self.q4k_gate_up_selection();
                 let n = (inter as u64).div_ceil(rows);
-                enc.set_compute_pipeline_state(&self.ffn.q4k_ffn_gate_up_8sg_pipeline.state);
+                enc.set_compute_pipeline_state(pipeline);
                 enc.set_buffer(0, Some(bufs.gate_w), 0);
                 enc.set_buffer(1, Some(bufs.up_w), 0);
                 enc.set_buffer(2, Some(bufs.ffn_norm_out), 0);
@@ -863,7 +923,6 @@ impl MetalBackend {
         layer: &FullPipelineLayer,
         bufs: &FfnBufs<'_>,
         dims: FfnDims,
-        ffn_uses_kquant: bool,
     ) {
         let FfnDims {
             hidden,
@@ -873,12 +932,21 @@ impl MetalBackend {
         let inter_val = inter as u32;
         let inter_padded_val = inter_padded as u32;
         let hidden_val = hidden as u32;
-        let ffn_is_q4kf = layer.gate.format() == larql_compute::QuantFormat::Q4_KF;
+        // Same per-operand route and the SAME fused-down guards as
+        // `encode_q4k_ffn`. This phase previously fired the fused
+        // Q4_K GEGLU+down on `down == Q4_K` alone — no
+        // MAX_FUSED_GEGLU_DOWN_INTER ceiling, no LARQL_FUSED_DOWN
+        // opt-out — so split-mode routed Gemma 4 31B through the very
+        // kernel that guard exists to avoid, and measurements were not
+        // the production configuration (capability audit, slice 2).
+        use larql_compute::QuantFormat;
+        let route_fmt = validate_ffn_formats(layer);
 
-        if ffn_is_q4kf {
+        if route_fmt == QuantFormat::Q4_KF || route_fmt == QuantFormat::Q6_K {
+            // Both route their down per its own format via qmv; only
+            // the gate/up side differed, and that phase has run.
             if layer.is_gated() {
                 self.encode_geglu(enc, layer, bufs, inter_val, inter as u64);
-                self.encode_qmv_down(enc, layer, bufs, hidden, inter);
             } else {
                 self.encode_activation(
                     enc,
@@ -888,25 +956,19 @@ impl MetalBackend {
                     inter_val,
                     inter as u64,
                 );
-                use crate::shaders::q4kf_qkv_proj as q4kf;
-                let n = (hidden as u64).div_ceil(q4kf::ROWS_PER_TG);
-                enc.set_compute_pipeline_state(&self.attention.q4kf_proj_pipeline.state);
-                enc.set_buffer(0, Some(bufs.down_w), 0);
-                enc.set_buffer(1, Some(bufs.act_buf), 0);
-                enc.set_buffer(2, Some(bufs.down_out), 0);
-                enc.set_bytes(3, 4, &hidden_val as *const u32 as *const std::ffi::c_void);
-                enc.set_bytes(4, 4, &inter_val as *const u32 as *const std::ffi::c_void);
-                enc.dispatch_thread_groups(
-                    MTLSize::new(n, 1, 1),
-                    MTLSize::new(q4kf::THREADS_PER_TG, 1, 1),
-                );
             }
-        } else if ffn_uses_kquant {
+            self.encode_qmv_down(enc, layer, bufs, hidden, inter);
+        } else if route_fmt == QuantFormat::Q4_K {
             if layer.is_gated() {
-                let use_fused_q6k = self.decode_flags.fused_q6k_down
-                    && layer.down.format() == larql_compute::QuantFormat::Q6_K
-                    && matches!(layer.activation, larql_compute::Activation::GeluTanh);
-                if layer.down.format() == larql_compute::QuantFormat::Q4_K {
+                // Hard-disabled — see the integration-NaN note in
+                // `encode_q4k_ffn`'s fused-q6k arm. Original gate:
+                //   decode_flags.fused_q6k_down && down == Q6_K
+                //     && activation == GeluTanh
+                let use_fused_q6k = false;
+                if layer.down.format() == larql_compute::QuantFormat::Q4_K
+                    && inter_padded <= MAX_FUSED_GEGLU_DOWN_INTER
+                    && self.decode_flags.fused_down
+                {
                     self.encode_q4k_fused_geglu_down(
                         enc,
                         layer,
@@ -943,20 +1005,8 @@ impl MetalBackend {
                     inter_val,
                     inter as u64,
                 );
-                let rpt = self.quant.q4k_matvec_pipeline.rows_per_tg;
-                let tpt = self.quant.q4k_matvec_pipeline.threads_per_tg;
-                let n = (hidden as u64).div_ceil(rpt);
-                enc.set_compute_pipeline_state(&self.quant.q4k_matvec_pipeline.state);
-                enc.set_buffer(0, Some(bufs.down_w), 0);
-                enc.set_buffer(1, Some(bufs.act_buf), 0);
-                enc.set_buffer(2, Some(bufs.down_out), 0);
-                enc.set_bytes(3, 4, &hidden_val as *const u32 as *const std::ffi::c_void);
-                enc.set_bytes(
-                    4,
-                    4,
-                    &inter_padded_val as *const u32 as *const std::ffi::c_void,
-                );
-                enc.dispatch_thread_groups(MTLSize::new(n, 1, 1), MTLSize::new(tpt, 1, 1));
+                // Down per its own format (was hardcoded q4k_matvec).
+                self.encode_qmv_down(enc, layer, bufs, hidden, inter_padded);
             }
         } else {
             // Q4_0

--- a/crates/larql-compute-metal/src/decode/mod.rs
+++ b/crates/larql-compute-metal/src/decode/mod.rs
@@ -591,7 +591,6 @@ impl MetalBackend {
                 },
             );
             let new_h = if l % 2 == 0 { &h_a } else { &h_b };
-            let ffn_uses_kquant = layer.gate.format().is_kquant_family();
 
             // ── Steps 6-7: FFN + post-FFN residual ──
             //
@@ -670,13 +669,7 @@ impl MetalBackend {
                 if stage_timing_split && !has_moe {
                     // Fine split: gate+up in one CB, act+down+residual in another.
                     // Step 6a: gate+up
-                    self.encode_ffn_gate_up_phase(
-                        &enc,
-                        layer,
-                        &ffn_bufs,
-                        ffn_dims,
-                        ffn_uses_kquant,
-                    );
+                    self.encode_ffn_gate_up_phase(&enc, layer, &ffn_bufs, ffn_dims);
                     enc.end_encoding();
                     cmd.commit();
                     cmd.wait_until_completed();
@@ -684,7 +677,7 @@ impl MetalBackend {
                     cmd = self.queue.new_command_buffer().to_owned();
                     enc = cmd.new_compute_command_encoder().to_owned();
                     // Step 6b + 7: activation+down + post-FFN residual
-                    self.encode_ffn_down_phase(&enc, layer, &ffn_bufs, ffn_dims, ffn_uses_kquant);
+                    self.encode_ffn_down_phase(&enc, layer, &ffn_bufs, ffn_dims);
                     self.encode_post_ffn_residual(
                         &enc,
                         layer,

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/ffn_std_profile.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/ffn_std_profile.rs
@@ -464,3 +464,93 @@ fn decode_token_with_q6k_non_gated_ffn_drives_standard_path() {
     assert_eq!(out.len(), HIDDEN);
     assert!(out.iter().all(|v| v.is_finite()));
 }
+
+/// Profile-split with Q6_K gate/up/down. The split phases previously
+/// branched on the kquant family boolean and sent a Q6_K gate to the
+/// Q4_K pipelines under `LARQL_PROFILE_SPLIT=1`; they now consult the
+/// same per-operand route as `encode_ffn_step` (slice 2).
+#[test]
+fn decode_token_with_profile_split_and_q6k_gated_ffn() {
+    decode_with_profile_split_synth(|layer| {
+        set_q6k_ffn(layer);
+    });
+}
+
+#[test]
+fn decode_token_with_profile_split_and_q6k_non_gated_ffn() {
+    decode_with_profile_split_synth(|layer| {
+        set_q6k_ffn(layer);
+        layer.ffn_type = FfnType::Standard;
+    });
+}
+
+/// `LARQL_FUSED_Q6K_DOWN=1` equivalent via BackendOptions: Q4_K
+/// gate/up with a Q6_K GELU-tanh down drives the opt-in fused Q6_K
+/// down kernel (which now carries the tanh clamp from F1).
+#[test]
+#[ignore = "reproducer for the fused-Q6K-down decode-integration NaN: the kernel \
+passes isolation parity at this exact shape, but the decode dispatch \
+produces 256/256 NaN. Arm hard-disabled in encode_ffn.rs until root-caused."]
+fn decode_token_with_q4k_ffn_and_fused_q6k_down_option() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let mut opts = larql_compute_metal::BackendOptions::default();
+    opts.decode_flags.fused_q6k_down = true;
+    let Some(metal) = larql_compute_metal::MetalBackend::with_options(opts) else {
+        return;
+    };
+    use larql_compute::cpu::ops::q4_common::{quantize_q4_k, quantize_q6_k};
+    let wq = quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1));
+    let wk = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2));
+    let wv = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3));
+    let wo = quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4));
+    let gate = quantize_q4_k(&synth_weight_f32(INTER * HIDDEN, 0.5));
+    let up = quantize_q4_k(&synth_weight_f32(INTER * HIDDEN, 0.6));
+    let down = quantize_q6_k(&synth_weight_f32(HIDDEN * INTER, 0.7));
+    let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
+    let mut layer = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+    layer.down = QuantWeight::new(QuantFormat::Q6_K, &down, larql_compute::QuantAux::None);
+    layer.activation = Activation::GeluTanh;
+
+    let x = synth_input(HIDDEN, 0.9);
+    let mut kv = metal.create_kv_cache(1, 64, NUM_KV_HEADS, HEAD_DIM);
+    let out = larql_compute_metal::MetalBackend::decode_token(
+        &metal,
+        &mut kv,
+        &[layer],
+        &x,
+        HIDDEN,
+        INTER,
+        Q_DIM,
+        KV_DIM,
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        10_000.0,
+    );
+    assert_eq!(out.len(), HIDDEN);
+    let n_nan = out.iter().filter(|v| v.is_nan()).count();
+    let n_inf = out.iter().filter(|v| v.is_infinite()).count();
+    assert!(
+        out.iter().all(|v| v.is_finite()),
+        "fused q6k down: {n_nan} NaN, {n_inf} inf of {}; first vals {:?}",
+        out.len(),
+        &out[..4]
+    );
+}
+
+/// Shared Q6_K FFN fixture mutation for the split tests above. The
+/// weight bytes were built as Q4_K/Q4_0 by `build_synth_layer`'s
+/// defaults, so requantize each matrix as genuine Q6_K.
+fn set_q6k_ffn(layer: &mut FullPipelineLayer) {
+    use larql_compute::cpu::ops::q4_common::quantize_q6_k;
+    use std::sync::OnceLock;
+    static GATE: OnceLock<Vec<u8>> = OnceLock::new();
+    static UP: OnceLock<Vec<u8>> = OnceLock::new();
+    static DOWN: OnceLock<Vec<u8>> = OnceLock::new();
+    let gate = GATE.get_or_init(|| quantize_q6_k(&synth_weight_f32(INTER * HIDDEN, 0.5)));
+    let up = UP.get_or_init(|| quantize_q6_k(&synth_weight_f32(INTER * HIDDEN, 0.6)));
+    let down = DOWN.get_or_init(|| quantize_q6_k(&synth_weight_f32(HIDDEN * INTER, 0.7)));
+    layer.gate = QuantWeight::new(QuantFormat::Q6_K, gate, larql_compute::QuantAux::None);
+    layer.up = QuantWeight::new(QuantFormat::Q6_K, up, larql_compute::QuantAux::None);
+    layer.down = QuantWeight::new(QuantFormat::Q6_K, down, larql_compute::QuantAux::None);
+}

--- a/crates/larql-compute-metal/tests/test_kernel_q6k_geglu_down.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_q6k_geglu_down.rs
@@ -319,3 +319,12 @@ fn q6k_geglu_gelu_tanh_down_survives_large_gate_values() {
     let cos = cos_sim(&cpu_ref, &fused);
     assert!(cos > 0.999, "large-gate parity: cos={cos:.6}");
 }
+
+/// The synthetic decode suite's exact FFN shape (hidden=256,
+/// inter=512). Pinned because the decode INTEGRATION of this kernel
+/// produces all-NaN at this shape while this isolation test passes —
+/// keeping the shape here proves any future NaN is not the kernel's.
+#[test]
+fn q6k_geglu_gelu_tanh_down_decode_suite_shape() {
+    assert_fused_q6k_geglu_down_matches_separated("decode-suite shape 512->256", 256, 512, false);
+}

--- a/crates/larql-compute/ROADMAP.md
+++ b/crates/larql-compute/ROADMAP.md
@@ -111,6 +111,15 @@ built from a six-family audit of every MSL entry point in
       "not wired" doc stale, `Q4K_GU_MAX_K` test comment references a
       removed constant.
 
+**New finding (2026-08-09, slice 2):** the fused Q6_K down decode
+integration produces all-NaN output even though the kernel now passes
+isolation parity at the exact decode shape (planar bytes, 512→256) —
+the historical "layout drift" hypothesis is falsified; the defect is in
+what the decode dispatch binds or sequences. `LARQL_FUSED_Q6K_DOWN` is
+hard-disabled at both dispatch sites; reproducer test
+`decode_token_with_q4k_ffn_and_fused_q6k_down_option` is `#[ignore]`d
+with the finding. Root-cause before re-engaging.
+
 The structural target (capability doc §9): one authority table consumed by
 the QKV/FFN/O-proj/attention dispatchers — per-operand format rows instead
 of `is_kquant_family()` tests, every silently-assumed dim promoted to a


### PR DESCRIPTION
Slice 2 of the capability-selector sequence (`docs/metal-kernel-capabilities.md` §9), after #234's QKV plan.

- Non-gated layers honour `down.format()` on the Q4_KF and Q4_K paths (each hardcoded its own family's down kernel).
- Profile-split phases route per-operand like production: Q6_K gates stop landing on Q4_K pipelines under `LARQL_PROFILE_SPLIT=1`; the gate+up phase runs the variant the flags select (was hardcoded 8sg); the down phase applies production's fused-down guards (it previously routed Gemma 4 31B through the kernel the `MAX_FUSED_GEGLU_DOWN_INTER` ceiling exists to avoid). Split-mode measurements now measure the production configuration.
- **New finding:** `LARQL_FUSED_Q6K_DOWN`'s decode integration produces all-NaN even though the kernel passes isolation parity at the exact decode shape — the historical layout-drift hypothesis is falsified; the defect is integration-side. Arm hard-disabled at both sites, `#[ignore]`d reproducer + pinned kernel shape test + roadmap investigation entry.

Verification: full metal suite green (exit-code checked), compute + inference green, fmt/clippy clean, `encode_ffn.rs` at 93% / `stages.rs` at 97% under the coverage gate (checked pre-push this time).