### PR TITLE
docs: capability-audit close-out + the long-riding kv engine-registration verdict

### DIFF
--- a/crates/larql-compute/ROADMAP.md
+++ b/crates/larql-compute/ROADMAP.md
@@ -41,6 +41,35 @@ from them are still load-bearing and worth restating:
 
 ## P0: Metal kernel capability audit findings (2026-08-09)
 
+**PROGRAMME CLOSED 2026-08-09** — all 22 findings resolved across PRs
+#231 (audit doc + F1–F4), #233 (guard batch), #234 (slice 1: one QKV
+plan for decode/prefill/hybrid), #235 (F15 verdict: Q4_KF is a
+kernel-route tag over 144-byte GGUF blocks; F16; F22), #236 (slice 2:
+per-operand FFN everywhere incl. profile-split), #237 (slice 3: sinks
+and softcap travel with every attention path). Only F17's per-kernel
+tail and F21 (retention-gated) remain open below.
+
+Performance: **neutral** — canonical baseline in
+[`CHANGELOG.md`](CHANGELOG.md) 2026-08-09 (10 paired alternating
+rounds on gemma4-26b-a4b: median paired Δ +0.54% decode p50, GPU
+fraction unchanged at 95.2%).
+
+Three kernels found broken-since-written along the way:
+`q4k_ffn_gate_up_coop` (parity-mixed scale staging, cos 0.52 vs CPU —
+fixed), the fused-Q6K-down **decode integration** (all-NaN while the
+kernel passes isolation parity at the exact shape — hard-disabled,
+`#[ignore]`d reproducer, open thread below), and the `attn_fused`
+test runner (scalar bound into the inv_freq table slot — fixed).
+
+**Open threads out of the programme:** the fused-Q6K-down integration
+NaN root-cause; `norm_type` honoured only at the decode input norm
+(LayerNorm archs silently get RMS for post-attn/pre-FFN/post-FFN and
+all of prefill — no guard); `MAX_FUSED_GEGLU_DOWN_INTER` possibly
+removable now the tanh clamp landed (untested); the bench's
+EOS-vs-GPU-fallback ambiguity (instrument note below); production MoE
+still routes on CPU with per-expert down loops (perf, deliberately
+sequenced after dispatch authority).
+
 Source of truth: [`docs/metal-kernel-capabilities.md`](../../docs/metal-kernel-capabilities.md)
 — the Phase B per-kernel capability table (formats, reduction unit, legal
 dims asserted-vs-assumed, aux buffers, dispatch geometry, fallback chain)
@@ -92,7 +121,12 @@ built from a six-family audit of every MSL entry point in
 - [x] **F16** (fixed on fix/metal-audit-f15-f16-f22) `gate_out`/`up_out` sized `inter` while fused Q4_K down
       reads `inter_padded`; unify the `inter` vs `inter_padded` K
       convention across the five down dispatch variants.
-- [ ] **F17** K-alignment asserted in 2 of ~30 quant kernels; GQA
+- [ ] **F17** (narrowed by the selector slices: `plan_qkv` asserts
+      hidden%256 at the fused f32 QKV dispatch, GQA divisibility is
+      asserted in `stages/attention.rs`, and the K≤8192 staging
+      ceilings are asserted at every production site — remaining scope
+      is the per-kernel K%256/%32 truncation checks in the matvec/FFN
+      dispatchers) K-alignment asserted in 2 of ~30 quant kernels; GQA
       divisibility asserted nowhere — add dispatch-time checks.
 - [x] **F18** (fixed 4408d18a) `residual_multiplier == 1.0` guard missing on
       `post_attn_residual_norm_store` selection and the PLE reuse of

--- a/crates/larql-kv/ROADMAP.md
+++ b/crates/larql-kv/ROADMAP.md
@@ -508,6 +508,41 @@ risk/leverage; the first is a live correctness bug.
    `KvCacheKind` duplicate. The larger refactors (DecodeOptions threading, the
    engine-walk collapse, the kernel-fn table) are scoped follow-ups.
 
+   **INVESTIGATED 2026-06-19 — this item is over-scoped; most sub-tasks are NOT
+   clean wins.** Three angles checked against the actual code:
+   - **`KvCacheKind` delete — entangled, low value.** `EngineKind::from_name`
+     collapses `standard` and `markov-bounded` to the *same* `Standard{window}`,
+     so it can't recover the distinction the legacy flag needs to apply
+     `--context-window` (which is sliding-only). Routing `--kv-cache` straight
+     through `from_name` silently breaks that semantic. And `KvCacheKind` is a
+     *frozen* 3-variant legacy flag — new engines go through `--engine`, so it
+     never grows per-engine. Not the registration burden it was billed as.
+   - **`SKIP_MOE` fold — touches a contract.** The unprefixed `SKIP_MOE` (and
+     `MOE_TOP_K`/`MOE_NO_SPLIT`) are *intentional* grid-tooling names on
+     `GridRuntimeConfig`, arguably a different flag from compute's
+     `LARQL_SKIP_MOE` (grid-bypass vs local-decode-skip). Not a trivial alias.
+   - **`AnyEngine` → enum_dispatch — doesn't fit, and it's already fine.**
+     `AnyEngine` is a 2-variant *family* enum over *two different traits*
+     (`KvEngine` / `RetrievalEngine`), with intentionally **asymmetric**
+     forwarders (`prefill` passes `ffn` for `Kv` only; `supports_multimodal` is
+     `Kv`-only; `prefill_from_hidden` panics on `Retrieval`). `enum_dispatch`
+     needs one shared trait + uniform signatures, so it can't apply, and a macro
+     would only obscure the explicit 2-arm matches. It grows per *family* (rare),
+     not per *engine* — so it's not the boilerplate driver.
+
+   **Reality:** the only genuine per-engine cost is the `lib.rs` registration
+   (`EngineKind` variant + `from_name` + `display_name` + `supported_names` +
+   `build_with_profiling`), and even that resists a clean `register_engine!`
+   macro because each engine parses *different* params (`window`/`bits`/`layer`/
+   `coef`/`top_k`) and constructs a different type. A data-driven table could
+   drive `display_name`/`supported_names` (and kill
+   `engine_kind_supported_names_covers_every_variant`), but `from_name` +
+   `build_with_profiling` stay hand-written. **Recommendation: DE-PRIORITIZE.**
+   The `LayerExecutor`/`decode_step_walk` collapse (the 8-method override
+   cross-product) is the one part with real leverage left, but it's a scoped
+   refactor, not a quick win. Prefer quant Step 2 (timed with BitNet) or the P0
+   perf frontier (W1-GPU Metal matvecs) for higher return.
+
 ### P1 — MoE-aware KV engines (C1) — new 2026-05-28
 
 The KvEngine layer is **dense-only today**: `do_prefill` / `do_decode_step`


### PR DESCRIPTION
Two docs commits:

1. **Capability-audit programme close-out** in the larql-compute roadmap: all 22 findings resolved (#231–#237), performance-neutral per the canonical baseline, the three broken-since-written kernels recorded, F17 narrowed to its per-kernel tail, open threads listed.
2. **The larql-kv engine-registration investigation note** (dated 2026-06-19) that has ridden the working tree uncommitted ever since: verdict is DE-PRIORITIZE with the reasoning per sub-item.