### PR TITLE
Fix BufferCache address-identity aliasing: test fixtures and diagnostic uploads

### DIFF
--- a/crates/larql-compute-metal/src/buffers/mod.rs
+++ b/crates/larql-compute-metal/src/buffers/mod.rs
@@ -183,6 +183,18 @@ impl BufferCache {
     /// Use this for anything built on the fly — offset tables, per-call index
     /// lists — where address identity says nothing about content. Always copies,
     /// so the caller's buffer may be dropped immediately afterwards.
+    ///
+    /// **This is the safe default; [`Self::get_bytes`] is the optimisation.**
+    /// Caching on `(ptr, len)` is what keeps decode from re-uploading
+    /// gigabytes of weights per token, so the serving path must keep using
+    /// it — its operands are mmap'd and satisfy the contract. Everything
+    /// else should come here. `diag/` in particular builds synthetic
+    /// weights in locals and uploads once, outside the timed region, so it
+    /// gains nothing from the cache and carries all of its risk: a freed
+    /// local's address reused by the next arm's same-sized tensor returns
+    /// the *previous* arm's buffer, and since the aliasing guard in
+    /// `get_bytes` is a `debug_assert!`, a release-mode benchmark would
+    /// report a number computed on the wrong weights with no symptom.
     pub fn uncached_bytes(&self, data: &[u8]) -> Buffer {
         if data.is_empty() {
             return self

--- a/crates/larql-compute-metal/src/diag/kernel_profile/all.rs
+++ b/crates/larql-compute-metal/src/diag/kernel_profile/all.rs
@@ -71,7 +71,7 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
             let _ = metal.q6k_matvec(&w, &x, n, k);
         });
 
-        let wb = metal.bufs().get_bytes(&w);
+        let wb = metal.bufs().uncached_bytes(&w);
         let xb = metal.bufs().transient_from_f32(&x);
         let ob = metal.bufs().output((n * 4) as u64);
         let kh = &metal.quant.q6k_matvec_pipeline;
@@ -176,8 +176,8 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
 
         // Isolated: use the trait method which handles dispatch internally.
         // We can't use trait method for gate+up (it's internal), so dispatch directly.
-        let wg = metal.bufs().get_bytes(&gate_q4k);
-        let wu = metal.bufs().get_bytes(&up_q4k);
+        let wg = metal.bufs().uncached_bytes(&gate_q4k);
+        let wu = metal.bufs().uncached_bytes(&up_q4k);
         let xb = metal.bufs().transient_from_f32(&x);
         let go = metal.bufs().output((n * 4) as u64);
         let uo = metal.bufs().output((n * 4) as u64);
@@ -326,7 +326,7 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
         // missing here historically — Wo's "13.4 ms/tok" earlier
         // estimate was iso_ms × 34 which over-counts cmd-buffer
         // overhead.
-        let wb = metal.bufs().get_bytes(&w);
+        let wb = metal.bufs().uncached_bytes(&w);
         let xb = metal.bufs().transient_from_f32(&x);
         let ob = metal.bufs().output((n * 4) as u64);
         let kh = &metal.quant.q4k_matvec_pipeline;
@@ -390,9 +390,9 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
         let wv = quantize_q4_k(&synth_f32(v_rows * k, 0.7));
         let x = synth_f32(k, 0.4);
 
-        let wqb = metal.bufs().get_bytes(&wq);
-        let wkb = metal.bufs().get_bytes(&wk);
-        let wvb = metal.bufs().get_bytes(&wv);
+        let wqb = metal.bufs().uncached_bytes(&wq);
+        let wkb = metal.bufs().uncached_bytes(&wk);
+        let wvb = metal.bufs().uncached_bytes(&wv);
         let xb = metal.bufs().transient_from_f32(&x);
         let qo = metal.bufs().output((q_rows * 4) as u64);
         let ko = metal.bufs().output((k_rows * 4) as u64);
@@ -480,9 +480,9 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
         let h = synth_f32(k, 0.4);
         let norm_w = vec![1.0f32; k];
 
-        let wqb = metal.bufs().get_bytes(&wq);
-        let wkb = metal.bufs().get_bytes(&wk);
-        let wvb = metal.bufs().get_bytes(&wv);
+        let wqb = metal.bufs().uncached_bytes(&wq);
+        let wkb = metal.bufs().uncached_bytes(&wk);
+        let wvb = metal.bufs().uncached_bytes(&wv);
         let hb = metal.bufs().transient_from_f32(&h);
         let nb = metal.bufs().get_f32(&norm_w);
         let qo = metal.bufs().output((q_rows * 4) as u64);

--- a/crates/larql-compute-metal/src/diag/kernel_profile/grouped.rs
+++ b/crates/larql-compute-metal/src/diag/kernel_profile/grouped.rs
@@ -45,9 +45,9 @@ pub fn profile_grouped_experts(
     let total_mb = (per_expert * top_k) as f64 / 1e6;
     let x = synth_f32(k, 0.5);
 
-    let wb = metal.bufs().get_bytes(&bank);
+    let wb = metal.bufs().uncached_bytes(&bank);
     let off_bytes: Vec<u8> = offsets.iter().flat_map(|o| o.to_ne_bytes()).collect();
-    let offb = metal.bufs().get_bytes(&off_bytes);
+    let offb = metal.bufs().uncached_bytes(&off_bytes);
     let xb = metal.bufs().transient_from_f32(&x);
     let out_single = metal.bufs().output((n * 4) as u64);
     let out_group = metal.bufs().output((top_k * n * 4) as u64);

--- a/crates/larql-compute-metal/src/diag/mxfp4_layout.rs
+++ b/crates/larql-compute-metal/src/diag/mxfp4_layout.rs
@@ -256,9 +256,9 @@ pub fn race(
         .flat_map(|q| reference(q, &x, k, ORACLE_ROWS))
         .collect();
 
-    let bw_split = metal.bufs().get_bytes(&split_w);
-    let bs_split = metal.bufs().get_bytes(&split_s);
-    let bw_inter = metal.bufs().get_bytes(&inter);
+    let bw_split = metal.bufs().uncached_bytes(&split_w);
+    let bs_split = metal.bufs().uncached_bytes(&split_s);
+    let bw_inter = metal.bufs().uncached_bytes(&inter);
     let obytes = |v: &[u32]| -> Vec<u8> { v.iter().flat_map(|o| o.to_ne_bytes()).collect() };
     // Offset tables are ephemeral, so they must NOT go through the
     // address-keyed weight cache — see `BufferCache::uncached_bytes`.

--- a/crates/larql-compute-metal/src/diag/shader_bench/kernels.rs
+++ b/crates/larql-compute-metal/src/diag/shader_bench/kernels.rs
@@ -20,7 +20,7 @@ pub(crate) fn bench_q4_0_matvec(metal: &MetalBackend, cfg: &Config, shape: Shape
     let x = synth_f32(k, 0.31);
     let (q8_x, q8_scales) = quantize_to_q8(&x);
     let bufs = metal.bufs();
-    let wb = bufs.get_bytes(&w);
+    let wb = bufs.uncached_bytes(&w);
     let xb = bufs.transient_from_i8(&q8_x);
     let sb = bufs.transient_from_f32(&q8_scales);
     let ob = bufs.output((n * 4) as u64);
@@ -118,7 +118,7 @@ pub(crate) fn bench_qk_matvec(
 ) -> BenchResult {
     let x = synth_f32(k, 0.41);
     let bufs = metal.bufs();
-    let wb = bufs.get_bytes(w);
+    let wb = bufs.uncached_bytes(w);
     let xb = bufs.transient_from_f32(&x);
     let ob = bufs.output((n * 4) as u64);
     let n_val = n as u32;
@@ -229,8 +229,8 @@ pub(crate) fn bench_gate_up(
 ) -> BenchResult {
     let x = synth_f32(k, 0.61);
     let bufs = metal.bufs();
-    let gb = bufs.get_bytes(gate);
-    let ub = bufs.get_bytes(up);
+    let gb = bufs.uncached_bytes(gate);
+    let ub = bufs.uncached_bytes(up);
     let xb = bufs.transient_from_f32(&x);
     let go = bufs.output((n * 4) as u64);
     let uo = bufs.output((n * 4) as u64);
@@ -364,7 +364,7 @@ pub(crate) fn bench_geglu_down(
     let n = shape.hidden;
     let k = shape.inter;
     let bufs = metal.bufs();
-    let wb = bufs.get_bytes(weights);
+    let wb = bufs.uncached_bytes(weights);
     let gb = bufs.transient_from_f32(gate);
     let ub = bufs.transient_from_f32(up);
     let ob = bufs.output((n * 4) as u64);
@@ -481,9 +481,9 @@ pub(crate) fn bench_q4k_qkv(
 ) -> BenchResult {
     let x = synth_f32(shape.hidden, 0.91);
     let bufs = metal.bufs();
-    let wqb = bufs.get_bytes(wq);
-    let wkb = bufs.get_bytes(wk);
-    let wvb = bufs.get_bytes(wv);
+    let wqb = bufs.uncached_bytes(wq);
+    let wkb = bufs.uncached_bytes(wk);
+    let wvb = bufs.uncached_bytes(wv);
     let xb = bufs.transient_from_f32(&x);
     let qb = bufs.output((shape.q_rows * 4) as u64);
     let kb = bufs.output((shape.kv_rows * 4) as u64);
@@ -547,9 +547,9 @@ pub(crate) fn bench_q4k_q6k_qkv(
     let x = synth_f32(shape.hidden, 0.92);
     let norm_w = vec![1.0f32; shape.hidden];
     let bufs = metal.bufs();
-    let wqb = bufs.get_bytes(wq);
-    let wkb = bufs.get_bytes(wk);
-    let wvb = bufs.get_bytes(wv);
+    let wqb = bufs.uncached_bytes(wq);
+    let wkb = bufs.uncached_bytes(wk);
+    let wvb = bufs.uncached_bytes(wv);
     let xb = bufs.transient_from_f32(&x);
     let nb = bufs.transient_from_f32(&norm_w);
     let qb = bufs.output((shape.q_rows * 4) as u64);

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/attention_reaches_residual.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/attention_reaches_residual.rs
@@ -35,30 +35,76 @@ use super::common::{
     build_synth_layer, synth_input, synth_weight_f32, ENV_TEST_LOCK, HIDDEN, INTER, KV_DIM, Q_DIM,
 };
 
+/// The fixture weights, allocated **once for the process**.
+///
+/// `BufferCache::get_bytes` keys on `(ptr, len)` and is documented as
+/// sound only for allocations that live for the process and never change
+/// — mmap'd weights, which is what `pipeline_layer` hands the decode path
+/// for a real model. `decode::setup::new` calls it unconditionally on
+/// `l.wq.data` and friends, so a caller supplying ephemeral data breaks
+/// the contract rather than the cache.
+///
+/// These used to be locals. They were freed on return, the allocator
+/// handed a later same-sized fixture the same address, and `get_bytes`
+/// returned the *earlier* buffer — which the aliasing guard caught about
+/// one whole-crate run in three, always here, never in isolation.
+/// Allocating once satisfies the contract and removes the collision by
+/// construction; it is not a workaround for the guard.
+///
+/// Note the guard is a `debug_assert!`. In a release build the same
+/// collision returns the stale buffer silently, so "the tests pass" is
+/// not on its own evidence that ephemeral data is safe here.
+struct SynthWeights {
+    wq: Vec<u8>,
+    wk: Vec<u8>,
+    wv: Vec<u8>,
+    wo: Vec<u8>,
+    gate: Vec<u8>,
+    up: Vec<u8>,
+    down: Vec<u8>,
+    norm_w: Vec<f32>,
+}
+
+fn synth_weights() -> &'static SynthWeights {
+    static WEIGHTS: std::sync::OnceLock<SynthWeights> = std::sync::OnceLock::new();
+    WEIGHTS.get_or_init(|| SynthWeights {
+        wq: quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1)),
+        wk: quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2)),
+        wv: quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3)),
+        wo: quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4)),
+        gate: quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.5)),
+        up: quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.6)),
+        down: quantize_q4_0(&synth_weight_f32(HIDDEN * INTER, 0.7)),
+        norm_w: (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect(),
+    })
+}
+
 /// Decode `seeds` in order against one cache and return the LAST output.
 ///
 /// Every call starts from a reset cache, so the returned token is a
 /// function of `seeds` alone.
 fn decode_sequence(metal: &larql_compute_metal::MetalBackend, seeds: &[f32]) -> Vec<f32> {
-    let wq = quantize_q4_k(&synth_weight_f32(Q_DIM * HIDDEN, 0.1));
-    let wk = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.2));
-    let wv = quantize_q4_k(&synth_weight_f32(KV_DIM * HIDDEN, 0.3));
-    let wo = quantize_q4_k(&synth_weight_f32(HIDDEN * Q_DIM, 0.4));
-    let gate = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.5));
-    let up = quantize_q4_0(&synth_weight_f32(INTER * HIDDEN, 0.6));
-    let down = quantize_q4_0(&synth_weight_f32(HIDDEN * INTER, 0.7));
-    let norm_w: Vec<f32> = (0..HIDDEN).map(|i| 1.0 + (i as f32 * 0.001)).collect();
+    let SynthWeights {
+        wq,
+        wk,
+        wv,
+        wo,
+        gate,
+        up,
+        down,
+        norm_w,
+    } = synth_weights();
 
     let backend: &dyn DecodeBackend = metal;
     // Settle the cache shape first, then reset: a decode that has to
     // CREATE the cache is not comparable with one that reuses it.
