### PR TITLE
fix(metal): size decode-path KV for every position it reaches; check every command-buffer wait (#229)

### DIFF
--- a/crates/larql-cli/src/commands/primary/bench/local_runtime.rs
+++ b/crates/larql-cli/src/commands/primary/bench/local_runtime.rs
@@ -114,7 +114,12 @@ pub(super) fn run_larql(
     // Metal buffer caches. The prefill timer would otherwise include this
     // one-time allocation cost.
     if metal {
-        let _ = generate_n(&mut weights, 1);
+        let warm = generate_n(&mut weights, 1);
+        if let Some(e) = &warm.error {
+            // A pre-warm that failed is a row-shaped lie waiting to happen:
+            // say so, rather than let the timed run inherit the state.
+            eprintln!("[bench] pre-warm generate failed: {e}");
+        }
     }
 
     // NOTE: `--profile` enables engine-side stage timers
@@ -131,6 +136,9 @@ pub(super) fn run_larql(
     let t0 = Instant::now();
     let result = generate_n(&mut weights, max_tokens);
     let wall_ms = t0.elapsed().as_secs_f64() * 1000.0;
+    if let Some(e) = &result.error {
+        eprintln!("[bench] generate failed: {e}");
+    }
 
     if args.verbose {
         let (slots, bytes) = index.kquant_ffn_cache_stats();

--- a/crates/larql-compute-metal/src/backend/mod.rs
+++ b/crates/larql-compute-metal/src/backend/mod.rs
@@ -160,6 +160,8 @@ pub struct MetalBackend {
     /// `out[slot] = descs[selected_ids[slot]]` — rung C's single runtime
     /// indirection from route result to stored-expert descriptor.
     pub moe_descriptor_gather_pipeline: ComputePipelineState,
+    /// Device-side count of router ids the gather kernel refused (#229).
+    pub route_guard: crate::route_guard::RouteGuard,
     /// GPU replacement for the CPU bias-staging memcpy loop: gathers the
     /// selected experts' interleaved gate/up bias rows into slot-aligned
     /// scratch, driven by descriptors instead of host pointers.
@@ -334,6 +336,7 @@ impl MetalBackend {
             moe_router_pipeline,
             moe_router_select_pipeline,
             moe_descriptor_gather_pipeline,
+            route_guard: crate::route_guard::RouteGuard::new(&device),
             moe_bias_stage_pipeline,
             moe_down_bias_stage_pipeline,
             flop_threshold: AtomicUsize::new(calibration::DEFAULT_FLOP_THRESHOLD),

--- a/crates/larql-compute-metal/src/buffers/mod.rs
+++ b/crates/larql-compute-metal/src/buffers/mod.rs
@@ -250,6 +250,21 @@ impl BufferCache {
     pub fn output(&self, bytes: u64) -> Buffer {
         let mut pool = self.scratch_pool.lock().unwrap();
         if let Some(buf) = pool.entry(bytes).or_default().pop() {
+            // A fresh Metal buffer arrives zeroed; a recycled one carries
+            // its previous tenant's bytes. Any caller that writes less
+            // than it reads therefore behaves differently once the pool
+            // has been churned — see `ENV_ZERO_POOLED_BUFFERS`, which
+            // exists to tell that defect apart from a real race.
+            if larql_compute::options::env_flag(larql_compute::options::ENV_ZERO_POOLED_BUFFERS) {
+                let ptr = buf.contents();
+                if !ptr.is_null() {
+                    // SAFETY: shared-storage buffer of exactly `bytes`
+                    // bytes, and the pool is keyed by that length. No GPU
+                    // work can be in flight against it: `recycle` is only
+                    // legal after `wait_until_completed`.
+                    unsafe { std::ptr::write_bytes(ptr as *mut u8, 0, bytes as usize) };
+                }
+            }
             return buf;
         }
         self.device

--- a/crates/larql-compute-metal/src/buffers/regions/tests.rs
+++ b/crates/larql-compute-metal/src/buffers/regions/tests.rs
@@ -101,7 +101,10 @@ fn sealing_is_a_no_op_under_the_implicit_arm() {
     let enc = cmd.new_compute_command_encoder();
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        cmd,
+        "crates/larql-compute-metal/src/buffers/regions/tests.rs:104",
+    );
 }
 
 /// Both explicit arms build, commit and attach a set over the registered
@@ -122,7 +125,10 @@ fn sealing_runs_both_explicit_arms_and_leaves_the_queue_usable() {
         let enc = cmd.new_compute_command_encoder();
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/buffers/regions/tests.rs:125",
+        );
     }
 }
 

--- a/crates/larql-compute-metal/src/buffers/residency/tests.rs
+++ b/crates/larql-compute-metal/src/buffers/residency/tests.rs
@@ -154,7 +154,10 @@ fn attaching_to_a_queue_reports_whether_it_took() {
         let enc = cmd.new_compute_command_encoder();
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/buffers/residency/tests.rs:157",
+        );
     }
 }
 

--- a/crates/larql-compute-metal/src/cb_status.rs
+++ b/crates/larql-compute-metal/src/cb_status.rs
@@ -1,0 +1,93 @@
+//! Command-buffer completion status — the check every `wait_until_completed`
+//! site was missing.
+//!
+//! `waitUntilCompleted` returns for a *failed* buffer just as it does for a
+//! finished one: `status == Error`, immediately. Once the GPU has faulted,
+//! later buffers on the queue may be dropped outright ("ignored for causing
+//! prior/excessive GPU errors"), which also completes instantly. Nothing
+//! downstream can tell — the output buffers simply hold whatever was there
+//! before — so a caller that only waits will read stale or garbage results
+//! at full speed. See #229 and `docs/kv-attention-scaling.md`, "The fault is
+//! on main and predates seqpar": impossible ~0.5 ms/token decode steps,
+//! token ids past the vocabulary, EOS at token 1.
+//!
+//! This module names the condition. It does not yet change control flow —
+//! that is the fix, and it needs the evidence this produces first.
+
+use metal::foreign_types::ForeignTypeRef;
+use metal::{CommandBufferRef, MTLCommandBufferStatus};
+use objc::runtime::Object;
+use objc::{msg_send, sel, sel_impl};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Buffers observed in a non-`Completed` state since process start.
+static NON_COMPLETED: AtomicUsize = AtomicUsize::new(0);
+
+/// How many command buffers this process has seen finish in any state other
+/// than `Completed`. Zero on a healthy process.
+pub fn non_completed_count() -> usize {
+    NON_COMPLETED.load(Ordering::Relaxed)
+}
+
+/// Wait for `cmd`, then inspect it. This is the only sanctioned way to
+/// wait on a command buffer in this crate: `wait_until_completed` alone
+/// cannot distinguish a finished buffer from a failed or ignored one, and
+/// a test pins that no production site calls it directly. Callers with a
+/// result channel propagate the `Err`; callers without one at least leave
+/// the line in the log.
+pub fn wait_checked(cmd: &CommandBufferRef, site: &'static str) -> Result<(), String> {
+    cmd.wait_until_completed();
+    check_completed(cmd, site)
+}
+
+/// Inspect `cmd` after `wait_until_completed`. Returns `Ok(())` for
+/// `Completed`; otherwise records the event, prints one line naming the
+/// site, the status and Metal's own error description, and returns that
+/// description so a caller can decide what to do with a poisoned step.
+pub fn check_completed(cmd: &CommandBufferRef, site: &'static str) -> Result<(), String> {
+    let status = cmd.status();
+    if status == MTLCommandBufferStatus::Completed {
+        return Ok(());
+    }
+    let n = NON_COMPLETED.fetch_add(1, Ordering::Relaxed) + 1;
+    let desc = error_description(cmd).unwrap_or_else(|| "<no NSError>".to_string());
+    let msg = format!("command buffer at {site} finished with status {status:?} (#{n}): {desc}");
+    eprintln!("[metal] {msg}");
+    Err(msg)
+}
+
+/// UTF-8 contents of an `NSString*`, or `None` for nil.
+unsafe fn ns_string(ns: *mut Object) -> Option<String> {
+    if ns.is_null() {
+        return None;
+    }
+    let utf8: *const std::os::raw::c_char = msg_send![ns, UTF8String];
+    if utf8.is_null() {
+        return None;
+    }
+    Some(
+        std::ffi::CStr::from_ptr(utf8)
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+/// `-[MTLCommandBuffer error].localizedDescription`, or `None` when the
+/// buffer carries no NSError (e.g. `NotEnqueued`, or an ignored buffer on
+/// some OS versions).
+fn error_description(cmd: &CommandBufferRef) -> Option<String> {
+    // SAFETY: `cmd` is a live MTLCommandBuffer; `error` returns an
+    // autoreleased NSError* or nil, and `localizedDescription` an
+    // autoreleased NSString*. Both are read, never retained or released.
+    unsafe {
+        let obj: *mut Object = cmd.as_ptr() as *mut Object;
+        let err: *mut Object = msg_send![obj, error];
+        if err.is_null() {
+            return None;
+        }
+        ns_string(msg_send![err, localizedDescription])
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/larql-compute-metal/src/cb_status/tests.rs
+++ b/crates/larql-compute-metal/src/cb_status/tests.rs
@@ -1,0 +1,106 @@
+use super::*;
+use std::path::Path;
+
+/// Every `.rs` file under `src/`, recursively.
+fn rust_sources(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("src dir readable") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// The containment rule for #229: no production code waits on a command
+/// buffer without reading its status afterwards. `wait_until_completed`
+/// returns for a failed or ignored buffer exactly as for a finished one,
+/// so a naked wait is a step that can hand GPU garbage to the sampler.
+/// This module is the only place the raw call may appear.
+#[test]
+fn no_naked_wait_until_completed_outside_cb_status() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rust_sources(&src, &mut files);
+    assert!(files.len() > 50, "walked too few files: {}", files.len());
+
+    let mut offenders = Vec::new();
+    for path in files {
+        // The definition site, and this test's own needle below.
+        if path.ends_with("cb_status.rs") || path.ends_with("cb_status/tests.rs") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).expect("source readable");
+        for (i, line) in text.lines().enumerate() {
+            let code = line.split("//").next().unwrap_or("");
+            if code.contains(concat!(".wait_until_", "completed()")) {
+                offenders.push(format!("{}:{}", path.display(), i + 1));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "naked wait_until_completed — use cb_status::wait_checked:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn non_completed_count_starts_at_zero_and_is_monotonic() {
+    let a = non_completed_count();
+    let b = non_completed_count();
+    assert!(b >= a);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn a_completed_empty_command_buffer_passes() {
+    let Some(device) = metal::Device::system_default() else {
+        return;
+    };
+    let queue = device.new_command_queue();
+    let cmd = queue.new_command_buffer();
+    cmd.commit();
+    let before = non_completed_count();
+    assert!(wait_checked(cmd, "cb_status test").is_ok());
+    assert_eq!(non_completed_count(), before);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn a_buffer_that_never_ran_is_reported_and_counted() {
+    let Some(device) = metal::Device::system_default() else {
+        return;
+    };
+    let queue = device.new_command_queue();
+    // Never committed: status stays NotEnqueued, and there is no NSError,
+    // which exercises the "<no NSError>" arm.
+    let cmd = queue.new_command_buffer();
+    let before = non_completed_count();
+    let err = check_completed(cmd, "cb_status test: not enqueued").expect_err("not completed");
+    assert!(err.contains("NotEnqueued"), "{err}");
+    assert!(err.contains("<no NSError>"), "{err}");
+    assert!(err.contains("cb_status test: not enqueued"), "{err}");
+    assert_eq!(non_completed_count(), before + 1);
+}
+
+#[test]
+fn ns_string_of_nil_is_none() {
+    // SAFETY: nil is a valid argument; the function checks it first.
+    assert!(unsafe { ns_string(std::ptr::null_mut()) }.is_none());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn ns_string_reads_an_nsstring() {
+    use objc::{class, msg_send, sel, sel_impl};
+    let text = c"command buffer text";
+    // SAFETY: standard Foundation call; the returned NSString is
+    // autoreleased and only read.
+    let got = unsafe {
+        let ns: *mut Object = msg_send![class!(NSString), stringWithUTF8String: text.as_ptr()];
+        ns_string(ns)
+    };
+    assert_eq!(got.as_deref(), Some("command buffer text"));
+}

--- a/crates/larql-compute-metal/src/decode/encode_post_ffn.rs
+++ b/crates/larql-compute-metal/src/decode/encode_post_ffn.rs
@@ -278,7 +278,10 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/decode/encode_post_ffn.rs:281",
+        );
 
         let out = crate::buffers::read_buffer_f32(&new_h, hidden);
         assert_eq!(out.len(), hidden);

--- a/crates/larql-compute-metal/src/decode/gpu_timing.rs
+++ b/crates/larql-compute-metal/src/decode/gpu_timing.rs
@@ -394,7 +394,10 @@ mod tests {
         };
         let cmd = m.queue.new_command_buffer();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/decode/gpu_timing.rs:397",
+        );
 
         let mut t = TokenGpuTime::default();
         // gpu_elapsed_ms returns 0.0 for an empty cmd buffer (no GPU

--- a/crates/larql-compute-metal/src/decode/head/tests.rs
+++ b/crates/larql-compute-metal/src/decode/head/tests.rs
@@ -85,7 +85,10 @@ fn run_head(
     let out = metal.encode_decode_head(enc, &h_buf, HIDDEN, plan);
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        cmd,
+        "crates/larql-compute-metal/src/decode/head/tests.rs:88",
+    );
     out.map(|b| b.reduce_and_recycle(&metal.bufs))
 }
 

--- a/crates/larql-compute-metal/src/decode/kv_setup.rs
+++ b/crates/larql-compute-metal/src/decode/kv_setup.rs
@@ -54,20 +54,29 @@ impl MetalBackend {
             .collect()
     }
 
-    /// Per-layer capacities implied by each layer's own attention window.
+    /// Per-layer capacities for the decode path: **every layer holds the
+    /// full `default_capacity`**, windowed or not.
+    ///
+    /// The window-derived capacity (`kv_capacity_for_window`, i.e.
+    /// `window x KV_COMPACTION_SLACK`) is a residency policy that is only
+    /// sound where something compacts the cache back below it. On this
+    /// path nothing does: `compact_kv_to_window` is called by the
+    /// KV-engine `coarse_*` steps alone, while the decode path appends at
+    /// row `current_len` and attends absolute rows `[T - window, T)`. A
+    /// sliding layer sized to 256 rows was therefore written and read
+    /// past its buffer from position 256 onward, by a margin growing with
+    /// position — the memory corruption behind #229 (NaN mid-stack, router
+    /// ids past `num_experts`, GPU page faults, hangs). Pinned by
+    /// `decode_path_sizes_sliding_layers_for_the_full_max_seq_because_it_never_compacts`.
+    ///
+    /// `layers` is still the input so that a future decode-path compaction
+    /// can reintroduce per-layer capacities here, at the one site that
+    /// owns the fact.
     pub(crate) fn kv_capacities_for_layers(
         layers: &[larql_compute::FullPipelineLayer<'_>],
         default_capacity: usize,
     ) -> Vec<usize> {
-        layers
-            .iter()
-            .map(|layer| {
-                larql_compute::pipeline_layer::kv_capacity_for_window(
-                    layer.sliding_window,
-                    default_capacity,
-                )
-            })
-            .collect()
+        layers.iter().map(|_| default_capacity).collect()
     }
 
     /// Ensure a cache sized by each layer's *own* capacity.

--- a/crates/larql-compute-metal/src/decode/moe_interleave.rs
+++ b/crates/larql-compute-metal/src/decode/moe_interleave.rs
@@ -245,7 +245,10 @@ impl MetalBackend {
                 std::hint::spin_loop();
             }
         } else {
-            state.cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                state.cmd,
+                "crates/larql-compute-metal/src/decode/moe_interleave.rs:248",
+            );
         }
         gpu_timing::add_host_segment(|h| &mut h.wait_ms, _t_wait.elapsed().as_secs_f64() * 1000.0);
         // R16 control — see ENV_EXTRA_BARRIERS.
@@ -253,7 +256,10 @@ impl MetalBackend {
             for _ in 0..extra {
                 let cb = self.queue.new_command_buffer();
                 cb.commit();
-                cb.wait_until_completed();
+                let _ = crate::cb_status::wait_checked(
+                    cb,
+                    "crates/larql-compute-metal/src/decode/moe_interleave.rs:256",
+                );
             }
         }
         // In split mode the cb we just waited contains ONLY attention
@@ -354,7 +360,10 @@ impl MetalBackend {
                 .as_deref_mut()
                 .expect("split_mode implies moe_collect_fn");
             let result = collect(ctx.layer_idx);
-            state.cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                state.cmd,
+                "crates/larql-compute-metal/src/decode/moe_interleave.rs:357",
+            );
             state
                 .gpu_time
                 .record_stage(state.cmd, gpu_timing::DecodeStage::DenseFfn);

--- a/crates/larql-compute-metal/src/decode/moe_interleave/tests.rs
+++ b/crates/larql-compute-metal/src/decode/moe_interleave/tests.rs
@@ -210,7 +210,10 @@ fn try_inline_zero_copy_moe_encodes_experts_and_combine_on_registered_region() {
     // that was never `end_encoding()`'d.
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        &cmd,
+        "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:213",
+    );
     let took_zero_copy_path = m.try_inline_zero_copy_moe(
         &layer,
         &ctx,
@@ -229,7 +232,10 @@ fn try_inline_zero_copy_moe_encodes_experts_and_combine_on_registered_region() {
 
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        &cmd,
+        "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:232",
+    );
 
     let out = unsafe { std::slice::from_raw_parts(new_h_buf.contents() as *const f32, hidden) };
     assert!(
@@ -385,7 +391,10 @@ fn try_inline_zero_copy_moe_uses_non_grouped_dispatch_across_separate_regions() 
     let mut encoder_ended = true;
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        &cmd,
+        "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:388",
+    );
     let took_zero_copy_path = m.try_inline_zero_copy_moe(
         &layer,
         &ctx,
@@ -404,7 +413,10 @@ fn try_inline_zero_copy_moe_uses_non_grouped_dispatch_across_separate_regions() 
 
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        &cmd,
+        "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:407",
+    );
 
     let out = unsafe { std::slice::from_raw_parts(new_h_buf.contents() as *const f32, hidden) };
     assert!(
@@ -561,7 +573,10 @@ fn try_inline_zero_copy_moe_uses_q6k_grouped_dispatch() {
     let mut encoder_ended = true;
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        &cmd,
+        "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:564",
+    );
     let took_zero_copy_path = m.try_inline_zero_copy_moe(
         &layer,
         &ctx,
@@ -580,7 +595,10 @@ fn try_inline_zero_copy_moe_uses_q6k_grouped_dispatch() {
 
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        &cmd,
+        "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:583",
+    );
 
     let out = unsafe { std::slice::from_raw_parts(new_h_buf.contents() as *const f32, hidden) };
     assert!(
@@ -648,7 +666,10 @@ fn try_inline_zero_copy_moe_returns_false_without_moe_layer() {
     // that was never `end_encoding()`'d.
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        &cmd,
+        "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:651",
+    );
     let took_zero_copy_path = m.try_inline_zero_copy_moe(
         &layer,
         &ctx,

--- a/crates/larql-compute-metal/src/decode/tests.rs
+++ b/crates/larql-compute-metal/src/decode/tests.rs
@@ -161,3 +161,93 @@ fn ensure_kv_cache_does_not_shrink_for_a_shorter_prompt() {
         "cache shrank on a shorter request"
     );
 }
+
+/// A minimal `FullPipelineLayer` whose only live fact is `sliding_window`.
+fn layer_with_window(norm: &[f32], sliding_window: usize) -> larql_compute::FullPipelineLayer<'_> {
+    use larql_compute::{Activation, FfnType, NormType, QuantAux, QuantFormat, QuantWeight};
+    let empty_q4 = QuantWeight::new(QuantFormat::Q4_K, &[], QuantAux::None);
+    larql_compute::FullPipelineLayer {
+        attn_sinks: None,
+        attn_q_bias: None,
+        attn_k_bias: None,
+        attn_v_bias: None,
+        attn_o_bias: None,
+        attn_softcap: 0.0,
+        wq: empty_q4,
+        wk: empty_q4,
+        wv: empty_q4,
+        wo: empty_q4,
+        gate: empty_q4,
+        up: empty_q4,
+        down: empty_q4,
+        input_norm: norm,
+        post_attn_norm: norm,
+        pre_ffn_norm: None,
+        post_ffn_norm: None,
+        input_norm_bias: None,
+        post_attn_norm_bias: None,
+        norm_offset: 1.0,
+        qk_norm_offset: 0.0,
+        eps: 1e-6,
+        has_post_norms: false,
+        norm_type: NormType::RmsNorm,
+        ffn_type: FfnType::Gated,
+        activation: Activation::Silu,
+        attn_scale: 0.125,
+        head_dim: 64,
+        num_q_heads: 8,
+        num_kv_heads: 8,
+        rope_base: 10000.0,
+        rotary_dim: 0,
+        rope_freq: larql_compute::attention::rope::RopeFreqPlan::unscaled(
+            64_usize,
+            0_usize,
+            10000.0_f64,
+        ),
+        sliding_window,
+        has_v_norm: false,
+        layer_scalar: 1.0,
+        q_norm_weight: None,
+        k_norm_weight: None,
+        ffn_up_bias: None,
+        ffn_down_bias: None,
+        moe: None,
+        ffn_is_remote: false,
+        moe_combined_output_norm: false,
+        moe_outer_post_norm: None,
+        kv_shared_source: None,
+        residual_multiplier: 1.0,
+        ple_input_gate: None,
+        ple_projection: None,
+        ple_post_norm: None,
+    }
+}
+
+/// #229. The decode path appends row `current_len` and attends absolute
+/// rows `[T - window, T)`; **nothing on it compacts** — `compact_kv_to_window`
+/// is called only by the KV-engine `coarse_*` path. So a sliding layer
+/// allocated at `window x KV_COMPACTION_SLACK` (256 rows for gpt-oss) is
+/// written and read past its buffer from position 256 on, by a growing
+/// margin: ~3.5 MB per K/V buffer at a ~2K prompt. That is self-consistent
+/// until another allocation lands on the same memory — then NaN in the
+/// residual, NaN router softmax, `~0u` expert ids, and a GPU page fault in
+/// the descriptor gather. Every layer this path allocates must hold the
+/// full requested `max_seq`.
+#[test]
+fn decode_path_sizes_sliding_layers_for_the_full_max_seq_because_it_never_compacts() {
+    let be = gpu_or_skip!();
+    let norm = vec![1.0f32; 64];
+    let layers = [layer_with_window(&norm, 128), layer_with_window(&norm, 0)];
+    let mut cache = None;
+    let kv = be.ensure_kv_cache_for_layers(&mut cache, &layers, 4096);
+    for (i, layer) in kv.layers.iter().enumerate() {
+        assert!(
+            layer.max_seq >= 4096,
+            "layer {i} (sliding_window {}) allocated {} rows for a 4096-row request; \
+             the decode path never compacts, so position {} would append past the buffer",
+            layers[i].sliding_window,
+            layer.max_seq,
+            layer.max_seq
+        );
+    }
+}

--- a/crates/larql-compute-metal/src/decode/token.rs
+++ b/crates/larql-compute-metal/src/decode/token.rs
@@ -356,7 +356,10 @@ impl MetalBackend {
             if stage_timing_split {
                 enc.end_encoding();
                 cmd.commit();
-                cmd.wait_until_completed();
+                let _ = crate::cb_status::wait_checked(
+                    &cmd,
+                    "crates/larql-compute-metal/src/decode/token.rs:359",
+                );
                 gpu_time.record_stage(&cmd, gpu_timing::DecodeStage::Attention);
                 cmd = self.queue.new_command_buffer().to_owned();
                 enc = cmd.new_compute_command_encoder().to_owned();
@@ -413,7 +416,10 @@ impl MetalBackend {
                     self.encode_ffn_gate_up_phase(&enc, layer, &ffn_bufs, ffn_dims);
                     enc.end_encoding();
                     cmd.commit();
-                    cmd.wait_until_completed();
+                    let _ = crate::cb_status::wait_checked(
+                        &cmd,
+                        "crates/larql-compute-metal/src/decode/token.rs:416",
+                    );
                     gpu_time.record_stage(&cmd, gpu_timing::DecodeStage::GateUp);
                     cmd = self.queue.new_command_buffer().to_owned();
                     enc = cmd.new_compute_command_encoder().to_owned();
@@ -429,7 +435,10 @@ impl MetalBackend {
                     );
                     enc.end_encoding();
                     cmd.commit();
-                    cmd.wait_until_completed();
+                    let _ = crate::cb_status::wait_checked(
+                        &cmd,
+                        "crates/larql-compute-metal/src/decode/token.rs:432",
+                    );
                     gpu_time.record_stage(&cmd, gpu_timing::DecodeStage::Down);
                     cmd = self.queue.new_command_buffer().to_owned();
                     enc = cmd.new_compute_command_encoder().to_owned();
@@ -515,7 +524,10 @@ impl MetalBackend {
                     enc.end_encoding();
                 }
                 cmd.commit();
-                cmd.wait_until_completed();
+                let _ = crate::cb_status::wait_checked(
+                    &cmd,
+                    "crates/larql-compute-metal/src/decode/token.rs:518",
+                );
                 let h = super::buffers::read_buffer_f32(h_buf, hidden);
                 let nans = h.iter().filter(|v| v.is_nan()).count();
                 eprintln!(
@@ -624,7 +636,10 @@ impl MetalBackend {
                     if !encoder_ended {
                         enc.end_encoding();
                         cmd.commit();
-                        cmd.wait_until_completed();
+                        let _ = crate::cb_status::wait_checked(
+                            &cmd,
+                            "crates/larql-compute-metal/src/decode/token.rs:627",
+                        );
                         encoder_ended = true;
                     }
                     let ha = super::buffers::read_buffer_f32(&h_post_attn, hidden);
@@ -660,7 +675,10 @@ impl MetalBackend {
                 if !encoder_ended {
                     enc.end_encoding();
                     cmd.commit();
-                    cmd.wait_until_completed();
+                    let _ = crate::cb_status::wait_checked(
+                        &cmd,
+                        "crates/larql-compute-metal/src/decode/token.rs:663",
+                    );
                     encoder_ended = true;
                 }
                 let hidden_bytes = super::buffers::read_buffer_f32(new_h, hidden);
@@ -713,7 +731,10 @@ impl MetalBackend {
                 if !encoder_ended {
                     enc.end_encoding();
                     cmd.commit();
-                    cmd.wait_until_completed();
+                    let _ = crate::cb_status::wait_checked(
+                        &cmd,
+                        "crates/larql-compute-metal/src/decode/token.rs:716",
+                    );
                 }
                 let bufs = diag::LayerDiagBufs {
                     norm_f32_buf: &norm_f32_buf,
@@ -758,7 +779,13 @@ impl MetalBackend {
         if !encoder_ended {
             enc.end_encoding();
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                &cmd,
+                "crates/larql-compute-metal/src/decode/token.rs:761",
+            );
+            // A failed or ignored buffer returns from the wait just like a
+            // finished one; only the status tells them apart. The MoE entry
+            // seam turns any failure inside this step into `None`.
             gpu_time.record(&cmd);
         }
 

--- a/crates/larql-compute-metal/src/decode_hybrid.rs
+++ b/crates/larql-compute-metal/src/decode_hybrid.rs
@@ -559,7 +559,10 @@ impl MetalBackend {
         enc_c.end_encoding();
 
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/decode_hybrid.rs:562",
+        );
 
         super::buffers::read_buffer_f32(&h_post_attn, hidden)
     }

--- a/crates/larql-compute-metal/src/diag/kernel_profile/all.rs
+++ b/crates/larql-compute-metal/src/diag/kernel_profile/all.rs
@@ -42,7 +42,10 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
             let enc = cmd.new_compute_command_encoder();
             enc.end_encoding();
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                cmd,
+                "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:45",
+            );
             let ms = t.elapsed().as_secs_f64() * 1000.0;
             if i >= warmup {
                 times.push(ms);
@@ -129,7 +132,10 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
                 }
                 enc.end_encoding();
                 cmd.commit();
-                cmd.wait_until_completed();
+                let _ = crate::cb_status::wait_checked(
+                    cmd,
+                    "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:132",
+                );
                 let ms = t.elapsed().as_secs_f64() * 1000.0;
                 if i >= warmup {
                     times.push(ms / n_layers as f64);
@@ -207,7 +213,10 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
             dispatch(enc);
             enc.end_encoding();
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                cmd,
+                "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:210",
+            );
         });
         // TRUE batched (warm-cache): all n_layers dispatches reuse the
         // SAME weight buffers (wg/wu). After the first call, weights
@@ -275,7 +284,10 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
                 }
                 enc.end_encoding();
                 cmd.commit();
-                cmd.wait_until_completed();
+                let _ = crate::cb_status::wait_checked(
+                    cmd,
+                    "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:278",
+                );
                 let ms = t.elapsed().as_secs_f64() * 1000.0;
                 if i >= warmup {
                     times.push(ms / n_layers as f64);
@@ -429,7 +441,10 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
             dispatch(enc);
             enc.end_encoding();
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                cmd,
+                "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:432",
+            );
         });
         let bat_ms = measure_single_cmdbuf_batched(&metal, warmup, iters, n_layers, &dispatch);
 
@@ -525,7 +540,10 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
             dispatch(enc);
             enc.end_encoding();
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                cmd,
+                "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:528",
+            );
         });
         let bat_ms = measure_single_cmdbuf_batched(&metal, warmup, iters, n_layers, &dispatch);
 

--- a/crates/larql-compute-metal/src/diag/kernel_profile/census.rs
+++ b/crates/larql-compute-metal/src/diag/kernel_profile/census.rs
@@ -120,7 +120,10 @@ pub fn profile_shape_census(n_layers: usize, warmup: usize, iters: usize) -> Vec
                 }
                 enc.end_encoding();
                 cmd.commit();
-                cmd.wait_until_completed();
+                let _ = crate::cb_status::wait_checked(
+                    cmd,
+                    "crates/larql-compute-metal/src/diag/kernel_profile/census.rs:123",
+                );
                 let ms = t.elapsed().as_secs_f64() * 1000.0;
                 if i >= warmup {
                     times.push(ms / n_layers as f64);

--- a/crates/larql-compute-metal/src/diag/kernel_profile/grouped.rs
+++ b/crates/larql-compute-metal/src/diag/kernel_profile/grouped.rs
@@ -81,7 +81,10 @@ pub fn profile_grouped_experts(
             }
             enc.end_encoding();
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                cmd,
+                "crates/larql-compute-metal/src/diag/kernel_profile/grouped.rs:84",
+            );
             let ms = t.elapsed().as_secs_f64() * 1000.0;
             if i >= warmup {
                 times.push(ms / batch as f64);
@@ -113,7 +116,10 @@ pub fn profile_grouped_experts(
             }
             enc.end_encoding();
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                cmd,
+                "crates/larql-compute-metal/src/diag/kernel_profile/grouped.rs:116",
+            );
             let ms = t.elapsed().as_secs_f64() * 1000.0;
             if i >= warmup {
                 times.push(ms / batch as f64);

--- a/crates/larql-compute-metal/src/diag/kernel_profile/measure.rs
+++ b/crates/larql-compute-metal/src/diag/kernel_profile/measure.rs
@@ -95,7 +95,10 @@ pub(super) fn measure_single_cmdbuf_batched(
         }
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/diag/kernel_profile/measure.rs:98",
+        );
         let ms = t.elapsed().as_secs_f64() * 1000.0;
         if i >= warmup {
             times.push(ms / n_layers as f64);

--- a/crates/larql-compute-metal/src/diag/mxfp4_layout.rs
+++ b/crates/larql-compute-metal/src/diag/mxfp4_layout.rs
@@ -377,7 +377,10 @@ pub fn race(
             }
             enc.end_encoding();
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                cmd,
+                "crates/larql-compute-metal/src/diag/mxfp4_layout.rs:380",
+            );
             if i >= warmup {
                 times.push(t.elapsed().as_secs_f64() * 1e3 / batch as f64);
             }

--- a/crates/larql-compute-metal/src/diag/shader_bench/measure.rs
+++ b/crates/larql-compute-metal/src/diag/shader_bench/measure.rs
@@ -61,7 +61,10 @@ pub(crate) fn measure_isolated(
         encode(enc);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/diag/shader_bench/measure.rs:64",
+        );
         if i >= warmup {
             times.push(t.elapsed().as_secs_f64() * 1000.0);
         }
@@ -86,7 +89,10 @@ pub(crate) fn measure_batched(
         }
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/diag/shader_bench/measure.rs:89",
+        );
         if i >= warmup {
             times.push(t.elapsed().as_secs_f64() * 1000.0 / n_layers as f64);
         }

--- a/crates/larql-compute-metal/src/f32_ops.rs
+++ b/crates/larql-compute-metal/src/f32_ops.rs
@@ -37,7 +37,7 @@ impl F32Ops {
         Self::encode_static(&self.sgemm_pipeline, enc, &buf_a, &buf_b, &buf_c, m, n, k);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/f32_ops.rs:40");
 
         super::buffers::read_buffer_f32(&buf_c, m * n)
     }
@@ -63,7 +63,7 @@ impl F32Ops {
         Self::encode_static(&self.transb_pipeline, enc, &buf_a, &buf_b, &buf_c, m, n, k);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/f32_ops.rs:66");
 
         super::buffers::read_buffer_f32(&buf_c, m * n)
     }

--- a/crates/larql-compute-metal/src/lib.rs
+++ b/crates/larql-compute-metal/src/lib.rs
@@ -59,6 +59,10 @@ pub mod backend;
 pub mod buffers;
 #[cfg(target_os = "macos")]
 pub mod calibration;
+
+/// Command-buffer completion status (#229 instrumentation).
+pub mod cb_status;
+
 #[cfg(target_os = "macos")]
 pub mod decode;
 #[cfg(target_os = "macos")]
@@ -73,6 +77,8 @@ pub mod kv_residency_contract;
 pub mod ops;
 #[cfg(target_os = "macos")]
 pub mod options;
+/// Router-id bounds guard for the descriptor gather (#229).
+pub mod route_guard;
 #[cfg(target_os = "macos")]
 pub mod shaders;
 #[cfg(target_os = "macos")]

--- a/crates/larql-compute-metal/src/moe_descriptor.rs
+++ b/crates/larql-compute-metal/src/moe_descriptor.rs
@@ -309,6 +309,9 @@ impl MetalBackend {
             4,
             &gate_half_bytes as *const u32 as *const std::ffi::c_void,
         );
+        let num_experts = table.descs_host.len() as u32;
+        enc.set_bytes(10, 4, &num_experts as *const u32 as *const std::ffi::c_void);
+        enc.set_buffer(11, Some(&self.route_guard.counter), 0);
         enc.dispatch_threads(
             metal::MTLSize::new(n_slots as u64, 1, 1),
             metal::MTLSize::new(n_slots as u64, 1, 1),
@@ -376,7 +379,10 @@ impl MetalBackend {
         let out = self.encode_descriptor_gather(enc, table, &ids_buf, n_slots, gate_half_bytes);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/moe_descriptor.rs:382",
+        );
 
         let ptr = out.slot_descs.contents() as *const GpuExpertDescriptor;
         if ptr.is_null() {
@@ -437,7 +443,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/moe_descriptor.rs:443",
+        );
 
         let gate = crate::buffers::try_read_buffer_f32(&gate_out, n_slots * inter)?;
         let up = crate::buffers::try_read_buffer_f32(&up_out, n_slots * inter)?;

--- a/crates/larql-compute-metal/src/moe_dispatch/dense.rs
+++ b/crates/larql-compute-metal/src/moe_dispatch/dense.rs
@@ -106,7 +106,10 @@ impl MetalBackend {
 
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/moe_dispatch/dense.rs:109",
+        );
 
         let result = read_buffer_f32(&out_buf, hidden);
 

--- a/crates/larql-compute-metal/src/moe_dispatch/dispatch.rs
+++ b/crates/larql-compute-metal/src/moe_dispatch/dispatch.rs
@@ -327,7 +327,10 @@ impl MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/moe_dispatch/dispatch.rs:330",
+        );
 
         // ── 7. CPU weighted sum + post-experts norm ──────────────────────
         // The down bias joins each expert's output BEFORE the routing

--- a/crates/larql-compute-metal/src/moe_dispatch/entry.rs
+++ b/crates/larql-compute-metal/src/moe_dispatch/entry.rs
@@ -104,7 +104,15 @@ impl MetalBackend {
         // closure above stays as the per-layer fallback.
         let inline_ctx = scratch_ref.map(|s| crate::decode::InlineMoeCtx::new(s, norm_eps));
 
-        Some(self.decode_token_with_moe_split_fn(
+        // A step whose command buffer failed (GPU address fault, ignored
+        // buffer after an earlier fault) returns from its wait exactly like
+        // a healthy one, with stale or garbage bytes in `h_buf`. Count the
+        // failures across the whole step — every wait on this path goes
+        // through `cb_status::wait_checked` — and refuse to hand a poisoned
+        // hidden state to the sampler. The caller treats `None` as
+        // "GPU decode returned None; stopping generation" (#229).
+        let failures_before = crate::cb_status::non_completed_count();
+        let h = self.decode_token_with_moe_split_fn(
             kv,
             layers,
             x,
@@ -122,7 +130,21 @@ impl MetalBackend {
             larql_compute::StateDumpMask::Full,
             inline_ctx.as_ref(),
             head,
-        ))
+        );
+        if crate::cb_status::non_completed_count() != failures_before {
+            return None;
+        }
+        // The gather kernel clamps router ids past `num_experts` and
+        // counts them; a step that needed the clamp computed with the wrong
+        // expert and must not be sampled from either.
+        let refused = self.route_guard.take_new_refusals();
+        if refused != 0 {
+            eprintln!(
+                "[metal] router emitted {refused} expert id(s) >= num_experts in this decode step; refusing the step (#229)"
+            );
+            return None;
+        }
+        Some(h)
     }
 
     /// Public single-layer MoE block entry — the parity/test surface for

--- a/crates/larql-compute-metal/src/moe_dispatch/experts.rs
+++ b/crates/larql-compute-metal/src/moe_dispatch/experts.rs
@@ -137,7 +137,10 @@ impl MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/moe_dispatch/experts.rs:140",
+        );
         let t_gpu = t_start.elapsed();
 
         let all_expert_outputs = read_buffer_f32(&scratch.expert_outs, valid_count * hidden);
@@ -346,7 +349,10 @@ impl MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/moe_dispatch/experts.rs:349",
+        );
         let t_gpu = t_start.elapsed();
 
         // CPU weighted sum (no post-experts norm — client does that across shards).

--- a/crates/larql-compute-metal/src/moe_gpu_route/encode/tests.rs
+++ b/crates/larql-compute-metal/src/moe_gpu_route/encode/tests.rs
@@ -385,7 +385,10 @@ fn run_gpu_route(metal: &MetalBackend, moe: &MoeLayerWeights<'_>, x: &[f32]) -> 
     metal.encode_moe_layer_gpu_route(enc, moe, &s, &table, &h_post_attn, &new_h, 1e-6);
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        cmd,
+        "crates/larql-compute-metal/src/moe_gpu_route/encode/tests.rs:388",
+    );
     crate::buffers::read_buffer_f32(&new_h, HIDDEN)
 }
 

--- a/crates/larql-compute-metal/src/moe_gpu_route/forward.rs
+++ b/crates/larql-compute-metal/src/moe_gpu_route/forward.rs
@@ -43,7 +43,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/moe_gpu_route/forward.rs:46",
+        );
         crate::buffers::try_read_buffer_f32(&new_h, hidden)
     }
 
@@ -153,7 +156,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/moe_gpu_route/forward.rs:156",
+        );
         crate::buffers::try_read_buffer_f32(&new_h, hidden)
     }
 }
