### PR TITLE
ci(quality): stop masking cargo-mutants baseline failures, add a macOS mutants pass for larql-compute-metal

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -185,33 +185,65 @@ jobs:
         run: buf build --output /dev/null
 
   mutants:
-    name: cargo-mutants (informational)
-    runs-on: ubuntu-latest
+    name: cargo-mutants${{ matrix.label }} (informational)
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     # PR-only: --in-diff needs a base to diff against, and a full-workspace
     # mutation run is many hours of compute.
     if: github.event_name == 'pull_request'
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      # Same shape as `msrv` above, and for the same underlying reason:
+      # larql-compute-metal "compiles to an empty crate on non-macOS
+      # hosts" (its own doc comment) — every line inside its
+      # `#[cfg(target_os = "macos")]` modules is structurally invisible to
+      # a ubuntu runner, for every PR, forever. The macos-14 leg, scoped
+      # to `-p larql-compute-metal`, is the only way this workspace's
+      # mutation testing ever sees that code at all.
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: ""
+            package_args: ""
+            diff_paths: "."
+            openblas: true
+          - os: macos-14
+            label: " · larql-compute-metal"
+            package_args: "-p larql-compute-metal"
+            diff_paths: "crates/larql-compute-metal"
+            openblas: false
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
+      # Computed before any install so an empty diff (e.g. a PR that
+      # never touches crates/larql-compute-metal, on the macOS leg) skips
+      # the toolchain/cargo-mutants install entirely — macOS runner
+      # minutes cost roughly 10x a Linux minute, and most PRs will not
+      # touch this specific crate.
+      - name: Compute PR diff
+        id: diff
+        run: |
+          git diff "origin/${{ github.base_ref }}...HEAD" -- ${{ matrix.diff_paths }} > /tmp/pr.diff
+          lines=$(wc -l < /tmp/pr.diff)
+          echo "diff is $lines lines"
+          echo "has_changes=$([ "$lines" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
       - name: Install stable Rust
+        if: steps.diff.outputs.has_changes == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-mutants
+        if: steps.diff.outputs.has_changes == 'true'
         uses: taiki-e/install-action@cargo-mutants
 
       - name: Install OpenBLAS
+        if: steps.diff.outputs.has_changes == 'true' && matrix.openblas
         run: |
           sudo apt-get update
           sudo apt-get install -y libopenblas-dev pkg-config
-
-      - name: Compute PR diff
-        run: |
-          git diff "origin/${{ github.base_ref }}...HEAD" > /tmp/pr.diff
-          echo "diff is $(wc -l < /tmp/pr.diff) lines"
 
       # This job is a signal, not a gate, and it is capped twice over:
       # `--in-diff` restricts mutants to lines the PR touched, and
@@ -223,125 +255,32 @@ jobs:
       # `--no-shuffle` at least makes the mutants it did get through a
       # deterministic prefix rather than a random sample, and the report
       # upload runs `if: always()` so partial results survive.
+      #
+      # Exit-status interpretation lives in scripts/check_mutants_exit_status.sh
+      # — shared by both matrix legs so they can't drift out of sync. See
+      # that script for why exit 4 gets its own, louder treatment: this
+      # exact job hit it (841, then 1317 candidate mutants, zero ever run)
+      # across two pushes while moe_zero_copy.rs broke the ubuntu build
+      # (chrishayuk/larql#244), and still showed a plain green
+      # "cargo-mutants (informational) success" in the PR checks tab.
       - name: Mutation-test the diff
+        if: steps.diff.outputs.has_changes == 'true'
         run: |
           set +e
-          cargo mutants --in-diff /tmp/pr.diff --timeout 120 --no-shuffle
+          cargo mutants ${{ matrix.package_args }} --in-diff /tmp/pr.diff --timeout 120 --no-shuffle
           status=$?
           echo "cargo-mutants exit status: $status"
