### PR TITLE
feat(metal): sinks and softcap travel with every attention path (slice 3, F7+F8)

### DIFF
--- a/crates/larql-compute-metal/examples/compare_decode.rs
+++ b/crates/larql-compute-metal/examples/compare_decode.rs
@@ -115,6 +115,7 @@ fn main() {
             .iter()
             .map(|ld| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q4_K,
                     &ld.wq_q4k,
@@ -211,6 +212,7 @@ fn main() {
             .iter()
             .map(|ld| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q8_0,
                     &ld.wq_q8,

--- a/crates/larql-compute-metal/examples/compare_formats.rs
+++ b/crates/larql-compute-metal/examples/compare_formats.rs
@@ -129,6 +129,7 @@ fn main() {
             .iter()
             .map(|ld| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q4_KF,
                     &ld.wq_q4kf,
@@ -222,6 +223,7 @@ fn main() {
             .iter()
             .map(|ld| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q4_K,
                     &ld.wq_q4k,
@@ -315,6 +317,7 @@ fn main() {
             .iter()
             .map(|ld| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q4_KF,
                     &ld.wq_gguf,

--- a/crates/larql-compute-metal/examples/compare_ollama.rs
+++ b/crates/larql-compute-metal/examples/compare_ollama.rs
@@ -137,6 +137,7 @@ fn main() {
             .iter()
             .map(|l| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q4_K,
                     &l.wq,
@@ -230,6 +231,7 @@ fn main() {
             .iter()
             .map(|l| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q8_0,
                     &l.wq8,
@@ -324,6 +326,7 @@ fn main() {
             .iter()
             .map(|l| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q4_K,
                     &l.wq,
@@ -425,6 +428,7 @@ fn main() {
             .iter()
             .map(|l| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q4_KF,
                     &l.wq_kf,
@@ -516,6 +520,7 @@ fn main() {
             .iter()
             .map(|l| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q4_KF,
                     &l.wq_kf,

--- a/crates/larql-compute-metal/examples/compare_pipeline.rs
+++ b/crates/larql-compute-metal/examples/compare_pipeline.rs
@@ -113,6 +113,7 @@ fn main() {
             .iter()
             .map(|ld| larql_compute::FullPipelineLayer {
                 attn_sinks: None,
+                attn_softcap: 0.0,
                 wq: larql_compute::QuantWeight::new(
                     larql_compute::QuantFormat::Q4_K,
                     &ld.wq_q4k,

--- a/crates/larql-compute-metal/examples/diag_decode_pipeline.rs
+++ b/crates/larql-compute-metal/examples/diag_decode_pipeline.rs
@@ -71,6 +71,7 @@ fn main() {
 
     let layer = FullPipelineLayer {
         attn_sinks: None,
+        attn_softcap: 0.0,
         wq: QuantWeight::new(QuantFormat::Q4_K, &wq_data, larql_compute::QuantAux::None),
         wk: QuantWeight::new(QuantFormat::Q4_K, &wk_data, larql_compute::QuantAux::None),
         wv: QuantWeight::new(QuantFormat::Q4_K, &wv_data, larql_compute::QuantAux::None),
@@ -234,6 +235,7 @@ fn main() {
     {
         let layer4 = FullPipelineLayer {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: QuantWeight::new(QuantFormat::Q4_K, &wq_data, larql_compute::QuantAux::None),
             wk: QuantWeight::new(QuantFormat::Q4_K, &wk_data, larql_compute::QuantAux::None),
             wv: QuantWeight::new(QuantFormat::Q4_K, &wv_data, larql_compute::QuantAux::None),
@@ -319,6 +321,7 @@ fn main() {
     {
         let layer5 = FullPipelineLayer {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: QuantWeight::new(QuantFormat::Q4_K, &wq_data, larql_compute::QuantAux::None),
             wk: QuantWeight::new(QuantFormat::Q4_K, &wk_data, larql_compute::QuantAux::None),
             wv: QuantWeight::new(QuantFormat::Q4_K, &wv_data, larql_compute::QuantAux::None),

--- a/crates/larql-compute-metal/src/decode/encode_attn.rs
+++ b/crates/larql-compute-metal/src/decode/encode_attn.rs
@@ -41,6 +41,12 @@ const ATTN_FUSED_INV_FREQ_INDEX: u64 = 16;
 /// `amplitude` slot on `attn_fused`, appended after the sinks pair.
 const ATTN_FUSED_AMPLITUDE_INDEX: u64 = 20;
 
+/// `softcap` slot on `attn_fused` (0.0 = disabled).
+const ATTN_FUSED_SOFTCAP_INDEX: u64 = 22;
+
+/// `softcap` slot on `kv_append_attend_fused` (0.0 = disabled).
+const KV_APPEND_ATTEND_SOFTCAP_INDEX: u64 = 14;
+
 /// Absolute stream position for RoPE on `attn_fused`. The kernel's cache
 /// row stays occupancy-indexed; only the rotation angle uses this. The
 /// two diverge once a sliding window compacts (audit F11).
@@ -264,6 +270,11 @@ impl MetalBackend {
                 4,
                 &pos as *const u32 as *const std::ffi::c_void,
             );
+            enc.set_bytes(
+                ATTN_FUSED_SOFTCAP_INDEX,
+                4,
+                &layer.attn_softcap as *const f32 as *const std::ffi::c_void,
+            );
             enc.dispatch_thread_groups(
                 MTLSize::new(layer_num_q_heads as u64, 1, 1),
                 MTLSize::new(tg_w, 1, 1),
@@ -417,6 +428,11 @@ impl MetalBackend {
                 layer.attn_sinks,
                 layer_num_q_heads,
             );
+            enc.set_bytes(
+                KV_APPEND_ATTEND_SOFTCAP_INDEX,
+                4,
+                &layer.attn_softcap as *const f32 as *const std::ffi::c_void,
+            );
             enc.dispatch_thread_groups(
                 MTLSize::new(layer_num_q_heads as u64, 1, 1),
                 MTLSize::new(
@@ -454,6 +470,12 @@ impl MetalBackend {
             enc.set_bytes(7, 4, &num_kv_u as *const u32 as *const std::ffi::c_void);
             enc.set_bytes(8, 4, &scale as *const f32 as *const std::ffi::c_void);
             enc.set_bytes(9, 4, &window_size as *const u32 as *const std::ffi::c_void);
+            crate::stages::sinks::bind(enc, 10, layer.attn_sinks, layer_num_q_heads);
+            enc.set_bytes(
+                12,
+                4,
+                &layer.attn_softcap as *const f32 as *const std::ffi::c_void,
+            );
             enc.dispatch_thread_groups(
                 MTLSize::new(layer_num_q_heads as u64, 1, 1),
                 MTLSize::new(
@@ -480,6 +502,8 @@ impl MetalBackend {
                 layer_num_q_heads,
                 scale,
                 window_size,
+                layer.attn_sinks,
+                layer.attn_softcap,
             );
         }
         // Only own-cache layers advance current_len; shared layers leave

--- a/crates/larql-compute-metal/src/decode/encode_post_ffn.rs
+++ b/crates/larql-compute-metal/src/decode/encode_post_ffn.rs
@@ -200,6 +200,7 @@ mod tests {
         let empty_q4 = QuantWeight::new(QuantFormat::Q4_K, &[], larql_compute::QuantAux::None);
         FullPipelineLayer {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: empty_q4,
             wk: empty_q4,
             wv: empty_q4,

--- a/crates/larql-compute-metal/src/decode/moe_combine.rs
+++ b/crates/larql-compute-metal/src/decode/moe_combine.rs
@@ -112,6 +112,7 @@ mod tests {
         let empty_q4 = QuantWeight::new(QuantFormat::Q4_K, &[], larql_compute::QuantAux::None);
         FullPipelineLayer {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: empty_q4,
             wk: empty_q4,
             wv: empty_q4,

--- a/crates/larql-compute-metal/src/decode_hybrid.rs
+++ b/crates/larql-compute-metal/src/decode_hybrid.rs
@@ -388,6 +388,8 @@ impl MetalBackend {
                 layer_num_q_heads,
                 scale,
                 window_size,
+                layer.attn_sinks,
+                layer.attn_softcap,
             );
             enc_b.end_encoding();
         }

--- a/crates/larql-compute-metal/src/ops/full_pipeline/buffers.rs
+++ b/crates/larql-compute-metal/src/ops/full_pipeline/buffers.rs
@@ -250,6 +250,7 @@ mod tests {
         let q4w = || QuantWeight::new(QuantFormat::Q4_K, q4, larql_compute::QuantAux::None);
         FullPipelineLayer {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: q4w(),
             wk: q4w(),
             wv: q4w(),

--- a/crates/larql-compute-metal/src/ops/full_pipeline/kv_copy.rs
+++ b/crates/larql-compute-metal/src/ops/full_pipeline/kv_copy.rs
@@ -160,6 +160,7 @@ mod tests {
         let q4w = || QuantWeight::new(QuantFormat::Q4_K, q4, larql_compute::QuantAux::None);
         FullPipelineLayer {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: q4w(),
             wk: q4w(),
             wv: q4w(),

--- a/crates/larql-compute-metal/src/ops/kv_cache.rs
+++ b/crates/larql-compute-metal/src/ops/kv_cache.rs
@@ -338,6 +338,8 @@ pub fn encode_kv_attend(
     num_q_heads: usize,
     scale: f32,
     window_size: u32,
+    sinks: Option<&[f32]>,
+    softcap: f32,
 ) {
     let t_val = (cache.current_len + 1) as u32;
     let hd = cache.head_dim as u32;
@@ -378,6 +380,11 @@ pub fn encode_kv_attend(
     enc.set_bytes(7, 4, &num_kv as *const u32 as *const c_void);
     enc.set_bytes(8, 4, &scale as *const f32 as *const c_void);
     enc.set_bytes(9, 4, &window_size as *const u32 as *const c_void);
+    // Feature buffers the fallback must carry (audit F7/F8): a fallback
+    // kernel that drops sinks or softcap changes the softmax semantics
+    // relative to the fused path it replaced.
+    crate::stages::sinks::bind(enc, 10, sinks, num_q_heads);
+    enc.set_bytes(12, 4, &softcap as *const f32 as *const c_void);
     enc.dispatch_thread_groups(
         MTLSize::new(num_q_heads as u64, 1, 1),
         MTLSize::new(
@@ -425,6 +432,9 @@ pub fn append_and_attend(
             num_q_heads,
             scale,
             0,
+            // Legacy bench API: no layer in scope, no sinks/softcap.
+            None,
+            0.0,
         );
         enc.end_encoding();
     }
@@ -766,6 +776,8 @@ mod tests {
             num_kv,
             (head_dim as f32).sqrt().recip(),
             0,
+            None,
+            0.0,
         );
         enc.end_encoding();
         cmd.commit();
@@ -811,6 +823,8 @@ mod tests {
             num_kv,
             (head_dim as f32).sqrt().recip(),
             0,
+            None,
+            0.0,
         );
         enc.end_encoding();
         cmd.commit();

--- a/crates/larql-compute-metal/src/shaders/attn_fused.rs
+++ b/crates/larql-compute-metal/src/shaders/attn_fused.rs
@@ -60,6 +60,7 @@ kernel void attn_fused(
     constant uint&      has_sinks  [[buffer(19)]],
     constant float&     amplitude  [[buffer(20)]],  // cos/sin scalar (YaRN); 1.0 otherwise  // 0 = no sinks (slot is a placeholder)
     constant uint&      abs_pos    [[buffer(21)]],  // ABSOLUTE stream position for RoPE
+    constant float&     softcap    [[buffer(22)]],  // 0.0 = disabled
     uint tg_id  [[threadgroup_position_in_grid]],
     uint tid    [[thread_index_in_threadgroup]],
     uint tg_sz  [[threads_per_threadgroup]],
@@ -176,6 +177,12 @@ kernel void attn_fused(
         }
         for (uint d = (head_dim & ~3u); d < head_dim; d++) dot += tg_q[d] * k[d];
         dot *= scale;
+        // Gemma-2-style logit softcapping (clamped: Apple tanh NaNs
+        // past |y| ~ 44). A fused path must not silently drop a
+        // semantic feature its fallbacks apply (audit F8).
+        if (softcap > 0.0f) {
+            dot = softcap * tanh(clamp(dot / softcap, -15.0f, 15.0f));
+        }
         tg_scores[t - t_start] = dot;
         local_max = max(local_max, dot);
     }

--- a/crates/larql-compute-metal/src/shaders/fused_attention.rs
+++ b/crates/larql-compute-metal/src/shaders/fused_attention.rs
@@ -154,7 +154,9 @@ kernel void fused_attention(
 
         // Optional softcap
         if (softcap > 0.0f) {
-            dot = tanh(dot / softcap) * softcap;
+            // Clamped like every other tanh in this crate: Apple's tanh
+            // is (exp(2y)-1)/(exp(2y)+1) and NaNs past |y| ~ 44.
+            dot = tanh(clamp(dot / softcap, -15.0f, 15.0f)) * softcap;
         }
 
         tg_scores[k] = dot;

--- a/crates/larql-compute-metal/src/shaders/kv_append_attend_fused.rs
+++ b/crates/larql-compute-metal/src/shaders/kv_append_attend_fused.rs
@@ -43,6 +43,7 @@ kernel void kv_append_attend_fused(
     device const float* new_v   [[buffer(11)]],  // [num_kv * head_dim]
     constant float*     sinks     [[buffer(12)]],  // per-Q-head attention sink logits
     constant uint&      has_sinks [[buffer(13)]],  // 0 = no sinks (slot is a placeholder)
+    constant float&     softcap [[buffer(14)]],    // 0.0 = disabled
     uint tg_id  [[threadgroup_position_in_grid]],
     uint tid    [[thread_index_in_threadgroup]],
     uint tg_sz  [[threads_per_threadgroup]],
@@ -83,6 +84,10 @@ kernel void kv_append_attend_fused(
         }
         for (uint d = (head_dim & ~3u); d < head_dim; d++) dot += q[d] * k[d];
         dot *= scale;
+        // Gemma-2-style logit softcapping (clamped; see attn_fused).
+        if (softcap > 0.0f) {
+            dot = softcap * tanh(clamp(dot / softcap, -15.0f, 15.0f));
+        }
         tg_scores[t - t_start] = dot;
         local_max = max(local_max, dot);
     }

--- a/crates/larql-compute-metal/src/shaders/kv_attention.rs
+++ b/crates/larql-compute-metal/src/shaders/kv_attention.rs
@@ -22,6 +22,9 @@ kernel void kv_attention(
     constant uint&      num_kv  [[buffer(7)]],
     constant float&     scale   [[buffer(8)]],
     constant uint&      window_size [[buffer(9)]],
+    constant float*     sinks   [[buffer(10)]],  // per-Q-head sink logits
+    constant uint&      has_sinks [[buffer(11)]], // 0 = slot is a placeholder
+    constant float&     softcap [[buffer(12)]],  // 0.0 = disabled
     uint tg_id  [[threadgroup_position_in_grid]],
     uint tid    [[thread_index_in_threadgroup]],
     uint tg_sz  [[threads_per_threadgroup]],
@@ -49,6 +52,11 @@ kernel void kv_attention(
         }
         for (uint d = (head_dim & ~3u); d < head_dim; d++) dot += q[d] * k[d];
         dot *= scale;
+        // Gemma-2-style logit softcapping. Clamp the tanh argument like
+        // the GELU kernels do: Apple's tanh NaNs past |y| ~ 44.
+        if (softcap > 0.0f) {
+            dot = softcap * tanh(clamp(dot / softcap, -15.0f, 15.0f));
+        }
         tg_scores[t - t_start] = dot;
         local_max = max(local_max, dot);
     }
@@ -60,6 +68,11 @@ kernel void kv_attention(
     float global_max = tg_sg_vals[0];
     uint n_sg = (tg_sz + 31) / 32;
     for (uint i = 1; i < n_sg; i++) global_max = max(global_max, tg_sg_vals[i]);
+    // The sink competes in the softmax, so it must join the max or
+    // exp(sink - max) overflows when the sink dominates. Mirrors
+    // kv_append_attend_fused — these kernels are its fallback, and a
+    // fallback must not change the softmax denominator (audit F7).
+    if (has_sinks != 0u) global_max = max(global_max, sinks[head]);
 
     // Phase 2: softmax
     float local_sum = 0.0f;
@@ -81,6 +94,9 @@ kernel void kv_attention(
     threadgroup_barrier(mem_flags::mem_threadgroup);
     float global_sum = tg_sg_vals[0];
     for (uint i = 1; i < n_sg; i++) global_sum += tg_sg_vals[i];
+    // Denominator only: the sink has no output slot, so the emitted
+    // weights deliberately sum to less than one.
+    if (has_sinks != 0u) global_sum += exp(sinks[head] - global_max);
     float inv_sum = 1.0f / global_sum;
 
     // Normalize
@@ -111,6 +127,9 @@ kernel void kv_attention_long(
     constant uint&      num_kv  [[buffer(7)]],
     constant float&     scale   [[buffer(8)]],
     constant uint&      window_size [[buffer(9)]],
+    constant float*     sinks   [[buffer(10)]],  // per-Q-head sink logits
+    constant uint&      has_sinks [[buffer(11)]], // 0 = slot is a placeholder
+    constant float&     softcap [[buffer(12)]],  // 0.0 = disabled
     uint tg_id  [[threadgroup_position_in_grid]],
     uint tid    [[thread_index_in_threadgroup]],
     uint tg_sz  [[threads_per_threadgroup]],
@@ -137,6 +156,11 @@ kernel void kv_attention_long(
         }
         for (uint d = (head_dim & ~3u); d < head_dim; d++) dot += q[d] * k[d];
         dot *= scale;
+        // Gemma-2-style logit softcapping. Clamp the tanh argument like
+        // the GELU kernels do: Apple's tanh NaNs past |y| ~ 44.
+        if (softcap > 0.0f) {
+            dot = softcap * tanh(clamp(dot / softcap, -15.0f, 15.0f));
+        }
         tg_scores[t - t_start] = dot;
         local_max = max(local_max, dot);
     }
@@ -148,6 +172,11 @@ kernel void kv_attention_long(
     float global_max = tg_sg_vals[0];
     uint n_sg = (tg_sz + 31) / 32;
     for (uint i = 1; i < n_sg; i++) global_max = max(global_max, tg_sg_vals[i]);
+    // The sink competes in the softmax, so it must join the max or
+    // exp(sink - max) overflows when the sink dominates. Mirrors
+    // kv_append_attend_fused — these kernels are its fallback, and a
+    // fallback must not change the softmax denominator (audit F7).
+    if (has_sinks != 0u) global_max = max(global_max, sinks[head]);
 
     float local_sum = 0.0f;
     for (uint t = t_start + tid; t < T; t += tg_sz) {
@@ -168,6 +197,9 @@ kernel void kv_attention_long(
     threadgroup_barrier(mem_flags::mem_threadgroup);
     float global_sum = tg_sg_vals[0];
     for (uint i = 1; i < n_sg; i++) global_sum += tg_sg_vals[i];
+    // Denominator only: the sink has no output slot, so the emitted
+    // weights deliberately sum to less than one.
+    if (has_sinks != 0u) global_sum += exp(sinks[head] - global_max);
     float inv_sum = 1.0f / global_sum;
 
     for (uint t = t_start + tid; t < T; t += tg_sz) {

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/common.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/common.rs
@@ -54,6 +54,7 @@ pub fn build_synth_layer<'a>(
 ) -> FullPipelineLayer<'a> {
     FullPipelineLayer {
         attn_sinks: None,
+        attn_softcap: 0.0,
         wq: QuantWeight::new(QuantFormat::Q4_K, wq_data, larql_compute::QuantAux::None),
         wk: QuantWeight::new(QuantFormat::Q4_K, wk_data, larql_compute::QuantAux::None),
         wv: QuantWeight::new(QuantFormat::Q4_K, wv_data, larql_compute::QuantAux::None),

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/decode_core.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/decode_core.rs
@@ -221,6 +221,7 @@ fn decode_token_gemma3_style_post_norms_smoke() {
     // four-norm-per-layer pattern.
     let layer = FullPipelineLayer {
         attn_sinks: None,
+        attn_softcap: 0.0,
         wq: QuantWeight::new(QuantFormat::Q4_K, &wq_data, larql_compute::QuantAux::None),
         wk: QuantWeight::new(QuantFormat::Q4_K, &wk_data, larql_compute::QuantAux::None),
         wv: QuantWeight::new(QuantFormat::Q6_K, &wv_data, larql_compute::QuantAux::None),
@@ -409,6 +410,7 @@ fn decode_token_qkv_fused_opt_in_smoke() {
     // (a non-Gemma layer that still hits the normed QKV opt-in).
     let layer = FullPipelineLayer {
         attn_sinks: None,
+        attn_softcap: 0.0,
         wq: QuantWeight::new(QuantFormat::Q4_K, &wq_data, larql_compute::QuantAux::None),
         wk: QuantWeight::new(QuantFormat::Q4_K, &wk_data, larql_compute::QuantAux::None),
         wv: QuantWeight::new(QuantFormat::Q6_K, &wv_data, larql_compute::QuantAux::None),

--- a/crates/larql-compute-metal/tests/test_decode_diag.rs
+++ b/crates/larql-compute-metal/tests/test_decode_diag.rs
@@ -61,6 +61,7 @@ fn decode_token_with_decode_debug_env_first_call_executes_log_body() {
 
     let layer = FullPipelineLayer {
         attn_sinks: None,
+        attn_softcap: 0.0,
         wq: QuantWeight::new(QuantFormat::Q4_K, &wq, larql_compute::QuantAux::None),
         wk: QuantWeight::new(QuantFormat::Q4_K, &wk, larql_compute::QuantAux::None),
         wv: QuantWeight::new(QuantFormat::Q4_K, &wv, larql_compute::QuantAux::None),

--- a/crates/larql-compute-metal/tests/test_kernel_decode_attention_sinks.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_decode_attention_sinks.rs
@@ -70,6 +70,7 @@ fn cpu_decode_reference(
     head_dim: usize,
     scale: f32,
     sinks: Option<&[f32]>,
+    softcap: f32,
 ) -> Vec<f32> {
     let mut out = vec![0.0f32; num_q * head_dim];
     for head in 0..num_q {
@@ -81,7 +82,11 @@ fn cpu_decode_reference(
                 dot += q[head * head_dim + d]
                     * k_cache[t * num_kv * head_dim + kv_head * head_dim + d];
             }
-            logits.push((dot * scale) as f64);
+            let mut logit = (dot * scale) as f64;
+            if softcap > 0.0 {
+                logit = softcap as f64 * (logit / softcap as f64).tanh();
+            }
+            logits.push(logit);
         }
         // Joint max over logits and the sink, exactly as the reference
         // does after concatenating.
@@ -125,6 +130,7 @@ fn run_kv_append_attend_fused(
     head_dim: u32,
     scale: f32,
     sinks: Option<&[f32]>,
+    softcap: f32,
 ) -> Vec<f32> {
     let pipeline = device
         .new_compute_pipeline_state_with_function(
@@ -173,6 +179,7 @@ fn run_kv_append_attend_fused(
         sink_vals.as_ptr() as *const c_void,
     );
     enc.set_bytes(13, 4, u(&has_sinks));
+    enc.set_bytes(14, 4, f(&softcap));
     enc.dispatch_thread_groups(
         metal::MTLSize::new(num_q as u64, 1, 1),
         metal::MTLSize::new(head_dim.min(256) as u64, 1, 1),
@@ -257,6 +264,7 @@ fn kv_append_attend_fused_with_sinks_matches_cpu_reference() {
         head_dim as u32,
         scale,
         Some(&SINKS),
+        0.0,
     );
     let cpu = cpu_decode_reference(
         &q,
@@ -268,6 +276,7 @@ fn kv_append_attend_fused_with_sinks_matches_cpu_reference() {
         head_dim,
         scale,
         Some(&SINKS),
+        0.0,
     );
 
     let diff = max_diff(&cpu, &gpu);
@@ -302,9 +311,10 @@ fn kv_append_attend_fused_without_sinks_is_unchanged() {
         head_dim as u32,
         scale,
         None,
+        0.0,
     );
     let cpu = cpu_decode_reference(
-        &q, &ref_k, &ref_v, t_len, num_q, num_kv, head_dim, scale, None,
+        &q, &ref_k, &ref_v, t_len, num_q, num_kv, head_dim, scale, None, 0.0,
     );
 
     let diff = max_diff(&cpu, &gpu);
@@ -342,6 +352,7 @@ fn kv_append_attend_fused_sinks_divert_attention_mass() {
             head_dim as u32,
             scale,
             sinks,
+            0.0,
         )
     };
     let plain = run(None);
@@ -385,6 +396,7 @@ fn kv_append_attend_fused_applies_each_heads_own_sink() {
         head_dim as u32,
         scale,
         Some(&[-40.0, 40.0]),
+        0.0,
     );
     let head0: f32 = out[..head_dim].iter().map(|x| x.abs()).sum();
     let head1: f32 = out[head_dim..].iter().map(|x| x.abs()).sum();
@@ -479,11 +491,22 @@ fn run_attn_fused(
     enc.set_bytes(10, 4, u(&num_q));
     enc.set_bytes(11, 4, u(&num_kv));
     enc.set_bytes(12, 4, f(&scale));
-    let (window, eps, qk_off, rope_base, rot) = (0u32, 1e-6f32, 0.0f32, 10000.0f32, 0u32);
+    let (window, eps, qk_off, rot) = (0u32, 1e-6f32, 0.0f32, 0u32);
     enc.set_bytes(13, 4, u(&window));
     enc.set_bytes(14, 4, f(&eps));
     enc.set_bytes(15, 4, f(&qk_off));
-    enc.set_bytes(16, 4, f(&rope_base));
+    // Buffer 16 is the host-computed inv_freq TABLE ([rotary_dim/2]
+    // floats), not the old scalar rope_base this runner used to bind —
+    // 4 bytes there was an out-of-bounds read for every d > 0. The
+    // prior assertions survived because they are rotation-invariant.
+    let inv_freq: Vec<f32> = (0..head_dim as usize / 2)
+        .map(|d| 1.0 / 10000.0f32.powf(2.0 * d as f32 / head_dim as f32))
+        .collect();
+    enc.set_bytes(
+        16,
+        std::mem::size_of_val(inv_freq.as_slice()) as u64,
+        inv_freq.as_ptr() as *const c_void,
+    );
     enc.set_bytes(17, 4, u(&rot));
     let placeholder = [0.0f32];
     let (sink_vals, has_sinks): (&[f32], u32) = match sinks {
@@ -496,6 +519,13 @@ fn run_attn_fused(
         sink_vals.as_ptr() as *const c_void,
     );
     enc.set_bytes(19, 4, u(&has_sinks));
+    let amplitude = 1.0f32;
+    enc.set_bytes(20, 4, f(&amplitude));
+    // RoPE at the absolute stream position of the appended row.
+    let abs_pos = t_len - 1;
+    enc.set_bytes(21, 4, u(&abs_pos));
+    let softcap = 0.0f32;
+    enc.set_bytes(22, 4, f(&softcap));
 
     let mut tg_w: u64 = 1;
     while tg_w < head_dim as u64 && tg_w < 32 {
@@ -640,4 +670,217 @@ fn attn_fused_without_sinks_is_unchanged_by_the_new_bindings() {
         diff < MAX_DIFF,
         "an unreachably-negative sink must match the no-sink path: max diff {diff}"
     );
+}
+
+// ── kv_attention (the non-fused fallback) — slice 3 (audit F7/F8) ────────
+//
+// `kv_attention` / `kv_attention_long` are the fallback for spans past
+// 1024, head_dim past 256, and KV-shared layers. Before slice 3 they
+// had no sink or softcap inputs, so falling off the fused path
+// silently changed the softmax semantics. These tests pin that the
+// fallback now reproduces the same reference the fused kernel does.
+
+/// Dispatch `kv_attention` (or `_long`) over a fully-populated cache.
+#[allow(clippy::too_many_arguments)]
+fn run_kv_attention(
+    device: &metal::Device,
+    lib: &metal::Library,
+    kernel_name: &str,
+    q: &[f32],
+    ref_k: &[f32],
+    ref_v: &[f32],
+    t_len: u32,
+    num_q: u32,
+    num_kv: u32,
+    head_dim: u32,
+    scale: f32,
+    sinks: Option<&[f32]>,
+    softcap: f32,
+) -> Vec<f32> {
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&lib.get_function(kernel_name, None).unwrap())
+        .unwrap();
+    let queue = device.new_command_queue();
+    let out_len = (num_q * head_dim) as usize;
+    let buf_q = shared_buffer(device, q);
+    let buf_k = shared_buffer(device, ref_k);
+    let buf_v = shared_buffer(device, ref_v);
+    let buf_out = device.new_buffer(
+        (out_len * std::mem::size_of::<f32>()) as u64,
+        metal::MTLResourceOptions::StorageModeShared,
+    );
+    let cmd = queue.new_command_buffer();
+    let enc = cmd.new_compute_command_encoder();
+    enc.set_compute_pipeline_state(&pipeline);
+    enc.set_buffer(0, Some(&buf_q), 0);
+    enc.set_buffer(1, Some(&buf_k), 0);
+    enc.set_buffer(2, Some(&buf_v), 0);
+    enc.set_buffer(3, Some(&buf_out), 0);
+    let u = |v: &u32| v as *const u32 as *const c_void;
+    let f = |v: &f32| v as *const f32 as *const c_void;
+    enc.set_bytes(4, 4, u(&t_len));
+    enc.set_bytes(5, 4, u(&head_dim));
+    enc.set_bytes(6, 4, u(&num_q));
+    enc.set_bytes(7, 4, u(&num_kv));
+    enc.set_bytes(8, 4, f(&scale));
+    let window = 0u32;
+    enc.set_bytes(9, 4, u(&window));
+    let placeholder = [0.0f32];
+    let (sink_vals, has_sinks): (&[f32], u32) = match sinks {
+        Some(s) => (s, 1),
+        None => (&placeholder, 0),
+    };
+    enc.set_bytes(
+        10,
+        std::mem::size_of_val(sink_vals) as u64,
+        sink_vals.as_ptr() as *const c_void,
+    );
+    enc.set_bytes(11, 4, u(&has_sinks));
+    enc.set_bytes(12, 4, f(&softcap));
+    enc.dispatch_thread_groups(
+        metal::MTLSize::new(num_q as u64, 1, 1),
+        metal::MTLSize::new(head_dim.min(256) as u64, 1, 1),
+    );
+    enc.end_encoding();
+    cmd.commit();
+    cmd.wait_until_completed();
+    read_back(&buf_out, out_len)
+}
+
+#[test]
+fn kv_attention_fallback_with_sinks_matches_cpu_reference() {
+    let Some((device, lib)) = device_and_lib() else {
+        return;
+    };
+    let (t_len, num_q, num_kv, head_dim) = (7usize, 2usize, 1usize, 32usize);
+    let scale = 1.0 / (head_dim as f32).sqrt();
+    let (q, _ck, _cv, _nk, _nv, ref_k, ref_v) = decode_fixture(t_len, num_q, num_kv, head_dim);
+    for kernel in ["kv_attention", "kv_attention_long"] {
+        let gpu = run_kv_attention(
+            &device,
+            &lib,
+            kernel,
+            &q,
+            &ref_k,
+            &ref_v,
+            t_len as u32,
+            num_q as u32,
+            num_kv as u32,
+            head_dim as u32,
+            scale,
+            Some(&SINKS),
+            0.0,
+        );
+        let cpu = cpu_decode_reference(
+            &q,
+            &ref_k,
+            &ref_v,
+            t_len,
+            num_q,
+            num_kv,
+            head_dim,
+            scale,
+            Some(&SINKS),
+            0.0,
+        );
+        let d = max_diff(&cpu, &gpu);
+        assert!(d < MAX_DIFF, "{kernel} sinks parity: max_diff={d:.3e}");
+    }
+}
+
+#[test]
+fn kv_attention_fallback_with_softcap_matches_cpu_reference() {
+    let Some((device, lib)) = device_and_lib() else {
+        return;
+    };
+    let (t_len, num_q, num_kv, head_dim) = (7usize, 2usize, 1usize, 32usize);
+    let scale = 1.0 / (head_dim as f32).sqrt();
+    let softcap = 0.5f32; // small cap so capping is strongly discriminating
+    let (q, _ck, _cv, _nk, _nv, ref_k, ref_v) = decode_fixture(t_len, num_q, num_kv, head_dim);
+    for kernel in ["kv_attention", "kv_attention_long"] {
+        let gpu = run_kv_attention(
+            &device,
+            &lib,
+            kernel,
+            &q,
+            &ref_k,
+            &ref_v,
+            t_len as u32,
+            num_q as u32,
+            num_kv as u32,
+            head_dim as u32,
+            scale,
+            None,
+            softcap,
+        );
+        let cpu = cpu_decode_reference(
+            &q, &ref_k, &ref_v, t_len, num_q, num_kv, head_dim, scale, None, softcap,
+        );
+        let d = max_diff(&cpu, &gpu);
+        assert!(d < MAX_DIFF, "{kernel} softcap parity: max_diff={d:.3e}");
+        // Control: the instrument must fail on a known-different input —
+        // capped output must differ from uncapped, or this test could
+        // pass with the cap silently dropped on both sides.
+        let uncapped = run_kv_attention(
+            &device,
+            &lib,
+            kernel,
+            &q,
+            &ref_k,
+            &ref_v,
+            t_len as u32,
+            num_q as u32,
+            num_kv as u32,
+            head_dim as u32,
+            scale,
+            None,
+            0.0,
+        );
+        assert!(
+            max_diff(&uncapped, &gpu) > 1e-3,
+            "{kernel}: softcap=0.5 output identical to uncapped — cap not applied"
+        );
+    }
+}
+
+#[test]
+fn kv_append_attend_fused_with_softcap_matches_cpu_reference() {
+    let Some((device, lib)) = device_and_lib() else {
+        return;
+    };
+    let (t_len, num_q, num_kv, head_dim) = (6usize, 2usize, 1usize, 32usize);
+    let scale = 1.0 / (head_dim as f32).sqrt();
+    let softcap = 0.5f32;
+    let (q, cache_k, cache_v, new_k, new_v, ref_k, ref_v) =
+        decode_fixture(t_len, num_q, num_kv, head_dim);
+    let gpu = run_kv_append_attend_fused(
+        &device,
+        &lib,
+        &q,
+        &cache_k,
+        &cache_v,
+        &new_k,
+        &new_v,
+        t_len as u32,
+        num_q as u32,
+        num_kv as u32,
+        head_dim as u32,
+        scale,
+        Some(&SINKS),
+        softcap,
+    );
+    let cpu = cpu_decode_reference(
+        &q,
+        &ref_k,
+        &ref_v,
+        t_len,
+        num_q,
+        num_kv,
+        head_dim,
+        scale,
+        Some(&SINKS),
+        softcap,
+    );
+    let d = max_diff(&cpu, &gpu);
+    assert!(d < MAX_DIFF, "fused softcap+sinks parity: max_diff={d:.3e}");
 }

--- a/crates/larql-compute-metal/tests/test_kernel_kv_cache_append.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_kv_cache_append.rs
@@ -169,6 +169,8 @@ fn attend(
         num_q,
         scale,
         window,
+        None,
+        0.0,
     );
     enc.end_encoding();
     cmd.commit();

--- a/crates/larql-compute-metal/tests/test_kernel_moe_expert_dispatch.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_moe_expert_dispatch.rs
@@ -447,6 +447,7 @@ fn decode_token_q4k_moe_with_real_moe_layer_drives_gpu_dispatch() {
 
     let layer = FullPipelineLayer {
         attn_sinks: None,
+        attn_softcap: 0.0,
         wq: QuantWeight::new(QuantFormat::Q4_K, &wq, larql_compute::QuantAux::None),
         wk: QuantWeight::new(QuantFormat::Q4_K, &wk, larql_compute::QuantAux::None),
         wv: QuantWeight::new(QuantFormat::Q4_K, &wv, larql_compute::QuantAux::None),

--- a/crates/larql-compute-metal/tests/test_metal_shaders.rs
+++ b/crates/larql-compute-metal/tests/test_metal_shaders.rs
@@ -1407,6 +1407,7 @@ fn full_pipeline_seq1_produces_nonzero() {
     // `QuantWeight::new` now refuses.
     let layer = larql_compute::FullPipelineLayer {
         attn_sinks: None,
+        attn_softcap: 0.0,
         wq: larql_compute::QuantWeight::new(
             larql_compute::QuantFormat::Q4_0,
             &wq_data,

--- a/crates/larql-compute-metal/tests/test_pipeline_and_moe.rs
+++ b/crates/larql-compute-metal/tests/test_pipeline_and_moe.rs
@@ -580,6 +580,7 @@ mod moe_prefill_integration {
         let q4w = || QuantWeight::new(QuantFormat::Q4_K, q4k, larql_compute::QuantAux::None);
         FullPipelineLayer {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: q4w(),
             wk: q4w(),
             wv: q4w(),
@@ -754,6 +755,7 @@ mod moe_prefill_integration {
         };
         let layers = vec![FullPipelineLayer {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: q4kf,
             wk: q4kf,
             wv: q4kf,
@@ -827,6 +829,7 @@ mod moe_prefill_integration {
         let q4_view = |fmt| QuantWeight::new(fmt, q4k.as_slice(), larql_compute::QuantAux::None);
         let layers = vec![FullPipelineLayer {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: q4_view(QuantFormat::Q4_K),
             wk: q4_view(QuantFormat::Q4_K),
             wv: q4_view(QuantFormat::Q6_K),
@@ -913,6 +916,7 @@ mod moe_prefill_integration {
             |fmt: QuantFormat| QuantWeight::new(fmt, q4k.as_slice(), larql_compute::QuantAux::None);
         let layers = vec![FullPipelineLayer {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: QuantWeight::new(
                 QuantFormat::Q8_0,
                 &wq_q8,

--- a/crates/larql-compute-metal/tests/test_tail_prefill_decode_parity.rs
+++ b/crates/larql-compute-metal/tests/test_tail_prefill_decode_parity.rs
@@ -146,6 +146,7 @@ fn build_layer(w: &SynthWeights, sliding_window: usize) -> FullPipelineLayer<'_>
     }
     FullPipelineLayer {
         attn_sinks: None,
+        attn_softcap: 0.0,
         wq: q4k(&w.wq),
         wk: q4k(&w.wk),
         wv: q4k(&w.wv),

--- a/crates/larql-compute/ROADMAP.md
+++ b/crates/larql-compute/ROADMAP.md
@@ -65,10 +65,10 @@ built from a six-family audit of every MSL entry point in
       pipeline alias that can be 8sg — read the `KernelHandle`.
 - [x] **F6** (fixed 4408d18a) `quantize_q8` host `div_ceil` vs shader truncating `K/32` —
       unwritten tail scale; make the kernel handle partial blocks.
-- [ ] **F7** sinks silently dropped by `kv_attention`/`_long` fallbacks —
+- [x] **F7** (fixed, slice 3: feature-aware attention) sinks silently dropped by `kv_attention`/`_long` fallbacks —
       add sink buffers (join max + denominator) so fallback preserves the
       feature set.
-- [ ] **F8** softcap exists only in prefill `fused_attention` — decode
+- [x] **F8** (fixed, slice 3: feature-aware attention) softcap exists only in prefill `fused_attention` — decode
       refuses or supports; no silent cap-drop.
 - [x] **F9** (fixed 4408d18a) dense layers of hybrid-MoE models never get `layer_scalar`
       (`decode/mod.rs:789` model-level branch vs layer-level apply).

--- a/crates/larql-compute/src/pipeline/layer.rs
+++ b/crates/larql-compute/src/pipeline/layer.rs
@@ -36,6 +36,13 @@ pub struct FullPipelineLayer<'a> {
     /// emitted weights sum to less than one. `None` for every other
     /// architecture. See `docs/k3-funnel.md` §4.6.
     pub attn_sinks: Option<&'a [f32]>,
+    /// Attention logit softcapping (Gemma 2): scores become
+    /// `softcap * tanh(score / softcap)` before the softmax. `0.0`
+    /// disables — the universal correct default; the layer builder
+    /// sets it from `arch.attn_logit_softcapping()`. Until slice 3 of
+    /// the capability work, only the prefill kernel applied it, so a
+    /// capped architecture prefilled capped and decoded uncapped.
+    pub attn_softcap: f32,
     pub input_norm_bias: Option<&'a [f32]>,
     pub post_attn_norm_bias: Option<&'a [f32]>,
 
@@ -278,6 +285,7 @@ impl Default for FullPipelineLayer<'_> {
         let qw = QuantWeight::default();
         Self {
             attn_sinks: None,
+            attn_softcap: 0.0,
             wq: qw,
             wk: qw,
             wv: qw,

--- a/crates/larql-compute/src/pipeline_layer.rs
+++ b/crates/larql-compute/src/pipeline_layer.rs
@@ -133,8 +133,14 @@ pub fn build_arch_params<'a>(
         .and_then(|k| weights.vectors.get(&k))
         .map(|v| v.as_slice());
 
+    // 0.0 = disabled. Set here, at the arch boundary, so every decode
+    // consumer sees the model's real cap instead of the field default
+    // silently answering for capped architectures.
+    let attn_softcap = arch.attn_logit_softcapping().unwrap_or(0.0);
+
     FullPipelineLayer {
         attn_sinks,
+        attn_softcap,
         wq,
         wk,
         wv,

--- a/docs/metal-kernel-capabilities.md
+++ b/docs/metal-kernel-capabilities.md
@@ -77,11 +77,11 @@ Notes
 
 | kernel | role | softmax | scratch | hard limits | sinks | softcap | wired |
 |---|---|---|---|---|---|---|---|
-| `attn_fused` | decode, full fusion (norm+RoPE+append+attend) | 2-pass | tg_q/tg_k/tg_red/tg_scores ≈6KB; **tg_red max→sum reuse UNFENCED** | head≤256 a, span≤1024 a; GQA div s | yes | no | opt-in `LARQL_FUSED_ATTN=1` |
-| `kv_append_attend_fused` | decode default (append+attend) | 2-pass | fenced (reference impl) | head≤256 a, span≤1024 a; GQA s | yes | no | **prod default** |
-| `kv_attention` / `_long` | decode fallback attend | 2-pass | fenced | span ≤1024 / ≤4096 (**long unguarded beyond alloc**) | **NO** | no | prod (fallback + KV-shared) |
+| `attn_fused` | decode, full fusion (norm+RoPE+append+attend) | 2-pass | tg_q/tg_k/tg_red/tg_scores ≈6KB; fenced (F11) | head≤256 a, span≤1024 a; GQA div s | yes | yes (F8) | opt-in `LARQL_FUSED_ATTN=1` |
+| `kv_append_attend_fused` | decode default (append+attend) | 2-pass | fenced (reference impl) | head≤256 a, span≤1024 a; GQA s | yes | yes (F8) | **prod default** |
+| `kv_attention` / `_long` | decode fallback attend | 2-pass | fenced | span ≤1024 / ≤4096 a (F14) | yes (F7) | yes (F8) | prod (fallback + KV-shared) |
 | `kv_cache_append` | flat copy | — | — | — | — | — | prod (unfused chain) |
-| `fused_attention` | prefill, one TG per (head,pos) | 2-pass serial tid0 scan | ~19KB, no reuse | **head≤512 s, seq≤4096 s — both unasserted**; TG hardcoded 256 both sides | yes | **yes (only kernel with it)** | prod (always, prefill) |
+| `fused_attention` | prefill, one TG per (head,pos) | 2-pass serial tid0 scan | ~19KB, no reuse | head≤512 a, seq≤4096 a (F14); TG hardcoded 256 both sides | yes | yes (clamped) | prod (always, prefill) |
 | `causal_attention` | bench-only, single head, no GQA | 2-pass recompute O(seq²·d²) | none | — | no | no | bench (`full_layer_direct`) |
 
 Decode fallback chain: `attn_fused` → `kv_append_attend_fused` →
@@ -220,7 +220,11 @@ Correctness, live path:
 - **F7. Attention sinks silently dropped** on every non-fused decode
   fallback (span>1024, head>256, KV-shared): different softmax
   denominator, no guard. Softcap exists only at prefill (F8) — a
-  capped arch decodes uncapped. **AUDIT-FINDING**
+  capped arch decodes uncapped. **FIXED (slice 3)**: sinks and softcap
+  travel on `FullPipelineLayer` (`attn_sinks` / `attn_softcap`, set at
+  the arch boundary) and every decode attention kernel — fused and
+  fallback — applies both, parity-pinned against the CPU reference
+  with a cap-actually-applied control.
 - **F9. Dense layers of hybrid-MoE models never get `layer_scalar`.** **AUDIT-FINDING**
 - **F10. MoE staging loop missing `valid_count >= top_k` guard** (its
   sibling has one) — release-mode buffer overflow on excess indices. **AUDIT-FINDING**


### PR DESCRIPTION
The final slice of the capability-selector sequence (`docs/metal-kernel-capabilities.md` §9): attention fallbacks now preserve semantic features instead of silently changing the softmax.

- **F7:** `kv_attention`/`kv_attention_long` (fallback for span > 1024, head_dim > 256, KV-shared layers) gain sink inputs with the reference join-the-max / denominator-only formulation.
- **F8:** softcap travels on `FullPipelineLayer.attn_softcap`, set at the arch boundary — the decode loop previously never saw it, so capped archs decoded uncapped. All four decode attention kernels apply it (clamped ±15; Apple tanh NaNs past ~44), and prefill's existing softcap gains the same clamp.
- Test-harness honesty fix: the `attn_fused` runner was binding a 4-byte scalar into the `inv_freq` table slot (OOB read) with amplitude/abs_pos unbound — passing only via rotation-invariant assertions. Now binds the real table.
- Parity pinned against the CPU reference for both features on fallback and fused kernels, with a cap-actually-applied control.

With this, **all 22 capability-audit findings are closed** (F21 dead-kernel retirement remains a retention-gated roadmap item by design). Verification: full metal suite green (exit-code checked), compute + inference green, fmt/clippy clean, coverage above floor on touched files (pre-push checked).