@@ -275,7 +281,10 @@ impl MetalBackend {
             }
             enc.end_encoding();
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                cmd,
+                "crates/larql-compute-metal/src/moe_gpu_route/forward.rs:278",
+            );
             windows.push(unsafe {
                 let start: f64 = msg_send![cmd, GPUStartTime];
                 let end: f64 = msg_send![cmd, GPUEndTime];
@@ -290,7 +299,10 @@ impl MetalBackend {
                 encode_layer(enc, &prev, out);
                 enc.end_encoding();
                 cmd.commit();
-                cmd.wait_until_completed();
+                let _ = crate::cb_status::wait_checked(
+                    cmd,
+                    "crates/larql-compute-metal/src/moe_gpu_route/forward.rs:293",
+                );
                 windows.push(unsafe {
                     let start: f64 = msg_send![cmd, GPUStartTime];
                     let end: f64 = msg_send![cmd, GPUEndTime];

--- a/crates/larql-compute-metal/src/moe_zero_copy.rs
+++ b/crates/larql-compute-metal/src/moe_zero_copy.rs
@@ -511,7 +511,10 @@ impl MetalBackend {
         self.encode_experts_zero_copy(enc, expert_input, moe, scratch, resolved);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/moe_zero_copy.rs:514",
+        );
         let t_gpu = t_start.elapsed();
 
         // ── Readback: down bias joins each expert's output BEFORE the

--- a/crates/larql-compute-metal/src/ops/full_layer.rs
+++ b/crates/larql-compute-metal/src/ops/full_layer.rs
@@ -140,7 +140,8 @@ pub fn dispatch(
     // For now, return attention output only (FFN benchmarked separately)
 
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ =
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/ops/full_layer.rs:143");
 
     crate::buffers::read_buffer_f32(&buf_o_out, seq_len * hidden)
 }

--- a/crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs
+++ b/crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs
@@ -462,7 +462,10 @@ pub fn dispatch_full_pipeline(
         if let Some(iv) = intervention {
             if l == iv.target_layer {
                 cmd.commit();
-                cmd.wait_until_completed();
+                let _ = crate::cb_status::wait_checked(
+                    &cmd,
+                    "crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs:465",
+                );
                 let q_dim = iv.num_q_heads * iv.head_dim;
 
                 // A.1: Capture pre-W_O for oracle code computation.
@@ -529,7 +532,10 @@ pub fn dispatch_full_pipeline(
         if let Some(iv) = intervention {
             if l == iv.target_layer {
                 cmd.commit();
-                cmd.wait_until_completed();
+                let _ = crate::cb_status::wait_checked(
+                    &cmd,
+                    "crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs:532",
+                );
                 debug_assert_eq!(
                     iv.replacement_delta.len(),
                     seq_len * hidden,
@@ -742,7 +748,10 @@ pub fn dispatch_full_pipeline(
         // restart the command buffer for the next layer.
         if needs_per_layer_commit {
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                &cmd,
+                "crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs:745",
+            );
 
             // KV cache: copy this layer's K/V before the caller reads
             // `h_post_attn` or touches `new_h`.
@@ -770,7 +779,10 @@ pub fn dispatch_full_pipeline(
 
     if !needs_per_layer_commit {
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            &cmd,
+            "crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs:773",
+        );
 
         // Post-commit: populate persistent KV cache from GPU-computed
         // RoPE'd K/V (buffers are readable now that the command buffer is

--- a/crates/larql-compute-metal/src/ops/full_pipeline/dump.rs
+++ b/crates/larql-compute-metal/src/ops/full_pipeline/dump.rs
@@ -67,7 +67,10 @@ pub(super) fn dump_layer0_q_after_stage(
         return cmd;
     }
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        &cmd,
+        "crates/larql-compute-metal/src/ops/full_pipeline/dump.rs:70",
+    );
     let name = format!("metal_L0_q_out_{stage_name}.f32");
     write_f32_buffer(dir, &name, &lb.q_out[layer_idx], seq_len * layer_q_dim);
     queue.new_command_buffer().to_owned()
@@ -93,7 +96,10 @@ pub(super) fn dump_layer_snapshots(
         return cmd;
     };
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        &cmd,
+        "crates/larql-compute-metal/src/ops/full_pipeline/dump.rs:96",
+    );
     let layer_q_dim = layers[l].num_q_heads * layers[l].head_dim;
     let layer_kv_dim = layers[l].num_kv_heads * layers[l].head_dim;
     let layer_dump = |name: &str, buf: &Buffer, n: usize| {

--- a/crates/larql-compute-metal/src/ops/kv_cache.rs
+++ b/crates/larql-compute-metal/src/ops/kv_cache.rs
@@ -294,6 +294,15 @@ impl KVCache {
 
 /// Encode KV append dispatch into an existing encoder.
 /// The encoder is NOT ended — caller continues adding dispatches.
+///
+/// # Panics
+///
+/// If the cache is full (`current_len >= max_seq`). The append kernel
+/// writes row `current_len` with no bound of its own, so a full cache
+/// would mean a write past the buffer — memory corruption that surfaces
+/// only much later and somewhere else (#229: a sliding layer sized to its
+/// window on a path that never compacts). Refusing here turns that into a
+/// named failure at the site that owns the fact.
 #[allow(clippy::too_many_arguments)]
 pub fn encode_kv_append(
     enc: &ComputeCommandEncoderRef,
@@ -302,6 +311,14 @@ pub fn encode_kv_append(
     new_k: &Buffer,
     new_v: &Buffer,
 ) {
+    assert!(
+        cache.current_len < cache.max_seq,
+        "KV append past capacity: current_len {} >= max_seq {} — the cache must be \
+         sized for every position this path will reach, or compacted before this \
+         append; either way the write must not happen (#229)",
+        cache.current_len,
+        cache.max_seq
+    );
     let pos = cache.current_len as u32;
     let num_kv = cache.num_kv_heads as u32;
     let hd = cache.head_dim as u32;
@@ -951,6 +968,49 @@ mod tests {
         (8, 2, 64)
     }
 
+    /// #229. A full cache must refuse the append rather than write row
+    /// `max_seq` past its buffer. Encoding, not execution: the assertion
+    /// fires before any dispatch is recorded.
+    #[test]
+    fn encode_kv_append_refuses_a_full_cache() {
+        let m = backend();
+        let (_, num_kv, head_dim) = append_attend_shapes();
+        let max_seq = 4;
+        let mut layer = LayerKVCache::new(&m.bufs, max_seq, num_kv, head_dim);
+        layer.current_len = max_seq; // positions 0..4 stored; the 5th must not land
+        let zeros = vec![0.0f32; num_kv * head_dim];
+        let new_k_buf = m.bufs.transient_from_f32(&zeros);
+        let new_v_buf = m.bufs.transient_from_f32(&zeros);
+        let cmd = m.queue.new_command_buffer();
+        let enc = cmd.new_compute_command_encoder();
+        // Metal aborts the process if an encoder is dropped mid-panic, so
+        // catch the refusal and end the encoder before asserting on it.
+        let refused = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            encode_kv_append(
+                enc,
+                &layer,
+                &m.attention.kv_append_pipeline,
+                &new_k_buf,
+                &new_v_buf,
+            )
+        }));
+        enc.end_encoding();
+        cmd.commit();
+        let _ = crate::cb_status::wait_checked(cmd, "kv_cache refuse test");
+        let msg = match refused {
+            Err(payload) => payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+                .unwrap_or_default(),
+            Ok(()) => panic!("a full cache accepted an append past its buffer"),
+        };
+        assert!(
+            msg.contains("KV append past capacity"),
+            "unexpected refusal message: {msg}"
+        );
+    }
+
     /// `encode_kv_append` writes new K/V rows into the cache slot at
     /// `current_len`.  After a single dispatch + commit + wait the
     /// dispatch should complete and the kernel input/output buffers
@@ -979,7 +1039,10 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/ops/kv_cache.rs:1042",
+        );
 
         // The callsite is responsible for bumping `current_len`; the
         // encoder itself only writes the buffer.  Mirror the legacy
@@ -1021,7 +1084,10 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/ops/kv_cache.rs:1084",
+        );
 
         let out = crate::buffers::read_buffer_f32(&out_buf, num_kv * head_dim);
         assert!(out.iter().all(|v| v.is_finite()));
@@ -1068,7 +1134,10 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/ops/kv_cache.rs:1131",
+        );
 
         // Output buffer length matches the requested shape (a weak but
         // valid post-condition: a panicked kernel never gets here, and
@@ -1113,7 +1182,10 @@ mod tests {
             (head_dim as f32).sqrt().recip(),
         );
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/ops/kv_cache.rs:1176",
+        );
 
         assert_eq!(
             layer.current_len, 1,

--- a/crates/larql-compute-metal/src/ops/moe_router.rs
+++ b/crates/larql-compute-metal/src/ops/moe_router.rs
@@ -95,7 +95,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/ops/moe_router.rs:98",
+        );
 
         crate::buffers::try_read_buffer_f32(&out_buf, num_experts)
     }
@@ -215,7 +218,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/ops/moe_router.rs:218",
+        );
 
         let weights = crate::buffers::try_read_buffer_f32(&weights_buf, top_k)?;
         let ids: Vec<usize> = unsafe {

--- a/crates/larql-compute-metal/src/ops/q4_batched.rs
+++ b/crates/larql-compute-metal/src/ops/q4_batched.rs
@@ -83,7 +83,8 @@ pub fn pair_batch(
     }
 
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ =
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/ops/q4_batched.rs:86");
 
     let mut gate_results = Vec::with_capacity(seq_len);
     let mut up_results = Vec::with_capacity(seq_len);
@@ -224,7 +225,8 @@ pub fn multi_layer_ffn(
     }
 
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ =
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/ops/q4_batched.rs:227");
 
     let last = num_layers - 1;
     crate::buffers::read_buffer_f32(&down_outs[last], hidden)

--- a/crates/larql-compute-metal/src/ops/q4_f32_matvec.rs
+++ b/crates/larql-compute-metal/src/ops/q4_f32_matvec.rs
@@ -45,7 +45,10 @@ pub fn dispatch(
     enc.dispatch_threads(threads, tg);
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ = crate::cb_status::wait_checked(
+        cmd,
+        "crates/larql-compute-metal/src/ops/q4_f32_matvec.rs:48",
+    );
 
     crate::buffers::read_buffer_f32(&buf_out, num_rows)
 }

--- a/crates/larql-compute-metal/src/ops/q4_matvec.rs
+++ b/crates/larql-compute-metal/src/ops/q4_matvec.rs
@@ -56,7 +56,8 @@ pub fn dispatch(
     );
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ =
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/ops/q4_matvec.rs:59");
 
     crate::buffers::read_buffer_f32(&buf_out, num_rows)
 }

--- a/crates/larql-compute-metal/src/ops/q4_vecmat.rs
+++ b/crates/larql-compute-metal/src/ops/q4_vecmat.rs
@@ -45,7 +45,8 @@ pub fn dispatch(
     enc.dispatch_threads(threads, tg);
     enc.end_encoding();
     cmd.commit();
-    cmd.wait_until_completed();
+    let _ =
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/ops/q4_vecmat.rs:48");
 
     crate::buffers::read_buffer_f32(&buf_out, hidden)
 }

--- a/crates/larql-compute-metal/src/route_guard.rs
+++ b/crates/larql-compute-metal/src/route_guard.rs
@@ -1,0 +1,52 @@
+//! Bounds guard on the router → descriptor indirection (#229).
+//!
+//! `moe_descriptor_gather` reads `descs[selected_ids[slot]]`; `descs` has
+//! `num_experts` entries and the ids come off the GPU router with nothing
+//! between them and that read. An id past the end is a GPU address fault,
+//! and a faulted command buffer returns from its wait like a finished one
+//! (see `cb_status`). The kernel now clamps such an id to expert 0 and
+//! bumps this counter; the host reads the counter after every decode step
+//! and refuses the step if it moved. That turns a silent page fault into a
+//! named, counted, refused event — and tells us whether the router is the
+//! source of the fault at all.
+
+use metal::{Buffer, Device, MTLResourceOptions};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// One `u32` in shared memory, incremented by the gather kernel.
+pub struct RouteGuard {
+    pub counter: Buffer,
+    /// Value last observed by the host, so a step reads a delta.
+    last_seen: AtomicU32,
+}
+
+impl RouteGuard {
+    pub fn new(device: &Device) -> Self {
+        let counter = device.new_buffer(4, MTLResourceOptions::StorageModeShared);
+        // A fresh Metal buffer is zeroed, but say so rather than rely on it.
+        // SAFETY: 4-byte shared buffer, no GPU work in flight yet.
+        unsafe { std::ptr::write(counter.contents() as *mut u32, 0) };
+        Self {
+            counter,
+            last_seen: AtomicU32::new(0),
+        }
+    }
+
+    /// Current device-side total. Valid after the command buffers that
+    /// could have bumped it have completed.
+    pub fn total(&self) -> u32 {
+        // SAFETY: shared 4-byte buffer owned by `self`; a torn read is
+        // impossible for an aligned u32 and the value is only advisory.
+        unsafe { std::ptr::read_volatile(self.counter.contents() as *const u32) }
+    }
+
+    /// Ids refused since the previous call. Zero on a healthy step.
+    pub fn take_new_refusals(&self) -> u32 {
+        let now = self.total();
+        let before = self.last_seen.swap(now, Ordering::Relaxed);
+        now.wrapping_sub(before)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/larql-compute-metal/src/route_guard/tests.rs
+++ b/crates/larql-compute-metal/src/route_guard/tests.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+#[cfg(target_os = "macos")]
+#[test]
+fn a_fresh_guard_reads_zero_and_deltas_are_relative_to_the_last_read() {
+    let Some(device) = metal::Device::system_default() else {
+        return;
+    };
+    let g = RouteGuard::new(&device);
+    assert_eq!(g.total(), 0);
+    assert_eq!(g.take_new_refusals(), 0);
+    // Stand in for the gather kernel bumping the shared counter.
+    // SAFETY: 4-byte shared buffer owned by `g`; no GPU work in flight.
+    unsafe { std::ptr::write_volatile(g.counter.contents() as *mut u32, 3) };
+    assert_eq!(g.total(), 3);
+    assert_eq!(g.take_new_refusals(), 3);
+    assert_eq!(g.take_new_refusals(), 0, "a delta is consumed once");
+    unsafe { std::ptr::write_volatile(g.counter.contents() as *mut u32, 5) };
+    assert_eq!(g.take_new_refusals(), 2);
+}

--- a/crates/larql-compute-metal/src/shaders/moe_descriptor.rs
+++ b/crates/larql-compute-metal/src/shaders/moe_descriptor.rs
@@ -58,10 +58,22 @@ kernel void moe_descriptor_gather(
     device uint*                      dn_scale_offs [[buffer(7)]], // [n_slots]
     constant uint&                    n_slots      [[buffer(8)]],
     constant uint&                    gate_half_bytes [[buffer(9)]],
+    // Bounds guard (#229): `descs` has exactly `num_experts` entries and
+    // nothing upstream proves the router's ids stay inside it. An id past
+    // the end is a GPU page fault — a failed command buffer whose stale
+    // outputs read like a finished one. Instead: count it, and gather
+    // expert 0 so the step completes and the host can refuse it.
+    constant uint&                    num_experts  [[buffer(10)]],
+    device atomic_uint*               bad_ids      [[buffer(11)]],
     uint tid [[thread_position_in_grid]])
 {
     if (tid < n_slots) {
-        MoeExpertDescriptor d = descs[selected_ids[tid]];
+        uint id = selected_ids[tid];
+        if (id >= num_experts) {
+            atomic_fetch_add_explicit(bad_ids, 1u, memory_order_relaxed);
+            id = 0u;
+        }
+        MoeExpertDescriptor d = descs[id];
         out[tid] = d;
         gate0_offs[tid] = d.gate_up_payload_off;
         gate1_offs[tid] = d.gate_up_payload_off + gate_half_bytes;

--- a/crates/larql-compute-metal/src/stages/ffn.rs
+++ b/crates/larql-compute-metal/src/stages/ffn.rs
@@ -510,7 +510,8 @@ mod dispatch_tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ =
+            crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/stages/ffn.rs:513");
     }
 
     /// Same shape, GeluTanh activation — covers the `Activation::GeluTanh`
@@ -558,7 +559,8 @@ mod dispatch_tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ =
+            crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/stages/ffn.rs:561");
     }
 
     /// `encode_gated` with `LARQL_FUSED_DOWN=1` + Q4_K down dispatches
@@ -616,7 +618,8 @@ mod dispatch_tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ =
+            crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/stages/ffn.rs:619");
         unsafe {
             std::env::remove_var(larql_compute::options::ENV_FUSED_DOWN);
         }
@@ -662,7 +665,8 @@ mod dispatch_tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ =
+            crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/stages/ffn.rs:665");
     }
 
     /// `encode_standard` with `Activation::GeluTanh` — covers the
@@ -705,6 +709,7 @@ mod dispatch_tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ =
+            crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/stages/ffn.rs:708");
     }
 }

--- a/crates/larql-compute-metal/src/stages/layer_scalar.rs
+++ b/crates/larql-compute-metal/src/stages/layer_scalar.rs
@@ -91,7 +91,10 @@ mod tests {
         encode(enc, &pipeline, &h_buf, seq_len, hidden, scalar);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/stages/layer_scalar.rs:94",
+        );
 
         let out_ptr = h_buf.contents() as *const f32;
         let metal_out: Vec<f32> =
@@ -136,7 +139,10 @@ mod tests {
         encode(enc, &pipeline, &h_buf, 1, hidden, 0.0);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/stages/layer_scalar.rs:139",
+        );
 
         let out_ptr = h_buf.contents() as *const f32;
         let out: Vec<f32> = unsafe { std::slice::from_raw_parts(out_ptr, hidden).to_vec() };

--- a/crates/larql-compute-metal/src/stages/qk_norm.rs
+++ b/crates/larql-compute-metal/src/stages/qk_norm.rs
@@ -191,7 +191,10 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/stages/qk_norm.rs:194",
+        );
 
         let q_out = crate::buffers::read_buffer_f32(&q_buf, num_q_heads * head_dim);
         let k_out = crate::buffers::read_buffer_f32(&k_buf, num_kv_heads * head_dim);
@@ -240,7 +243,10 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/stages/qk_norm.rs:243",
+        );
 
         let v_out = crate::buffers::read_buffer_f32(&v_buf, num_kv_heads * head_dim);
         assert!(

--- a/crates/larql-compute-metal/src/stages/qkv_proj.rs
+++ b/crates/larql-compute-metal/src/stages/qkv_proj.rs
@@ -566,7 +566,10 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/stages/qkv_proj.rs:569",
+        );
 
         let q = crate::buffers::read_buffer_f32(&q_out, q_rows);
         let k = crate::buffers::read_buffer_f32(&k_out, kv_rows);

--- a/crates/larql-compute-metal/src/stages/quant_matvec.rs
+++ b/crates/larql-compute-metal/src/stages/quant_matvec.rs
@@ -355,7 +355,10 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/stages/quant_matvec.rs:358",
+        );
     }
 
     /// Q4_KF format dispatches the dedicated Q4_KF shader when the
@@ -458,7 +461,10 @@ mod tests {
         }));
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/stages/quant_matvec.rs:461",
+        );
         if let Err(payload) = result {
             std::panic::resume_unwind(payload);
         }