-
-          # Summarise from the per-outcome text files rather than
-          # outcomes.json — these filenames are cargo-mutants' stable
-          # surface, and one line per mutant is what a reviewer wants in
-          # the log anyway.
-          echo "--- mutation summary ---"
-          for f in caught missed timeout unviable; do
-            path="mutants.out/$f.txt"
-            if [ -f "$path" ]; then
-              printf '%5d  %s\n' "$(wc -l < "$path")" "$f"
-            fi
-          done
-
-          if [ -s mutants.out/missed.txt ]; then
-            echo
-            echo "Mutants that survived — the tests did not notice these edits:"
-            cat mutants.out/missed.txt
-          fi
-
-          # Exit 4 means the UNMUTATED baseline itself failed to build or
-          # test, before cargo-mutants ever tried a mutation — see
-          # https://mutants.rs/exit-codes.html. That is a fundamentally
-          # different, more serious result than "0 caught/0 missed", and
-          # the two must not be allowed to look identical: this exact job
-          # hit exit 4 (841, then 1317 candidate mutants, zero ever run)
-          # across two pushes while `moe_zero_copy.rs` broke the ubuntu
-          # build (chrishayuk/larql#244), and both runs still showed a
-          # plain green "cargo-mutants (informational) success" in the PR
-          # checks tab — the blanket `exit 0` below swallowed a real
-          # workspace build break, not an absence of mutants.
-          if [ "$status" -eq 4 ]; then
-            echo "::warning::cargo-mutants baseline build/test failed before any mutant ran (exit 4) — this is NOT a clean mutation-testing pass, the workspace baseline itself is broken. See the build log above."
-            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-              {
-                echo "### :warning: cargo-mutants baseline failed (exit 4)"
-                echo
-                echo "The unmutated baseline failed to build or test — **zero mutants were tested**. Do not read this job's green check as \"no mutants in this diff\"; the run is incomplete, not clean."
-              } >> "$GITHUB_STEP_SUMMARY"
-            fi
-          elif [ "$status" -ge 3 ]; then
-            echo "::warning::cargo-mutants exited $status (timeout / diff-parse / internal error, see mutants.rs/exit-codes.html) — treat this run as incomplete, not clean."
-          fi
+          bash scripts/check_mutants_exit_status.sh "$status"
           exit 0
+
+      - name: No changes in scope
+        if: steps.diff.outputs.has_changes == 'false'
+        run: echo "No changes under '${{ matrix.diff_paths }}' — skipping mutation testing for this leg."
 
       - name: Upload mutants report
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: mutants-report
-          path: mutants.out/
-          if-no-files-found: ignore
-
-  mutants-macos:
-    name: cargo-mutants · larql-compute-metal (informational)
-    runs-on: macos-14
-    timeout-minutes: 45
-    # Same reasoning as `mutants` above, but on macos-14 and scoped to
-    # larql-compute-metal specifically: that crate's own doc comment says
-    # it "compiles to an empty crate on non-macOS hosts" — every line
-    # inside its `#[cfg(target_os = "macos")]` modules is structurally
-    # invisible to the ubuntu `mutants` job above, for every PR, forever.
-    # This job is the only way this workspace's mutation testing ever
-    # sees that code at all.
-    if: github.event_name == 'pull_request'
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-mutants
-        uses: taiki-e/install-action@cargo-mutants
-
-      - name: Compute PR diff (larql-compute-metal only)
-        run: |
-          git diff "origin/${{ github.base_ref }}...HEAD" -- crates/larql-compute-metal > /tmp/pr.diff
-          echo "diff is $(wc -l < /tmp/pr.diff) lines"
-
-      - name: Mutation-test the diff
-        run: |
-          set +e
-          cargo mutants -p larql-compute-metal --in-diff /tmp/pr.diff --timeout 120 --no-shuffle
-          status=$?
-          echo "cargo-mutants exit status: $status"
-
-          echo "--- mutation summary ---"
-          for f in caught missed timeout unviable; do
-            path="mutants.out/$f.txt"
-            if [ -f "$path" ]; then
-              printf '%5d  %s\n' "$(wc -l < "$path")" "$f"
-            fi
-          done
-
-          if [ -s mutants.out/missed.txt ]; then
-            echo
-            echo "Mutants that survived — the tests did not notice these edits:"
-            cat mutants.out/missed.txt
-          fi
-
-          if [ "$status" -eq 4 ]; then
-            echo "::warning::cargo-mutants baseline build/test failed before any mutant ran (exit 4) on macos-14 — larql-compute-metal itself is broken, not just untested. See the build log above."
-          elif [ "$status" -ge 3 ]; then
-            echo "::warning::cargo-mutants exited $status (timeout / diff-parse / internal error, see mutants.rs/exit-codes.html) — treat this run as incomplete, not clean."
-          fi
-          exit 0
-
-      - name: Upload mutants report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: mutants-report-macos
+          name: mutants-report-${{ matrix.os }}
           path: mutants.out/
           if-no-files-found: ignore

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -227,7 +227,8 @@ jobs:
         run: |
           set +e
           cargo mutants --in-diff /tmp/pr.diff --timeout 120 --no-shuffle
-          echo "cargo-mutants exit status: $?"
+          status=$?
+          echo "cargo-mutants exit status: $status"
 
           # Summarise from the per-outcome text files rather than
           # outcomes.json — these filenames are cargo-mutants' stable
@@ -246,6 +247,30 @@ jobs:
             echo "Mutants that survived — the tests did not notice these edits:"
             cat mutants.out/missed.txt
           fi
