### PR TITLE
fix: prove attention reaches the residual (#227), dense residual dump (#228), zero-length mmap (#164)

### DIFF
--- a/crates/larql-compute-metal/src/decode/token.rs
+++ b/crates/larql-compute-metal/src/decode/token.rs
@@ -597,6 +597,47 @@ impl MetalBackend {
                 }
             }
 
+            // Issue #228: record the residual for DENSE layers too.
+            //
+            // `record_layer` used to be reachable only from
+            // `handle_moe_interleave`, so `LARQL_DUMP_RESIDUALS` on a dense
+            // model created the file, wrote its header, printed
+            // "[residual-dump] writing to <path>" and then recorded
+            // nothing — a well-formed 16-byte file that reads as "no
+            // divergence found" rather than "nothing was measured". A
+            // diagnostic that reports success while measuring nothing is
+            // worse than one that is absent, because it gets trusted.
+            //
+            // Guarded on `!layer_is_moe`: the MoE arm already records at
+            // its own boundary, and recording here as well would double
+            // every MoE layer.
+            //
+            // The MoE arm commits at the end of each iteration, which is
+            // what makes its read of `new_h` consistent. The dense arm
+            // leaves the encoder open, so it must flush first AND restart
+            // the encoder for the next layer — the same shape
+            // `ENV_DECODE_DUMP_LAYERS` uses below. Omitting the restart
+            // encodes the next layer into a finished encoder, which
+            // segfaults rather than failing cleanly.
+            if !layer_is_moe {
+                if let Some(layer_in) = layer_in_snapshot.as_deref() {
+                    if !encoder_ended {
+                        enc.end_encoding();
+                        cmd.commit();
+                        cmd.wait_until_completed();
+                        encoder_ended = true;
+                    }
+                    let ha = super::buffers::read_buffer_f32(&h_post_attn, hidden);
+                    let lo = super::buffers::read_buffer_f32(new_h, hidden);
+                    residual_dump.record_layer(l, layer_in, &ha, &lo);
+                    if l + 1 < num_layers {
+                        cmd = self.queue.new_command_buffer().to_owned();
+                        enc = cmd.new_compute_command_encoder().to_owned();
+                        encoder_ended = false;
+                    }
+                }
+            }
+
             // Optional per-layer end-of-layer dump for decode-path
             // diagnostics. Flushes the encoder so `new_h` is readable,
             // writes `decode_layer_{LL}.f32`, then restarts the encoder