@@ -503,7 +509,10 @@ mod tests {
             }));
             enc.end_encoding();
             cmd.commit();
-            cmd.wait_until_completed();
+            let _ = crate::cb_status::wait_checked(
+                cmd,
+                "crates/larql-compute-metal/src/stages/quant_matvec.rs:506",
+            );
             let payload = result.expect_err("float formats must refuse, not no-op");
             let msg = payload
                 .downcast_ref::<String>()

--- a/crates/larql-compute-metal/src/trait_impl/decode.rs
+++ b/crates/larql-compute-metal/src/trait_impl/decode.rs
@@ -850,10 +850,16 @@ impl DecodeBackend for MetalBackend {
                 out: &mut hits,
             }),
         );
-        // A decode that produced no hidden state produced no logits
-        // either; report that as `None` rather than an empty top-K, which
-        // the caller would read as "the head ran and found nothing".
-        hidden_out?;
+        // `None` from the step means a command buffer inside it failed
+        // (`cb_status`): the step *ran* — KV was appended — but its bytes
+        // are poison. That must not read as a refusal, or the caller would
+        // fall through to the unfused path and run the same token again on
+        // top of the appended KV. Report it as an empty top-K instead:
+        // "the step ran and has no usable candidates", which the caller
+        // treats as terminal.
+        if hidden_out.is_none() {
+            return Some(Vec::new());
+        }
         hits
     }
 