+
+          # Exit 4 means the UNMUTATED baseline itself failed to build or
+          # test, before cargo-mutants ever tried a mutation — see
+          # https://mutants.rs/exit-codes.html. That is a fundamentally
+          # different, more serious result than "0 caught/0 missed", and
+          # the two must not be allowed to look identical: this exact job
+          # hit exit 4 (841, then 1317 candidate mutants, zero ever run)
+          # across two pushes while `moe_zero_copy.rs` broke the ubuntu
+          # build (chrishayuk/larql#244), and both runs still showed a
+          # plain green "cargo-mutants (informational) success" in the PR
+          # checks tab — the blanket `exit 0` below swallowed a real
+          # workspace build break, not an absence of mutants.
+          if [ "$status" -eq 4 ]; then
+            echo "::warning::cargo-mutants baseline build/test failed before any mutant ran (exit 4) — this is NOT a clean mutation-testing pass, the workspace baseline itself is broken. See the build log above."
+            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+              {
+                echo "### :warning: cargo-mutants baseline failed (exit 4)"
+                echo
+                echo "The unmutated baseline failed to build or test — **zero mutants were tested**. Do not read this job's green check as \"no mutants in this diff\"; the run is incomplete, not clean."
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          elif [ "$status" -ge 3 ]; then
+            echo "::warning::cargo-mutants exited $status (timeout / diff-parse / internal error, see mutants.rs/exit-codes.html) — treat this run as incomplete, not clean."
+          fi
           exit 0
 
       - name: Upload mutants report
@@ -253,5 +278,70 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: mutants-report
+          path: mutants.out/
+          if-no-files-found: ignore
+
+  mutants-macos:
+    name: cargo-mutants · larql-compute-metal (informational)
+    runs-on: macos-14
+    timeout-minutes: 45
+    # Same reasoning as `mutants` above, but on macos-14 and scoped to
+    # larql-compute-metal specifically: that crate's own doc comment says
+    # it "compiles to an empty crate on non-macOS hosts" — every line
+    # inside its `#[cfg(target_os = "macos")]` modules is structurally
+    # invisible to the ubuntu `mutants` job above, for every PR, forever.
+    # This job is the only way this workspace's mutation testing ever
+    # sees that code at all.
+    if: github.event_name == 'pull_request'
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@cargo-mutants
+
+      - name: Compute PR diff (larql-compute-metal only)
+        run: |
+          git diff "origin/${{ github.base_ref }}...HEAD" -- crates/larql-compute-metal > /tmp/pr.diff
+          echo "diff is $(wc -l < /tmp/pr.diff) lines"
+
+      - name: Mutation-test the diff
+        run: |
+          set +e
+          cargo mutants -p larql-compute-metal --in-diff /tmp/pr.diff --timeout 120 --no-shuffle
+          status=$?
+          echo "cargo-mutants exit status: $status"
+
+          echo "--- mutation summary ---"
+          for f in caught missed timeout unviable; do
+            path="mutants.out/$f.txt"
+            if [ -f "$path" ]; then
+              printf '%5d  %s\n' "$(wc -l < "$path")" "$f"
+            fi
+          done
+
+          if [ -s mutants.out/missed.txt ]; then
+            echo
+            echo "Mutants that survived — the tests did not notice these edits:"
+            cat mutants.out/missed.txt
+          fi
+
+          if [ "$status" -eq 4 ]; then
+            echo "::warning::cargo-mutants baseline build/test failed before any mutant ran (exit 4) on macos-14 — larql-compute-metal itself is broken, not just untested. See the build log above."
+          elif [ "$status" -ge 3 ]; then
+            echo "::warning::cargo-mutants exited $status (timeout / diff-parse / internal error, see mutants.rs/exit-codes.html) — treat this run as incomplete, not clean."
+          fi
+          exit 0
+
+      - name: Upload mutants report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutants-report-macos
           path: mutants.out/
           if-no-files-found: ignore

--- a/scripts/check_mutants_exit_status.sh
+++ b/scripts/check_mutants_exit_status.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Interpret a `cargo mutants` exit status and report the outcome.
+#
+# Usage: check_mutants_exit_status.sh <exit-status>
+#
+# Exit codes (https://mutants.rs/exit-codes.html):
+#   0  - every viable mutant was caught
+#   2  - some mutants were not covered by tests
+#   3  - some tests timed out
+#   4  - the baseline itself already fails/hangs — NO mutants were tested
+#   5/6 - the --in-diff diff didn't apply / wasn't a valid diff
+#   70 - internal error
+#
+# Called from the `mutants` job's "Mutation-test the diff" step in
+# quality.yml, once per matrix leg (ubuntu-latest, macos-14) — this is the
+# one place both legs interpret cargo-mutants' outcome, so the two never
+# drift out of sync the way inlined copies would.
+set -euo pipefail
+
+status="$1"
+
+echo "--- mutation summary ---"
+for f in caught missed timeout unviable; do
+  path="mutants.out/$f.txt"
+  if [ -f "$path" ]; then
+    printf '%5d  %s\n' "$(wc -l < "$path")" "$f"
+  fi
+done
+
+if [ -s mutants.out/missed.txt ]; then
+  echo
+  echo "Mutants that survived — the tests did not notice these edits:"
+  cat mutants.out/missed.txt
+fi
+
+# Exit 4 means the UNMUTATED baseline itself failed to build or test,
+# before cargo-mutants ever tried a mutation. That is a fundamentally
+# different, more serious result than "0 caught/0 missed", and the two
+# must not be allowed to look identical: this exact job hit exit 4 (841,
+# then 1317 candidate mutants, zero ever run) across two pushes while
+# moe_zero_copy.rs broke the ubuntu build (chrishayuk/larql#244), and both
+# runs still showed a plain green "cargo-mutants (informational) success"
+# in the PR checks tab — a blanket `exit 0` swallowed a real workspace
+# build break, not an absence of mutants.
+if [ "$status" -eq 4 ]; then
+  echo "::warning::cargo-mutants baseline build/test failed before any mutant ran (exit 4) — this is NOT a clean mutation-testing pass, the workspace baseline itself is broken. See the build log above."
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "### :warning: cargo-mutants baseline failed (exit 4)"
+      echo
+      echo "The unmutated baseline failed to build or test — **zero mutants were tested**. Do not read this job's green check as \"no mutants in this diff\"; the run is incomplete, not clean."
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+elif [ "$status" -ge 3 ]; then
+  echo "::warning::cargo-mutants exited $status (timeout / diff-parse / internal error, see mutants.rs/exit-codes.html) — treat this run as incomplete, not clean."
+fi


### PR DESCRIPTION
## Summary

Found while diagnosing why #244's coverage-policy gate was failing (unrelated at first glance, but the trail led straight back to this workflow):

- **The `mutants` job's baseline build silently failed** across two pushes on #241 (`feat/k3-r1-p5-moe-bias-gate-policy`, commits `3ed9623f` and `a07cf870f6`) — `moe_zero_copy.rs` wasn't cfg-gated to macOS yet (that's exactly what #244 fixes) and broke the whole-workspace build on `ubuntu-latest`. `cargo-mutants` exited **4** — ["baseline tests are already failing... no mutations were tested"](https://mutants.rs/exit-codes.html) — after finding 841 and then 1317 candidate mutants that were **never run**. Because the step is `continue-on-error: true` with its own `set +e; ...; exit 0`, both runs still showed a plain green **"cargo-mutants (informational) success"** in the PR checks tab — indistinguishable from an actual clean pass. Logs: [run 31341919447](https://github.com/chrishayuk/larql/actions/runs/31341919447/job/93317000812), [run 31342657933](https://github.com/chrishayuk/larql/actions/runs/31342657933/job/93318879078).

- **Structural blind spot, separate from the masking bug**: `larql-compute-metal` "compiles to an empty crate on non-macOS hosts" (its own doc comment) — every line inside its `#[cfg(target_os = "macos")]` modules is invisible to the ubuntu-only `mutants` job, for every PR, forever, by construction. That's exactly the crate currently failing the coverage-policy gate on #244.

## Changes

1. **`mutants`**: capture the real exit code; treat `4` (baseline failed) and `>=3` (timeout/diff-parse/internal error) as a distinct, visibly-flagged outcome (`::warning::` annotation + `$GITHUB_STEP_SUMMARY`) instead of silently `exit 0`-ing over it. Still fully non-blocking — `continue-on-error: true` is unchanged, this is still informational, just no longer misleading.
2. **New `mutants-macos`** job: same `--in-diff` pattern, scoped to `-p larql-compute-metal` on `macos-14`, so PRs touching Metal-specific code get *some* real mutation signal instead of a permanent no-op.

## Cross-repo PRs

- #244 — the PR whose coverage-gate failure led to this investigation. It now also carries direct unit tests for the specific `moe_zero_copy.rs` / `decode/moe_interleave.rs` code paths that this masked baseline could never have caught regardless (they're macOS-only, so the *old* ubuntu `mutants` job was structurally blind to them even when it wasn't outright broken).

## Test plan

- [x] YAML re-parsed with `yaml.safe_load` — valid structure, both jobs present.
- [x] Every new/changed `run:` block checked with `bash -n` — no syntax errors.
- [ ] Could not execute `cargo-mutants` itself locally (this environment has no macOS/Metal toolchain and cargo-mutants doesn't support cross-compilation) — relying on this repo's own CI to exercise both jobs for real on this PR.