-    let warm = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+    let warm = build_synth_layer(wq, wk, wv, wo, gate, up, down, norm_w);
     let _ = backend.decode_token(&[warm], &synth_input(HIDDEN, 0.9), HIDDEN, INTER);
     metal.reset_kv_cache();
 
     let mut out = Vec::new();
     for &seed in seeds {
-        let layer = build_synth_layer(&wq, &wk, &wv, &wo, &gate, &up, &down, &norm_w);
+        let layer = build_synth_layer(wq, wk, wv, wo, gate, up, down, norm_w);
         out = backend
             .decode_token(&[layer], &synth_input(HIDDEN, seed), HIDDEN, INTER)
             .expect("decode returns Some");

--- a/crates/larql-compute-metal/tests/metal_decode_synthetic/common.rs
+++ b/crates/larql-compute-metal/tests/metal_decode_synthetic/common.rs
@@ -84,6 +84,19 @@ pub fn synth_weight_f32(len: usize, seed: f32) -> Vec<f32> {
 // the production `FullPipelineLayer` constructor surface; collapsing to
 // a single struct just for the test would obscure the per-tensor
 // fixture-builder pattern callers actually want.
+//
+// **The tensor slices must outlive the process, not the test.**
+// `decode::setup::new` passes each one to `BufferCache::get_bytes`, which
+// caches on `(ptr, len)` and is sound only for allocations that never
+// move or change — mmap'd weights, which is what a real model supplies.
+// A fixture built in a local `Vec` is freed on return; the allocator then
+// hands a later same-sized fixture the same address and the cache returns
+// the earlier buffer. Hold fixture tensors in a `OnceLock` (see
+// `attention_reaches_residual::synth_weights`) rather than in locals.
+//
+// The aliasing guard that catches this is a `debug_assert!`, so it exists
+// in test builds only. Do not treat a green suite as evidence that
+// ephemeral fixture data is safe.
 #[allow(clippy::too_many_arguments)]
 pub fn build_synth_layer<'a>(
     wq_data: &'a [u8],


### PR DESCRIPTION
Two fixes for one root cause: `BufferCache::get_bytes` keys on `(ptr, len)`, which is sound only for allocations that live for the process and never change. Callers supplying ephemeral data get the *previous* allocation's Metal buffer once the allocator reuses an address.

Found while gating #261; unrelated to that work, hence a separate branch off main.

### `test(metal): give the synthetic decode fixtures process lifetime`

`metal_decode_synthetic::attention_reaches_residual` failed roughly **one whole-crate run in three**, always on the aliasing guard, never in isolation — the binary is 100/100 alone.

The fixture was at fault, not the cache. `decode::setup::new` calls `get_bytes` unconditionally on `l.wq.data` and friends, so provenance is the caller's responsibility; a real model satisfies the contract because `pipeline_layer` hands the decode path mmap-backed slices. `decode_sequence` built its seven quantised tensors in locals, freed on return, and a later same-sized fixture landed on the same address.

Hoisted into a `OnceLock`. This satisfies the contract rather than working around the guard — the guard was right.

**Verified: 8 consecutive whole-crate runs green**, 47 binaries each. Against the ~1-in-3 prior that is a ~4% chance of being luck.

`build_synth_layer` gains the contract note, since every fixture goes through it.

### `fix(metal): stop the diagnostics uploading weights through the address-keyed cache`

Same root cause, worse blast radius. `diag/` builds synthetic tensors in locals and caches them by address, so between benchmark arms a freed local's address is reused by the next arm's same-sized tensor and the cache returns the previous arm's buffer.

The aliasing guard is a `debug_assert!`. **Benchmarks run in release, where it does not exist** — so rather than panicking, a layout A/B or kernel profile would report a timing and a correctness check computed on the wrong weights, with no symptom.

26 call sites move to `uncached_bytes` across `mxfp4_layout`, `kernel_profile::{all, grouped}`, `shader_bench::kernels`. Every one is a one-time hoist outside the timed region — checked before converting — so this costs one upload per bench and moves no reported number.

**The ~44 serving-path callers are deliberately untouched.** Caching on address identity is what stops decode re-uploading gigabytes of weights per token, and those operands are mmap-backed. Converting them would trade a harness correctness bug for an inference regression. The distinction is now documented on `uncached_bytes`: it is the safe default, `get_bytes` is the optimisation that requires a provenance argument.

Diag lib tests 52 passed; three whole-crate runs green.

### Gates

fmt, clippy `--all-targets`, diag lib 52, whole-crate 47 binaries × 3 after the diag change, × 8 after the fixture change.

### Follow-up, not in this PR

This does not imply any past measurement was wrong — only that the harness permitted silent cross-arm contamination and could not have reported it. Numbers currently load-bearing for an architectural choice are worth re-running on the fixed harness: MXFP4 layout comparisons, grouped-vs-ungrouped, and `kernel_profile` throughput estimates.

Note the two hazards compound for exactly those measurements. A layout A/B allocates one arm's tensors, frees them, then allocates the next arm's at the same size — the precise pattern that triggers address reuse, and also the pattern where an under-powered adapter clips whichever arm is faster (see the protocol section added in #261). Those numbers were taken under two independent contaminants at once.