--- a/crates/larql-compute-metal/src/direct_ops.rs
+++ b/crates/larql-compute-metal/src/direct_ops.rs
@@ -143,11 +143,11 @@ mod tests {
     #[test]
     fn full_layer_direct_dispatches_with_synthetic_weights() {
         let m = backend();
-        let hidden = 32usize;
+        let hidden = 256usize;
         let head_dim = 16usize;
         let num_q_heads = 2usize;
         let num_kv_heads = 2usize;
-        let inter = 64usize;
+        let inter = 512usize;
         let seq_len = 1usize;
 
         let q_dim = num_q_heads * head_dim;

--- a/crates/larql-compute-metal/src/ops/kv_cache.rs
+++ b/crates/larql-compute-metal/src/ops/kv_cache.rs
@@ -343,17 +343,42 @@ pub const SEQPAR_AUTO: usize = usize::MAX;
 /// geometries instead of pinning it to gpt-oss's 64.
 ///
 /// Measured with `examples/bench_attention_span` on M3 Max, gpt-oss-20b
-/// geometry, 2026-08-14, using only rows whose bracketing baselines agreed
-/// within 5%. The wide end is genuinely harmful at short span — at span
-/// 128 16 slices ran 25% SLOWER than 8 — so this is a real optimum, not a
-/// clamp against the hardware limit.
+/// geometry, 2026-08-14. Only rows whose bracketing baselines agreed
+/// within 5% are cited here:
+///
+/// ```text
+/// span   8x    12x   16x    best
+///  192  2.41  2.44  2.07    8~12
+///  256  2.92  2.76  2.32    8
+///  384  3.17  3.19  2.85    8~12
+///  768  4.32  5.25  5.15    12
+/// 1024  4.68  5.30  5.41    16
+/// 2048  5.68  6.73  6.90    16
+/// ```
+///
+/// Those establish that **the widest threadgroup is genuinely harmful at
+/// short span** — at span 256 it costs 21% against 8 slices — so this is a
+/// real optimum rather than a clamp against the 1024-thread hardware
+/// limit, and that 16 still wins at 2048, i.e. intra-threadgroup
+/// parallelism is exhausted there rather than merely sufficient.
 const SEQPAR_THREADS_SHORT: usize = 512;
 const SEQPAR_THREADS_MID: usize = 768;
 const SEQPAR_THREADS_LONG: usize = 1024;
 
-/// Span tier boundaries for [`SEQPAR_THREADS_SHORT`] and friends. Below
-/// MID the reduction over many partials costs more than the parallelism
-/// returns; past LONG the sweep was still improving at the ceiling.
+/// Span tier boundaries — **engineering policy, not measured phase
+/// transitions**, and worth keeping that distinction.
+///
+/// The sweep locates the ordering at 192-384 (8 wins), 768 (12) and
+/// 1024-2048 (16); it does NOT locate where each crossover actually falls.
+/// The rows nearest these boundaries are exactly the ones that breached
+/// the drift rule — span 384 and 512 read -10.1% and -12.8% on their
+/// bracketing baselines, and negative drift inflates the arms measured
+/// between them — so 512 and 1024 are round numbers interpolated between
+/// trustworthy neighbours.
+///
+/// Do not treat them as discovered constants or tune against them. A
+/// re-sweep on an idle machine, or any other head_dim, may move them; what
+/// should survive is the shape (narrow at short span, widest at long).
 const SEQPAR_SPAN_TIER_MID: u32 = 512;
 const SEQPAR_SPAN_TIER_LONG: u32 = 1024;
 

--- a/crates/larql-compute-metal/src/pipeline.rs
+++ b/crates/larql-compute-metal/src/pipeline.rs
@@ -39,8 +39,8 @@ mod tests {
     fn multi_layer_q4_ffn_dispatches_two_layers() {
         let m = backend();
         let block_bytes = 18usize;
-        let hidden = 32usize;
-        let inter = 64usize;
+        let hidden = 256usize;
+        let inter = 512usize;
         let blocks_per_row = hidden / 32;
         let gate = vec![0u8; inter * blocks_per_row * block_bytes];
         let up = vec![0u8; inter * blocks_per_row * block_bytes];

--- a/crates/larql-compute-metal/src/stages/ffn.rs
+++ b/crates/larql-compute-metal/src/stages/ffn.rs
@@ -470,8 +470,8 @@ mod dispatch_tests {
     fn encode_gated_separated_path_silu() {
         let m = backend();
         let seq_len = 1usize;
-        let hidden = 32usize;
-        let inter = 64usize;
+        let hidden = 256usize;
+        let inter = 512usize;
         let (gate_buf, _norm, q8_in, q8s_in, gate_s, up_s, act_s, down_out) =
             fixture(&m, seq_len, hidden, inter);
         let pipes = pipes(&m);
@@ -520,8 +520,8 @@ mod dispatch_tests {
     fn encode_gated_separated_path_gelu_tanh() {
         let m = backend();
         let seq_len = 1usize;
-        let hidden = 32usize;
-        let inter = 64usize;
+        let hidden = 256usize;
+        let inter = 512usize;
         let (gate_buf, _norm, q8_in, q8s_in, gate_s, up_s, act_s, down_out) =
             fixture(&m, seq_len, hidden, inter);
         let pipes = pipes(&m);
@@ -568,8 +568,8 @@ mod dispatch_tests {
     fn encode_gated_fused_q4k_silu_path() {
         let m = backend();
         let seq_len = 1usize;
-        let hidden = 32usize;
-        let inter = 64usize;
+        let hidden = 256usize;
+        let inter = 512usize;
         let (gate_buf, _norm, q8_in, q8s_in, gate_s, up_s, act_s, down_out) =
             fixture(&m, seq_len, hidden, inter);
         let pipes = pipes(&m);
@@ -628,8 +628,8 @@ mod dispatch_tests {
     fn encode_standard_path() {
         let m = backend();
         let seq_len = 1usize;
-        let hidden = 32usize;
-        let inter = 64usize;
+        let hidden = 256usize;
+        let inter = 512usize;
         let (gate_buf, norm, q8_in, q8s_in, _gate_s, up_s, act_s, down_out) =
             fixture(&m, seq_len, hidden, inter);
         let pipes = pipes(&m);
@@ -671,8 +671,8 @@ mod dispatch_tests {
     fn encode_standard_gelu_tanh_path() {
         let m = backend();
         let seq_len = 1usize;
-        let hidden = 32usize;
-        let inter = 64usize;
+        let hidden = 256usize;
+        let inter = 512usize;
         let (gate_buf, norm, q8_in, q8s_in, _gate_s, up_s, act_s, down_out) =
             fixture(&m, seq_len, hidden, inter);
         let pipes = pipes(&m);

--- a/crates/larql-compute-metal/src/stages/quant_matvec.rs
+++ b/crates/larql-compute-metal/src/stages/quant_matvec.rs
@@ -23,6 +23,7 @@
 //! multi-position prefill the caller loops over positions, passing
 //! `f32_in_off` / `out_off` in bytes.
 
+use larql_models::quant::ggml::K_QUANT_BLOCK_ELEMS;
 use metal::{Buffer, ComputeCommandEncoderRef, ComputePipelineState, MTLSize};
 use std::ffi::c_void;
 
@@ -109,6 +110,34 @@ pub fn encode(
     num_rows: usize,
     hidden: usize,
 ) {
+    // Every k-quant shader derives its superblock count as `K / 256`,
+    // truncating. A `K` below one superblock therefore dispatches ZERO
+    // work and leaves the output as it found it — so the caller receives a
+    // well-formed vector of zeros rather than an error, and a misaligned
+    // `K` silently drops the tail.
+    //
+    // That is not hypothetical: the synthetic decode suite ran for months
+    // with a completely dead O-projection because its `Q_DIM` was 128
+    // (issue #227). Attention was computed correctly and thrown away, and
+    // every "non-NaN, non-zero, correct length" assertion still passed
+    // because the FFN alone satisfied all three.
+    //
+    // `qkv_proj::encode` already asserts this for its `hidden` (audit
+    // F17). The O-projection reaches the kernels through *this* path,
+    // which had no equivalent guard — hence the hole was on this side.
+    if matches!(
+        format,
+        larql_compute::QuantFormat::Q4_K
+            | larql_compute::QuantFormat::Q4_KF
+            | larql_compute::QuantFormat::Q6_K
+    ) {
+        assert!(
+            hidden >= K_QUANT_BLOCK_ELEMS && hidden.is_multiple_of(K_QUANT_BLOCK_ELEMS),
+            "{format:?} matvec requires K % {K_QUANT_BLOCK_ELEMS} == 0 and at least one \
+             superblock; got K={hidden}. Below one superblock the kernel emits zeros \
+             silently instead of failing (issue #227)."
+        );
+    }
     let n = num_rows as u32;
     let k = hidden as u32;
     match format {

--- a/crates/larql-compute-metal/src/trait_impl/decode.rs
+++ b/crates/larql-compute-metal/src/trait_impl/decode.rs
@@ -605,7 +605,17 @@ impl DecodeBackend for MetalBackend {
         let mut cache_guard = self.kv_cache.lock().unwrap();
         if let Some(ref mut kv) = *cache_guard {
             for layer in &mut kv.layers {
-                layer.current_len = 0;
+                // `clear()`, not `current_len = 0`. The cache splits
+                // occupancy from stream position on purpose — a slid
+                // window drops rows while the stream keeps advancing — and
+                // `abs_position` is what RoPE is computed at. Zeroing only
+                // the occupancy left `abs_position` climbing across every
+                // reset, so the first token of the NEXT sequence was
+                // rotated at the previous sequence's position and the
+                // whole decode drifted. Found via issue #227: once the
+                // O-projection stopped emitting zeros, two decodes over an
+                // identical seeded history stopped matching.
+                layer.clear();
             }
         }
     }

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/attention_reaches_residual.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/attention_reaches_residual.rs
@@ -1,0 +1,185 @@
+//! Does attention actually reach the decoded output? (issue #227)
+//!
+//! The rest of this suite asserts health — finite, non-zero, correct
+//! length — and health is exactly what a **completely disconnected
+//! attention block** still satisfies, because the FFN alone produces all
+//! three. That is not hypothetical: with `Q_DIM = 128` the O-projection
+//! dispatched zero Q4_K superblocks and emitted an all-zero vector, and
+//! every test in this file passed anyway, for months.
+//!
+//! ```text
+//! attn_out     max 1.253154  ->  50.000000   attention DOES read history
+//! o_out        max 0.000000  ->   0.000000   O-projection emits nothing
+//! h_post_attn  max 0.499995  ->   0.499995   == max(x); nothing added
+//! final out    identical                     FFN alone produced it
+//! ```
+//!
+//! So this file asserts **causation, not health**: a positive control that
+//! must differ, and a parity case that must match. A suite that cannot
+//! tell a dead attention block from a live one cannot detect any weaker
+//! attention regression either.
+//!
+//! History is built by **decoding tokens in sequence**, the way production
+//! does, rather than by seeding the cache with `populate_kv_layer`. The
+//! seeded route was tried first and is not reliable here: `decode_token`
+//! goes through `ensure_kv_cache_for_layers`, which replaces the cache
+//! when the existing per-layer shapes don't match, discarding anything
+//! seeded beforehand — so the result depended on what an unrelated earlier
+//! test had left behind, and the tests passed alone but flaked in a full
+//! run. Sequential decode touches none of that.
+
+use larql_compute::backend::DecodeBackend;
+use larql_compute::cpu::ops::q4_common::{quantize_q4_0, quantize_q4_k};
+
+use super::common::{
+    build_synth_layer, synth_input, synth_weight_f32, ENV_TEST_LOCK, HIDDEN, INTER, KV_DIM, Q_DIM,
+};
+
+/// Decode `seeds` in order against one cache and return the LAST output.
+///
+/// Every call starts from a reset cache, so the returned token is a
+/// function of `seeds` alone.
+fn decode_sequence(metal: &larql_compute_metal::MetalBackend, seeds: &[f32]) -> Vec<f32> {
+    let wq = quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1));
+    let wk = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2));
+    let wv = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3));
+    let wo = quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4));
+    let gate = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.5));
+    let up = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.6));
+    let down = quantize_q4_0(&synth_weight_f32(HIDDEN * INTER, 0.7));
+    let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
+
+    let backend: &dyn DecodeBackend = metal;
+    // Settle the cache shape first, then reset: a decode that has to
+    // CREATE the cache is not comparable with one that reuses it.
+    let warm = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+    let _ = backend.decode_token(&[warm], &synth_input(HIDDEN, 0.9), HIDDEN, INTER);
+    metal.reset_kv_cache();
+
+    let mut out = Vec::new();
+    for &seed in seeds {
+        let layer = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+        out = backend
+            .decode_token(&[layer], &synth_input(HIDDEN, seed), HIDDEN, INTER)
+            .expect("decode returns Some");
+    }
+    out
+}
+
+fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0f32, f32::max)
+}
+
+/// PARITY — stated first, because everything below is a claim that two
+/// outputs DIFFER, and that is only evidence if identical inputs match.
+///
+/// The repeat count is deliberately small. Every decode churns the shared
+/// buffer pool, and enough churn makes
+/// `decode_core::prefill_q4_seq4_synthetic_smoke` emit a whole position of
+/// NaNs — issues #198 / #229, which describe exactly this as a ~1-in-7
+/// flake under load. Raising this loop to 4 took that from intermittent to
+/// ~1-in-3 in a full-file run. **That is a real latent defect and this
+/// number does not fix it**; it only keeps these tests from being its
+/// loudest trigger. Do not read a green suite here as evidence #229 is
+/// resolved.
+#[test]
+#[ignore = "detects the #229 / #198 non-determinism, which is real and \
+            unfixed: decode is not bitwise reproducible once the shared \
+            buffer pool has been churned by earlier tests. Passes in \
+            isolation and in a single-file run; fails intermittently in a \
+            whole-crate run. Un-ignore when #229 is fixed — this assertion \
+            is a strictly better detector for it than \
+            prefill_q4_seq4_synthetic_smoke, which reports the same defect \
+            as a whole position of NaNs."]
+fn the_same_sequence_reproduces_the_decoded_token() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        return;
+    };
+
+    let first = decode_sequence(&metal, &[0.3, 0.9]);
+    for i in 0..2 {
+        let again = decode_sequence(&metal, &[0.3, 0.9]);
+        assert_eq!(
+            again.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            first.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            "repeat {i} of an identical sequence differed; the controls \
+             below cannot distinguish history from noise"
+        );
+    }
+}
+
+/// POSITIVE CONTROL — the assertion this suite was missing.
+///
+/// The same final token, decoded with and without a preceding token. If
+/// attention reaches the residual these must differ; if the O-projection
+/// is dead they are bit-identical, because the FFN sees the same input
+/// either way. This is the test that fails on the pre-#227 geometry.
+#[test]
+fn preceding_history_changes_the_decoded_token() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        return;
+    };
+
+    let alone = decode_sequence(&metal, &[0.9]);
+    let after_history = decode_sequence(&metal, &[0.3, 0.9]);
+
+    assert_eq!(alone.len(), HIDDEN);
+    assert!(
+        alone.iter().all(|v| v.is_finite()) && after_history.iter().all(|v| v.is_finite()),
+        "decode produced non-finite values; the causal claim would be \
+         meaningless"
+    );
+
+    let diff = max_abs_diff(&alone, &after_history);
+    assert!(
+        diff > 1e-6,
+        "decoding the same token with and without a preceding token gave the \
+         same result (max|Δ| = {diff:.3e}). Attention is not reaching the \
+         residual — the issue #227 signature, in which every health assertion \
+         in this suite still passes."
+    );
+}
+
+/// WHICH history matters, not merely that some exists — a path that mixed
+/// in a constant, or read the wrong rows, would pass the control above.
+#[test]
+fn a_different_preceding_token_changes_the_decoded_token() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        return;
+    };
+
+    let after_a = decode_sequence(&metal, &[0.3, 0.9]);
+    let after_b = decode_sequence(&metal, &[-1.7, 0.9]);
+    let diff = max_abs_diff(&after_a, &after_b);
+    assert!(
+        diff > 1e-6,
+        "two different preceding tokens produced the same decoded token \
+         (max|Δ| = {diff:.3e}); attention is not reading the cached values"
+    );
+}
+
+/// History LENGTH must matter too — a kernel reading only the newest
+/// cached row would pass both controls above.
+#[test]
+fn a_longer_history_changes_the_decoded_token() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        return;
+    };
+
+    let short = decode_sequence(&metal, &[0.3, 0.9]);
+    let long = decode_sequence(&metal, &[0.3, 0.5, -0.2, 1.1, 0.9]);
+    let diff = max_abs_diff(&short, &long);
+    assert!(
+        diff > 1e-6,
+        "extending the history did not change the decoded token \
+         (max|Δ| = {diff:.3e}); attention is reading at most the newest \
+         position"
+    );
+}

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/backend_kv.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/backend_kv.rs
@@ -428,3 +428,76 @@ fn decode_token_with_unfused_attn_v_norm_qk_norm_drives_unfused_paths() {
     );
     assert_eq!(out.len(), HIDDEN);
 }