--- a/crates/larql-compute-metal/src/trait_impl/grouped_experts.rs
+++ b/crates/larql-compute-metal/src/trait_impl/grouped_experts.rs
@@ -155,7 +155,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/grouped_experts.rs:158",
+        );
 
         Ok(crate::buffers::read_buffer_f32(&buf_out, offsets.len() * n))
     }
@@ -237,7 +240,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/grouped_experts.rs:240",
+        );
 
         Ok(crate::buffers::read_buffer_f32(&buf_out, offsets.len() * n))
     }

--- a/crates/larql-compute-metal/src/trait_impl/matmul.rs
+++ b/crates/larql-compute-metal/src/trait_impl/matmul.rs
@@ -137,7 +137,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/matmul.rs:140",
+        );
 
         // `try_read_buffer_f32` returns `None` if the GPU ran out of
         // memory and `contents()` is null — callers fall back to CPU
@@ -191,7 +194,10 @@ impl MetalBackend {
         let (partial_vals, partial_idxs, n_partials) = self.encode_argmax_partial(enc, &scores, n);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/matmul.rs:194",
+        );
         Self::reduce_argmax_partial(&partial_vals, &partial_idxs, n_partials)
     }
 
@@ -235,7 +241,10 @@ impl MetalBackend {
         let (partial_vals, partial_idxs, n_partials) = self.encode_argmax_partial(enc, &scores, n);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/matmul.rs:238",
+        );
         Self::reduce_argmax_partial(&partial_vals, &partial_idxs, n_partials)
     }
 
