### PR TITLE
Native MXFP4 experts served end to end — 68.3 → 77.2 tok/s

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,12 +680,21 @@ Dense and full-precision MoE models support all operations (DESCRIBE, WALK, INFE
 
 **GPT-OSS-20B is served end to end (2026-08-10).** `larql run
 gpt-oss-20b-q4k.vindex` generates coherent harmony-format output on CPU
-(~60 ms/token) and on Metal at **16.7 ms/token (59.8 tok/s)** with the
-identical greedy trajectory — see the [Pure MoE
-benchmark](#pure-moe-gpt-oss-20b-q6_k-m3-max) and
+(~60 ms/token) and on Metal with the identical greedy trajectory — see
+the [Pure MoE benchmark](#pure-moe-gpt-oss-20b-q6_k-m3-max) and
 [`docs/k3-funnel.md`](docs/k3-funnel.md) §4.11. The experts serve from a
 lossless MXFP4→Q6_K transcode; sliding-window + YaRN attention, per-layer
 sinks, and all four projection biases are applied on both backends.
+
+**Native MXFP4 experts are served end to end (2026-08-14).** `larql run
+<vindex> --routed-from <container> --metal` (with `LARQL_GPU_ROUTE=1`)
+composes the Q6_K spine with a VINDEX3 container's native MXFP4 expert
+banks — payloads, paired e8m0 scale streams, layout and format all owned
+by the container, admission complete-or-refuse with tamper-tested
+negative controls. Same machine, same session, paired: Q6_K **68.3
+tok/s**, native MXFP4 **77.2 tok/s** (12.95 ms/token) through the
+GPU-resident route (one command buffer per token, zero route-dependent
+host work).
 
 **GPT-OSS attention sinks (2026-07-29).** GPT-OSS attention uses a learned per-head *sink* logit that competes in the softmax and is then discarded, so attention weights over real positions deliberately sum to less than one. Until 2026-07-29 larql neither extracted nor applied it — along with all four projection biases — so 5 of 11 attention tensors per layer were silently dropped and the forward pass was systematically wrong. Both are now extracted and applied on the CPU and Metal paths, with numerical parity tests against the reference implementation. Details and the measured sink magnitudes are in [`docs/k3-funnel.md`](docs/k3-funnel.md) §4.6.
 
@@ -838,13 +847,21 @@ every rung of this ladder (2026-08-10, `docs/k3-funnel.md` §4.11):
 | 22.7 | 44.0 | **grouped expert kernels** — all selected experts in one 2-D dispatch (η 0.64→0.90) |
 | 22.6 | — | **fused attention** (no-QK-norm + QKV biases in `attn_fused`): attention GPU 8→3.3 ms, wall unmoved — the sync structure was the term |
 | 16.7 | **59.8** | **merged command buffers** — GPU MoE combine; a layer's experts + the next layer's attention share one CB (one wait/layer) |
+| 14.6 | 68.3 | **GPU-resident routing** (`LARQL_GPU_ROUTE=1`) — router + top-k + expert dispatch as GPU dataflow; **one command buffer per token**, witness counters prove zero route-dependent host work |
+| 13.4 | 74.6 | **native MXFP4 expert banks** (`--routed-from` a VINDEX3 container) — 4.25 bpw experts replace the 6.56 bpw Q6_K transcode; expert reads drop 1 959 → 1 269 MB/token |
+| 12.95 | **77.2** | **vectorised MXFP4 kernel** (`uint4` group loads; arm `a2`, the default) — the three rows above are one paired same-session A/B/A ladder (2026-08-14) |
 
 CPU decode on the same vindex: ~60 ms/token (15-17 tok/s). Comparison
-framing: native-MXFP4 engines (oMLX, ~4.25 bpw experts) report ~85-90 tok/s
-on this class of machine at 1k-4k context — LARQL is moving ~1.54× the expert
-bytes, so 59.8 tok/s is ≈92 tok/s byte-normalised. The remaining budget is
-~11.5 ms MoE (bandwidth), ~3.3 ms attention, ~2 ms sync residue; the
-MXFP4-native path (shaders already in-tree) is the open experiment.
+framing: native-MXFP4 engines (oMLX, ~4.25 bpw experts) report ~83-90 tok/s
+on this class of machine at 1k-4k context. With the native path served,
+the comparison is apples-to-apples: **77.2 vs ~83** is a ~0.9 ms/token gap,
+fully attributed — ~1.09 ms of the lm_head stage is Q4_K matvec at the
+bandwidth ceiling (irreducible as stored), ~0.5 ms is the command-buffer
+boundary between the decode submission and the lm_head submission (the
+open experiment: fold final norm → lm_head → top-K into the decode CB).
+Kernel-level attribution for the MXFP4 rungs: measured grouped-kernel
+bandwidth predicts the expert-read delta within 0.1 ms of the e2e number,
+so nothing is hiding in integration.
 
 ### Load-bearing environment flags (serving & measurement)
 
@@ -857,6 +874,8 @@ flag state. The ones that change what a measured number means:
 | Flag | Default | Effect |
 |---|---|---|
 | `LARQL_SKIP_MOE=1` | off | Bypass MoE entirely (the ceiling-arm flag above) — local AND grid paths |
+| `LARQL_GPU_ROUTE=1` | off | GPU-resident MoE routing (one CB/token). Off, decode falls back to the legacy CPU-routed path — a healthy-looking run at ~2/3 the speed, so any recorded MoE number must state this flag |
+| `LARQL_MXFP4_ARM=<a\|a2\|b\|c\|d>` | `a2` | MXFP4 grouped-expert kernel arm. `a2` (vectorised split, exact) is the default and demotes itself to `a` per layer bank when payload offsets are not 16-byte aligned — loudly, never silently |
 | `LARQL_Q4K_DIRECT_ATTN` / `_ATTN_INT8` / `_LM_HEAD` / `_DIRECT_FFN` / `_Q4K_ASM` / `_SPIN_POOL` | **on** (`=0` opts out) | CPU decode fast-path stages; A/B against the f32 path |
 | `LARQL_COMPUTE_CONCURRENCY=N` | auto (physical cores) | Expert-server batch compute parallelism (`layer_batch`) — load-bearing for tier throughput |
 | `LARQL_DISABLE_Q8K_WIRE=1` | off | Fall back from the Q8K predispatch wire to f32/f16 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1593,11 +1593,61 @@ CB-window sum before optimising a kernel.
 
 | # | Item | Crate | Status |
 |---|---|---|---|
-| P5-F1 | **Native-MXFP4 expert execution** — the apples-to-apples experiment. Shaders `mxfp4_matvec` + `mxfp4_grouped_experts` already exist; the work is the store path (serve MXFP4 bytes without the Q6_K transcode) + wiring them into the zero-copy/grouped dispatch. First-order budget from the measured profile: MoE 11.5 ms / 1.54 ≈ 7.5 + 3.3 attention + ~2 residue ≈ **~78 tok/s** before any tuning — the ~85-90 reference falls out of the remaining milliseconds, not a miracle. Run it as *going past* the baseline, not reaching it. | larql-compute-metal, larql-vindex | open |
-| P5-F2 | **GPU routing + device-side offset tables** — kill the remaining 24 per-layer waits (~2 ms). Router matvec (32×2880) + policy top-k as a kernel writing the weights/offsets buffers the grouped kernels ALREADY read from device memory (their offset tables were designed for this — "K3b … without a signature change"). Gets decode to one command buffer per token. Policy scope: start with GPT-OSS's `top_k_then_softmax`; others keep the CPU route. | larql-compute-metal | open |
+| P5-F1 | **Native-MXFP4 expert execution — DONE (2026-08-14).** Served composed: `--routed-from` a VINDEX3 container carrying the checkpoint's own MXFP4 payload + paired e8m0 streams; expert-bank authority override is generic (no format branch in the plumbing). Paired same-session ladder: Q6_K 68.3 → MXFP4 74.6 → vectorised kernel **77.2 tok/s**. The first-order ~78 budget was honest: the ~2.6 ms byte-projection assumed equal kernel η, and the measured MXFP4 η deficit (skeleton, not decode — fixed for ~0.46 ms by `uint4` loads) accounts for the rest. See "Native MXFP4 served" below. | larql-compute-metal, larql-vindex | **done** |
+| P5-F2 | **GPU routing + device-side offset tables — DONE (2026-08-13, PR #249).** Router + top-k + descriptor gather as GPU dataflow; one command buffer per token; route-witness counters (host_resolves / bias_copies / weight_binds / offset_binds) pinned at zero by gates and printed by the composed serve. Opt-in via `LARQL_GPU_ROUTE=1`. 59.8 → 67.5 tok/s at landing. | larql-compute-metal | **done** |
 | P5-F3 | **`predict_kquant_metal` panics on pure MoE** ("ffn Q4K slices missing for layer") — the max-tokens-1 predict path is a separate dense-assuming forward; either route it through the MoE-aware decode or refuse with the typed capability error. | larql-inference | open |
 | P5-F4 | **`metal_decode_synthetic` parallel-run flake** — pre-existing (clean-tree reproducible, ~2/5 parallel runs, victim varies, prefill NaN; single-threaded always green; CI blind — runners have no Metal device). Cross-test interaction under concurrent GPU load, mechanism unidentified; suspect list starts at pooled-buffer recycling vs in-flight command buffers under parallel backends. Until fixed, local red on this suite means: re-run single-threaded before diagnosing. | larql-compute-metal | open |
 | P5-F5 | **GB-style bits/token scoring of the served vindex** — `shannon score` still can't load vindexes (raw-model only), so the serve path's quality gate is greedy-trajectory parity, not measured bits/token (§4.6.8's scorer gap, still open). | larql-cli, larql-inference | open |
+
+---
+
+### Native MXFP4 served end to end — 77.2 tok/s, every remaining millisecond named (2026-08-14)
+
+Branch `feat/moe-g4b3-region-registration` (commits `ba7418b9`,
+`1f0a5909`, `e9af233d`). Three results, one paired same-session A/B/A
+ladder on GPT-OSS-20B / M3 Max (warmup 16, n 256, long prompt; battery,
+idle — an AC-protocol repeat is owed for the books):
+
+| ms/token | tok/s | What changed |
+|---:|---:|---|
+| 14.63 | 68.3 | Q6_K control through the GPU route (reproduces the recorded 67.5) |
+| 13.41 | 74.6 | **native MXFP4 expert banks** — `--routed-from` composes a VINDEX3 container's payload + paired e8m0 streams over the Q6_K spine; expert reads 1 959 → 1 269 MB/token |
+| 12.95 | **77.2** | **vectorised split kernel** (`mxfp4g_split_lut16_vec`, arm `a2`, now default) — `uint4` group loads replace 16 single-byte loads; oracle-exact; 16-byte-alignment precondition checked per bank with loud scalar demotion |
+
+**What each step proved, and what it didn't:**
+
+- **G4b.3 (serve seam).** VINDEX3 segments are now mmapped (page-aligned
+  by construction) and registered with the Metal buffer cache beside the
+  spine's packed mmaps. Fired evidence, all in one run: 24 layers
+  overridden as MXFP4/SplitE8M0, `GPU_ROUTE_LAYERS = 24 × forwards`
+  remainder 0, all four route-witness counters zero, cmd_bufs/token 1,
+  output byte-identical to the legacy arm. Five tamper controls (wrong
+  declared format / missing scale pair / short scale pair / payload one
+  group short → refuse; untampered + the real 9.5 GB container → admit)
+  — composed open now derives paired scale-partner sizes from the
+  container's declared format, so moving byte authority did not weaken
+  validation. Trap worth recording: the GPU route is opt-in
+  (`LARQL_GPU_ROUTE=1`); unset, the run falls back healthy-looking at
+  cmd_bufs=25.
+- **G5 attribution.** Measured grouped-kernel bandwidth at production
+  geometry predicts the expert-read delta within ~0.1 ms of e2e — no
+  integration tax; the old −2.6 ms projection had assumed equal η.
+  Instrument caveat, learned the honest way: isolated tournament η at
+  17–35 MB working sets is SLC-confounded (arm-A down η read
+  0.36/0.57/0.65 across three runs); within-run ordering is stable, the
+  paired e2e numbers are the claim-bearers.
+- **TOKEN-B1 rung 1 (lm_head).** `q4k_matvec_topk` fuses the Q4_K
+  matvec with the partial top-K reduction in one submission (8 KB back
+  instead of ~800 KB + a 201K CPU scan). e2e-neutral — readback was
+  never the cost — but it pinned the stage: **~1.09 ms is Q4_K matvec
+  at the bandwidth ceiling; ~0.5 ms is the CB boundary/host round trip.**
+
+**Open next (in order):**
+
+| # | Item | Crate | Status |
+|---|---|---|---|
+| B1-2 | **Fold final norm → lm_head → top-K into the decode CB** — single wait per token, partials-only readback; the measured ~0.5 ms boundary is the prize (77.2 → ~80; MLX ≈ 83 sits ~0.9 ms away in total). Acceptance: token parity, fired-path witness, no hidden readback before lm_head, then the paired bench. | larql-compute-metal, larql-inference | open |
+| K1-2 | **Cold-fixture kernel instrument** — rotate expert banks ≫ SLC (the `bench_mxfp4_dequant` discipline) so isolated MXFP4 η is claim-bearing; then ask whether `a2` leaves more on the table at the down shape. | larql-compute-metal | open |
 
 ---
 

--- a/crates/larql-cli/src/commands/primary/bench/args.rs
+++ b/crates/larql-cli/src/commands/primary/bench/args.rs
@@ -123,6 +123,13 @@ pub struct BenchArgs {
     #[arg(long, value_name = "SHARDS")]
     pub moe_shards: Option<String>,
 
+    /// Serve the routed expert banks from a VINDEX3 container, exactly as
+    /// `larql run --routed-from` composes them. Everything else — the
+    /// prompt, the instrument, the spine — is identical to the plain
+    /// bench, so a run without this flag is the controlled comparison.
+    #[arg(long, value_name = "DIR")]
+    pub routed_from: Option<String>,
+
     /// Dispatch strategy for --moe-shards.
     ///   streaming  (default) — one round-trip per layer per token.
     ///   batch      — all layers in one round-trip per token (approximate).

--- a/crates/larql-cli/src/commands/primary/bench/local_runtime.rs
+++ b/crates/larql-cli/src/commands/primary/bench/local_runtime.rs
@@ -69,21 +69,52 @@ pub(super) fn run_larql(
 
     let cached_layers = CachedLayerGraph::from_residuals(Vec::new());
 
-    // Pre-warm: one generate call to allocate the KV cache and populate the
-    // Metal buffer caches. The prefill timer would otherwise include this
-    // one-time allocation cost.
-    if metal {
-        let num_layers = weights.num_layers;
-        let _ = generate(
-            &mut weights,
+    // Composed bench: the routed container replaces the expert-bank
+    // authority and nothing else, exactly as `larql run --routed-from`.
+    // Opened before any timer so composition refusals cannot read as a
+    // slow prefill.
+    let routed = args
+        .routed_from
+        .as_deref()
+        .map(|dir| {
+            larql_inference::ffn::ContainerRoutedBackend::open(
+                std::path::Path::new(dir),
+                &weights,
+                true,
+            )
+        })
+        .transpose()
+        .map_err(|e| format!("--routed-from refused: {e}"))?;
+    let num_layers = weights.num_layers;
+    let generate_n = |weights: &mut larql_models::ModelWeights, max_tokens: usize| match &routed {
+        Some(routed) => larql_inference::layer_graph::generate_routed(
+            weights,
             &tokenizer,
             &token_ids,
-            1,
+            max_tokens,
             &index,
             &*backend,
             &cached_layers,
             0..num_layers,
-        );
+            routed,
+        ),
+        None => generate(
+            weights,
+            &tokenizer,
+            &token_ids,
+            max_tokens,
+            &index,
+            &*backend,
+            &cached_layers,
+            0..num_layers,
+        ),
+    };
+
+    // Pre-warm: one generate call to allocate the KV cache and populate the
+    // Metal buffer caches. The prefill timer would otherwise include this
+    // one-time allocation cost.
+    if metal {
+        let _ = generate_n(&mut weights, 1);
     }
 
     // NOTE: `--profile` enables engine-side stage timers
@@ -97,18 +128,8 @@ pub(super) fn run_larql(
     // masked the actual W10 deltas. Users who specifically want the
     // GPU-stage breakdown set `LARQL_PROFILE_SPLIT=1` explicitly.
     let max_tokens = args.warmup + args.tokens;
-    let num_layers = weights.num_layers;
     let t0 = Instant::now();
-    let result = generate(
-        &mut weights,
-        &tokenizer,
-        &token_ids,
-        max_tokens,
-        &index,
-        &*backend,
-        &cached_layers,
-        0..num_layers,
-    );
+    let result = generate_n(&mut weights, max_tokens);
     let wall_ms = t0.elapsed().as_secs_f64() * 1000.0;
 
     if args.verbose {

--- a/crates/larql-cli/src/commands/primary/run_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd.rs
@@ -1036,6 +1036,14 @@ fn run_with_routed_container(
         let cached_layers =
             larql_inference::layer_graph::CachedLayerGraph::from_residuals(Vec::new());
         let num_layers = weights.num_layers;
+        // Fired evidence for the composed serve: witness counters must not
+        // move (no route-dependent host work) while the GPU-dataflow route
+        // fires on every routed layer of every decoded token.
+        use larql_compute_metal::route_witness;
+        use std::sync::atomic::Ordering;
+        let witness_before = route_witness::snapshot();
+        let route_layers_before = route_witness::GPU_ROUTE_LAYERS.load(Ordering::Relaxed);
+        let legacy_waits_before = route_witness::WAIT_MOE_ROUTE_LEGACY.load(Ordering::Relaxed);
         let result = larql_inference::layer_graph::generate_routed(
             &mut weights,
             &tokenizer,
@@ -1046,6 +1054,26 @@ fn run_with_routed_container(
             &cached_layers,
             0..num_layers,
             &routed,
+        );
+        let witness = witness_before.delta(&route_witness::snapshot());
+        let route_layers =
+            route_witness::GPU_ROUTE_LAYERS.load(Ordering::Relaxed) - route_layers_before;
+        let legacy_waits =
+            route_witness::WAIT_MOE_ROUTE_LEGACY.load(Ordering::Relaxed) - legacy_waits_before;
+        // Every forwarded position (prefill and decode alike) must route
+        // all of its MoE layers on the GPU, so the honest statement is the
+        // layers-per-forward quotient, not a per-decoded-token average.
+        eprintln!(
+            "[routed-metal] witness: gpu_route_layers={route_layers} \
+             (= {num_layers} layers x {} forwards, remainder {}), \
+             legacy_waits={legacy_waits}, host_resolves={}, bias_copies={}, \
+             weight_binds={}, offset_binds={}",
+            route_layers / num_layers as u64,
+            route_layers % num_layers as u64,
+            witness.host_resolves,
+            witness.bias_copies,
+            witness.weight_binds,
+            witness.offset_binds,
         );
         // Normalise to the CPU arm's (token, id) shape; the id is unused
         // downstream, and the GPU result carries probabilities instead.

--- a/crates/larql-compute-metal/examples/bench_moe_expert_format_split.rs
+++ b/crates/larql-compute-metal/examples/bench_moe_expert_format_split.rs
@@ -84,53 +84,66 @@ fn main() {
 
     let mut q6k_token_ms = 0.0;
     let mut mxfp4_token_ms = 0.0;
+    let mut mxfp4_vec_token_ms = 0.0;
     for s in &stages {
         let (_ungrouped, q6k_gbs) =
             kernel_profile::profile_grouped_experts(s.n, s.k, TOP_K, BATCH, WARMUP, ITERS);
         let arms = mxfp4_layout::race(s.n, s.k, TOP_K, BATCH, WARMUP, ITERS);
-        let split = &arms[0]; // arm A: split / LUT16 — the production pipeline
+        // Arm A (scalar split) and arm A2 (vectorised split) — the
+        // production pipeline is A2 with A as the alignment fallback.
+        let split = &arms[0];
+        let split_vec = &arms[1];
         assert!(
-            split.name.contains("split"),
-            "arm order changed; refusing to report the wrong kernel: {}",
-            split.name
+            split.name.contains("split") && split_vec.name.contains("vec"),
+            "arm order changed; refusing to report the wrong kernel: {} / {}",
+            split.name,
+            split_vec.name
         );
 
         let stage_bytes =
             |bpw: f64| weights_per_expert(s.n, s.k) * (bpw / 8.0) * (TOP_K * LAYERS) as f64;
         let q6k_ms = stage_bytes(Q6K_BPW) / (q6k_gbs * 1e6);
         let mx_ms = stage_bytes(MXFP4_BPW) / (split.gbs * 1e6);
+        let mxv_ms = stage_bytes(MXFP4_BPW) / (split_vec.gbs * 1e6);
         q6k_token_ms += q6k_ms;
         mxfp4_token_ms += mx_ms;
+        mxfp4_vec_token_ms += mxv_ms;
 
         println!(
-            "  {:<8} Q6_K  {:>6.1} GB/s  eta {:>5.2}   -> {:>6.3} ms/token",
+            "  {:<8} Q6_K       {:>6.1} GB/s  eta {:>5.2}   -> {:>6.3} ms/token",
             s.name,
             q6k_gbs,
             q6k_gbs / ROOFLINE,
             q6k_ms
         );
-        println!(
-            "  {:<8} MXFP4 {:>6.1} GB/s  eta {:>5.2}   -> {:>6.3} ms/token   (oracle {:.2e})",
-            s.name,
-            split.gbs,
-            split.eta(ROOFLINE),
-            mx_ms,
-            split.max_abs_diff
-        );
+        for (label, arm, ms) in [("MXFP4 a", split, mx_ms), ("MXFP4 a2", split_vec, mxv_ms)] {
+            println!(
+                "  {:<8} {:<10} {:>6.1} GB/s  eta {:>5.2}   -> {:>6.3} ms/token   (oracle {:.2e})",
+                s.name,
+                label,
+                arm.gbs,
+                arm.eta(ROOFLINE),
+                ms,
+                arm.max_abs_diff
+            );
+        }
     }
 
     println!();
     println!("--- per-token expert read predictions ---");
     println!(
-        "  Q6_K  reads {:>7.1} MB -> {:.3} ms    MXFP4 reads {:>7.1} MB -> {:.3} ms",
+        "  Q6_K  reads {:>7.1} MB -> {:.3} ms    MXFP4 reads {:>7.1} MB -> a {:.3} / a2 {:.3} ms",
         token_bytes(Q6K_BPW) / 1e6,
         q6k_token_ms,
         token_bytes(MXFP4_BPW) / 1e6,
         mxfp4_token_ms,
+        mxfp4_vec_token_ms,
     );
     println!(
-        "  predicted delta {:.3} ms  |  e2e measured delta 1.25 ms (GPU busy 11.56 -> 10.31)",
-        q6k_token_ms - mxfp4_token_ms
+        "  predicted deltas: a {:.3} ms (e2e 1.25), a2-over-a {:.3} ms (e2e 0.46, \
+         GPU busy 11.56 -> 10.31 -> 9.93)",
+        q6k_token_ms - mxfp4_token_ms,
+        mxfp4_token_ms - mxfp4_vec_token_ms
     );
     println!();
     println!("  If the predicted delta lands near 1.25 ms, the kernels are already");

--- a/crates/larql-compute-metal/examples/bench_moe_expert_format_split.rs
+++ b/crates/larql-compute-metal/examples/bench_moe_expert_format_split.rs
@@ -1,0 +1,140 @@
+//! G5 attribution — where did the projected MXFP4 expert saving go?
+//!
+//! The composed serve measured Q6_K 14.56 ms/token against MXFP4 13.40
+//! (GPU busy 11.56 vs 10.31), a −1.25 ms delta where bytes alone predict
+//! more. Everything in the command buffer other than the expert matvecs
+//! is identical between the arms, so the question is a kernel question:
+//! at the production geometry, what bandwidth does each format's grouped
+//! expert kernel realise?
+//!
+//! Both instruments already exist and share one protocol — grouped
+//! dispatch, batched into one command buffer, cold working set:
+//!
+//! - Q6_K:  `kernel_profile::profile_grouped_experts` (the K3a bench).
+//! - MXFP4: `mxfp4_layout::race` arm A (`split / LUT16`), which is the
+//!   pipeline `grouped_experts_for(MXFP4)` serves in production
+//!   (`Mxfp4Arm::SplitLut16` + `ExpertScaleBinding::SplitE8M0`).
+//!
+//! Geometry is gpt-oss-20b's routed bank: fused gate/up `[5760, 2880]`
+//! and down `[2880, 2880]`, top-4 of 32 experts, 24 MoE layers per
+//! token. The per-token prediction each arm implies is printed next to
+//! the e2e numbers it must explain.
+//!
+//! Usage:
+//!   cargo run --release -p larql-compute-metal --example bench_moe_expert_format_split
+
+extern crate blas_src;
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    eprintln!("Requires macOS + Metal");
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    use larql_compute_metal::diag::{kernel_profile, mxfp4_layout};
+
+    const HIDDEN: usize = 2880;
+    const INTER: usize = 2880;
+    const GATE_UP_ROWS: usize = 2 * INTER; // fused halves
+    const TOP_K: usize = 4;
+    const LAYERS: usize = 24;
+    const ROOFLINE: f64 = 367.0;
+    const BATCH: usize = 24; // dispatches per command buffer, one per layer
+    const WARMUP: usize = 3;
+    const ITERS: usize = 20;
+
+    const Q6K_BPW: f64 = 210.0 / 256.0 * 8.0; // super-block bytes over elems
+    const MXFP4_BPW: f64 = 4.25; // payload nibbles + e8m0 partner stream
+
+    println!("G5 attribution — grouped expert kernels at gpt-oss geometry");
+    println!("============================================================");
+    println!(
+        "  gate_up [{GATE_UP_ROWS}, {HIDDEN}]  down [{HIDDEN}, {INTER}]  top-{TOP_K}, \
+         {LAYERS} layers/token"
+    );
+    println!("  grouped dispatch, batched {BATCH}/cmdbuf, cold payloads");
+    println!();
+
+    // Per-token bytes each stage reads in each format.
+    let weights_per_expert = |rows: usize, k: usize| (rows * k) as f64;
+    let token_bytes = |bpw: f64| {
+        (weights_per_expert(GATE_UP_ROWS, HIDDEN) + weights_per_expert(HIDDEN, INTER))
+            * (bpw / 8.0)
+            * (TOP_K * LAYERS) as f64
+    };
+
+    struct Stage {
+        name: &'static str,
+        n: usize,
+        k: usize,
+    }
+    let stages = [
+        Stage {
+            name: "gate_up",
+            n: GATE_UP_ROWS,
+            k: HIDDEN,
+        },
+        Stage {
+            name: "down",
+            n: HIDDEN,
+            k: INTER,
+        },
+    ];
+
+    let mut q6k_token_ms = 0.0;
+    let mut mxfp4_token_ms = 0.0;
+    for s in &stages {
+        let (_ungrouped, q6k_gbs) =
+            kernel_profile::profile_grouped_experts(s.n, s.k, TOP_K, BATCH, WARMUP, ITERS);
+        let arms = mxfp4_layout::race(s.n, s.k, TOP_K, BATCH, WARMUP, ITERS);
+        let split = &arms[0]; // arm A: split / LUT16 — the production pipeline
+        assert!(
+            split.name.contains("split"),
+            "arm order changed; refusing to report the wrong kernel: {}",
+            split.name
+        );
+
+        let stage_bytes =
+            |bpw: f64| weights_per_expert(s.n, s.k) * (bpw / 8.0) * (TOP_K * LAYERS) as f64;
+        let q6k_ms = stage_bytes(Q6K_BPW) / (q6k_gbs * 1e6);
+        let mx_ms = stage_bytes(MXFP4_BPW) / (split.gbs * 1e6);
+        q6k_token_ms += q6k_ms;
+        mxfp4_token_ms += mx_ms;
+
+        println!(
+            "  {:<8} Q6_K  {:>6.1} GB/s  eta {:>5.2}   -> {:>6.3} ms/token",
+            s.name,
+            q6k_gbs,
+            q6k_gbs / ROOFLINE,
+            q6k_ms
+        );
+        println!(
+            "  {:<8} MXFP4 {:>6.1} GB/s  eta {:>5.2}   -> {:>6.3} ms/token   (oracle {:.2e})",
+            s.name,
+            split.gbs,
+            split.eta(ROOFLINE),
+            mx_ms,
+            split.max_abs_diff
+        );
+    }
+
+    println!();
+    println!("--- per-token expert read predictions ---");
+    println!(
+        "  Q6_K  reads {:>7.1} MB -> {:.3} ms    MXFP4 reads {:>7.1} MB -> {:.3} ms",
+        token_bytes(Q6K_BPW) / 1e6,
+        q6k_token_ms,
+        token_bytes(MXFP4_BPW) / 1e6,
+        mxfp4_token_ms,
+    );
+    println!(
+        "  predicted delta {:.3} ms  |  e2e measured delta 1.25 ms (GPU busy 11.56 -> 10.31)",
+        q6k_token_ms - mxfp4_token_ms
+    );
+    println!();
+    println!("  If the predicted delta lands near 1.25 ms, the kernels are already");
+    println!("  realising their bandwidth and the remaining gap to MLX lives at the");
+    println!("  token boundary (lm_head). If it is much larger, the MXFP4 kernel is");
+    println!("  leaving bandwidth on the table under the real route.");
+}

--- a/crates/larql-compute-metal/examples/bench_mxfp4_layouts.rs
+++ b/crates/larql-compute-metal/examples/bench_mxfp4_layouts.rs
@@ -26,7 +26,10 @@
 //!     bit. That tail, not any global scale table, is the entire difference.
 //!
 //! Usage:
-//!   cargo run --release -p larql-compute-metal --example bench_mxfp4_layouts
+//!   cargo run --release -p larql-compute-metal --example bench_mxfp4_layouts [N K TOP_K]
+//!
+//! Defaults are the K3 expert branch; `5760 2880 4` and `2880 2880 4` are
+//! gpt-oss-20b's fused gate/up and down shapes.
 
 extern crate blas_src;
 
@@ -39,9 +42,17 @@ fn main() {
 fn main() {
     use larql_compute_metal::diag::mxfp4_layout;
 
-    const N: usize = 3584; // K3 expert branch rows
-    const K: usize = 3072; // latent reduction
-    const TOP_K: usize = 16;
+    let mut args = std::env::args().skip(1);
+    let mut dim = |default: usize| {
+        args.next()
+            .map(|a| a.parse().expect("N K TOP_K must be integers"))
+            .unwrap_or(default)
+    };
+    let n: usize = dim(3584); // K3 expert branch rows
+    let k: usize = dim(3072); // latent reduction
+    let top_k: usize = dim(16);
+    #[allow(non_snake_case)]
+    let (N, K, TOP_K) = (n, k, top_k);
     const ROOFLINE: f64 = 367.0;
     const BATCH: usize = 8;
     const WARMUP: usize = 3;
@@ -78,8 +89,24 @@ fn main() {
     println!();
 
     let get = |i: usize| &arms[i];
-    let (a, b, c, d, g, e, f) = (get(0), get(1), get(2), get(3), get(4), get(5), get(6));
-    println!("--- the four pre-registered comparisons ---");
+    let (a, a2, b, c, d, g, e, f) = (
+        get(0),
+        get(1),
+        get(2),
+        get(3),
+        get(4),
+        get(5),
+        get(6),
+        get(7),
+    );
+    println!("--- the pre-registered comparisons ---");
+    {
+        let pct = 100.0 * (a.ms / a2.ms - 1.0);
+        println!(
+            "  {:<28} {:>+7.2}%   ({:.4} -> {:.4} ms)",
+            "A2 - A vectorised skeleton", pct, a.ms, a2.ms
+        );
+    }
     let cmp = |label: &str, from: &mxfp4_layout::ArmResult, to: &mxfp4_layout::ArmResult| {
         let pct = 100.0 * (from.ms / to.ms - 1.0);
         println!(

--- a/crates/larql-compute-metal/src/diag/mxfp4_layout.rs
+++ b/crates/larql-compute-metal/src/diag/mxfp4_layout.rs
@@ -273,10 +273,17 @@ pub fn race(
     // ceiling probes that deliberately compute something else, so gating them on
     // numerical agreement would be meaningless.
     #[allow(clippy::type_complexity)]
-    let arms: [(&'static str, &crate::kernels::KernelHandle, bool, f64, bool); 7] = [
+    let arms: [(&'static str, &crate::kernels::KernelHandle, bool, f64, bool); 8] = [
         (
             "A split / LUT16",
             &metal.quant.mxfp4g_split_lut16_pipeline,
+            true,
+            4.25,
+            true,
+        ),
+        (
+            "A2 split / LUT16 vec4",
+            &metal.quant.mxfp4g_split_lut16_vec_pipeline,
             true,
             4.25,
             true,

--- a/crates/larql-compute-metal/src/kernels/quant.rs
+++ b/crates/larql-compute-metal/src/kernels/quant.rs
@@ -50,6 +50,10 @@ pub struct QuantKernels {
     /// the same weights through different scale layouts and decode strategies.
     /// Candidates, not production paths — see `shaders::mxfp4_grouped_experts`.
     pub mxfp4g_split_lut16_pipeline: KernelHandle,
+    /// Arm A2: arm A's layout and math with a vectorised skeleton
+    /// (`uint4` weight loads, `float4` X loads). Requires 16-byte-aligned
+    /// payload region bases; see the kernel docs.
+    pub mxfp4g_split_lut16_vec_pipeline: KernelHandle,
     pub mxfp4g_inter_lut16_pipeline: KernelHandle,
     pub mxfp4g_inter_pair_pipeline: KernelHandle,
     pub mxfp4g_inter_magsign_pipeline: KernelHandle,
@@ -88,6 +92,11 @@ pub struct QuantKernels {
     /// binding arities, so a call site cannot bind one without knowing
     /// which it got.
     pub mxfp4_grouped_binding: ExpertScaleBinding,
+    /// Which arm [`Self::mxfp4_grouped_pipeline`] is. The encode path
+    /// needs the identity, not just the pipeline: the vectorised arm
+    /// carries an alignment precondition it must check per descriptor
+    /// table, falling back to the scalar split arm when it fails.
+    pub mxfp4_grouped_arm: shaders::mxfp4_grouped_experts::Mxfp4Arm,
 }
 
 /// How a grouped-expert kernel receives its dequantisation scales.
@@ -145,6 +154,8 @@ impl QuantKernels {
 
         let mxfp4g_split_lut16_pipeline =
             h::<shaders::mxfp4_grouped_experts::KernelSplitLut16>(device, library);
+        let mxfp4g_split_lut16_vec_pipeline =
+            h::<shaders::mxfp4_grouped_experts::KernelSplitLut16Vec>(device, library);
         let mxfp4g_inter_lut16_pipeline =
             h::<shaders::mxfp4_grouped_experts::KernelInterLut16>(device, library);
         let mxfp4g_inter_pair_pipeline =
@@ -180,10 +191,12 @@ impl QuantKernels {
         use shaders::mxfp4_grouped_experts::Mxfp4Arm;
         let mxfp4_grouped_pipeline = match options.mxfp4_arm {
             Mxfp4Arm::SplitLut16 => mxfp4g_split_lut16_pipeline.clone(),
+            Mxfp4Arm::SplitLut16Vec => mxfp4g_split_lut16_vec_pipeline.clone(),
             Mxfp4Arm::InterLut16 => mxfp4g_inter_lut16_pipeline.clone(),
             Mxfp4Arm::InterPair => mxfp4g_inter_pair_pipeline.clone(),
             Mxfp4Arm::InterMagSign => mxfp4g_inter_magsign_pipeline.clone(),
         };
+        let mxfp4_grouped_arm = options.mxfp4_arm;
         let mxfp4_grouped_binding = if options.mxfp4_arm.is_split_scale() {
             ExpertScaleBinding::SplitE8M0
         } else {
@@ -197,6 +210,7 @@ impl QuantKernels {
             q6k_grouped_experts_pipeline,
             q4k_grouped_experts_pipeline,
             mxfp4g_split_lut16_pipeline,
+            mxfp4g_split_lut16_vec_pipeline,
             mxfp4g_inter_lut16_pipeline,
             mxfp4g_inter_pair_pipeline,
             mxfp4g_inter_magsign_pipeline,
@@ -213,6 +227,7 @@ impl QuantKernels {
             q6k_matvec_8sg_pipeline,
             mxfp4_grouped_pipeline,
             mxfp4_grouped_binding,
+            mxfp4_grouped_arm,
         }
     }
 

--- a/crates/larql-compute-metal/src/kernels/quant/tests.rs
+++ b/crates/larql-compute-metal/src/kernels/quant/tests.rs
@@ -9,12 +9,14 @@
 
 use crate::shaders::mxfp4_grouped_experts::Mxfp4Arm;
 
-/// Arm A is the default, and it is the exact one. Both halves matter:
+/// Arm A2 is the default, and it is an exact one. Both halves matter:
 /// the default must be servable under a losslessness claim without the
-/// caller opting in to anything.
+/// caller opting in to anything. (A2 additionally carries an alignment
+/// precondition, but the encode path demotes it to arm A — also exact —
+/// rather than weakening the claim.)
 #[test]
 fn default_arm_is_exact() {
-    assert_eq!(Mxfp4Arm::default(), Mxfp4Arm::SplitLut16);
+    assert_eq!(Mxfp4Arm::default(), Mxfp4Arm::SplitLut16Vec);
     assert!(Mxfp4Arm::default().is_exact());
 }
 

--- a/crates/larql-compute-metal/src/moe_descriptor.rs
+++ b/crates/larql-compute-metal/src/moe_descriptor.rs
@@ -71,6 +71,11 @@ pub struct MoeExpertDescriptorTable {
     pub gate_up_expert_bytes: usize,
     pub down_expert_bytes: usize,
     pub num_experts: usize,
+    /// Whether every payload offset is 16-byte aligned — the vectorised
+    /// split kernel's load precondition, computed once at build. Base
+    /// buffers are page-aligned (registered mmapped regions or fresh
+    /// Metal allocations), so the per-expert offsets are the whole fact.
+    pub payload_offsets_vec16: bool,
 }
 
 /// One route's GPU-resident bindings, produced by `moe_descriptor_gather`:
@@ -235,6 +240,21 @@ impl MetalBackend {
         };
         let descs = self.bufs.transient_from_bytes(bytes);
 
+        let payload_offsets_vec16 = descs_host
+            .iter()
+            .all(|d| d.gate_up_payload_off % 16 == 0 && d.down_payload_off % 16 == 0);
+        if !payload_offsets_vec16
+            && self.quant.mxfp4_grouped_arm
+                == crate::shaders::mxfp4_grouped_experts::Mxfp4Arm::SplitLut16Vec
+        {
+            // Once per layer bank, at build — fired evidence that the
+            // vectorised arm was demoted, never a silent slow path.
+            eprintln!(
+                "[moe-descriptor] payload offsets not 16-byte aligned; \
+                 vectorised MXFP4 arm demoted to scalar for this bank"
+            );
+        }
+
         Some(MoeExpertDescriptorTable {
             descs,
             descs_host,
@@ -247,6 +267,7 @@ impl MetalBackend {
             gate_up_expert_bytes,
             down_expert_bytes,
             num_experts,
+            payload_offsets_vec16,
         })
     }
 

--- a/crates/larql-compute-metal/src/moe_gpu_route/encode.rs
+++ b/crates/larql-compute-metal/src/moe_gpu_route/encode.rs
@@ -134,7 +134,7 @@ impl MetalBackend {
         match scratch.format {
             larql_compute::QuantFormat::MXFP4 => {
                 use larql_models::quant::mxfp4::FusedHalf;
-                let (kh, binding) = self.quant.grouped_experts_for(scratch.format);
+                let (kh, binding) = self.mxfp4_grouped_for_table(table);
                 assert_eq!(
                     binding,
                     crate::kernels::quant::ExpertScaleBinding::SplitE8M0,
@@ -247,7 +247,7 @@ impl MetalBackend {
                 use crate::shaders::mxfp4_grouped_experts::{
                     ROW_BASE_IDENTITY, ROW_STRIDE_IDENTITY,
                 };
-                let (kh, _) = self.quant.grouped_experts_for(scratch.format);
+                let (kh, _) = self.mxfp4_grouped_for_table(table);
                 let scale_base = table
                     .down_scale_base
                     .as_ref()
@@ -332,6 +332,28 @@ impl MetalBackend {
 }
 
 impl MetalBackend {
+    /// The grouped MXFP4 kernel to encode this table with: the
+    /// options-selected arm, demoted to the scalar split arm when the
+    /// vectorised arm's 16-byte payload-alignment precondition does not
+    /// hold for this bank. The demotion was already announced once at
+    /// table build; here it must only be correct.
+    fn mxfp4_grouped_for_table(
+        &self,
+        table: &MoeExpertDescriptorTable,
+    ) -> (
+        &crate::kernels::KernelHandle,
+        crate::kernels::quant::ExpertScaleBinding,
+    ) {
+        use crate::shaders::mxfp4_grouped_experts::Mxfp4Arm;
+        let (kh, binding) = self
+            .quant
+            .grouped_experts_for(larql_compute::QuantFormat::MXFP4);
+        if self.quant.mxfp4_grouped_arm == Mxfp4Arm::SplitLut16Vec && !table.payload_offsets_vec16 {
+            return (&self.quant.mxfp4g_split_lut16_pipeline, binding);
+        }
+        (kh, binding)
+    }
+
     /// Everything the GPU route needs to hold, checked BEFORE any
     /// command-buffer state is touched — a `false` here means the CPU
     /// arm proceeds with nothing to roll back.

--- a/crates/larql-compute-metal/src/shaders/mxfp4_grouped_experts.rs
+++ b/crates/larql-compute-metal/src/shaders/mxfp4_grouped_experts.rs
@@ -173,6 +173,78 @@ kernel void mxfp4g_split_lut16(
 }
 "#;
 
+/// Arm A2: arm A's layout and math with a vectorised skeleton.
+///
+/// The tournament's ceiling probes said the split kernel's deficit on the
+/// gpt-oss down shape is the **skeleton**, not the decode: arm A streams
+/// each 16-byte group with sixteen single-`uchar` loads, so consecutive
+/// lanes read addresses 16 bytes apart and every load moves one byte. Here
+/// each group is one `uint4` load — consecutive lanes read consecutive
+/// 16-byte chunks (the coalescing shape `q6k_grouped_experts` already has)
+/// and the issue rate drops 16×. X moves through `float4`s the same way.
+///
+/// Alignment contract, stated because `uint4`/`float4` device loads
+/// require it: every payload region base must be 16-byte aligned and
+/// `XSTRIDE` a multiple of 4 floats. Both hold for the bench fixture and
+/// for VINDEX3 payload regions (per-expert payloads are whole groups of
+/// 16 bytes); a caller that cannot guarantee them keeps arm A.
+const KERNEL_A2: &str = r#"
+inline float mxg_dot8(uint v, float4 xa, float4 xb) {
+    return MXG_LUT[v         & 0x0Fu] * xa.x
+         + MXG_LUT[(v >>  4u) & 0x0Fu] * xa.y
+         + MXG_LUT[(v >>  8u) & 0x0Fu] * xa.z
+         + MXG_LUT[(v >> 12u) & 0x0Fu] * xa.w
+         + MXG_LUT[(v >> 16u) & 0x0Fu] * xb.x
+         + MXG_LUT[(v >> 20u) & 0x0Fu] * xb.y
+         + MXG_LUT[(v >> 24u) & 0x0Fu] * xb.z
+         + MXG_LUT[(v >> 28u) & 0x0Fu] * xb.w;
+}
+
+kernel void mxfp4g_split_lut16_vec(
+    device const uchar*  Wp        [[buffer(0)]],
+    device const uint*   offsets   [[buffer(1)]],
+    device const uchar*  Ws        [[buffer(2)]],
+    device const uint*   s_offsets [[buffer(3)]],
+    device const float*  X         [[buffer(4)]],
+    device float*        out       [[buffer(5)]],
+    constant uint&       N         [[buffer(6)]],
+    constant uint&       K         [[buffer(7)]],
+    constant uint&       XSTRIDE   [[buffer(8)]],
+    constant uint&       ROWBASE   [[buffer(9)]],
+    constant uint&       ROWSTRIDE [[buffer(10)]],
+    uint2 tg_id [[threadgroup_position_in_grid]],
+    uint  lane  [[thread_index_in_simdgroup]],
+    uint  sg_id [[simdgroup_index_in_threadgroup]])
+{
+    const uint slot = tg_id.y;
+    const uint row  = tg_id.x * MXG_ROWS_PER_TG + sg_id;
+    if (row >= N) { return; }
+
+    const uint groups = K / MXG_GROUP_ELEMS;
+    const uint frow = ROWBASE + row * ROWSTRIDE;
+    const ulong pbase = (ulong)offsets[slot]   + (ulong)frow * groups * MXG_GROUP_BYTES;
+    const ulong sbase = (ulong)s_offsets[slot] + (ulong)frow * groups;
+    device const uint4* row_p = (device const uint4*)(Wp + pbase);
+    device const uchar* row_s = Ws + sbase;
+    device const float4* Xs4 =
+        (device const float4*)(X + (ulong)slot * XSTRIDE);
+
+    float acc = 0.0f;
+    for (uint g = lane; g < groups; g += 32u) {
+        const float scale = mxg_e8m0(row_s[g]);
+        const uint4 w = row_p[g];
+        const uint xb = g * 8u; // group g's X span, in float4s
+        float part = mxg_dot8(w.x, Xs4[xb],      Xs4[xb + 1u])
+                   + mxg_dot8(w.y, Xs4[xb + 2u], Xs4[xb + 3u])
+                   + mxg_dot8(w.z, Xs4[xb + 4u], Xs4[xb + 5u])
+                   + mxg_dot8(w.w, Xs4[xb + 6u], Xs4[xb + 7u]);
+        acc += scale * part;
+    }
+    acc = simd_sum(acc);
+    if (lane == 0u) { out[slot * N + row] = acc; }
+}
+"#;
+
 /// Body shared by the interleaved arms; only the inner decode differs.
 fn interleaved(name: &str, decode: &str) -> String {
     format!(
@@ -320,6 +392,7 @@ pub fn shader() -> String {
     let mut s = String::from(PRELUDE);
     s.push_str(&pair_table());
     s.push_str(KERNEL_A);
+    s.push_str(KERNEL_A2);
     s.push_str(&interleaved("mxfp4g_inter_lut16", DECODE_LUT16));
     s.push_str(&interleaved("mxfp4g_inter_pair", DECODE_PAIR));
     s.push_str(&interleaved("mxfp4g_inter_magsign", DECODE_MAG_SIGN));
@@ -341,6 +414,7 @@ macro_rules! arm {
 }
 
 arm!(KernelSplitLut16, "mxfp4g_split_lut16");
+arm!(KernelSplitLut16Vec, "mxfp4g_split_lut16_vec");
 arm!(KernelInterLut16, "mxfp4g_inter_lut16");
 arm!(KernelInterPair, "mxfp4g_inter_pair");
 arm!(KernelInterMagSign, "mxfp4g_inter_magsign");
@@ -370,8 +444,15 @@ arm!(KernelInterNoX, "mxfp4g_inter_nox");
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub enum Mxfp4Arm {
     /// Arm A — separate packed/scale streams, 4.25 bpw, **exact**.
-    #[default]
     SplitLut16,
+    /// Arm A2 — arm A's layout and math with a vectorised skeleton
+    /// (`uint4` weight loads, `float4` X loads). **Exact**, and the
+    /// tournament winner at every measured expert shape (+47% on the
+    /// gpt-oss down shape, +10-13% elsewhere). Requires every payload
+    /// offset to be 16-byte aligned; the encode path checks the built
+    /// descriptor table and falls back to arm A when it is not.
+    #[default]
+    SplitLut16Vec,
     /// Arm B — interleaved superblock, 16-entry LUT decode.
     InterLut16,
     /// Arm C — interleaved, 256-entry byte-pair LUT decode.
@@ -388,6 +469,7 @@ impl Mxfp4Arm {
     pub fn from_name(name: &str) -> Option<Self> {
         Some(match name.to_ascii_lowercase().as_str() {
             "split_lut16" | "a" => Self::SplitLut16,
+            "split_lut16_vec" | "a2" => Self::SplitLut16Vec,
             "inter_lut16" | "b" => Self::InterLut16,
             "inter_pair" | "c" => Self::InterPair,
             "inter_magsign" | "d" => Self::InterMagSign,
@@ -400,7 +482,7 @@ impl Mxfp4Arm {
     /// An inexact arm may not be parity-gated against the Q6_K transcode,
     /// and may not serve a model claiming lossless expert weights.
     pub fn is_exact(self) -> bool {
-        matches!(self, Self::SplitLut16)
+        matches!(self, Self::SplitLut16 | Self::SplitLut16Vec)
     }
 
     /// Whether this arm's kernel takes the e8m0 exponents as a **separate**
@@ -410,7 +492,7 @@ impl Mxfp4Arm {
     /// depend on `kernels`, so the mapping to a binding shape is made one
     /// level up, where the pipelines live.
     pub fn is_split_scale(self) -> bool {
-        matches!(self, Self::SplitLut16)
+        matches!(self, Self::SplitLut16 | Self::SplitLut16Vec)
     }
 }
 
@@ -448,6 +530,7 @@ mod tests {
         let src = shader();
         for name in [
             "mxfp4g_split_lut16",
+            "mxfp4g_split_lut16_vec",
             "mxfp4g_inter_lut16",
             "mxfp4g_inter_pair",
             "mxfp4g_inter_magsign",
@@ -455,8 +538,10 @@ mod tests {
             "mxfp4g_inter_affine",
             "mxfp4g_inter_nox",
         ] {
+            // The `(` closes the name: `mxfp4g_split_lut16` must not also
+            // count its `_vec` sibling.
             assert_eq!(
-                src.matches(&format!("kernel void {name}")).count(),
+                src.matches(&format!("kernel void {name}(")).count(),
                 1,
                 "{name}"
             );
@@ -488,11 +573,20 @@ mod tests {
                 "arm A must bind {name} at buffer({slot})"
             );
         }
+        // Arm A2 binds the identical table — same slots, same names — so the
+        // two split arms are interchangeable at every call site.
+        let flat_vec = KERNEL_A2.split_whitespace().collect::<Vec<_>>().join(" ");
+        for (name, slot) in [("s_offsets", 3), ("ROWBASE", 9), ("ROWSTRIDE", 10)] {
+            assert!(
+                flat_vec.contains(&format!("{name} [[buffer({slot})]]")),
+                "arm A2 must bind {name} at buffer({slot})"
+            );
+        }
         // The interleaved arms deliberately do NOT carry either: they keep the
         // shared inline-scale arity, which is also why they can only serve a
         // contiguous-halves bank. A call site holding an interleaved bank must
         // refuse rather than pick one of them.
-        let interleaved_src: String = src.replace(KERNEL_A, "");
+        let interleaved_src: String = src.replace(KERNEL_A, "").replace(KERNEL_A2, "");
         assert!(!interleaved_src.contains("s_offsets"));
         assert!(!interleaved_src.contains("ROWSTRIDE"));
     }

--- a/crates/larql-compute-metal/src/trait_impl/quant_matvec.rs
+++ b/crates/larql-compute-metal/src/trait_impl/quant_matvec.rs
@@ -186,6 +186,60 @@ impl QuantMatVec for MetalBackend {
         Some(crate::buffers::read_buffer_f32(&buf_out, num_rows))
     }
 
+    /// Q4_K matvec + GPU partial top-K in one command buffer. The scores
+    /// vector never leaves the GPU: only `num_tgs × K_TOPK` (val, idx)
+    /// pairs come back for a small CPU merge — on a 201K-row lm_head that
+    /// replaces an ~800 KB readback and a full-vocab CPU heap scan.
+    fn q4k_matvec_topk(
+        &self,
+        q4k_data: &[u8],
+        x: &[f32],
+        num_rows: usize,
+        hidden: usize,
+        top_k: usize,
+    ) -> Option<Vec<(u32, f32)>> {
+        if top_k == 0 || top_k > crate::shaders::f32_gemv::K_TOPK {
+            return None;
+        }
+        if num_rows == 0 || x.len() != hidden {
+            return None;
+        }
+        let buf_w = self.bufs.get_bytes(q4k_data);
+        let buf_x = self.bufs.transient_from_f32(x);
+        let buf_out = self.bufs.output((num_rows * 4) as u64);
+        let n = num_rows as u32;
+        let k = hidden as u32;
+        // Geometry from the bound pipeline, same as `q4k_matvec` — see the
+        // dispatch-geometry note there.
+        let rows_per_tg = self.quant.q4k_matvec_pipeline.rows_per_tg;
+        let threads_per_tg = self.quant.q4k_matvec_pipeline.threads_per_tg;
+        let num_tgs = (num_rows as u64).div_ceil(rows_per_tg);
+
+        let cmd = self.queue.new_command_buffer();
+        let enc = cmd.new_compute_command_encoder();
+        enc.set_compute_pipeline_state(&self.quant.q4k_matvec_pipeline.state);
+        enc.set_buffer(0, Some(&buf_w), 0);
+        enc.set_buffer(1, Some(&buf_x), 0);
+        enc.set_buffer(2, Some(&buf_out), 0);
+        enc.set_bytes(3, 4, &n as *const u32 as *const std::ffi::c_void);
+        enc.set_bytes(4, 4, &k as *const u32 as *const std::ffi::c_void);
+        enc.dispatch_thread_groups(
+            metal::MTLSize::new(num_tgs, 1, 1),
+            metal::MTLSize::new(threads_per_tg, 1, 1),
+        );
+        let (partial_vals, partial_idxs, topk_tgs) =
+            self.encode_topk_partial(enc, &buf_out, num_rows);
+        enc.end_encoding();
+        cmd.commit();
+        cmd.wait_until_completed();
+        Some(MetalBackend::reduce_topk_partial(
+            &partial_vals,
+            &partial_idxs,
+            topk_tgs,
+            top_k,
+        ))
+    }
+
     /// Q4_K matrix-matrix multiply: `C[m, n] = sum_k W[n, k] * X[m, k]`.
     ///
     /// `W` is `[num_rows, hidden]` Q4_K row-major. `X` is `[seq_len,
@@ -420,5 +474,88 @@ mod tests {
             .q4k_matmul(&[], &[], 1, 4, 0)
             .expect("zero-dim path returns Some(empty)");
         assert!(out.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod q4k_topk_tests {
+    use crate::MetalBackend;
+    use larql_compute::backend::QuantMatVec;
+    use larql_compute::cpu::ops::q4_common::quantize_q4_k;
+
+    fn backend() -> MetalBackend {
+        MetalBackend::new().expect("Metal device available on test host")
+    }
+
+    /// Rows deliberately not a multiple of the tile so the remainder path
+    /// runs; K a Q4_K super-block multiple.
+    const N: usize = 517;
+    const K: usize = 512;
+
+    fn fixture() -> (Vec<u8>, Vec<f32>) {
+        // Knuth-hash mix, NOT a short-period ramp: a pattern with period p
+        // makes rows p apart byte-identical, and tied duplicate rows turn
+        // rank order into a coin flip the parity assert would then fail on.
+        let w: Vec<f32> = (0..N * K)
+            .map(|i| {
+                let h = (i as u32).wrapping_mul(2654435761) >> 16;
+                ((h % 4001) as f32 - 2000.0) * 1e-3
+            })
+            .collect();
+        let x: Vec<f32> = (0..K).map(|i| ((i % 89) as f32 - 44.0) * 0.02).collect();
+        (quantize_q4_k(&w), x)
+    }
+
+    /// The one contract that lets the lm_head path take the small-K arm:
+    /// the fused matvec+top-K submission returns exactly what the full
+    /// readback + CPU reduce returns.
+    #[test]
+    fn q4k_matvec_topk_matches_full_readback_reduce() {
+        let m = backend();
+        let (q, x) = fixture();
+        let scores = m.q4k_matvec(&q, &x, N, K).expect("full matvec");
+        let mut want: Vec<(u32, f32)> = scores
+            .iter()
+            .enumerate()
+            .map(|(i, &s)| (i as u32, s))
+            .collect();
+        want.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        for top_k in [1usize, 5, 8] {
+            let hits = m
+                .q4k_matvec_topk(&q, &x, N, K, top_k)
+                .expect("topk path fires for top_k <= K_TOPK");
+            assert_eq!(hits.len(), top_k.min(N));
+            for (rank, (id, score)) in hits.iter().enumerate() {
+                // Exact ties order arbitrarily between the two reduces, so
+                // the id contract is "an id whose score is this rank's
+                // score", with score parity exact-tolerance either way.
+                assert!(
+                    (score - want[rank].1).abs() <= 1e-5 * want[rank].1.abs().max(1.0),
+                    "rank {rank} score {score} vs {} (top_k={top_k})",
+                    want[rank].1
+                );
+                assert!(
+                    *id == want[rank].0 || scores[*id as usize] == want[rank].1,
+                    "rank {rank}: id {id} is not the rank-{rank} id {} and its \
+                     score {} is not tied with {} (top_k={top_k})",
+                    want[rank].0,
+                    scores[*id as usize],
+                    want[rank].1
+                );
+            }
+        }
+    }
+
+    /// The refusals that keep the caller's fallback honest.
+    #[test]
+    fn q4k_matvec_topk_refuses_out_of_capacity_and_bad_shapes() {
+        let m = backend();
+        let (q, x) = fixture();
+        assert!(m.q4k_matvec_topk(&q, &x, N, K, 0).is_none());
+        assert!(m
+            .q4k_matvec_topk(&q, &x, N, K, crate::shaders::f32_gemv::K_TOPK + 1)
+            .is_none());
+        assert!(m.q4k_matvec_topk(&q, &x[..K - 1], N, K, 1).is_none());
+        assert!(m.q4k_matvec_topk(&q, &x, 0, K, 1).is_none());
     }
 }

--- a/crates/larql-compute-metal/tests/test_kernel_moe_g_mxfp4.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_moe_g_mxfp4.rs
@@ -203,6 +203,15 @@ fn mxfp4_descriptor_arm_matches_production_bitwise() {
         .build_expert_descriptor_table(&moe, INTER, HIDDEN)
         .expect("split-scale table builds (C1b class)");
     assert!(table.gate_up_scale_base.is_some() && table.down_scale_base.is_some());
+    // Gate–claim congruence: the arm this parity licenses is the arm the
+    // backend will actually encode. The vectorised default only fires on
+    // a 16-aligned table, so pin that this fixture IS one — otherwise a
+    // silent demotion would leave the default arm parity-ungated.
+    assert!(
+        table.payload_offsets_vec16,
+        "fixture payload offsets must be 16-byte aligned so the parity \
+         gate exercises the default (vectorised) arm"
+    );
     let h = h_post_attn();
 
     for seed in 0..4u32 {

--- a/crates/larql-compute/src/backend/quant_matvec.rs
+++ b/crates/larql-compute/src/backend/quant_matvec.rs
@@ -259,6 +259,23 @@ pub trait QuantMatVec {
         None
     }
 
+    /// Q4_K matvec + GPU partial top-K in one submission — the Q4_K
+    /// sibling of [`Self::q4_matvec_topk`], for lm_heads stored as Q4_K.
+    /// Returns up to `top_k` `(row, score)` pairs sorted descending
+    /// without the full-vocab scores readback. `None` when not
+    /// specialised or `top_k` exceeds the kernel's per-TG capacity; the
+    /// caller falls back to [`Self::q4k_matvec`] + a CPU reduce.
+    fn q4k_matvec_topk(
+        &self,
+        _q4k_data: &[u8],
+        _x: &[f32],
+        _num_rows: usize,
+        _hidden: usize,
+        _top_k: usize,
+    ) -> Option<Vec<(u32, f32)>> {
+        None
+    }
+
     /// Fused two-weight Q4_K matvec sharing one input vector.
     ///
     /// `out_a[N] = W_a[N, K] · x[K]`, `out_b[N] = W_b[N, K] · x[K]`

--- a/crates/larql-inference/src/ffn/moe_container/mod.rs
+++ b/crates/larql-inference/src/ffn/moe_container/mod.rs
@@ -300,6 +300,46 @@ impl ContainerRoutedBackend {
             }
         }
 
+        // A format whose scales live in partner streams is unservable
+        // without them, and a stream of the wrong length resolves into the
+        // wrong expert's exponents — arithmetically valid, silently wrong.
+        // Both are composition failures, caught here for the same reason
+        // the payload sizes are.
+        if let Some((want_gu_scales, want_dn_scales)) = declared_scale_sizes(
+            declared,
+            moe.intermediate_size,
+            self.container.index().hidden_size,
+        ) {
+            for expert in 0..experts as u32 {
+                for (role, want) in [
+                    (RegionRole::GateUpFused, want_gu_scales),
+                    (RegionRole::Down, want_dn_scales),
+                ] {
+                    let got = reader
+                        .paired_region_bytes(ROUTED_BANK, expert, role, RegionRole::Scales)
+                        .map_err(|e| CompositionError::UnreadableLayer {
+                            layer,
+                            why: format!("expert {expert} {role:?} scales: {e}"),
+                        })?
+                        .ok_or_else(|| CompositionError::UnreadableLayer {
+                            layer,
+                            why: format!(
+                                "expert {expert} {role:?} declares a split-scale \
+                                 format but carries no scale partner"
+                            ),
+                        })?;
+                    if got.len() != want {
+                        return Err(CompositionError::Shape {
+                            layer,
+                            what: "scale partner bytes",
+                            spine: want as u64,
+                            container: got.len() as u64,
+                        });
+                    }
+                }
+            }
+        }
+
         // Resolve the two storage facts here as well, and discard them. They
         // are re-read per forward, but a bank whose scales are half-present or
         // whose row arrangement this build cannot act on must fail at
@@ -369,6 +409,14 @@ impl ContainerRoutedBackend {
         })
     }
 
+    /// The container's mapped segment regions, for the compute backend to
+    /// register alongside the spine's packed mmaps — the routed bank's
+    /// bytes must alias into GPU buffers the same way the spine's do, or
+    /// zero-copy resolve refuses every expert the override supplies.
+    pub fn weight_regions(&self) -> impl Iterator<Item = &[u8]> {
+        self.container.segment_regions()
+    }
+
     /// One line describing what this run actually composed.
     pub fn describe(&self, spine: &Path) -> String {
         format!(
@@ -407,6 +455,30 @@ fn declared_region_sizes(
             let row = |cols: usize| (cols / MXFP4_GROUP_ELEMS) * MXFP4_GROUP_BYTES;
             Some((FUSED_HALVES * inter * row(hidden), hidden * row(inter)))
         }
+        _ => None,
+    }
+}
+
+/// Scale-partner byte lengths a bank of `format` must carry per expert —
+/// `None` for formats whose scales ride inside the payload blocks.
+///
+/// For a split-scale format this is one e8m0 exponent per group of
+/// [`MXFP4_GROUP_ELEMS`](larql_models::quant::mxfp4::MXFP4_GROUP_ELEMS)
+/// input elements, per output row: the gate/up region is
+/// `[FUSED_HALVES x inter, hidden]` and the down region `[hidden, inter]`.
+/// A `Some` here also states the format cannot be served without its
+/// partner streams — nibbles with no exponents decode to nothing.
+fn declared_scale_sizes(
+    format: RegionFormat,
+    inter: usize,
+    hidden: usize,
+) -> Option<(usize, usize)> {
+    use larql_models::quant::mxfp4::{FUSED_HALVES, MXFP4_GROUP_ELEMS};
+    match format {
+        RegionFormat::Mxfp4 => Some((
+            FUSED_HALVES * inter * (hidden / MXFP4_GROUP_ELEMS),
+            hidden * (inter / MXFP4_GROUP_ELEMS),
+        )),
         _ => None,
     }
 }
@@ -579,114 +651,4 @@ impl MoeExpertBackend for ContainerRoutedBackend {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test_utils::make_test_gemma4_moe_weights;
-    use larql_vindex::format::lyrw2::region_format::RegionFormat;
-    use larql_vindex::format::lyrw2::region_layout::RegionLayout;
-    use larql_vindex::format::vindex3::{ContainerBuilder, ExpertScaleStreams, MoeLayerSource};
-    use tempfile::TempDir;
-
-    /// Build a container from the fixture model's own expert bytes.
-    ///
-    /// `skip` omits that layer, so a test can produce a container that is
-    /// well-formed but cannot serve the model it is composed with — the
-    /// distinction the coverage check exists to make.
-    fn container_for(weights: &larql_models::ModelWeights, skip: Option<usize>) -> TempDir {
-        let dir = TempDir::new().unwrap();
-        let mut builder = ContainerBuilder::create(dir.path()).unwrap();
-        let arch = &*weights.arch;
-        let mut wrote = false;
-        for layer in 0..weights.num_layers {
-            if Some(layer) == skip {
-                continue;
-            }
-            let Some(moe) = build_moe_weights(weights, arch, layer) else {
-                continue;
-            };
-            let source = MoeLayerSource {
-                layer: layer as u32,
-                experts_gate_up: moe.experts_gate_up.clone(),
-                experts_down: moe.experts_down.clone(),
-                format: RegionFormat::Q4K,
-                // Q4_K packs its scales inside each super-block.
-                scales: ExpertScaleStreams::Inline,
-                // A fact about the bytes this fixture writes, not about any
-                // checkpoint: `build_moe_weights` yields `[all gate | all up]`.
-                gate_up_layout: RegionLayout::ContiguousHalves,
-                hidden_size: weights.hidden_size as u32,
-                gate_up_stored_intermediate: moe.intermediate_size as u32,
-                down_stored_intermediate: moe.inter_padded() as u32,
-                semantic_intermediate: moe.intermediate_size as u32,
-                top_k: moe.top_k as u32,
-            };
-            if builder.add_moe_layer(&source).is_ok() {
-                wrote = true;
-            }
-        }
-        assert!(wrote, "fixture produced no routed layers to import");
-        builder
-            .finish(
-                weights.arch.family(),
-                weights.arch.family(),
-                weights.hidden_size,
-                weights.num_layers,
-            )
-            .unwrap();
-        dir
-    }
-
-    #[test]
-    fn a_container_missing_a_routed_layer_is_refused_before_generation() {
-        // Coverage is checked against the model, so an omitted layer must be
-        // caught at open — not at the token where that layer first runs, by
-        // which point part of an answer has already been produced.
-        let weights = make_test_gemma4_moe_weights();
-        let full = container_for(&weights, None);
-        ContainerRoutedBackend::open(full.path(), &weights, true)
-            .expect("a complete container must compose");
-
-        let missing = container_for(&weights, Some(0));
-        let err = ContainerRoutedBackend::open(missing.path(), &weights, true)
-            .err()
-            .expect("a container missing a routed layer must be refused");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("no bank for it") || msg.contains("layer 0"),
-            "the refusal must name the missing layer, got: {msg}"
-        );
-    }
-
-    #[test]
-    fn a_container_describing_another_model_is_refused() {
-        let weights = make_test_gemma4_moe_weights();
-        let dir = container_for(&weights, None);
-
-        // Rewrite the family in place: same banks, different identity.
-        let index_path = dir.path().join("index.json");
-        let text = std::fs::read_to_string(&index_path).unwrap();
-        let mut json: serde_json::Value = serde_json::from_str(&text).unwrap();
-        json["family"] = serde_json::Value::String("not-this-model".into());
-        std::fs::write(&index_path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
-
-        let err = ContainerRoutedBackend::open(dir.path(), &weights, true)
-            .err()
-            .expect("composing a container for another model must be refused");
-        assert!(
-            err.to_string().contains("not-this-model"),
-            "the refusal must name both sides, got: {err}"
-        );
-    }
-
-    #[test]
-    fn a_composed_route_reports_both_artifacts() {
-        // Provenance is not decoration: a composed run is two directories and
-        // a result recorded against only one of them is unreproducible.
-        let weights = make_test_gemma4_moe_weights();
-        let dir = container_for(&weights, None);
-        let backend = ContainerRoutedBackend::open(dir.path(), &weights, true).unwrap();
-        let line = backend.describe(std::path::Path::new("/models/spine.vindex"));
-        assert!(line.contains("/models/spine.vindex"), "{line}");
-        assert!(line.contains(&dir.path().display().to_string()), "{line}");
-    }
-}
+mod tests;

--- a/crates/larql-inference/src/ffn/moe_container/tests/mod.rs
+++ b/crates/larql-inference/src/ffn/moe_container/tests/mod.rs
@@ -1,0 +1,253 @@
+//! Composition gate tests: what the routed-container open admits and
+//! refuses, proven against containers built by the real writer.
+
+use super::*;
+use crate::test_utils::make_test_gemma4_moe_weights;
+use larql_vindex::format::lyrw2::region_format::RegionFormat;
+use larql_vindex::format::lyrw2::region_layout::RegionLayout;
+use larql_vindex::format::vindex3::{ContainerBuilder, ExpertScaleStreams, MoeLayerSource};
+use tempfile::TempDir;
+
+/// Build a container from the fixture model's own expert bytes.
+///
+/// `skip` omits that layer, so a test can produce a container that is
+/// well-formed but cannot serve the model it is composed with — the
+/// distinction the coverage check exists to make.
+fn container_for(weights: &larql_models::ModelWeights, skip: Option<usize>) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let mut builder = ContainerBuilder::create(dir.path()).unwrap();
+    let arch = &*weights.arch;
+    let mut wrote = false;
+    for layer in 0..weights.num_layers {
+        if Some(layer) == skip {
+            continue;
+        }
+        let Some(moe) = build_moe_weights(weights, arch, layer) else {
+            continue;
+        };
+        let source = MoeLayerSource {
+            layer: layer as u32,
+            experts_gate_up: moe.experts_gate_up.clone(),
+            experts_down: moe.experts_down.clone(),
+            format: RegionFormat::Q4K,
+            // Q4_K packs its scales inside each super-block.
+            scales: ExpertScaleStreams::Inline,
+            // A fact about the bytes this fixture writes, not about any
+            // checkpoint: `build_moe_weights` yields `[all gate | all up]`.
+            gate_up_layout: RegionLayout::ContiguousHalves,
+            hidden_size: weights.hidden_size as u32,
+            gate_up_stored_intermediate: moe.intermediate_size as u32,
+            down_stored_intermediate: moe.inter_padded() as u32,
+            semantic_intermediate: moe.intermediate_size as u32,
+            top_k: moe.top_k as u32,
+        };
+        if builder.add_moe_layer(&source).is_ok() {
+            wrote = true;
+        }
+    }
+    assert!(wrote, "fixture produced no routed layers to import");
+    builder
+        .finish(
+            weights.arch.family(),
+            weights.arch.family(),
+            weights.hidden_size,
+            weights.num_layers,
+        )
+        .unwrap();
+    dir
+}
+
+#[test]
+fn a_container_missing_a_routed_layer_is_refused_before_generation() {
+    // Coverage is checked against the model, so an omitted layer must be
+    // caught at open — not at the token where that layer first runs, by
+    // which point part of an answer has already been produced.
+    let weights = make_test_gemma4_moe_weights();
+    let full = container_for(&weights, None);
+    ContainerRoutedBackend::open(full.path(), &weights, true)
+        .expect("a complete container must compose");
+
+    let missing = container_for(&weights, Some(0));
+    let err = ContainerRoutedBackend::open(missing.path(), &weights, true)
+        .err()
+        .expect("a container missing a routed layer must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no bank for it") || msg.contains("layer 0"),
+        "the refusal must name the missing layer, got: {msg}"
+    );
+}
+
+#[test]
+fn a_container_describing_another_model_is_refused() {
+    let weights = make_test_gemma4_moe_weights();
+    let dir = container_for(&weights, None);
+
+    // Rewrite the family in place: same banks, different identity.
+    let index_path = dir.path().join("index.json");
+    let text = std::fs::read_to_string(&index_path).unwrap();
+    let mut json: serde_json::Value = serde_json::from_str(&text).unwrap();
+    json["family"] = serde_json::Value::String("not-this-model".into());
+    std::fs::write(&index_path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+
+    let err = ContainerRoutedBackend::open(dir.path(), &weights, true)
+        .err()
+        .expect("composing a container for another model must be refused");
+    assert!(
+        err.to_string().contains("not-this-model"),
+        "the refusal must name both sides, got: {err}"
+    );
+}
+
+#[test]
+fn a_composed_route_reports_both_artifacts() {
+    // Provenance is not decoration: a composed run is two directories and
+    // a result recorded against only one of them is unreproducible.
+    let weights = make_test_gemma4_moe_weights();
+    let dir = container_for(&weights, None);
+    let backend = ContainerRoutedBackend::open(dir.path(), &weights, true).unwrap();
+    let line = backend.describe(std::path::Path::new("/models/spine.vindex"));
+    assert!(line.contains("/models/spine.vindex"), "{line}");
+    assert!(line.contains(&dir.path().display().to_string()), "{line}");
+}
+
+// ── Tamper controls for the native split-scale open ─────────────────────
+//
+// The byte authority moved from the model's slices to the container's
+// declared format; these prove the move did not weaken validation. Each
+// tamper is a container the real writer happily produces (the writer
+// checks uniformity, not format arithmetic) that the composed open must
+// still refuse — and the untampered sibling must admit, or the refusals
+// prove nothing.
+
+/// How a synthetic native container deviates from a servable one.
+#[derive(Clone, Copy, PartialEq)]
+enum Tamper {
+    None,
+    /// Payloads sized for MXFP4 but declared as the spine's format —
+    /// the declaration is the byte authority, so it must stop being one.
+    WrongDeclaredFormat,
+    /// A split-scale format shipped with no scale partners at all.
+    MissingScalePair,
+    /// Scale partners present but one byte short per expert.
+    ShortScalePair,
+    /// Payloads one MXFP4 group short.
+    ShortPayload,
+}
+
+/// Build an MXFP4 split-scale container for the fixture model, `tamper`ed.
+fn mxfp4_container_for(weights: &larql_models::ModelWeights, tamper: Tamper) -> TempDir {
+    use larql_models::quant::mxfp4::{FUSED_HALVES, MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS};
+
+    let dir = TempDir::new().unwrap();
+    let mut builder = ContainerBuilder::create(dir.path()).unwrap();
+    let arch = &*weights.arch;
+    let hidden = weights.hidden_size;
+    let mut wrote = false;
+    for layer in 0..weights.num_layers {
+        let Some(moe) = build_moe_weights(weights, arch, layer) else {
+            continue;
+        };
+        let inter = moe.intermediate_size;
+        let row = |cols: usize| (cols / MXFP4_GROUP_ELEMS) * MXFP4_GROUP_BYTES;
+        let payload_cut = if tamper == Tamper::ShortPayload {
+            MXFP4_GROUP_BYTES
+        } else {
+            0
+        };
+        let scale_cut = usize::from(tamper == Tamper::ShortScalePair);
+        let per_expert = |len: usize| vec![vec![0x11u8; len]; moe.num_experts];
+        let gate_up = per_expert(FUSED_HALVES * inter * row(hidden) - payload_cut);
+        let down = per_expert(hidden * row(inter) - payload_cut);
+        let gu_scales = per_expert(FUSED_HALVES * inter * (hidden / MXFP4_GROUP_ELEMS) - scale_cut);
+        let dn_scales = per_expert(hidden * (inter / MXFP4_GROUP_ELEMS) - scale_cut);
+
+        fn as_slices(v: &[Vec<u8>]) -> Vec<&[u8]> {
+            v.iter().map(|e| e.as_slice()).collect()
+        }
+        let source = MoeLayerSource {
+            layer: layer as u32,
+            experts_gate_up: as_slices(&gate_up),
+            experts_down: as_slices(&down),
+            format: if tamper == Tamper::WrongDeclaredFormat {
+                RegionFormat::Q4K
+            } else {
+                RegionFormat::Mxfp4
+            },
+            scales: if tamper == Tamper::MissingScalePair {
+                ExpertScaleStreams::Inline
+            } else {
+                ExpertScaleStreams::Paired {
+                    gate_up: as_slices(&gu_scales),
+                    down: as_slices(&dn_scales),
+                }
+            },
+            gate_up_layout: RegionLayout::ContiguousHalves,
+            hidden_size: hidden as u32,
+            gate_up_stored_intermediate: inter as u32,
+            down_stored_intermediate: inter as u32,
+            semantic_intermediate: inter as u32,
+            top_k: moe.top_k as u32,
+        };
+        builder.add_moe_layer(&source).unwrap();
+        wrote = true;
+    }
+    assert!(wrote, "fixture produced no routed layers to import");
+    builder
+        .finish(
+            weights.arch.family(),
+            weights.arch.family(),
+            weights.hidden_size,
+            weights.num_layers,
+        )
+        .unwrap();
+    dir
+}
+
+fn refusal_for(weights: &larql_models::ModelWeights, tamper: Tamper) -> String {
+    let dir = mxfp4_container_for(weights, tamper);
+    ContainerRoutedBackend::open(dir.path(), weights, true)
+        .err()
+        .expect("the tampered container must be refused at open")
+        .to_string()
+}
+
+#[test]
+fn a_native_split_scale_container_admits() {
+    // The restore arm: every tamper below must be the ONLY reason its
+    // container is refused, which this untampered sibling proves.
+    let weights = make_test_gemma4_moe_weights();
+    let dir = mxfp4_container_for(&weights, Tamper::None);
+    ContainerRoutedBackend::open(dir.path(), &weights, true)
+        .expect("an untampered native split-scale container must admit");
+}
+
+#[test]
+fn a_wrong_declared_format_is_refused_by_the_declarations_own_arithmetic() {
+    // Declaring the spine's format hands byte authority back to the model's
+    // slices, which these MXFP4-sized payloads cannot satisfy.
+    let weights = make_test_gemma4_moe_weights();
+    let msg = refusal_for(&weights, Tamper::WrongDeclaredFormat);
+    assert!(msg.contains("routed region bytes"), "{msg}");
+}
+
+#[test]
+fn a_split_scale_bank_with_no_scale_partner_is_refused() {
+    let weights = make_test_gemma4_moe_weights();
+    let msg = refusal_for(&weights, Tamper::MissingScalePair);
+    assert!(msg.to_lowercase().contains("scale"), "{msg}");
+}
+
+#[test]
+fn a_scale_partner_of_the_wrong_length_is_refused() {
+    let weights = make_test_gemma4_moe_weights();
+    let msg = refusal_for(&weights, Tamper::ShortScalePair);
+    assert!(msg.contains("scale partner bytes"), "{msg}");
+}
+
+#[test]
+fn a_payload_one_group_short_is_refused() {
+    let weights = make_test_gemma4_moe_weights();
+    let msg = refusal_for(&weights, Tamper::ShortPayload);
+    assert!(msg.contains("routed region bytes"), "{msg}");
+}

--- a/crates/larql-inference/src/layer_graph/generate/gpu/mod.rs
+++ b/crates/larql-inference/src/layer_graph/generate/gpu/mod.rs
@@ -80,8 +80,6 @@ pub fn generate(
     )
 }
 
-/// Fallible variant of [`generate`].
-#[allow(clippy::too_many_arguments)]
 /// [`generate`] with the expert-bank authority supplied by a routed
 /// VINDEX3 container — the composed Metal serve path. Everything except
 /// the routed banks is identical to [`generate`].
@@ -114,6 +112,8 @@ pub fn generate_routed(
     )
 }
 
+/// Fallible variant of [`generate`].
+#[allow(clippy::too_many_arguments)]
 pub fn try_generate(
     weights: &mut ModelWeights,
     tokenizer: &tokenizers::Tokenizer,
@@ -258,6 +258,14 @@ where
             .unwrap_or(false);
     if !backend_supports_fused_q4_pipeline(backend) || (needs_per_layer_embed && !metal_ple_enabled)
     {
+        // The CPU fallback runs the spine's banks; falling into it with a
+        // routed override would silently measure or serve the wrong bytes.
+        if routed.is_some() {
+            return GenerateResult::empty_error(GenerateError::missing_weights(
+                "the routed expert-bank override requires the fused GPU pipeline; \
+                 this backend would silently serve the spine's banks instead",
+            ));
+        }
         return generate_via_cpu_q4k(weights, tokenizer, token_ids, max_tokens, index, eos);
     }
 
@@ -268,6 +276,15 @@ where
     // backend's default impl does nothing.
     for mmap in weights.packed_mmaps.values() {
         backend.register_weight_region(&mmap[..]);
+    }
+    // The routed container's banks are weight regions of the same standing:
+    // when the expert-bank authority is overridden, the override's bytes are
+    // what the per-expert offsets bind into, so they must be registered
+    // before the residency set is sealed.
+    if let Some(routed) = routed {
+        for region in routed.weight_regions() {
+            backend.register_weight_region(region);
+        }
     }
     // Every region is registered; let the backend prepare them once. Metal
     // uses this to declare an explicit residency set instead of paying
@@ -590,6 +607,7 @@ mod tests {
             SamplingConfig::greedy(),
             &EosConfig::builtin(),
             |_, _, _| fired = true,
+            None,
         );
         assert!(result.tokens.is_empty());
         assert!(!fired, "callback must not fire when max_tokens == 0");
@@ -748,6 +766,7 @@ mod tests {
             SamplingConfig::greedy(),
             &EosConfig::builtin(),
             |id, _text, _prob| streamed.push(id),
+            None,
         );
         assert!(
             result.error.is_none(),

--- a/crates/larql-inference/src/layer_graph/generate/mod.rs
+++ b/crates/larql-inference/src/layer_graph/generate/mod.rs
@@ -189,6 +189,7 @@ mod tests {
             SamplingConfig::greedy(),
             &EosConfig::builtin(),
             |id, text, prob| streamed.push((id, text.to_string(), prob)),
+            None,
         );
 
         // The streaming callback must fire exactly once per emitted token.
@@ -321,6 +322,7 @@ mod tests {
             SamplingConfig::greedy(),
             &EosConfig::builtin(),
             |id, text, prob| streamed.push((id, text.to_string(), prob)),
+            None,
         );
         // Callback may or may not fire on the CPU fallback path. Either
         // outcome is acceptable for coverage purposes.

--- a/crates/larql-router-protocol/build.rs
+++ b/crates/larql-router-protocol/build.rs
@@ -5,8 +5,15 @@
 // up `protoc` from the `PROTOC` env var or PATH automatically.
 #[cfg(not(windows))]
 fn set_protoc() {
-    let mut prost_build = prost_build::Config::new();
-    prost_build.protoc_executable(protobuf_src::protoc());
+    // `tonic_build::compile_protos` builds its own prost config and
+    // discovers protoc via the PROTOC env var — a locally-built
+    // `prost_build::Config` pointing at the bundled binary never reaches
+    // it (the historical form of this function did exactly that, and the
+    // build only worked while the CI runner images happened to ship a
+    // system protoc). Respect an explicit PROTOC if the caller set one.
+    if std::env::var_os("PROTOC").is_none() {
+        std::env::set_var("PROTOC", protobuf_src::protoc());
+    }
 }
 
 #[cfg(windows)]

--- a/crates/larql-server/build.rs
+++ b/crates/larql-server/build.rs
@@ -4,8 +4,15 @@
 // against the debug UCRT runtime on the GitHub windows-latest runner.
 #[cfg(not(windows))]
 fn set_protoc() {
-    let mut prost_build = prost_build::Config::new();
-    prost_build.protoc_executable(protobuf_src::protoc());
+    // `tonic_build::compile_protos` discovers protoc via the PROTOC env
+    // var — a locally-built `prost_build::Config` pointing at the bundled
+    // binary never reaches it (the historical form of this function did
+    // exactly that, and the build only worked while the CI runner images
+    // happened to ship a system protoc). Respect an explicit PROTOC if
+    // the caller set one.
+    if std::env::var_os("PROTOC").is_none() {
+        std::env::set_var("PROTOC", protobuf_src::protoc());
+    }
 }
 
 #[cfg(windows)]

--- a/crates/larql-server/src/routes/openai/chat.rs
+++ b/crates/larql-server/src/routes/openai/chat.rs
@@ -589,6 +589,7 @@ fn stream_chat_completion(
                 sampling,
                 &eos,
                 on_token,
+                None,
             )
         };
 

--- a/crates/larql-server/src/routes/openai/completions.rs
+++ b/crates/larql-server/src/routes/openai/completions.rs
@@ -388,6 +388,7 @@ fn stream_completions(
                     early_stop = true;
                 }
             },
+            None,
         );
 
         let finish_reason: &'static str = if early_stop || result.tokens.len() < max_tokens {

--- a/crates/larql-server/src/routes/stream.rs
+++ b/crates/larql-server/src/routes/stream.rs
@@ -474,6 +474,7 @@ async fn handle_stream_generate(
             sampling,
             &eos,
             on_token,
+            None,
         );
     });
 

--- a/crates/larql-vindex/benches/extract_throughput.rs
+++ b/crates/larql-vindex/benches/extract_throughput.rs
@@ -159,6 +159,8 @@ fn bench_extract_throughput(c: &mut Criterion) {
                     larql_vindex::WriteWeightsOptions::default(),
                     larql_vindex::KquantWriteOptions::default(),
                     false,
+                    larql_vindex::ExtractionRequest::Legacy,
+                    None,
                     &mut cb,
                 )
                 .expect("extract");
@@ -187,6 +189,8 @@ fn bench_extract_throughput(c: &mut Criterion) {
             larql_vindex::WriteWeightsOptions::default(),
             larql_vindex::KquantWriteOptions::default(),
             false,
+            larql_vindex::ExtractionRequest::Legacy,
+            None,
             &mut cb,
         )
         .expect("reference extract for resume bench");
@@ -234,6 +238,8 @@ fn bench_extract_throughput(c: &mut Criterion) {
                 larql_vindex::WriteWeightsOptions::default(),
                 larql_vindex::KquantWriteOptions::default(),
                 false,
+                larql_vindex::ExtractionRequest::Legacy,
+                None,
                 &mut cb,
             )
             .expect("resumed extract");

--- a/crates/larql-vindex/benches/q4k_vs_f32.rs
+++ b/crates/larql-vindex/benches/q4k_vs_f32.rs
@@ -176,6 +176,8 @@ fn bench_q4k_vs_f32(c: &mut Criterion) {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();
@@ -194,6 +196,8 @@ fn bench_q4k_vs_f32(c: &mut Criterion) {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();

--- a/crates/larql-vindex/src/format/vindex3/read.rs
+++ b/crates/larql-vindex/src/format/vindex3/read.rs
@@ -30,13 +30,16 @@ fn contextual_io(what: &str, e: std::io::Error) -> VindexError {
 }
 
 /// An opened VINDEX3 container: root authority, programme manifest, and the
-/// segment bytes held resident for the reader's lifetime.
+/// segment bytes mapped for the reader's lifetime.
 pub struct Vindex3Container {
     root: PathBuf,
     index: Vindex3Index,
     manifest: MoeManifest,
-    /// Segment key → raw LYRW v2 file bytes.
-    segments: HashMap<String, Vec<u8>>,
+    /// Segment key → mmap of the LYRW v2 file. A map, not a heap read:
+    /// segment bases are page-aligned, which is what lets a GPU backend
+    /// register them for zero-copy aliasing (a `Vec` base carries no
+    /// alignment guarantee, so heap segments could never be registered).
+    segments: HashMap<String, memmap2::Mmap>,
 }
 
 /// Whether opening refuses a malformed manifest or loads it to be described.
@@ -111,9 +114,13 @@ impl Vindex3Container {
         let mut segments = HashMap::new();
         for key in index.segments.keys() {
             let path = segment_path(root, key);
-            let bytes =
-                std::fs::read(&path).map_err(|e| contextual_io(&format!("segment {key}"), e))?;
-            segments.insert(key.clone(), bytes);
+            let file = std::fs::File::open(&path)
+                .map_err(|e| contextual_io(&format!("segment {key}"), e))?;
+            // Safety: the container is serving data — the same not-modified-
+            // while-mapped contract every spine weight mmap already relies on.
+            let mmap = unsafe { memmap2::Mmap::map(&file) }
+                .map_err(|e| contextual_io(&format!("segment {key}"), e))?;
+            segments.insert(key.clone(), mmap);
         }
 
         Ok(Self {
@@ -164,7 +171,15 @@ impl Vindex3Container {
                 self.index.segments.keys().collect::<Vec<_>>()
             ))
         })?;
-        Lyrw2Reader::parse(bytes).map_err(|e| VindexError::Parse(format!("segment '{key}': {e}")))
+        Lyrw2Reader::parse(&bytes[..])
+            .map_err(|e| VindexError::Parse(format!("segment '{key}': {e}")))
+    }
+
+    /// Every segment's mapped bytes, for a compute backend to register as
+    /// zero-copy weight regions. Bases are page-aligned (they are mmaps),
+    /// which is the registration precondition.
+    pub fn segment_regions(&self) -> impl Iterator<Item = &[u8]> {
+        self.segments.values().map(|m| &m[..])
     }
 }
 

--- a/crates/larql-vindex/src/index/storage/lm_head/knn.rs
+++ b/crates/larql-vindex/src/index/storage/lm_head/knn.rs
@@ -123,6 +123,22 @@ impl VectorIndex {
                 if vocab > 0 {
                     if let Some(x) = query.as_slice() {
                         if let Some((cols, xp)) = q4k_row_query(q4_data, x, vocab, hidden) {
+                            // Small-K fast path: matvec + partial top-K in
+                            // one GPU submission — the full-vocab scores
+                            // never come back to the host. Greedy decode
+                            // (top_k ≤ 8) lives here; larger K falls
+                            // through to the full readback below.
+                            if let Some(hits) =
+                                backend.q4k_matvec_topk(q4_data, xp.as_query(x), vocab, cols, top_k)
+                            {
+                                static FIRED: std::sync::Once = std::sync::Once::new();
+                                FIRED.call_once(|| {
+                                    eprintln!(
+                                        "[lm-head] q4k matvec+topk fused path active (k={top_k})"
+                                    )
+                                });
+                                return hits;
+                            }
                             if let Some(scores_vec) =
                                 backend.q4k_matvec(q4_data, xp.as_query(x), vocab, cols)
                             {

--- a/crates/larql-vindex/tests/golden_resume.rs
+++ b/crates/larql-vindex/tests/golden_resume.rs
@@ -136,6 +136,8 @@ fn run_extract(model_dir: &Path, output_dir: &Path) {
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();

--- a/crates/larql-vindex/tests/test_streaming_stages_moe.rs
+++ b/crates/larql-vindex/tests/test_streaming_stages_moe.rs
@@ -216,7 +216,9 @@ fn streaming_extract_mixtral_exercises_moe_arms() {
         QuantFormat::None,
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
-        false, // drop_gate_vectors
+        false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None, // drop_gate_vectors
         &mut cb,
     )
     .expect("streaming extract on mixtral fixture");
@@ -457,6 +459,8 @@ fn streaming_extract_gemma4_hybrid_moe_exercises_packed_bf16_arms() {
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .expect("streaming extract on gemma4 hybrid MoE fixture");
@@ -704,6 +708,8 @@ fn streaming_extract_gpt_oss_exercises_packed_mxfp4_arms() {
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .expect("streaming extract on gpt-oss MXFP4 fixture");
@@ -823,6 +829,8 @@ fn streaming_extract_mixtral_resumes_when_run_twice_on_same_output_dir() {
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .expect("first-pass extract");
@@ -855,6 +863,8 @@ fn streaming_extract_mixtral_resumes_when_run_twice_on_same_output_dir() {
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb2,
     )
     .expect("second-pass extract reuses checkpoint");
@@ -908,6 +918,8 @@ fn streaming_extract_mixtral_with_real_tokenizer_records_top_k_entries() {
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .expect("streaming extract with real tokenizer");
@@ -972,7 +984,9 @@ fn streaming_extract_mixtral_with_drop_gate_vectors_removes_zero_byte_file() {
             skip_ffn: false,
         },
         KquantWriteOptions::default(),
-        true, // drop_gate_vectors
+        true,
+        larql_vindex::ExtractionRequest::Legacy,
+        None, // drop_gate_vectors
         &mut cb,
     )
     .expect("streaming extract with drop_gate_vectors=true");
@@ -1037,6 +1051,8 @@ fn streaming_extract_mixtral_with_summary_k_runs_svd_and_caps_down_meta() {
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .expect("streaming extract on mixtral fixture with summary_k");
@@ -1183,7 +1199,9 @@ fn streaming_extract_gguf_llama_browse_runs_end_to_end() {
         QuantFormat::None,
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
-        false, // drop_gate_vectors
+        false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None, // drop_gate_vectors
         &mut cb,
     )
     .expect("streaming extract on GGUF llama fixture");
@@ -1232,6 +1250,8 @@ fn streaming_extract_gguf_single_file_path_is_accepted() {
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .expect("streaming extract on single-file GGUF");
@@ -1263,7 +1283,9 @@ fn streaming_extract_drop_gate_without_q4k_is_rejected() {
         QuantFormat::None, // not Q4K — drop_gate is invalid here
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
-        true, // drop_gate_vectors
+        true,
+        larql_vindex::ExtractionRequest::Legacy,
+        None, // drop_gate_vectors
         &mut cb,
     )
     .expect_err("drop_gate_vectors without Q4K must be rejected");
@@ -1307,6 +1329,8 @@ fn streaming_extract_dense_with_missing_ffn_down_skips_down_projection() {
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .expect("extract should succeed even when ffn_down is absent");
@@ -1343,6 +1367,8 @@ fn streaming_extract_moe_with_missing_expert_down_skips_layer() {
         WriteWeightsOptions::default(),
         KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .expect("extract should succeed when expert down tensors are absent");
@@ -1383,6 +1409,8 @@ fn streaming_extract_resumes_and_skips_down_meta_when_checkpoint_marks_it() {
             WriteWeightsOptions::default(),
             KquantWriteOptions::default(),
             false,
+            larql_vindex::ExtractionRequest::Legacy,
+            None,
             &mut cb,
         )
         .expect("streaming extract");

--- a/crates/larql-vindex/tests/test_vindex.rs
+++ b/crates/larql-vindex/tests/test_vindex.rs
@@ -2627,6 +2627,8 @@ fn streaming_extract_from_safetensors() {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();
@@ -2832,6 +2834,8 @@ fn streaming_extract_q4k_from_safetensors() {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();
@@ -3847,6 +3851,8 @@ fn streaming_extract_q4k_carries_ple_tensors() {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();
@@ -4028,6 +4034,8 @@ fn streaming_extract_noquant_carries_ple_tensors() {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();
@@ -4199,6 +4207,8 @@ fn load_model_weights_rejects_ple_arch_with_missing_sidecars() {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();
@@ -4412,6 +4422,8 @@ fn streaming_extract_preserves_per_layer_intermediate_for_variable_ffn() {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();

--- a/crates/larql-vindex/tests/test_vindex_to_q4k.rs
+++ b/crates/larql-vindex/tests/test_vindex_to_q4k.rs
@@ -287,6 +287,8 @@ fn q4k_end_to_end_from_synthetic_safetensors() {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();
@@ -458,6 +460,8 @@ fn q4k_feature_major_down_round_trip() {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();
@@ -562,6 +566,8 @@ fn legacy_q4k_filenames_load_via_dual_read() {
         larql_vindex::WriteWeightsOptions::default(),
         larql_vindex::KquantWriteOptions::default(),
         false,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
         &mut cb,
     )
     .unwrap();

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -178,6 +178,7 @@ larql bench <MODEL> [OPTIONS]
 | `--ffn <URL>` | Bench the grid path: route FFN to a remote larql-server | — |
 | `--ffn-dispatch <streaming\|batch>` | Same shape as `larql run --ffn-dispatch` | streaming |
 | `--moe-shards <SPEC>` | Bench the remote MoE expert path | — |
+| `--routed-from <DIR>` | Serve the routed expert banks from a VINDEX3 container, exactly as `larql run --routed-from` composes them — the plain bench on the same spine is the controlled comparison | — |
 | `--moe-dispatch <streaming\|batch>` | Same shape as `larql run --moe-dispatch` | streaming |
 | `--moe-predispatch-iters <N>` | Refinement iterations for batch dispatch | 2 |
 | `--profile` | Print per-stage timing breakdown for each engine (markov-rs only for now) | false |
@@ -193,6 +194,7 @@ Examples:
 larql bench gemma3-4b-it-vindex --backends metal,cpu
 larql bench gemma3-4b-it-vindex --ollama gemma3:4b
 larql bench gemma4-26b-a4b.vindex --moe-shards "0-63=http://a:8081,64-127=http://b:8082"
+LARQL_GPU_ROUTE=1 larql bench gpt-oss-20b-q4k.vindex --warmup 16 -n 256 --routed-from ~/models/gpt-oss-20b-experts-mxfp4.v3
 ```
 
 ### `larql accuracy`

--- a/docs/k3-funnel.md
+++ b/docs/k3-funnel.md
@@ -888,6 +888,27 @@ accelerator, not a rescue operation.
 panics on pure MoE — a separate dense-assuming path; GB-style bits/token
 scoring of the served vindex (§4.6.8's scorer gap) remains unbuilt.
 
+### 4.12 GPU-resident routing + native MXFP4 experts — 59.8 → 77.2 tok/s (2026-08-13/14)
+
+Both "next MoE wins" named at the end of §4.11 landed. GPU routing (PR
+#249) turned the route into an index — router matvec, top-k, and the
+descriptor gather run as GPU dataflow, one command buffer per token,
+route-witness counters pinned at zero (opt-in: `LARQL_GPU_ROUTE=1`) —
+59.8 → 67.5 tok/s. The representation win followed on
+`feat/moe-g4b3-region-registration`: `--routed-from` serves a VINDEX3
+container's native MXFP4 banks (paired e8m0 streams, complete-or-refuse
+admission with five tamper controls) over the Q6_K spine, and a
+vectorised split kernel (`uint4` group loads, arm `a2`, oracle-exact)
+recovers the skeleton deficit the K2 ceiling probes located. Paired
+same-session ladder: Q6_K 68.3 → MXFP4 74.6 → **77.2 tok/s** (12.95
+ms/token). Kernel-measured bandwidth predicts the expert-read delta
+within ~0.1 ms of e2e — no integration tax. The remaining ~0.9 ms to
+the MLX-class ~83 reference is fully attributed: ~1.09 ms lm_head
+Q4_K matvec at bandwidth ceiling (irreducible as stored) + ~0.5 ms
+decode↔lm_head command-buffer boundary (open: fold final norm →
+lm_head → top-K into the decode CB). Full ladder + evidence: ROADMAP
+"Native MXFP4 served end to end (2026-08-14)".
+
 ## 5. Claims under test
 
 | ID | Claim | Falsifier |


### PR DESCRIPTION
## Native MXFP4 experts served end to end — 68.3 → 77.2 tok/s

Four commits, one paired same-session A/B/A ladder (GPT-OSS-20B, M3 Max, warmup 16, n 256, long prompt):

| ms/token | tok/s | What changed |
|---:|---:|---|
| 14.63 | 68.3 | Q6_K control through the GPU route (reproduces the recorded 67.5) |
| 13.41 | 74.6 | native MXFP4 expert banks (`--routed-from`) — expert reads 1 959 → 1 269 MB/token |
| 12.95 | **77.2** | vectorised MXFP4 split kernel (`uint4` group loads, arm `a2`, new default) |

### G4b.3 — the last serve seam (`ba7418b9`)

`Vindex3Container` segments were heap `Vec<u8>` copies; `register_region` requires page-aligned bases, so zero-copy resolve refused every overridden expert. Segments are now mmaps, and `generate_streaming` registers the routed container's regions beside the spine's packed mmaps before the residency seal. Fired evidence, all in one run: 24 layers overridden as MXFP4/SplitE8M0, `GPU_ROUTE_LAYERS = 24 × forwards` remainder 0, all four route-witness counters zero, cmd_bufs/token 1, output byte-identical to the legacy arm.

Composed open now derives paired scale-partner sizes from the container's **declared** format (`declared_scale_sizes`) — five tamper controls prove the byte-authority move did not weaken validation: wrong declared format, missing scale pair, short scale pair, payload one group short → refuse; untampered sibling and the real 9.5 GB container → admit.

`larql bench --routed-from` serves the routed banks through the identical instrument, so control and candidate differ only in the expert bytes. The CPU fallback now refuses a routed override rather than silently serving spine banks.

### MXFP4-K1 — kernel attribution then the fix (`1f0a5909`)

Grouped-kernel profiling at production geometry predicted the expert-read delta within ~0.1 ms of e2e — no integration tax; the old −2.6 ms projection had assumed equal η. The K2 tournament's ceiling probes placed the MXFP4 deficit in the **skeleton** (16 single-byte loads per group), not the decode. Arm `a2` (`mxfp4g_split_lut16_vec`) loads each group as one `uint4` — oracle-exact, +47% on the down shape in the coldest tournament run, −0.46 ms/token e2e. It is the new default, with a 16-byte payload-alignment precondition checked per descriptor table and loud demotion to the scalar arm; the parity gate asserts its fixture is aligned so it licenses the arm the backend actually encodes.

Instrument caveat recorded rather than smoothed over: isolated tournament η at 17–35 MB working sets is SLC-confounded (arm-A down η read 0.36/0.57/0.65 across three runs). Within-run ordering is stable; the paired e2e numbers are the claim-bearers.

### TOKEN-B1 rung 1 — lm_head decomposition (`e9af233d`)

`q4k_matvec_topk` fuses the Q4_K lm_head matvec with the existing partial top-K reduction in one submission (8 KB back instead of ~800 KB + a 201K-element CPU scan), parity-gated tie-aware. **e2e-neutral** — the readback was never the cost — but the stage is now pinned: ~1.09 ms of Q4_K matvec at the bandwidth ceiling + ~0.5 ms of command-buffer boundary. That boundary is the open B1-2 rung (fold final norm → lm_head → top-K into the decode CB; 77.2 → ~80 expected, MLX ≈ 83 sits ~0.9 ms away in total).

### Also

- 26 pre-existing 13-arg `build_vindex_streaming` call sites in larql-vindex tests/benches updated to the 15-arg signature (those targets had not compiled since the G4 extraction wiring merged).
- `moe_container.rs` split into `moe_container/{mod.rs,tests/}`.
- Docs: README ladder + flags, ROADMAP closes P5-F1/P5-F2 with a new dated section, k3-funnel §4.12, cli.md `--routed-from`.

Gates: fmt clean, clippy 0 warnings, full test suites green on larql-vindex (2 441 lib + all integration targets), larql-inference (24 targets), larql-compute (1 053), larql-compute-metal (43 targets incl. the MXFP4 parity gates).