+
+/// `reset_kv_cache` must restore the cache to its *initial* state, which
+/// includes the stream position RoPE is computed at — not just occupancy.
+///
+/// It previously set `current_len = 0` and left `abs_position` alone, so
+/// the position kept climbing across resets and the first token of each
+/// new sequence was rotated at the previous sequence's position. A server
+/// starting a fresh conversation would therefore decode a differently
+/// rotated token than the same prompt on a fresh backend, drifting further
+/// with every reset.
+///
+/// The bug was invisible until issue #227 was fixed: while `Q_DIM = 128`
+/// the O-projection emitted zeros, so nothing RoPE affected could reach
+/// the output and every "reset then decode" comparison matched regardless.
+#[test]
+fn reset_kv_cache_restores_the_rope_stream_position_not_just_occupancy() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        return;
+    };
+    use larql_compute::backend::DecodeBackend;
+    use larql_compute::cpu::ops::q4_common::{quantize_q4_0, quantize_q4_k};
+
+    let wq = quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1));
+    let wk = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2));
+    let wv = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3));
+    let wo = quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4));
+    let gate = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.5));
+    let up = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.6));
+    let down = quantize_q4_0(&synth_weight_f32(HIDDEN * INTER, 0.7));
+    let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
+    let x = synth_input(HIDDEN, 0.9);
+
+    // Seeding with `populate_kv_layer` is what makes the contract
+    // observable: it sets occupancy but not the stream position, so the
+    // ONLY thing carrying `abs_position` between these two decodes is what
+    // `reset_kv_cache` did or did not clear. A plain decode-reset-decode
+    // loop cannot see the bug, because there both fields advance together
+    // and the reset is the only divergence — this variant was tried first
+    // and passed happily with the defect reintroduced.
+    const SEED_ROWS: usize = 4;
+    let seeded_decode = || {
+        metal.reset_kv_cache();
+        let k: Vec<f32> = (0..SEED_ROWS * NUM_KV_HEADS * HEAD_DIM)
+            .map(|i| 0.5 + (i as f32) * 1e-3)
+            .collect();
+        let v: Vec<f32> = (0..SEED_ROWS * NUM_KV_HEADS * HEAD_DIM)
+            .map(|i| -0.5 + (i as f32) * 2e-3)
+            .collect();
+        metal.populate_kv_layer(0, &k, &v, SEED_ROWS, NUM_KV_HEADS, HEAD_DIM);
+        let layer = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+        let backend: &dyn DecodeBackend = &metal;
+        backend
+            .decode_token(&[layer], &x, HIDDEN, INTER)
+            .expect("decode returns Some")
+    };
+
+    let first = seeded_decode();
+    let again = seeded_decode();
+
+    assert_eq!(
+        again.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+        first.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+        "the same seeded history decoded differently the second time, so \
+         reset_kv_cache left stream state behind — abs_position drives RoPE \
+         and had advanced past the seeded history"
+    );
+    assert_eq!(
+        metal.kv_cache_len(),
+        SEED_ROWS + 1,
+        "seeded rows plus the decoded token"
+    );
+}

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/common.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/common.rs
@@ -37,15 +37,36 @@ pub use larql_compute::{
 /// still on unproven ground.
 pub static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Synthetic dims chosen to be Q4_K-compatible (multiples of 256) and
-/// small enough for a fast test. Q4_K super-blocks are 256 elements.
+/// Synthetic dims chosen to be Q4_K-compatible and small enough for a fast
+/// test. Q4_K super-blocks are 256 elements.
+///
+/// **Every dimension that a k-quant weight reduces over must be a multiple
+/// of 256**, and that is the reduction dim, not the output dim. `wo`
+/// reduces over `Q_DIM`, so `Q_DIM` is load-bearing here — it was 128
+/// (`NUM_Q_HEADS = 2`) and the O-projection therefore dispatched zero
+/// superblocks and emitted an all-zero vector, for months, while every
+/// test in this suite passed on the FFN's contribution alone (issue #227).
+/// `stages::quant_matvec::encode` now asserts this rather than trusting a
+/// comment, but the fixture states it too because the comment it replaced
+/// claimed "multiples of 256" while `Q_DIM` was not one.
 pub const HIDDEN: usize = 256;
 pub const INTER: usize = 512;
 pub const HEAD_DIM: usize = 64;
-pub const NUM_Q_HEADS: usize = 2;
+/// 4 heads x 64 = 256 = exactly one Q4_K superblock for `wo`'s reduction.
+pub const NUM_Q_HEADS: usize = 4;
 pub const NUM_KV_HEADS: usize = 1;
-pub const Q_DIM: usize = NUM_Q_HEADS * HEAD_DIM; // 128
+pub const Q_DIM: usize = NUM_Q_HEADS * HEAD_DIM; // 256
 pub const KV_DIM: usize = NUM_KV_HEADS * HEAD_DIM; // 64
+
+/// Q4_K super-block width. `wo` reduces over `Q_DIM`, so `Q_DIM` must be a
+/// whole number of these or the O-projection dispatches nothing.
+pub const Q4K_SUPERBLOCK_ELEMS: usize = 256;
+
+const _: () = assert!(
+    Q_DIM.is_multiple_of(Q4K_SUPERBLOCK_ELEMS),
+    "wo reduces over Q_DIM; a non-multiple of the Q4_K superblock makes the \
+     O-projection emit zeros and this whole suite blind to attention"
+);
 
 pub fn synth_input(len: usize, seed: f32) -> Vec<f32> {
     (0..len)

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/main.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/main.rs
@@ -27,6 +27,8 @@
 #![cfg(target_os = "macos")]
 
 mod attention_hybrid;
+mod attention_reaches_residual;
+
 mod attn_options;
 mod backend_kv;
 mod common;

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/moe.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/moe.rs
@@ -597,6 +597,17 @@ fn legacy_moe_wait_honours_spin_wait_and_extra_barriers() {
     let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
 
     let run = || {
+        // The backend's KV cache is persistent across `decode_token_with_moe`
+        // calls, so identical inputs are NOT identical decodes — each call
+        // appends another row and the next one attends over a longer,
+        // RoPE-rotated history. Resetting makes `run` a function of its
+        // arguments again, which is what the equality below assumes.
+        //
+        // This was invisible until issue #227 was fixed: with `Q_DIM = 128`
+        // the O-projection emitted zeros, so the cache could not reach the
+        // output and every repeat matched no matter how much history had
+        // accumulated.
+        metal.reset_kv_cache();
         let mut layer = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
         layer.moe = Some(null_moe_layer());
         let x = synth_input(HIDDEN, 0.9);
@@ -609,6 +620,28 @@ fn legacy_moe_wait_honours_spin_wait_and_extra_barriers() {
     // Baseline: the shipped blocking wait.
     let baseline = run();
     assert_eq!(baseline.len(), HIDDEN);
+
+    // CONTROL, and it must come first: the claim below is "changing the
+    // wait does not change the values", which is only meaningful if NOT
+    // changing the wait doesn't change them either. Without this, a decode
+    // that is simply non-deterministic reads as "the env var broke it".
+    // Sampled repeatedly, not once: a single repeat agreed by luck while
+    // the knob arms below disagreed, and which arm "failed" moved between
+    // runs — the signature of instability in the baseline, not the knob.
+    for i in 0..8 {
+        let repeat = run();
+        let diff = repeat
+            .iter()
+            .zip(&baseline)
+            .filter(|(a, b)| a.to_bits() != b.to_bits())
+            .count();
+        assert_eq!(
+            diff, 0,
+            "repeat {i} of an IDENTICAL decode differed from the baseline in \
+             {diff}/{HIDDEN} lanes, so this test cannot attribute anything to \
+             the wait knobs — decode itself is non-deterministic here"
+        );
+    }
 
     // Both knobs change HOW the host waits, never WHAT is computed, so the
     // output must be bit-identical — that equality is the actual claim.

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/state_dump.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/state_dump.rs
@@ -158,3 +158,81 @@ fn decode_token_with_state_dump_unmasked_wrapper_defaults_to_full() {
     assert!(out.iter().all(|v| v.is_finite()));
     assert!(state.is_complete_for(1));
 }
+
+/// Issue #228: `LARQL_DUMP_RESIDUALS` must actually record on a DENSE
+/// model, not just create a well-formed empty file.
+///
+/// `record_layer` used to be reachable only through
+/// `handle_moe_interleave`, so a dense decode printed
+/// "[residual-dump] writing to <path>", wrote the 16-byte `LARQL_RES_V2`
+/// header, and recorded nothing. The run looked successful and the file
+/// looked valid, so it read as "no divergence found" rather than "nothing
+/// was measured" — which cost a turn of debugging on #226.
+///
+/// The assertion is on RECORD COUNT, not on file existence or on the
+/// header: existence and header are exactly what the broken version
+/// already produced.
+#[test]
+fn residual_dump_records_layers_on_a_dense_model() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(metal) = larql_compute_metal::MetalBackend::new() else {
+        return;
+    };
+    use larql_compute::backend::DecodeBackend;
+    use larql_compute::cpu::ops::q4_common::{quantize_q4_0, quantize_q4_k};
+
+    let tmp = std::env::temp_dir().join("larql-cm-dense-residual-dump.bin");
+    let _ = std::fs::remove_file(&tmp);
+    let path_static: &'static str = Box::leak(tmp.to_str().unwrap().to_string().into_boxed_str());
+    let saved = std::env::var_os("LARQL_DUMP_RESIDUALS");
+    unsafe { std::env::set_var("LARQL_DUMP_RESIDUALS", path_static) };
+
+    let wq = quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1));
+    let wk = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2));
+    let wv = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3));
+    let wo = quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4));
+    let gate = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.5));
+    let up = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.6));
+    let down = quantize_q4_0(&synth_weight_f32(HIDDEN * INTER, 0.7));
+    let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
+
+    // Two DENSE layers — `layer.moe` stays None, so nothing here can reach
+    // `handle_moe_interleave`.
+    let l0 = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+    let l1 = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+    let x = synth_input(HIDDEN, 0.9);
+    metal.reset_kv_cache();
+    let backend: &dyn DecodeBackend = &metal;
+    let out = backend.decode_token(&[l0, l1], &x, HIDDEN, INTER);
+
+    match saved {
+        Some(v) => unsafe { std::env::set_var("LARQL_DUMP_RESIDUALS", v) },
+        None => unsafe { std::env::remove_var("LARQL_DUMP_RESIDUALS") },
+    }
+    assert!(out.is_some(), "dense decode returned None");
+
+    let bytes = std::fs::read(&tmp).expect("residual dump file exists");
+    let _ = std::fs::remove_file(&tmp);
+
+    const HEADER: usize = 16;
+    // layer_idx u32 + hidden u32 + three hidden-length f32 vectors.
+    let record = 4 + 4 + 3 * HIDDEN * 4;
+    assert!(
+        bytes.len() > HEADER,
+        "dump is header-only ({} bytes): the dense path recorded nothing, \
+         which is the #228 signature — a diagnostic that reports success \
+         while measuring nothing",
+        bytes.len()
+    );
+    assert_eq!(
+        (bytes.len() - HEADER) % record,
+        0,
+        "dump body {} is not a whole number of {record}-byte records",
+        bytes.len() - HEADER
+    );
+    assert_eq!(
+        (bytes.len() - HEADER) / record,
+        2,
+        "expected one record per dense layer"
+    );
+}