@@ -447,7 +456,10 @@ impl MetalBackend {
         let (partial_vals, partial_idxs, num_tgs) = self.encode_topk_partial(enc, &scores, n);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/matmul.rs:450",
+        );
         Some(Self::reduce_topk_partial(
             &partial_vals,
             &partial_idxs,
@@ -495,7 +507,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/matmul.rs:498",
+        );
 
         Some(crate::buffers::read_buffer_f32(&buf_out, num_rows))
     }
@@ -527,7 +542,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/matmul.rs:530",
+        );
 
         Some(crate::buffers::read_buffer_f32(&out_buf, n))
     }
@@ -567,7 +585,10 @@ mod tests {
         let (vals, idxs, num_tgs) = metal.encode_topk_partial(enc, &scores_buf, n);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/matmul.rs:570",
+        );
 
         let hits = MetalBackend::reduce_topk_partial(&vals, &idxs, num_tgs, 5);
         assert_eq!(hits.len(), 5);
@@ -597,7 +618,10 @@ mod tests {
         let (vals, idxs, num_tgs) = metal.encode_topk_partial(enc, &scores_buf, n);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/matmul.rs:600",
+        );
         let hits = MetalBackend::reduce_topk_partial(&vals, &idxs, num_tgs, 2);
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].0, 42);

