### PR TITLE
perf(metal): default KV seqpar on for head_dim 64 — the A/B/C ladder licenses it

### DIFF
--- a/crates/larql-compute-metal/src/ops/kv_seqpar.rs
+++ b/crates/larql-compute-metal/src/ops/kv_seqpar.rs
@@ -68,13 +68,9 @@ pub enum SeqparRequest {
 /// sweep at that head_dim on an idle GPU showing the same tier ordering.
 /// Until then a new geometry can still opt in explicitly with `auto`.
 ///
-/// **Currently empty: nothing defaults on.** head_dim 64 (gpt-oss-20b) is
-/// the only geometry the KV-B1 sweep covered and its short-context result
-/// is clean, but the pre-registered long-prompt and deep-context blocks in
-/// `docs/kv-attention-scaling.md` have not been run on an exclusively
-/// owned GPU. Adding 64 here is the flip those blocks license — one
-/// constant plus the two expectation tests that pin the pending state.
-const SEQPAR_DEFAULT_ON_HEAD_DIMS: &[usize] = &[];
+/// 64 is gpt-oss-20b, the only geometry the KV-B1 sweep covered, enabled
+/// on the A/B/C gate in `docs/kv-attention-scaling.md`.
+const SEQPAR_DEFAULT_ON_HEAD_DIMS: &[usize] = &[64];
 
 /// Whether an unset `LARQL_KV_SEQPAR` means `auto` for this geometry.
 ///

--- a/crates/larql-compute-metal/src/ops/kv_seqpar/tests.rs
+++ b/crates/larql-compute-metal/src/ops/kv_seqpar/tests.rs
@@ -129,21 +129,20 @@ fn unset_resolves_through_the_default_list() {
 /// starts failing, either the default list grew without the A/B/C gate or
 /// the gate closed and this expectation is stale — check which.
 #[test]
-fn nothing_defaults_on_until_the_gate_closes() {
-    for hd in [32usize, 64, 128, 256, 512] {
+fn head_dim_64_defaults_on_and_nothing_else_does() {
+    // The measured geometry gets the span-tracking policy, not a fixed count.
+    assert_eq!(slices_for(SeqparRequest::Unset, HD, 256), 8);
+    assert_eq!(slices_for(SeqparRequest::Unset, HD, 2048), 16);
+
+    for hd in [32usize, 128, 256, 512] {
         for span in [64u32, 512, 2048] {
             assert_eq!(
                 slices_for(SeqparRequest::Unset, hd, span),
                 0,
-                "head_dim {hd} must not default on before docs/\
-                 kv-attention-scaling.md's A/B/C gate closes"
+                "head_dim {hd} is unmeasured and must not default on"
             );
         }
     }
-    // The capability is present and waiting — this is a policy refusal,
-    // not a missing kernel. Cf. `unset_resolves_through_the_default_list`.
-    assert_eq!(slices_for(SeqparRequest::Auto, HD, 256), 8);
-    assert_eq!(slices_for(SeqparRequest::Auto, HD, 2048), 16);
 }
 
 /// head_dim 128 is supported by the kernel and would produce a legal
@@ -221,15 +220,15 @@ fn explicit_slices_are_honoured_on_unmeasured_geometries() {
 /// by accident. This test is expected to be edited *with* the evidence
 /// that justifies the new entry — never on its own.
 #[test]
-fn the_default_list_is_empty_pending_the_gate() {
+fn the_default_list_holds_the_measured_geometry() {
     assert_eq!(
         SEQPAR_DEFAULT_ON_HEAD_DIMS,
-        &[] as &[usize],
+        &[64],
         "adding a head_dim requires the A/B/C gate in \
          docs/kv-attention-scaling.md (for 64) or a bench_attention_span \
          sweep on an idle GPU (for any other); see the const's doc comment"
     );
-    assert!(!default_is_auto(HD));
+    assert!(default_is_auto(HD));
     for hd in [32usize, 128, 256, 512] {
         assert!(!default_is_auto(hd), "head_dim {hd} is unmeasured");
     }

--- a/docs/kv-attention-scaling.md
+++ b/docs/kv-attention-scaling.md
@@ -1066,6 +1066,27 @@ statement about the *slope*, which is the metric this ladder was set up to
 move. It needs block A re-run under the full preconditions to be said at
 all, and block C to be said about depth.
 
-**Not yet licensed:** `SEQPAR_DEFAULT_ON_HEAD_DIMS = &[64]`. The decision
-table wants short + medium + deep; one valid block in the middle is not
-that. Block C additionally cannot run until #229 is fixed.
+**Licensed — 2026-08-16, after #229 (#263).** The full ladder, one binary,
+one session, `off / default / off` with 300 s rests, every arm at its full
+255-step budget, both `off` arms of each block carrying one fingerprint:
+
+```text
+block  prompt          serial (off)    seqpar (default)   Δ throughput   brackets
+A      ~36 + 256 tok      12.04 ms         10.80 ms          +11.5%        0.08%
+B      ~574 + 256         13.71 ms         11.01 ms          +24.5%        0.51%
+C      ~2024 + 256        18.11 ms         11.88 ms          +52.4%        0.55%
+```
+
+Serial degrades 12.0 → 13.7 → 18.1 ms/token with context; seqpar holds
+10.8 → 11.0 → 11.9. That is the slope claim, and it is what the decision
+table wanted: short, medium and deep all VALID, the candidate ahead in
+every block, brackets agreeing. `SEQPAR_DEFAULT_ON_HEAD_DIMS = &[64]` is
+therefore the shipping default for gpt-oss's geometry, and the two
+expectation tests in `kv_seqpar/tests.rs` pin that state instead of the
+pending one.
+
+Recorded deviation: the session ran on the 65 W adapter with a full battery
+(user's call), so precondition 1 was not met as written; the brackets
+(≤0.55%) are the evidence that power did not move under the blocks. Block C
+was runnable at all only because #229's KV overrun is fixed — its `off`
+arms complete 255/255 where the same prompt used to stop at token 1.


### PR DESCRIPTION
The flip is one policy constant and its two expectation tests, exactly as
the candidate-tree recipe in docs/kv-attention-scaling.md prescribes; the
evidence is the bracketed ladder run on one binary in one session after
#229 (#263) unblocked the deep block:

    block  prompt          serial (off)   seqpar (default)   Δ throughput   brackets
    A      ~36 + 256 tok      12.04 ms        10.80 ms          +11.5%        0.08%
    B      ~574 + 256         13.71 ms        11.01 ms          +24.5%        0.51%
    C      ~2024 + 256        18.11 ms        11.88 ms          +52.4%        0.55%

Serial degrades 12.0 -> 13.7 -> 18.1 ms/token with context; seqpar holds
10.8 -> 11.0 -> 11.9. Every arm ran its full 255-step budget, both `off`
arms of each block carry one fingerprint, and all three brackets agree
inside 1%. Recorded deviation: 65 W adapter with a full battery; the
brackets are the evidence power did not move under the blocks.

`SEQPAR_DEFAULT_ON_HEAD_DIMS = &[64]`; other geometries stay off until
measured. `unset_resolves_through_the_default_list` and
`explicit_off_stays_off_on_every_geometry` are unchanged.