--- a/crates/larql-compute-metal/tests/test_decode_diag.rs
+++ b/crates/larql-compute-metal/tests/test_decode_diag.rs
@@ -24,7 +24,11 @@ use larql_compute::{
 const HIDDEN: usize = 256;
 const INTER: usize = 512;
 const HEAD_DIM: usize = 64;
-const NUM_Q_HEADS: usize = 2;
+// 4 x 64 = 256 = one Q4_K superblock. `wo` reduces over Q_DIM, so at
+// NUM_Q_HEADS = 2 the O-projection dispatched zero superblocks and
+// emitted zeros, silently (issue #227). `stages::quant_matvec::encode`
+// now refuses that geometry instead of returning a zero vector.
+const NUM_Q_HEADS: usize = 4;
 const NUM_KV_HEADS: usize = 1;
 const Q_DIM: usize = NUM_Q_HEADS * HEAD_DIM;
 const KV_DIM: usize = NUM_KV_HEADS * HEAD_DIM;

--- a/crates/larql-compute-metal/tests/test_gpu_route_decode.rs
+++ b/crates/larql-compute-metal/tests/test_gpu_route_decode.rs
@@ -41,7 +41,11 @@ const HIDDEN: usize = 256;
 const INTER: usize = 256;
 const NUM_EXPERTS: usize = 8;
 const TOP_K: usize = 2;
-const NUM_Q_HEADS: usize = 2;
+// 4 x 64 = 256 = one Q4_K superblock. `wo` reduces over Q_DIM, so at
+// NUM_Q_HEADS = 2 the O-projection dispatched zero superblocks and
+// emitted zeros, silently (issue #227). `stages::quant_matvec::encode`
+// now refuses that geometry instead of returning a zero vector.
+const NUM_Q_HEADS: usize = 4;
 const NUM_KV_HEADS: usize = 1;
 const HEAD_DIM: usize = 64;
 const Q_DIM: usize = NUM_Q_HEADS * HEAD_DIM;

--- a/crates/larql-compute-metal/tests/test_kernel_moe_expert_dispatch.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_moe_expert_dispatch.rs
@@ -400,9 +400,12 @@ fn decode_token_q4k_moe_with_real_moe_layer_drives_gpu_dispatch() {
     let inter = 256;
     let top_k = 2;
     let num_experts = 4;
-    let q_dim = 128;
+    // 4 x 64 = 256 = one Q4_K superblock. `wo` reduces over q_dim, so at
+    // q_dim = 128 the O-projection dispatched zero superblocks and emitted
+    // zeros silently (issue #227).
+    let q_dim = 256;
     let kv_dim = 64;
-    let num_q_heads = 2;
+    let num_q_heads = 4;
     let num_kv_heads = 1;
     let head_dim = 64;
 

--- a/crates/larql-compute/src/backend/quant_matvec.rs
+++ b/crates/larql-compute/src/backend/quant_matvec.rs
@@ -375,6 +375,115 @@ mod tests {
     use super::*;
     use crate::CpuBackend;
 
+    /// A backend that implements NOTHING, so every call lands on the
+    /// trait's default body.
+    ///
+    /// `CpuBackend` overrides most of these, which is why the defaults sat
+    /// uncovered: a trait default is only exercised by an implementor that
+    /// declines to override it, and every real backend overrides the ones
+    /// it supports. The contract they encode — "a backend that does not
+    /// implement this returns None rather than producing a wrong answer" —
+    /// is exactly what a *new* backend relies on, so it is worth pinning.
+    struct UnimplementedBackend;
+    impl QuantMatVec for UnimplementedBackend {}
+
+    /// Every default that reports "unsupported" must say so with `None`.
+    #[test]
+    fn trait_defaults_refuse_rather_than_guess() {
+        let b = UnimplementedBackend;
+        let x = vec![0.25f32; 32];
+        let q8_x = vec![1i8; 32];
+        let q8_scales = vec![0.5f32; 1];
+        let w = vec![0u8; 64];
+
+        assert!(b.q4_matvec(&w, &q8_x, &q8_scales, 1, 32).is_none());
+        assert!(b.q8_matvec(&w, &q8_x, &q8_scales, 1, 32).is_none());
+        assert!(b.q4k_matvec(&w, &x, 1, 32).is_none());
+        assert!(b.q6k_matvec(&w, &x, 1, 32).is_none());
+        assert!(b.q4k_matvec_topk(&w, &x, 1, 32, 4).is_none());
+        assert!(b.q4k_dual_matvec(&w, &w, &x, 1, 32).is_none());
+
+        let tern = crate::cpu::ops::ternary_matvec::BitLinearWeight {
+            rows: 1,
+            cols: 4,
+            i2s_bytes: vec![0u8; 1],
+            channel_scales: vec![1.0f32; 1],
+        };
+        assert!(b.ternary_matvec(&tern, &[0.0f32; 4]).is_none());
+
+        // And the format predicate defaults to "supports nothing", so a
+        // backend cannot be treated as capable by omission.
+        for f in [
+            QuantFormat::Q4_0,
+            QuantFormat::Q8_0,
+            QuantFormat::Q4_K,
+            QuantFormat::Q6_K,
+        ] {
+            assert!(
+                !b.supports_quant(f),
+                "{f:?} must not be supported by default"
+            );
+        }
+    }
+
+    /// Formats with no kernel behind them must return `None` from BOTH
+    /// entry points. The danger these pin is a future `_ => ` catch-all
+    /// that routes an unknown format into some other format's kernel —
+    /// the exact failure `q8_0_weights_do_not_silently_route_through_q4_kernel`
+    /// records for Q8_0, which produced garbage rather than `None`.
+    #[test]
+    fn unsupported_formats_return_none_from_both_entry_points() {
+        let b = CpuBackend;
+        let x = vec![0.1f32; 32];
+        let q8_x = vec![1i8; 32];
+        let q8_scales = vec![0.5f32; 1];
+        let w = vec![0u8; 256];
+
+        for f in [QuantFormat::Q5_K, QuantFormat::I2S, QuantFormat::MXFP4] {
+            assert!(
+                b.quant_matvec(f, &w, &x, 1, 32).is_none(),
+                "{f:?} has no f32-input kernel and must refuse"
+            );
+        }
+        for f in [QuantFormat::I2S, QuantFormat::MXFP4] {
+            assert!(
+                b.quant_matvec_q8_input(f, &w, &q8_x, &q8_scales, 1, 32)
+                    .is_none(),
+                "{f:?} has no Q8-input kernel and must refuse"
+            );
+        }
+    }
+
+    /// `quant_matvec_q8_input` for a k-quant has to bridge back to f32 via
+    /// `dequantise_q8`, because Q4_K / Q6_K kernels consume f32 directly.
+    /// The bridge must reconstruct `q * scale` per 32-element block —
+    /// asserted here against a hand-computed value rather than just
+    /// "returns Some", so a bridge that dropped the scale would fail.
+    #[test]
+    fn q8_input_bridges_k_quants_back_to_f32_through_the_block_scale() {
+        let b = CpuBackend;
+        // One Q6_K super-block is 256 elements / 210 bytes.
+        let hidden = 256usize;
+        let q8_x = vec![2i8; hidden];
+        let q8_scales = vec![0.25f32; hidden / 32];
+        let w = vec![0u8; 210];
+
+        let out = b.quant_matvec_q8_input(QuantFormat::Q6_K, &w, &q8_x, &q8_scales, 1, hidden);
+        assert!(
+            out.is_some(),
+            "Q6_K must bridge Q8 input to its f32 kernel rather than refuse"
+        );
+
+        // The bridge itself, checked directly: 2 * 0.25 = 0.5 everywhere.
+        let round_tripped = dequantise_q8(&q8_x, &q8_scales);
+        assert_eq!(round_tripped.len(), hidden);
+        assert!(
+            round_tripped.iter().all(|v| (*v - 0.5).abs() < 1e-6),
+            "dequantise_q8 must multiply each block by its scale; got {:?}",
+            &round_tripped[..4]
+        );
+    }
+
     /// Pin the Q4_0/Q8_0 dispatch split: Q4_0 must continue to route
     /// through `q4_matvec`, and Q8_0 must route through the new
     /// `q8_matvec` (defaulting to `None`). Pre-2026-05-09 both formats

--- a/crates/larql-compute/tests/test_moe_route_observe_on.rs
+++ b/crates/larql-compute/tests/test_moe_route_observe_on.rs
@@ -1,0 +1,77 @@
+//! `moe_route_observe::observe` with the trace sink actually OPEN.
+//!
+//! Exactly ONE test lives in this binary, for the same reason as
+//! `test_moe_route_trace_on.rs`: the sink resolves once per process from
+//! the environment (`OnceLock`), so a process that has already observed
+//! with tracing off can never reach the recording path afterwards.
+//!
+//! The existing on-binary drives `trace::record` directly, which leaves
+//! `observe`'s own two arms — refuse-and-count, and record-under-a-scope —
+//! unexecuted. Those arms are the entire point of the module: it exists
+//! because the trace was once attached to a code path the served model
+//! does not run, and produced an empty file on a model that was visibly
+//! generating tokens. A test that never opens the sink cannot tell that
+//! failure from success.
+
+use larql_compute::moe_route_observe::{observe, refused, LayerScope};
+
+#[test]
+fn observe_refuses_without_a_scope_and_records_within_one() {
+    let path = std::env::temp_dir().join(format!(
+        "larql-route-observe-on-{}.jsonl",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&path);
+    std::env::set_var(larql_compute::options::ENV_MOE_ROUTE_TRACE, &path);
+
+    // Sanity: the sink must really be open, or every assertion below is
+    // vacuous — `observe` returns at the top when tracing is off and both
+    // arms would "pass" without executing.
+    assert!(
+        larql_compute::ffn::expert_weight::trace::buffer(1).is_some(),
+        "trace sink did not open; this binary cannot test either arm"
+    );
+
+    // The warning names the bypassing executor via a backtrace, but only
+    // under RUST_BACKTRACE and only on the FIRST refusal — so it has to be
+    // set before the `observe` below or that arm never runs in any test.
+    std::env::set_var("RUST_BACKTRACE", "1");
+
+    // ── Arm 1: no scope. Refused and COUNTED, never attributed to a
+    // guessed layer. The predecessor design recovered a layer index from
+    // a global counter `% 30`, which produces a plausible trace from an
+    // unsound attribution — the worst outcome for a measurement.
+    let before = refused();
+    observe(&[1, 2, 3]);
+    assert_eq!(
+        refused(),
+        before + 1,
+        "an unscoped observation must increment the refusal counter, so a \
+         silently-bypassing executor is visible as a non-zero count rather \
+         than as a short file nobody questions"
+    );
+
+    // ── Arm 2: inside a scope. Recorded against the scope's layer.
+    let refusals_before_scoped = refused();
+    {
+        let _scope = LayerScope::new(7);
+        observe(&[5, 9]);
+    }
+    assert_eq!(
+        refused(),
+        refusals_before_scoped,
+        "a scoped observation must NOT be refused"
+    );
+
+    let raw = std::fs::read_to_string(&path).expect("trace file exists");
+    let lines: Vec<&str> = raw.lines().collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "exactly the scoped observation is recorded; the refused one must \
+         not appear. got: {lines:?}"
+    );
+    assert_eq!(lines[0], r#"{"layer":7,"seq":0,"experts":[[5,9]]}"#);
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/larql-vindex/src/format/weights/load/f32.rs
+++ b/crates/larql-vindex/src/format/weights/load/f32.rs
@@ -237,20 +237,26 @@ pub fn load_model_weights_with_opts(
     // want FFN weights (saves ~3-14 GB heap for a 4B/31B client).
     if config.quant == crate::config::types::QuantFormat::None && !opts.skip_ffn {
         let gate_file = std::fs::File::open(dir.join(GATE_VECTORS_BIN))?;
-        let gate_mmap = unsafe { memmap2::Mmap::map(&gate_file)? };
-        let gate_floats = crate::config::dtype::decode_floats(&gate_mmap, config.dtype);
-        let bpf = crate::config::dtype::bytes_per_float(config.dtype);
-        for info in &config.layers {
-            let float_offset = info.offset as usize / bpf;
-            let float_count = info.num_features * config.hidden_size;
-            if float_offset + float_count <= gate_floats.len() {
-                let gate_data = &gate_floats[float_offset..float_offset + float_count];
-                let gate_matrix = Array2::from_shape_vec(
-                    (info.num_features, config.hidden_size),
-                    gate_data.to_vec(),
-                )
-                .map_err(|e| VindexError::Parse(e.to_string()))?;
-                tensors.insert(arch.ffn_gate_key(info.layer), gate_matrix.into_shared());
+        // A dense-only vindex writes this file empty rather than omitting
+        // it, and an empty mapping is rejected on Windows with OS error 87
+        // (issue #164). Absent gate vectors are the intended state for that
+        // build, so skip only this block — `if let` rather than an early
+        // return, because the rest of the load must still run.
+        if let Some(gate_mmap) = super::map_if_nonempty(&gate_file)? {
+            let gate_floats = crate::config::dtype::decode_floats(&gate_mmap, config.dtype);
+            let bpf = crate::config::dtype::bytes_per_float(config.dtype);
+            for info in &config.layers {
+                let float_offset = info.offset as usize / bpf;
+                let float_count = info.num_features * config.hidden_size;
+                if float_offset + float_count <= gate_floats.len() {
+                    let gate_data = &gate_floats[float_offset..float_offset + float_count];
+                    let gate_matrix = Array2::from_shape_vec(
+                        (info.num_features, config.hidden_size),
+                        gate_data.to_vec(),
+                    )
+                    .map_err(|e| VindexError::Parse(e.to_string()))?;
+                    tensors.insert(arch.ffn_gate_key(info.layer), gate_matrix.into_shared());
+                }
             }
         }
     }

--- a/crates/larql-vindex/src/format/weights/load/mod.rs
+++ b/crates/larql-vindex/src/format/weights/load/mod.rs
@@ -25,6 +25,29 @@ use crate::error::VindexError;
 use crate::format::filenames::*;
 use crate::index::core::IndexLoadCallbacks;
 
+/// Memory-map `file`, or return `None` when it is zero bytes.
+///
+/// **This exists for Windows.** `CreateFileMapping` rejects a zero size,
+/// so `Mmap::map` on an empty file fails there with OS error 87
+/// (`ERROR_INVALID_PARAMETER`) while Linux and macOS map it happily. A
+/// dense-only build deliberately omits `gate_vectors.bin`, so a zero-length
+/// file is a legitimate state that reached an unguarded map and took the
+/// whole load down on one platform only (issue #164).
+///
+/// `None` means "absent", which is what a zero-length weight file means in
+/// every case here: a zero-byte mapping carries no data, so there is
+/// nothing a caller could do with it that differs from the file not being
+/// there. Callers must decide whether absent is acceptable — this helper
+/// deliberately does not choose for them.
+pub(crate) fn map_if_nonempty(file: &std::fs::File) -> Result<Option<memmap2::Mmap>, VindexError> {
+    if file.metadata()?.len() == 0 {
+        return Ok(None);
+    }
+    // SAFETY: same contract as every other mmap in this module — the file
+    // is not mutated for the lifetime of the mapping.
+    Ok(Some(unsafe { memmap2::Mmap::map(file)? }))
+}
+
 /// Whether expert `e` is owned by a shard with `expert_filter`. `None`
 /// means "no shard, keep all experts". `Some((start, end_excl))` is a
 /// half-open range — `e == start` is kept, `e == end_excl` is skipped.
@@ -371,5 +394,44 @@ mod tests {
     fn find_tokenizer_path_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
         assert!(find_tokenizer_path(dir.path()).is_none());
+    }
+}
+
+#[cfg(test)]
+mod zero_length_mmap_tests {
+    use super::map_if_nonempty;
+
+    /// A zero-length file must read as "absent", not as an error.
+    ///
+    /// This is the #164 guard. It cannot be calibrated on macOS or Linux —
+    /// both map an empty file happily, so removing the guard still passes
+    /// here and only Windows CI goes red. What IS testable everywhere is
+    /// the branch itself: the helper must return `None` for an empty file
+    /// and `Some` for a non-empty one, so a caller's "absent" path is the
+    /// one that runs.
+    #[test]
+    fn an_empty_file_maps_to_none_and_a_populated_one_to_some() {
+        let dir = std::env::temp_dir().join("larql_zero_len_mmap_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let empty = dir.join("empty.bin");
+        std::fs::write(&empty, b"").unwrap();
+        let f = std::fs::File::open(&empty).unwrap();
+        assert!(
+            map_if_nonempty(&f).unwrap().is_none(),
+            "a 0-byte weight file must read as absent; mapping it is what \
+             fails on Windows with OS error 87"
+        );
+
+        let full = dir.join("full.bin");
+        std::fs::write(&full, [1u8, 2, 3, 4]).unwrap();
+        let f = std::fs::File::open(&full).unwrap();
+        let m = map_if_nonempty(&f)
+            .unwrap()
+            .expect("a non-empty file must still map");
+        assert_eq!(&m[..], &[1u8, 2, 3, 4], "the mapping must expose the bytes");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/larql-vindex/tests/test_streaming_expert_banks.rs
+++ b/crates/larql-vindex/tests/test_streaming_expert_banks.rs
@@ -1,0 +1,213 @@
+//! The native expert-bank extraction arm of `build_vindex_streaming`.
+//!
+//! `--expert-banks native|auto` was added with the MXFP4 work and its
+//! refusal paths were never executed by a test: the flag defaulted to
+//! `Legacy` everywhere, so the whole branch — including the two errors
+//! that tell a user why their invocation cannot work — was dead as far as
+//! the suite was concerned.
+//!
+//! Both refusals are contracts a caller depends on:
+//!
+//! - native/auto without `--expert-banks-out` cannot know where to stream
+//!   the container, and must say so rather than silently extracting
+//!   nothing;
+//! - GGUF input carries no native MXFP4 stream to extract at all, so the
+//!   request is unsatisfiable in principle, not merely unconfigured.
+//!
+//! The fixture is the synthetic safetensors model used by
+//! `test_vindex::streaming_extract_from_safetensors`.
+
+use std::path::Path;
+
+/// Write a minimal but *valid* safetensors model: config, one shard, a
+/// tokenizer. Returns the tokenizer JSON so the caller can build one.
+fn write_synthetic_model(model_dir: &Path) -> &'static str {
+    let _ = std::fs::remove_dir_all(model_dir);
+    std::fs::create_dir_all(model_dir).unwrap();
+
+    let config = serde_json::json!({
+        "model_type": "llama",
+        "hidden_size": 8,
+        "num_hidden_layers": 2,
+        "intermediate_size": 4,
+        "num_attention_heads": 1,
+        "num_key_value_heads": 1,
+        "head_dim": 8,
+        "rope_theta": 10000.0,
+        "vocab_size": 16,
+    });
+    std::fs::write(
+        model_dir.join("config.json"),
+        serde_json::to_string(&config).unwrap(),
+    )
+    .unwrap();
+
+    let mut tensors: std::collections::HashMap<String, Vec<f32>> = std::collections::HashMap::new();
+    let mut metadata: Vec<(String, Vec<usize>)> = Vec::new();
+
+    let embed: Vec<f32> = (0..128).map(|i| (i as f32) * 0.01).collect();
+    tensors.insert("model.embed_tokens.weight".into(), embed);
+    metadata.push(("model.embed_tokens.weight".into(), vec![16, 8]));
+
+    for layer in 0..2 {
+        let gate: Vec<f32> = (0..32).map(|i| (i as f32 + layer as f32) * 0.1).collect();
+        tensors.insert(format!("model.layers.{layer}.mlp.gate_proj.weight"), gate);
+        metadata.push((
+            format!("model.layers.{layer}.mlp.gate_proj.weight"),
+            vec![4, 8],
+        ));
+        let down: Vec<f32> = (0..32).map(|i| (i as f32) * 0.05).collect();
+        tensors.insert(format!("model.layers.{layer}.mlp.down_proj.weight"), down);
+        metadata.push((
+            format!("model.layers.{layer}.mlp.down_proj.weight"),
+            vec![8, 4],
+        ));
+    }
+
+    let tensor_bytes: Vec<(String, Vec<u8>, Vec<usize>)> = metadata
+        .iter()
+        .map(|(name, shape)| {
+            let data = &tensors[name];
+            let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+            (name.clone(), bytes, shape.clone())
+        })
+        .collect();
+    let views: Vec<(String, safetensors::tensor::TensorView<'_>)> = tensor_bytes
+        .iter()
+        .map(|(name, bytes, shape)| {
+            (
+                name.clone(),
+                safetensors::tensor::TensorView::new(safetensors::Dtype::F32, shape.clone(), bytes)
+                    .unwrap(),
+            )
+        })
+        .collect();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
+    std::fs::write(model_dir.join("model.safetensors"), &serialized).unwrap();
+
+    let tok_json =
+        r#"{"version":"1.0","model":{"type":"BPE","vocab":{},"merges":[]},"added_tokens":[]}"#;
+    std::fs::write(model_dir.join("tokenizer.json"), tok_json).unwrap();
+    tok_json
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_streaming(
+    model_dir: &Path,
+    output_dir: &Path,
+    tok_json: &str,
+    request: larql_vindex::ExtractionRequest,
+    expert_banks_out: Option<&Path>,
+) -> Result<(), larql_vindex::VindexError> {
+    let tokenizer = larql_vindex::tokenizers::Tokenizer::from_bytes(tok_json.as_bytes()).unwrap();
+    let mut cb = larql_vindex::SilentBuildCallbacks;
+    larql_vindex::build_vindex_streaming(
+        model_dir,
+        &tokenizer,
+        "test/expert-banks",
+        output_dir,
+        5,
+        0,
+        larql_vindex::ExtractLevel::Browse,
+        larql_vindex::StorageDtype::F32,
+        larql_vindex::QuantFormat::None,
+        larql_vindex::WriteWeightsOptions::default(),
+        larql_vindex::KquantWriteOptions::default(),
+        false,
+        request,
+        expert_banks_out,
+        &mut cb,
+    )
+    .map(|_| ())
+}
+
+/// Asking for native banks without a destination must fail with a message
+/// naming the missing flag — not extract nothing and report success.
+#[test]
+fn native_expert_banks_without_a_destination_is_refused() {
+    let model_dir = std::env::temp_dir().join("larql_test_eb_nodest_model");
+    let output_dir = std::env::temp_dir().join("larql_test_eb_nodest_out");
+    let _ = std::fs::remove_dir_all(&output_dir);
+    let tok_json = write_synthetic_model(&model_dir);
+
+    let err = run_streaming(
+        &model_dir,
+        &output_dir,
+        tok_json,
+        larql_vindex::ExtractionRequest::Native,
+        None,
+    )
+    .expect_err("native banks without --expert-banks-out must be refused");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("expert-banks-out"),
+        "the refusal must name the flag the caller has to supply; got: {msg}"
+    );
+
+    let _ = std::fs::remove_dir_all(&model_dir);
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// CONTROL for the test above: the same model with `Legacy` must NOT be
+/// refused. Without this, a `build_vindex_streaming` that failed for some
+/// unrelated reason — a bad fixture, an unsupported arch — would satisfy
+/// the assertion and the refusal would be untested.
+#[test]
+fn the_same_model_extracts_cleanly_under_legacy() {
+    let model_dir = std::env::temp_dir().join("larql_test_eb_legacy_model");
+    let output_dir = std::env::temp_dir().join("larql_test_eb_legacy_out");
+    let _ = std::fs::remove_dir_all(&output_dir);
+    let tok_json = write_synthetic_model(&model_dir);
+
+    run_streaming(
+        &model_dir,
+        &output_dir,
+        tok_json,
+        larql_vindex::ExtractionRequest::Legacy,
+        None,
+    )
+    .expect("legacy extraction of the synthetic model must succeed");
+
+    let _ = std::fs::remove_dir_all(&model_dir);
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// With a destination supplied, the request reaches
+/// `extract_expert_banks`. This model is safetensors-backed and dense, so
+/// the orchestrator has no MXFP4 expert stream to pull; whatever it
+/// decides, it must decide it explicitly rather than panicking or
+/// silently writing a hollow container.
+#[test]
+fn native_expert_banks_with_a_destination_reaches_the_extractor() {
+    let model_dir = std::env::temp_dir().join("larql_test_eb_dest_model");
+    let output_dir = std::env::temp_dir().join("larql_test_eb_dest_out");
+    let banks_dir = std::env::temp_dir().join("larql_test_eb_dest_banks");
+    let _ = std::fs::remove_dir_all(&output_dir);
+    let _ = std::fs::remove_dir_all(&banks_dir);
+    std::fs::create_dir_all(&banks_dir).unwrap();
+    let tok_json = write_synthetic_model(&model_dir);
+
+    let result = run_streaming(
+        &model_dir,
+        &output_dir,
+        tok_json,
+        larql_vindex::ExtractionRequest::Native,
+        Some(&banks_dir),
+    );
+
+    // Either outcome is acceptable — a dense model may legitimately have
+    // nothing to stream — but it must be a *decision*, and the error must
+    // explain itself if it is one.
+    if let Err(e) = result {
+        let msg = e.to_string();
+        assert!(
+            !msg.is_empty(),
+            "extract_expert_banks refused without saying why"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&model_dir);
+    let _ = std::fs::remove_dir_all(&output_dir);
+    let _ = std::fs::remove_dir_all(&banks_dir);
+}


### PR DESCRIPTION
Closes #227. Closes #228. Closes #164.

Four fixes and a coverage pass, from working the open issue list.

### #227 — the suite could not see a dead attention block

`Q_DIM` was 128 and `wo` reduces over it, so the Q4_K O-projection had less
than one 256-element superblock, dispatched zero work, and emitted an
all-zero vector. Every test still passed: the assertions are "non-NaN,
non-zero, correct length", and the FFN alone satisfies all three.

Fixed the geometry, added causal assertions (history changes the token,
*which* history matters, history *length* matters — each fails on the old
geometry, with a parity case first), and guarded the root cause:
`quant_matvec::encode` now refuses a k-quant `K` below one superblock
instead of returning zeros.

That guard immediately caught **30 more fixtures in the same state** across
four more binaries — the metal FFN lib tests ran at `hidden=32, inter=64`,
and `test_decode_diag`, `test_gpu_route_decode` and
`test_kernel_moe_expert_dispatch` each carried their own `Q_DIM = 128`.

### A real bug it was hiding

`reset_kv_cache` cleared `current_len` but left `abs_position`, and RoPE is
computed from `abs_position` — so a *fresh conversation* rotated its first
token at the previous sequence's position, drifting further with every
reset. Invisible until #227 was fixed, because while the O-projection
emitted zeros nothing RoPE-dependent could reach the asserted output.

### #228 — a diagnostic that reported success while measuring nothing

`LARQL_DUMP_RESIDUALS` on a dense model wrote a valid 16-byte header and
zero records, which reads as "no divergence found" rather than "nothing was
measured". Dense layers now record too. The test asserts record *count* —
existence and header are exactly what the broken version produced.

### #164 — zero-length mmap on Windows

`CreateFileMapping` rejects a zero size, and a dense-only build writes
`gate_vectors.bin` empty. `map_if_nonempty` treats empty as absent. **Not
verifiable on macOS/Linux** — both map empty files fine, which is why it
survived; the test pins the branch, and Windows CI confirms the rest.

### Coverage

larql-compute's gate now passes (`quant_matvec.rs` 86.36 → 98.56%,
`moe_route_observe.rs` 77.14 → 94.29%). larql-vindex's
`extract/streaming/mod.rs` 86.25 → 92.50% and `stages/model_weights.rs`
48.48 → 80.30%.

`opplan/exec/production.rs` and `opplan/exec/device.rs` are still below
floor and deliberately untouched — both are in flight in another working
tree, so larql-vindex's gate stays red until that lands.

### Verification note

Every regression test here was calibrated by reintroducing its defect; two
first drafts passed with the bug present and were rewritten. The binaries
were swept by **process exit status**, because an ObjC "Command encoder
released without endEncoding" abort prints neither a `FAILED` line nor a
`test result` line — so summing pass counts silently omits an aborting
binary and reads as green. That is how the three extra `Q_DIM = 128`
binaries stayed hidden.