--- a/crates/larql-compute-metal/src/trait_impl/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/mod.rs
@@ -291,6 +291,9 @@ mod tests {
         let enc = cmd.new_compute_command_encoder();
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/mod.rs:294",
+        );
     }
 }

--- a/crates/larql-compute-metal/src/trait_impl/mxfp4.rs
+++ b/crates/larql-compute-metal/src/trait_impl/mxfp4.rs
@@ -159,7 +159,10 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/mxfp4.rs:162",
+        );
 
         Ok(crate::buffers::read_buffer_f32(&buf_out, m))
     }

--- a/crates/larql-compute-metal/src/trait_impl/quant_matvec.rs
+++ b/crates/larql-compute-metal/src/trait_impl/quant_matvec.rs
@@ -56,7 +56,10 @@ impl QuantMatVec for MetalBackend {
             self.encode_argmax_partial(enc, &scores, num_rows);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:59",
+        );
         Self::reduce_argmax_partial(&partial_vals, &partial_idxs, n_partials)
     }
 
@@ -100,7 +103,10 @@ impl QuantMatVec for MetalBackend {
             self.encode_topk_partial(enc, &scores, num_rows);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:103",
+        );
         Some(MetalBackend::reduce_topk_partial(
             &partial_vals,
             &partial_idxs,
@@ -181,7 +187,10 @@ impl QuantMatVec for MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:184",
+        );
 
         Some(crate::buffers::read_buffer_f32(&buf_out, num_rows))
     }
@@ -231,7 +240,10 @@ impl QuantMatVec for MetalBackend {
             self.encode_topk_partial(enc, &buf_out, num_rows);
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:234",
+        );
         Some(MetalBackend::reduce_topk_partial(
             &partial_vals,
             &partial_idxs,
@@ -288,7 +300,10 @@ impl QuantMatVec for MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:291",
+        );
 
         Some(crate::buffers::read_buffer_f32(
             &buf_out,
@@ -333,7 +348,10 @@ impl QuantMatVec for MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        cmd.wait_until_completed();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:336",
+        );
 
         Some(crate::buffers::read_buffer_f32(&buf_out, num_rows))
     }

--- a/crates/larql-compute-metal/tests/test_kernel_moe_q6k_descriptor_parity.rs
+++ b/crates/larql-compute-metal/tests/test_kernel_moe_q6k_descriptor_parity.rs
@@ -184,6 +184,13 @@ impl Rig {
             enc.set_buffer(7, Some(&dn_sc), 0);
             enc.set_bytes(8, 4, &n as *const u32 as *const _);
             enc.set_bytes(9, 4, &ghb as *const u32 as *const _);
+            // #229 bounds guard: the table's length and a refusal counter.
+            let num_experts = NUM_EXPERTS as u32;
+            enc.set_bytes(10, 4, &num_experts as *const u32 as *const _);
+            let bad_ids = self
+                .device
+                .new_buffer(4, MTLResourceOptions::StorageModeShared);
+            enc.set_buffer(11, Some(&bad_ids), 0);
             enc.dispatch_threads(
                 MTLSize::new(n_slots as u64, 1, 1),
                 MTLSize::new(n_slots as u64, 1, 1),
@@ -355,6 +362,13 @@ fn up_half_table_matches_shifted_control_bitwise() {
     enc.set_buffer(7, Some(&dn_sc), 0);
     enc.set_bytes(8, 4, &n as *const u32 as *const _);
     enc.set_bytes(9, 4, &ghb as *const u32 as *const _);
+    // #229 bounds guard: the table's length and a refusal counter.
+    let num_experts = NUM_EXPERTS as u32;
+    enc.set_bytes(10, 4, &num_experts as *const u32 as *const _);
+    let bad_ids = rig
+        .device
+        .new_buffer(4, MTLResourceOptions::StorageModeShared);
+    enc.set_buffer(11, Some(&bad_ids), 0);
     enc.dispatch_threads(MTLSize::new(n as u64, 1, 1), MTLSize::new(n as u64, 1, 1));
 
     let n_u32 = N_ROWS as u32;

--- a/crates/larql-compute/src/options.rs
+++ b/crates/larql-compute/src/options.rs
@@ -198,6 +198,18 @@ pub const ENV_Q4K_DIRECT_FFN: &str = "LARQL_Q4K_DIRECT_FFN";
 pub const ENV_Q4K_ASM: &str = "LARQL_Q4K_ASM";
 /// Spin-barrier thread pool for the decode hot path (vs rayon's sleeping pool).
 pub const ENV_SPIN_POOL: &str = "LARQL_SPIN_POOL";
+/// Zero every scratch buffer handed back by the pool, instead of trusting
+/// callers to write before they read.
+///
+/// Diagnostic, not a tuning knob. `BufferCache::output` recycles buffers
+/// with their previous tenant's bytes intact, so a kernel that writes only
+/// part of its output silently reads stale data — and only once the pool
+/// has been churned, which is why such a defect is invisible on the first
+/// runs of a process and appears later. Setting this makes recycled
+/// buffers indistinguishable from fresh ones, so a non-determinism that
+/// disappears under it is a read-before-write, and one that survives is
+/// not. Costs a memset per allocation; never set it while timing.
+pub const ENV_ZERO_POOLED_BUFFERS: &str = "LARQL_ZERO_POOLED_BUFFERS";
 
 thread_local! {
     /// Per-thread override for env-var reads ([`env_override`]). Tests inject

--- a/crates/larql-compute/src/pipeline_layer/mod.rs
+++ b/crates/larql-compute/src/pipeline_layer/mod.rs
@@ -57,6 +57,13 @@ pub fn kv_capacity_for_window(sliding_window: usize, default_capacity: usize) ->
 /// Per-layer KV capacities for a model, parallel to
 /// [`kv_cache_shapes_for_arch`].
 ///
+/// **Presumes compaction.** A window-derived capacity is only sound on a
+/// path that compacts the cache back below `window x slack`; the GPU
+/// decode path does not (it appends at `current_len` and attends absolute
+/// rows), and sizing its sliding layers with this function ran them off
+/// the end of their buffers (#229). That path now allocates every layer at
+/// the full default; use this only where `compact_kv_to_window` runs.
+///
 /// Deliberately a separate slice rather than a third tuple element:
 /// `num_kv_heads` and `head_dim` describe the *representation* of a row,
 /// while capacity is *residency policy*. Widening the shape tuple would

--- a/crates/larql-inference/src/layer_graph/generate/gpu/decode_loop.rs
+++ b/crates/larql-inference/src/layer_graph/generate/gpu/decode_loop.rs
@@ -235,8 +235,15 @@ where
             generated_ids,
             on_token,
         ) else {
+            // Empty candidates: either the head found nothing, or the fused
+            // step ran and a command buffer inside it failed (a GPU fault —
+            // the backend reports that as an empty top-K so the token is
+            // not re-run on top of its already-appended KV). Terminal
+            // either way; a poisoned step must never reach the sampler.
             if profile {
-                eprintln!("[profile] step={step} — lm_head returned empty; break");
+                eprintln!(
+                    "[profile] step={step} — no candidates (empty head, or GPU step failed); break"
+                );
             }
             break;
         };

--- a/crates/larql-inference/src/layer_graph/generate/gpu/prefill.rs
+++ b/crates/larql-inference/src/layer_graph/generate/gpu/prefill.rs
@@ -49,9 +49,15 @@ pub(super) fn prefill_for_streaming(
         for pos in 0..seq_len {
             let x_pos: Vec<f32> = x[pos * hidden..(pos + 1) * hidden].to_vec();
             upload(token_ids[pos], &x_pos);
+            // A step that produced no hidden state is a failed GPU step
+            // (#229: a faulted or ignored command buffer). Substituting
+            // zeros here would let the pass continue on poisoned KV and
+            // surface later as EOS at token 1 or an out-of-range token id.
             last_h = backend
                 .decode_token(layers, &x_pos, hidden, intermediate)
-                .unwrap_or_else(|| vec![0.0f32; hidden]);
+                .ok_or_else(|| {
+                    GenerateError::prefill_failed("GPU decode step failed during prompt pass")
+                })?;
         }
         let mut out = vec![0.0f32; seq_len * hidden];
         out[(seq_len - 1) * hidden..].copy_from_slice(&last_h);
@@ -102,9 +108,16 @@ fn prefill_kquant_moe(
         let x_pos: Vec<f32> = x[pos * hidden..(pos + 1) * hidden].to_vec();
         let get_expert =
             |layer_idx, expert_idx| weights.get_layer_entry_bytes(layer_idx, expert_idx);
+        // See the PLE branch above: `None` is a failed GPU step, not an
+        // empty one, and the prompt pass must stop rather than continue
+        // on poisoned KV.
         last_h = backend
             .decode_token_q4k_moe(layers, &x_pos, hidden, intermediate, norm_eps, &get_expert)
-            .unwrap_or_else(|| vec![0.0f32; hidden]);
+            .ok_or_else(|| {
+                GenerateError::prefill_failed(format!(
+                    "GPU decode step failed during prompt pass at position {pos}"
+                ))
+            })?;
     }
     let mut out = vec![0.0f32; seq_len * hidden];
     out[(seq_len - 1) * hidden..].copy_from_slice(&last_h);

--- a/crates/larql-inference/src/layer_graph/generate/gpu_setup.rs
+++ b/crates/larql-inference/src/layer_graph/generate/gpu_setup.rs
@@ -164,13 +164,15 @@ pub(super) fn ensure_prompt_fits(seq_len: usize) -> Result<(), GenerateError> {
 pub(super) fn reset_and_preallocate_kv_cache(weights: &ModelWeights, backend: &dyn ComputeBackend) {
     backend.reset_kv_cache();
     let kv_shapes = kv_cache_shapes_for_arch(weights);
-    // Sliding layers are sized for what they can reach plus compaction
-    // slack, not for the global default — on Gemma 3 4B that is 29 of 34
-    // layers at 2048 rows instead of 4096. Global layers are unchanged.
-    let kv_capacities = larql_compute::pipeline_layer::kv_capacities_for_arch(
-        weights,
-        DEFAULT_GPU_KV_CACHE_MAX_SEQ,
-    );
+    // Every layer at the full default, sliding or not. The window-derived
+    // capacity (`kv_capacities_for_arch`) presumes compaction, and the GPU
+    // decode path never compacts — it appends at `current_len` and attends
+    // absolute rows — so a sliding layer sized to its window ran off the
+    // end of its buffer past position `window x slack` (#229). The Metal
+    // backend applies the same rule in `ensure_kv_cache_for_layers`; stating
+    // it here too keeps the preallocation from being grown on the first
+    // step.
+    let kv_capacities = vec![DEFAULT_GPU_KV_CACHE_MAX_SEQ; kv_shapes.len()];
     backend.preallocate_kv_cache_per_layer_with_capacity(&kv_shapes, &kv_capacities);
 }
 


### PR DESCRIPTION
Closes #229.

Root cause. `decode/kv_setup.rs::kv_capacities_for_layers` sized sliding
layers at `kv_capacity_for_window(window, max_seq)` = window x 2 (256
rows on gpt-oss), a residency policy that presumes compaction — and the
routed decode path never compacts (`compact_kv_to_window` is called only
by the KV-engine `coarse_*` steps). The path appends at `current_len` and
attends absolute rows `[T - window, T)`, so from position 256 every
sliding layer wrote and read past its K/V buffers by a margin growing
with position (~3.5 MB per buffer at a ~2K prompt). The overrun is
self-consistent until another allocation shares the memory; then the
residual goes NaN mid-stack, the router softmax degenerates, top-k emits
`~0u` ids, `moe_descriptor_gather` reads `descs[0xFFFFFFFF]`, and the GPU
page-faults. A failed command buffer returns from `wait_until_completed`
like a finished one, and later buffers on the queue are ignored — so the
symptoms were EOS at token 1, token ids past the vocabulary, "decode" at
0.5 ms/token over a full step budget, wrong-but-plausible trajectories,
and hangs. All faces of #229; none of them the attention kernel, the
fused head, buffer pooling, `--repeat`, power state, or #262.

Fix. The decode path allocates every layer at the full requested
`max_seq` (`kv_capacities_for_layers`, `reset_and_preallocate_kv_cache`);
`kv_capacities_for_arch` stays for paths that compact and now says so.
Pinned by `decode_path_sizes_sliding_layers_for_the_full_max_seq_because_it_never_compacts`
(fails on the old sizing) and `encode_kv_append_refuses_a_full_cache`
(the append now refuses `current_len >= max_seq` instead of writing).

Containment, kept regardless of the root cause:
- `cb_status::wait_checked` replaces all 101 naked `wait_until_completed`
  calls; a non-Completed status is counted and printed with Metal's
  NSError; a test forbids naked waits outside `cb_status.rs`.
- `moe_dispatch/entry.rs` returns `None` for a step in which any command
  buffer failed; the fused-head path reports that as terminal instead of
  re-running the token on top of its appended KV.
- The prompt pass propagates a failed step as `GenerateError` instead of
  substituting zeros; `larql bench` prints generate errors.
- `moe_descriptor_gather` bounds `selected_ids` by `num_experts`, clamps
  and counts refusals (`route_guard`); the entry seam refuses the step.

Acceptance: 16 fresh C-prompt processes on the fixed binary — 16/16 full
completion, 0 command-buffer errors, 0 guard events, 0 hangs, 0 panics;
4 fresh `larql run --metal` processes byte-identical. Metal crate: 47 test
binaries green (785 tests); larql-compute 1056/1056; larql-inference
1499/1499. New files at 92.7% / 100% line coverage.
