### PR TITLE
feat(vindex3): A-9 — gpt-oss-20b through the generic graph → plan → CPU/Metal, interpreter ≡ Metal at rel_rms ≤ 1e-6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -120,7 +120,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -649,7 +649,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1139,7 +1139,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1558,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1827,7 +1827,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2078,7 +2078,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2947,7 +2947,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3599,7 +3599,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3637,7 +3637,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4032,7 +4032,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4405,7 +4405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4550,7 +4550,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5777,7 +5777,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -337,7 +337,7 @@ container ladder
 [x] c5  structural verify with {layer, entry, role} defects; CLI dual-generation
 [ ] c6  fixtures B–D (GPT-OSS, Inkling, Mini-K3) — proves nothing is hard-coded
 [ ] c7  WALK/DESCRIBE parity over in-place bank regions
-[ ] c8  a real Gemma MoE layer written as a VINDEX3 container
+[x] c8  a real Gemma MoE layer written as a VINDEX3 container (CLOSED 2026-08-04, below)
 [ ] c9  every Gemma layer — the first real model that *is* a VINDEX3 container
 ```
 
@@ -1735,7 +1735,18 @@ is dense on that path, and the two container shapes, `system_graph.json` vs
 `index.moe_manifest = None`):
 
 ```text
-A-9.0  plan admissibility as REPRESENTATION, not suppression:
+A-9.0  DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): `larql vindex3 plan` on the HF
+       checkpoint is admissible — 50 representable / 0 mismatched / 4 unrepresented (all
+       alias or training_only) / 0 blocking; PositionPolicy::Yarn{theta 150000, factor 32,
+       β 32/1, orig 4096} carried, amplitude derived by ONE authority
+       (YarnRopeScaling::attention_amplitude); ffn.gate_policy = ClampedGlu{7, 1.702};
+       decoder_stack encodings BF16+MXFP4. Executors and the lowering REFUSE Yarn and
+       ClampedGlu (typed, before any bytes) rather than serve the wrong model. Two finds
+       the gate forced: the parser read theta from transformers-5 `rope_parameters` but
+       SCALING only from legacy `rope_scaling` (a 5.x YaRN block was dropped at parse —
+       §4.7.8 again; fixed, pinned); and the YaRN leaves had carriage rules but were not
+       classified execution-semantic, so the rules were never reached. As mapped:
+       plan admissibility as REPRESENTATION, not suppression:
        PositionPolicy gains a YaRN variant carrying {theta, factor, beta_fast, beta_slow,
        truncate, original_max_position_embeddings, amplitude} — amplitude is the part that
        moves every logit and lowering/mod.rs:397 fakes 1.0 today; probe_rope_type reads it
@@ -1768,6 +1779,175 @@ geometry-dependent.** VINDEX3 carries semantic geometry; the Metal planner
 owns the execution choice; the KV engines belong under the same planner.
 Individual techniques (kernel selection, seqpar) are not novel; the claim is
 integration from semantics down to execution.
+
+### VINDEX3 stabilisation — freeze gauntlet, positioning, standard-grade backlog (2026-08-17)
+
+**Judgement: the architecture is converged; the ABI has one adversarial pass
+left, and that pass is A-9.** Distinguish *architectural stability* from
+*freezing schema 3*. The question is no longer "is the VINDEX3 abstraction
+right?" but "have we discovered every semantic noun and relationship the
+frozen ABI must carry?" — and gpt-oss is the last high-value attack on it,
+because every A-9 blocker is a **schema-vocabulary** fact (YaRN incl.
+amplitude, clamped-GLU policy, representation-level quantisation policy,
+sinks, Q/K/V/O biases, expert-bank objects, router/expert/bias roles, MoE
+FFN op, over-selected normalisation), not a kernel. Freeze before A-9.0–A-9.3
+close and schema 3.0 immediately fails to describe a production architecture.
+
+| Layer | Assessment |
+|---|---|
+| Core VINDEX3 idea (state the working set before execution) | ~95 % settled — 200 predicted / 200 resident / 0 overshoot |
+| Object / region / addressability model | ~90 % settled |
+| Plan / execution architecture (reference → production → lowered) | ~90 % settled |
+| Dense / Glimmer execution model | proven (real-model parity, GPU-resident multi-layer, KV through the plan) |
+| Routed-bank serving | proven in production machinery (native MXFP4, GPU routing, one CB/token) |
+| Generic MoE graph semantics | **still moving** (A-9.2/A-9.3) |
+| Representation / profile machinery | conceptually settled, plumbing incomplete (selection does not yet steer bytes) |
+| V3 extraction / default lifecycle | not ready to freeze |
+| On-disk ABI / schema 3 | one serious architecture pass from freeze |
+
+The pattern that says the centre is stable: *new architecture → missing
+semantic fact exposed → added to graph/plan → the existing lowerer can reason
+about it.* The 2026-08-16 representation algebra is the milestone —
+attention policy stopped being a model-name decision and became
+`(head_dim, q_heads, kv_heads, span) → execution geometry`, unmeasured cases
+falling back rather than guessing. VINDEX3 knows *what the operation means,
+what representations exist, what semantic geometry exists*; the backend
+planner knows *how this hardware executes it*. **Protect that boundary.** The
+Metal work strengthened it rather than distorting it: VINDEX3 segments are
+mmap'd and registered straight into Metal buffers, expert selection stays
+GPU-side, host resolution/binding witnesses stay zero, output byte-identical
+— the bytes remain authoritative, so **bind, never reconstruct** graduates
+from standing method to a design principle of the format.
+
+**One smell to resolve before freeze:** `system_graph.json` and
+`moe_manifest.json` are mutually exclusive container shapes. The frozen
+answer must be *MoE is another operation/object arrangement inside a VINDEX3
+system*, not a different container type — `moe_manifest.json` may survive as
+a physical/indexing artefact, but MoE must not live outside the graph
+universe. A-9.2 is that closure.
+
+```text
+VINDEX3
+   ├── objects          tensor · expert_bank · embedding · norm · …
+   ├── representations  F16 · Q4_K · MXFP4+E8M0 · NVFP4 · …
+   ├── operations       attention · dense_ffn · routed_ffn · norm · vocab_projection · …
+   └── plans / profiles
+```
+
+**Freeze gauntlet — seven gates, all required before "schema 3.0 is frozen":**
+
+```text
+F1  ontology closure      A-9.0/1/2/3 close without a NEW CATEGORY of semantic fact
+F2  cross-family witness  Glimmer (dense, local/global) · gpt-oss (pure routed MoE +
+                          biases/sinks/YaRN) · Gemma 4 (hybrid MoE); recurrent/KDA later,
+                          non-blocking if unsupported ops fail loudly
+F3  representation witness ONE container genuinely carries ≥2 representations of the same
+                          semantic role; profile choice changes the BOUND bytes; a tamper
+                          control proves it cannot silently hit the other
+F4  independent execution reference → production → lowered parity (the discipline in hand)
+F5  database parity       WALK/DESCRIBE run against V3 authority, not a V2 shadow — the
+                          exact expert-bank bytes execution binds ARE the addressable
+                          objects; no second KNN index unless declared a derived repr
+F6  E0                    VINDEX2 untouched: full golden matrix + legacy CLI dispatch
+F7  mutation test         corrupt every load-bearing relationship (wrong role, dims,
+                          representation, missing partner scale, impossible profile,
+                          illegal programme, wrong bank ownership, overlapping ranges,
+                          unsupported policy) → typed refusal, every one
+```
+
+After F1–F7: *"VINDEX3 schema 3.0 is frozen. Additive extensions preserve the
+3.x compatibility rules; semantic breaking changes require VINDEX4."*
+Extraction default is a **later, separate** ladder — semantic freeze → schema
+freeze → conformance fixtures → `--format vindex3` opt-in → soak → default →
+VINDEX2 readable indefinitely. Not on the same day.
+
+Housekeeping the freeze implies: this file has stopped being the right
+authority for schema status (c8 was `[ ]` in the ladder above and CLOSED in
+the prose below it). At freeze the status moves to one canonical
+requirement × status × test × fixture × since matrix in the spec, and the
+roadmap points at it.
+
+**Where VINDEX3 sits.** Safetensors stores tensors; GGUF packages an
+inference model; ONNX describes a computation; ExecuTorch/MLC/TensorRT
+describe or compile an execution. VINDEX3 describes the model, its physical
+representations, and how those may be *selectively bound* into execution
+while the model stays addressable as data. Ticks below are *what the format
+represents*, not maturity — GGUF's ecosystem, stability, tooling and
+architecture coverage, ONNX's independent normative standard, and
+TensorRT/TVM's compiler depth all beat VINDEX3 today, and none of those is the
+battle.
+
+| Format | Semantic graph | Quantised layout | mmap/segmented | Exec planning | Multi-repr / placement | Queryable model data | HW-neutral |
+|---|---|---|---|---|---|---|---|
+| Safetensors | ✗ | limited | ✓ | ✗ | ✗ | tensor-level | ✓ |
+| GGUF | metadata/naming | ✓✓ | ✓✓ | ✗ | limited | tensor-level | mostly |
+| ONNX | ✓✓ | some | external data | ✗ | limited | graph-level | ✓✓ |
+| OpenVINO IR / Core ML | ✓ | some/✓ | separate/package | runtime/✓ | some | limited | mostly / Apple |
+| ExecuTorch PTE | ✓ | ✓ | ✓ segmented | ✓✓ | delegates/mem plan | limited | ✓-ish |
+| MLC/TVM | ✓ | ✓✓ | ✓ | ✓✓✓ | target compile | ✗ | source-portable |
+| TensorRT engine | compiled | ✓✓✓ | internal | ✓✓✓ | HW-selected | ✗ | ✗ |
+| **VINDEX3** | ✓ | ✓✓ | ✓✓✓ | ✓✓ | **✓✓✓** | **✓✓✓** | designed to be |
+
+Safetensors is a *source* format for VINDEX3, not a competitor. GGUF's unit
+of authority is the tensor at an offset; VINDEX3's is the semantic object
+with representations and regions — the moat is that *operation → working set*
+is part of the format contract, not a clever runtime's external policy.
+ONNX is the closest to the semantic graph but deliberately declines to
+prescribe physical representation; VINDEX3 keeps meaning + representations +
+locations + bindability together, and encodes a higher-level neural algebra
+(attention, routed_ffn, norm, …) rather than an SSA op graph, so one semantic
+op can lower differently by length, residency, representation, hardware,
+selected experts, prefill vs decode. ExecuTorch is the closest cousin
+(graph + data + lowering + memory plan) but its output is a *prepared
+program*; VINDEX3 is a *datastore from which an execution is constructed at
+serve time*. TensorRT is the far extreme VINDEX3 must not become — an opaque
+compiled artefact cannot answer "where are expert 37's up-projection bytes"
+or "which pages will this op touch". Combined: GGUF's physical storage +
+ONNX's versioned semantic contracts + OCI's content-addressed packaging +
+Arrow/Parquet's random-access engineering + a database's addressability +
+LARQL's representation-aware planning, under **one authority model whose
+bottom does not sever from its top**. "Format" undersells it — it is a
+neural-database storage-engine format.
+
+**Standard-grade backlog** — optimise against the format we would design from
+scratch if models were large, queryable, heterogeneous databases, not against
+GGUF:
+
+| Pri | Improvement | Why |
+|---|---|---|
+| P0 | **Separate container / semantic-IR / opset / representation-set versioning** (ONNX's model: `container 3`, `semantic_ir 1`, `org.larql.core:1`, `org.larql.moe:2`, `org.larql.attn:3`, `org.larql.quant:4`) | KDA arrives as `org.larql.kda:1`, not VINDEX4; a reader says "cannot execute ops 46–91" instead of branching on architecture name |
+| P0 | **Content-address every physical segment** (OCI descriptor: media type + digest + size + locations; manifests as Merkle DAGs) | dedup across fine-tunes, one-segment publishes, local/remote indistinguishable, per-region verification, model identity = hash of the semantic manifest |
+| P0 | **Finish genuine multi-representation objects** — representation as an independently describable entity (encoding, layout, scale encoding, block geometry, alignment, companion streams, accuracy contract, source repr, transformation, HW compat); profiles select a *physical representation* | the signature VINDEX3 capability; F3 above |
+| P0 | **Formal unknown-field semantics** — every extension is `annotation` (ignore) · `execution_metadata` · `semantic_required` (refuse) · `representation_required` (fine if another admissible repr exists) · `interface_required` | criticality work already invented the answer; put it in the spec, avoid GGUF's accumulate-conventions-forever fate |
+| P0 | **Conformance suite + tiny independent reader** (`vindex-spec/`: spec, schema, test-vectors, reference-{c,rust,python}; open/validate/list objects+ops/resolve reprs/map segments/verify hashes, no LARQL dependency) | if only `larql-vindex` can read it, it is a good LARQL format; if a compatible reader is a weekend, it can be a standard |
+| P1 | Transformation/provenance DAG per representation (tool, version, args, input/output digest, calibration corpus digest) | reproducible builds; "where did these 64 bytes come from" has an answer |
+| P1 | First-class overlays/deltas/adapters (`parent: sha256:… ; replace object 391 MXFP4 → sha256:… ; add adapter`) | LoRA, patches, expert replacement, LARQL INSERTs, spec heads as composable artefacts — no 30 GB duplicate, no base mutation |
+| P1 | Remote/range-addressable segments — objects refer to segment *identity*, a resolver yields RAM/mmap/NVMe/HTTP-range/S3/peer/GPU | model-as-database at its logical conclusion |
+| P1 | Compact binary navigation index alongside (or canonical under) `index.json` (`index.vxb`; Arrow footer / Parquet metadata model) | opening K3 must not mean parsing 300 MB of JSON |
+| P1 | Compatibility/capability query — `vindex compat model --runtime metal-m3-max` → per-opset ✓/✗, executable layers, no model data touched | complete-or-refuse, before touching weights |
+| P2 | Per-region measured quality contracts (reference, max_abs, rel_rms, cosine, shannon_delta, fixture digest) | representation choice becomes a correctness decision — the Shannon work meets the representation algebra |
+| P2 | Optional signatures / encryption / access policy | distributed commercial models |
+| P2 | Standard packaging profile (HF, OCI registries, S3, local disk) | natural homes |
+
+Never embed executable code (no Python/dylib/CUDA/wasm-with-host-access to
+*load* a model): operators are declarative contracts, unknown ones fail
+closed, backend code belongs to runtimes — downloading a VINDEX stays closer
+to downloading data than a program.
+
+If only three land before 1.0: **independent IR/opset/representation
+versioning, content-addressed immutable segments, conformance suite + tiny
+reader.** Target end state:
+
+```text
+vindex describe model      → operators, representations by count, local/remote/hot-set bytes,
+                             per-runtime FULL/PARTIAL, derivation digests
+vindex plan model --hardware this-machine --memory 12GB
+                           → a valid physical plan WITHOUT loading the weights
+```
+
+Then K3/Kimi stop being about discovering VINDEX3 and become the stronger
+test: *can the frozen algebra express exotic architectures without changing
+its ontology?*
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1809,7 +1809,20 @@ A-9.2  DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): ObjectKind::ExpertBa
        output moves), absence (dense FFN plan byte-identical), container universality (no
        executor reaches outside the generic graph to find a bank), real gpt-oss closure
        264 → ~0 (only genuinely later-rung semantics may survive).
-A-9.3  MoE execution in the interpreter (exec/mod.rs, reference.rs, production.rs) with
+A-9.3  DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): the interpreter executes YaRN —
+       kernels::rope_rotate_scaled + kernels::yarn_frequencies (reference transcription) and
+       the served rope_freq_plan(Yarn) on production/device; MoE execution landed with A-9.2.
+       Gates: fixture with GPT-OSS's YaRN block, served ≡ reference ≡ production ≡ device at
+       2e-5; persisted `factor` 32→4 moves position 0 (amplitude) and layer 0. REAL gpt-oss:
+       `vindex3 exec` runs end-to-end (24 layers, 65-id prompt: 20.8 s single forward, 148
+       ms/token prefill, 7.5 tok/s CPU decode); argmax = oracle's first id; `--generate 16`
+       matches a 3-id prefix then diverges at step 4 and re-syncs; TEACHER-FORCED over the
+       oracle's 81 ids: 14/16 per-position argmax agreement, both misses at the two lowest
+       margins (+0.47, +0.12 logits; oracle id ranked #2). CONGRUENCE: the banked oracle is a
+       Q4_K-SPINE served run; the container is BF16 attention + native MXFP4 — so this is
+       "same semantics, different representation", NOT the A-9.5 byte-identical claim, which
+       needs a same-representation oracle (served path over the same BF16 spine bytes).
+       As mapped: MoE execution in the interpreter (exec/mod.rs, reference.rs, production.rs) with
        gpt-oss routing (top-k then softmax over the selected — MoeRouterKind::TopKThenSoftmax,
        ExpertRoutingPolicy::NormalisedOverSelected) and ClampedGlu (pipeline/moe.rs:43).
 A-9.4  MoE + sinks + biases + YaRN amplitude in the Metal lowering — moe_zero_copy.rs is the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1829,6 +1829,15 @@ A-9.4  MoE + sinks + biases + YaRN amplitude in the Metal lowering — moe_zero_
        served path's machinery and is not plan-reachable; make it so.
 A-9.5  the parity chain: ops closure → exec reference → production → lowered, byte-identical
        to the banked oracle; then the bracketed ladder.
+       INTERPRETER HALF CLOSED 2026-08-17: `shannon layer-dump --tokens` (new; given ids) over
+       the HF checkpoint = the served CPU forward on the exact BF16+MXFP4 bytes, vs `vindex3
+       exec --dump-layers` on the container, same 81 oracle ids → `layer-diff`: cos
+       1.000000000, rel_rms 1e-6 (layers 0–16) to 3e-6 (17–23), max_abs ≤ 0.08, "no capture
+       drifts". SAME weights, SAME semantics, two engines, f32-reassociation agreement through
+       all 24 layers. Corollary: the 14/16 vs the Q4_K-spine oracle is the spine's
+       representation (final residual within 3e-6 rel-RMS ⇒ logits within ~1e-3 ≪ the 0.12/
+       0.47 miss margins). Remaining: the lowered arm (A-9.4) against the same dumps, and a
+       BF16-spine served id oracle if a byte-identical id claim is wanted.
 ```
 
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1825,8 +1825,22 @@ A-9.3  DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): the interpreter exec
        As mapped: MoE execution in the interpreter (exec/mod.rs, reference.rs, production.rs) with
        gpt-oss routing (top-k then softmax over the selected — MoeRouterKind::TopKThenSoftmax,
        ExpertRoutingPolicy::NormalisedOverSelected) and ClampedGlu (pipeline/moe.rs:43).
-A-9.4  MoE + sinks + biases + YaRN amplitude in the Metal lowering — moe_zero_copy.rs is the
-       served path's machinery and is not plan-reachable; make it so.
+A-9.4  ATTENTION HALF DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): sinks, Q/K/V/O
+       biases and YaRN (scaled inv_freq + amplitude) lowered in lowering/attention.rs +
+       mod.rs, reusing the existing bias_add / sinks-slot(10,11) / rope-amplitude(slot 6)
+       kernels; lowered.rs feeds them from the plan and lifts the three refusals (LoweredMatrix
+       gains Scaled{theta, amplitude}; per-(theta,yarn) inv_freq table; resident bias/sink
+       vectors). Gate: tests/test_lowering_attention_extras.rs — lowered ≡ reference (biases +
+       YaRN + sink) < 1e-4, with four controls (drop sink / drop Q bias / amplitude→1 / ramp→
+       plain rope) each moving output ≥20× the parity residual; all 421+ Metal lowering tests
+       green. REMAINING (routed FFN): the lowered stack still refuses a routed layer, so
+       gpt-oss does not yet lower e2e. moe_zero_copy.rs / moe_gpu_route encode the served MoE
+       into one CB but resolve experts through registered mmap REGIONS (BufferCache::
+       register_region → resolve_region); the lowering loads operands as owned bytes, so the
+       routed rung must register the container's expert-bank segment as a region and thread a
+       MoeLayerWeights-shaped call (router in stack, experts in bank) through encode_stack —
+       then layer-diff the lowered dump against the served/interpreter dumps from A-9.5.
+       As mapped: moe_zero_copy.rs is the served path's machinery and is not plan-reachable.
 A-9.5  the parity chain: ops closure → exec reference → production → lowered, byte-identical
        to the banked oracle; then the bracketed ladder.
        INTERPRETER HALF CLOSED 2026-08-17: `shannon layer-dump --tokens` (new; given ids) over

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1756,14 +1756,40 @@ A-9.0  DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): `larql vindex3 plan`
        at plan/tests/carriage.rs:86 already says "MOE1 is where it gets one").
        quantization_config.{quant_method, modules_to_not_convert} classified (semantics.rs
        registries / config_keys.rs:116) as the representation fact they are.
-A-9.1  attention sinks + q/k/v/o biases in AttentionSurface / AttentionCall and every
-       backend — the reference interpreter has neither (reference.rs:165 softmax without the
-       sink, :92 projection without bias); the lowering binds has_sinks=0 with a placeholder
-       (lowering/attention.rs:344) although the kernels support sinks.
+A-9.1  DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): judged AttentionSinkSpec::
+       SoftmaxDenominator (models crate, derived from attn_sinks_key so the schema fact and
+       the served kernel cannot disagree) + `attention_bias` on AttentionSurface; roles
+       Attn{Q,K,V,O}Bias/AttnSinks; closure paired both ways (declared ⇒ all four operands,
+       operand ⇒ declaration; sink operand ⇒ judgment, judgment ⇒ operand; shapes pinned);
+       AttentionOp.{q,k,v,o}_bias/sinks → BiasCall/SinkCall → reference (append-and-drop
+       softmax), production + device (served `softmax_in_place(scores, sink)`), lowering
+       REFUSES until A-9.4. Gates: golden parity (denominator form, third transcription),
+       3-backend parity, 5 causal controls (each operand moves layer-0 attention 1e-2…6e-1,
+       propagates to logits), absence (bias-free plan serialises byte-identically; four
+       fail-closed refusals). gpt-oss `vindex3 ops`: 384 → 264 defects, ZERO attention
+       defects, every survivor MoE (A-9.2). As mapped: attention sinks + q/k/v/o biases in
+       AttentionSurface / AttentionCall and every backend — the reference interpreter had
+       neither (reference.rs:165 softmax without the sink, :92 projection without bias); the
+       lowering still binds has_sinks=0 with a placeholder (lowering/attention.rs:344).
 A-9.2  MoE in the generic system graph: an expert-bank ObjectKind (graph/object.rs:11),
        router/expert/bias OperandRoles (graph/roles.rs:22,58), an MoE FfnOp; encode writes
        banks into the system container (or exec composes system + routed containers the way
        `run --routed-from` composes VINDEX2 + banks).
+       SUCCESS CRITERION (2026-08-17, stronger than "zero MoE defects"): an MoE is
+       expressible ENTIRELY inside the object/operand/op-plan universe dense attention and
+       FFN use — no second container semantics, no side-loaded expert manifest execution
+       must reinterpret; `moe_manifest.json` disappears or shrinks to physical layout.
+       Shape: DecoderLayer → FfnOp::Moe { RouterWeight, RouterBias, ExpertBank(ObjectKind)
+       { gate/up repr, down repr, biases, quant auxiliaries } }. The judged MoE vocabulary
+       already exists in format/moe_manifest (Router{activation, selection, post}, Reduction,
+       Combine, Programme, BankRef{experts, expert_dims}) — A-9.2 lifts it into the graph,
+       it does not re-judge it. Gates mirror A-9.1: bidirectional closure (declared MoE ⇒
+       every operand; stray MoE operand ⇒ the op), shape/count closure (router [E,H], E,
+       top-k, packed geometry gate_up [E,2I,K/32,16]+[E,2I,K/32] scales, down [E,H,I/32,16]),
+       causal controls (perturb router weight, one expert gate/up, one down, one bias →
+       output moves), absence (dense FFN plan byte-identical), container universality (no
+       executor reaches outside the generic graph to find a bank), real gpt-oss closure
+       264 → ~0 (only genuinely later-rung semantics may survive).
 A-9.3  MoE execution in the interpreter (exec/mod.rs, reference.rs, production.rs) with
        gpt-oss routing (top-k then softmax over the selected — MoeRouterKind::TopKThenSoftmax,
        ExpertRoutingPolicy::NormalisedOverSelected) and ClampedGlu (pipeline/moe.rs:43).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1726,7 +1726,8 @@ query was verified as `{64,64,8,1025} → 16 slices` and pinned by test instead.
 | A-6 | **(layer, role) → representation policy** from the Meta recipes + quality matrix. | Bytes down without the coarse FFN-only cost. | open |
 | A-7 | **Speculative decoding last**, entering at ~22–24 tok/s native. | — | open |
 | A-8 | **B2 (sequence tiles across threadgroups)** once B1's intra-TG width is spent — at head_dim 128 that is 8 slices. | Planner rung. | after A-2 |
-| A-9 | **gpt-oss through the same lowerer** — the proof it is an engine architecture, not a Glimmer implementation. Mapped 2026-08-17: `larql vindex3 plan` on the HF checkpoint is inadmissible on four facts, and that is only rung 0 of six (below). Oracle banked: `bench/prompts/gpt-oss/vindex3-oracle-2026-08-17.txt` (65 chat-wrapped prompt ids → 16 generated ids, via `larql run --emit-ids`, #268). | Same oracle discipline on gpt-oss: byte-identical greedy ids to the served path through `vindex3 exec --backend metal-lowered`. | after A-3 |
+| A-9 | **gpt-oss through the same lowerer** — the proof it is an engine architecture, not a Glimmer implementation. Mapped 2026-08-17: `larql vindex3 plan` on the HF checkpoint is inadmissible on four facts, and that is only rung 0 of six (below). Oracle banked: `bench/prompts/gpt-oss/vindex3-oracle-2026-08-17.txt` (65 chat-wrapped prompt ids → 16 generated ids, via `larql run --emit-ids`, #268). | Same oracle discipline on gpt-oss: byte-identical greedy ids to the served path through `vindex3 exec --backend metal-lowered`. | **closed 2026-08-18** (parity chain, rungs A-9.0–A-9.5 below); the bracketed ladder is A-10 |
+| A-10 | **Cost of abstraction — gpt-oss bracketed perf ladder** through the generic plan. Arms: served routed Metal path (`larql run --routed-from`) · `vindex3 exec --backend metal-lowered` f16-attention · the same with NVFP4 attention; contexts short / ~512 / ~1K / ~2K / ~4K; baseline/candidate/baseline brackets, full decode budget, route/plan witness on every row, same trajectory fingerprint, rests between arms (the KV-B1 hygiene). The question is the delta between the generic lowering and the mature served path — single-digit % says the execution architecture generalised without discarding the optimised backend; larger says there is a clean, correctness-free profiling problem. | A rested bracketed table with witnesses; a stated delta per context. | open, next |
 
 A-9's rungs, each with its file coordinates (from the 2026-08-17 map; the
 generic system-graph path is **dense-only today** — Glimmer encodes because it
@@ -1869,8 +1870,10 @@ A-9.5  the parity chain: ops closure → exec reference → production → lower
        This MEASURES the earlier generated-token flip: with all-NVFP4 attention the layer-0
        rel_rms is 0.058 (cos still 0.998, direction preserved), and swapping attention to f16
        collapses it to 0.000000 — the drift was the NVFP4 attention weight representation, not a
-       semantic defect (both paths read the SAME MXFP4 expert codes, so experts contribute no
-       divergence). CPU interpreter and Metal now execute the represented GPT-OSS semantics —
+       semantic defect. Stated at the strength the measurement licenses: any divergence
+       attributable to the common MXFP4 expert path is BELOW the ~1e-6 residual of the
+       congruent f16-attention run — the end-to-end measurement bounds it, not only the fact
+       that both paths read the same expert codes). CPU interpreter and Metal now execute the represented GPT-OSS semantics —
        YaRN, sinks, biases, routed MXFP4 MoE, ClampedGlu — numerically identically to f32 noise.
        Remaining: the bracketed performance ladder. Earlier note kept:
        INTERPRETER HALF CLOSED 2026-08-17: `shannon layer-dump --tokens` (new; given ids) over
@@ -1893,8 +1896,12 @@ integration from semantics down to execution.
 
 ### VINDEX3 stabilisation — freeze gauntlet, positioning, standard-grade backlog (2026-08-17)
 
-**Judgement: the architecture is converged; the ABI has one adversarial pass
-left, and that pass is A-9.** Distinguish *architectural stability* from
+**Judgement: the architecture is converged; the ABI had one adversarial pass
+left, and that pass was A-9 — closed 2026-08-18 (below): gpt-oss went through
+the same graph → plan → CPU interpreter / Metal lowering as Glimmer, no
+family branch, interpreter ≡ Metal at rel_rms ≤ 1e-6 across all 24 layers, and
+every A-9 rung added vocabulary to existing categories rather than a new
+category (F1 held).** Distinguish *architectural stability* from
 *freezing schema 3*. The question is no longer "is the VINDEX3 abstraction
 right?" but "have we discovered every semantic noun and relationship the
 frozen ABI must carry?" — and gpt-oss is the last high-value attack on it,
@@ -1911,7 +1918,7 @@ close and schema 3.0 immediately fails to describe a production architecture.
 | Plan / execution architecture (reference → production → lowered) | ~90 % settled |
 | Dense / Glimmer execution model | proven (real-model parity, GPU-resident multi-layer, KV through the plan) |
 | Routed-bank serving | proven in production machinery (native MXFP4, GPU routing, one CB/token) |
-| Generic MoE graph semantics | **still moving** (A-9.2/A-9.3) |
+| Generic MoE graph semantics | settled 2026-08-18 — A-9.2/A-9.3 closed; MoE is an object/operand/op arrangement inside the graph, `moe_manifest.json` absent from the gpt-oss container |
 | Representation / profile machinery | conceptually settled, plumbing incomplete (selection does not yet steer bytes) |
 | V3 extraction / default lifecycle | not ready to freeze |
 | On-disk ABI / schema 3 | one serious architecture pass from freeze |
@@ -1949,13 +1956,17 @@ VINDEX3
 
 ```text
 F1  ontology closure      A-9.0/1/2/3 close without a NEW CATEGORY of semantic fact
+                          → HELD 2026-08-18 (YaRN, ClampedGlu, sinks, biases, expert bank,
+                          MoE roles/op all landed as vocabulary in existing categories)
 F2  cross-family witness  Glimmer (dense, local/global) · gpt-oss (pure routed MoE +
                           biases/sinks/YaRN) · Gemma 4 (hybrid MoE); recurrent/KDA later,
                           non-blocking if unsupported ops fail loudly
+                          → Glimmer + gpt-oss WITNESSED 2026-08-18; Gemma 4 open
 F3  representation witness ONE container genuinely carries ≥2 representations of the same
                           semantic role; profile choice changes the BOUND bytes; a tamper
                           control proves it cannot silently hit the other
 F4  independent execution reference → production → lowered parity (the discipline in hand)
+                          → exercised on gpt-oss 2026-08-18: served HF ≡ interpreter ≡ lowered
 F5  database parity       WALK/DESCRIBE run against V3 authority, not a V2 shadow — the
                           exact expert-bank bytes execution binds ARE the addressable
                           objects; no second KNN index unless declared a derived repr

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1860,6 +1860,19 @@ A-9.4  DONE 2026-08-18 (branch feat/vindex3-gpt-oss-rung0): the real gpt-oss-20b
        As mapped: moe_zero_copy.rs is the served path's machinery and is not plan-reachable.
 A-9.5  the parity chain: ops closure → exec reference → production → lowered, byte-identical
        to the banked oracle; then the bracketed ladder.
+       CLOSED 2026-08-18: the three-way chain holds on the real gpt-oss-20b. `vindex3 exec
+       --dump-layers` now works on the Metal-lowered path (encode_stack Checkpoints capture
+       every layer per position into [seq,hidden] planes, byte-compatible with the interpreter
+       dump). Over the same 81 ids, `shannon layer-diff` metal-lowered-ffn (f16 attention/head,
+       native MXFP4 experts) vs the production interpreter: cos 1.000000000 and rel_rms ≤ 1e-6
+       through ALL 24 layers, "no capture drifts" — the same congruence as served-vs-interpreter.
+       This MEASURES the earlier generated-token flip: with all-NVFP4 attention the layer-0
+       rel_rms is 0.058 (cos still 0.998, direction preserved), and swapping attention to f16
+       collapses it to 0.000000 — the drift was the NVFP4 attention weight representation, not a
+       semantic defect (both paths read the SAME MXFP4 expert codes, so experts contribute no
+       divergence). CPU interpreter and Metal now execute the represented GPT-OSS semantics —
+       YaRN, sinks, biases, routed MXFP4 MoE, ClampedGlu — numerically identically to f32 noise.
+       Remaining: the bracketed performance ladder. Earlier note kept:
        INTERPRETER HALF CLOSED 2026-08-17: `shannon layer-dump --tokens` (new; given ids) over
        the HF checkpoint = the served CPU forward on the exact BF16+MXFP4 bytes, vs `vindex3
        exec --dump-layers` on the container, same 81 oracle ids → `layer-diff`: cos

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1771,7 +1771,26 @@ A-9.1  DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): judged AttentionSink
        AttentionSurface / AttentionCall and every backend — the reference interpreter had
        neither (reference.rs:165 softmax without the sink, :92 projection without bias); the
        lowering still binds has_sinks=0 with a placeholder (lowering/attention.rs:344).
-A-9.2  MoE in the generic system graph: an expert-bank ObjectKind (graph/object.rs:11),
+A-9.2  DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): ObjectKind::ExpertBank, carved out
+       of the stack by binding SPECIFICITY (`most_specific_owner`: longest binding prefix owns
+       a tensor — the graph's one membership rule, consulted by encode/verify/closure; no
+       exclusion lists, no manifest); FfnSurface.moe (MoeSurface lifted from the family
+       judgment: experts, top_k, router_kind, routing_policy, router_bias, expert_format,
+       gate_up_layout, …); roles MoeRouter{Weight,Bias} (stack) + Expert{GateUp,Down}
+       {,Scales,Bias} (bank); LayerFfn::{Dense,Routed} untagged so dense plans serialise
+       byte-identically; RoutedFfnOp → RoutedFfnCall → reference (literal transcription),
+       production (served router::select + MoeGateRule), device (per-expert gemv, NATIVE
+       MXFP4 bytes bound when declared); lowering refuses (A-9.4). Gates on a miniature
+       gpt_oss-FAMILY fixture (packed MXFP4 + biases + sinks + router bias + clamped GLU):
+       served CPU forward ≡ reference ≡ production ≡ device(mxfp4) at 2e-5; four causal
+       controls (router / gate_up / down / bias → 3e-2…5e-1); closure fail-closed both ways
+       (no judgment ⇒ 8 stray operands/layer; wrong expert count ⇒ 8 geometry/layer; expert
+       operand in the stack ⇒ misplaced). REAL gpt-oss: `vindex3 ops` 264 → 0, "plan closed:
+       24 layer(s), every executable operand accounted"; container = decoder_stack@BF16 1.28 GB
+       + expert_bank@BF16+MXFP4 10.17 GB (24 bindings) + embedding/final_norm/output_head, NO
+       moe_manifest.json, `inspect` coherent; `vindex3 exec` now runs to the executor and
+       refuses at YaRN — the last unexecuted semantic (A-9.3). As mapped:
+       MoE in the generic system graph: an expert-bank ObjectKind (graph/object.rs:11),
        router/expert/bias OperandRoles (graph/roles.rs:22,58), an MoE FfnOp; encode writes
        banks into the system container (or exec composes system + routed containers the way
        `run --routed-from` composes VINDEX2 + banks).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1825,7 +1825,24 @@ A-9.3  DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): the interpreter exec
        As mapped: MoE execution in the interpreter (exec/mod.rs, reference.rs, production.rs) with
        gpt-oss routing (top-k then softmax over the selected — MoeRouterKind::TopKThenSoftmax,
        ExpertRoutingPolicy::NormalisedOverSelected) and ClampedGlu (pipeline/moe.rs:43).
-A-9.4  ATTENTION HALF DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): sinks, Q/K/V/O
+A-9.4  DONE 2026-08-18 (branch feat/vindex3-gpt-oss-rung0): the real gpt-oss-20b container
+       lowers END-TO-END through the generic Metal path — routed MXFP4 MoE + YaRN + sinks +
+       biases, no family-name branching. Routed FFN: LayerFfnLowering::{Dense,Routed} in the
+       stack encoder; lowered.rs registers the container's expert-bank segments as zero-copy
+       regions (AlignedBytes page-aligned == PAGE_SIZE 16384) and builds a MoeLayerWeights
+       (router from decoder_stack, experts from expert_bank, top_k_then_softmax, Interleaved,
+       Paired MXFP4 scales, ClampedGlu via MoeGateRule) → the SERVED descriptor MoE encode
+       (encode_moe_layer_gpu_route) — ClampedGlu executes through the existing clamped_glu_bias
+       kernel, so no new gate. `vindex3 exec --backend metal-lowered` on the 65-id oracle
+       prompt: argmax 200005 = oracle id 1; `--generate 16` = 15/16 IDENTICAL to the production
+       interpreter's own trajectory (one flip at position 6, NVFP4 attention vs f32, re-syncs
+       immediately), 18.5 tok/s. Fragment gate: tests/test_lowering_attention_extras.rs (YaRN+
+       sinks+biases <1e-4 + 4 controls); routed FFN reuses the tested served MoE encode. 821
+       Metal tests green. REMAINING for a per-layer congruent gate: wire lowered `--dump-layers`
+       (encode_stack Checkpoints, per-position [seq,hidden] planes) so `shannon layer-diff` can
+       localise the lowered vs interpreter/served dumps to a first-differing layer (whole-model
+       argmax+trajectory already agree within NVFP4-attention noise). Was:
+       ATTENTION HALF DONE 2026-08-17 (branch feat/vindex3-gpt-oss-rung0): sinks, Q/K/V/O
        biases and YaRN (scaled inv_freq + amplitude) lowered in lowering/attention.rs +
        mod.rs, reusing the existing bias_add / sinks-slot(10,11) / rope-amplitude(slot 6)
        kernels; lowered.rs feeds them from the plan and lifts the three refusals (LoweredMatrix

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1894,6 +1894,52 @@ owns the execution choice; the KV engines belong under the same planner.
 Individual techniques (kernel selection, seqpar) are not novel; the claim is
 integration from semantics down to execution.
 
+### VINDEX3 evolution — versioned by capability, not by model architecture (2026-08-18)
+
+The organising rule, adopted 2026-08-18: **freeze the VINDEX3 ontology soon;
+everything after that evolves through opsets, representation sets, profiles
+and packaging — not schema redesign.** Stages are defined by the capability
+they add, each with an exit criterion; what may land in each stage is
+disciplined. The gauntlet (F1–F7) and standard-grade backlog (P0–P2) below
+are the *detail* of the first two stages and are tagged with their stage.
+
+| Stage | Goal | Defining capability | Status 2026-08-18 |
+|---|---|---|---|
+| **V3-F0 — Saturation** | prove the ontology | awkward architectures fit without changing a foundational relationship | **2 of 3 witnesses**: Glimmer (dense) and gpt-oss (routed MoE + sinks + biases + YaRN + clamped GLU, A-9) both went graph → plan → interpreter → Metal with new *vocabulary* only (F1 held). Third not started through the generic chain: Gemma 4 hybrid MoE exists only via the V2→V3 *import* path (c8), Kimi Linear/KDA/MLA only via the K3 adapter, multimodal only served. |
+| **V3.0 — Stable Core** | freeze the model-database ABI | Model · Object · Representation · Segment/Region · Operation · Operand · Graph · Profile · Reference, and their relationships; separate versioning (container 3 / semantic IR 1 / opsets / representation sets); formal unknown-field rules; canonical serialisation + deterministic ids; corruption fixtures; independent reference reader | **~half**: generic MoE graph done (A-9.2, no `moe_manifest.json`); multi-representation *binding* not done (refusal real, selection does not yet steer bytes — F3); WALK/DESCRIBE against V3 authority not done (V2-1/c7 — F5); opset versioning not started (one integer today); criticality classes exist in code but not in the spec; F7 mutation sweep unwritten; canonical serialisation only as "dense plans serialise byte-identically under absence"; reference reader/conformance not started. |
+| **V3.1 — Immutable Distribution** | composable, distributable models | content-addressed segments (OCI descriptor: type + digest + size + locations, manifests as Merkle DAGs), overlays/deltas/adapters (`parent: sha256:…; replace object 391 MXFP4 → sha256:…; add adapter`), provenance DAG per representation (tool, version, args, input/output/calibration digests) | not designed; Hub publish/slice contract (larql-factory, ADR-0026) is the packaging start |
+| **V3.2 — Adaptive Representation** | runtime-selectable physical model | one semantic object with several *legitimate* representations; declarative profiles (`prefer: MXFP4`, `allow_remote`) that carry no kernel names; quality as metadata per representation (reference, rel_rms, cosine, kl_delta, shannon_delta, calibration digest) so a profile can say `max_shannon_loss: 0.01` and the planner chooses | the representation algebra exists in the lowering (F16/Q4_K/MXFP4/NVFP4 priced under identical scheduling) and Shannon scoring exists; nothing is *carried* as representation metadata yet |
+| **V3.3 — Location Independence** | model bigger than machine | `segment == local file` removed: segment identity → resolver (GPU-resident / RAM / mmap / NVMe / HTTP-range / S3 / remote expert node); `PLAN operation|layer|token|prompt` returns inputs, selected experts, representations, required regions, expected bytes, residency, missing bytes — before execution | groundwork only: segments are page-aligned, mmapped and registered straight into Metal buffers ("bind, never reconstruct"); the working-set instrument (200 predicted / 200 resident / 0 overshoot) is `PLAN operation` before it has a name |
+| **V3.4 — Ecosystem Standard** | no dependency on LARQL | `vindex-spec/` + `vindex-conformance/` + `vindex-reference/` (tiny C reader, Rust reader with no engine, Python reader); conformance corpus (dense, GQA, MoE, multi-rep, overlay, remote segment, unknown optional/mandatory extension, corruption); `vindex pull/inspect/verify/diff/compat`; registries (HF, OCI, S3, HTTP, LAN peer) equivalent | not started |
+| **V4** | only if the ontology fails | a foundational relationship must change (e.g. object identity genuinely dynamic/context-dependent in a way operations/state/relations cannot express) | — VINDEX4 means "our ontology was wrong", not "there is a new model" (no FP3, no KDA2, no video) |
+
+**Exit criterion for V3-F0 (the freeze trigger):** *three consecutive
+structurally different architectures require new operators or
+representation types, but no new foundational relationship.* Not "N tests
+pass", not "all models work" — ontology saturation. Candidates for the
+third witness, in the order they attack different parts of the ontology:
+hybrid MoE (dense + routed/shared experts in one layer — cheapest, the
+vocabulary already exists), Kimi Linear (recurrent/KDA state + MLA — the
+most informative, because *state as an object* is where the V4 trigger
+would show if it exists), another MLA model (attention/KV independently),
+one multimodal architecture (towers/projectors/decoder graph); later, a
+Mamba/Jamba/RWKV-type model to test "neural model" versus "transformer".
+
+**Discipline per stage.** V3-F0: attack the ontology, add no ecosystem
+feature. V3.0: freeze, publish the spec, ship the reference reader and
+conformance suite, add no architectural idea; remote execution, cost models
+and Shannon *selection* stay out of the frozen core. After ~V3.2, resist
+3.5/3.6/…: the semantic IR stays at 1, and innovation happens in
+`vindex.moe:3`, `vindex.kda:2`, `vindex.ssm:1`, `vindex.audio:2`, quant
+representation sets, placement, quality contracts. Engine work (A-1…A-10)
+continues throughout but is **not permitted to move schema** — a schema
+change is a V3-F0/V3.0 event, argued as such.
+
+**Immediate queue this implies:** (1) the third hostile architecture through
+the generic chain; (2) multi-representation binding, WALK/DESCRIBE on V3
+authority, the opset/version model, refusal semantics in the spec (the
+V3.0 pre-freeze list); (3) freeze. A-10 runs alongside as engine work.
+
 ### VINDEX3 stabilisation — freeze gauntlet, positioning, standard-grade backlog (2026-08-17)
 
 **Judgement: the architecture is converged; the ABI had one adversarial pass
@@ -2035,21 +2081,21 @@ neural-database storage-engine format.
 scratch if models were large, queryable, heterogeneous databases, not against
 GGUF:
 
-| Pri | Improvement | Why |
+| Pri · stage | Improvement | Why |
 |---|---|---|
-| P0 | **Separate container / semantic-IR / opset / representation-set versioning** (ONNX's model: `container 3`, `semantic_ir 1`, `org.larql.core:1`, `org.larql.moe:2`, `org.larql.attn:3`, `org.larql.quant:4`) | KDA arrives as `org.larql.kda:1`, not VINDEX4; a reader says "cannot execute ops 46–91" instead of branching on architecture name |
-| P0 | **Content-address every physical segment** (OCI descriptor: media type + digest + size + locations; manifests as Merkle DAGs) | dedup across fine-tunes, one-segment publishes, local/remote indistinguishable, per-region verification, model identity = hash of the semantic manifest |
-| P0 | **Finish genuine multi-representation objects** — representation as an independently describable entity (encoding, layout, scale encoding, block geometry, alignment, companion streams, accuracy contract, source repr, transformation, HW compat); profiles select a *physical representation* | the signature VINDEX3 capability; F3 above |
-| P0 | **Formal unknown-field semantics** — every extension is `annotation` (ignore) · `execution_metadata` · `semantic_required` (refuse) · `representation_required` (fine if another admissible repr exists) · `interface_required` | criticality work already invented the answer; put it in the spec, avoid GGUF's accumulate-conventions-forever fate |
-| P0 | **Conformance suite + tiny independent reader** (`vindex-spec/`: spec, schema, test-vectors, reference-{c,rust,python}; open/validate/list objects+ops/resolve reprs/map segments/verify hashes, no LARQL dependency) | if only `larql-vindex` can read it, it is a good LARQL format; if a compatible reader is a weekend, it can be a standard |
-| P1 | Transformation/provenance DAG per representation (tool, version, args, input/output digest, calibration corpus digest) | reproducible builds; "where did these 64 bytes come from" has an answer |
-| P1 | First-class overlays/deltas/adapters (`parent: sha256:… ; replace object 391 MXFP4 → sha256:… ; add adapter`) | LoRA, patches, expert replacement, LARQL INSERTs, spec heads as composable artefacts — no 30 GB duplicate, no base mutation |
-| P1 | Remote/range-addressable segments — objects refer to segment *identity*, a resolver yields RAM/mmap/NVMe/HTTP-range/S3/peer/GPU | model-as-database at its logical conclusion |
-| P1 | Compact binary navigation index alongside (or canonical under) `index.json` (`index.vxb`; Arrow footer / Parquet metadata model) | opening K3 must not mean parsing 300 MB of JSON |
-| P1 | Compatibility/capability query — `vindex compat model --runtime metal-m3-max` → per-opset ✓/✗, executable layers, no model data touched | complete-or-refuse, before touching weights |
-| P2 | Per-region measured quality contracts (reference, max_abs, rel_rms, cosine, shannon_delta, fixture digest) | representation choice becomes a correctness decision — the Shannon work meets the representation algebra |
-| P2 | Optional signatures / encryption / access policy | distributed commercial models |
-| P2 | Standard packaging profile (HF, OCI registries, S3, local disk) | natural homes |
+| P0 · V3.0 | **Separate container / semantic-IR / opset / representation-set versioning** (ONNX's model: `container 3`, `semantic_ir 1`, `org.larql.core:1`, `org.larql.moe:2`, `org.larql.attn:3`, `org.larql.quant:4`) | KDA arrives as `org.larql.kda:1`, not VINDEX4; a reader says "cannot execute ops 46–91" instead of branching on architecture name |
+| P0 · V3.1 | **Content-address every physical segment** (OCI descriptor: media type + digest + size + locations; manifests as Merkle DAGs) | dedup across fine-tunes, one-segment publishes, local/remote indistinguishable, per-region verification, model identity = hash of the semantic manifest |
+| P0 · V3.0 (binding) / V3.2 (algebra) | **Finish genuine multi-representation objects** — representation as an independently describable entity (encoding, layout, scale encoding, block geometry, alignment, companion streams, accuracy contract, source repr, transformation, HW compat); profiles select a *physical representation* | the signature VINDEX3 capability; F3 above |
+| P0 · V3.0 | **Formal unknown-field semantics** — every extension is `annotation` (ignore) · `execution_metadata` · `semantic_required` (refuse) · `representation_required` (fine if another admissible repr exists) · `interface_required` | criticality work already invented the answer; put it in the spec, avoid GGUF's accumulate-conventions-forever fate |
+| P0 · V3.0 (reader) / V3.4 (ecosystem) | **Conformance suite + tiny independent reader** (`vindex-spec/`: spec, schema, test-vectors, reference-{c,rust,python}; open/validate/list objects+ops/resolve reprs/map segments/verify hashes, no LARQL dependency) | if only `larql-vindex` can read it, it is a good LARQL format; if a compatible reader is a weekend, it can be a standard |
+| P1 · V3.1 | Transformation/provenance DAG per representation (tool, version, args, input/output digest, calibration corpus digest) | reproducible builds; "where did these 64 bytes come from" has an answer |
+| P1 · V3.1 | First-class overlays/deltas/adapters (`parent: sha256:… ; replace object 391 MXFP4 → sha256:… ; add adapter`) | LoRA, patches, expert replacement, LARQL INSERTs, spec heads as composable artefacts — no 30 GB duplicate, no base mutation |
+| P1 · V3.3 | Remote/range-addressable segments — objects refer to segment *identity*, a resolver yields RAM/mmap/NVMe/HTTP-range/S3/peer/GPU | model-as-database at its logical conclusion |
+| P1 · V3.1 | Compact binary navigation index alongside (or canonical under) `index.json` (`index.vxb`; Arrow footer / Parquet metadata model) | opening K3 must not mean parsing 300 MB of JSON |
+| P1 · V3.3 | Compatibility/capability query — `vindex compat model --runtime metal-m3-max` → per-opset ✓/✗, executable layers, no model data touched | complete-or-refuse, before touching weights |
+| P2 · V3.2 | Per-region measured quality contracts (reference, max_abs, rel_rms, cosine, shannon_delta, fixture digest) | representation choice becomes a correctness decision — the Shannon work meets the representation algebra |
+| P2 · V3.1 | Optional signatures / encryption / access policy | distributed commercial models |
+| P2 · V3.4 | Standard packaging profile (HF, OCI registries, S3, local disk) | natural homes |
 
 Never embed executable code (no Python/dylib/CUDA/wasm-with-host-access to
 *load* a model): operators are declarative contracts, unknown ones fail

--- a/crates/larql-cli/src/commands/primary/run_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd.rs
@@ -1014,6 +1014,7 @@ fn generate_routed_metal(
     _max_tokens: usize,
     _index: &larql_vindex::VectorIndex,
     _routed: &larql_inference::ffn::ContainerRoutedBackend,
+    _emit_ids: bool,
 ) -> Result<Vec<(String, u32)>, Box<dyn std::error::Error>> {
     Err(
         "--routed-from --metal serves expert banks on the GPU, so it needs a macOS host with \

--- a/crates/larql-cli/src/commands/primary/shannon_trace/dump.rs
+++ b/crates/larql-cli/src/commands/primary/shannon_trace/dump.rs
@@ -106,20 +106,29 @@ pub fn read_manifest(dir: &Path) -> Result<LayerDumpManifest, Box<dyn std::error
 }
 
 pub fn run_layer_dump(args: LayerDumpArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let text = shannon_cmd::read_text(&args.corpus, args.bytes)?;
     let model = shannon_cmd::load_model(&args.model)?;
-    let mut ids = larql_inference::encode_prompt(model.tokenizer(), &*model.weights().arch, &text)?;
+    let mut ids = match (&args.tokens, &args.corpus) {
+        (Some(tokens), _) => tokens
+            .split(',')
+            .map(|t| t.trim().parse::<u32>())
+            .collect::<Result<Vec<u32>, _>>()
+            .map_err(|e| format!("--tokens: {e}"))?,
+        (None, Some(corpus)) => {
+            let text = shannon_cmd::read_text(corpus, args.bytes)?;
+            larql_inference::encode_prompt(model.tokenizer(), &*model.weights().arch, &text)?
+        }
+        (None, None) => return Err("one of --corpus or --tokens is required".into()),
+    };
     if ids.is_empty() {
-        return Err("corpus tokenized to nothing".into());
+        return Err("token window is empty".into());
     }
     ids.truncate(args.context);
 
     let weights = model.weights();
     eprintln!(
-        "dumping {} layers over {} tokens ({} bytes)...",
+        "dumping {} layers over {} tokens...",
         weights.num_layers,
         ids.len(),
-        text.len(),
     );
     let captures = shannon_cmd::forward_hidden_all_layers(weights, &ids)?;
 

--- a/crates/larql-cli/src/commands/primary/shannon_trace/mod.rs
+++ b/crates/larql-cli/src/commands/primary/shannon_trace/mod.rs
@@ -59,8 +59,20 @@ pub struct LayerDumpArgs {
     pub model: String,
 
     /// UTF-8 corpus file supplying the token window.
-    #[arg(long, value_name = "FILE")]
-    pub corpus: PathBuf,
+    #[arg(
+        long,
+        value_name = "FILE",
+        required_unless_present = "tokens",
+        conflicts_with = "tokens"
+    )]
+    pub corpus: Option<PathBuf>,
+
+    /// Comma-separated token ids to run instead of tokenising a corpus —
+    /// given, never tokenised here, so this dump can be diffed against a
+    /// `vindex3 exec --dump-layers` run of the *same* ids: the two engines
+    /// then cannot silently score different token sequences.
+    #[arg(long, value_name = "IDS", conflicts_with = "corpus")]
+    pub tokens: Option<String>,
 
     /// Limit input to the first N bytes, truncated on a UTF-8 boundary.
     #[arg(long)]

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
@@ -91,7 +91,7 @@ pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
         .ok_or_else(|| format!("component `{}` produced no plan", args.component))?;
     let store = OperandStore::open(&args.container, &inspection)?;
 
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     {
         use larql_vindex::format::vindex3::opplan::exec::backend::{WeightFormat, WeightFormats};
         // The lowered path's per-class policy. Same scheduling for every
@@ -130,7 +130,7 @@ pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
     match args.backend {
         ExecBackend::Reference => run_on(&ReferenceBackend::new(), &args, &tokens, &plan, &store),
         ExecBackend::Production => run_on(&ProductionBackend::new(), &args, &tokens, &plan, &store),
-        #[cfg(feature = "gpu")]
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::MetalMxfp4 => {
             let gpu = larql_compute_metal::MetalBackend::new()
                 .ok_or("no Metal device available for --backend metal-mxfp4")?;
@@ -156,12 +156,12 @@ pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
                 );
             run_on(&backend, &args, &tokens, &plan, &store)
         }
-        #[cfg(feature = "gpu")]
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::MetalLowered
         | ExecBackend::MetalLoweredFfn
         | ExecBackend::MetalLoweredNoHead
         | ExecBackend::MetalLoweredMxfp4 => unreachable!("handled above"),
-        #[cfg(feature = "gpu")]
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::MetalMxfp4All => {
             let gpu = larql_compute_metal::MetalBackend::new()
                 .ok_or("no Metal device available for --backend metal-mxfp4-all")?;
@@ -179,7 +179,7 @@ pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
                 );
             run_on(&backend, &args, &tokens, &plan, &store)
         }
-        #[cfg(feature = "gpu")]
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::MetalNvfp4 | ExecBackend::MetalNvfp4Ffn | ExecBackend::MetalNvfp4NoHead => {
             let gpu = larql_compute_metal::MetalBackend::new()
                 .ok_or("no Metal device available for the nvfp4 backends")?;
@@ -228,7 +228,7 @@ pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
                 );
             run_on(&backend, &args, &tokens, &plan, &store)
         }
-        #[cfg(feature = "gpu")]
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::Metal => {
             // vindex never links Metal: the CLI injects the concrete
             // device through larql-compute's MatMul seam. f16 weights so

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
@@ -224,6 +224,35 @@ impl<'a> LoweredSession<'a> {
         max_positions: usize,
         keep: &mut Vec<LoadedWeight>,
     ) -> Result<Self, VindexError> {
+        // Represented, not yet lowered: a YaRN layer is scaled frequencies
+        // AND an attention amplitude, and `LoweredPosition` speaks plain
+        // rope or none. Refuse the whole session rather than let the layer
+        // fall through to `None` below and serve a different model (A-9.4).
+        if let Some(l) = plan
+            .layers
+            .iter()
+            .find(|l| l.attention.position.yarn().is_some())
+        {
+            return Err(VindexError::Parse(format!(
+                "layer {} carries PositionPolicy::Yarn, which the Metal lowering does not \
+                 execute yet (A-9.4); refusing rather than lowering it as unscaled rope",
+                l.layer
+            )));
+        }
+        // Likewise a clamped-GLU FFN (GPT-OSS's `swiglu_limit`): the
+        // lowering encodes plain gated FFNs only, and running the clamped
+        // policy as plain gating would be a different model (A-9.4).
+        if let Some(l) = plan
+            .layers
+            .iter()
+            .find(|l| !matches!(l.ffn.gate_policy, larql_models::ExpertGatePolicy::Gated))
+        {
+            return Err(VindexError::Parse(format!(
+                "layer {} carries {:?}, which the Metal lowering does not execute yet (A-9.4); \
+                 refusing rather than lowering it as plain gating",
+                l.layer, l.ffn.gate_policy
+            )));
+        }
         let embedding = plan
             .embedding
             .as_ref()
@@ -558,6 +587,10 @@ impl<'a> LoweredSession<'a> {
                     PositionPolicy::Rope { theta } if !self.ablate.no_rope => {
                         LoweredPosition::Rope { theta }
                     }
+                    // Refused in `new`; a Yarn layer never reaches a step.
+                    PositionPolicy::Yarn { .. } => {
+                        unreachable!("PositionPolicy::Yarn is refused by LoweredSession::new")
+                    }
                     _ => LoweredPosition::None,
                 },
                 // A window applies only to a sliding span; a full layer
@@ -647,6 +680,15 @@ pub(super) fn run_lowered(
     if let Some((rows, cols)) = session.head_geometry() {
         eprintln!("head geometry: [{rows}, {cols}]");
     }
+    eprintln!(
+        "plan: {} rope base(s), final norm {}",
+        session.rope_bases(),
+        if session.has_final_norm() {
+            "present"
+        } else {
+            "absent"
+        }
+    );
 
     let prompt_started = std::time::Instant::now();
     let mut logits: Option<Vec<f32>> = None;

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
@@ -21,7 +21,9 @@ use larql_compute::backend::MatMul;
 use larql_compute_metal::lowering::attention::{AttnShape, AttnWeights, LoweredPosition};
 use larql_compute_metal::lowering::ffn::{FfnShape, FfnWeights};
 use larql_compute_metal::lowering::head::{HeadScratch, HeadShape, HeadWeights};
-use larql_compute_metal::lowering::stack::{LayerLowering, StackScratch};
+use larql_compute_metal::lowering::stack::{
+    LayerFfnLowering, LayerLowering, RoutedFfnLowering, StackScratch,
+};
 use larql_compute_metal::lowering::{DeviceBuffer, LoweredMatrix, PostNorm};
 use larql_compute_metal::MetalBackend;
 use larql_models::config::PositionPolicy;
@@ -29,7 +31,9 @@ use larql_vindex::error::VindexError;
 use larql_vindex::format::vindex3::graph::policy::AttentionSpan;
 use larql_vindex::format::vindex3::opplan::exec::backend::{WeightFormat, WeightFormats};
 use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
-use larql_vindex::format::vindex3::opplan::exec::weights::{load_weight, LoadedWeight};
+use larql_vindex::format::vindex3::opplan::exec::weights::{
+    load_weight, AlignedBytes, LoadedWeight,
+};
 use larql_vindex::format::vindex3::opplan::{
     ComponentOpPlan, FfnOp, LayerPlan, NormOp, OperandRef,
 };
@@ -78,15 +82,104 @@ struct LayerResident {
     o_bias: Option<DeviceBuffer>,
     sinks: Option<DeviceBuffer>,
     gate: Option<DeviceMatrix>,
-    ffn_gate: DeviceMatrix,
-    ffn_up: DeviceMatrix,
-    ffn_down: DeviceMatrix,
+    ffn: FfnResident,
     pre_attn_norm: DeviceBuffer,
     post_attn_norm: Option<(DeviceBuffer, f32, f32)>,
     pre_ffn_norm: DeviceBuffer,
     post_ffn_norm: Option<(DeviceBuffer, f32, f32)>,
     k_cache: DeviceBuffer,
     v_cache: DeviceBuffer,
+}
+
+/// A layer's resident FFN: dense gate/up/down matrices, or a routed
+/// expert bank resolved to registered regions plus the served MoE
+/// scratch and descriptor table.
+enum FfnResident {
+    Dense {
+        gate: DeviceMatrix,
+        up: DeviceMatrix,
+        down: DeviceMatrix,
+    },
+    Routed(Box<RoutedLayer>),
+}
+
+/// One routed layer's expert bank and MoE machinery, held for the
+/// session: the packed expert bytes in page-aligned, region-registered
+/// buffers (bound zero-copy, never copied per token), the f32 router and
+/// bias operands, the per-layer `MoeScratch`, and the descriptor table.
+struct RoutedLayer {
+    gate_up_blocks: AlignedBytes,
+    gate_up_scales: AlignedBytes,
+    down_blocks: AlignedBytes,
+    down_scales: AlignedBytes,
+    router_proj: Vec<f32>,
+    router_bias: Vec<f32>,
+    gate_up_bias: Vec<f32>,
+    down_bias: Vec<f32>,
+    pre_ffn_norm: Vec<f32>,
+    gu_expert_bytes: usize,
+    gu_scale_bytes: usize,
+    dn_expert_bytes: usize,
+    dn_scale_bytes: usize,
+    experts: usize,
+    top_k: usize,
+    inter: usize,
+    gate_rule: larql_compute::MoeGateRule,
+    table: std::sync::Arc<larql_compute_metal::moe_descriptor::MoeExpertDescriptorTable>,
+    scratch: larql_compute_metal::MoeScratch,
+    eps: f32,
+}
+
+/// Per-expert byte slices into a packed bank: expert `e` occupies
+/// `[e*per .. (e+1)*per]` of the bank's logical bytes.
+fn expert_slices(bank: &AlignedBytes, per: usize, experts: usize) -> Vec<&[u8]> {
+    let all = &bank.as_slice()[..per * experts];
+    (0..experts).map(|e| &all[e * per..(e + 1) * per]).collect()
+}
+
+impl RoutedLayer {
+    /// The `MoeLayerWeights` view the served descriptor path consumes,
+    /// assembled from a `RoutedFfnOp` — per-expert slices into the
+    /// registered banks, router/bias from f32 storage, GPT-OSS routing
+    /// and gate semantics from the plan. Rebuilt per step (borrows are
+    /// cheap; no bytes move).
+    fn moe(&self) -> larql_compute::MoeLayerWeights<'_> {
+        use larql_compute::{
+            MoeExpertScales, MoeFusedRowLayout, MoeRoutingPolicy, MoeWeightLayout, QuantFormat,
+        };
+        larql_compute::MoeLayerWeights {
+            experts_gate_up: expert_slices(
+                &self.gate_up_blocks,
+                self.gu_expert_bytes,
+                self.experts,
+            ),
+            experts_down: expert_slices(&self.down_blocks, self.dn_expert_bytes, self.experts),
+            routing_policy: MoeRoutingPolicy::top_k_then_softmax(),
+            weight_layout: MoeWeightLayout::unpadded(),
+            expert_scales: MoeExpertScales::Paired {
+                gate_up: expert_slices(&self.gate_up_scales, self.gu_scale_bytes, self.experts),
+                down: expert_slices(&self.down_scales, self.dn_scale_bytes, self.experts),
+            },
+            fused_row_layout: MoeFusedRowLayout::Interleaved,
+            expert_data_format: QuantFormat::MXFP4,
+            router_proj: &self.router_proj,
+            router_bias: &self.router_bias,
+            experts_gate_up_bias: &self.gate_up_bias,
+            experts_down_bias: &self.down_bias,
+            router_scale: &[],
+            router_per_expert_scale: &[],
+            router_norm: &[],
+            router_norm_parameter_free: false,
+            router_input_scalar: 1.0,
+            pre_experts_norm: &self.pre_ffn_norm,
+            post_ffn1_norm: &[],
+            post_experts_norm: &[],
+            num_experts: self.experts,
+            top_k: self.top_k,
+            intermediate_size: self.inter,
+            gate_rule: self.gate_rule,
+        }
+    }
 }
 
 /// Stages this run omits, for marginal-cost profiling.
@@ -299,17 +392,8 @@ impl<'a> LoweredSession<'a> {
         // YaRN, sinks and Q/K/V/O biases are lowered (A-9.4): the
         // amplitude rides slot 6 of the rope kernel, the sinks slot 10/11
         // of the attention kernel, the biases the `bias_add` kernel after
-        // each projection. A routed FFN: represented and executed by the interpreter, but
-        // the lowering binds dense gate/up/down matrices only; the served
-        // MoE machinery (moe_zero_copy) is not plan-reachable yet (A-9.4).
-        if let Some(l) = plan.layers.iter().find(|l| l.ffn.routed().is_some()) {
-            return Err(VindexError::Parse(format!(
-                "layer {} carries a routed FFN (mixture of experts), which the Metal lowering \
-                 does not execute yet (A-9.4); refusing rather than dropping the experts",
-                l.layer
-            )));
-        }
-        // Likewise a clamped-GLU FFN (GPT-OSS's `swiglu_limit`): the
+        // each projection, and a routed FFN through the served descriptor
+        // MoE path (build_routed). A dense clamped-GLU FFN: the
         // lowering encodes plain gated FFNs only, and running the clamped
         // policy as plain gating would be a different model (A-9.4).
         if let Some(l) = plan.layers.iter().find(|l| {
@@ -356,17 +440,7 @@ impl<'a> LoweredSession<'a> {
                     )?),
                     None => None,
                 },
-                ffn_gate: resident_matrix(
-                    gpu,
-                    store,
-                    dense_ffn(layer)?.gate.as_ref().ok_or_else(|| {
-                        VindexError::Parse("lowering requires a gated FFN".into())
-                    })?,
-                    formats.ffn,
-                    keep,
-                )?,
-                ffn_up: resident_matrix(gpu, store, &dense_ffn(layer)?.up, formats.ffn, keep)?,
-                ffn_down: resident_matrix(gpu, store, &dense_ffn(layer)?.down, formats.ffn, keep)?,
+                ffn: build_ffn(gpu, store, layer, formats, keep)?,
                 pre_attn_norm: resident_norm(gpu, store, &layer.pre_attention_norm)?.0,
                 post_attn_norm: match &layer.post_attention_norm {
                     Some(op) => Some(resident_norm(gpu, store, op)?),
@@ -699,22 +773,34 @@ impl<'a> LoweredSession<'a> {
                 position_index: t,
                 kv_len: t + 1,
             },
-            ffn: FfnWeights {
-                gate: r.ffn_gate.as_lowered(),
-                up: r.ffn_up.as_lowered(),
-                down: r.ffn_down.as_lowered(),
-                norm_weight: &r.pre_ffn_norm,
-                post_norm: post(&r.post_ffn_norm, &self.scratch[14])
-                    .filter(|_| !self.ablate.no_post_norms),
-            },
-            ffn_shape: FfnShape {
-                hidden: self.hidden,
-                intermediate: plan_layer
-                    .ffn
-                    .dense()
-                    .map_or(self.hidden, |f| f.intermediate_size),
-                norm_eps: plan_layer.pre_ffn_norm.eps as f32,
-                norm_weight_offset: plan_layer.pre_ffn_norm.weight_offset,
+            ffn: match &r.ffn {
+                FfnResident::Dense { gate, up, down } => LayerFfnLowering::Dense {
+                    weights: FfnWeights {
+                        gate: gate.as_lowered(),
+                        up: up.as_lowered(),
+                        down: down.as_lowered(),
+                        norm_weight: &r.pre_ffn_norm,
+                        post_norm: post(&r.post_ffn_norm, &self.scratch[14])
+                            .filter(|_| !self.ablate.no_post_norms),
+                    },
+                    shape: FfnShape {
+                        hidden: self.hidden,
+                        intermediate: plan_layer
+                            .ffn
+                            .dense()
+                            .map_or(self.hidden, |f| f.intermediate_size),
+                        norm_eps: plan_layer.pre_ffn_norm.eps as f32,
+                        norm_weight_offset: plan_layer.pre_ffn_norm.weight_offset,
+                    },
+                },
+                FfnResident::Routed(routed) => {
+                    LayerFfnLowering::Routed(Box::new(RoutedFfnLowering {
+                        moe: routed.moe(),
+                        scratch: &routed.scratch,
+                        table: &routed.table,
+                        eps: routed.eps,
+                    }))
+                }
             },
             k_cache: &r.k_cache,
             v_cache: &r.v_cache,
@@ -740,6 +826,193 @@ impl<'a> LoweredSession<'a> {
     pub fn rope_bases(&self) -> usize {
         self.inv_freq.len()
     }
+}
+
+/// Build a layer's resident FFN: dense matrices, or the routed expert
+/// bank loaded into registered regions with its MoE machinery.
+fn build_ffn(
+    gpu: &MetalBackend,
+    store: &OperandStore,
+    layer: &LayerPlan,
+    formats: WeightFormats,
+    keep: &mut Vec<LoadedWeight>,
+) -> Result<FfnResident, VindexError> {
+    if let Some(op) = layer.ffn.routed() {
+        return Ok(FfnResident::Routed(Box::new(build_routed(
+            gpu, store, layer, op,
+        )?)));
+    }
+    let dense = dense_ffn(layer)?;
+    Ok(FfnResident::Dense {
+        gate: resident_matrix(
+            gpu,
+            store,
+            dense
+                .gate
+                .as_ref()
+                .ok_or_else(|| VindexError::Parse("lowering requires a gated FFN".into()))?,
+            formats.ffn,
+            keep,
+        )?,
+        up: resident_matrix(gpu, store, &dense.up, formats.ffn, keep)?,
+        down: resident_matrix(gpu, store, &dense.down, formats.ffn, keep)?,
+    })
+}
+
+/// Load a routed layer's expert bank into page-aligned, region-registered
+/// buffers and build its MoE scratch + descriptor table. The expert bytes
+/// are bound zero-copy through the same registered-region path the served
+/// `--routed-from` run uses — never copied per token.
+fn build_routed(
+    gpu: &MetalBackend,
+    store: &OperandStore,
+    layer: &LayerPlan,
+    op: &larql_vindex::format::vindex3::opplan::RoutedFfnOp,
+) -> Result<RoutedLayer, VindexError> {
+    use larql_vindex::format::vindex3::opplan::exec::weights::AlignedBytes;
+    // Only the packed-MXFP4 gpt-oss bank lowers today (native experts,
+    // split scales); any other routed shape refuses rather than guess.
+    if op.expert_format != larql_models::ExpertFormat::PackedMxfp4 {
+        return Err(VindexError::Parse(format!(
+            "layer {}: the Metal lowering serves only PackedMxfp4 routed experts, not {:?}",
+            layer.layer, op.expert_format
+        )));
+    }
+    let hidden = op.router.shape.get(1).copied().unwrap_or(0);
+    let experts = op.experts;
+    let inter = op.expert_intermediate_size;
+
+    // Packed blocks and scales into aligned, registered banks.
+    let aligned = |operand: &larql_vindex::format::vindex3::opplan::OperandRef| -> Result<AlignedBytes, VindexError> {
+        let raw = store.load_raw(operand)?;
+        Ok(AlignedBytes::from_bytes(&raw.bytes))
+    };
+    let gate_up_blocks = aligned(&op.gate_up.weights)?;
+    let gate_up_scales = aligned(op.gate_up.scales.as_ref().ok_or_else(|| {
+        VindexError::Parse(format!(
+            "layer {}: routed gate_up carries no scales",
+            layer.layer
+        ))
+    })?)?;
+    let down_blocks = aligned(&op.down.weights)?;
+    let down_scales = aligned(op.down.scales.as_ref().ok_or_else(|| {
+        VindexError::Parse(format!(
+            "layer {}: routed down carries no scales",
+            layer.layer
+        ))
+    })?)?;
+    for (bank, what) in [
+        (&gate_up_blocks, "gate_up blocks"),
+        (&gate_up_scales, "gate_up scales"),
+        (&down_blocks, "down blocks"),
+        (&down_scales, "down scales"),
+    ] {
+        if !gpu.lowering_register_region(bank.as_slice()) {
+            return Err(VindexError::Parse(format!(
+                "layer {}: could not register the routed {what} region (not page-aligned)",
+                layer.layer
+            )));
+        }
+    }
+    let gu_expert_bytes = gate_up_blocks.logical_len() / experts;
+    let gu_scale_bytes = gate_up_scales.logical_len() / experts;
+    let dn_expert_bytes = down_blocks.logical_len() / experts;
+    let dn_scale_bytes = down_scales.logical_len() / experts;
+
+    let f32_or_empty =
+        |o: Option<&larql_vindex::format::vindex3::opplan::OperandRef>| -> Result<Vec<f32>, VindexError> {
+            match o {
+                Some(op) => store.load(op),
+                None => Ok(Vec::new()),
+            }
+        };
+    let router_proj = store.load(&op.router)?;
+    let router_bias = f32_or_empty(op.router_bias.as_ref())?;
+    let gate_up_bias = f32_or_empty(op.gate_up.bias.as_ref())?;
+    let down_bias = f32_or_empty(op.down.bias.as_ref())?;
+    let pre_ffn_norm = store.load(&layer.pre_ffn_norm.weight)?;
+    let gate_rule = larql_compute::MoeGateRule::from_arch(op.gate_policy, op.activation);
+
+    let scratch = larql_compute_metal::MoeScratch::new_public_with_format(
+        gpu,
+        op.top_k,
+        hidden,
+        inter,
+        larql_compute::QuantFormat::MXFP4,
+        hidden,
+    );
+    // Build the descriptor table from a temporary `MoeLayerWeights`
+    // borrowing the freshly-loaded storage, before that storage moves
+    // into `RoutedLayer` — the table keeps only region buffers, no borrow.
+    let table = {
+        use larql_compute::{
+            MoeExpertScales, MoeFusedRowLayout, MoeRoutingPolicy, MoeWeightLayout, QuantFormat,
+        };
+        let moe = larql_compute::MoeLayerWeights {
+            experts_gate_up: expert_slices(&gate_up_blocks, gu_expert_bytes, experts),
+            experts_down: expert_slices(&down_blocks, dn_expert_bytes, experts),
+            routing_policy: MoeRoutingPolicy::top_k_then_softmax(),
+            weight_layout: MoeWeightLayout::unpadded(),
+            expert_scales: MoeExpertScales::Paired {
+                gate_up: expert_slices(&gate_up_scales, gu_scale_bytes, experts),
+                down: expert_slices(&down_scales, dn_scale_bytes, experts),
+            },
+            fused_row_layout: MoeFusedRowLayout::Interleaved,
+            expert_data_format: QuantFormat::MXFP4,
+            router_proj: &router_proj,
+            router_bias: &router_bias,
+            experts_gate_up_bias: &gate_up_bias,
+            experts_down_bias: &down_bias,
+            router_scale: &[],
+            router_per_expert_scale: &[],
+            router_norm: &[],
+            router_norm_parameter_free: false,
+            router_input_scalar: 1.0,
+            pre_experts_norm: &pre_ffn_norm,
+            post_ffn1_norm: &[],
+            post_experts_norm: &[],
+            num_experts: experts,
+            top_k: op.top_k,
+            intermediate_size: inter,
+            gate_rule,
+        };
+        if !gpu.lowering_moe_supported(&moe, &scratch) {
+            return Err(VindexError::Parse(format!(
+                "layer {}: the descriptor MoE path does not support this routed layer \
+                 (format/policy/geometry) — refusing before encode",
+                layer.layer
+            )));
+        }
+        gpu.lowering_moe_descriptor(layer.layer, &moe, inter, hidden)
+            .ok_or_else(|| {
+                VindexError::Parse(format!(
+                    "layer {}: expert operands did not resolve inside their registered regions",
+                    layer.layer
+                ))
+            })?
+    };
+    Ok(RoutedLayer {
+        gate_up_blocks,
+        gate_up_scales,
+        down_blocks,
+        down_scales,
+        router_proj,
+        router_bias,
+        gate_up_bias,
+        down_bias,
+        pre_ffn_norm,
+        gu_expert_bytes,
+        gu_scale_bytes,
+        dn_expert_bytes,
+        dn_scale_bytes,
+        experts,
+        top_k: op.top_k,
+        inter,
+        gate_rule,
+        table,
+        scratch,
+        eps: layer.pre_ffn_norm.eps as f32,
+    })
 }
 
 /// The dense FFN op of a layer the lowering has already admitted (routed

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
@@ -598,6 +598,27 @@ impl<'a> LoweredSession<'a> {
     /// Step one token: embed on the host, then the entire stack and
     /// head in one command buffer with a single wait.
     pub fn step(&mut self, token: u32) -> Result<Option<Vec<f32>>, VindexError> {
+        self.step_impl(token, None)
+    }
+
+    /// One step, capturing the embedding row and every layer's output for
+    /// this position — the per-layer planes a `shannon layer-diff` reads.
+    /// `layers_out[i]` is layer `i`'s post-FFN-residual hidden state.
+    pub fn step_capturing(
+        &mut self,
+        token: u32,
+    ) -> Result<(Option<Vec<f32>>, Vec<f32>, Vec<Vec<f32>>), VindexError> {
+        let mut embedding = Vec::new();
+        let mut layers_out = Vec::new();
+        let logits = self.step_impl(token, Some((&mut embedding, &mut layers_out)))?;
+        Ok((logits, embedding, layers_out))
+    }
+
+    fn step_impl(
+        &mut self,
+        token: u32,
+        capture: Option<(&mut Vec<f32>, &mut Vec<Vec<f32>>)>,
+    ) -> Result<Option<Vec<f32>>, VindexError> {
         let t = self.position;
         let row = &self.embed_table[token as usize * self.hidden..][..self.hidden];
         let embedding = self
@@ -622,6 +643,17 @@ impl<'a> LoweredSession<'a> {
             let inv = 1.0 / (ms + norm.eps).sqrt();
             h0.iter_mut().for_each(|v| *v = (*v as f64 * inv) as f32);
         }
+        let capturing = capture.is_some();
+        // Per-layer capture buffers (hidden-sized), read back after the
+        // command buffer completes — a copy inside the stream, never a
+        // mid-stream readback.
+        let captures: Vec<DeviceBuffer> = if capturing {
+            (0..self.plan.layers.len())
+                .map(|_| self.gpu.lowering_scratch(self.hidden))
+                .collect()
+        } else {
+            Vec::new()
+        };
         let h_in = self
             .gpu
             .lowering_upload(&h0)
@@ -658,9 +690,21 @@ impl<'a> LoweredSession<'a> {
             .map(|(plan_layer, r)| self.layer_lowering(plan_layer, r, t))
             .collect();
 
+        let checkpoints: Vec<larql_compute_metal::lowering::stack::Checkpoint> = captures
+            .iter()
+            .enumerate()
+            .map(
+                |(i, buf)| larql_compute_metal::lowering::stack::Checkpoint {
+                    after_layer: i,
+                    into: buf,
+                },
+            )
+            .collect();
         let cmd = self.gpu.new_lowering_command_buffer();
         let enc = cmd.new_compute_command_encoder();
-        let h_final = self.gpu.encode_stack(enc, &h_in, &layers, &scratch, &[]);
+        let h_final = self
+            .gpu
+            .encode_stack(enc, &h_in, &layers, &scratch, &checkpoints);
 
         let logits_buf = match (&self.final_norm, &self.head) {
             (Some((nw, eps, off)), Some(head)) => {
@@ -690,6 +734,19 @@ impl<'a> LoweredSession<'a> {
         cmd.wait_until_completed();
 
         let out = logits_buf.and_then(|b| self.gpu.lowering_readback(b, self.vocab));
+        if let Some((embedding, layers_out)) = capture {
+            *embedding = h0;
+            for buf in &captures {
+                layers_out.push(
+                    self.gpu
+                        .lowering_readback(buf, self.hidden)
+                        .ok_or_else(|| VindexError::Parse("capture readback failed".into()))?,
+                );
+            }
+        }
+        for buf in captures {
+            self.gpu.recycle_lowering_scratch(buf);
+        }
         self.gpu.recycle_lowering_scratch(h_in);
         self.position += 1;
         Ok(out)
@@ -1044,6 +1101,67 @@ fn argmax_of(logits: &[f32]) -> u32 {
         .0 as u32
 }
 
+/// Teacher-force `tokens` through the lowering, capturing every layer's
+/// output per position, and write the planes + manifest a `shannon
+/// layer-diff` consumes — byte-compatible with `vindex3 exec --dump-layers`
+/// on the interpreter backends, so the two can be diffed directly.
+fn dump_lowered(
+    session: &mut LoweredSession<'_>,
+    tokens: &[u32],
+    plan: &ComponentOpPlan,
+    container: &std::path::Path,
+    label: &str,
+    dir: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use super::super::shannon_trace::dump::{
+        plane_name, LayerDumpManifest, MANIFEST_NAME, PLANE_DTYPE,
+    };
+    let hidden = session.hidden;
+    let num_layers = plan.layers.len();
+    let seq = tokens.len();
+    std::fs::create_dir_all(dir)?;
+    // Row-major [seq, hidden] planes: plane 0 = embeddings, plane i+1 =
+    // layer i's post-FFN-residual hidden.
+    let mut planes: Vec<Vec<f32>> = vec![Vec::with_capacity(seq * hidden); num_layers + 1];
+    for (pos, &token) in tokens.iter().enumerate() {
+        let (_logits, embedding, layers_out) = session.step_capturing(token)?;
+        planes[0].extend_from_slice(&embedding);
+        for (i, row) in layers_out.into_iter().enumerate() {
+            planes[i + 1].extend_from_slice(&row);
+        }
+        eprintln!("captured position {}/{seq}", pos + 1);
+    }
+    let plane_names: Vec<String> = (0..=num_layers).map(plane_name).collect();
+    for (name, data) in plane_names.iter().zip(&planes) {
+        use std::io::Write;
+        let mut f = std::io::BufWriter::new(std::fs::File::create(dir.join(name))?);
+        for v in data {
+            f.write_all(&v.to_le_bytes())?;
+        }
+        f.flush()?;
+    }
+    let manifest = LayerDumpManifest {
+        engine: format!("vindex3-metal-lowered-{label}"),
+        model: container.display().to_string(),
+        num_layers,
+        seq_len: seq,
+        hidden_size: hidden,
+        token_ids: tokens.to_vec(),
+        planes: plane_names,
+        dtype: PLANE_DTYPE.to_string(),
+    };
+    std::fs::write(
+        dir.join(MANIFEST_NAME),
+        serde_json::to_string_pretty(&manifest)?,
+    )?;
+    eprintln!(
+        "wrote {} planes + manifest to {}",
+        num_layers + 1,
+        dir.display()
+    );
+    Ok(())
+}
+
 /// Run the plan through the lowering and report the final position's
 /// logits, in the same shape `run_exec`'s other arms do.
 pub(super) fn run_lowered(
@@ -1073,6 +1191,13 @@ pub(super) fn run_lowered(
             "absent"
         }
     );
+
+    // ── per-layer dump: teacher-force the given tokens, capturing every
+    //    layer's output per position into [seq, hidden] planes a
+    //    `shannon layer-diff` reads (the lowered arm of the A-9.5 chain).
+    if let Some(dir) = &args.dump_layers {
+        return dump_lowered(&mut session, tokens, plan, &args.container, label, dir);
+    }
 
     let prompt_started = std::time::Instant::now();
     let mut logits: Option<Vec<f32>> = None;

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
@@ -72,6 +72,11 @@ struct LayerResident {
     k: DeviceMatrix,
     v: DeviceMatrix,
     o: DeviceMatrix,
+    q_bias: Option<DeviceBuffer>,
+    k_bias: Option<DeviceBuffer>,
+    v_bias: Option<DeviceBuffer>,
+    o_bias: Option<DeviceBuffer>,
+    sinks: Option<DeviceBuffer>,
     gate: Option<DeviceMatrix>,
     ffn_gate: DeviceMatrix,
     ffn_up: DeviceMatrix,
@@ -200,6 +205,71 @@ fn resident_matrix(
     Ok(m)
 }
 
+/// Upload an optional f32 vector operand (a bias or the sink logits) to
+/// the device, or `None` when the plan carries none.
+fn resident_vector(
+    gpu: &MetalBackend,
+    store: &OperandStore,
+    operand: Option<&OperandRef>,
+) -> Result<Option<DeviceBuffer>, VindexError> {
+    match operand {
+        Some(op) => {
+            let v = store.load(op)?;
+            let buf = gpu
+                .lowering_upload(&v)
+                .ok_or_else(|| VindexError::Parse("vector operand upload failed".into()))?;
+            Ok(Some(buf))
+        }
+        None => Ok(None),
+    }
+}
+
+/// The `inv_freq` map key for a rotary policy — distinct per (theta,
+/// scaled-or-plain) so YaRN and plain rope at the same base never share a
+/// table; `None` for NoPE.
+fn rope_table_key(position: &PositionPolicy) -> Option<u64> {
+    match position {
+        PositionPolicy::Rope { theta } => Some(theta.to_bits()),
+        // Fold the yarn block into the key so two different blocks (or a
+        // block vs plain rope) at one theta get their own tables. The
+        // block's f64 fields hash deterministically.
+        PositionPolicy::Yarn { theta, scaling } => {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            use std::hash::{Hash, Hasher};
+            theta.to_bits().hash(&mut h);
+            scaling.factor.to_bits().hash(&mut h);
+            scaling.beta_fast.to_bits().hash(&mut h);
+            scaling.beta_slow.to_bits().hash(&mut h);
+            scaling
+                .original_max_position_embeddings
+                .to_bits()
+                .hash(&mut h);
+            scaling.truncate.hash(&mut h);
+            Some(h.finish() | 1)
+        }
+        PositionPolicy::None => None,
+    }
+}
+
+/// The inverse-frequency table for a rotary policy, matching the
+/// interpreter kernel exactly: plain `theta^(-2i/d)` for rope, the YaRN
+/// ramp for a scaled layer.
+fn rope_inv_freq_table(position: &PositionPolicy, head_dim: usize) -> Vec<f32> {
+    match position {
+        PositionPolicy::Rope { theta } => (0..head_dim / 2)
+            .map(|i| theta.powf(-2.0 * i as f64 / head_dim as f64) as f32)
+            .collect(),
+        PositionPolicy::Yarn { theta, scaling } => {
+            let (inv_freq, _amplitude) =
+                larql_vindex::format::vindex3::opplan::exec::kernels::yarn_frequencies(
+                    scaling, head_dim, *theta,
+                );
+            inv_freq.iter().map(|f| *f as f32).collect()
+        }
+        PositionPolicy::None => Vec::new(),
+    }
+}
+
 fn resident_norm(
     gpu: &MetalBackend,
     store: &OperandStore,
@@ -226,39 +296,10 @@ impl<'a> LoweredSession<'a> {
         max_positions: usize,
         keep: &mut Vec<LoadedWeight>,
     ) -> Result<Self, VindexError> {
-        // Represented, not yet lowered: a YaRN layer is scaled frequencies
-        // AND an attention amplitude, and `LoweredPosition` speaks plain
-        // rope or none. Refuse the whole session rather than let the layer
-        // fall through to `None` below and serve a different model (A-9.4).
-        if let Some(l) = plan
-            .layers
-            .iter()
-            .find(|l| l.attention.position.yarn().is_some())
-        {
-            return Err(VindexError::Parse(format!(
-                "layer {} carries PositionPolicy::Yarn, which the Metal lowering does not \
-                 execute yet (A-9.4); refusing rather than lowering it as unscaled rope",
-                l.layer
-            )));
-        }
-        // Likewise attention sinks and Q/K/V/O biases: represented on the
-        // surface and executed by the interpreter backends, but the
-        // lowering binds `has_sinks = 0` and no bias buffers, so it would
-        // serve the model without them (A-9.4).
-        if let Some(l) = plan.layers.iter().find(|l| {
-            l.attention.sinks.is_some()
-                || l.attention.q_bias.is_some()
-                || l.attention.k_bias.is_some()
-                || l.attention.v_bias.is_some()
-                || l.attention.o_bias.is_some()
-        }) {
-            return Err(VindexError::Parse(format!(
-                "layer {} carries attention sinks and/or projection biases, which the Metal \
-                 lowering does not execute yet (A-9.4); refusing rather than dropping them",
-                l.layer
-            )));
-        }
-        // A routed FFN: represented and executed by the interpreter, but
+        // YaRN, sinks and Q/K/V/O biases are lowered (A-9.4): the
+        // amplitude rides slot 6 of the rope kernel, the sinks slot 10/11
+        // of the attention kernel, the biases the `bias_add` kernel after
+        // each projection. A routed FFN: represented and executed by the interpreter, but
         // the lowering binds dense gate/up/down matrices only; the served
         // MoE machinery (moe_zero_copy) is not plan-reachable yet (A-9.4).
         if let Some(l) = plan.layers.iter().find(|l| l.ffn.routed().is_some()) {
@@ -300,6 +341,11 @@ impl<'a> LoweredSession<'a> {
                 k: resident_matrix(gpu, store, &a.k, formats.attention, keep)?,
                 v: resident_matrix(gpu, store, &a.v, formats.attention, keep)?,
                 o: resident_matrix(gpu, store, &a.o, formats.attention, keep)?,
+                q_bias: resident_vector(gpu, store, a.q_bias.as_ref())?,
+                k_bias: resident_vector(gpu, store, a.k_bias.as_ref())?,
+                v_bias: resident_vector(gpu, store, a.v_bias.as_ref())?,
+                o_bias: resident_vector(gpu, store, a.o_bias.as_ref())?,
+                sinks: resident_vector(gpu, store, a.sinks.as_ref().map(|s| &s.logits))?,
                 gate: match &a.output_gate {
                     Some(g) => Some(resident_matrix(
                         gpu,
@@ -399,15 +445,18 @@ impl<'a> LoweredSession<'a> {
         ];
         let scratch = sizes.iter().map(|n| gpu.lowering_scratch(*n)).collect();
 
-        // One inverse-frequency table per distinct rope base in the plan.
-        let mut inv_freq = HashMap::new();
+        // One inverse-frequency table per distinct rotary policy in the
+        // plan — keyed on (theta, yarn-or-plain), so a YaRN layer's ramped
+        // frequencies and a plain layer's `theta^(-2i/d)` never collide on
+        // theta alone. The table matches the interpreter's exactly: plain
+        // rope from `rope_rotate`, YaRN from `kernels::yarn_frequencies`.
+        let mut inv_freq: HashMap<u64, DeviceBuffer> = HashMap::new();
         for layer in &plan.layers {
-            if let PositionPolicy::Rope { theta } = layer.attention.position {
-                let hd = layer.attention.head_dim;
-                inv_freq.entry(theta.to_bits()).or_insert_with(|| {
-                    let table: Vec<f32> = (0..hd / 2)
-                        .map(|i| theta.powf(-2.0 * i as f64 / hd as f64) as f32)
-                        .collect();
+            let a = &layer.attention;
+            let key = rope_table_key(&a.position);
+            if let Some(key) = key {
+                inv_freq.entry(key).or_insert_with(|| {
+                    let table = rope_inv_freq_table(&a.position, a.head_dim);
                     gpu.lowering_upload(&table).expect("inv_freq upload")
                 });
             }
@@ -445,6 +494,13 @@ impl<'a> LoweredSession<'a> {
             wiring.elapsed().as_secs_f64()
         );
 
+        if inv_freq.len() > 1 {
+            return Err(VindexError::Parse(format!(
+                "plan carries {} distinct rotary tables; the lowered stack binds one shared \
+                 inv_freq per token and cannot yet select per layer",
+                inv_freq.len()
+            )));
+        }
         Ok(Self {
             gpu,
             plan,
@@ -514,10 +570,9 @@ impl<'a> LoweredSession<'a> {
             ffn_act: &s[11],
             ffn_down: &s[13],
             ffn_post: &s[14],
-            // Every rotary layer in this plan shares one base; a plan
-            // with several would need per-layer selection, which the
-            // stack encoder does not yet express. Refuse rather than
-            // silently rotate at the wrong frequency.
+            // Every rotary layer in this plan shares one table (checked
+            // in `new`); a plan with several would need per-layer
+            // selection, which the stack encoder does not yet express.
             inv_freq: self.inv_freq.values().next().unwrap_or(&self.scratch[0]),
         };
 
@@ -592,6 +647,11 @@ impl<'a> LoweredSession<'a> {
                     .as_ref()
                     .filter(|_| !self.ablate.no_gate)
                     .map(DeviceMatrix::as_lowered),
+                q_bias: r.q_bias.as_ref(),
+                k_bias: r.k_bias.as_ref(),
+                v_bias: r.v_bias.as_ref(),
+                o_bias: r.o_bias.as_ref(),
+                sinks: r.sinks.as_ref(),
                 norm_weight: &r.pre_attn_norm,
                 post_norm: post(&r.post_attn_norm, &self.scratch[7])
                     .filter(|_| !self.ablate.no_post_norms),
@@ -614,14 +674,20 @@ impl<'a> LoweredSession<'a> {
                     .filter(|_| !self.ablate.no_query_scale),
                 score_scale: a.score_scale as f32,
                 position: match a.position {
-                    PositionPolicy::Rope { theta } if !self.ablate.no_rope => {
-                        LoweredPosition::Rope { theta }
+                    _ if self.ablate.no_rope => LoweredPosition::None,
+                    PositionPolicy::Rope { theta } => LoweredPosition::Rope { theta },
+                    // YaRN's ramped `inv_freq` rides the shared table
+                    // (built for this layer's policy in `new`); the
+                    // amplitude rides slot 6 of the rope kernel.
+                    PositionPolicy::Yarn { theta, scaling } => {
+                        let amplitude =
+                            larql_vindex::format::vindex3::opplan::exec::kernels::yarn_frequencies(
+                                &scaling, a.head_dim, theta,
+                            )
+                            .1;
+                        LoweredPosition::Scaled { theta, amplitude }
                     }
-                    // Refused in `new`; a Yarn layer never reaches a step.
-                    PositionPolicy::Yarn { .. } => {
-                        unreachable!("PositionPolicy::Yarn is refused by LoweredSession::new")
-                    }
-                    _ => LoweredPosition::None,
+                    PositionPolicy::None => LoweredPosition::None,
                 },
                 // A window applies only to a sliding span; a full layer
                 // attends the whole prefix whatever the plan records.

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
@@ -239,6 +239,23 @@ impl<'a> LoweredSession<'a> {
                 l.layer
             )));
         }
+        // Likewise attention sinks and Q/K/V/O biases: represented on the
+        // surface and executed by the interpreter backends, but the
+        // lowering binds `has_sinks = 0` and no bias buffers, so it would
+        // serve the model without them (A-9.4).
+        if let Some(l) = plan.layers.iter().find(|l| {
+            l.attention.sinks.is_some()
+                || l.attention.q_bias.is_some()
+                || l.attention.k_bias.is_some()
+                || l.attention.v_bias.is_some()
+                || l.attention.o_bias.is_some()
+        }) {
+            return Err(VindexError::Parse(format!(
+                "layer {} carries attention sinks and/or projection biases, which the Metal \
+                 lowering does not execute yet (A-9.4); refusing rather than dropping them",
+                l.layer
+            )));
+        }
         // Likewise a clamped-GLU FFN (GPT-OSS's `swiglu_limit`): the
         // lowering encodes plain gated FFNs only, and running the clamped
         // policy as plain gating would be a different model (A-9.4).

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered.rs
@@ -30,7 +30,9 @@ use larql_vindex::format::vindex3::graph::policy::AttentionSpan;
 use larql_vindex::format::vindex3::opplan::exec::backend::{WeightFormat, WeightFormats};
 use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
 use larql_vindex::format::vindex3::opplan::exec::weights::{load_weight, LoadedWeight};
-use larql_vindex::format::vindex3::opplan::{ComponentOpPlan, LayerPlan, NormOp, OperandRef};
+use larql_vindex::format::vindex3::opplan::{
+    ComponentOpPlan, FfnOp, LayerPlan, NormOp, OperandRef,
+};
 
 /// One matrix operand, resident on the device.
 struct DeviceMatrix {
@@ -256,18 +258,29 @@ impl<'a> LoweredSession<'a> {
                 l.layer
             )));
         }
+        // A routed FFN: represented and executed by the interpreter, but
+        // the lowering binds dense gate/up/down matrices only; the served
+        // MoE machinery (moe_zero_copy) is not plan-reachable yet (A-9.4).
+        if let Some(l) = plan.layers.iter().find(|l| l.ffn.routed().is_some()) {
+            return Err(VindexError::Parse(format!(
+                "layer {} carries a routed FFN (mixture of experts), which the Metal lowering \
+                 does not execute yet (A-9.4); refusing rather than dropping the experts",
+                l.layer
+            )));
+        }
         // Likewise a clamped-GLU FFN (GPT-OSS's `swiglu_limit`): the
         // lowering encodes plain gated FFNs only, and running the clamped
         // policy as plain gating would be a different model (A-9.4).
-        if let Some(l) = plan
-            .layers
-            .iter()
-            .find(|l| !matches!(l.ffn.gate_policy, larql_models::ExpertGatePolicy::Gated))
-        {
+        if let Some(l) = plan.layers.iter().find(|l| {
+            l.ffn
+                .dense()
+                .is_some_and(|f| !matches!(f.gate_policy, larql_models::ExpertGatePolicy::Gated))
+        }) {
             return Err(VindexError::Parse(format!(
                 "layer {} carries {:?}, which the Metal lowering does not execute yet (A-9.4); \
                  refusing rather than lowering it as plain gating",
-                l.layer, l.ffn.gate_policy
+                l.layer,
+                l.ffn.dense().map(|f| f.gate_policy)
             )));
         }
         let embedding = plan
@@ -300,14 +313,14 @@ impl<'a> LoweredSession<'a> {
                 ffn_gate: resident_matrix(
                     gpu,
                     store,
-                    layer.ffn.gate.as_ref().ok_or_else(|| {
+                    dense_ffn(layer)?.gate.as_ref().ok_or_else(|| {
                         VindexError::Parse("lowering requires a gated FFN".into())
                     })?,
                     formats.ffn,
                     keep,
                 )?,
-                ffn_up: resident_matrix(gpu, store, &layer.ffn.up, formats.ffn, keep)?,
-                ffn_down: resident_matrix(gpu, store, &layer.ffn.down, formats.ffn, keep)?,
+                ffn_up: resident_matrix(gpu, store, &dense_ffn(layer)?.up, formats.ffn, keep)?,
+                ffn_down: resident_matrix(gpu, store, &dense_ffn(layer)?.down, formats.ffn, keep)?,
                 pre_attn_norm: resident_norm(gpu, store, &layer.pre_attention_norm)?.0,
                 post_attn_norm: match &layer.post_attention_norm {
                     Some(op) => Some(resident_norm(gpu, store, op)?),
@@ -355,7 +368,7 @@ impl<'a> LoweredSession<'a> {
         let max_inter = plan
             .layers
             .iter()
-            .map(|l| l.ffn.intermediate_size)
+            .filter_map(|l| l.ffn.dense().map(|f| f.intermediate_size))
             .max()
             .unwrap_or(hidden);
         // Slots 16 and 17 are both vocabulary-sized: the head writes raw
@@ -630,7 +643,10 @@ impl<'a> LoweredSession<'a> {
             },
             ffn_shape: FfnShape {
                 hidden: self.hidden,
-                intermediate: plan_layer.ffn.intermediate_size,
+                intermediate: plan_layer
+                    .ffn
+                    .dense()
+                    .map_or(self.hidden, |f| f.intermediate_size),
                 norm_eps: plan_layer.pre_ffn_norm.eps as f32,
                 norm_weight_offset: plan_layer.pre_ffn_norm.weight_offset,
             },
@@ -658,6 +674,18 @@ impl<'a> LoweredSession<'a> {
     pub fn rope_bases(&self) -> usize {
         self.inv_freq.len()
     }
+}
+
+/// The dense FFN op of a layer the lowering has already admitted (routed
+/// layers are refused in `new`, so this only fails on a plan that changed
+/// under us).
+fn dense_ffn(layer: &LayerPlan) -> Result<&FfnOp, VindexError> {
+    layer.ffn.dense().ok_or_else(|| {
+        VindexError::Parse(format!(
+            "layer {} carries a routed FFN the lowering does not execute (A-9.4)",
+            layer.layer
+        ))
+    })
 }
 
 fn argmax_of(logits: &[f32]) -> u32 {

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/dump.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/dump.rs
@@ -1,0 +1,67 @@
+//! Teacher-force a token window through the lowering, capturing every
+//! layer's output per position into planes a `shannon layer-diff` reads.
+
+use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
+
+use super::LoweredSession;
+
+/// Teacher-force `tokens` through the lowering, capturing every layer's
+/// output per position, and write the planes + manifest a `shannon
+/// layer-diff` consumes — byte-compatible with `vindex3 exec --dump-layers`
+/// on the interpreter backends, so the two can be diffed directly.
+pub(super) fn dump_lowered(
+    session: &mut LoweredSession<'_>,
+    tokens: &[u32],
+    plan: &ComponentOpPlan,
+    container: &std::path::Path,
+    label: &str,
+    dir: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use super::super::super::shannon_trace::dump::{
+        plane_name, LayerDumpManifest, MANIFEST_NAME, PLANE_DTYPE,
+    };
+    let hidden = session.hidden;
+    let num_layers = plan.layers.len();
+    let seq = tokens.len();
+    std::fs::create_dir_all(dir)?;
+    // Row-major [seq, hidden] planes: plane 0 = embeddings, plane i+1 =
+    // layer i's post-FFN-residual hidden.
+    let mut planes: Vec<Vec<f32>> = vec![Vec::with_capacity(seq * hidden); num_layers + 1];
+    for (pos, &token) in tokens.iter().enumerate() {
+        let (_logits, embedding, layers_out) = session.step_capturing(token)?;
+        planes[0].extend_from_slice(&embedding);
+        for (i, row) in layers_out.into_iter().enumerate() {
+            planes[i + 1].extend_from_slice(&row);
+        }
+        eprintln!("captured position {}/{seq}", pos + 1);
+    }
+    let plane_names: Vec<String> = (0..=num_layers).map(plane_name).collect();
+    for (name, data) in plane_names.iter().zip(&planes) {
+        use std::io::Write;
+        let mut f = std::io::BufWriter::new(std::fs::File::create(dir.join(name))?);
+        for v in data {
+            f.write_all(&v.to_le_bytes())?;
+        }
+        f.flush()?;
+    }
+    let manifest = LayerDumpManifest {
+        engine: format!("vindex3-metal-lowered-{label}"),
+        model: container.display().to_string(),
+        num_layers,
+        seq_len: seq,
+        hidden_size: hidden,
+        token_ids: tokens.to_vec(),
+        planes: plane_names,
+        dtype: PLANE_DTYPE.to_string(),
+    };
+    std::fs::write(
+        dir.join(MANIFEST_NAME),
+        serde_json::to_string_pretty(&manifest)?,
+    )?;
+    eprintln!(
+        "wrote {} planes + manifest to {}",
+        num_layers + 1,
+        dir.display()
+    );
+    Ok(())
+}

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/mod.rs
@@ -31,27 +31,33 @@ use larql_vindex::error::VindexError;
 use larql_vindex::format::vindex3::graph::policy::AttentionSpan;
 use larql_vindex::format::vindex3::opplan::exec::backend::{WeightFormat, WeightFormats};
 use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
-use larql_vindex::format::vindex3::opplan::exec::weights::{
-    load_weight, AlignedBytes, LoadedWeight,
-};
-use larql_vindex::format::vindex3::opplan::{
-    ComponentOpPlan, FfnOp, LayerPlan, NormOp, OperandRef,
-};
+use larql_vindex::format::vindex3::opplan::exec::weights::LoadedWeight;
+use larql_vindex::format::vindex3::opplan::{ComponentOpPlan, LayerPlan};
 
 /// One matrix operand, resident on the device.
-struct DeviceMatrix {
+mod dump;
+mod resident;
+mod routed;
+
+use dump::dump_lowered;
+use resident::{
+    resident_matrix, resident_norm, resident_vector, rope_inv_freq_table, rope_table_key, Ablation,
+};
+use routed::{build_ffn, FfnResident};
+
+pub(super) struct DeviceMatrix {
     /// `scales` is unused for f16; the representation is what the plan's
     /// per-class policy asked for, not something inferred here.
-    packed: DeviceBuffer,
-    scales: DeviceBuffer,
-    tensor_scale: f32,
-    format: WeightFormat,
-    rows: usize,
-    cols: usize,
+    pub(super) packed: DeviceBuffer,
+    pub(super) scales: DeviceBuffer,
+    pub(super) tensor_scale: f32,
+    pub(super) format: WeightFormat,
+    pub(super) rows: usize,
+    pub(super) cols: usize,
 }
 
 impl DeviceMatrix {
-    fn as_lowered(&self) -> LoweredMatrix<'_> {
+    pub(super) fn as_lowered(&self) -> LoweredMatrix<'_> {
         match self.format {
             WeightFormat::F16 => LoweredMatrix::F16 {
                 bytes: &self.packed,
@@ -91,135 +97,6 @@ struct LayerResident {
     v_cache: DeviceBuffer,
 }
 
-/// A layer's resident FFN: dense gate/up/down matrices, or a routed
-/// expert bank resolved to registered regions plus the served MoE
-/// scratch and descriptor table.
-enum FfnResident {
-    Dense {
-        gate: DeviceMatrix,
-        up: DeviceMatrix,
-        down: DeviceMatrix,
-    },
-    Routed(Box<RoutedLayer>),
-}
-
-/// One routed layer's expert bank and MoE machinery, held for the
-/// session: the packed expert bytes in page-aligned, region-registered
-/// buffers (bound zero-copy, never copied per token), the f32 router and
-/// bias operands, the per-layer `MoeScratch`, and the descriptor table.
-struct RoutedLayer {
-    gate_up_blocks: AlignedBytes,
-    gate_up_scales: AlignedBytes,
-    down_blocks: AlignedBytes,
-    down_scales: AlignedBytes,
-    router_proj: Vec<f32>,
-    router_bias: Vec<f32>,
-    gate_up_bias: Vec<f32>,
-    down_bias: Vec<f32>,
-    pre_ffn_norm: Vec<f32>,
-    gu_expert_bytes: usize,
-    gu_scale_bytes: usize,
-    dn_expert_bytes: usize,
-    dn_scale_bytes: usize,
-    experts: usize,
-    top_k: usize,
-    inter: usize,
-    gate_rule: larql_compute::MoeGateRule,
-    table: std::sync::Arc<larql_compute_metal::moe_descriptor::MoeExpertDescriptorTable>,
-    scratch: larql_compute_metal::MoeScratch,
-    eps: f32,
-}
-
-/// Per-expert byte slices into a packed bank: expert `e` occupies
-/// `[e*per .. (e+1)*per]` of the bank's logical bytes.
-fn expert_slices(bank: &AlignedBytes, per: usize, experts: usize) -> Vec<&[u8]> {
-    let all = &bank.as_slice()[..per * experts];
-    (0..experts).map(|e| &all[e * per..(e + 1) * per]).collect()
-}
-
-impl RoutedLayer {
-    /// The `MoeLayerWeights` view the served descriptor path consumes,
-    /// assembled from a `RoutedFfnOp` — per-expert slices into the
-    /// registered banks, router/bias from f32 storage, GPT-OSS routing
-    /// and gate semantics from the plan. Rebuilt per step (borrows are
-    /// cheap; no bytes move).
-    fn moe(&self) -> larql_compute::MoeLayerWeights<'_> {
-        use larql_compute::{
-            MoeExpertScales, MoeFusedRowLayout, MoeRoutingPolicy, MoeWeightLayout, QuantFormat,
-        };
-        larql_compute::MoeLayerWeights {
-            experts_gate_up: expert_slices(
-                &self.gate_up_blocks,
-                self.gu_expert_bytes,
-                self.experts,
-            ),
-            experts_down: expert_slices(&self.down_blocks, self.dn_expert_bytes, self.experts),
-            routing_policy: MoeRoutingPolicy::top_k_then_softmax(),
-            weight_layout: MoeWeightLayout::unpadded(),
-            expert_scales: MoeExpertScales::Paired {
-                gate_up: expert_slices(&self.gate_up_scales, self.gu_scale_bytes, self.experts),
-                down: expert_slices(&self.down_scales, self.dn_scale_bytes, self.experts),
-            },
-            fused_row_layout: MoeFusedRowLayout::Interleaved,
-            expert_data_format: QuantFormat::MXFP4,
-            router_proj: &self.router_proj,
-            router_bias: &self.router_bias,
-            experts_gate_up_bias: &self.gate_up_bias,
-            experts_down_bias: &self.down_bias,
-            router_scale: &[],
-            router_per_expert_scale: &[],
-            router_norm: &[],
-            router_norm_parameter_free: false,
-            router_input_scalar: 1.0,
-            pre_experts_norm: &self.pre_ffn_norm,
-            post_ffn1_norm: &[],
-            post_experts_norm: &[],
-            num_experts: self.experts,
-            top_k: self.top_k,
-            intermediate_size: self.inter,
-            gate_rule: self.gate_rule,
-        }
-    }
-}
-
-/// Stages this run omits, for marginal-cost profiling.
-///
-/// Every one of these is an operation the plan marks **optional**, so
-/// omitting it exercises a path the lowering already supports rather
-/// than a special diagnostic branch. The numbers are wrong by
-/// construction; the *time difference* is the measurement.
-///
-/// Ablation is used because this hardware supports counter sampling only
-/// at compute-pass boundaries (`AtDispatchBoundary` is false on M3), so
-/// per-dispatch GPU timestamps are unavailable. Splitting stages into
-/// separate encoders to get boundaries would change what can overlap;
-/// ablation leaves the schedule of everything that remains intact.
-#[derive(Clone, Copy, Default)]
-pub struct Ablation {
-    pub no_query_scale: bool,
-    pub no_rope: bool,
-    pub no_qk_norm: bool,
-    pub no_gate: bool,
-    pub no_post_norms: bool,
-}
-
-impl Ablation {
-    fn from_env() -> Self {
-        let on = |k: &str| std::env::var(k).is_ok();
-        Self {
-            no_query_scale: on("LARQL_ABLATE_QUERY_SCALE"),
-            no_rope: on("LARQL_ABLATE_ROPE"),
-            no_qk_norm: on("LARQL_ABLATE_QK_NORM"),
-            no_gate: on("LARQL_ABLATE_GATE"),
-            no_post_norms: on("LARQL_ABLATE_POST_NORMS"),
-        }
-    }
-
-    fn any(&self) -> bool {
-        self.no_query_scale || self.no_rope || self.no_qk_norm || self.no_gate || self.no_post_norms
-    }
-}
-
 /// A plan lowered onto the device, ready to step positions.
 pub struct LoweredSession<'a> {
     gpu: &'a MetalBackend,
@@ -239,140 +116,6 @@ pub struct LoweredSession<'a> {
     position: usize,
     /// Destination for resolved GPU timestamps, when profiling.
     ablate: Ablation,
-}
-
-/// Load one matrix operand as NVFP4 and hand it to the device.
-///
-/// The buffers are keyed on the `AlignedBytes` address, which lives for
-/// the session, so `lowering_weight` caches them and the weight is
-/// uploaded once rather than per position.
-fn resident_matrix(
-    gpu: &MetalBackend,
-    store: &OperandStore,
-    operand: &OperandRef,
-    format: WeightFormat,
-    keep: &mut Vec<LoadedWeight>,
-) -> Result<DeviceMatrix, VindexError> {
-    let rows = operand.shape.first().copied().unwrap_or(0);
-    let cols = operand.shape.get(1).copied().unwrap_or(0);
-    let loaded = load_weight(store, operand, format)?;
-    let m = match &loaded {
-        LoadedWeight::Nvfp4 {
-            packed,
-            scales,
-            tensor_scale,
-        } => DeviceMatrix {
-            packed: gpu.lowering_weight(packed.as_slice()),
-            scales: gpu.lowering_weight(scales.as_slice()),
-            tensor_scale: *tensor_scale,
-            format: WeightFormat::Nvfp4,
-            rows,
-            cols,
-        },
-        LoadedWeight::Mxfp4 { packed, scales } => DeviceMatrix {
-            packed: gpu.lowering_weight(packed.as_slice()),
-            scales: gpu.lowering_weight(scales.as_slice()),
-            tensor_scale: 1.0,
-            format: WeightFormat::Mxfp4,
-            rows,
-            cols,
-        },
-        LoadedWeight::F16(bytes) => DeviceMatrix {
-            packed: gpu.lowering_weight(bytes.as_slice()),
-            scales: gpu.lowering_weight(&[]),
-            tensor_scale: 1.0,
-            format: WeightFormat::F16,
-            rows,
-            cols,
-        },
-        _ => {
-            return Err(VindexError::Parse(format!(
-                "operand `{}`: unsupported lowering format {format:?}",
-                operand.tensor
-            )))
-        }
-    };
-    // The device buffers alias these allocations, so the session owns
-    // them for its lifetime.
-    keep.push(loaded);
-    Ok(m)
-}
-
-/// Upload an optional f32 vector operand (a bias or the sink logits) to
-/// the device, or `None` when the plan carries none.
-fn resident_vector(
-    gpu: &MetalBackend,
-    store: &OperandStore,
-    operand: Option<&OperandRef>,
-) -> Result<Option<DeviceBuffer>, VindexError> {
-    match operand {
-        Some(op) => {
-            let v = store.load(op)?;
-            let buf = gpu
-                .lowering_upload(&v)
-                .ok_or_else(|| VindexError::Parse("vector operand upload failed".into()))?;
-            Ok(Some(buf))
-        }
-        None => Ok(None),
-    }
-}
-
-/// The `inv_freq` map key for a rotary policy — distinct per (theta,
-/// scaled-or-plain) so YaRN and plain rope at the same base never share a
-/// table; `None` for NoPE.
-fn rope_table_key(position: &PositionPolicy) -> Option<u64> {
-    match position {
-        PositionPolicy::Rope { theta } => Some(theta.to_bits()),
-        // Fold the yarn block into the key so two different blocks (or a
-        // block vs plain rope) at one theta get their own tables. The
-        // block's f64 fields hash deterministically.
-        PositionPolicy::Yarn { theta, scaling } => {
-            let mut h = std::collections::hash_map::DefaultHasher::new();
-            use std::hash::{Hash, Hasher};
-            theta.to_bits().hash(&mut h);
-            scaling.factor.to_bits().hash(&mut h);
-            scaling.beta_fast.to_bits().hash(&mut h);
-            scaling.beta_slow.to_bits().hash(&mut h);
-            scaling
-                .original_max_position_embeddings
-                .to_bits()
-                .hash(&mut h);
-            scaling.truncate.hash(&mut h);
-            Some(h.finish() | 1)
-        }
-        PositionPolicy::None => None,
-    }
-}
-
-/// The inverse-frequency table for a rotary policy, matching the
-/// interpreter kernel exactly: plain `theta^(-2i/d)` for rope, the YaRN
-/// ramp for a scaled layer.
-fn rope_inv_freq_table(position: &PositionPolicy, head_dim: usize) -> Vec<f32> {
-    match position {
-        PositionPolicy::Rope { theta } => (0..head_dim / 2)
-            .map(|i| theta.powf(-2.0 * i as f64 / head_dim as f64) as f32)
-            .collect(),
-        PositionPolicy::Yarn { theta, scaling } => {
-            let (inv_freq, _amplitude) =
-                larql_vindex::format::vindex3::opplan::exec::kernels::yarn_frequencies(
-                    scaling, head_dim, *theta,
-                );
-            inv_freq.iter().map(|f| *f as f32).collect()
-        }
-        PositionPolicy::None => Vec::new(),
-    }
-}
-
-fn resident_norm(
-    gpu: &MetalBackend,
-    store: &OperandStore,
-    op: &NormOp,
-) -> Result<(DeviceBuffer, f32, f32), VindexError> {
-    let w = store.load(&op.weight)?;
-    let buf = gpu
-        .lowering_upload(&w)
-        .ok_or_else(|| VindexError::Parse("norm weight upload failed".into()))?;
-    Ok((buf, op.eps as f32, op.weight_offset))
 }
 
 impl<'a> LoweredSession<'a> {
@@ -885,205 +628,6 @@ impl<'a> LoweredSession<'a> {
     }
 }
 
-/// Build a layer's resident FFN: dense matrices, or the routed expert
-/// bank loaded into registered regions with its MoE machinery.
-fn build_ffn(
-    gpu: &MetalBackend,
-    store: &OperandStore,
-    layer: &LayerPlan,
-    formats: WeightFormats,
-    keep: &mut Vec<LoadedWeight>,
-) -> Result<FfnResident, VindexError> {
-    if let Some(op) = layer.ffn.routed() {
-        return Ok(FfnResident::Routed(Box::new(build_routed(
-            gpu, store, layer, op,
-        )?)));
-    }
-    let dense = dense_ffn(layer)?;
-    Ok(FfnResident::Dense {
-        gate: resident_matrix(
-            gpu,
-            store,
-            dense
-                .gate
-                .as_ref()
-                .ok_or_else(|| VindexError::Parse("lowering requires a gated FFN".into()))?,
-            formats.ffn,
-            keep,
-        )?,
-        up: resident_matrix(gpu, store, &dense.up, formats.ffn, keep)?,
-        down: resident_matrix(gpu, store, &dense.down, formats.ffn, keep)?,
-    })
-}
-
-/// Load a routed layer's expert bank into page-aligned, region-registered
-/// buffers and build its MoE scratch + descriptor table. The expert bytes
-/// are bound zero-copy through the same registered-region path the served
-/// `--routed-from` run uses — never copied per token.
-fn build_routed(
-    gpu: &MetalBackend,
-    store: &OperandStore,
-    layer: &LayerPlan,
-    op: &larql_vindex::format::vindex3::opplan::RoutedFfnOp,
-) -> Result<RoutedLayer, VindexError> {
-    use larql_vindex::format::vindex3::opplan::exec::weights::AlignedBytes;
-    // Only the packed-MXFP4 gpt-oss bank lowers today (native experts,
-    // split scales); any other routed shape refuses rather than guess.
-    if op.expert_format != larql_models::ExpertFormat::PackedMxfp4 {
-        return Err(VindexError::Parse(format!(
-            "layer {}: the Metal lowering serves only PackedMxfp4 routed experts, not {:?}",
-            layer.layer, op.expert_format
-        )));
-    }
-    let hidden = op.router.shape.get(1).copied().unwrap_or(0);
-    let experts = op.experts;
-    let inter = op.expert_intermediate_size;
-
-    // Packed blocks and scales into aligned, registered banks.
-    let aligned = |operand: &larql_vindex::format::vindex3::opplan::OperandRef| -> Result<AlignedBytes, VindexError> {
-        let raw = store.load_raw(operand)?;
-        Ok(AlignedBytes::from_bytes(&raw.bytes))
-    };
-    let gate_up_blocks = aligned(&op.gate_up.weights)?;
-    let gate_up_scales = aligned(op.gate_up.scales.as_ref().ok_or_else(|| {
-        VindexError::Parse(format!(
-            "layer {}: routed gate_up carries no scales",
-            layer.layer
-        ))
-    })?)?;
-    let down_blocks = aligned(&op.down.weights)?;
-    let down_scales = aligned(op.down.scales.as_ref().ok_or_else(|| {
-        VindexError::Parse(format!(
-            "layer {}: routed down carries no scales",
-            layer.layer
-        ))
-    })?)?;
-    for (bank, what) in [
-        (&gate_up_blocks, "gate_up blocks"),
-        (&gate_up_scales, "gate_up scales"),
-        (&down_blocks, "down blocks"),
-        (&down_scales, "down scales"),
-    ] {
-        if !gpu.lowering_register_region(bank.as_slice()) {
-            return Err(VindexError::Parse(format!(
-                "layer {}: could not register the routed {what} region (not page-aligned)",
-                layer.layer
-            )));
-        }
-    }
-    let gu_expert_bytes = gate_up_blocks.logical_len() / experts;
-    let gu_scale_bytes = gate_up_scales.logical_len() / experts;
-    let dn_expert_bytes = down_blocks.logical_len() / experts;
-    let dn_scale_bytes = down_scales.logical_len() / experts;
-
-    let f32_or_empty =
-        |o: Option<&larql_vindex::format::vindex3::opplan::OperandRef>| -> Result<Vec<f32>, VindexError> {
-            match o {
-                Some(op) => store.load(op),
-                None => Ok(Vec::new()),
-            }
-        };
-    let router_proj = store.load(&op.router)?;
-    let router_bias = f32_or_empty(op.router_bias.as_ref())?;
-    let gate_up_bias = f32_or_empty(op.gate_up.bias.as_ref())?;
-    let down_bias = f32_or_empty(op.down.bias.as_ref())?;
-    let pre_ffn_norm = store.load(&layer.pre_ffn_norm.weight)?;
-    let gate_rule = larql_compute::MoeGateRule::from_arch(op.gate_policy, op.activation);
-
-    let scratch = larql_compute_metal::MoeScratch::new_public_with_format(
-        gpu,
-        op.top_k,
-        hidden,
-        inter,
-        larql_compute::QuantFormat::MXFP4,
-        hidden,
-    );
-    // Build the descriptor table from a temporary `MoeLayerWeights`
-    // borrowing the freshly-loaded storage, before that storage moves
-    // into `RoutedLayer` — the table keeps only region buffers, no borrow.
-    let table = {
-        use larql_compute::{
-            MoeExpertScales, MoeFusedRowLayout, MoeRoutingPolicy, MoeWeightLayout, QuantFormat,
-        };
-        let moe = larql_compute::MoeLayerWeights {
-            experts_gate_up: expert_slices(&gate_up_blocks, gu_expert_bytes, experts),
-            experts_down: expert_slices(&down_blocks, dn_expert_bytes, experts),
-            routing_policy: MoeRoutingPolicy::top_k_then_softmax(),
-            weight_layout: MoeWeightLayout::unpadded(),
-            expert_scales: MoeExpertScales::Paired {
-                gate_up: expert_slices(&gate_up_scales, gu_scale_bytes, experts),
-                down: expert_slices(&down_scales, dn_scale_bytes, experts),
-            },
-            fused_row_layout: MoeFusedRowLayout::Interleaved,
-            expert_data_format: QuantFormat::MXFP4,
-            router_proj: &router_proj,
-            router_bias: &router_bias,
-            experts_gate_up_bias: &gate_up_bias,
-            experts_down_bias: &down_bias,
-            router_scale: &[],
-            router_per_expert_scale: &[],
-            router_norm: &[],
-            router_norm_parameter_free: false,
-            router_input_scalar: 1.0,
-            pre_experts_norm: &pre_ffn_norm,
-            post_ffn1_norm: &[],
-            post_experts_norm: &[],
-            num_experts: experts,
-            top_k: op.top_k,
-            intermediate_size: inter,
-            gate_rule,
-        };
-        if !gpu.lowering_moe_supported(&moe, &scratch) {
-            return Err(VindexError::Parse(format!(
-                "layer {}: the descriptor MoE path does not support this routed layer \
-                 (format/policy/geometry) — refusing before encode",
-                layer.layer
-            )));
-        }
-        gpu.lowering_moe_descriptor(layer.layer, &moe, inter, hidden)
-            .ok_or_else(|| {
-                VindexError::Parse(format!(
-                    "layer {}: expert operands did not resolve inside their registered regions",
-                    layer.layer
-                ))
-            })?
-    };
-    Ok(RoutedLayer {
-        gate_up_blocks,
-        gate_up_scales,
-        down_blocks,
-        down_scales,
-        router_proj,
-        router_bias,
-        gate_up_bias,
-        down_bias,
-        pre_ffn_norm,
-        gu_expert_bytes,
-        gu_scale_bytes,
-        dn_expert_bytes,
-        dn_scale_bytes,
-        experts,
-        top_k: op.top_k,
-        inter,
-        gate_rule,
-        table,
-        scratch,
-        eps: layer.pre_ffn_norm.eps as f32,
-    })
-}
-
-/// The dense FFN op of a layer the lowering has already admitted (routed
-/// layers are refused in `new`, so this only fails on a plan that changed
-/// under us).
-fn dense_ffn(layer: &LayerPlan) -> Result<&FfnOp, VindexError> {
-    layer.ffn.dense().ok_or_else(|| {
-        VindexError::Parse(format!(
-            "layer {} carries a routed FFN the lowering does not execute (A-9.4)",
-            layer.layer
-        ))
-    })
-}
-
 fn argmax_of(logits: &[f32]) -> u32 {
     logits
         .iter()
@@ -1099,67 +643,6 @@ fn argmax_of(logits: &[f32]) -> u32 {
             },
         )
         .0 as u32
-}
-
-/// Teacher-force `tokens` through the lowering, capturing every layer's
-/// output per position, and write the planes + manifest a `shannon
-/// layer-diff` consumes — byte-compatible with `vindex3 exec --dump-layers`
-/// on the interpreter backends, so the two can be diffed directly.
-fn dump_lowered(
-    session: &mut LoweredSession<'_>,
-    tokens: &[u32],
-    plan: &ComponentOpPlan,
-    container: &std::path::Path,
-    label: &str,
-    dir: &std::path::Path,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use super::super::shannon_trace::dump::{
-        plane_name, LayerDumpManifest, MANIFEST_NAME, PLANE_DTYPE,
-    };
-    let hidden = session.hidden;
-    let num_layers = plan.layers.len();
-    let seq = tokens.len();
-    std::fs::create_dir_all(dir)?;
-    // Row-major [seq, hidden] planes: plane 0 = embeddings, plane i+1 =
-    // layer i's post-FFN-residual hidden.
-    let mut planes: Vec<Vec<f32>> = vec![Vec::with_capacity(seq * hidden); num_layers + 1];
-    for (pos, &token) in tokens.iter().enumerate() {
-        let (_logits, embedding, layers_out) = session.step_capturing(token)?;
-        planes[0].extend_from_slice(&embedding);
-        for (i, row) in layers_out.into_iter().enumerate() {
-            planes[i + 1].extend_from_slice(&row);
-        }
-        eprintln!("captured position {}/{seq}", pos + 1);
-    }
-    let plane_names: Vec<String> = (0..=num_layers).map(plane_name).collect();
-    for (name, data) in plane_names.iter().zip(&planes) {
-        use std::io::Write;
-        let mut f = std::io::BufWriter::new(std::fs::File::create(dir.join(name))?);
-        for v in data {
-            f.write_all(&v.to_le_bytes())?;
-        }
-        f.flush()?;
-    }
-    let manifest = LayerDumpManifest {
-        engine: format!("vindex3-metal-lowered-{label}"),
-        model: container.display().to_string(),
-        num_layers,
-        seq_len: seq,
-        hidden_size: hidden,
-        token_ids: tokens.to_vec(),
-        planes: plane_names,
-        dtype: PLANE_DTYPE.to_string(),
-    };
-    std::fs::write(
-        dir.join(MANIFEST_NAME),
-        serde_json::to_string_pretty(&manifest)?,
-    )?;
-    eprintln!(
-        "wrote {} planes + manifest to {}",
-        num_layers + 1,
-        dir.display()
-    );
-    Ok(())
 }
 
 /// Run the plan through the lowering and report the final position's

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/resident.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/resident.rs
@@ -1,0 +1,186 @@
+//! Resident device operands (matrices, norms, rope tables) and the
+//! ablation flags the lowered session binds — loaded once, held for the
+//! session's lifetime.
+
+use larql_compute_metal::lowering::DeviceBuffer;
+use larql_compute_metal::MetalBackend;
+use larql_models::config::PositionPolicy;
+use larql_vindex::error::VindexError;
+use larql_vindex::format::vindex3::opplan::exec::backend::WeightFormat;
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::weights::{load_weight, LoadedWeight};
+use larql_vindex::format::vindex3::opplan::{NormOp, OperandRef};
+
+use super::DeviceMatrix;
+
+/// Stages this run omits, for marginal-cost profiling.
+///
+/// Every one of these is an operation the plan marks **optional**, so
+/// omitting it exercises a path the lowering already supports rather
+/// than a special diagnostic branch. The numbers are wrong by
+/// construction; the *time difference* is the measurement.
+///
+/// Ablation is used because this hardware supports counter sampling only
+/// at compute-pass boundaries (`AtDispatchBoundary` is false on M3), so
+/// per-dispatch GPU timestamps are unavailable. Splitting stages into
+/// separate encoders to get boundaries would change what can overlap;
+/// ablation leaves the schedule of everything that remains intact.
+#[derive(Clone, Copy, Default)]
+pub(super) struct Ablation {
+    pub no_query_scale: bool,
+    pub no_rope: bool,
+    pub no_qk_norm: bool,
+    pub no_gate: bool,
+    pub no_post_norms: bool,
+}
+
+impl Ablation {
+    pub(super) fn from_env() -> Self {
+        let on = |k: &str| std::env::var(k).is_ok();
+        Self {
+            no_query_scale: on("LARQL_ABLATE_QUERY_SCALE"),
+            no_rope: on("LARQL_ABLATE_ROPE"),
+            no_qk_norm: on("LARQL_ABLATE_QK_NORM"),
+            no_gate: on("LARQL_ABLATE_GATE"),
+            no_post_norms: on("LARQL_ABLATE_POST_NORMS"),
+        }
+    }
+
+    pub(super) fn any(&self) -> bool {
+        self.no_query_scale || self.no_rope || self.no_qk_norm || self.no_gate || self.no_post_norms
+    }
+}
+
+/// Load one matrix operand as NVFP4 and hand it to the device.
+///
+/// The buffers are keyed on the `AlignedBytes` address, which lives for
+/// the session, so `lowering_weight` caches them and the weight is
+/// uploaded once rather than per position.
+pub(super) fn resident_matrix(
+    gpu: &MetalBackend,
+    store: &OperandStore,
+    operand: &OperandRef,
+    format: WeightFormat,
+    keep: &mut Vec<LoadedWeight>,
+) -> Result<DeviceMatrix, VindexError> {
+    let rows = operand.shape.first().copied().unwrap_or(0);
+    let cols = operand.shape.get(1).copied().unwrap_or(0);
+    let loaded = load_weight(store, operand, format)?;
+    let m = match &loaded {
+        LoadedWeight::Nvfp4 {
+            packed,
+            scales,
+            tensor_scale,
+        } => DeviceMatrix {
+            packed: gpu.lowering_weight(packed.as_slice()),
+            scales: gpu.lowering_weight(scales.as_slice()),
+            tensor_scale: *tensor_scale,
+            format: WeightFormat::Nvfp4,
+            rows,
+            cols,
+        },
+        LoadedWeight::Mxfp4 { packed, scales } => DeviceMatrix {
+            packed: gpu.lowering_weight(packed.as_slice()),
+            scales: gpu.lowering_weight(scales.as_slice()),
+            tensor_scale: 1.0,
+            format: WeightFormat::Mxfp4,
+            rows,
+            cols,
+        },
+        LoadedWeight::F16(bytes) => DeviceMatrix {
+            packed: gpu.lowering_weight(bytes.as_slice()),
+            scales: gpu.lowering_weight(&[]),
+            tensor_scale: 1.0,
+            format: WeightFormat::F16,
+            rows,
+            cols,
+        },
+        _ => {
+            return Err(VindexError::Parse(format!(
+                "operand `{}`: unsupported lowering format {format:?}",
+                operand.tensor
+            )))
+        }
+    };
+    // The device buffers alias these allocations, so the session owns
+    // them for its lifetime.
+    keep.push(loaded);
+    Ok(m)
+}
+
+/// Upload an optional f32 vector operand (a bias or the sink logits) to
+/// the device, or `None` when the plan carries none.
+pub(super) fn resident_vector(
+    gpu: &MetalBackend,
+    store: &OperandStore,
+    operand: Option<&OperandRef>,
+) -> Result<Option<DeviceBuffer>, VindexError> {
+    match operand {
+        Some(op) => {
+            let v = store.load(op)?;
+            let buf = gpu
+                .lowering_upload(&v)
+                .ok_or_else(|| VindexError::Parse("vector operand upload failed".into()))?;
+            Ok(Some(buf))
+        }
+        None => Ok(None),
+    }
+}
+
+/// The `inv_freq` map key for a rotary policy — distinct per (theta,
+/// scaled-or-plain) so YaRN and plain rope at the same base never share a
+/// table; `None` for NoPE.
+pub(super) fn rope_table_key(position: &PositionPolicy) -> Option<u64> {
+    match position {
+        PositionPolicy::Rope { theta } => Some(theta.to_bits()),
+        // Fold the yarn block into the key so two different blocks (or a
+        // block vs plain rope) at one theta get their own tables. The
+        // block's f64 fields hash deterministically.
+        PositionPolicy::Yarn { theta, scaling } => {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            use std::hash::{Hash, Hasher};
+            theta.to_bits().hash(&mut h);
+            scaling.factor.to_bits().hash(&mut h);
+            scaling.beta_fast.to_bits().hash(&mut h);
+            scaling.beta_slow.to_bits().hash(&mut h);
+            scaling
+                .original_max_position_embeddings
+                .to_bits()
+                .hash(&mut h);
+            scaling.truncate.hash(&mut h);
+            Some(h.finish() | 1)
+        }
+        PositionPolicy::None => None,
+    }
+}
+
+/// The inverse-frequency table for a rotary policy, matching the
+/// interpreter kernel exactly: plain `theta^(-2i/d)` for rope, the YaRN
+/// ramp for a scaled layer.
+pub(super) fn rope_inv_freq_table(position: &PositionPolicy, head_dim: usize) -> Vec<f32> {
+    match position {
+        PositionPolicy::Rope { theta } => (0..head_dim / 2)
+            .map(|i| theta.powf(-2.0 * i as f64 / head_dim as f64) as f32)
+            .collect(),
+        PositionPolicy::Yarn { theta, scaling } => {
+            let (inv_freq, _amplitude) =
+                larql_vindex::format::vindex3::opplan::exec::kernels::yarn_frequencies(
+                    scaling, head_dim, *theta,
+                );
+            inv_freq.iter().map(|f| *f as f32).collect()
+        }
+        PositionPolicy::None => Vec::new(),
+    }
+}
+
+pub(super) fn resident_norm(
+    gpu: &MetalBackend,
+    store: &OperandStore,
+    op: &NormOp,
+) -> Result<(DeviceBuffer, f32, f32), VindexError> {
+    let w = store.load(&op.weight)?;
+    let buf = gpu
+        .lowering_upload(&w)
+        .ok_or_else(|| VindexError::Parse("norm weight upload failed".into()))?;
+    Ok((buf, op.eps as f32, op.weight_offset))
+}

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/routed.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/routed.rs
@@ -1,0 +1,347 @@
+//! Lowering a routed FFN: the expert bank into page-aligned,
+//! region-registered buffers and the `MoeLayerWeights` the served
+//! descriptor MoE path consumes — routing, layout and format all from
+//! the plan's `RoutedFfnOp`, never a model name.
+
+use larql_compute_metal::MetalBackend;
+use larql_vindex::error::VindexError;
+use larql_vindex::format::vindex3::opplan::exec::backend::WeightFormats;
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::weights::{AlignedBytes, LoadedWeight};
+use larql_vindex::format::vindex3::opplan::{FfnOp, LayerPlan};
+
+use super::resident::resident_matrix;
+use super::DeviceMatrix;
+
+/// A layer's resident FFN: dense gate/up/down matrices, or a routed
+/// expert bank resolved to registered regions plus the served MoE
+/// scratch and descriptor table.
+pub(super) enum FfnResident {
+    Dense {
+        gate: DeviceMatrix,
+        up: DeviceMatrix,
+        down: DeviceMatrix,
+    },
+    Routed(Box<RoutedLayer>),
+}
+
+/// One routed layer's expert bank and MoE machinery, held for the
+/// session: the packed expert bytes in page-aligned, region-registered
+/// buffers (bound zero-copy, never copied per token), the f32 router and
+/// bias operands, the per-layer `MoeScratch`, and the descriptor table.
+pub(super) struct RoutedLayer {
+    gate_up_blocks: AlignedBytes,
+    gate_up_scales: AlignedBytes,
+    down_blocks: AlignedBytes,
+    down_scales: AlignedBytes,
+    router_proj: Vec<f32>,
+    router_bias: Vec<f32>,
+    gate_up_bias: Vec<f32>,
+    down_bias: Vec<f32>,
+    pre_ffn_norm: Vec<f32>,
+    gu_expert_bytes: usize,
+    gu_scale_bytes: usize,
+    dn_expert_bytes: usize,
+    dn_scale_bytes: usize,
+    experts: usize,
+    top_k: usize,
+    inter: usize,
+    gate_rule: larql_compute::MoeGateRule,
+    routing_policy: larql_compute::MoeRoutingPolicy,
+    fused_row_layout: larql_compute::MoeFusedRowLayout,
+    expert_qformat: larql_compute::QuantFormat,
+    pub(super) table: std::sync::Arc<larql_compute_metal::moe_descriptor::MoeExpertDescriptorTable>,
+    pub(super) scratch: larql_compute_metal::MoeScratch,
+    pub(super) eps: f32,
+}
+
+/// The served routing policy for the plan's judged router kind — a
+/// mapping, not a model-name lookup: the routed op carries the kind and
+/// this turns it into the compute-layer policy.
+fn routing_policy(kind: larql_models::MoeRouterKind) -> larql_compute::MoeRoutingPolicy {
+    use larql_compute::MoeRoutingPolicy;
+    match kind {
+        larql_models::MoeRouterKind::TopKSoftmax => MoeRoutingPolicy::top_k_softmax(),
+        larql_models::MoeRouterKind::TopKThenSoftmax => MoeRoutingPolicy::top_k_then_softmax(),
+        larql_models::MoeRouterKind::Gemma4Hybrid => MoeRoutingPolicy::gemma4_hybrid(),
+    }
+}
+
+/// The served fused-row layout for the plan's declared gate/up layout.
+fn fused_row_layout(layout: larql_models::GateUpLayout) -> larql_compute::MoeFusedRowLayout {
+    use larql_compute::MoeFusedRowLayout;
+    match layout {
+        larql_models::GateUpLayout::Interleaved => MoeFusedRowLayout::Interleaved,
+        larql_models::GateUpLayout::ContiguousHalves => MoeFusedRowLayout::ContiguousHalves,
+    }
+}
+
+/// The served quant format for the plan's expert storage format, or
+/// `None` for a format the descriptor MoE path does not serve.
+fn expert_quant_format(format: larql_models::ExpertFormat) -> Option<larql_compute::QuantFormat> {
+    match format {
+        larql_models::ExpertFormat::PackedMxfp4 => Some(larql_compute::QuantFormat::MXFP4),
+        larql_models::ExpertFormat::PackedBF16 | larql_models::ExpertFormat::PerExpert => None,
+    }
+}
+
+/// Per-expert byte slices into a packed bank: expert `e` occupies
+/// `[e*per .. (e+1)*per]` of the bank's logical bytes.
+fn expert_slices(bank: &AlignedBytes, per: usize, experts: usize) -> Vec<&[u8]> {
+    let all = &bank.as_slice()[..per * experts];
+    (0..experts).map(|e| &all[e * per..(e + 1) * per]).collect()
+}
+
+impl RoutedLayer {
+    /// The `MoeLayerWeights` view the served descriptor path consumes,
+    /// assembled from a `RoutedFfnOp` — per-expert slices into the
+    /// registered banks, router/bias from f32 storage, GPT-OSS routing
+    /// and gate semantics from the plan. Rebuilt per step (borrows are
+    /// cheap; no bytes move).
+    pub(super) fn moe(&self) -> larql_compute::MoeLayerWeights<'_> {
+        use larql_compute::{MoeExpertScales, MoeWeightLayout};
+        larql_compute::MoeLayerWeights {
+            experts_gate_up: expert_slices(
+                &self.gate_up_blocks,
+                self.gu_expert_bytes,
+                self.experts,
+            ),
+            experts_down: expert_slices(&self.down_blocks, self.dn_expert_bytes, self.experts),
+            routing_policy: self.routing_policy,
+            weight_layout: MoeWeightLayout::unpadded(),
+            expert_scales: MoeExpertScales::Paired {
+                gate_up: expert_slices(&self.gate_up_scales, self.gu_scale_bytes, self.experts),
+                down: expert_slices(&self.down_scales, self.dn_scale_bytes, self.experts),
+            },
+            fused_row_layout: self.fused_row_layout,
+            expert_data_format: self.expert_qformat,
+            router_proj: &self.router_proj,
+            router_bias: &self.router_bias,
+            experts_gate_up_bias: &self.gate_up_bias,
+            experts_down_bias: &self.down_bias,
+            router_scale: &[],
+            router_per_expert_scale: &[],
+            router_norm: &[],
+            router_norm_parameter_free: false,
+            router_input_scalar: 1.0,
+            pre_experts_norm: &self.pre_ffn_norm,
+            post_ffn1_norm: &[],
+            post_experts_norm: &[],
+            num_experts: self.experts,
+            top_k: self.top_k,
+            intermediate_size: self.inter,
+            gate_rule: self.gate_rule,
+        }
+    }
+}
+
+/// Build a layer's resident FFN: dense matrices, or the routed expert
+/// bank loaded into registered regions with its MoE machinery.
+pub(super) fn build_ffn(
+    gpu: &MetalBackend,
+    store: &OperandStore,
+    layer: &LayerPlan,
+    formats: WeightFormats,
+    keep: &mut Vec<LoadedWeight>,
+) -> Result<FfnResident, VindexError> {
+    if let Some(op) = layer.ffn.routed() {
+        return Ok(FfnResident::Routed(Box::new(build_routed(
+            gpu, store, layer, op,
+        )?)));
+    }
+    let dense = dense_ffn(layer)?;
+    Ok(FfnResident::Dense {
+        gate: resident_matrix(
+            gpu,
+            store,
+            dense
+                .gate
+                .as_ref()
+                .ok_or_else(|| VindexError::Parse("lowering requires a gated FFN".into()))?,
+            formats.ffn,
+            keep,
+        )?,
+        up: resident_matrix(gpu, store, &dense.up, formats.ffn, keep)?,
+        down: resident_matrix(gpu, store, &dense.down, formats.ffn, keep)?,
+    })
+}
+
+/// Load a routed layer's expert bank into page-aligned, region-registered
+/// buffers and build its MoE scratch + descriptor table. The expert bytes
+/// are bound zero-copy through the same registered-region path the served
+/// `--routed-from` run uses — never copied per token.
+fn build_routed(
+    gpu: &MetalBackend,
+    store: &OperandStore,
+    layer: &LayerPlan,
+    op: &larql_vindex::format::vindex3::opplan::RoutedFfnOp,
+) -> Result<RoutedLayer, VindexError> {
+    use larql_vindex::format::vindex3::opplan::exec::weights::AlignedBytes;
+    // Every routing/layout/format fact comes from the plan's RoutedFfnOp,
+    // never a model name. A storage format the descriptor path cannot
+    // serve, or a fused operand with no declared row layout, refuses here
+    // rather than guessing.
+    let expert_qformat = expert_quant_format(op.expert_format).ok_or_else(|| {
+        VindexError::Parse(format!(
+            "layer {}: the descriptor MoE path does not serve expert format {:?}",
+            layer.layer, op.expert_format
+        ))
+    })?;
+    let fused_row_layout = fused_row_layout(op.gate_up_layout.ok_or_else(|| {
+        VindexError::Parse(format!(
+            "layer {}: routed FFN carries no gate_up layout",
+            layer.layer
+        ))
+    })?);
+    let routing_policy = routing_policy(op.router_kind);
+    let hidden = op.router.shape.get(1).copied().unwrap_or(0);
+    let experts = op.experts;
+    let inter = op.expert_intermediate_size;
+
+    // Packed blocks and scales into aligned, registered banks.
+    let aligned = |operand: &larql_vindex::format::vindex3::opplan::OperandRef| -> Result<AlignedBytes, VindexError> {
+        let raw = store.load_raw(operand)?;
+        Ok(AlignedBytes::from_bytes(&raw.bytes))
+    };
+    let gate_up_blocks = aligned(&op.gate_up.weights)?;
+    let gate_up_scales = aligned(op.gate_up.scales.as_ref().ok_or_else(|| {
+        VindexError::Parse(format!(
+            "layer {}: routed gate_up carries no scales",
+            layer.layer
+        ))
+    })?)?;
+    let down_blocks = aligned(&op.down.weights)?;
+    let down_scales = aligned(op.down.scales.as_ref().ok_or_else(|| {
+        VindexError::Parse(format!(
+            "layer {}: routed down carries no scales",
+            layer.layer
+        ))
+    })?)?;
+    for (bank, what) in [
+        (&gate_up_blocks, "gate_up blocks"),
+        (&gate_up_scales, "gate_up scales"),
+        (&down_blocks, "down blocks"),
+        (&down_scales, "down scales"),
+    ] {
+        if !gpu.lowering_register_region(bank.as_slice()) {
+            return Err(VindexError::Parse(format!(
+                "layer {}: could not register the routed {what} region (not page-aligned)",
+                layer.layer
+            )));
+        }
+    }
+    let gu_expert_bytes = gate_up_blocks.logical_len() / experts;
+    let gu_scale_bytes = gate_up_scales.logical_len() / experts;
+    let dn_expert_bytes = down_blocks.logical_len() / experts;
+    let dn_scale_bytes = down_scales.logical_len() / experts;
+
+    let f32_or_empty =
+        |o: Option<&larql_vindex::format::vindex3::opplan::OperandRef>| -> Result<Vec<f32>, VindexError> {
+            match o {
+                Some(op) => store.load(op),
+                None => Ok(Vec::new()),
+            }
+        };
+    let router_proj = store.load(&op.router)?;
+    let router_bias = f32_or_empty(op.router_bias.as_ref())?;
+    let gate_up_bias = f32_or_empty(op.gate_up.bias.as_ref())?;
+    let down_bias = f32_or_empty(op.down.bias.as_ref())?;
+    let pre_ffn_norm = store.load(&layer.pre_ffn_norm.weight)?;
+    let gate_rule = larql_compute::MoeGateRule::from_arch(op.gate_policy, op.activation);
+
+    let scratch = larql_compute_metal::MoeScratch::new_public_with_format(
+        gpu,
+        op.top_k,
+        hidden,
+        inter,
+        expert_qformat,
+        hidden,
+    );
+    // Build the descriptor table from a temporary `MoeLayerWeights`
+    // borrowing the freshly-loaded storage, before that storage moves
+    // into `RoutedLayer` — the table keeps only region buffers, no borrow.
+    let table = {
+        use larql_compute::{
+            MoeExpertScales, MoeFusedRowLayout, MoeRoutingPolicy, MoeWeightLayout, QuantFormat,
+        };
+        let moe = larql_compute::MoeLayerWeights {
+            experts_gate_up: expert_slices(&gate_up_blocks, gu_expert_bytes, experts),
+            experts_down: expert_slices(&down_blocks, dn_expert_bytes, experts),
+            routing_policy: MoeRoutingPolicy::top_k_then_softmax(),
+            weight_layout: MoeWeightLayout::unpadded(),
+            expert_scales: MoeExpertScales::Paired {
+                gate_up: expert_slices(&gate_up_scales, gu_scale_bytes, experts),
+                down: expert_slices(&down_scales, dn_scale_bytes, experts),
+            },
+            fused_row_layout: MoeFusedRowLayout::Interleaved,
+            expert_data_format: QuantFormat::MXFP4,
+            router_proj: &router_proj,
+            router_bias: &router_bias,
+            experts_gate_up_bias: &gate_up_bias,
+            experts_down_bias: &down_bias,
+            router_scale: &[],
+            router_per_expert_scale: &[],
+            router_norm: &[],
+            router_norm_parameter_free: false,
+            router_input_scalar: 1.0,
+            pre_experts_norm: &pre_ffn_norm,
+            post_ffn1_norm: &[],
+            post_experts_norm: &[],
+            num_experts: experts,
+            top_k: op.top_k,
+            intermediate_size: inter,
+            gate_rule,
+        };
+        if !gpu.lowering_moe_supported(&moe, &scratch) {
+            return Err(VindexError::Parse(format!(
+                "layer {}: the descriptor MoE path does not support this routed layer \
+                 (format/policy/geometry) — refusing before encode",
+                layer.layer
+            )));
+        }
+        gpu.lowering_moe_descriptor(layer.layer, &moe, inter, hidden)
+            .ok_or_else(|| {
+                VindexError::Parse(format!(
+                    "layer {}: expert operands did not resolve inside their registered regions",
+                    layer.layer
+                ))
+            })?
+    };
+    Ok(RoutedLayer {
+        gate_up_blocks,
+        gate_up_scales,
+        down_blocks,
+        down_scales,
+        router_proj,
+        router_bias,
+        gate_up_bias,
+        down_bias,
+        pre_ffn_norm,
+        gu_expert_bytes,
+        gu_scale_bytes,
+        dn_expert_bytes,
+        dn_scale_bytes,
+        experts,
+        top_k: op.top_k,
+        inter,
+        gate_rule,
+        routing_policy,
+        fused_row_layout,
+        expert_qformat,
+        table,
+        scratch,
+        eps: layer.pre_ffn_norm.eps as f32,
+    })
+}
+
+/// The dense FFN op of a layer the lowering has already admitted (routed
+/// layers are refused in `new`, so this only fails on a plan that changed
+/// under us).
+fn dense_ffn(layer: &LayerPlan) -> Result<&FfnOp, VindexError> {
+    layer.ffn.dense().ok_or_else(|| {
+        VindexError::Parse(format!(
+            "layer {} carries a routed FFN the lowering does not execute (A-9.4)",
+            layer.layer
+        ))
+    })
+}

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -54,45 +54,45 @@ pub enum ExecBackend {
     Production,
     /// GPU matmuls via `larql-compute-metal` (rung 1: matrix work on
     /// the device, elementwise glue on the CPU).
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     Metal,
     /// Metal with every matrix operand quantised to MXFP4 at load —
     /// the compressed-execution realisation (VINDEX3-Q1). Lossy;
     /// judged by the parity gates, not assumed.
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     MetalMxfp4,
     /// Every matrix operand MXFP4 — the preset Q1's 6-token gate
     /// *falsified*. Kept as the control arm: a Q2 result showing NVFP4
     /// holds the prediction means nothing unless the same harness is
     /// shown to break on the format Q1 broke on.
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     MetalMxfp4All,
     /// VINDEX3-Q2 arm A: every matrix operand NVFP4 — e2m1 elements,
     /// 16-element groups, E4M3 scales. 4.5 bpw everywhere.
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     MetalNvfp4,
     /// Q2 arm B: attention and FFN NVFP4, head f16.
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     MetalNvfp4NoHead,
     /// Q2 arm C: FFN NVFP4 only — Q1's passing partition under the new
     /// scale geometry, so the formats are compared at one class split.
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     MetalNvfp4Ffn,
     /// VINDEX3-G6d: the plan lowered onto GPU-resident execution — the
     /// whole stack and head in one command buffer per token, KV resident,
     /// host out of the dependency chain. All-NVFP4.
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     MetalLowered,
     /// Lowered execution, NVFP4 FFN with attention and head f16 — the
     /// quality end of the Q2 frontier, under identical scheduling.
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     MetalLoweredFfn,
     /// Lowered execution, NVFP4 attention and FFN with an f16 head.
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     MetalLoweredNoHead,
     /// Lowered execution, all-MXFP4 — the format bakeoff arm, so the two
     /// representations are priced under one schedule.
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
     MetalLoweredMxfp4,
 }
 
@@ -235,7 +235,7 @@ pub fn run(cmd: Vindex3Command) -> Result<(), Box<dyn std::error::Error>> {
 
 mod exec;
 mod generate;
-#[cfg(feature = "gpu")]
+#[cfg(all(feature = "gpu", target_os = "macos"))]
 mod lowered;
 mod ops;
 mod optional_op;

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/ops.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/ops.rs
@@ -130,13 +130,31 @@ fn print_layer(component: &str, layer: &LayerPlan) {
         norm(op, "post_attention");
     }
     norm(&layer.pre_ffn_norm, "pre_ffn");
-    let ffn = &layer.ffn;
-    println!(
-        "  {}FFN({:?}, {})",
-        if ffn.gate.is_some() { "Gated" } else { "" },
-        ffn.activation,
-        ffn.intermediate_size
-    );
+    match &layer.ffn {
+        larql_vindex::format::vindex3::opplan::LayerFfn::Dense(ffn) => println!(
+            "  {}FFN({:?}, {})",
+            if ffn.gate.is_some() { "Gated" } else { "" },
+            ffn.activation,
+            ffn.intermediate_size
+        ),
+        larql_vindex::format::vindex3::opplan::LayerFfn::Routed(ffn) => println!(
+            "  RoutedFFN({} experts, top-{}, {:?}, {:?}, {}, {:?}{}) router={}/{}, bank={}",
+            ffn.experts,
+            ffn.top_k,
+            ffn.routing_policy,
+            ffn.gate_policy,
+            ffn.expert_intermediate_size,
+            ffn.expert_format,
+            if ffn.router_bias.is_some() {
+                ", router bias"
+            } else {
+                ""
+            },
+            ffn.router.object,
+            ffn.router.tensor,
+            ffn.gate_up.weights.object,
+        ),
+    }
     if let Some(op) = &layer.post_ffn_norm {
         norm(op, "post_ffn");
     }

--- a/crates/larql-compute-metal/src/lib.rs
+++ b/crates/larql-compute-metal/src/lib.rs
@@ -51,6 +51,7 @@
 // individually cfg-gated rather than nested inside a single `mod
 // platform` block so error messages point at the actual file paths.
 
+#[cfg(target_os = "macos")]
 pub mod async_compute_backend_impl;
 #[cfg(target_os = "macos")]
 pub mod backend;
@@ -60,6 +61,7 @@ pub mod buffers;
 pub mod calibration;
 
 /// Command-buffer completion status (#229 instrumentation).
+#[cfg(target_os = "macos")]
 pub mod cb_status;
 
 #[cfg(target_os = "macos")]
@@ -79,6 +81,7 @@ pub mod ops;
 #[cfg(target_os = "macos")]
 pub mod options;
 /// Router-id bounds guard for the descriptor gather (#229).
+#[cfg(target_os = "macos")]
 pub mod route_guard;
 #[cfg(target_os = "macos")]
 pub mod shaders;

--- a/crates/larql-compute-metal/src/lowering/attention.rs
+++ b/crates/larql-compute-metal/src/lowering/attention.rs
@@ -39,10 +39,26 @@ use crate::MetalBackend;
 /// model-wide default.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LoweredPosition {
-    /// Rotary at this base.
+    /// Rotary at this base, unit amplitude.
     Rope { theta: f64 },
+    /// Rotary at frequencies the caller's `inv_freq` table already
+    /// carries (YaRN's ramped blend), with this amplitude on `cos`/`sin`
+    /// — the part of YaRN that rescales every logit at every position.
+    Scaled { theta: f64, amplitude: f32 },
     /// The layer attends position-agnostically (NoPE).
     None,
+}
+
+impl LoweredPosition {
+    /// The `cos`/`sin` scalar this policy applies; `None` for a layer
+    /// that does not rotate.
+    fn amplitude(self) -> Option<f32> {
+        match self {
+            Self::Rope { .. } => Some(1.0),
+            Self::Scaled { amplitude, .. } => Some(amplitude),
+            Self::None => None,
+        }
+    }
 }
 
 /// Everything attention reads.
@@ -54,6 +70,17 @@ pub struct AttnWeights<'a> {
     /// The judged attention output gate. `None` = no gate op — which is
     /// a different claim from a gate that happens to be near 1.
     pub gate: Option<LoweredMatrix<'a>>,
+    /// Q/K/V/O projection biases (f32), from the plan's operands: added
+    /// right after each projection — before QK-norm/RoPE for Q and K,
+    /// before the cache holds V, after `o` before the residual. `None`
+    /// = the plan carries no bias for that projection.
+    pub q_bias: Option<&'a Buffer>,
+    pub k_bias: Option<&'a Buffer>,
+    pub v_bias: Option<&'a Buffer>,
+    pub o_bias: Option<&'a Buffer>,
+    /// Per-query-head attention-sink logits (f32), when the plan's
+    /// judged sink semantics apply; `None` = ordinary softmax.
+    pub sinks: Option<&'a Buffer>,
     /// Pre-attention norm weight (f32).
     pub norm_weight: &'a Buffer,
     /// The post-attention norm, under four-norm placement. `None` =
@@ -151,11 +178,13 @@ impl MetalBackend {
             shape.norm_eps,
             shape.norm_weight_offset,
         );
-        // 2. projections. K and V land in their cache slots directly.
-        for (p, out, off, n) in [
-            (&w.q, s.q, 0u64, q_rows),
-            (&w.k, s.k_cache, slot, kv_rows),
-            (&w.v, s.v_cache, slot, kv_rows),
+        // 2. projections. K and V land in their cache slots directly;
+        //    a projection's bias joins its output there, before anything
+        //    downstream reads it.
+        for (p, bias, out, off, n) in [
+            (&w.q, w.q_bias, s.q, 0u64, q_rows),
+            (&w.k, w.k_bias, s.k_cache, slot, kv_rows),
+            (&w.v, w.v_bias, s.v_cache, slot, kv_rows),
         ] {
             self.encode_matvec(
                 enc,
@@ -168,6 +197,9 @@ impl MetalBackend {
                     k: shape.hidden,
                 },
             );
+            if let Some(bias) = bias {
+                self.encode_bias_add(enc, out, off, bias, n);
+            }
         }
         if let Some(g) = &w.gate {
             // The gate reads the *attention input* — the same normalised
@@ -213,7 +245,7 @@ impl MetalBackend {
         //    the op is absent and nothing is encoded — not rotation by
         //    a zero angle, which would also be a no-op here but would
         //    be the wrong reason.
-        if let LoweredPosition::Rope { .. } = shape.position {
+        if let Some(amplitude) = shape.position.amplitude() {
             self.encode_rope(
                 enc,
                 s.q,
@@ -222,6 +254,7 @@ impl MetalBackend {
                 shape.head_dim,
                 s.inv_freq,
                 shape.position_index,
+                amplitude,
             );
             self.encode_rope(
                 enc,
@@ -231,10 +264,11 @@ impl MetalBackend {
                 shape.head_dim,
                 s.inv_freq,
                 shape.position_index,
+                amplitude,
             );
         }
         // 6. attention over the cache.
-        self.encode_kv_attention(enc, s, shape);
+        self.encode_kv_attention(enc, s, shape, w.sinks);
         // 7. the judged gate, then the output projection.
         let aggregated = match &w.gate {
             Some(_) => {
@@ -254,6 +288,9 @@ impl MetalBackend {
                 k: q_rows,
             },
         );
+        if let Some(bias) = w.o_bias {
+            self.encode_bias_add(enc, s.attn_out, 0, bias, shape.hidden);
+        }
         // 8. post-attention norm (four-norm placement only), then the
         //    residual — branch output normalised *before* the add.
         self.encode_branch_norm_then_residual(
@@ -291,6 +328,7 @@ impl MetalBackend {
         enc: &ComputeCommandEncoderRef,
         s: &AttnScratch<'_>,
         shape: &AttnShape,
+        sinks: Option<&Buffer>,
     ) {
         use crate::ops::kv_cache::{attention_span, LONG_ATTENTION_SPAN, SHORT_ATTENTION_SPAN};
 
@@ -342,12 +380,21 @@ impl MetalBackend {
         super::set_u32(enc, 7, shape.num_kv_heads as u32);
         super::set_f32(enc, 8, shape.score_scale);
         super::set_u32(enc, 9, window);
-        // No sink logits in this plan. The kernels read slot 10 only when
-        // `has_sinks` is non-zero, but Metal still requires the binding to
-        // exist, so a one-float placeholder goes in — `inv_freq` is a
-        // live buffer of the right kind and is not read by this kernel.
-        enc.set_buffer(10, Some(s.inv_freq), 0);
-        super::set_u32(enc, 11, 0);
+        // Sinks: the plan's per-head logits when the layer carries the
+        // judged semantics. The kernels read slot 10 only when `has_sinks`
+        // is non-zero, but Metal still requires the binding to exist, so
+        // a sink-free layer binds a one-float placeholder — `inv_freq` is
+        // a live buffer of the right kind and is not read by this kernel.
+        match sinks {
+            Some(sinks) => {
+                enc.set_buffer(10, Some(sinks), 0);
+                super::set_u32(enc, 11, 1);
+            }
+            None => {
+                enc.set_buffer(10, Some(s.inv_freq), 0);
+                super::set_u32(enc, 11, 0);
+            }
+        }
         super::set_f32(enc, 12, shape.softcap.unwrap_or(0.0));
         enc.dispatch_thread_groups(
             metal::MTLSize::new(shape.num_q_heads as u64, 1, 1),

--- a/crates/larql-compute-metal/src/lowering/mod.rs
+++ b/crates/larql-compute-metal/src/lowering/mod.rs
@@ -282,6 +282,40 @@ impl MetalBackend {
         self.bufs.get_bytes(bytes)
     }
 
+    /// Register a page-aligned, session-lived byte region so a routed
+    /// FFN's expert operands can be bound zero-copy (the same
+    /// `register_region` the served `--routed-from` path uses). Returns
+    /// `false` if `bytes` is not page-aligned — a lowering that copied
+    /// 10 GB of experts into owned buffers would defeat the point.
+    pub fn lowering_register_region(&self, bytes: &[u8]) -> bool {
+        self.bufs.register_region(bytes)
+    }
+
+    /// Build (or fetch) a routed layer's expert descriptor table from a
+    /// `MoeLayerWeights` whose expert slices lie in registered regions.
+    /// `None` = an operand missed its region or the geometry disagrees —
+    /// the caller must refuse, never fall back.
+    pub fn lowering_moe_descriptor(
+        &self,
+        layer_idx: usize,
+        moe: &larql_compute::MoeLayerWeights<'_>,
+        inter: usize,
+        hidden: usize,
+    ) -> Option<std::sync::Arc<crate::moe_descriptor::MoeExpertDescriptorTable>> {
+        self.descriptor_table_for_layer(layer_idx, moe, inter, hidden)
+    }
+
+    /// Whether the descriptor MoE path can serve this layer — checked
+    /// before encode so a refusal is typed, not a mid-command-buffer
+    /// failure.
+    pub fn lowering_moe_supported(
+        &self,
+        moe: &larql_compute::MoeLayerWeights<'_>,
+        scratch: &crate::MoeScratch,
+    ) -> bool {
+        self.gpu_route_supported(moe, scratch)
+    }
+
     /// A command buffer for a lowered unit of work. Owned by the caller,
     /// which decides how much to encode into it before committing —
     /// the decision this whole rung exists to hand over.

--- a/crates/larql-compute-metal/src/lowering/mod.rs
+++ b/crates/larql-compute-metal/src/lowering/mod.rs
@@ -383,6 +383,7 @@ impl MetalBackend {
         head_dim: usize,
         inv_freq: &Buffer,
         position: usize,
+        amplitude: f32,
     ) {
         let pipeline = &self.attention.rope_at_pos_batched_pipeline;
         enc.set_compute_pipeline_state(pipeline);
@@ -393,14 +394,34 @@ impl MetalBackend {
         // rotary_dim 0 = rotate the whole head, matching `rope_rotate`.
         set_u32(enc, 4, 0);
         set_u32(enc, 5, num_heads as u32);
-        // Amplitude 1.0: a YaRN cos/sin scalar is a judged fact VINDEX3
-        // does not yet carry (see the MOE0 carriage gate), and inventing
-        // one here would be exactly the silent-default shape that gate
-        // exists to catch.
-        set_f32(enc, 6, 1.0);
+        // The cos/sin amplitude — 1.0 for plain rope, YaRN's
+        // `attention_amplitude` for a scaled layer — comes from the plan's
+        // position policy, never invented here (A-9.4).
+        set_f32(enc, 6, amplitude);
         enc.dispatch_thread_groups(
             metal::MTLSize::new((head_dim / 2) as u64, num_heads as u64, 1),
             metal::MTLSize::new(1, 1, 1),
+        );
+    }
+
+    /// Encode `x[off..][i] += bias[i]` over `len` elements — a projection
+    /// bias joining its output in place (the same `bias_add` kernel the
+    /// decode path uses).
+    pub fn encode_bias_add(
+        &self,
+        enc: &ComputeCommandEncoderRef,
+        x: &Buffer,
+        x_offset: u64,
+        bias: &Buffer,
+        len: usize,
+    ) {
+        crate::stages::bias_add::encode(
+            enc,
+            &self.attention.bias_add_pipeline,
+            x,
+            x_offset,
+            bias,
+            len,
         );
     }
 

--- a/crates/larql-compute-metal/src/lowering/stack.rs
+++ b/crates/larql-compute-metal/src/lowering/stack.rs
@@ -44,14 +44,44 @@ use metal::{Buffer, ComputeCommandEncoderRef};
 
 use super::attention::{AttnScratch, AttnShape, AttnWeights};
 use super::ffn::{FfnScratch, FfnShape, FfnWeights};
+use crate::moe_descriptor::MoeExpertDescriptorTable;
+use crate::moe_dispatch::MoeScratch;
 use crate::MetalBackend;
+use larql_compute::MoeLayerWeights;
+
+/// A layer's routed FFN, as the served descriptor MoE path consumes it:
+/// the router (a decoder-stack operand) and the expert bank (its own
+/// object) resolved to registered regions, with the routing/gate
+/// semantics carried on `moe` — the same `MoeLayerWeights` a served
+/// `--routed-from` run builds, but assembled from a `RoutedFfnOp` rather
+/// than a model family. Scratch and the descriptor table are per layer
+/// because the whole stack encodes into one command buffer, so two
+/// layers cannot share output buffers.
+pub struct RoutedFfnLowering<'a> {
+    pub moe: MoeLayerWeights<'a>,
+    pub scratch: &'a MoeScratch,
+    pub table: &'a MoeExpertDescriptorTable,
+    /// Pre-experts norm epsilon (GPT-OSS: the pre-FFN norm's).
+    pub eps: f32,
+}
+
+/// A layer's FFN: dense or routed. The stack encoder runs one or the
+/// other into the same hidden-state slot.
+pub enum LayerFfnLowering<'a> {
+    Dense {
+        weights: FfnWeights<'a>,
+        shape: FfnShape,
+    },
+    /// Boxed: a routed FFN carries a whole `MoeLayerWeights` (per-expert
+    /// slice vectors), several times a dense op's size.
+    Routed(Box<RoutedFfnLowering<'a>>),
+}
 
 /// One layer's complete lowering input.
 pub struct LayerLowering<'a> {
     pub attn: AttnWeights<'a>,
     pub attn_shape: AttnShape,
-    pub ffn: FfnWeights<'a>,
-    pub ffn_shape: FfnShape,
+    pub ffn: LayerFfnLowering<'a>,
     /// This layer's KV cache, `[T, num_kv, head_dim]`. Per layer, and
     /// resident for the whole stack — sharing one across layers would
     /// silently make every layer attend to the last layer's keys.
@@ -143,20 +173,35 @@ impl MetalBackend {
             };
             self.encode_attention(enc, src, mid, &layer.attn, &ascratch, &layer.attn_shape);
 
-            let fscratch = FfnScratch {
-                normed: s.ffn_normed,
-                gate: s.ffn_gate,
-                up: s.ffn_up,
-                act: s.ffn_act,
-                down: s.ffn_down,
+            let hidden = match &layer.ffn {
+                LayerFfnLowering::Dense { weights, shape } => {
+                    let fscratch = FfnScratch {
+                        normed: s.ffn_normed,
+                        gate: s.ffn_gate,
+                        up: s.ffn_up,
+                        act: s.ffn_act,
+                        down: s.ffn_down,
+                    };
+                    self.encode_gated_ffn(enc, mid, dst, weights, &fscratch, shape);
+                    shape.hidden
+                }
+                // The routed FFN reads the post-attention residual (`mid`)
+                // and writes `dst = mid + Σ w·expert` — the same slot the
+                // dense FFN fills, so the stack schedule is unchanged. The
+                // pre-experts norm rides inside the routed encode.
+                LayerFfnLowering::Routed(r) => {
+                    self.encode_moe_layer_gpu_route(
+                        enc, &r.moe, r.scratch, r.table, mid, dst, r.eps,
+                    );
+                    hidden_of(&r.moe)
+                }
             };
-            self.encode_gated_ffn(enc, mid, dst, &layer.ffn, &fscratch, &layer.ffn_shape);
 
             for cp in checkpoints.iter().filter(|c| c.after_layer == index) {
                 // A copy, not a readback: the value lands in a device
                 // buffer the caller reads *after* the stream completes,
                 // so localisation costs no round trip.
-                self.encode_residual_add(enc, dst, dst, cp.into, layer.ffn_shape.hidden, 0.0);
+                self.encode_residual_add(enc, dst, dst, cp.into, hidden, 0.0);
             }
             src = dst;
         }
@@ -170,4 +215,10 @@ impl StackScratch<'_> {
     pub const ATTENTION_BUFFERS: usize = 7;
     /// Buffers the FFN half needs.
     pub const FFN_BUFFERS: usize = 6;
+}
+
+/// Hidden width a routed layer writes — the router projection's input
+/// width (`[num_experts, hidden]`).
+fn hidden_of(moe: &MoeLayerWeights<'_>) -> usize {
+    moe.router_proj.len() / moe.num_experts.max(1)
 }

--- a/crates/larql-compute-metal/tests/lowering_routed_support/mod.rs
+++ b/crates/larql-compute-metal/tests/lowering_routed_support/mod.rs
@@ -1,0 +1,226 @@
+//! Fixture and CPU-reference helpers for
+//! `test_lowering_representations_routed.rs`.
+//!
+//! Everything here is independent of the Metal code under test: the
+//! MXFP4 bytes are produced by a small OCP-rule quantiser and *decoded*
+//! by `larql-models`' own `dequantize_expert`, the f16 arm round-trips
+//! through `larql-models`' half codec, and the MoE reference is written
+//! straight from the served semantics (`moe_route_from_router_input`
+//! for the route, `MoeGateRule::combine` for the gate, biases inside
+//! the expert, weights outside).
+
+#![allow(dead_code)]
+
+use larql_compute::MoeLayerWeights;
+use larql_models::quant::fp4::{f32_to_e2m1, pack_nibbles};
+use larql_models::quant::half::{f16_to_f32, f32_to_f16};
+use larql_models::quant::mxfp4::{
+    dequantize_expert, e8m0_to_f32, FusedHalf, MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS,
+};
+
+/// The Metal buffer cache's page size — `register_region` refuses any
+/// start address that is not a multiple of it. Mirrors the crate's
+/// private `buffers::PAGE_SIZE`.
+pub const REGION_PAGE_BYTES: usize = 16384;
+
+/// e8m0 exponent bias: byte `b` decodes to `2^(b - 127)`.
+const E8M0_BIAS: i32 = 127;
+/// Exponent of e2m1's largest magnitude (6.0 → `floor(log2 6) = 2`).
+const E2M1_EMAX: i32 = 2;
+/// e8m0 byte range that decodes to a finite non-zero scale (0 and 255
+/// are the zero / NaN sentinels).
+const E8M0_MIN_FINITE: i32 = 1;
+const E8M0_MAX_FINITE: i32 = 254;
+
+/// Deterministic pseudo-random floats in roughly `±0.5 * amplitude`.
+pub fn det(n: usize, seed: u32, amplitude: f32) -> Vec<f32> {
+    let mut s = seed.wrapping_mul(2654435761).wrapping_add(17);
+    (0..n)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            ((s as f32 / u32::MAX as f32) - 0.5) * amplitude
+        })
+        .collect()
+}
+
+pub fn rel_rms(a: &[f32], b: &[f32]) -> f64 {
+    assert_eq!(a.len(), b.len());
+    let (mut n, mut d) = (0.0f64, 0.0f64);
+    for (x, y) in a.iter().zip(b) {
+        n += (*x as f64 - *y as f64).powi(2);
+        d += (*x as f64).powi(2);
+    }
+    (n / d).sqrt()
+}
+
+/// `y = x * rsqrt(mean(x²) + eps) * (offset + w)`.
+pub fn rms_norm(x: &[f32], w: &[f32], eps: f32, offset: f32) -> Vec<f32> {
+    let ms = x.iter().map(|v| v * v).sum::<f32>() / x.len() as f32;
+    let inv = 1.0 / (ms + eps).sqrt();
+    x.iter()
+        .zip(w)
+        .map(|(v, wv)| v * inv * (offset + wv))
+        .collect()
+}
+
+/// `out[r] = Σ_c m[r, c] · x[c]`, `m` row-major `[n, k]`.
+pub fn matvec(m: &[f32], x: &[f32], n: usize, k: usize) -> Vec<f32> {
+    (0..n)
+        .map(|r| (0..k).map(|c| m[r * k + c] * x[c]).sum())
+        .collect()
+}
+
+// ── MXFP4 ─────────────────────────────────────────────────────────────
+
+/// One `[rows, k]` matrix in the kernel's split-scale MXFP4 layout:
+/// `packed[(row * groups + g) * 16 ..][..16]` (lo nibble first) and
+/// `scales[row * groups + g]` (e8m0).
+pub struct Mxfp4Matrix {
+    pub packed: Vec<u8>,
+    pub scales: Vec<u8>,
+    pub rows: usize,
+    pub k: usize,
+}
+
+impl Mxfp4Matrix {
+    /// OCP microscaling rule: per 32-group shared scale
+    /// `2^(floor(log2 max|x|) - 2)`, elements to nearest e2m1.
+    pub fn quantize(values: &[f32], rows: usize, k: usize) -> Self {
+        assert_eq!(k % MXFP4_GROUP_ELEMS, 0, "MXFP4 needs k ≡ 0 mod 32");
+        assert_eq!(values.len(), rows * k);
+        let groups = k / MXFP4_GROUP_ELEMS;
+        let mut packed = Vec::with_capacity(rows * groups * MXFP4_GROUP_BYTES);
+        let mut scales = Vec::with_capacity(rows * groups);
+        for row in values.chunks_exact(k) {
+            for group in row.chunks_exact(MXFP4_GROUP_ELEMS) {
+                let max_abs = group.iter().fold(0.0f32, |m, v| m.max(v.abs()));
+                let byte = if max_abs == 0.0 {
+                    0u8
+                } else {
+                    let exponent = max_abs.log2().floor() as i32 - E2M1_EMAX;
+                    (exponent + E8M0_BIAS).clamp(E8M0_MIN_FINITE, E8M0_MAX_FINITE) as u8
+                };
+                let scale = e8m0_to_f32(byte);
+                let inv = if scale == 0.0 { 0.0 } else { scale.recip() };
+                let codes: Vec<u8> = group.iter().map(|v| f32_to_e2m1(v * inv)).collect();
+                packed.extend_from_slice(&pack_nibbles(&codes));
+                scales.push(byte);
+            }
+        }
+        Self {
+            packed,
+            scales,
+            rows,
+            k,
+        }
+    }
+
+    /// The independent decoder's view of these bytes — the reference the
+    /// GPU arm is judged against.
+    pub fn dequantized(&self) -> Vec<f32> {
+        dequantize_expert(
+            &self.packed,
+            &self.scales,
+            self.rows,
+            self.k / MXFP4_GROUP_ELEMS,
+        )
+        .expect("fixture bytes decode")
+    }
+}
+
+/// f16 round-trip of a matrix, and its little-endian f16 bytes.
+pub fn f16_matrix(values: &[f32]) -> (Vec<f32>, Vec<u8>) {
+    let rounded: Vec<f32> = values.iter().map(|v| f16_to_f32(f32_to_f16(*v))).collect();
+    let bytes = rounded
+        .iter()
+        .flat_map(|v| f32_to_f16(*v).to_le_bytes())
+        .collect();
+    (rounded, bytes)
+}
+
+// ── page-aligned regions ─────────────────────────────────────────────
+
+/// A byte region whose logical start is page-aligned, so it can be
+/// registered with the Metal buffer cache and bound zero-copy. Backed by
+/// an over-allocated `Vec` (registration rounds the length up to whole
+/// pages, and `new_buffer_with_bytes_no_copy` must own that tail).
+pub struct AlignedRegion {
+    mem: Vec<u8>,
+    off: usize,
+    len: usize,
+}
+
+impl AlignedRegion {
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut mem = vec![0u8; bytes.len() + 2 * REGION_PAGE_BYTES];
+        let off = mem.as_ptr().align_offset(REGION_PAGE_BYTES);
+        mem[off..off + bytes.len()].copy_from_slice(bytes);
+        Self {
+            mem,
+            off,
+            len: bytes.len(),
+        }
+    }
+    pub fn as_slice(&self) -> &[u8] {
+        &self.mem[self.off..self.off + self.len]
+    }
+    /// A slice starting one byte *past* the aligned start — the same
+    /// allocation, but not a registrable region.
+    pub fn misaligned_slice(&self) -> &[u8] {
+        &self.mem[self.off + 1..self.off + self.len]
+    }
+    /// Expert `e`'s slice of a bank holding equal `per` byte slices.
+    pub fn expert(&self, e: usize, per: usize) -> &[u8] {
+        &self.as_slice()[e * per..(e + 1) * per]
+    }
+}
+
+// ── routed FFN CPU reference ─────────────────────────────────────────
+
+/// One routed layer's dequantised expert bank plus the f32 operands,
+/// as the CPU reference reads them.
+pub struct RoutedRef {
+    /// Per expert, `[2·inter, hidden]` interleaved gate/up rows.
+    pub gate_up: Vec<Vec<f32>>,
+    /// Per expert, `[hidden, inter]`.
+    pub down: Vec<Vec<f32>>,
+    pub hidden: usize,
+    pub inter: usize,
+}
+
+/// `h_post_attn + Σ_k w_k · (down_k · rule(gate_k·x + b, up_k·x + b) + b_down)`
+/// with `x = rms(h_post_attn, pre_experts_norm)`; the route from the
+/// served CPU router. Written from the semantics, not from the encode.
+pub fn routed_ffn_reference(
+    h_post_attn: &[f32],
+    moe: &MoeLayerWeights<'_>,
+    r: &RoutedRef,
+    eps: f32,
+    norm_offset: f32,
+) -> Vec<f32> {
+    let (hidden, inter) = (r.hidden, r.inter);
+    let x = rms_norm(h_post_attn, moe.pre_experts_norm, eps, norm_offset);
+    let (ids, weights) = larql_compute::cpu::ops::moe::moe_route_from_router_input(&x, moe);
+    let mut out = h_post_attn.to_vec();
+    for (&e, &w) in ids.iter().zip(&weights) {
+        let gu = &r.gate_up[e];
+        let gub = &moe.experts_gate_up_bias[e * 2 * inter..(e + 1) * 2 * inter];
+        let act: Vec<f32> = (0..inter)
+            .map(|i| {
+                let (gr, ur) = (FusedHalf::Gate.fused_row(i), FusedHalf::Up.fused_row(i));
+                let g: f32 = (0..hidden).map(|c| gu[gr * hidden + c] * x[c]).sum::<f32>() + gub[gr];
+                let u: f32 = (0..hidden).map(|c| gu[ur * hidden + c] * x[c]).sum::<f32>() + gub[ur];
+                moe.gate_rule.combine(g, u)
+            })
+            .collect();
+        let dn = &r.down[e];
+        let dnb = &moe.experts_down_bias[e * hidden..(e + 1) * hidden];
+        for j in 0..hidden {
+            let y: f32 = (0..inter).map(|i| dn[j * inter + i] * act[i]).sum::<f32>() + dnb[j];
+            out[j] += w * y;
+        }
+    }
+    out
+}

--- a/crates/larql-compute-metal/tests/test_lowering_attention_extras.rs
+++ b/crates/larql-compute-metal/tests/test_lowering_attention_extras.rs
@@ -1,0 +1,518 @@
+//! A-9.4: the lowered attention fragment executes the three GPT-OSS
+//! semantics the interpreter proved — attention **sinks**, **Q/K/V/O
+//! projection biases**, and **YaRN** (scaled inverse frequencies plus a
+//! `cos`/`sin` amplitude) — and each is load-bearing.
+//!
+//! The reference is transcribed from the interpreter's own kernels
+//! (`condition_qk_in_place` biases, `yarn_frequencies`, `softmax_with_sink`),
+//! in f32, consuming the same round-tripped NVFP4 weights the lowering
+//! reads, so quantisation error cannot masquerade as a semantic gap. As in
+//! `test_lowering_attention_parity`, agreement is necessary and not
+//! sufficient: each judged fact carries a control that must dwarf the
+//! parity residual.
+//!
+//! ```text
+//! parity     lowered attention ≡ reference (biases + YaRN + sink)
+//! sink       drop the sink logits              → output moves
+//! bias       drop the Q bias                   → output moves
+//! amplitude  YaRN amplitude → 1.0              → output moves (position 0 too)
+//! frequency  YaRN inv_freq → plain rope        → output moves
+//! ```
+
+#![cfg(target_os = "macos")]
+
+use larql_compute_metal::lowering::attention::{
+    AttnScratch, AttnShape, AttnWeights, LoweredPosition,
+};
+use larql_compute_metal::lowering::LoweredMatrix;
+use larql_models::quant::nvfp4;
+use larql_models::YarnRopeScaling;
+
+const HIDDEN: usize = 256;
+const NUM_Q: usize = 8;
+const NUM_KV: usize = 2;
+const HEAD_DIM: usize = 32;
+const Q_ROWS: usize = NUM_Q * HEAD_DIM;
+const KV_ROWS: usize = NUM_KV * HEAD_DIM;
+const T: usize = 10;
+const POS: usize = T - 1;
+const EPS: f32 = 1e-5;
+const SCORE_SCALE: f32 = 0.176_776_7; // 1/sqrt(32)
+const THETA: f64 = 150_000.0;
+
+fn det(n: usize, seed: u32) -> Vec<f32> {
+    let mut s = seed.wrapping_mul(2_654_435_761).wrapping_add(9);
+    (0..n)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            ((s as f32 / u32::MAX as f32) - 0.5) * 0.5
+        })
+        .collect()
+}
+
+fn rel_rms(reference: &[f32], got: &[f32]) -> f64 {
+    let (mut num, mut den) = (0.0f64, 0.0f64);
+    for (a, b) in reference.iter().zip(got) {
+        num += (*a as f64 - *b as f64).powi(2);
+        den += (*a as f64).powi(2);
+    }
+    (num / den).sqrt()
+}
+
+/// GPT-OSS's published YaRN block.
+fn yarn() -> YarnRopeScaling {
+    YarnRopeScaling {
+        factor: 32.0,
+        beta_fast: 32.0,
+        beta_slow: 1.0,
+        original_max_position_embeddings: 4096.0,
+        truncate: false,
+        mscale: None,
+        mscale_all_dim: None,
+    }
+}
+
+/// YaRN inverse frequencies and amplitude, transcribed from HF's
+/// `_compute_yarn_parameters` (the same maths the interpreter's
+/// `kernels::yarn_frequencies` and the lowering both use). Independent
+/// here so the test does not depend on the vindex crate.
+fn yarn_inv_freq(scaling: &YarnRopeScaling) -> (Vec<f64>, f32) {
+    let d = HEAD_DIM as f64;
+    let correction_dim = |rot: f64| {
+        (d * (scaling.original_max_position_embeddings / (rot * std::f64::consts::TAU)).ln())
+            / (2.0 * THETA.ln())
+    };
+    let mut low = correction_dim(scaling.beta_fast);
+    let mut high = correction_dim(scaling.beta_slow);
+    if scaling.truncate {
+        low = low.floor();
+        high = high.ceil();
+    }
+    let low = low.max(0.0);
+    let high = high.min(d - 1.0);
+    let high = if high == low { high + 0.001 } else { high };
+    let inv_freq = (0..HEAD_DIM / 2)
+        .map(|i| {
+            let extrap = THETA.powf(-2.0 * i as f64 / d);
+            let ramp = ((i as f64 - low) / (high - low)).clamp(0.0, 1.0);
+            extrap / scaling.factor * ramp + extrap * (1.0 - ramp)
+        })
+        .collect();
+    (inv_freq, scaling.attention_amplitude() as f32)
+}
+
+fn plain_inv_freq() -> Vec<f64> {
+    (0..HEAD_DIM / 2)
+        .map(|i| THETA.powf(-2.0 * i as f64 / HEAD_DIM as f64))
+        .collect()
+}
+
+fn matvec(m: &[f32], x: &[f32], n: usize, k: usize) -> Vec<f32> {
+    (0..n)
+        .map(|r| (0..k).map(|c| m[r * k + c] * x[c]).sum())
+        .collect()
+}
+
+fn rope_scaled(v: &mut [f32], heads: usize, pos: usize, inv_freq: &[f64], amplitude: f32) {
+    let half = HEAD_DIM / 2;
+    for h in 0..heads {
+        let off = h * HEAD_DIM;
+        for i in 0..half {
+            let a = pos as f64 * inv_freq[i];
+            let s = a.sin() as f32 * amplitude;
+            let c = a.cos() as f32 * amplitude;
+            let (x0, x1) = (v[off + i], v[off + half + i]);
+            v[off + i] = x0 * c - x1 * s;
+            v[off + half + i] = x0 * s + x1 * c;
+        }
+    }
+}
+
+struct Extras {
+    sink: bool,
+    q_bias: bool,
+    inv_freq: Vec<f64>,
+    amplitude: f32,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cpu_reference(
+    h: &[f32],
+    norm_w: &[f32],
+    wq: &[f32],
+    wk: &[f32],
+    wv: &[f32],
+    wo: &[f32],
+    qb: &[f32],
+    kb: &[f32],
+    vb: &[f32],
+    ob: &[f32],
+    sinks: &[f32],
+    k_cache: &[f32],
+    v_cache: &[f32],
+    e: &Extras,
+) -> Vec<f32> {
+    let ms = h.iter().map(|v| v * v).sum::<f32>() / HIDDEN as f32;
+    let inv = 1.0 / (ms + EPS).sqrt();
+    let normed: Vec<f32> = h.iter().zip(norm_w).map(|(x, w)| x * inv * w).collect();
+
+    let mut q = matvec(wq, &normed, Q_ROWS, HIDDEN);
+    let mut k = matvec(wk, &normed, KV_ROWS, HIDDEN);
+    let mut v = matvec(wv, &normed, KV_ROWS, HIDDEN);
+    // Biases join the projections before anything reads them.
+    if e.q_bias {
+        for (x, b) in q.iter_mut().zip(qb) {
+            *x += b;
+        }
+    }
+    for (x, b) in k.iter_mut().zip(kb) {
+        *x += b;
+    }
+    for (x, b) in v.iter_mut().zip(vb) {
+        *x += b;
+    }
+
+    rope_scaled(&mut q, NUM_Q, POS, &e.inv_freq, e.amplitude);
+    rope_scaled(&mut k, NUM_KV, POS, &e.inv_freq, e.amplitude);
+
+    let mut kc = k_cache.to_vec();
+    let mut vc = v_cache.to_vec();
+    kc[POS * KV_ROWS..(POS + 1) * KV_ROWS].copy_from_slice(&k);
+    vc[POS * KV_ROWS..(POS + 1) * KV_ROWS].copy_from_slice(&v);
+
+    let mut concat = vec![0.0f32; Q_ROWS];
+    let group = NUM_Q / NUM_KV;
+    for head in 0..NUM_Q {
+        let kv = head / group;
+        let qh = &q[head * HEAD_DIM..(head + 1) * HEAD_DIM];
+        let mut scores = Vec::with_capacity(T);
+        for t in 0..T {
+            let kh = &kc[t * KV_ROWS + kv * HEAD_DIM..t * KV_ROWS + (kv + 1) * HEAD_DIM];
+            scores.push(qh.iter().zip(kh).map(|(a, b)| a * b).sum::<f32>() * SCORE_SCALE);
+        }
+        let mut m = scores.iter().cloned().fold(f32::MIN, f32::max);
+        if e.sink {
+            m = m.max(sinks[head]);
+        }
+        let exps: Vec<f32> = scores.iter().map(|s| (s - m).exp()).collect();
+        let mut denom: f32 = exps.iter().sum();
+        if e.sink {
+            denom += (sinks[head] - m).exp();
+        }
+        for d in 0..HEAD_DIM {
+            let mut acc = 0.0f32;
+            for (i, vt) in (0..T).enumerate() {
+                acc += exps[i] / denom * vc[vt * KV_ROWS + kv * HEAD_DIM + d];
+            }
+            concat[head * HEAD_DIM + d] = acc;
+        }
+    }
+
+    let mut out = matvec(wo, &concat, HIDDEN, Q_ROWS);
+    for (x, b) in out.iter_mut().zip(ob) {
+        *x += b;
+    }
+    h.iter().zip(&out).map(|(a, b)| a + b).collect()
+}
+
+struct Fixture {
+    h: Vec<f32>,
+    norm_w: Vec<f32>,
+    k_cache: Vec<f32>,
+    v_cache: Vec<f32>,
+    qb: Vec<f32>,
+    kb: Vec<f32>,
+    vb: Vec<f32>,
+    ob: Vec<f32>,
+    sinks: Vec<f32>,
+    q: nvfp4::Nvfp4Matrix,
+    k: nvfp4::Nvfp4Matrix,
+    v: nvfp4::Nvfp4Matrix,
+    o: nvfp4::Nvfp4Matrix,
+    #[allow(dead_code)]
+    qq: Vec<f32>,
+    kq: Vec<f32>,
+    vq: Vec<f32>,
+    oq: Vec<f32>,
+}
+
+fn fixture() -> Fixture {
+    let qf = det(Q_ROWS * HIDDEN, 1);
+    let kf = det(KV_ROWS * HIDDEN, 2);
+    let vf = det(KV_ROWS * HIDDEN, 3);
+    let of = det(HIDDEN * Q_ROWS, 4);
+    Fixture {
+        h: det(HIDDEN, 5),
+        // Norm weight near 1 (this fixture folds no offset in).
+        norm_w: det(HIDDEN, 6).iter().map(|w| 1.0 + w).collect(),
+        k_cache: det(T * KV_ROWS, 8),
+        v_cache: det(T * KV_ROWS, 9),
+        qb: det(Q_ROWS, 10).iter().map(|x| x * 4.0).collect(),
+        kb: det(KV_ROWS, 11).iter().map(|x| x * 4.0).collect(),
+        vb: det(KV_ROWS, 12).iter().map(|x| x * 4.0).collect(),
+        ob: det(HIDDEN, 13).iter().map(|x| x * 4.0).collect(),
+        sinks: det(NUM_Q, 14).iter().map(|x| x * 4.0).collect(),
+        q: nvfp4::quantize(&qf, Q_ROWS, HIDDEN).unwrap(),
+        k: nvfp4::quantize(&kf, KV_ROWS, HIDDEN).unwrap(),
+        v: nvfp4::quantize(&vf, KV_ROWS, HIDDEN).unwrap(),
+        o: nvfp4::quantize(&of, HIDDEN, Q_ROWS).unwrap(),
+        qq: nvfp4::round_trip(&qf, Q_ROWS, HIDDEN).unwrap(),
+        kq: nvfp4::round_trip(&kf, KV_ROWS, HIDDEN).unwrap(),
+        vq: nvfp4::round_trip(&vf, KV_ROWS, HIDDEN).unwrap(),
+        oq: nvfp4::round_trip(&of, HIDDEN, Q_ROWS).unwrap(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_lowered(
+    gpu: &larql_compute_metal::MetalBackend,
+    f: &Fixture,
+    inv_freq: &[f64],
+    amplitude: f32,
+    with_sink: bool,
+    with_q_bias: bool,
+) -> Vec<f32> {
+    let h_in = gpu.lowering_upload(&f.h).unwrap();
+    let norm_buf = gpu.lowering_upload(&f.norm_w).unwrap();
+    let k_cache = gpu.lowering_upload(&f.k_cache).unwrap();
+    let v_cache = gpu.lowering_upload(&f.v_cache).unwrap();
+    let inv_freq_f32: Vec<f32> = inv_freq.iter().map(|x| *x as f32).collect();
+    let inv_freq_buf = gpu.lowering_upload(&inv_freq_f32).unwrap();
+    let qb = gpu.lowering_upload(&f.qb).unwrap();
+    let kb = gpu.lowering_upload(&f.kb).unwrap();
+    let vb = gpu.lowering_upload(&f.vb).unwrap();
+    let ob = gpu.lowering_upload(&f.ob).unwrap();
+    let sinks = gpu.lowering_upload(&f.sinks).unwrap();
+    let h_out = gpu.lowering_scratch(HIDDEN);
+    let normed = gpu.lowering_scratch(HIDDEN);
+    let q = gpu.lowering_scratch(Q_ROWS);
+    let gate = gpu.lowering_scratch(Q_ROWS);
+    let concat = gpu.lowering_scratch(Q_ROWS);
+    let gated = gpu.lowering_scratch(Q_ROWS);
+    let attn_out = gpu.lowering_scratch(HIDDEN);
+
+    let proj = |m: &nvfp4::Nvfp4Matrix| LoweredMatrix::Nvfp4 {
+        packed: Box::leak(Box::new(gpu.lowering_weight(&m.packed))),
+        scales: Box::leak(Box::new(gpu.lowering_weight(&m.scales))),
+        tensor_scale: m.tensor_scale,
+    };
+    let w = AttnWeights {
+        q: proj(&f.q),
+        k: proj(&f.k),
+        v: proj(&f.v),
+        o: proj(&f.o),
+        gate: None,
+        q_bias: with_q_bias.then_some(&qb),
+        k_bias: Some(&kb),
+        v_bias: Some(&vb),
+        o_bias: Some(&ob),
+        sinks: with_sink.then_some(&sinks),
+        norm_weight: &norm_buf,
+        post_norm: None,
+    };
+    let s = AttnScratch {
+        normed: &normed,
+        q: &q,
+        k_cache: &k_cache,
+        v_cache: &v_cache,
+        gate: &gate,
+        concat: &concat,
+        gated: &gated,
+        attn_out: &attn_out,
+        inv_freq: &inv_freq_buf,
+    };
+    let shape = AttnShape {
+        hidden: HIDDEN,
+        num_q_heads: NUM_Q,
+        num_kv_heads: NUM_KV,
+        head_dim: HEAD_DIM,
+        norm_eps: EPS,
+        norm_weight_offset: 0.0,
+        qk_norm_eps: EPS,
+        parameter_free_q: false,
+        parameter_free_k: false,
+        query_scale: None,
+        score_scale: SCORE_SCALE,
+        position: LoweredPosition::Scaled {
+            theta: THETA,
+            amplitude,
+        },
+        window: None,
+        softcap: None,
+        position_index: POS,
+        kv_len: T,
+    };
+
+    let cmd = gpu.new_lowering_command_buffer();
+    let enc = cmd.new_compute_command_encoder();
+    gpu.encode_attention(enc, &h_in, &h_out, &w, &s, &shape);
+    enc.end_encoding();
+    cmd.commit();
+    cmd.wait_until_completed();
+    let out = gpu.lowering_readback(&h_out, HIDDEN).unwrap();
+    for b in [
+        h_in,
+        norm_buf,
+        k_cache,
+        v_cache,
+        inv_freq_buf,
+        qb,
+        kb,
+        vb,
+        ob,
+        sinks,
+        h_out,
+        normed,
+        q,
+        gate,
+        concat,
+        gated,
+        attn_out,
+    ] {
+        gpu.recycle_lowering_scratch(b);
+    }
+    out
+}
+
+fn assert_control(what: &str, parity: f64, moved: f64) {
+    assert!(
+        moved > parity * 20.0,
+        "control `{what}` moved the result only {:.1}x the parity residual — the lowering \
+         is not executing it (parity {parity:.3e}, moved {moved:.3e})",
+        moved / parity,
+    );
+}
+
+#[test]
+fn lowered_attention_executes_sinks_biases_and_yarn() {
+    let gpu = larql_compute_metal::MetalBackend::new().expect("metal");
+    let f = fixture();
+    let (yarn_if, amp) = yarn_inv_freq(&yarn());
+    assert!(
+        amp > 1.3,
+        "gpt-oss YaRN amplitude should be ~1.35, got {amp}"
+    );
+
+    let full = Extras {
+        sink: true,
+        q_bias: true,
+        inv_freq: yarn_if.clone(),
+        amplitude: amp,
+    };
+    let reference = cpu_reference(
+        &f.h, &f.norm_w, &f.qq, &f.kq, &f.vq, &f.oq, &f.qb, &f.kb, &f.vb, &f.ob, &f.sinks,
+        &f.k_cache, &f.v_cache, &full,
+    );
+    let got = run_lowered(&gpu, &f, &yarn_if, amp, true, true);
+    assert!(got.iter().all(|v| v.is_finite()));
+    let parity = rel_rms(&reference, &got);
+    assert!(parity < 1e-4, "lowered attention disagrees: {parity:.3e}");
+
+    // Control: no sink — the softmax mass the sink held returns to the keys.
+    let no_sink = cpu_reference(
+        &f.h,
+        &f.norm_w,
+        &f.qq,
+        &f.kq,
+        &f.vq,
+        &f.oq,
+        &f.qb,
+        &f.kb,
+        &f.vb,
+        &f.ob,
+        &f.sinks,
+        &f.k_cache,
+        &f.v_cache,
+        &Extras {
+            sink: false,
+            ..full_like(&full)
+        },
+    );
+    assert_control("attention sink applied", parity, rel_rms(&no_sink, &got));
+
+    // Control: no Q bias.
+    let no_qbias = cpu_reference(
+        &f.h,
+        &f.norm_w,
+        &f.qq,
+        &f.kq,
+        &f.vq,
+        &f.oq,
+        &f.qb,
+        &f.kb,
+        &f.vb,
+        &f.ob,
+        &f.sinks,
+        &f.k_cache,
+        &f.v_cache,
+        &Extras {
+            q_bias: false,
+            ..full_like(&full)
+        },
+    );
+    assert_control(
+        "Q projection bias applied",
+        parity,
+        rel_rms(&no_qbias, &got),
+    );
+
+    // Control: amplitude 1.0 — the YaRN cos/sin scalar is executed.
+    let no_amp = cpu_reference(
+        &f.h,
+        &f.norm_w,
+        &f.qq,
+        &f.kq,
+        &f.vq,
+        &f.oq,
+        &f.qb,
+        &f.kb,
+        &f.vb,
+        &f.ob,
+        &f.sinks,
+        &f.k_cache,
+        &f.v_cache,
+        &Extras {
+            amplitude: 1.0,
+            ..full_like(&full)
+        },
+    );
+    assert_control("YaRN amplitude applied", parity, rel_rms(&no_amp, &got));
+
+    // Control: plain rope frequencies — the ramped blend is executed.
+    let plain = cpu_reference(
+        &f.h,
+        &f.norm_w,
+        &f.qq,
+        &f.kq,
+        &f.vq,
+        &f.oq,
+        &f.qb,
+        &f.kb,
+        &f.vb,
+        &f.ob,
+        &f.sinks,
+        &f.k_cache,
+        &f.v_cache,
+        &Extras {
+            inv_freq: plain_inv_freq(),
+            ..full_like(&full)
+        },
+    );
+    assert_control("YaRN frequency ramp applied", parity, rel_rms(&plain, &got));
+
+    // And the lowering built from the plain table disagrees with the YaRN
+    // run — the device path reads the table it is given, not a default.
+    let got_plain = run_lowered(&gpu, &f, &plain_inv_freq(), amp, true, true);
+    assert!(rel_rms(&got_plain, &got) > parity * 20.0);
+}
+
+fn full_like(e: &Extras) -> Extras {
+    Extras {
+        sink: e.sink,
+        q_bias: e.q_bias,
+        inv_freq: e.inv_freq.clone(),
+        amplitude: e.amplitude,
+    }
+}

--- a/crates/larql-compute-metal/tests/test_lowering_attention_parity.rs
+++ b/crates/larql-compute-metal/tests/test_lowering_attention_parity.rs
@@ -329,6 +329,11 @@ fn run_lowered(
         v: proj(&f.v),
         o: proj(&f.o),
         gate: with_gate.then(|| proj(&f.g)),
+        q_bias: None,
+        k_bias: None,
+        v_bias: None,
+        o_bias: None,
+        sinks: None,
         norm_weight: &norm_buf,
         post_norm: post_buf
             .as_ref()

--- a/crates/larql-compute-metal/tests/test_lowering_kv_evolution.rs
+++ b/crates/larql-compute-metal/tests/test_lowering_kv_evolution.rs
@@ -417,35 +417,37 @@ fn step(d: &Device<'_>, ws: &[LayerW], h0: &[f32], t: usize, share: bool) -> Vec
                     position_index: t,
                     kv_len: t + 1,
                 },
-                ffn: FfnWeights {
-                    gate: LoweredMatrix::Nvfp4 {
-                        packed: &d.keep[b + 10],
-                        scales: &d.keep[b + 11],
-                        tensor_scale: w.fg.tensor_scale,
+                ffn: larql_compute_metal::lowering::stack::LayerFfnLowering::Dense {
+                    weights: FfnWeights {
+                        gate: LoweredMatrix::Nvfp4 {
+                            packed: &d.keep[b + 10],
+                            scales: &d.keep[b + 11],
+                            tensor_scale: w.fg.tensor_scale,
+                        },
+                        up: LoweredMatrix::Nvfp4 {
+                            packed: &d.keep[b + 12],
+                            scales: &d.keep[b + 13],
+                            tensor_scale: w.fu.tensor_scale,
+                        },
+                        down: LoweredMatrix::Nvfp4 {
+                            packed: &d.keep[b + 14],
+                            scales: &d.keep[b + 15],
+                            tensor_scale: w.fd.tensor_scale,
+                        },
+                        norm_weight: &d.norms[l][2],
+                        post_norm: Some(PostNorm {
+                            weight: &d.norms[l][3],
+                            eps: POST_EPS,
+                            weight_offset: OFFSET,
+                            scratch: &d.post_f,
+                        }),
                     },
-                    up: LoweredMatrix::Nvfp4 {
-                        packed: &d.keep[b + 12],
-                        scales: &d.keep[b + 13],
-                        tensor_scale: w.fu.tensor_scale,
+                    shape: FfnShape {
+                        hidden: HIDDEN,
+                        intermediate: INTER,
+                        norm_eps: EPS,
+                        norm_weight_offset: OFFSET,
                     },
-                    down: LoweredMatrix::Nvfp4 {
-                        packed: &d.keep[b + 14],
-                        scales: &d.keep[b + 15],
-                        tensor_scale: w.fd.tensor_scale,
-                    },
-                    norm_weight: &d.norms[l][2],
-                    post_norm: Some(PostNorm {
-                        weight: &d.norms[l][3],
-                        eps: POST_EPS,
-                        weight_offset: OFFSET,
-                        scratch: &d.post_f,
-                    }),
-                },
-                ffn_shape: FfnShape {
-                    hidden: HIDDEN,
-                    intermediate: INTER,
-                    norm_eps: EPS,
-                    norm_weight_offset: OFFSET,
                 },
                 k_cache: &d.kv[ci].0,
                 v_cache: &d.kv[ci].1,

--- a/crates/larql-compute-metal/tests/test_lowering_kv_evolution.rs
+++ b/crates/larql-compute-metal/tests/test_lowering_kv_evolution.rs
@@ -382,6 +382,11 @@ fn step(d: &Device<'_>, ws: &[LayerW], h0: &[f32], t: usize, share: bool) -> Vec
                     v: pr(4, w.v.tensor_scale),
                     o: pr(6, w.o.tensor_scale),
                     gate: Some(pr(8, w.g.tensor_scale)),
+                    q_bias: None,
+                    k_bias: None,
+                    v_bias: None,
+                    o_bias: None,
+                    sinks: None,
                     norm_weight: &d.norms[l][0],
                     post_norm: Some(PostNorm {
                         weight: &d.norms[l][1],

--- a/crates/larql-compute-metal/tests/test_lowering_layer_parity.rs
+++ b/crates/larql-compute-metal/tests/test_lowering_layer_parity.rs
@@ -420,6 +420,11 @@ fn run_lowered(
         v: proj(&f.v),
         o: proj(&f.o),
         gate: Some(proj(&f.g)),
+        q_bias: None,
+        k_bias: None,
+        v_bias: None,
+        o_bias: None,
+        sinks: None,
         norm_weight: &attn_norm_buf,
         post_norm: Some(larql_compute_metal::lowering::PostNorm {
             weight: &attn_post_buf,

--- a/crates/larql-compute-metal/tests/test_lowering_representations_routed.rs
+++ b/crates/larql-compute-metal/tests/test_lowering_representations_routed.rs
@@ -1,0 +1,670 @@
+//! The lowering's representation dispatch and its routed-FFN seam,
+//! isolated from the CLI (A-9): the arms `larql vindex3 exec
+//! --backend metal-lowered` exercises on gpt-oss-20b, on a synthetic
+//! fixture small enough to judge against a CPU reference.
+//!
+//! | proof | what it establishes |
+//! |---|---|
+//! | matvec arms | `encode_matvec` selects the F16 and MXFP4 kernels, each at parity with its own decoded reference, and the two arms are distinguishable |
+//! | region registration | page-aligned bytes register; a misaligned view of the same allocation refuses |
+//! | routed stack | a two-layer stack with routed FFNs, hidden state resident and ping-ponging through both scratch slots, checkpoints at parity with the CPU reference; the expert bytes are live |
+//! | descriptor refusal | operands outside a registered region yield `None`, never a fallback |
+//!
+//! ## Why the fixture is small and awkward
+//!
+//! MXFP4 fixes `k ≡ 0 mod 32`; everything else is chosen to leave the
+//! kernels' tiling non-trivial (matvec rows not a multiple of the
+//! rows-per-threadgroup, four experts of which two are routed, two
+//! layers so the ping-pong buffers actually alternate). The stack is
+//! entered with `h_in = h_a` on purpose: that is the branch of the
+//! ping-pong that a stack entered from a foreign upload never takes.
+
+#![cfg(target_os = "macos")]
+
+#[path = "lowering_routed_support/mod.rs"]
+mod support;
+
+use larql_compute::{
+    MoeExpertScales, MoeFusedRowLayout, MoeGateRule, MoeLayerWeights, MoeRoutingPolicy,
+    MoeWeightLayout, QuantFormat,
+};
+use larql_compute_metal::lowering::attention::{AttnShape, AttnWeights, LoweredPosition};
+use larql_compute_metal::lowering::stack::{
+    Checkpoint, LayerFfnLowering, LayerLowering, RoutedFfnLowering, StackScratch,
+};
+use larql_compute_metal::lowering::{LoweredMatrix, MatvecTarget};
+use larql_compute_metal::moe_descriptor::MoeExpertDescriptorTable;
+use larql_compute_metal::{MetalBackend, MoeScratch};
+use larql_models::quant::mxfp4::{MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS};
+use support::{
+    det, f16_matrix, matvec, rel_rms, rms_norm, routed_ffn_reference, AlignedRegion, Mxfp4Matrix,
+    RoutedRef,
+};
+
+// ── geometry ─────────────────────────────────────────────────────────
+
+const HIDDEN: usize = 64;
+const INTER: usize = 64;
+const NUM_EXPERTS: usize = 4;
+const TOP_K: usize = 2;
+const LAYERS: usize = 2;
+const NUM_Q: usize = 2;
+const NUM_KV: usize = 1;
+const HEAD_DIM: usize = 32;
+const Q_ROWS: usize = NUM_Q * HEAD_DIM;
+const KV_ROWS: usize = NUM_KV * HEAD_DIM;
+/// Cache length including the decoded position.
+const T: usize = 4;
+const POS: usize = T - 1;
+/// Matvec rows for the arm test — deliberately not a multiple of the
+/// kernels' rows-per-threadgroup, so the tail tile is exercised.
+const MATVEC_ROWS: usize = 50;
+const MATVEC_K: usize = 2 * MXFP4_GROUP_ELEMS;
+
+// ── semantics (gpt-oss shaped) ───────────────────────────────────────
+
+const EPS: f32 = 1e-5;
+/// gpt-oss norms multiply by the raw weight (no centred `1 + w`).
+const NORM_OFFSET: f32 = 0.0;
+const GATE_RULE: MoeGateRule = MoeGateRule::ClampedGlu {
+    limit: 7.0,
+    alpha: 1.702,
+};
+const WEIGHT_AMPLITUDE: f32 = 0.35;
+const BIAS_AMPLITUDE: f32 = 0.2;
+const HIDDEN_AMPLITUDE: f32 = 1.0;
+/// Norm weights sit near one so the routed layer's activations stay in
+/// range for a 4-bit expert.
+const NORM_WEIGHT_AMPLITUDE: f32 = 0.2;
+
+// ── tolerances ───────────────────────────────────────────────────────
+
+/// Both matvec arms are exact-grid references (f16 round-trip / MXFP4
+/// decode); the only slack is f32 reassociation on the GPU.
+const MATVEC_PARITY: f64 = 1e-4;
+/// The two representations of one matrix must be *distinguishable*, or
+/// the arm test could pass with either kernel bound to either variant.
+/// 4-bit noise on a dense product is far above this.
+const ARM_DISTINCTION_MIN: f64 = 1e-2;
+/// Two composed layers, gpt-oss routing, f32 both sides.
+const LAYER_PARITY: f64 = 1e-3;
+/// A perturbed expert must move the checkpoint by well over the parity
+/// bar, or the parity gate is blind to the expert bytes.
+const CONTROL_MIN: f64 = 1e-2;
+
+fn device() -> Option<MetalBackend> {
+    let gpu = MetalBackend::new();
+    if gpu.is_none() {
+        eprintln!("no Metal device; skipping");
+    }
+    gpu
+}
+
+/// Run one encoder-full of work in one command buffer and wait.
+fn run_once(gpu: &MetalBackend, encode: impl FnOnce(&metal::ComputeCommandEncoderRef)) {
+    let cmd = gpu.new_lowering_command_buffer();
+    let enc = cmd.new_compute_command_encoder();
+    encode(enc);
+    enc.end_encoding();
+    cmd.commit();
+    cmd.wait_until_completed();
+}
+
+// ── 1. encode_matvec representation arms ────────────────────────────
+
+/// `encode_matvec` binds the f16 gemv for `LoweredMatrix::F16` and the
+/// MXFP4 matvec for `LoweredMatrix::Mxfp4`; each lands at parity with
+/// its own decoded reference, and on the same source matrix the two arms
+/// disagree by 4-bit noise — so the arm genuinely selected the format.
+#[test]
+fn encode_matvec_selects_f16_and_mxfp4_arms_each_at_parity_with_its_decoder() {
+    let Some(gpu) = device() else { return };
+    let w = det(MATVEC_ROWS * MATVEC_K, 11, WEIGHT_AMPLITUDE);
+    let x = det(MATVEC_K, 12, HIDDEN_AMPLITUDE);
+    let (w_f16, f16_bytes) = f16_matrix(&w);
+    let mx = Mxfp4Matrix::quantize(&w, MATVEC_ROWS, MATVEC_K);
+    let w_mx = mx.dequantized();
+    let want_f16 = matvec(&w_f16, &x, MATVEC_ROWS, MATVEC_K);
+    let want_mx = matvec(&w_mx, &x, MATVEC_ROWS, MATVEC_K);
+
+    let f16_buf = gpu.lowering_weight(&f16_bytes);
+    let packed = gpu.lowering_weight(&mx.packed);
+    let scales = gpu.lowering_weight(&mx.scales);
+    let x_buf = gpu.lowering_upload(&x).unwrap();
+    let out_f16 = gpu.lowering_scratch(MATVEC_ROWS);
+    let out_mx = gpu.lowering_scratch(MATVEC_ROWS);
+
+    run_once(&gpu, |enc| {
+        gpu.encode_matvec(
+            enc,
+            &LoweredMatrix::F16 { bytes: &f16_buf },
+            &MatvecTarget {
+                x: &x_buf,
+                out: &out_f16,
+                out_offset: 0,
+                n: MATVEC_ROWS,
+                k: MATVEC_K,
+            },
+        );
+        gpu.encode_matvec(
+            enc,
+            &LoweredMatrix::Mxfp4 {
+                packed: &packed,
+                scales: &scales,
+            },
+            &MatvecTarget {
+                x: &x_buf,
+                out: &out_mx,
+                out_offset: 0,
+                n: MATVEC_ROWS,
+                k: MATVEC_K,
+            },
+        );
+    });
+    let got_f16 = gpu.lowering_readback(&out_f16, MATVEC_ROWS).unwrap();
+    let got_mx = gpu.lowering_readback(&out_mx, MATVEC_ROWS).unwrap();
+
+    let e_f16 = rel_rms(&want_f16, &got_f16);
+    let e_mx = rel_rms(&want_mx, &got_mx);
+    eprintln!("f16 arm rel_rms {e_f16:.3e}; mxfp4 arm rel_rms {e_mx:.3e}");
+    assert!(
+        e_f16 < MATVEC_PARITY,
+        "F16 arm off its reference: {e_f16:.3e}"
+    );
+    assert!(
+        e_mx < MATVEC_PARITY,
+        "MXFP4 arm off its reference: {e_mx:.3e}"
+    );
+
+    // Control: the arms are distinguishable on the same W.
+    let between = rel_rms(&got_f16, &got_mx);
+    eprintln!("f16 vs mxfp4 arms on the same W: rel_rms {between:.3e}");
+    assert!(
+        between > ARM_DISTINCTION_MIN,
+        "arm control BLIND: f16 and mxfp4 outputs agree to {between:.3e}"
+    );
+}
+
+// ── 2. region registration ──────────────────────────────────────────
+
+/// `lowering_register_region` accepts a page-aligned region and refuses
+/// a view of the same allocation that starts one byte in.
+#[test]
+fn register_region_accepts_page_aligned_and_refuses_misaligned_bytes() {
+    let Some(gpu) = device() else { return };
+    let region = AlignedRegion::from_bytes(&[0xA5u8; 3 * MXFP4_GROUP_BYTES]);
+    assert!(
+        gpu.lowering_register_region(region.as_slice()),
+        "page-aligned region refused"
+    );
+    assert!(
+        gpu.lowering_register_region(region.as_slice()),
+        "re-registering the same region is idempotent"
+    );
+    assert!(
+        !gpu.lowering_register_region(region.misaligned_slice()),
+        "a misaligned view registered — zero-copy binding would read the wrong bytes"
+    );
+}
+
+// ── 3. routed layers through the stack ──────────────────────────────
+
+/// One layer's host-side fixture: attention weights as f16 (the F16 arm
+/// in situ), a routed FFN with MXFP4 experts in registered regions.
+struct LayerFixture {
+    q: Vec<f32>,
+    k: Vec<f32>,
+    v: Vec<f32>,
+    o: Vec<f32>,
+    q_bytes: Vec<u8>,
+    k_bytes: Vec<u8>,
+    v_bytes: Vec<u8>,
+    o_bytes: Vec<u8>,
+    attn_norm: Vec<f32>,
+    k_cache: Vec<f32>,
+    v_cache: Vec<f32>,
+    gu_payload: AlignedRegion,
+    gu_scales: AlignedRegion,
+    dn_payload: AlignedRegion,
+    dn_scales: AlignedRegion,
+    router_proj: Vec<f32>,
+    router_bias: Vec<f32>,
+    gate_up_bias: Vec<f32>,
+    down_bias: Vec<f32>,
+    pre_norm: Vec<f32>,
+    reference: RoutedRef,
+}
+
+const GU_ROWS: usize = 2 * INTER;
+const GU_PAYLOAD_PER_EXPERT: usize = GU_ROWS * (HIDDEN / MXFP4_GROUP_ELEMS) * MXFP4_GROUP_BYTES;
+const GU_SCALES_PER_EXPERT: usize = GU_ROWS * (HIDDEN / MXFP4_GROUP_ELEMS);
+const DN_PAYLOAD_PER_EXPERT: usize = HIDDEN * (INTER / MXFP4_GROUP_ELEMS) * MXFP4_GROUP_BYTES;
+const DN_SCALES_PER_EXPERT: usize = HIDDEN * (INTER / MXFP4_GROUP_ELEMS);
+/// Byte mask the down-perturbation control XORs into one expert's
+/// packed nibbles — flips every code, so a live read must move.
+const PERTURB_MASK: u8 = 0x77;
+const SEED_STRIDE: u32 = 101;
+
+fn build_layer(l: u32, perturb_down_expert: Option<usize>) -> LayerFixture {
+    let s = |i: u32| l * SEED_STRIDE + i;
+    let mk16 = |n: usize, k: usize, seed: u32| f16_matrix(&det(n * k, seed, WEIGHT_AMPLITUDE));
+    let (q, q_bytes) = mk16(Q_ROWS, HIDDEN, s(1));
+    let (k, k_bytes) = mk16(KV_ROWS, HIDDEN, s(2));
+    let (v, v_bytes) = mk16(KV_ROWS, HIDDEN, s(3));
+    let (o, o_bytes) = mk16(HIDDEN, Q_ROWS, s(4));
+    let near_one = |seed: u32| -> Vec<f32> {
+        det(HIDDEN, seed, NORM_WEIGHT_AMPLITUDE)
+            .into_iter()
+            .map(|w| 1.0 + w)
+            .collect()
+    };
+
+    let mut gu_payload = Vec::new();
+    let mut gu_scales = Vec::new();
+    let mut dn_payload = Vec::new();
+    let mut dn_scales = Vec::new();
+    let mut gate_up = Vec::new();
+    let mut down = Vec::new();
+    for e in 0..NUM_EXPERTS as u32 {
+        let gu = Mxfp4Matrix::quantize(
+            &det(GU_ROWS * HIDDEN, s(20 + 2 * e), WEIGHT_AMPLITUDE),
+            GU_ROWS,
+            HIDDEN,
+        );
+        let mut dn = Mxfp4Matrix::quantize(
+            &det(HIDDEN * INTER, s(21 + 2 * e), WEIGHT_AMPLITUDE),
+            HIDDEN,
+            INTER,
+        );
+        if perturb_down_expert == Some(e as usize) {
+            dn.packed.iter_mut().for_each(|b| *b ^= PERTURB_MASK);
+        }
+        gate_up.push(gu.dequantized());
+        down.push(dn.dequantized());
+        gu_payload.extend_from_slice(&gu.packed);
+        gu_scales.extend_from_slice(&gu.scales);
+        dn_payload.extend_from_slice(&dn.packed);
+        dn_scales.extend_from_slice(&dn.scales);
+    }
+    assert_eq!(gu_payload.len(), NUM_EXPERTS * GU_PAYLOAD_PER_EXPERT);
+    assert_eq!(dn_payload.len(), NUM_EXPERTS * DN_PAYLOAD_PER_EXPERT);
+
+    LayerFixture {
+        q,
+        k,
+        v,
+        o,
+        q_bytes,
+        k_bytes,
+        v_bytes,
+        o_bytes,
+        attn_norm: near_one(s(5)),
+        k_cache: det(T * KV_ROWS, s(6), HIDDEN_AMPLITUDE),
+        v_cache: det(T * KV_ROWS, s(7), HIDDEN_AMPLITUDE),
+        gu_payload: AlignedRegion::from_bytes(&gu_payload),
+        gu_scales: AlignedRegion::from_bytes(&gu_scales),
+        dn_payload: AlignedRegion::from_bytes(&dn_payload),
+        dn_scales: AlignedRegion::from_bytes(&dn_scales),
+        router_proj: det(NUM_EXPERTS * HIDDEN, s(8), WEIGHT_AMPLITUDE),
+        router_bias: det(NUM_EXPERTS, s(9), BIAS_AMPLITUDE),
+        gate_up_bias: det(NUM_EXPERTS * GU_ROWS, s(10), BIAS_AMPLITUDE),
+        down_bias: det(NUM_EXPERTS * HIDDEN, s(11), BIAS_AMPLITUDE),
+        pre_norm: near_one(s(12)),
+        reference: RoutedRef {
+            gate_up,
+            down,
+            hidden: HIDDEN,
+            inter: INTER,
+        },
+    }
+}
+
+/// Per-expert byte slices into a bank of `NUM_EXPERTS` equal `per`-byte
+/// slices.
+fn expert_slices(bank: &[u8], per: usize) -> Vec<&[u8]> {
+    (0..NUM_EXPERTS)
+        .map(|e| &bank[e * per..(e + 1) * per])
+        .collect()
+}
+
+impl LayerFixture {
+    /// The `MoeLayerWeights` view over the registered banks — the same
+    /// shape the CLI's `RoutedLayer::moe` builds from a `RoutedFfnOp`.
+    fn moe(&self) -> MoeLayerWeights<'_> {
+        MoeLayerWeights {
+            experts_gate_up: expert_slices(self.gu_payload.as_slice(), GU_PAYLOAD_PER_EXPERT),
+            experts_down: expert_slices(self.dn_payload.as_slice(), DN_PAYLOAD_PER_EXPERT),
+            routing_policy: MoeRoutingPolicy::top_k_then_softmax(),
+            weight_layout: MoeWeightLayout::unpadded(),
+            expert_scales: MoeExpertScales::Paired {
+                gate_up: expert_slices(self.gu_scales.as_slice(), GU_SCALES_PER_EXPERT),
+                down: expert_slices(self.dn_scales.as_slice(), DN_SCALES_PER_EXPERT),
+            },
+            fused_row_layout: MoeFusedRowLayout::Interleaved,
+            expert_data_format: QuantFormat::MXFP4,
+            router_proj: &self.router_proj,
+            router_bias: &self.router_bias,
+            experts_gate_up_bias: &self.gate_up_bias,
+            experts_down_bias: &self.down_bias,
+            router_scale: &[],
+            router_per_expert_scale: &[],
+            router_norm: &[],
+            router_norm_parameter_free: false,
+            router_input_scalar: 1.0,
+            pre_experts_norm: &self.pre_norm,
+            post_ffn1_norm: &[],
+            post_experts_norm: &[],
+            num_experts: NUM_EXPERTS,
+            top_k: TOP_K,
+            intermediate_size: INTER,
+            gate_rule: GATE_RULE,
+        }
+    }
+
+    fn register(&self, gpu: &MetalBackend) {
+        for bank in [
+            &self.gu_payload,
+            &self.gu_scales,
+            &self.dn_payload,
+            &self.dn_scales,
+        ] {
+            assert!(gpu.lowering_register_region(bank.as_slice()));
+        }
+    }
+}
+
+/// CPU attention for one layer (NoPE, no gate, no post-norm, full
+/// span): `h + Wo · attend(Wq n, cache ∪ Wk n, cache ∪ Wv n)`.
+fn cpu_attention(h: &[f32], w: &LayerFixture) -> Vec<f32> {
+    let normed = rms_norm(h, &w.attn_norm, EPS, NORM_OFFSET);
+    let q = matvec(&w.q, &normed, Q_ROWS, HIDDEN);
+    let k = matvec(&w.k, &normed, KV_ROWS, HIDDEN);
+    let v = matvec(&w.v, &normed, KV_ROWS, HIDDEN);
+    let mut kc = w.k_cache.clone();
+    let mut vc = w.v_cache.clone();
+    kc[POS * KV_ROWS..].copy_from_slice(&k);
+    vc[POS * KV_ROWS..].copy_from_slice(&v);
+    let scale = 1.0 / (HEAD_DIM as f32).sqrt();
+    let mut concat = vec![0.0f32; Q_ROWS];
+    for head in 0..NUM_Q {
+        let kv = head / (NUM_Q / NUM_KV);
+        let qh = &q[head * HEAD_DIM..(head + 1) * HEAD_DIM];
+        let sc: Vec<f32> = (0..T)
+            .map(|t| {
+                let kh = &kc[t * KV_ROWS + kv * HEAD_DIM..t * KV_ROWS + (kv + 1) * HEAD_DIM];
+                qh.iter().zip(kh).map(|(a, b)| a * b).sum::<f32>() * scale
+            })
+            .collect();
+        let m = sc.iter().cloned().fold(f32::MIN, f32::max);
+        let ex: Vec<f32> = sc.iter().map(|s| (s - m).exp()).collect();
+        let den: f32 = ex.iter().sum();
+        for d in 0..HEAD_DIM {
+            concat[head * HEAD_DIM + d] = (0..T)
+                .map(|t| ex[t] / den * vc[t * KV_ROWS + kv * HEAD_DIM + d])
+                .sum();
+        }
+    }
+    let ao = matvec(&w.o, &concat, HIDDEN, Q_ROWS);
+    h.iter().zip(&ao).map(|(a, b)| a + b).collect()
+}
+
+/// CPU: attention then the routed FFN, per layer, capturing every
+/// layer's output.
+fn cpu_stack(h0: &[f32], layers: &[LayerFixture]) -> Vec<Vec<f32>> {
+    let mut h = h0.to_vec();
+    let mut caps = Vec::new();
+    for w in layers {
+        let h1 = cpu_attention(&h, w);
+        h = routed_ffn_reference(&h1, &w.moe(), &w.reference, EPS, NORM_OFFSET);
+        caps.push(h.clone());
+    }
+    caps
+}
+
+/// Device-side state for one layer, kept alive for the whole stack.
+struct LayerDevice {
+    weights: [metal::Buffer; 4],
+    attn_norm: metal::Buffer,
+    k_cache: metal::Buffer,
+    v_cache: metal::Buffer,
+    scratch: MoeScratch,
+    table: std::sync::Arc<MoeExpertDescriptorTable>,
+}
+
+fn upload_layer(gpu: &MetalBackend, idx: usize, w: &LayerFixture) -> LayerDevice {
+    w.register(gpu);
+    let moe = w.moe();
+    let scratch =
+        MoeScratch::new_public_with_format(gpu, TOP_K, HIDDEN, INTER, QuantFormat::MXFP4, HIDDEN);
+    assert!(
+        gpu.lowering_moe_supported(&moe, &scratch),
+        "layer {idx}: descriptor MoE path refused a gpt-oss-shaped routed layer"
+    );
+    let table = gpu
+        .lowering_moe_descriptor(idx, &moe, INTER, HIDDEN)
+        .expect("expert slices lie in registered regions");
+    LayerDevice {
+        weights: [
+            gpu.lowering_weight(&w.q_bytes),
+            gpu.lowering_weight(&w.k_bytes),
+            gpu.lowering_weight(&w.v_bytes),
+            gpu.lowering_weight(&w.o_bytes),
+        ],
+        attn_norm: gpu.lowering_upload(&w.attn_norm).unwrap(),
+        k_cache: gpu.lowering_upload(&w.k_cache).unwrap(),
+        v_cache: gpu.lowering_upload(&w.v_cache).unwrap(),
+        scratch,
+        table,
+    }
+}
+
+fn attn_shape() -> AttnShape {
+    AttnShape {
+        hidden: HIDDEN,
+        num_q_heads: NUM_Q,
+        num_kv_heads: NUM_KV,
+        head_dim: HEAD_DIM,
+        norm_eps: EPS,
+        norm_weight_offset: NORM_OFFSET,
+        qk_norm_eps: EPS,
+        parameter_free_q: false,
+        parameter_free_k: false,
+        query_scale: None,
+        score_scale: 1.0 / (HEAD_DIM as f32).sqrt(),
+        position: LoweredPosition::None,
+        window: None,
+        softcap: None,
+        position_index: POS,
+        kv_len: T,
+    }
+}
+
+/// Encode the whole stack once, entered from `h_a`, checkpoint after
+/// every layer, and return the per-layer captures.
+fn gpu_stack(gpu: &MetalBackend, h0: &[f32], fx: &[LayerFixture]) -> Vec<Vec<f32>> {
+    let dev: Vec<LayerDevice> = fx
+        .iter()
+        .enumerate()
+        .map(|(i, w)| upload_layer(gpu, i, w))
+        .collect();
+
+    // Enter the stack FROM h_a: the ping-pong then takes the h_b/h_a arm.
+    let h_a = gpu.lowering_upload(h0).unwrap();
+    let inv_freq = gpu.lowering_upload(&[0.0f32; HEAD_DIM / 2]).unwrap();
+    let sc: Vec<metal::Buffer> = (0..13)
+        .map(|i| match i {
+            2..=4 => gpu.lowering_scratch(Q_ROWS),
+            8..=10 => gpu.lowering_scratch(INTER),
+            _ => gpu.lowering_scratch(HIDDEN),
+        })
+        .collect();
+    let scratch = StackScratch {
+        h_a: &h_a,
+        h_b: &sc[0],
+        attn_normed: &sc[1],
+        q: &sc[2],
+        gate: &sc[3],
+        concat: &sc[4],
+        gated: &sc[11],
+        attn_out: &sc[5],
+        attn_post: &sc[6],
+        ffn_normed: &sc[7],
+        ffn_gate: &sc[8],
+        ffn_up: &sc[9],
+        ffn_act: &sc[10],
+        ffn_down: &sc[12],
+        ffn_post: &sc[1],
+        inv_freq: &inv_freq,
+    };
+    let caps: Vec<metal::Buffer> = (0..LAYERS).map(|_| gpu.lowering_scratch(HIDDEN)).collect();
+    let cps: Vec<Checkpoint> = caps
+        .iter()
+        .enumerate()
+        .map(|(l, b)| Checkpoint {
+            after_layer: l,
+            into: b,
+        })
+        .collect();
+
+    let layers: Vec<LayerLowering> = dev
+        .iter()
+        .zip(fx)
+        .map(|(d, w)| LayerLowering {
+            attn: AttnWeights {
+                q: LoweredMatrix::F16 {
+                    bytes: &d.weights[0],
+                },
+                k: LoweredMatrix::F16 {
+                    bytes: &d.weights[1],
+                },
+                v: LoweredMatrix::F16 {
+                    bytes: &d.weights[2],
+                },
+                o: LoweredMatrix::F16 {
+                    bytes: &d.weights[3],
+                },
+                gate: None,
+                q_bias: None,
+                k_bias: None,
+                v_bias: None,
+                o_bias: None,
+                sinks: None,
+                norm_weight: &d.attn_norm,
+                post_norm: None,
+            },
+            attn_shape: attn_shape(),
+            ffn: LayerFfnLowering::Routed(Box::new(RoutedFfnLowering {
+                moe: w.moe(),
+                scratch: &d.scratch,
+                table: &d.table,
+                eps: EPS,
+            })),
+            k_cache: &d.k_cache,
+            v_cache: &d.v_cache,
+        })
+        .collect();
+
+    let mut final_buf: Option<&metal::Buffer> = None;
+    run_once(gpu, |enc| {
+        final_buf = Some(gpu.encode_stack(enc, &h_a, &layers, &scratch, &cps));
+    });
+    // Two layers entered from h_a: each layer writes mid = h_b, dst = h_a.
+    assert!(
+        std::ptr::eq(final_buf.unwrap(), &h_a),
+        "stack entered from h_a must finish in h_a after {LAYERS} layers"
+    );
+    caps.iter()
+        .map(|b| gpu.lowering_readback(b, HIDDEN).unwrap())
+        .collect()
+}
+
+/// A two-layer stack whose FFNs are routed MXFP4 experts in registered
+/// regions matches the CPU reference at every checkpoint (route, gate
+/// rule, biases, pre-experts norm all judged); the residual ping-pongs
+/// through both scratch slots; and the expert bytes are live — flipping
+/// one selected expert's down nibbles moves the checkpoint.
+#[test]
+fn routed_stack_checkpoints_match_cpu_reference_and_expert_bytes_are_live() {
+    let Some(gpu) = device() else { return };
+    let h0 = det(HIDDEN, 999, HIDDEN_AMPLITUDE);
+    let fx: Vec<LayerFixture> = (0..LAYERS as u32).map(|l| build_layer(l, None)).collect();
+    let want = cpu_stack(&h0, &fx);
+    let got = gpu_stack(&gpu, &h0, &fx);
+    let mut worst = 0.0f64;
+    for (l, (w, g)) in want.iter().zip(&got).enumerate() {
+        assert!(g.iter().all(|v| v.is_finite()), "layer {l}: non-finite");
+        let e = rel_rms(w, g);
+        eprintln!("routed stack checkpoint after layer {l}: rel_rms {e:.3e}");
+        assert!(e < LAYER_PARITY, "layer {l} diverges: {e:.3e}");
+        worst = worst.max(e);
+    }
+
+    // Control: perturb the down bytes of layer 0's top-1 expert (known
+    // from the CPU route) and re-run. Both fixtures stay alive so no
+    // address-keyed cache can conflate them.
+    let victim = {
+        let x0 = layer0_router_input(&h0, &fx[0]);
+        larql_compute::cpu::ops::moe::moe_route_from_router_input(&x0, &fx[0].moe()).0[0]
+    };
+    // The descriptor cache keys on (layer, bank address); the perturbed
+    // bank is a fresh allocation and `fx` is still alive, so the two
+    // layer-0 tables cannot collide.
+    let perturbed: Vec<LayerFixture> = vec![build_layer(0, Some(victim)), build_layer(1, None)];
+    let got_p = gpu_stack(&gpu, &h0, &perturbed);
+    let moved = rel_rms(&got[0], &got_p[0]);
+    eprintln!("down-byte perturbation moved checkpoint 0 by rel_rms {moved:.3e} (parity worst {worst:.3e})");
+    assert!(
+        moved > CONTROL_MIN && moved > worst * 10.0,
+        "control BLIND: perturbing expert {victim}'s down bytes moved the output by only {moved:.3e}"
+    );
+    // And the perturbed stack still matches ITS OWN reference: the
+    // reference tracks the bytes, not a fixed answer.
+    let want_p = cpu_stack(&h0, &perturbed);
+    let e = rel_rms(&want_p[0], &got_p[0]);
+    assert!(
+        e < LAYER_PARITY,
+        "perturbed layer 0 off its reference: {e:.3e}"
+    );
+}
+
+/// Layer 0's routed-FFN router input on the CPU — the post-attention
+/// residual, pre-experts-normed.
+fn layer0_router_input(h0: &[f32], w: &LayerFixture) -> Vec<f32> {
+    rms_norm(&cpu_attention(h0, w), &w.pre_norm, EPS, NORM_OFFSET)
+}
+
+// ── 4. descriptor refusal ───────────────────────────────────────────
+
+/// A routed layer whose expert slices are owned `Vec` bytes — nowhere
+/// in a registered region — is *supported* by policy/format yet yields
+/// no descriptor: the fail-closed contract, not a copying fallback.
+#[test]
+fn moe_descriptor_refuses_expert_slices_outside_registered_regions() {
+    let Some(gpu) = device() else { return };
+    let fx = build_layer(7, None);
+    // Same bytes, owned copies: valid data, wrong residency.
+    let gu_payload = fx.gu_payload.as_slice().to_vec();
+    let gu_scales = fx.gu_scales.as_slice().to_vec();
+    let dn_payload = fx.dn_payload.as_slice().to_vec();
+    let dn_scales = fx.dn_scales.as_slice().to_vec();
+    let moe = MoeLayerWeights {
+        experts_gate_up: expert_slices(&gu_payload, GU_PAYLOAD_PER_EXPERT),
+        experts_down: expert_slices(&dn_payload, DN_PAYLOAD_PER_EXPERT),
+        expert_scales: MoeExpertScales::Paired {
+            gate_up: expert_slices(&gu_scales, GU_SCALES_PER_EXPERT),
+            down: expert_slices(&dn_scales, DN_SCALES_PER_EXPERT),
+        },
+        ..fx.moe()
+    };
+    let scratch =
+        MoeScratch::new_public_with_format(&gpu, TOP_K, HIDDEN, INTER, QuantFormat::MXFP4, HIDDEN);
+    assert!(
+        gpu.lowering_moe_supported(&moe, &scratch),
+        "policy/format support is independent of residency"
+    );
+    assert!(
+        gpu.lowering_moe_descriptor(7, &moe, INTER, HIDDEN)
+            .is_none(),
+        "descriptor built over unregistered expert bytes — the lowering would bind copies"
+    );
+}

--- a/crates/larql-compute-metal/tests/test_lowering_stack_parity.rs
+++ b/crates/larql-compute-metal/tests/test_lowering_stack_parity.rs
@@ -394,6 +394,11 @@ fn fifty_two_layers_lower_into_one_scheduling_domain() {
                     v: pr(i[2], w.v.tensor_scale),
                     o: pr(i[3], w.o.tensor_scale),
                     gate: Some(pr(i[4], w.g.tensor_scale)),
+                    q_bias: None,
+                    k_bias: None,
+                    v_bias: None,
+                    o_bias: None,
+                    sinks: None,
                     norm_weight: &norms[l][0],
                     post_norm: Some(PostNorm {
                         weight: &norms[l][1],

--- a/crates/larql-compute-metal/tests/test_lowering_stack_parity.rs
+++ b/crates/larql-compute-metal/tests/test_lowering_stack_parity.rs
@@ -429,35 +429,37 @@ fn fifty_two_layers_lower_into_one_scheduling_domain() {
                     position_index: POS,
                     kv_len: T,
                 },
-                ffn: FfnWeights {
-                    gate: LoweredMatrix::Nvfp4 {
-                        packed: &keep[i[5].0],
-                        scales: &keep[i[5].1],
-                        tensor_scale: w.fg.tensor_scale,
+                ffn: larql_compute_metal::lowering::stack::LayerFfnLowering::Dense {
+                    weights: FfnWeights {
+                        gate: LoweredMatrix::Nvfp4 {
+                            packed: &keep[i[5].0],
+                            scales: &keep[i[5].1],
+                            tensor_scale: w.fg.tensor_scale,
+                        },
+                        up: LoweredMatrix::Nvfp4 {
+                            packed: &keep[i[6].0],
+                            scales: &keep[i[6].1],
+                            tensor_scale: w.fu.tensor_scale,
+                        },
+                        down: LoweredMatrix::Nvfp4 {
+                            packed: &keep[i[7].0],
+                            scales: &keep[i[7].1],
+                            tensor_scale: w.fd.tensor_scale,
+                        },
+                        norm_weight: &norms[l][2],
+                        post_norm: Some(PostNorm {
+                            weight: &norms[l][3],
+                            eps: POST_EPS,
+                            weight_offset: OFFSET,
+                            scratch: &post_f,
+                        }),
                     },
-                    up: LoweredMatrix::Nvfp4 {
-                        packed: &keep[i[6].0],
-                        scales: &keep[i[6].1],
-                        tensor_scale: w.fu.tensor_scale,
+                    shape: FfnShape {
+                        hidden: HIDDEN,
+                        intermediate: INTER,
+                        norm_eps: EPS,
+                        norm_weight_offset: OFFSET,
                     },
-                    down: LoweredMatrix::Nvfp4 {
-                        packed: &keep[i[7].0],
-                        scales: &keep[i[7].1],
-                        tensor_scale: w.fd.tensor_scale,
-                    },
-                    norm_weight: &norms[l][2],
-                    post_norm: Some(PostNorm {
-                        weight: &norms[l][3],
-                        eps: POST_EPS,
-                        weight_offset: OFFSET,
-                        scratch: &post_f,
-                    }),
-                },
-                ffn_shape: FfnShape {
-                    hidden: HIDDEN,
-                    intermediate: INTER,
-                    norm_eps: EPS,
-                    norm_weight_offset: OFFSET,
                 },
                 k_cache: &kv[l].0,
                 v_cache: &kv[l].1,

--- a/crates/larql-compute/src/attention/rope/yarn.rs
+++ b/crates/larql-compute/src/attention/rope/yarn.rs
@@ -21,29 +21,12 @@ use larql_models::YarnRopeScaling;
 /// Amplitude applied to `cos`/`sin` when no scaling asks for one.
 pub const UNIT_AMPLITUDE: f64 = 1.0;
 
-/// HF's `get_mscale`: the amplitude a scale factor implies.
-///
-/// Returns 1.0 for `scale <= 1`, matching HF exactly — a factor of 1 is "no
-/// extension", and `0.1·ln(1) + 1` would coincidentally also be 1.0 but the
-/// guard is what makes `factor < 1` safe.
-fn get_mscale(scale: f64, mscale: f64) -> f64 {
-    if scale <= 1.0 {
-        return 1.0;
-    }
-    0.1 * mscale * scale.ln() + 1.0
-}
-
-/// The attention amplitude for a YaRN block.
-///
-/// Two forms, and picking the wrong one is a silent 35 % error:
-/// * both `mscale` and `mscale_all_dim` present (DeepSeek) → their **ratio**,
-///   which for the usual `mscale == mscale_all_dim` collapses to exactly 1.0;
-/// * otherwise (GPT-OSS) → the single-argument `get_mscale(factor)`.
+/// The attention amplitude for a YaRN block — delegates to the config
+/// crate's [`YarnRopeScaling::attention_amplitude`], the single authority
+/// (the VINDEX3 container carries the block and is judged against the
+/// same number).
 pub fn attention_amplitude(s: &YarnRopeScaling) -> f64 {
-    match (s.mscale, s.mscale_all_dim) {
-        (Some(m), Some(m_all)) => get_mscale(s.factor, m) / get_mscale(s.factor, m_all),
-        _ => get_mscale(s.factor, 1.0),
-    }
+    s.attention_amplitude()
 }
 
 /// HF's `find_correction_dim` — the dimension index at which the rotary

--- a/crates/larql-compute/src/backend/matmul.rs
+++ b/crates/larql-compute/src/backend/matmul.rs
@@ -217,3 +217,184 @@ pub trait MatMul {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    /// A backend that supplies only the two required matmuls, so every
+    /// default body of the trait runs as written. Trait defaults are only
+    /// exercised by an implementor that declines to override them, and
+    /// every real backend overrides what it supports — the contract they
+    /// encode ("no kernel ⇒ `None`, never a wrong answer") is what a *new*
+    /// backend relies on.
+    struct NaiveBackend;
+
+    impl MatMul for NaiveBackend {
+        fn matmul(&self, a: ArrayView2<f32>, b: ArrayView2<f32>) -> Array2<f32> {
+            a.dot(&b)
+        }
+
+        fn matmul_transb(&self, a: ArrayView2<f32>, b: ArrayView2<f32>) -> Array2<f32> {
+            a.dot(&b.t())
+        }
+    }
+
+    /// A backend with the single-matrix gemvs but no batched submission:
+    /// the `_multi` defaults must be the sequential calls, and the result
+    /// arrives per matrix in call order.
+    struct SingleGemvBackend;
+
+    /// Marker value each fake gemv writes so the caller can tell which
+    /// arm produced a row.
+    const F16_MARK: f32 = 16.0;
+    const MXFP4_MARK: f32 = 4.0;
+    const NVFP4_MARK: f32 = 44.0;
+
+    impl MatMul for SingleGemvBackend {
+        fn matmul(&self, a: ArrayView2<f32>, b: ArrayView2<f32>) -> Array2<f32> {
+            a.dot(&b)
+        }
+
+        fn matmul_transb(&self, a: ArrayView2<f32>, b: ArrayView2<f32>) -> Array2<f32> {
+            a.dot(&b.t())
+        }
+
+        fn f16_gemv(&self, _w: &[u8], _x: &[f32], n: usize, _k: usize) -> Option<Vec<f32>> {
+            Some(vec![F16_MARK; n])
+        }
+
+        fn mxfp4_gemv(
+            &self,
+            _packed: &[u8],
+            _scales: &[u8],
+            _x: &[f32],
+            n: usize,
+            _k: usize,
+        ) -> Option<Vec<f32>> {
+            Some(vec![MXFP4_MARK; n])
+        }
+
+        fn nvfp4_gemv(
+            &self,
+            _packed: &[u8],
+            _scales: &[u8],
+            tensor_scale: f32,
+            _x: &[f32],
+            n: usize,
+            _k: usize,
+        ) -> Option<Vec<f32>> {
+            Some(vec![NVFP4_MARK * tensor_scale; n])
+        }
+    }
+
+    const K: usize = 4;
+    const N: usize = 3;
+
+    /// The batched default dispatches each op to the matmul its
+    /// `transpose_b` flag names, in order.
+    #[test]
+    fn batch_default_dispatches_each_op_by_its_transpose_flag() {
+        let b = NaiveBackend;
+        let a = array![[1.0f32, 2.0], [3.0, 4.0]];
+        let m = array![[5.0f32, 6.0], [7.0, 8.0]];
+        let out = b.matmul_batch(&[
+            MatMulOp {
+                a: a.clone(),
+                b: m.clone(),
+                transpose_b: false,
+            },
+            MatMulOp {
+                a: a.clone(),
+                b: m.clone(),
+                transpose_b: true,
+            },
+        ]);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], b.matmul(a.view(), m.view()));
+        assert_eq!(out[1], b.matmul_transb(a.view(), m.view()));
+        assert_ne!(out[0], out[1], "the flag must select a different product");
+    }
+
+    /// Every specialised gemv defaults to "no kernel here" — `None`, so a
+    /// caller falls back rather than trusting a fabricated vector.
+    #[test]
+    fn gemv_defaults_refuse_rather_than_guess() {
+        let b = NaiveBackend;
+        let w = Array2::<f32>::zeros((N, K));
+        let x = vec![0.5f32; K];
+        let bytes = vec![0u8; N * K * 2];
+
+        assert!(b.f32_gemv(w.view(), &x).is_none());
+        assert!(b.f32_gemv_force(w.view(), &x).is_none());
+        assert!(b.f32_gemv_topk1(w.view(), &x).is_none());
+        assert!(b.f16_gemv(&bytes, &x, N, K).is_none());
+        assert!(b.f16_gemv_force(&bytes, &x, N, K).is_none());
+        assert!(b.f16_gemv_topk1(&bytes, &x, N, K).is_none());
+        assert!(b.f16_gemv_topk(&bytes, &x, N, K, 2).is_none());
+        assert!(b.mxfp4_gemv(&bytes, &bytes, &x, N, K).is_none());
+        assert!(b.nvfp4_gemv(&bytes, &bytes, 1.0, &x, N, K).is_none());
+        // A residency hint on a backend with no notion of residency is a
+        // no-op, not an error.
+        b.wire_resident(&[&bytes]);
+    }
+
+    /// With no single-matrix kernel the multi defaults are `None` as a
+    /// whole — one unsupported matrix refuses the submission, so a caller
+    /// cannot receive a partially fabricated batch.
+    #[test]
+    fn multi_defaults_refuse_when_the_single_gemv_refuses() {
+        let b = NaiveBackend;
+        let x = vec![0.5f32; K];
+        let bytes = vec![0u8; N * K * 2];
+        assert!(b.f16_gemv_multi(&[(&bytes, N, K)], &x).is_none());
+        assert!(b.mxfp4_gemv_multi(&[(&bytes, &bytes, N, K)], &x).is_none());
+        assert!(b
+            .nvfp4_gemv_multi(&[(&bytes, &bytes, 1.0, N, K)], &x)
+            .is_none());
+    }
+
+    /// With single-matrix kernels present, the multi defaults are exactly
+    /// the sequential calls: one output per matrix, in order, each the
+    /// row its own kernel produced (the NVFP4 tensor scale reaches the
+    /// per-matrix call).
+    #[test]
+    fn multi_defaults_are_the_sequential_single_gemvs_in_order() {
+        let b = SingleGemvBackend;
+        let x = vec![0.5f32; K];
+        let bytes = vec![0u8; N * K * 2];
+        let second_n = N + 1;
+
+        let f16 = b
+            .f16_gemv_multi(&[(&bytes, N, K), (&bytes, second_n, K)], &x)
+            .unwrap();
+        assert_eq!(f16, vec![vec![F16_MARK; N], vec![F16_MARK; second_n]]);
+
+        let mx = b
+            .mxfp4_gemv_multi(&[(&bytes, &bytes, N, K), (&bytes, &bytes, second_n, K)], &x)
+            .unwrap();
+        assert_eq!(mx, vec![vec![MXFP4_MARK; N], vec![MXFP4_MARK; second_n]]);
+
+        let scale_a = 2.0f32;
+        let scale_b = 0.5f32;
+        let nv = b
+            .nvfp4_gemv_multi(
+                &[
+                    (&bytes, &bytes, scale_a, N, K),
+                    (&bytes, &bytes, scale_b, second_n, K),
+                ],
+                &x,
+            )
+            .unwrap();
+        assert_eq!(
+            nv,
+            vec![
+                vec![NVFP4_MARK * scale_a; N],
+                vec![NVFP4_MARK * scale_b; second_n]
+            ]
+        );
+        // And the `_force` variants route to the same single kernels.
+        assert_eq!(b.f16_gemv_force(&bytes, &x, N, K), Some(vec![F16_MARK; N]));
+    }
+}

--- a/crates/larql-compute/src/ffn/expert_weight/mod.rs
+++ b/crates/larql-compute/src/ffn/expert_weight/mod.rs
@@ -21,7 +21,9 @@
 //! `docs/k3-funnel.md` §4.7.
 
 pub(crate) mod gate;
-pub(crate) mod router;
+/// Expert selection — public because the VINDEX3 production backend runs
+/// the served selection rule rather than a second transcription of it.
+pub mod router;
 // Public for the `tests/test_moe_route_trace_*.rs` end-to-end exercises:
 // the env-resolved sink is process-global (`OnceLock`), so each scenario
 // needs its own test binary, and those binaries can only reach a `pub` path.

--- a/crates/larql-models/src/config/architecture.rs
+++ b/crates/larql-models/src/config/architecture.rs
@@ -292,6 +292,19 @@ pub trait ModelArchitecture: Send + Sync {
         None
     }
 
+    /// Judged semantics of this family's attention sinks, when it carries
+    /// them. Derived from [`Self::attn_sinks_key`] rather than declared a
+    /// second time: a family that names a sink tensor is served through
+    /// `softmax_in_place(scores, sink)`, and this is that behaviour stated
+    /// as a schema fact — the two cannot disagree. `None` means *no
+    /// judgment exists*, never "no sinks": a stack shipping a
+    /// `self_attn.sinks` operand while this is `None` fails operand
+    /// closure downstream rather than run an ordinary softmax.
+    fn attention_sinks(&self) -> Option<crate::config::AttentionSinkSpec> {
+        self.attn_sinks_key(0)
+            .map(|_| crate::config::AttentionSinkSpec::SoftmaxDenominator)
+    }
+
     /// Parameter-free QK normalisation (RMS over Q/K with no learned
     /// weights). Default: none — families that normalise without weights
     /// declare it, because no tensor evidence can reveal a weightless op.

--- a/crates/larql-models/src/config/architecture.rs
+++ b/crates/larql-models/src/config/architecture.rs
@@ -405,16 +405,30 @@ pub trait ModelArchitecture: Send + Sync {
     /// The forward path for a family that declares NoPE layers must consume
     /// this policy, not a raw theta — a zero base is degenerate
     /// (`1/0^(i/d)`), never a parameter value.
+    ///
+    /// A checkpoint that declares `rope_scaling.rope_type = "yarn"` states a
+    /// second execution fact — scaled frequencies and an attention amplitude
+    /// — for every rotating layer, and the policy carries it
+    /// ([`PositionPolicy::Yarn`]) rather than letting it be read once by the
+    /// forward path and dropped by everything else ([`Self::yarn_rope_scaling`]
+    /// is the config read; this is where it becomes per-layer policy).
     fn position_policy_for_layer(&self, layer: usize) -> PositionPolicy {
+        let yarn = self.yarn_rope_scaling();
         match self
             .config()
             .layer_rope_theta
             .as_ref()
             .and_then(|thetas| thetas.get(layer))
         {
-            Some(&declared) => PositionPolicy::from_declared_theta(declared),
-            None => PositionPolicy::Rope {
-                theta: self.rope_base_for_layer(layer),
+            Some(&declared) => PositionPolicy::from_declared_theta_with_yarn(declared, yarn),
+            None => match yarn {
+                Some(scaling) => PositionPolicy::Yarn {
+                    theta: self.rope_base_for_layer(layer),
+                    scaling,
+                },
+                None => PositionPolicy::Rope {
+                    theta: self.rope_base_for_layer(layer),
+                },
             },
         }
     }

--- a/crates/larql-models/src/config/attention_sinks.rs
+++ b/crates/larql-models/src/config/attention_sinks.rs
@@ -1,0 +1,32 @@
+//! Attention sinks: the judged semantics of a per-head learned logit that
+//! competes in the softmax without a value slot (GPT-OSS).
+//!
+//! The reference behaviour, transcribed from the served path
+//! (`larql-compute::attention::softmax::softmax_in_place`) — one scalar
+//! per **query** head, appended to that head's score row before the
+//! softmax and dropped from the output afterwards:
+//!
+//! ```text
+//! m      = max(max_k score[k], sink)
+//! den    = Σ_k exp(score[k] − m) + exp(sink − m)
+//! p[k]   = exp(score[k] − m) / den            # Σ_k p[k] = 1 − p_sink
+//! out    = Σ_k p[k] · v[k]                     # the sink has no v
+//! ```
+//!
+//! Single-variant on purpose, like the attention-gate spec: the enum
+//! grows only when a judged instance actually differs (a sink with a
+//! value slot, a per-kv-head sink, …), and an unjudged difference must
+//! fail closed rather than reuse the nearest variant. A stack shipping a
+//! `self_attn.sinks` operand under no judgment fails operand closure.
+
+use serde::{Deserialize, Serialize};
+
+/// The fully judged semantics of a layer's attention sinks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttentionSinkSpec {
+    /// One learned logit per query head, joining the softmax denominator
+    /// (and its max) only — no value row, so the real keys' weights sum
+    /// to `1 − p_sink`. Operand shape `[num_q_heads]`.
+    SoftmaxDenominator,
+}

--- a/crates/larql-models/src/config/experts.rs
+++ b/crates/larql-models/src/config/experts.rs
@@ -101,7 +101,8 @@ impl GateUpLayout {
 /// adds one to the up branch. Modelling that as "SiLU with extra steps" is how
 /// a forward pass ends up plausibly wrong — hence an explicit policy rather
 /// than an [`Activation`] variant.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ExpertGatePolicy {
     /// `activation(gate) * up` — Mixtral, Gemma 4, OLMoE, GraniteMoE.
     Gated,
@@ -119,6 +120,15 @@ pub enum ExpertGatePolicy {
         /// Multiplier on the sigmoid argument (1.702 in the reference).
         alpha: f32,
     },
+}
+
+impl Default for ExpertGatePolicy {
+    /// The plain gated form — what every architecture that does not
+    /// override `expert_gate_policy` computes, and what an inventory or
+    /// container written before the policy was carried meant.
+    fn default() -> Self {
+        Self::Gated
+    }
 }
 
 /// How a router's top-k weights are normalised.

--- a/crates/larql-models/src/config/experts.rs
+++ b/crates/larql-models/src/config/experts.rs
@@ -2,7 +2,8 @@
 //! how an expert block computes: its gate shape and its router normalisation.
 
 /// How expert weights are stored in a MoE model.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ExpertFormat {
     /// Per-expert separate tensors (Mixtral, DeepSeek).
     /// Keys: `experts.{id}.w1.weight`, `experts.{id}.w2.weight`, etc.
@@ -59,7 +60,8 @@ impl ExpertFormat {
 /// (e.g. K3's MXFP4→Q6_K transcode) may canonicalise it on the way to an
 /// execution operand; when that happens the transform owns the invariant,
 /// not this declaration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum GateUpLayout {
     /// `[all gate rows | all up rows]` — the first half is gate.
     ContiguousHalves,
@@ -136,7 +138,8 @@ impl Default for ExpertGatePolicy {
 /// There are only two observable behaviours, and the difference is whether the
 /// selected weights sum to 1. Getting it wrong rescales the entire expert
 /// branch, which is a large error that still produces coherent-looking output.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ExpertRoutingPolicy {
     /// Softmax over **all** experts, then keep the top-k probabilities as they
     /// are. They sum to *less* than 1 — by whatever mass the unselected

--- a/crates/larql-models/src/config/mod.rs
+++ b/crates/larql-models/src/config/mod.rs
@@ -22,6 +22,7 @@
 pub mod activation;
 pub mod architecture;
 pub mod attention_gate;
+pub mod attention_sinks;
 pub mod experts;
 pub mod layer_types;
 pub mod model_config;
@@ -36,6 +37,7 @@ pub use architecture::ModelArchitecture;
 pub use attention_gate::{
     AttentionGateSpec, GateActivation, GateCombine, GatePlacement, GateSource,
 };
+pub use attention_sinks::AttentionSinkSpec;
 pub use experts::{
     ExpertFormat, ExpertGatePolicy, ExpertRoutingPolicy, GateUpBranch, GateUpLayout,
 };

--- a/crates/larql-models/src/config/moe_router.rs
+++ b/crates/larql-models/src/config/moe_router.rs
@@ -22,15 +22,22 @@ pub const ROUTER_WIRE_GEMMA4_TOP_K_SOFTMAX: &str = "gemma4_top_k_softmax";
 pub const ROUTER_WIRE_GPT_OSS_TOPK_THEN_SOFTMAX: &str = "gpt_oss_topk_then_softmax";
 
 /// The routing rule an architecture's MoE block uses.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// Serialises to the same wire values as [`MoeRouterKind::as_str`] — one
+/// spelling per fact, whether it travels in a VINDEX2 `MoeConfig` or a
+/// VINDEX3 execution surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum MoeRouterKind {
     /// Softmax over all experts, then take the top-k weights as they are.
     #[default]
+    #[serde(rename = "top_k_softmax")]
     TopKSoftmax,
     /// Gemma 4's hybrid: normalised softmax plus a per-expert scale.
+    #[serde(rename = "gemma4_top_k_softmax")]
     Gemma4Hybrid,
     /// Select the top-k logits *first*, then softmax over just those — the
     /// selected weights sum to 1. GPT-OSS.
+    #[serde(rename = "gpt_oss_topk_then_softmax")]
     TopKThenSoftmax,
 }
 

--- a/crates/larql-models/src/config/position.rs
+++ b/crates/larql-models/src/config/position.rs
@@ -127,10 +127,75 @@ mod tests {
 
     #[test]
     fn round_trips() {
-        for policy in [PositionPolicy::None, PositionPolicy::Rope { theta: 1e6 }] {
+        for policy in [
+            PositionPolicy::None,
+            PositionPolicy::Rope { theta: 1e6 },
+            PositionPolicy::Yarn {
+                theta: 150000.0,
+                scaling: gpt_oss_yarn(),
+            },
+        ] {
             let json = serde_json::to_string(&policy).unwrap();
             let back: PositionPolicy = serde_json::from_str(&json).unwrap();
             assert_eq!(back, policy);
         }
+    }
+
+    fn gpt_oss_yarn() -> YarnRopeScaling {
+        YarnRopeScaling {
+            factor: 32.0,
+            beta_fast: 32.0,
+            beta_slow: 1.0,
+            original_max_position_embeddings: 4096.0,
+            truncate: false,
+            mscale: None,
+            mscale_all_dim: None,
+        }
+    }
+
+    #[test]
+    fn a_yarn_block_attaches_only_to_a_rotating_layer() {
+        let scaling = gpt_oss_yarn();
+        assert_eq!(
+            PositionPolicy::from_declared_theta_with_yarn(150000.0, Some(scaling)),
+            PositionPolicy::Yarn {
+                theta: 150000.0,
+                scaling
+            }
+        );
+        // The NoPE sentinel wins over a checkpoint-wide YaRN block.
+        assert_eq!(
+            PositionPolicy::from_declared_theta_with_yarn(0.0, Some(scaling)),
+            PositionPolicy::None
+        );
+        // No block: plain rotary, exactly as `from_declared_theta`.
+        assert_eq!(
+            PositionPolicy::from_declared_theta_with_yarn(150000.0, None),
+            PositionPolicy::Rope { theta: 150000.0 }
+        );
+    }
+
+    #[test]
+    fn scaled_rotary_still_offers_its_theta_and_only_it_offers_yarn() {
+        let scaling = gpt_oss_yarn();
+        let yarn = PositionPolicy::Yarn {
+            theta: 150000.0,
+            scaling,
+        };
+        assert_eq!(yarn.rope_theta(), Some(150000.0));
+        assert_eq!(yarn.yarn(), Some(scaling));
+        assert_eq!(PositionPolicy::Rope { theta: 1e4 }.yarn(), None);
+        assert_eq!(PositionPolicy::None.yarn(), None);
+    }
+
+    #[test]
+    fn rotary_means_plain_or_scaled_but_not_nope() {
+        assert!(PositionPolicy::Rope { theta: 1e4 }.is_rotary());
+        assert!(PositionPolicy::Yarn {
+            theta: 1e4,
+            scaling: gpt_oss_yarn()
+        }
+        .is_rotary());
+        assert!(!PositionPolicy::None.is_rotary());
     }
 }

--- a/crates/larql-models/src/config/position.rs
+++ b/crates/larql-models/src/config/position.rs
@@ -13,6 +13,7 @@
 //! [`PositionPolicy::from_declared_theta`]; everything downstream matches on
 //! the variant.
 
+use super::rope::YarnRopeScaling;
 use serde::{Deserialize, Serialize};
 
 /// The HF `layer_rope_theta` sentinel for "no positional encoding on this
@@ -25,6 +26,18 @@ const NOPE_THETA_SENTINEL: f64 = 0.0;
 pub enum PositionPolicy {
     /// Rotary position embedding at the given base frequency.
     Rope { theta: f64 },
+    /// Rotary position embedding at `theta`, with YaRN scaling: a
+    /// per-dimension blend of extrapolated and interpolated frequencies
+    /// **and** an amplitude on `cos`/`sin` that rescales every logit at
+    /// every position (`YarnRopeScaling::attention_amplitude`). Carried as
+    /// its own variant because a consumer that only knows `Rope { theta }`
+    /// would serve the model at the wrong attention temperature everywhere
+    /// — the fact this variant exists to keep from being dropped at the
+    /// container boundary (VINDEX3 A-9.0).
+    Yarn {
+        theta: f64,
+        scaling: YarnRopeScaling,
+    },
     /// No positional encoding — the layer attends position-agnostically.
     None,
 }
@@ -40,13 +53,38 @@ impl PositionPolicy {
         }
     }
 
-    /// The rope base when the policy is rotary; `None` for a NoPE layer.
-    /// Callers that need a theta must handle absence — there is no default.
+    /// Interpret a declared per-layer theta under a checkpoint-wide YaRN
+    /// block: the NoPE sentinel still means none; a rotating layer carries
+    /// the scaling.
+    pub fn from_declared_theta_with_yarn(theta: f64, scaling: Option<YarnRopeScaling>) -> Self {
+        match (Self::from_declared_theta(theta), scaling) {
+            (Self::Rope { theta }, Some(scaling)) => Self::Yarn { theta, scaling },
+            (policy, _) => policy,
+        }
+    }
+
+    /// The rope base when the policy is rotary (scaled or not); `None` for a
+    /// NoPE layer. Callers that need a theta must handle absence — there is
+    /// no default.
     pub fn rope_theta(self) -> Option<f64> {
         match self {
-            Self::Rope { theta } => Some(theta),
+            Self::Rope { theta } | Self::Yarn { theta, .. } => Some(theta),
             Self::None => None,
         }
+    }
+
+    /// The YaRN block when the policy is scaled rotary; `None` for plain
+    /// rotary and NoPE alike.
+    pub fn yarn(self) -> Option<YarnRopeScaling> {
+        match self {
+            Self::Yarn { scaling, .. } => Some(scaling),
+            Self::Rope { .. } | Self::None => None,
+        }
+    }
+
+    /// Whether the layer rotates at all (plain or scaled).
+    pub fn is_rotary(self) -> bool {
+        !matches!(self, Self::None)
     }
 }
 

--- a/crates/larql-models/src/config/rope.rs
+++ b/crates/larql-models/src/config/rope.rs
@@ -150,7 +150,13 @@ pub struct Llama3RopeScaling {
 /// range", it is running attention at the wrong temperature everywhere. For
 /// `openai/gpt-oss-20b` (`factor: 32`) the amplitude is **1.3466**, so
 /// unscaled cos/sin are 34.7 % too small and `q·k` is off by 1.81×.
-#[derive(Debug, Clone, Copy)]
+///
+/// Serialisable and comparable because [`PositionPolicy::Yarn`] carries it
+/// into the VINDEX3 container: the block is a judged execution fact, not a
+/// parse-time convenience.
+///
+/// [`PositionPolicy::Yarn`]: super::position::PositionPolicy::Yarn
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct YarnRopeScaling {
     pub factor: f64,
     pub beta_fast: f64,
@@ -165,6 +171,41 @@ pub struct YarnRopeScaling {
     pub mscale: Option<f64>,
     /// DeepSeek's `mscale_all_dim`. See [`Self::mscale`].
     pub mscale_all_dim: Option<f64>,
+}
+
+impl YarnRopeScaling {
+    /// HF's `get_mscale`: the amplitude a scale factor implies.
+    ///
+    /// Returns 1.0 for `scale <= 1`, matching HF exactly — a factor of 1 is
+    /// "no extension", and `0.1·ln(1) + 1` would coincidentally also be 1.0
+    /// but the guard is what makes `factor < 1` safe.
+    fn get_mscale(scale: f64, mscale: f64) -> f64 {
+        if scale <= 1.0 {
+            return 1.0;
+        }
+        0.1 * mscale * scale.ln() + 1.0
+    }
+
+    /// The attention amplitude this block applies to `cos`/`sin` — the
+    /// part of YaRN that moves every logit, at every position.
+    ///
+    /// Two forms, and picking the wrong one is a silent 35 % error:
+    /// * both `mscale` and `mscale_all_dim` present (DeepSeek) → their
+    ///   **ratio**, which for the usual `mscale == mscale_all_dim`
+    ///   collapses to exactly 1.0;
+    /// * otherwise (GPT-OSS) → the single-argument `get_mscale(factor)`.
+    ///
+    /// This is the single authority; `larql-compute`'s rope module
+    /// delegates here, and the VINDEX3 carriage of `rope_scaling` is
+    /// judged against it.
+    pub fn attention_amplitude(&self) -> f64 {
+        match (self.mscale, self.mscale_all_dim) {
+            (Some(m), Some(m_all)) => {
+                Self::get_mscale(self.factor, m) / Self::get_mscale(self.factor, m_all)
+            }
+            _ => Self::get_mscale(self.factor, 1.0),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/larql-models/src/detect/parser.rs
+++ b/crates/larql-models/src/detect/parser.rs
@@ -214,7 +214,17 @@ pub(super) fn parse_model_config(config: &serde_json::Value) -> ModelConfig {
     //    scaling — sliding layers use plain RoPE — so we lift its `rope_type`
     //    + `factor` and mark `gemma3_global_only = true`.
     // 4. Missing entirely (older Llama, Mistral) → `None`.
-    let rope_scaling = text_config.get("rope_scaling").and_then(|rs| {
+    //
+    // And two *homes* for any of those shapes: the legacy `rope_scaling`
+    // key, and transformers-5.x's `rope_parameters`, which carries theta AND
+    // scaling in one block (`{rope_theta, rope_type: "yarn", factor, …}`).
+    // The theta read above already prefers `rope_parameters`; the scaling
+    // read must too, or a 5.x checkpoint's YaRN block is dropped at parse
+    // while its theta is honoured — the §4.7.8 shape again, caught by the
+    // VINDEX3 carriage test on a Glimmer-shaped fixture. A `rope_parameters`
+    // block that declares no scaling (`rope_type: "default"`, no `factor`)
+    // parses to `None` and the legacy key is consulted.
+    let parse_rope_scaling = |rs: &serde_json::Value| -> Option<RopeScaling> {
         // Gemma 3 per-layer-type form.
         if let Some(full) = rs.get("full_attention") {
             let scaling_type = full
@@ -278,7 +288,10 @@ pub(super) fn parse_model_config(config: &serde_json::Value) -> ModelConfig {
             yarn_mscale_all_dim,
             gemma3_global_only: false,
         })
-    });
+    };
+    let rope_scaling = rope_params
+        .and_then(parse_rope_scaling)
+        .or_else(|| text_config.get("rope_scaling").and_then(parse_rope_scaling));
 
     // RMS-norm / LayerNorm epsilon. Field-name aliases across families:
     //  - `rms_norm_eps`           — Llama, Mistral, Gemma

--- a/crates/larql-models/src/detect/tests/rope_scaling.rs
+++ b/crates/larql-models/src/detect/tests/rope_scaling.rs
@@ -228,3 +228,67 @@ fn flat_rope_parameters_beat_the_legacy_top_level_field() {
     }));
     assert_eq!(arch.config().rope_base, 500_000.0);
 }
+
+#[test]
+fn transformers5_rope_parameters_yarn_block_is_read_as_scaling() {
+    // The 5.x block carries theta AND scaling. Before this was read, a
+    // checkpoint declaring YaRN here had its theta honoured and its scaling
+    // dropped at parse — served at the unscaled frequencies and the wrong
+    // amplitude — which the VINDEX3 carriage gate caught on a
+    // Glimmer-shaped fixture. Every leaf must land, not just the type.
+    let arch = detect_from_json(&serde_json::json!({
+        "model_type": "some_transformers5_model",
+        "hidden_size": 1024,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 8,
+        "num_key_value_heads": 2,
+        "intermediate_size": 4096,
+        "rope_parameters": {
+            "rope_theta": 150000.0,
+            "rope_type": "yarn",
+            "factor": 32.0,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "truncate": false,
+            "original_max_position_embeddings": 4096
+        }
+    }));
+    assert_eq!(arch.config().rope_base, 150_000.0);
+    let yarn = arch
+        .yarn_rope_scaling()
+        .expect("a complete yarn block under rope_parameters is scaling");
+    assert_eq!(yarn.factor, 32.0);
+    assert_eq!(yarn.beta_fast, 32.0);
+    assert_eq!(yarn.beta_slow, 1.0);
+    assert!(!yarn.truncate);
+    assert_eq!(yarn.original_max_position_embeddings, 4096.0);
+    assert!(matches!(
+        arch.position_policy_for_layer(0),
+        crate::config::PositionPolicy::Yarn { theta, .. } if theta == 150_000.0
+    ));
+}
+
+#[test]
+fn unscaled_rope_parameters_leave_legacy_rope_scaling_reachable() {
+    // A 5.x block that declares no scaling (`default`, no `factor`) is not
+    // an answer of "no scaling" that silences the legacy key — the two are
+    // consulted in specificity order, and a legacy block still parses.
+    let arch = detect_from_json(&serde_json::json!({
+        "model_type": "some_transformers5_model",
+        "hidden_size": 1024,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 8,
+        "num_key_value_heads": 2,
+        "intermediate_size": 4096,
+        "rope_parameters": { "rope_theta": 500000.0, "rope_type": "default" },
+        "rope_scaling": {
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 8192
+        }
+    }));
+    assert_eq!(arch.config().rope_base, 500_000.0);
+    let yarn = arch.yarn_rope_scaling().expect("legacy block still read");
+    assert_eq!(yarn.factor, 4.0);
+    assert_eq!(yarn.original_max_position_embeddings, 8192.0);
+}

--- a/crates/larql-models/src/inventory/mod.rs
+++ b/crates/larql-models/src/inventory/mod.rs
@@ -20,6 +20,7 @@
 pub mod components;
 pub mod config_keys;
 pub mod report;
+pub mod representation;
 pub mod resolved;
 pub mod tensors;
 
@@ -60,12 +61,20 @@ pub fn build_inventory(model_dir: &Path) -> Result<ArchitectureInventory, ModelE
     let (detection, topology) = resolved::resolve(&config, &identity);
     // Nested components first: their recorded reads feed classification.
     let component_readings = components::read_components(&config);
-    let component_consumed: std::collections::BTreeSet<String> = component_readings
+    let mut recorded_reads: std::collections::BTreeSet<String> = component_readings
         .iter()
         .flat_map(|r| r.consumed_paths.iter().cloned())
         .collect();
     let nested_components = component_readings.into_iter().map(|r| r.topology).collect();
-    let config_facts = config_keys::classify_config(&config, &component_consumed);
+    // The stored-representation reader is the second recorded reader:
+    // `quantization_config` is credited only because something read it and
+    // stored what it read.
+    let representation_reading = representation::read_stored_representation(&config);
+    let stored_representation = representation_reading.map(|r| {
+        recorded_reads.extend(r.consumed_paths);
+        r.representation
+    });
+    let config_facts = config_keys::classify_config(&config, &recorded_reads);
     let interfaces = config_keys::find_interfaces(&config_facts);
     let tensor_inventory = tensors::scan_tensors(model_dir)?;
 
@@ -76,6 +85,7 @@ pub fn build_inventory(model_dir: &Path) -> Result<ArchitectureInventory, ModelE
         detection,
         resolved: topology,
         nested_components,
+        stored_representation,
         config_keys: config_facts,
         interfaces,
         tensors: tensor_inventory,

--- a/crates/larql-models/src/inventory/mod.rs
+++ b/crates/larql-models/src/inventory/mod.rs
@@ -77,6 +77,12 @@ pub fn build_inventory(model_dir: &Path) -> Result<ArchitectureInventory, ModelE
     let config_facts = config_keys::classify_config(&config, &recorded_reads);
     let interfaces = config_keys::find_interfaces(&config_facts);
     let tensor_inventory = tensors::scan_tensors(model_dir)?;
+    // The architecture names its expert banks in its own key namespace
+    // (post-strip: `layers.3.mlp.experts`); the graph binds source names.
+    // Resolve each bank prefix against the tensors actually present, so
+    // the recorded prefix is the one the checkpoint spells.
+    let mut topology = topology;
+    resolved::bind_expert_banks(&mut topology, &tensor_inventory.tensors);
 
     Ok(ArchitectureInventory {
         schema: INVENTORY_SCHEMA,

--- a/crates/larql-models/src/inventory/report.rs
+++ b/crates/larql-models/src/inventory/report.rs
@@ -56,6 +56,14 @@ pub struct ArchitectureInventory {
     /// single-component checkpoints.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub nested_components: Vec<crate::inventory::components::ComponentTopology>,
+    /// The checkpoint's declared stored representation
+    /// (`quantization_config`), read by
+    /// [`super::representation::read_stored_representation`]. `None` for
+    /// an unquantised checkpoint. Decides what raw-byte tensors *mean* —
+    /// GPT-OSS's `U8` expert blocks and scales are MXFP4 by this
+    /// declaration alone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stored_representation: Option<crate::inventory::representation::StoredRepresentation>,
     /// Every leaf in `config.json`, flattened to a dot path, classified.
     pub config_keys: Vec<ConfigKeyFact>,
     /// Declared cross-component interfaces (see
@@ -153,6 +161,12 @@ pub struct ResolvedExecution {
     pub attention_output_gate: Option<crate::config::AttentionGateSpec>,
     pub activation: crate::config::Activation,
     pub ffn_type: crate::config::FfnType,
+    /// How the FFN's gate combines with its up branch. `Gated` is the
+    /// plain `activation(gate) * up`; GPT-OSS's clamped GLU is a distinct
+    /// policy, not an activation variant — see `ExpertGatePolicy`.
+    /// Defaults for inventories written before it was recorded.
+    #[serde(default)]
+    pub gate_policy: crate::config::ExpertGatePolicy,
     /// Complete norm spec for the pre-attention / pre-FFN sites.
     pub norm_pre: crate::config::NormSpec,
     /// Complete norm spec for the post-attention / post-FFN sites.

--- a/crates/larql-models/src/inventory/report.rs
+++ b/crates/larql-models/src/inventory/report.rs
@@ -159,6 +159,18 @@ pub struct ResolvedExecution {
     /// exists (a shipped gate operand then fails operand closure).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attention_output_gate: Option<crate::config::AttentionGateSpec>,
+    /// Judged attention-sink semantics; `None` = no judgment exists (a
+    /// shipped `self_attn.sinks` operand then fails operand closure).
+    /// Defaults for inventories written before it was recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention_sinks: Option<crate::config::AttentionSinkSpec>,
+    /// Whether the Q/K/V/O projections carry additive biases, as the
+    /// checkpoint declares (`attention_bias`). `None` = undeclared, which
+    /// is not "no bias": bias operands shipped under `None` fail operand
+    /// closure; `Some(true)` requires all four. Defaults for inventories
+    /// written before it was recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention_bias: Option<bool>,
     pub activation: crate::config::Activation,
     pub ffn_type: crate::config::FfnType,
     /// How the FFN's gate combines with its up branch. `Gated` is the

--- a/crates/larql-models/src/inventory/report.rs
+++ b/crates/larql-models/src/inventory/report.rs
@@ -171,6 +171,11 @@ pub struct ResolvedExecution {
     /// written before it was recorded.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attention_bias: Option<bool>,
+    /// The routed-FFN facts when the family declares experts; `None` = a
+    /// dense-FFN model. Defaults for inventories written before it was
+    /// recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub moe: Option<MoeExecution>,
     pub activation: crate::config::Activation,
     pub ffn_type: crate::config::FfnType,
     /// How the FFN's gate combines with its up branch. `Gated` is the
@@ -229,6 +234,43 @@ pub struct LayerPolicy {
     pub position: crate::config::PositionPolicy,
     pub head_dim: usize,
     pub num_kv_heads: usize,
+    /// Source-name prefix of this layer's packed expert bank (the parent of
+    /// its `gate_up`/`down` operands), when the layer's FFN is routed —
+    /// `model.layers.3.mlp.experts`. `None` = a dense-FFN layer. Per layer,
+    /// so an arbitrary dense/routed schedule needs no dedicated field.
+    /// Defaults for inventories written before it was recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expert_bank: Option<String>,
+}
+
+/// The routed-FFN (mixture-of-experts) execution facts, resolved once
+/// from the architecture. Every field is a judged semantic the executor
+/// reads — none is re-derived from operand names downstream.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct MoeExecution {
+    /// Routed experts per layer.
+    pub experts: usize,
+    /// Experts selected per token.
+    pub top_k: usize,
+    /// Per-expert intermediate width.
+    pub expert_intermediate_size: usize,
+    /// How router logits become selected experts and weights.
+    pub router_kind: crate::config::MoeRouterKind,
+    /// Whether the selected weights are normalised to sum to one.
+    pub routing_policy: crate::config::ExpertRoutingPolicy,
+    /// Whether the router carries an additive bias on its logits.
+    pub router_bias: bool,
+    /// How the experts are stored (per-expert tensors, packed MXFP4, packed
+    /// BF16).
+    pub expert_format: crate::config::ExpertFormat,
+    /// How a fused `gate_up` operand splits into its branches; `None` when
+    /// no fused operand exists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate_up_layout: Option<crate::config::GateUpLayout>,
+    /// Always-active experts alongside the routed ones.
+    pub shared_experts: usize,
+    /// A dense MLP summed with the expert block every layer (Gemma 4 A4B).
+    pub hybrid: bool,
 }
 
 /// One flattened `config.json` leaf.

--- a/crates/larql-models/src/inventory/representation.rs
+++ b/crates/larql-models/src/inventory/representation.rs
@@ -1,0 +1,109 @@
+//! The checkpoint's declared *stored representation* — `quantization_config`.
+//!
+//! A quantised checkpoint states how its weights are encoded on disk:
+//! `quant_method` names the scheme, `modules_to_not_convert` the modules
+//! left in the base dtype. That is a tensor-representation fact, not an
+//! execution semantic — two checkpoints differing only here compute the same
+//! function — but it decides what the bytes *mean*: `openai/gpt-oss-20b`
+//! stores its experts as `U8` `*_blocks` / `*_scales` pairs that are MXFP4
+//! only by this declaration. A reader that dropped it would place those
+//! tensors as raw bytes.
+//!
+//! Read once, here, and recorded as consumed paths so `config_keys` credits
+//! the read (parser consumption is a recorded fact, not a name match — the
+//! same discipline as [`super::components`]). The VINDEX3 placement names
+//! the affected objects' encoding from it.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The `config.json` container this reader owns.
+pub const QUANTIZATION_CONFIG_KEY: &str = "quantization_config";
+/// The scheme name, in the checkpoint's own spelling.
+pub const QUANT_METHOD_KEY: &str = "quant_method";
+/// Module patterns (glob `*` over dotted paths) kept in the base dtype.
+pub const MODULES_TO_NOT_CONVERT_KEY: &str = "modules_to_not_convert";
+
+/// HF's spelling of the MXFP4 scheme (`quantization_config.quant_method`).
+pub const QUANT_METHOD_MXFP4: &str = "mxfp4";
+
+/// What the checkpoint declares about its stored representation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredRepresentation {
+    /// `quant_method`, verbatim (e.g. `mxfp4`).
+    pub method: String,
+    /// `modules_to_not_convert`, verbatim glob patterns over module paths.
+    #[serde(default)]
+    pub excluded_modules: Vec<String>,
+}
+
+impl StoredRepresentation {
+    /// Whether a tensor path is excluded from the scheme by
+    /// `modules_to_not_convert`. Patterns are dotted module paths with `*`
+    /// wildcards (`model.layers.*.self_attn`); a tensor is excluded when
+    /// its name starts with a module the pattern matches.
+    pub fn excludes(&self, tensor_name: &str) -> bool {
+        self.excluded_modules
+            .iter()
+            .any(|pattern| glob_prefix_matches(pattern, tensor_name))
+    }
+}
+
+/// `pattern` (with `*` wildcards) matches a *prefix* of `name` on module
+/// boundaries: `model.layers.*.self_attn` matches
+/// `model.layers.3.self_attn.q_proj.weight`.
+fn glob_prefix_matches(pattern: &str, name: &str) -> bool {
+    fn go(p: &[&str], n: &[&str]) -> bool {
+        match (p.first(), n.first()) {
+            (None, _) => true,
+            (Some(&"*"), None) => false,
+            (Some(&"*"), Some(_)) => go(&p[1..], &n[1..]) || go(p, &n[1..]),
+            (Some(seg), Some(head)) => seg == head && go(&p[1..], &n[1..]),
+            (Some(_), None) => false,
+        }
+    }
+    let p: Vec<&str> = pattern.split('.').collect();
+    let n: Vec<&str> = name.split('.').collect();
+    go(&p, &n)
+}
+
+/// One reader's result: the fact and the exact paths it read.
+#[derive(Debug, Clone)]
+pub struct RepresentationReading {
+    pub representation: StoredRepresentation,
+    pub consumed_paths: BTreeSet<String>,
+}
+
+/// Read `quantization_config`, when the checkpoint declares one with a
+/// `quant_method`. Anything else under the container is left unread and
+/// therefore unconsumed — surfaced by the planner, not swallowed here.
+pub fn read_stored_representation(config: &Value) -> Option<RepresentationReading> {
+    let block = config.get(QUANTIZATION_CONFIG_KEY)?.as_object()?;
+    let method = block.get(QUANT_METHOD_KEY)?.as_str()?.to_string();
+    let mut consumed_paths = BTreeSet::new();
+    consumed_paths.insert(format!("{QUANTIZATION_CONFIG_KEY}.{QUANT_METHOD_KEY}"));
+    let excluded_modules = match block.get(MODULES_TO_NOT_CONVERT_KEY) {
+        Some(Value::Array(items)) => {
+            consumed_paths.insert(format!(
+                "{QUANTIZATION_CONFIG_KEY}.{MODULES_TO_NOT_CONVERT_KEY}"
+            ));
+            items
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        }
+        _ => Vec::new(),
+    };
+    Some(RepresentationReading {
+        representation: StoredRepresentation {
+            method,
+            excluded_modules,
+        },
+        consumed_paths,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/larql-models/src/inventory/representation/tests.rs
+++ b/crates/larql-models/src/inventory/representation/tests.rs
@@ -1,0 +1,81 @@
+use super::*;
+use serde_json::json;
+
+/// GPT-OSS's real block, verbatim.
+fn gpt_oss_config() -> Value {
+    json!({
+        "model_type": "gpt_oss",
+        "quantization_config": {
+            "modules_to_not_convert": [
+                "model.layers.*.self_attn",
+                "model.layers.*.mlp.router",
+                "model.embed_tokens",
+                "lm_head"
+            ],
+            "quant_method": "mxfp4"
+        }
+    })
+}
+
+#[test]
+fn reads_gpt_oss_block_and_records_exactly_what_it_read() {
+    let r = read_stored_representation(&gpt_oss_config()).expect("declared");
+    assert_eq!(r.representation.method, "mxfp4");
+    assert_eq!(r.representation.excluded_modules.len(), 4);
+    let paths: Vec<&str> = r.consumed_paths.iter().map(String::as_str).collect();
+    assert_eq!(
+        paths,
+        [
+            "quantization_config.modules_to_not_convert",
+            "quantization_config.quant_method",
+        ]
+    );
+}
+
+#[test]
+fn a_checkpoint_without_the_block_declares_nothing() {
+    assert!(read_stored_representation(&json!({ "model_type": "llama" })).is_none());
+    // A block without a method names no scheme: unread, so unconsumed.
+    assert!(read_stored_representation(&json!({ "quantization_config": { "bits": 4 } })).is_none());
+}
+
+#[test]
+fn a_block_without_the_exclusion_list_consumes_only_the_method() {
+    let r = read_stored_representation(&json!({
+        "quantization_config": { "quant_method": "mxfp4" }
+    }))
+    .expect("declared");
+    assert!(r.representation.excluded_modules.is_empty());
+    assert_eq!(r.consumed_paths.len(), 1);
+    assert!(r
+        .consumed_paths
+        .contains("quantization_config.quant_method"));
+}
+
+#[test]
+fn exclusion_globs_match_module_prefixes_on_dotted_boundaries() {
+    let rep = read_stored_representation(&gpt_oss_config())
+        .expect("declared")
+        .representation;
+    // Excluded: attention, router, embeddings, head.
+    assert!(rep.excludes("model.layers.3.self_attn.q_proj.weight"));
+    assert!(rep.excludes("model.layers.23.mlp.router.weight"));
+    assert!(rep.excludes("model.embed_tokens.weight"));
+    assert!(rep.excludes("lm_head.weight"));
+    // Not excluded: the experts, whose blocks/scales the scheme applies to.
+    assert!(!rep.excludes("model.layers.3.mlp.experts.gate_up_proj_blocks"));
+    assert!(!rep.excludes("model.layers.3.mlp.experts.down_proj_scales"));
+    // `*` is one segment, on dotted boundaries — no substring accidents.
+    assert!(!rep.excludes("model.layers_extra.3.self_attn.q_proj.weight"));
+    assert!(!rep.excludes("lm_header.weight"));
+}
+
+#[test]
+fn round_trips_through_serde() {
+    let rep = read_stored_representation(&gpt_oss_config())
+        .expect("declared")
+        .representation;
+    let text = serde_json::to_string(&rep).expect("serialise");
+    let back: StoredRepresentation = serde_json::from_str(&text).expect("deserialise");
+    assert_eq!(back, rep);
+}

--- a/crates/larql-models/src/inventory/resolved.rs
+++ b/crates/larql-models/src/inventory/resolved.rs
@@ -125,6 +125,8 @@ pub fn resolve(config: &Value, identity: &Identity) -> (Detection, ResolvedTopol
         qk_norm_weight_offset: arch.qk_norm_weight_offset(),
         parameter_free_qk_norm: arch.parameter_free_qk_norm(),
         attention_output_gate: arch.attention_output_gate(),
+        attention_sinks: arch.attention_sinks(),
+        attention_bias: arch.attention_bias(),
         activation: arch.activation(),
         ffn_type: arch.ffn_type(),
         gate_policy: arch.expert_gate_policy(),

--- a/crates/larql-models/src/inventory/resolved.rs
+++ b/crates/larql-models/src/inventory/resolved.rs
@@ -13,8 +13,10 @@ use serde_json::Value;
 use crate::detect::{detect_from_json, find_architecture};
 
 use super::report::{
-    AttentionSummary, Detection, Identity, LayerPolicy, ResolvedExecution, ResolvedTopology,
+    AttentionSummary, Detection, Identity, LayerPolicy, MoeExecution, ResolvedExecution,
+    ResolvedTopology,
 };
+use crate::config::ModelArchitecture;
 
 /// Attention-kind labels for [`Detection::attention_kind`].
 const ATTENTION_SLIDING: &str = "sliding";
@@ -102,6 +104,7 @@ pub fn resolve(config: &Value, identity: &Identity) -> (Detection, ResolvedTopol
                 position: arch.position_policy_for_layer(layer),
                 head_dim: arch.head_dim_for_layer(layer),
                 num_kv_heads: arch.num_kv_heads_for_layer(layer),
+                expert_bank: expert_bank_prefix(arch.as_ref(), layer),
             }
         })
         .collect();
@@ -127,6 +130,18 @@ pub fn resolve(config: &Value, identity: &Identity) -> (Detection, ResolvedTopol
         attention_output_gate: arch.attention_output_gate(),
         attention_sinks: arch.attention_sinks(),
         attention_bias: arch.attention_bias(),
+        moe: arch.is_moe().then(|| MoeExecution {
+            experts: arch.num_experts(),
+            top_k: arch.num_experts_per_token(),
+            expert_intermediate_size: arch.moe_intermediate_size(),
+            router_kind: arch.moe_router_kind(),
+            routing_policy: arch.expert_routing_policy(),
+            router_bias: arch.moe_router_bias_key(0).is_some(),
+            expert_format: arch.expert_format(),
+            gate_up_layout: arch.gate_up_layout(),
+            shared_experts: arch.num_shared_experts(),
+            hybrid: arch.is_hybrid_moe(),
+        }),
         activation: arch.activation(),
         ffn_type: arch.ffn_type(),
         gate_policy: arch.expert_gate_policy(),
@@ -156,4 +171,42 @@ pub fn resolve(config: &Value, identity: &Identity) -> (Detection, ResolvedTopol
         execution: Some(execution),
     };
     (detection, topology)
+}
+
+/// The architecture-relative prefix of a layer's packed expert bank: the
+/// parent of the family's fused `gate_up` operand key. Asked of the arch,
+/// never inferred from a substring — the family names its own operands.
+/// [`bind_expert_banks`] resolves it to the source spelling once the
+/// tensor names are known.
+fn expert_bank_prefix(arch: &dyn ModelArchitecture, layer: usize) -> Option<String> {
+    let key = arch
+        .packed_gate_up_blocks_key(layer)
+        .or_else(|| arch.packed_experts_gate_up_key(layer))?;
+    key.rsplit_once('.').map(|(parent, _)| parent.to_string())
+}
+
+/// Resolve each layer's arch-relative expert-bank prefix to the source
+/// name the checkpoint actually spells (`layers.3.mlp.experts` →
+/// `model.layers.3.mlp.experts`): the tensor whose name ends with the
+/// arch prefix at a segment boundary names it. A bank the arch declares
+/// but no tensor spells resolves to `None` — the layer is then not
+/// routed by evidence, and closure says so.
+pub fn bind_expert_banks(topology: &mut ResolvedTopology, tensors: &[super::report::TensorFact]) {
+    for layer in &mut topology.layers {
+        let Some(relative) = layer.expert_bank.take() else {
+            continue;
+        };
+        let dotted = format!("{relative}.");
+        layer.expert_bank = tensors
+            .iter()
+            .filter_map(|t| {
+                // `…{relative}.{leaf}` at a segment boundary: the source
+                // prefix is everything before `{relative}.{leaf}` plus
+                // `{relative}` itself.
+                let at = t.name.find(&dotted)?;
+                let boundary_ok = at == 0 || t.name.as_bytes()[at - 1] == b'.';
+                boundary_ok.then(|| t.name[..at + relative.len()].to_string())
+            })
+            .next();
+    }
 }

--- a/crates/larql-models/src/inventory/resolved.rs
+++ b/crates/larql-models/src/inventory/resolved.rs
@@ -127,6 +127,7 @@ pub fn resolve(config: &Value, identity: &Identity) -> (Detection, ResolvedTopol
         attention_output_gate: arch.attention_output_gate(),
         activation: arch.activation(),
         ffn_type: arch.ffn_type(),
+        gate_policy: arch.expert_gate_policy(),
         norm_pre: arch.pre_norm_spec(),
         norm_post: arch.post_norm_spec(),
         norm_final: arch.final_norm_spec(),

--- a/crates/larql-models/src/inventory/tests/build.rs
+++ b/crates/larql-models/src/inventory/tests/build.rs
@@ -98,3 +98,75 @@ fn non_directory_is_an_error() {
     std::fs::write(&file, "x").unwrap();
     assert!(build_inventory(&file).is_err());
 }
+
+/// Minimal gpt-oss-shaped checkpoint: a routed family with a
+/// `quantization_config` block and one packed expert tensor.
+fn write_routed_fixture(dir: &std::path::Path) {
+    let config = serde_json::json!({
+        "architectures": ["GptOssForCausalLM"],
+        "model_type": "gpt_oss",
+        "hidden_size": 64,
+        "intermediate_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 8,
+        "num_key_value_heads": 2,
+        "head_dim": 8,
+        "num_local_experts": 4,
+        "experts_per_token": 2,
+        "vocab_size": 128,
+        "rope_theta": 150000.0,
+        "swiglu_limit": 7.0,
+        "layer_types": ["sliding_attention", "full_attention"],
+        "sliding_window": 16,
+        "quantization_config": {
+            "quant_method": "mxfp4",
+            "modules_to_not_convert": ["model.layers.*.self_attn", "lm_head"]
+        }
+    });
+    std::fs::write(
+        dir.join("config.json"),
+        serde_json::to_string_pretty(&config).unwrap(),
+    )
+    .unwrap();
+
+    let header = serde_json::json!({
+        "model.layers.0.mlp.experts.gate_up_proj_blocks": {
+            "dtype": "U8", "shape": [4, 128, 2, 16], "data_offsets": [0, 16384]
+        }
+    });
+    let header_bytes = serde_json::to_vec(&header).unwrap();
+    let mut file = std::fs::File::create(dir.join("model.safetensors")).unwrap();
+    file.write_all(&(header_bytes.len() as u64).to_le_bytes())
+        .unwrap();
+    file.write_all(&header_bytes).unwrap();
+}
+
+/// A routed checkpoint's inventory records the stored representation it
+/// read (crediting the keys as consumed) and binds the one expert bank the
+/// shard actually spells; the layer with no spelled bank stays unbound.
+#[test]
+fn routed_inventory_records_representation_and_binds_spelled_banks() {
+    let dir = tempfile::tempdir().unwrap();
+    write_routed_fixture(dir.path());
+
+    let inv = build_inventory(dir.path()).unwrap();
+    assert_eq!(inv.detection.family, "gpt_oss");
+    let representation = inv
+        .stored_representation
+        .expect("quantization_config was read");
+    assert_eq!(representation.method, "mxfp4");
+    assert_eq!(representation.excluded_modules.len(), 2);
+    for path in [
+        "quantization_config.quant_method",
+        "quantization_config.modules_to_not_convert",
+    ] {
+        let fact = inv.config_keys.iter().find(|f| f.path == path).unwrap();
+        assert_eq!(fact.status, KeyStatus::Consumed, "{path}");
+    }
+    assert_eq!(
+        inv.resolved.layers[0].expert_bank.as_deref(),
+        Some("model.layers.0.mlp.experts")
+    );
+    assert_eq!(inv.resolved.layers[1].expert_bank, None);
+    assert!(inv.resolved.execution.unwrap().moe.is_some());
+}

--- a/crates/larql-models/src/inventory/tests/resolved.rs
+++ b/crates/larql-models/src/inventory/tests/resolved.rs
@@ -180,3 +180,117 @@ fn validation_errors_are_data() {
     assert_eq!(topology.num_layers, 0);
     assert!(topology.layers.is_empty());
 }
+
+/// A gpt-oss-shaped config: routed MoE with router bias, attention sinks and
+/// projection biases, clamped GLU, YaRN — every A-9 semantic in one family.
+fn gpt_oss_shaped() -> serde_json::Value {
+    json!({
+        "architectures": ["GptOssForCausalLM"],
+        "model_type": "gpt_oss",
+        "hidden_size": 2880,
+        "intermediate_size": 2880,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 64,
+        "num_key_value_heads": 8,
+        "head_dim": 64,
+        "attention_bias": true,
+        "num_local_experts": 32,
+        "experts_per_token": 4,
+        "vocab_size": 201088,
+        "rope_theta": 150000.0,
+        "swiglu_limit": 7.0,
+        "layer_types": ["sliding_attention", "full_attention"],
+        "sliding_window": 128
+    })
+}
+
+/// A routed family resolves its MoE facts and names each layer's expert
+/// bank in the architecture's own namespace — before any tensor is seen.
+#[test]
+fn routed_family_resolves_moe_and_names_its_banks_arch_relative() {
+    let config = gpt_oss_shaped();
+    let identity = read_identity(&config);
+    let (detection, topology) = resolve(&config, &identity);
+    assert!(!detection.generic_fallback);
+    let execution = topology.execution.expect("judged execution");
+    let moe = execution.moe.expect("gpt-oss is routed");
+    assert_eq!(moe.experts, 32);
+    assert_eq!(moe.top_k, 4);
+    assert!(moe.router_bias);
+    assert!(execution.attention_sinks.is_some());
+    assert_eq!(execution.attention_bias, Some(true));
+    assert!(matches!(
+        execution.gate_policy,
+        crate::config::ExpertGatePolicy::ClampedGlu { .. }
+    ));
+    let banks: Vec<Option<String>> = topology
+        .layers
+        .iter()
+        .map(|l| l.expert_bank.clone())
+        .collect();
+    assert_eq!(
+        banks,
+        vec![
+            Some("layers.0.mlp.experts".to_string()),
+            Some("layers.1.mlp.experts".to_string())
+        ]
+    );
+}
+
+/// A dense family names no bank on any layer.
+#[test]
+fn dense_family_names_no_expert_bank() {
+    let config = glimmer_shaped();
+    let identity = read_identity(&config);
+    let (_, topology) = resolve(&config, &identity);
+    assert!(topology.layers.iter().all(|l| l.expert_bank.is_none()));
+    assert!(topology.execution.unwrap().moe.is_none());
+}
+
+fn tensor(name: &str) -> crate::inventory::TensorFact {
+    crate::inventory::TensorFact {
+        name: name.to_string(),
+        dtype: "U8".to_string(),
+        shape: vec![32, 5760, 90, 16],
+        bytes: 0,
+        file: "model.safetensors".to_string(),
+    }
+}
+
+/// Binding resolves the arch-relative prefix to the spelling the checkpoint
+/// uses, at a segment boundary; a bank no tensor spells resolves to `None`.
+#[test]
+fn expert_banks_bind_to_the_source_spelling_or_to_nothing() {
+    use crate::inventory::resolved::bind_expert_banks;
+    let config = gpt_oss_shaped();
+    let identity = read_identity(&config);
+    let (_, mut topology) = resolve(&config, &identity);
+    let tensors = vec![
+        // Layer 0 is spelled by the checkpoint under `model.`.
+        tensor("model.layers.0.mlp.experts.gate_up_proj_blocks"),
+        // A near-miss for layer 1: `xlayers.1…` is not a segment boundary.
+        tensor("model.xlayers.1.mlp.experts.gate_up_proj_blocks"),
+    ];
+    bind_expert_banks(&mut topology, &tensors);
+    assert_eq!(
+        topology.layers[0].expert_bank.as_deref(),
+        Some("model.layers.0.mlp.experts")
+    );
+    assert_eq!(topology.layers[1].expert_bank, None);
+}
+
+/// A bank spelled with no source prefix at all binds at offset zero.
+#[test]
+fn expert_bank_at_the_start_of_the_name_binds_too() {
+    use crate::inventory::resolved::bind_expert_banks;
+    let config = gpt_oss_shaped();
+    let identity = read_identity(&config);
+    let (_, mut topology) = resolve(&config, &identity);
+    let tensors = vec![tensor("layers.1.mlp.experts.down_proj_blocks")];
+    bind_expert_banks(&mut topology, &tensors);
+    assert_eq!(topology.layers[0].expert_bank, None);
+    assert_eq!(
+        topology.layers[1].expert_bank.as_deref(),
+        Some("layers.1.mlp.experts")
+    );
+}

--- a/crates/larql-models/src/quant/tests/nvfp4.rs
+++ b/crates/larql-models/src/quant/tests/nvfp4.rs
@@ -194,3 +194,38 @@ fn stored_size_is_four_and_a_half_bits_per_weight() {
         "expected 4.5 bpw, got {bits_per_weight}"
     );
 }
+
+/// Decoding refuses the same geometry quantising refuses, and the errors
+/// say what was wrong in the units the caller reasons in.
+#[test]
+fn decoding_refuses_bad_geometry_and_the_errors_name_it() {
+    let matrix = quantize(&[0.5; 16], 1, 16).unwrap();
+    let mut short = vec![0.0f32; 8];
+    assert_eq!(
+        dequantize_into(&matrix, 1, 16, &mut short).unwrap_err(),
+        Nvfp4Error::ShapeMismatch {
+            values: 8,
+            rows: 1,
+            k: 16
+        }
+    );
+    let mut out = vec![0.0f32; 20];
+    assert_eq!(
+        dequantize_into(&matrix, 1, 20, &mut out).unwrap_err(),
+        Nvfp4Error::UnalignedK { k: 20 }
+    );
+
+    let unaligned = Nvfp4Error::UnalignedK { k: 20 }.to_string();
+    assert!(unaligned.contains("k=20"), "{unaligned}");
+    assert!(unaligned.contains("16-element group"), "{unaligned}");
+    let mismatch = Nvfp4Error::ShapeMismatch {
+        values: 8,
+        rows: 1,
+        k: 16,
+    }
+    .to_string();
+    assert_eq!(mismatch, "8 values do not fill [1, 16]");
+    // It is a real `Error`, so it composes with `?` and `Box<dyn Error>`.
+    let boxed: Box<dyn std::error::Error> = Box::new(Nvfp4Error::UnalignedK { k: 20 });
+    assert!(boxed.to_string().starts_with("k=20"));
+}

--- a/crates/larql-vindex/src/format/vindex3/encode/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/encode/mod.rs
@@ -33,7 +33,7 @@ use std::path::{Path, PathBuf};
 
 use larql_models::inventory::ArchitectureInventory;
 
-use super::graph::{ComponentRole, LogicalObject, SystemGraph};
+use super::graph::{most_specific_owner, ComponentRole, LogicalObject, SystemGraph};
 use super::index::{RepresentationEntry, Vindex3Index};
 use super::plan::plan_system;
 use crate::error::VindexError;
@@ -74,7 +74,17 @@ pub fn encode_system(
             plan.summary.blocking
         )));
     }
-    let graph = plan.graph;
+    encode_graph(&plan.graph, named, out)
+}
+
+/// Encode an already-built system graph. `encode_system` is this after
+/// the plan gate; a caller holding a graph it built (or edited) itself
+/// comes in here and gets the same validation and the same bytes.
+pub fn encode_graph(
+    graph: &SystemGraph,
+    named: &[(String, ArchitectureInventory)],
+    out: &Path,
+) -> Result<EncodeOutcome, VindexError> {
     let defects = graph.validate();
     if !defects.is_empty() {
         return Err(VindexError::Parse(format!(
@@ -111,7 +121,7 @@ pub fn encode_system(
         );
         let segment_key = format!("{SEGMENTS_DIR}/{}", object.id);
         let segment_rel = format!("{segment_key}.{SEGMENT_BIN_EXT}");
-        let planned = plan_object_tensors(object, &inventories)?;
+        let planned = plan_object_tensors(object, &inventories, &graph.objects)?;
 
         let written = segment::write_segment(
             &out.join(&segment_rel),
@@ -148,11 +158,11 @@ pub fn encode_system(
 
     // Graph manifest, then the index last — a crash midway leaves a
     // directory that is not yet a container rather than one that lies.
-    let graph_json = serde_json::to_string_pretty(&graph)
+    let graph_json = serde_json::to_string_pretty(graph)
         .map_err(|e| VindexError::Parse(format!("serialise system graph: {e}")))?;
     std::fs::write(out.join(SYSTEM_GRAPH_JSON), graph_json)?;
 
-    let index = system_index(&graph, named, directory, segment_keys)?;
+    let index = system_index(graph, named, directory, segment_keys)?;
     let index_json = serde_json::to_string_pretty(&index)
         .map_err(|e| VindexError::Parse(format!("serialise index.json: {e}")))?;
     std::fs::write(out.join(INDEX_JSON), index_json)?;
@@ -171,21 +181,18 @@ pub(crate) fn binding_owner<'a>(object: &'a LogicalObject, source_name: &str) ->
     object
         .source_bindings
         .iter()
-        .find(|b| {
-            source_name == b.tensor_prefix
-                || source_name
-                    .strip_prefix(&b.tensor_prefix)
-                    .is_some_and(|rest| rest.starts_with('.'))
-        })
+        .find(|b| b.covers(source_name))
         .map(|b| b.artifact.as_str())
 }
 
 /// Plan the tensor table for one object: every source tensor under its
-/// bindings, named relative to the bindings' common segment-prefix so no
-/// artifact-global name survives into the container.
+/// bindings **that no other object owns more specifically** (see
+/// [`most_specific_owner`]), named relative to the bindings' common
+/// segment-prefix so no artifact-global name survives into the container.
 pub(crate) fn plan_object_tensors(
     object: &LogicalObject,
     inventories: &BTreeMap<&str, &ArchitectureInventory>,
+    all_objects: &[LogicalObject],
 ) -> Result<Vec<PlannedTensor>, VindexError> {
     let strip = common_segment_prefix(
         &object
@@ -203,10 +210,8 @@ pub(crate) fn plan_object_tensors(
             ))
         })?;
         for tensor in inventory.tensors.tensors.iter().filter(|t| {
-            t.name == binding.tensor_prefix
-                || t.name
-                    .strip_prefix(&binding.tensor_prefix)
-                    .is_some_and(|rest| rest.starts_with('.'))
+            binding.covers(&t.name)
+                && most_specific_owner(all_objects, &t.name).is_none_or(|o| o.id == object.id)
         }) {
             let relative_name = tensor
                 .name

--- a/crates/larql-vindex/src/format/vindex3/encode/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/encode/tests.rs
@@ -319,7 +319,7 @@ fn an_object_matching_no_source_tensors_refuses() {
         representations: Vec::<Representation>::new(),
     };
 
-    let err = match plan_object_tensors(&object, &inventories) {
+    let err = match plan_object_tensors(&object, &inventories, std::slice::from_ref(&object)) {
         Err(e) => e.to_string(),
         Ok(planned) => panic!(
             "planned {} tensors from a prefix nothing matches",

--- a/crates/larql-vindex/src/format/vindex3/graph/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/build.rs
@@ -223,6 +223,9 @@ pub fn build_from_inventories(named: &[(String, ArchitectureInventory)]) -> Buil
             match placement {
                 Some((component, kind)) => {
                     merge_binding(&mut objects, &component, kind, artifact, group, inventory);
+                    if kind == ObjectKind::DecoderStack {
+                        carve_expert_banks(&mut objects, &component, artifact, group, inventory);
+                    }
                 }
                 None => unplaced.push(UnplacedGroup {
                     artifact: artifact.clone(),
@@ -434,9 +437,11 @@ fn merge_binding(
         component: component.to_string(),
         kind,
         source_bindings: Vec::new(),
-        representations: canonical_representation(inventory, &group.prefix)
-            .into_iter()
-            .collect(),
+        representations: canonical_representation(inventory, |name| {
+            name.starts_with(&group.prefix)
+        })
+        .into_iter()
+        .collect(),
     });
     object.source_bindings.push(SourceBinding {
         artifact: artifact.to_string(),
@@ -444,6 +449,94 @@ fn merge_binding(
         tensors: group.tensors,
         bytes: group.bytes,
     });
+}
+
+/// Carve every routed layer's expert bank out of a just-placed decoder
+/// stack into the component's [`ObjectKind::ExpertBank`] object, one
+/// binding per layer at the prefix the architecture named
+/// (`resolved.layers[L].expert_bank`). Ownership is settled by binding
+/// specificity ([`super::object::most_specific_owner`]), so the stack keeps
+/// its whole-stack binding and simply stops owning what the bank binds;
+/// its recorded counts and representation are re-derived over what it
+/// still owns, so neither object describes bytes it does not hold.
+fn carve_expert_banks(
+    objects: &mut BTreeMap<String, LogicalObject>,
+    component: &str,
+    artifact: &str,
+    group: &TensorGroup,
+    inventory: &ArchitectureInventory,
+) {
+    let bank_prefixes: Vec<&str> = inventory
+        .resolved
+        .layers
+        .iter()
+        .filter_map(|l| l.expert_bank.as_deref())
+        .filter(|p| {
+            p.strip_prefix(&group.prefix)
+                .is_some_and(|r| r.starts_with('.'))
+        })
+        .collect();
+    if bank_prefixes.is_empty() {
+        return;
+    }
+    let in_bank = |name: &str| {
+        bank_prefixes
+            .iter()
+            .any(|p| name == *p || name.strip_prefix(p).is_some_and(|r| r.starts_with('.')))
+    };
+    let bank_id = format!("{component}.{}", ObjectKind::ExpertBank.name());
+    let bank = objects
+        .entry(bank_id.clone())
+        .or_insert_with(|| LogicalObject {
+            id: bank_id,
+            component: component.to_string(),
+            kind: ObjectKind::ExpertBank,
+            source_bindings: Vec::new(),
+            representations: canonical_representation(inventory, in_bank)
+                .into_iter()
+                .collect(),
+        });
+    let mut carved_tensors = 0usize;
+    let mut carved_bytes = 0u64;
+    for prefix in &bank_prefixes {
+        let (tensors, bytes) = inventory
+            .tensors
+            .tensors
+            .iter()
+            .filter(|t| {
+                t.name == *prefix
+                    || t.name
+                        .strip_prefix(prefix)
+                        .is_some_and(|r| r.starts_with('.'))
+            })
+            .fold((0usize, 0u64), |(n, b), t| (n + 1, b + t.bytes));
+        carved_tensors += tensors;
+        carved_bytes += bytes;
+        bank.source_bindings.push(SourceBinding {
+            artifact: artifact.to_string(),
+            tensor_prefix: (*prefix).to_string(),
+            tensors,
+            bytes,
+        });
+    }
+    // The stack no longer owns those tensors: correct its counts and its
+    // representation to what it still holds.
+    let stack_id = format!("{component}.{}", ObjectKind::DecoderStack.name());
+    if let Some(stack) = objects.get_mut(&stack_id) {
+        if let Some(binding) = stack
+            .source_bindings
+            .iter_mut()
+            .find(|b| b.artifact == artifact && b.tensor_prefix == group.prefix)
+        {
+            binding.tensors = binding.tensors.saturating_sub(carved_tensors);
+            binding.bytes = binding.bytes.saturating_sub(carved_bytes);
+        }
+        stack.representations = canonical_representation(inventory, |name| {
+            name.starts_with(&group.prefix) && !in_bank(name)
+        })
+        .into_iter()
+        .collect();
+    }
 }
 
 /// The MXFP4 pair suffixes HF writes for a block-quantised tensor: the
@@ -485,13 +578,13 @@ fn tensor_encoding<'a>(
 /// stripped. Never invented.
 fn canonical_representation(
     inventory: &ArchitectureInventory,
-    prefix: &str,
+    is_member: impl Fn(&str) -> bool,
 ) -> Option<Representation> {
     let mut encodings: Vec<&str> = inventory
         .tensors
         .tensors
         .iter()
-        .filter(|t| t.name.starts_with(prefix))
+        .filter(|t| is_member(&t.name))
         .map(|t| tensor_encoding(inventory, &t.name, t.dtype.as_str()))
         .collect();
     encodings.sort_unstable();

--- a/crates/larql-vindex/src/format/vindex3/graph/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/build.rs
@@ -446,9 +446,43 @@ fn merge_binding(
     });
 }
 
+/// The MXFP4 pair suffixes HF writes for a block-quantised tensor: the
+/// packed e2m1 nibbles and the e8m0 scales, both stored as `U8`.
+const MXFP4_BLOCKS_SUFFIX: &str = "_blocks";
+const MXFP4_SCALES_SUFFIX: &str = "_scales";
+/// The encoding name a declared MXFP4 tensor is placed under, in the same
+/// vocabulary as the region formats a container writes.
+const MXFP4_ENCODING: &str = "MXFP4";
+
+/// The encoding one tensor is placed under: its shard dtype, unless the
+/// checkpoint's declared stored representation says those bytes are
+/// something else. A `U8` `*_blocks` / `*_scales` tensor under an `mxfp4`
+/// declaration, outside `modules_to_not_convert`, is MXFP4 — placing it as
+/// raw bytes would drop the one fact that gives the bytes meaning.
+fn tensor_encoding<'a>(
+    inventory: &'a ArchitectureInventory,
+    name: &str,
+    dtype: &'a str,
+) -> &'a str {
+    let Some(rep) = inventory.stored_representation.as_ref() else {
+        return dtype;
+    };
+    let declared_mxfp4 = rep
+        .method
+        .eq_ignore_ascii_case(larql_models::inventory::representation::QUANT_METHOD_MXFP4);
+    let mxfp4_pair = name.ends_with(MXFP4_BLOCKS_SUFFIX) || name.ends_with(MXFP4_SCALES_SUFFIX);
+    if declared_mxfp4 && mxfp4_pair && dtype == "U8" && !rep.excludes(name) {
+        MXFP4_ENCODING
+    } else {
+        dtype
+    }
+}
+
 /// The canonical representation for an object: encodings actually observed
-/// in the shard headers under this prefix, falling back to the checkpoint's
-/// declared dtype when the per-tensor list was stripped. Never invented.
+/// in the shard headers under this prefix — read through the checkpoint's
+/// declared stored representation, see [`tensor_encoding`] — falling back
+/// to the checkpoint's declared dtype when the per-tensor list was
+/// stripped. Never invented.
 fn canonical_representation(
     inventory: &ArchitectureInventory,
     prefix: &str,
@@ -458,7 +492,7 @@ fn canonical_representation(
         .tensors
         .iter()
         .filter(|t| t.name.starts_with(prefix))
-        .map(|t| t.dtype.as_str())
+        .map(|t| tensor_encoding(inventory, &t.name, t.dtype.as_str()))
         .collect();
     encodings.sort_unstable();
     encodings.dedup();

--- a/crates/larql-vindex/src/format/vindex3/graph/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/mod.rs
@@ -49,7 +49,7 @@ pub use build::{build_from_inventories, BuiltGraph, IncompleteSurface, UnplacedG
 pub use complete::{execution_completeness, CompletenessDefect};
 pub use component::{Component, ComponentRole};
 pub use edge::HiddenStateEdge;
-pub use object::{LogicalObject, ObjectKind, Representation, SourceBinding};
+pub use object::{most_specific_owner, LogicalObject, ObjectKind, Representation, SourceBinding};
 pub use policy::AttentionLayerPolicy;
 pub use roles::{NormPlacement, OperandRole};
 pub use surface::ExecutionSurface;

--- a/crates/larql-vindex/src/format/vindex3/graph/object.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/object.rs
@@ -24,6 +24,13 @@ pub enum ObjectKind {
     /// The fusion/projection implementing the consumer side of a
     /// hidden-state interface (e.g. a drafter's tap-fusion projector).
     FeatureProjector,
+    /// The routed experts of a decoder stack — every layer's expert bank
+    /// as one logical object, bound per layer (`model.layers.{L}.mlp.
+    /// experts`), carved out of the stack by binding specificity (see
+    /// [`most_specific_owner`]). Its own object because it is the unit
+    /// residency, representation choice and remote placement address; the
+    /// stack keeps the router, which is dense.
+    ExpertBank,
 }
 
 impl ObjectKind {
@@ -37,6 +44,7 @@ impl ObjectKind {
             Self::PerceptionTower => "perception_tower",
             Self::PerceptionAdapter => "perception_adapter",
             Self::FeatureProjector => "feature_projector",
+            Self::ExpertBank => "expert_bank",
         }
     }
 }
@@ -88,4 +96,41 @@ pub enum Fidelity {
     Canonical,
     /// A lossy re-encoding selected by a profile.
     Approximate,
+}
+
+impl SourceBinding {
+    /// Whether `source_name` is this binding's prefix itself or lies under
+    /// it at a segment boundary (`model.layers` owns `model.layers.0.x`,
+    /// not `model.layers_extra.0`).
+    pub fn covers(&self, source_name: &str) -> bool {
+        source_name == self.tensor_prefix
+            || source_name
+                .strip_prefix(&self.tensor_prefix)
+                .is_some_and(|rest| rest.starts_with('.'))
+    }
+}
+
+/// The object owning `source_name`: among every binding of every object
+/// that covers the name, the one with the **longest** prefix wins. This is
+/// the single membership rule of the graph — it lets an expert bank bound
+/// at `model.layers.3.mlp.experts` carve its tensors out of a stack bound
+/// at `model.layers` with no exclusion lists, and it is what encode, verify
+/// and the operand tables all consult so none can disagree.
+pub fn most_specific_owner<'a>(
+    objects: impl IntoIterator<Item = &'a LogicalObject>,
+    source_name: &str,
+) -> Option<&'a LogicalObject> {
+    objects
+        .into_iter()
+        .filter_map(|object| {
+            object
+                .source_bindings
+                .iter()
+                .filter(|b| b.covers(source_name))
+                .map(|b| b.tensor_prefix.len())
+                .max()
+                .map(|depth| (depth, object))
+        })
+        .max_by_key(|(depth, _)| *depth)
+        .map(|(_, object)| object)
 }

--- a/crates/larql-vindex/src/format/vindex3/graph/roles.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/roles.rs
@@ -49,6 +49,37 @@ pub enum OperandRole {
     FfnGate,
     FfnUp,
     FfnDown,
+    /// Router logits `[experts, hidden]` of a routed FFN — lives in the
+    /// decoder stack (it is dense).
+    MoeRouterWeight,
+    /// Additive router bias `[experts]`.
+    MoeRouterBias,
+    /// Packed expert operands, living in the component's expert-bank
+    /// object: the fused gate+up projection of every expert, its
+    /// dequantisation scales (formats that keep them apart) and its
+    /// per-expert bias; likewise the down projection.
+    ExpertGateUp,
+    ExpertGateUpScales,
+    ExpertGateUpBias,
+    ExpertDown,
+    ExpertDownScales,
+    ExpertDownBias,
+}
+
+impl OperandRole {
+    /// Whether this operand lives in the expert-bank object rather than
+    /// the decoder stack.
+    pub fn is_expert_bank(self) -> bool {
+        matches!(
+            self,
+            Self::ExpertGateUp
+                | Self::ExpertGateUpScales
+                | Self::ExpertGateUpBias
+                | Self::ExpertDown
+                | Self::ExpertDownScales
+                | Self::ExpertDownBias
+        )
+    }
 }
 
 /// How norms are placed around attention and FFN in every layer of a
@@ -91,6 +122,27 @@ const ROLE_TABLE: &[(&str, OperandRole)] = &[
     ("mlp.gate_proj.weight", OperandRole::FfnGate),
     ("mlp.up_proj.weight", OperandRole::FfnUp),
     ("mlp.down_proj.weight", OperandRole::FfnDown),
+    ("mlp.router.weight", OperandRole::MoeRouterWeight),
+    ("mlp.router.bias", OperandRole::MoeRouterBias),
+    // Packed MXFP4 (GPT-OSS): blocks + scales + bias per projection.
+    ("mlp.experts.gate_up_proj_blocks", OperandRole::ExpertGateUp),
+    (
+        "mlp.experts.gate_up_proj_scales",
+        OperandRole::ExpertGateUpScales,
+    ),
+    (
+        "mlp.experts.gate_up_proj_bias",
+        OperandRole::ExpertGateUpBias,
+    ),
+    ("mlp.experts.down_proj_blocks", OperandRole::ExpertDown),
+    (
+        "mlp.experts.down_proj_scales",
+        OperandRole::ExpertDownScales,
+    ),
+    ("mlp.experts.down_proj_bias", OperandRole::ExpertDownBias),
+    // Packed BF16 (Gemma 4 A4B): one unquantised operand per projection.
+    ("mlp.experts.gate_up_proj", OperandRole::ExpertGateUp),
+    ("mlp.experts.down_proj", OperandRole::ExpertDown),
 ];
 
 /// Classify one stack tensor by its object-relative name

--- a/crates/larql-vindex/src/format/vindex3/graph/roles.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/roles.rs
@@ -27,6 +27,16 @@ pub enum OperandRole {
     /// Elementwise gate on attention output — the primitive the
     /// `self_attn.gate_proj` operand implies.
     AttnOutputGate,
+    /// Additive bias on the Q/K/V/O projections — present iff the surface
+    /// declares `attention_bias`, all four together (GPT-OSS).
+    AttnQBias,
+    AttnKBias,
+    AttnVBias,
+    AttnOBias,
+    /// Per-query-head attention-sink logits — the operand the judged
+    /// [`AttentionSinkSpec`](larql_models::config::AttentionSinkSpec)
+    /// consumes.
+    AttnSinks,
     AttnQNorm,
     AttnKNorm,
     /// `input_layernorm` — normalises the stream before attention.
@@ -61,6 +71,11 @@ const ROLE_TABLE: &[(&str, OperandRole)] = &[
     ("self_attn.v_proj.weight", OperandRole::AttnV),
     ("self_attn.o_proj.weight", OperandRole::AttnO),
     ("self_attn.gate_proj.weight", OperandRole::AttnOutputGate),
+    ("self_attn.q_proj.bias", OperandRole::AttnQBias),
+    ("self_attn.k_proj.bias", OperandRole::AttnKBias),
+    ("self_attn.v_proj.bias", OperandRole::AttnVBias),
+    ("self_attn.o_proj.bias", OperandRole::AttnOBias),
+    ("self_attn.sinks", OperandRole::AttnSinks),
     ("self_attn.q_norm.weight", OperandRole::AttnQNorm),
     ("self_attn.k_norm.weight", OperandRole::AttnKNorm),
     ("input_layernorm.weight", OperandRole::PreAttentionNorm),

--- a/crates/larql-vindex/src/format/vindex3/graph/surface.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/surface.rs
@@ -92,6 +92,14 @@ pub struct FfnSurface {
     pub intermediate_size: usize,
     pub activation: Activation,
     pub ffn_type: FfnType,
+    /// How the gate combines with the up branch: plain `activation(gate) *
+    /// up`, or GPT-OSS's clamped GLU (`swiglu_limit`, `alpha`). A distinct
+    /// policy rather than an `Activation` variant, because the clamp and
+    /// the `+1` change the model, not the nonlinearity — carried so the
+    /// declared `swiglu_limit` has a container site to be judged against
+    /// (A-9.0). Defaults for containers written before it existed.
+    #[serde(default)]
+    pub gate_policy: larql_models::ExpertGatePolicy,
 }
 
 /// What the norm op reads.
@@ -205,6 +213,7 @@ pub fn surface_from_resolved(
             intermediate_size: resolved.intermediate_size,
             activation: execution.activation,
             ffn_type: execution.ffn_type,
+            gate_policy: execution.gate_policy,
         },
         norm: NormSurface {
             pre: execution.norm_pre,
@@ -361,6 +370,9 @@ pub fn surface_from_nested(
             } else {
                 FfnType::Standard
             },
+            // Nested towers declare no gate policy; plain gating is the
+            // fact, not a fallback.
+            gate_policy: larql_models::ExpertGatePolicy::Gated,
         },
         norm: NormSurface {
             pre: NormSpec {

--- a/crates/larql-vindex/src/format/vindex3/graph/surface.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/surface.rs
@@ -20,8 +20,8 @@
 //! not a branch at run time.
 
 use larql_models::config::{
-    Activation, AttentionGateSpec, EmbeddingNorm, FfnType, NormSpec, NormType, ParameterFreeQkNorm,
-    QkNormScope,
+    Activation, AttentionGateSpec, AttentionSinkSpec, EmbeddingNorm, FfnType, NormSpec, NormType,
+    ParameterFreeQkNorm, QkNormScope,
 };
 use larql_models::inventory::components::ComponentTopology;
 use larql_models::inventory::ArchitectureInventory;
@@ -84,6 +84,23 @@ pub struct AttentionSurface {
     /// and closure refuses rather than guessing an activation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_gate: Option<AttentionGateSpec>,
+    /// Judged attention-sink semantics; `None` = no judgment exists —
+    /// **never "no sinks"**. A stack shipping an
+    /// [`OperandRole::AttnSinks`](super::roles::OperandRole) operand while
+    /// this is `None` fails operand closure; a surface stating a spec
+    /// while the operand is absent fails it too. Absent from the
+    /// serialised surface when `None`, so every pre-A-9.1 container reads
+    /// back unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sinks: Option<AttentionSinkSpec>,
+    /// Whether the Q/K/V/O projections carry additive biases, as the
+    /// checkpoint declares (`attention_bias`). `None` = undeclared, which
+    /// is not "no bias": bias operands under `None`/`Some(false)` fail
+    /// operand closure, and `Some(true)` requires all four operands. The
+    /// executor adds each bias after its projection, before QK-norm /
+    /// rope (Q, K), before caching (V) and after the output projection (O).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention_bias: Option<bool>,
 }
 
 /// What the FFN op reads.
@@ -208,6 +225,8 @@ pub fn surface_from_resolved(
             parameter_free_qk_norm: execution.parameter_free_qk_norm,
             // Judged per model; never inferred from operand presence.
             output_gate: execution.attention_output_gate,
+            sinks: execution.attention_sinks,
+            attention_bias: execution.attention_bias,
         },
         ffn: FfnSurface {
             intermediate_size: resolved.intermediate_size,
@@ -361,6 +380,8 @@ pub fn surface_from_nested(
             qk_norm_weight_offset: 0.0,
             parameter_free_qk_norm: ParameterFreeQkNorm::default(),
             output_gate: None,
+            sinks: None,
+            attention_bias: None,
         },
         ffn: FfnSurface {
             intermediate_size,

--- a/crates/larql-vindex/src/format/vindex3/graph/surface.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/surface.rs
@@ -20,7 +20,8 @@
 //! not a branch at run time.
 
 use larql_models::config::{
-    Activation, AttentionGateSpec, AttentionSinkSpec, EmbeddingNorm, FfnType, NormSpec, NormType,
+    Activation, AttentionGateSpec, AttentionSinkSpec, EmbeddingNorm, ExpertFormat,
+    ExpertRoutingPolicy, FfnType, GateUpLayout, MoeRouterKind, NormSpec, NormType,
     ParameterFreeQkNorm, QkNormScope,
 };
 use larql_models::inventory::components::ComponentTopology;
@@ -117,6 +118,47 @@ pub struct FfnSurface {
     /// (A-9.0). Defaults for containers written before it existed.
     #[serde(default)]
     pub gate_policy: larql_models::ExpertGatePolicy,
+    /// The routed-FFN judgment, when the component's FFN is a mixture of
+    /// experts. `None` = dense — and, as everywhere on the surface, a stack
+    /// shipping router or expert-bank operands under `None` fails operand
+    /// closure rather than running them as something else. Absent from the
+    /// serialised surface when `None`, so every dense container reads back
+    /// unchanged. Which layers are routed is operand evidence: a layer with
+    /// an expert bank is routed, one with dense FFN operands is dense, and
+    /// the two may interleave.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub moe: Option<MoeSurface>,
+}
+
+/// The routed-FFN (mixture-of-experts) semantics of a component, lifted
+/// from the family's judgment. Every field is something the executor
+/// reads; none is re-derived from operand names.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct MoeSurface {
+    /// Routed experts per layer.
+    pub experts: usize,
+    /// Experts selected per token.
+    pub top_k: usize,
+    /// Per-expert intermediate width (the down projection's input).
+    pub expert_intermediate_size: usize,
+    /// How router logits become selected experts and weights.
+    pub router_kind: MoeRouterKind,
+    /// Whether the selected weights are normalised to sum to one.
+    pub routing_policy: ExpertRoutingPolicy,
+    /// Whether the router carries an additive bias on its logits — the
+    /// `MoeRouterBias` operand is required iff this is set.
+    pub router_bias: bool,
+    /// How the experts are stored; decides which expert-bank operand roles
+    /// closure requires (packed MXFP4: blocks + scales + bias per
+    /// projection).
+    pub expert_format: ExpertFormat,
+    /// How a fused `gate_up` operand's rows split into gate and up.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate_up_layout: Option<GateUpLayout>,
+    /// Always-active experts alongside the routed ones.
+    pub shared_experts: usize,
+    /// A dense MLP summed with the expert block every layer.
+    pub hybrid: bool,
 }
 
 /// What the norm op reads.
@@ -233,6 +275,18 @@ pub fn surface_from_resolved(
             activation: execution.activation,
             ffn_type: execution.ffn_type,
             gate_policy: execution.gate_policy,
+            moe: execution.moe.map(|m| MoeSurface {
+                experts: m.experts,
+                top_k: m.top_k,
+                expert_intermediate_size: m.expert_intermediate_size,
+                router_kind: m.router_kind,
+                routing_policy: m.routing_policy,
+                router_bias: m.router_bias,
+                expert_format: m.expert_format,
+                gate_up_layout: m.gate_up_layout,
+                shared_experts: m.shared_experts,
+                hybrid: m.hybrid,
+            }),
         },
         norm: NormSurface {
             pre: execution.norm_pre,
@@ -394,6 +448,7 @@ pub fn surface_from_nested(
             // Nested towers declare no gate policy; plain gating is the
             // fact, not a fallback.
             gate_policy: larql_models::ExpertGatePolicy::Gated,
+            moe: None,
         },
         norm: NormSurface {
             pre: NormSpec {

--- a/crates/larql-vindex/src/format/vindex3/graph/tests/roles.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/tests/roles.rs
@@ -15,9 +15,24 @@ fn classification_is_exact_not_fuzzy() {
         classify_stack_tensor("0.pre_feedforward_layernorm.weight"),
         Some((0, OperandRole::PreFfnNorm))
     );
+    // A-9.1: the projection biases and sinks are judged roles.
+    assert_eq!(
+        classify_stack_tensor("0.self_attn.q_proj.bias"),
+        Some((0, OperandRole::AttnQBias))
+    );
+    assert_eq!(
+        classify_stack_tensor("7.self_attn.o_proj.bias"),
+        Some((7, OperandRole::AttnOBias))
+    );
+    assert_eq!(
+        classify_stack_tensor("2.self_attn.sinks"),
+        Some((2, OperandRole::AttnSinks))
+    );
     // A new upstream spelling classifies as nothing — it must block, not
-    // fuzzy-match into the wrong op.
-    assert_eq!(classify_stack_tensor("0.self_attn.q_proj.bias"), None);
+    // fuzzy-match into the wrong op: a bias on a projection no row names,
+    // a sink tensor under another spelling.
+    assert_eq!(classify_stack_tensor("0.self_attn.gate_proj.bias"), None);
+    assert_eq!(classify_stack_tensor("0.self_attn.sink.weight"), None);
     assert_eq!(
         classify_stack_tensor("0.self_attn.q_projection.weight"),
         None

--- a/crates/larql-vindex/src/format/vindex3/opplan/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/build.rs
@@ -21,19 +21,28 @@ use larql_models::config::FfnType;
 use super::super::encode::segment::{read_segment_header, SegmentTensor};
 use super::super::encode::REPRESENTATION_ID_SEP;
 use super::super::graph::roles::classify_stack_tensor;
+use super::super::graph::surface::MoeSurface;
 use super::super::graph::{LogicalObject, NormPlacement, ObjectKind, OperandRole};
 use super::super::inspect::SystemInspection;
 use super::{
-    AttentionOp, ClosureDefect, ComponentOpPlan, EmbeddingOp, FfnOp, GateOp, LayerPlan, NormOp,
-    OpPlanOutcome, OperandRef, OutputOp, QkNormOp, SinkOp,
+    AttentionOp, ClosureDefect, ComponentOpPlan, EmbeddingOp, FfnOp, GateOp, LayerFfn, LayerPlan,
+    NormOp, OpPlanOutcome, OperandRef, OutputOp, PackedProjection, QkNormOp, RoutedFfnOp, SinkOp,
 };
 use crate::error::VindexError;
+use larql_models::config::ExpertFormat;
 
 /// The post-norm epsilon, named as [`ClosureDefect::UnjudgedSemantic`]
 /// reports it.
 const POST_NORM_EPS_FACT: &str = "post-norm epsilon";
 /// The structure that makes the post-norm epsilon load-bearing.
 const FOUR_NORM_PLACEMENT: &str = "four-norm placement";
+/// The routed-FFN op, as the requirer of its judged facts.
+const ROUTED_FFN_OP: &str = "routed FFN op";
+/// Judged elsewhere, not yet expressible as an op here.
+const MOE_SHARED_OR_HYBRID_FACT: &str =
+    "shared experts / hybrid dense+expert block (no routed-FFN op variant expresses them yet)";
+/// A packed fused operand with no declared branch layout cannot be read.
+const GATE_UP_LAYOUT_FACT: &str = "gate_up branch layout";
 
 /// Build the operation plan for `component_id` from a container's
 /// inspection plus its segment tables. I/O failures are hard errors;
@@ -107,6 +116,7 @@ pub fn plan_component_ops(
         if matches!(
             object.kind,
             ObjectKind::DecoderStack
+                | ObjectKind::ExpertBank
                 | ObjectKind::Embedding
                 | ObjectKind::FinalNorm
                 | ObjectKind::OutputHead
@@ -135,73 +145,135 @@ pub fn plan_component_ops(
         qk_scope: attn.qk_norm_scope,
     };
 
+    // Judged routed-FFN semantics the plan can express today: pure routed
+    // experts with a declared fused-operand layout. Shared experts and a
+    // hybrid dense+expert block are judged for other families but have no
+    // op here yet — refuse, never drop.
+    if let Some(moe) = &surface.ffn.moe {
+        if moe.hybrid || moe.shared_experts > 0 {
+            defects.push(ClosureDefect::UnjudgedSemantic {
+                component: component.id.clone(),
+                fact: MOE_SHARED_OR_HYBRID_FACT.to_string(),
+                required_by: ROUTED_FFN_OP.to_string(),
+            });
+        }
+        if moe.gate_up_layout.is_none() {
+            defects.push(ClosureDefect::UnjudgedSemantic {
+                component: component.id.clone(),
+                fact: GATE_UP_LAYOUT_FACT.to_string(),
+                required_by: ROUTED_FFN_OP.to_string(),
+            });
+        }
+    }
+
+    // Stack operands by layer, and expert-bank operands by layer — two
+    // objects, one role vocabulary, one classifier.
     let mut by_layer: BTreeMap<usize, BTreeMap<OperandRole, SegmentTensor>> = BTreeMap::new();
-    if let Some((stack, tensors)) = tables.get(&ObjectKind::DecoderStack) {
+    let mut bank_by_layer: BTreeMap<usize, BTreeMap<OperandRole, SegmentTensor>> = BTreeMap::new();
+    for kind in [ObjectKind::DecoderStack, ObjectKind::ExpertBank] {
+        let Some((object, tensors)) = tables.get(&kind) else {
+            continue;
+        };
         for tensor in tensors {
             match classify_stack_tensor(&tensor.name) {
                 None => defects.push(ClosureDefect::UnclassifiedOperand {
-                    object: stack.id.clone(),
+                    object: object.id.clone(),
                     tensor: tensor.name.clone(),
                 }),
+                // Expert operands belong in the bank and only there; a
+                // router or any dense operand belongs in the stack.
+                Some((_, role)) if role.is_expert_bank() != (kind == ObjectKind::ExpertBank) => {
+                    defects.push(ClosureDefect::MisplacedOperand {
+                        object: object.id.clone(),
+                        tensor: tensor.name.clone(),
+                        belongs_in: if role.is_expert_bank() {
+                            ObjectKind::ExpertBank
+                        } else {
+                            ObjectKind::DecoderStack
+                        },
+                    })
+                }
                 Some((layer, role)) => {
-                    let slot = by_layer.entry(layer).or_default();
+                    let table = if kind == ObjectKind::ExpertBank {
+                        &mut bank_by_layer
+                    } else {
+                        &mut by_layer
+                    };
+                    let slot = table.entry(layer).or_default();
                     if slot.insert(role, tensor.clone()).is_some() {
                         defects.push(ClosureDefect::DuplicateOperand { layer, role });
                     }
                 }
             }
         }
+    }
 
+    if let Some((stack, _)) = tables.get(&ObjectKind::DecoderStack) {
+        let bank_id = tables
+            .get(&ObjectKind::ExpertBank)
+            .map(|(o, _)| o.id.clone())
+            .unwrap_or_default();
         for layer in 0..component.num_layers {
             let present = by_layer.get(&layer);
-            for role in required_roles(
+            let bank = bank_by_layer.get(&layer);
+            // A layer is routed by operand evidence — it has an expert
+            // bank or a router — under the surface's judgment; the
+            // judgment alone routes nothing, the evidence alone is a
+            // stray operand (`absent_op` names it).
+            let routed = surface.ffn.moe.is_some()
+                && (bank.is_some()
+                    || present.is_some_and(|s| s.contains_key(&OperandRole::MoeRouterWeight)));
+            let ops = LayerOps {
                 placement,
                 gated_ffn,
-                attn.output_gate.is_some(),
-                attn.attention_bias == Some(true),
-                attn.sinks.is_some(),
-            ) {
-                if present.is_none_or(|slot| !slot.contains_key(&role)) {
+                output_gate: attn.output_gate.is_some(),
+                attention_bias: attn.attention_bias == Some(true),
+                sinks: attn.sinks.is_some(),
+                routed,
+                moe: surface.ffn.moe,
+            };
+            for role in required_roles(&ops) {
+                let holder = if role.is_expert_bank() { bank } else { present };
+                if holder.is_none_or(|slot| !slot.contains_key(&role)) {
                     defects.push(ClosureDefect::MissingOperand { layer, role });
                 }
             }
-            let Some(slot) = present else { continue };
             // QK norms travel as a pair.
-            match (
-                slot.contains_key(&OperandRole::AttnQNorm),
-                slot.contains_key(&OperandRole::AttnKNorm),
-            ) {
-                (true, false) => defects.push(ClosureDefect::MissingOperand {
-                    layer,
-                    role: OperandRole::AttnKNorm,
-                }),
-                (false, true) => defects.push(ClosureDefect::MissingOperand {
-                    layer,
-                    role: OperandRole::AttnQNorm,
-                }),
-                _ => {}
-            }
-            for (role, tensor) in slot {
-                // An operand whose op the surface does not carry.
-                if let Some(primitive) = absent_op(
-                    *role,
-                    placement,
-                    gated_ffn,
-                    attn.output_gate.is_some(),
-                    attn.attention_bias == Some(true),
-                    attn.sinks.is_some(),
+            if let Some(slot) = present {
+                match (
+                    slot.contains_key(&OperandRole::AttnQNorm),
+                    slot.contains_key(&OperandRole::AttnKNorm),
                 ) {
+                    (true, false) => defects.push(ClosureDefect::MissingOperand {
+                        layer,
+                        role: OperandRole::AttnKNorm,
+                    }),
+                    (false, true) => defects.push(ClosureDefect::MissingOperand {
+                        layer,
+                        role: OperandRole::AttnQNorm,
+                    }),
+                    _ => {}
+                }
+            }
+            let stack_operands = present
+                .into_iter()
+                .flatten()
+                .map(|(r, t)| (r, t, &stack.id));
+            let bank_operands = bank.into_iter().flatten().map(|(r, t)| (r, t, &bank_id));
+            for (role, tensor, object_id) in stack_operands.chain(bank_operands) {
+                // An operand whose op the surface does not carry.
+                if let Some(primitive) = absent_op(*role, &ops) {
                     defects.push(ClosureDefect::OperandImpliesAbsentOp {
-                        object: stack.id.clone(),
+                        object: object_id.clone(),
                         tensor: tensor.name.clone(),
                         required_primitive: primitive.to_string(),
                     });
                     continue;
                 }
-                if let Some(expected) = expected_shape(*role, &geometry) {
+                if let Some(expected) = expected_shape(*role, &geometry, surface.ffn.moe.as_ref()) {
                     if tensor.shape != expected {
                         defects.push(ClosureDefect::GeometryMismatch {
-                            tensor: format!("{}/{}", stack.id, tensor.name),
+                            tensor: format!("{object_id}/{}", tensor.name),
                             expected,
                             actual: tensor.shape.clone(),
                         });
@@ -317,7 +389,51 @@ pub fn plan_component_ops(
             }
             NormPlacement::PreOnly => (None, OperandRole::PostAttentionNorm, None),
         };
-        let consumed = slot.len();
+        let bank_slot = bank_by_layer.get(&layer);
+        let bank_id = tables
+            .get(&ObjectKind::ExpertBank)
+            .map(|(o, _)| o.id.clone())
+            .unwrap_or_default();
+        let ffn = match (surface.ffn.moe, bank_slot) {
+            (Some(moe), Some(bank)) => {
+                let bank_operand = |role: OperandRole| operand(&bank_id, &bank[&role]);
+                let optional = |role: OperandRole| bank.get(&role).map(|t| operand(&bank_id, t));
+                LayerFfn::Routed(Box::new(RoutedFfnOp {
+                    experts: moe.experts,
+                    top_k: moe.top_k,
+                    expert_intermediate_size: moe.expert_intermediate_size,
+                    router_kind: moe.router_kind,
+                    routing_policy: moe.routing_policy,
+                    activation: surface.ffn.activation,
+                    gate_policy: surface.ffn.gate_policy,
+                    expert_format: moe.expert_format,
+                    gate_up_layout: moe.gate_up_layout,
+                    router: operand(&stack_id, get(OperandRole::MoeRouterWeight)),
+                    router_bias: moe
+                        .router_bias
+                        .then(|| operand(&stack_id, get(OperandRole::MoeRouterBias))),
+                    gate_up: PackedProjection {
+                        weights: bank_operand(OperandRole::ExpertGateUp),
+                        scales: optional(OperandRole::ExpertGateUpScales),
+                        bias: optional(OperandRole::ExpertGateUpBias),
+                    },
+                    down: PackedProjection {
+                        weights: bank_operand(OperandRole::ExpertDown),
+                        scales: optional(OperandRole::ExpertDownScales),
+                        bias: optional(OperandRole::ExpertDownBias),
+                    },
+                }))
+            }
+            _ => LayerFfn::Dense(Box::new(FfnOp {
+                intermediate_size: inter,
+                activation: surface.ffn.activation,
+                gate_policy: surface.ffn.gate_policy,
+                gate: gated_ffn.then(|| operand(&stack_id, get(OperandRole::FfnGate))),
+                up: operand(&stack_id, get(OperandRole::FfnUp)),
+                down: operand(&stack_id, get(OperandRole::FfnDown)),
+            })),
+        };
+        let consumed = slot.len() + bank_slot.map_or(0, |b| b.len());
         layers.push(LayerPlan {
             layer,
             pre_attention_norm: norm_op(
@@ -358,14 +474,7 @@ pub fn plan_component_ops(
             },
             post_attention_norm,
             pre_ffn_norm: norm_op(surface.norm.pre, &stack_id, get(pre_ffn_role)),
-            ffn: FfnOp {
-                intermediate_size: inter,
-                activation: surface.ffn.activation,
-                gate_policy: surface.ffn.gate_policy,
-                gate: gated_ffn.then(|| operand(&stack_id, get(OperandRole::FfnGate))),
-                up: operand(&stack_id, get(OperandRole::FfnUp)),
-                down: operand(&stack_id, get(OperandRole::FfnDown)),
-            },
+            ffn,
             post_ffn_norm,
             operands_accounted: consumed,
             operands_present: consumed,
@@ -421,14 +530,22 @@ fn object_tensors(
     Ok(header.tensors)
 }
 
-/// Roles every layer must supply, given the surface's ops.
-fn required_roles(
+/// The ops one layer's surface declares — what decides which operands
+/// it must have and which it may not.
+struct LayerOps {
     placement: NormPlacement,
     gated_ffn: bool,
     output_gate: bool,
     attention_bias: bool,
     sinks: bool,
-) -> Vec<OperandRole> {
+    /// This layer's FFN is routed (bank/router evidence under a MoE
+    /// judgment); dense otherwise.
+    routed: bool,
+    moe: Option<MoeSurface>,
+}
+
+/// Roles every layer must supply, given the surface's ops.
+fn required_roles(ops: &LayerOps) -> Vec<OperandRole> {
     let mut roles = vec![
         OperandRole::PreAttentionNorm,
         OperandRole::PostAttentionNorm,
@@ -436,20 +553,15 @@ fn required_roles(
         OperandRole::AttnK,
         OperandRole::AttnV,
         OperandRole::AttnO,
-        OperandRole::FfnUp,
-        OperandRole::FfnDown,
     ];
-    if placement == NormPlacement::PrePost {
+    if ops.placement == NormPlacement::PrePost {
         roles.push(OperandRole::PreFfnNorm);
         roles.push(OperandRole::PostFfnNorm);
     }
-    if gated_ffn {
-        roles.push(OperandRole::FfnGate);
-    }
-    if output_gate {
+    if ops.output_gate {
         roles.push(OperandRole::AttnOutputGate);
     }
-    if attention_bias {
+    if ops.attention_bias {
         roles.extend([
             OperandRole::AttnQBias,
             OperandRole::AttnKBias,
@@ -457,38 +569,79 @@ fn required_roles(
             OperandRole::AttnOBias,
         ]);
     }
-    if sinks {
+    if ops.sinks {
         roles.push(OperandRole::AttnSinks);
+    }
+    match (ops.routed, ops.moe) {
+        (true, Some(moe)) => {
+            roles.extend([
+                OperandRole::MoeRouterWeight,
+                OperandRole::ExpertGateUp,
+                OperandRole::ExpertDown,
+            ]);
+            if moe.router_bias {
+                roles.push(OperandRole::MoeRouterBias);
+            }
+            if moe.expert_format.has_split_scale_streams() {
+                roles.push(OperandRole::ExpertGateUpScales);
+                roles.push(OperandRole::ExpertDownScales);
+            }
+        }
+        _ => {
+            roles.push(OperandRole::FfnUp);
+            roles.push(OperandRole::FfnDown);
+            if ops.gated_ffn {
+                roles.push(OperandRole::FfnGate);
+            }
+        }
     }
     roles
 }
 
 /// The primitive a found operand requires when the surface does not carry
 /// its op. `None` when the operand is consumed by a declared op.
-fn absent_op(
-    role: OperandRole,
-    placement: NormPlacement,
-    gated_ffn: bool,
-    output_gate: bool,
-    attention_bias: bool,
-    sinks: bool,
-) -> Option<&'static str> {
+fn absent_op(role: OperandRole, ops: &LayerOps) -> Option<&'static str> {
     match role {
-        OperandRole::AttnOutputGate if !output_gate => {
+        OperandRole::AttnOutputGate if !ops.output_gate => {
             Some("attention output gate (judged semantics)")
         }
         OperandRole::AttnQBias
         | OperandRole::AttnKBias
         | OperandRole::AttnVBias
         | OperandRole::AttnOBias
-            if !attention_bias =>
+            if !ops.attention_bias =>
         {
             Some("attention projection bias (declared `attention_bias`)")
         }
-        OperandRole::AttnSinks if !sinks => Some("attention sinks (judged semantics)"),
-        OperandRole::FfnGate if !gated_ffn => Some("gated FFN"),
+        OperandRole::AttnSinks if !ops.sinks => Some("attention sinks (judged semantics)"),
+        OperandRole::FfnGate if !ops.routed && !ops.gated_ffn => Some("gated FFN"),
+        OperandRole::FfnGate | OperandRole::FfnUp | OperandRole::FfnDown if ops.routed => {
+            Some("dense FFN (this layer is routed)")
+        }
+        OperandRole::MoeRouterWeight
+        | OperandRole::MoeRouterBias
+        | OperandRole::ExpertGateUp
+        | OperandRole::ExpertGateUpScales
+        | OperandRole::ExpertGateUpBias
+        | OperandRole::ExpertDown
+        | OperandRole::ExpertDownScales
+        | OperandRole::ExpertDownBias
+            if !ops.routed =>
+        {
+            Some("routed FFN (judged semantics)")
+        }
+        OperandRole::MoeRouterBias if ops.moe.is_some_and(|m| !m.router_bias) => {
+            Some("router bias (declared by the routed-FFN judgment)")
+        }
+        OperandRole::ExpertGateUpScales | OperandRole::ExpertDownScales
+            if ops
+                .moe
+                .is_some_and(|m| !m.expert_format.has_split_scale_streams()) =>
+        {
+            Some("a scaled expert format (this format carries no separate scales)")
+        }
         OperandRole::PreFfnNorm | OperandRole::PostFfnNorm
-            if placement == NormPlacement::PreOnly =>
+            if ops.placement == NormPlacement::PreOnly =>
         {
             Some("four-norm placement")
         }
@@ -509,7 +662,11 @@ struct StackGeometry {
 
 /// Expected stored shape per role, from the surface's geometry. `None`
 /// for roles whose shape contract is not yet pinned.
-fn expected_shape(role: OperandRole, g: &StackGeometry) -> Option<Vec<usize>> {
+fn expected_shape(
+    role: OperandRole,
+    g: &StackGeometry,
+    moe: Option<&MoeSurface>,
+) -> Option<Vec<usize>> {
     use larql_models::config::QkNormScope;
     let StackGeometry {
         hidden,
@@ -544,5 +701,64 @@ fn expected_shape(role: OperandRole, g: &StackGeometry) -> Option<Vec<usize>> {
         OperandRole::AttnOBias => Some(vec![hidden]),
         // One logit per query head, per the judged spec.
         OperandRole::AttnSinks => Some(vec![num_q_heads]),
+        // Routed FFN: every shape follows from the judgment's expert count,
+        // width and storage format; with no judgment there is no contract
+        // (the operand is refused by `absent_op` before this is asked).
+        OperandRole::MoeRouterWeight => Some(vec![moe?.experts, hidden]),
+        OperandRole::MoeRouterBias => Some(vec![moe?.experts]),
+        OperandRole::ExpertGateUp => {
+            let m = moe?;
+            Some(packed_shape(
+                m,
+                FUSED_BRANCHES * m.expert_intermediate_size,
+                hidden,
+            ))
+        }
+        OperandRole::ExpertGateUpScales => {
+            let m = moe?;
+            Some(scales_shape(
+                m,
+                FUSED_BRANCHES * m.expert_intermediate_size,
+                hidden,
+            ))
+        }
+        OperandRole::ExpertGateUpBias => {
+            let m = moe?;
+            Some(vec![m.experts, FUSED_BRANCHES * m.expert_intermediate_size])
+        }
+        OperandRole::ExpertDown => {
+            let m = moe?;
+            Some(packed_shape(m, hidden, m.expert_intermediate_size))
+        }
+        OperandRole::ExpertDownScales => {
+            let m = moe?;
+            Some(scales_shape(m, hidden, m.expert_intermediate_size))
+        }
+        OperandRole::ExpertDownBias => Some(vec![moe?.experts, hidden]),
+    }
+}
+
+/// Gate and up: the two branches sharing one fused operand.
+const FUSED_BRANCHES: usize = larql_models::quant::mxfp4::FUSED_HALVES;
+
+/// Stored shape of a packed `[experts, rows, k]` projection under the
+/// judged format: MXFP4 packs `k` as `k/32` groups of 16 bytes (32
+/// nibbles); an unquantised packed store keeps `[experts, rows, k]`.
+fn packed_shape(moe: &MoeSurface, rows: usize, k: usize) -> Vec<usize> {
+    use larql_models::quant::mxfp4::{MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS};
+    match moe.expert_format {
+        ExpertFormat::PackedMxfp4 => {
+            vec![moe.experts, rows, k / MXFP4_GROUP_ELEMS, MXFP4_GROUP_BYTES]
+        }
+        ExpertFormat::PackedBF16 | ExpertFormat::PerExpert => vec![moe.experts, rows, k],
+    }
+}
+
+/// Stored shape of the companion scales stream: one E8M0 byte per group.
+fn scales_shape(moe: &MoeSurface, rows: usize, k: usize) -> Vec<usize> {
+    use larql_models::quant::mxfp4::MXFP4_GROUP_ELEMS;
+    match moe.expert_format {
+        ExpertFormat::PackedMxfp4 => vec![moe.experts, rows, k / MXFP4_GROUP_ELEMS],
+        ExpertFormat::PackedBF16 | ExpertFormat::PerExpert => vec![moe.experts, rows],
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/build.rs
@@ -336,6 +336,7 @@ pub fn plan_component_ops(
             ffn: FfnOp {
                 intermediate_size: inter,
                 activation: surface.ffn.activation,
+                gate_policy: surface.ffn.gate_policy,
                 gate: gated_ffn.then(|| operand(&stack_id, get(OperandRole::FfnGate))),
                 up: operand(&stack_id, get(OperandRole::FfnUp)),
                 down: operand(&stack_id, get(OperandRole::FfnDown)),

--- a/crates/larql-vindex/src/format/vindex3/opplan/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/build.rs
@@ -25,7 +25,7 @@ use super::super::graph::{LogicalObject, NormPlacement, ObjectKind, OperandRole}
 use super::super::inspect::SystemInspection;
 use super::{
     AttentionOp, ClosureDefect, ComponentOpPlan, EmbeddingOp, FfnOp, GateOp, LayerPlan, NormOp,
-    OpPlanOutcome, OperandRef, OutputOp, QkNormOp,
+    OpPlanOutcome, OperandRef, OutputOp, QkNormOp, SinkOp,
 };
 use crate::error::VindexError;
 
@@ -125,6 +125,15 @@ pub fn plan_component_ops(
     let kv_rows = attn.num_kv_heads * attn.head_dim;
     let inter = surface.ffn.intermediate_size;
     let gated_ffn = surface.ffn.ffn_type == FfnType::Gated;
+    let geometry = StackGeometry {
+        hidden,
+        q_rows,
+        kv_rows,
+        intermediate: inter,
+        head_dim: attn.head_dim,
+        num_q_heads: attn.num_q_heads,
+        qk_scope: attn.qk_norm_scope,
+    };
 
     let mut by_layer: BTreeMap<usize, BTreeMap<OperandRole, SegmentTensor>> = BTreeMap::new();
     if let Some((stack, tensors)) = tables.get(&ObjectKind::DecoderStack) {
@@ -145,7 +154,13 @@ pub fn plan_component_ops(
 
         for layer in 0..component.num_layers {
             let present = by_layer.get(&layer);
-            for role in required_roles(placement, gated_ffn, attn.output_gate.is_some()) {
+            for role in required_roles(
+                placement,
+                gated_ffn,
+                attn.output_gate.is_some(),
+                attn.attention_bias == Some(true),
+                attn.sinks.is_some(),
+            ) {
                 if present.is_none_or(|slot| !slot.contains_key(&role)) {
                     defects.push(ClosureDefect::MissingOperand { layer, role });
                 }
@@ -168,9 +183,14 @@ pub fn plan_component_ops(
             }
             for (role, tensor) in slot {
                 // An operand whose op the surface does not carry.
-                if let Some(primitive) =
-                    absent_op(*role, placement, gated_ffn, attn.output_gate.is_some())
-                {
+                if let Some(primitive) = absent_op(
+                    *role,
+                    placement,
+                    gated_ffn,
+                    attn.output_gate.is_some(),
+                    attn.attention_bias == Some(true),
+                    attn.sinks.is_some(),
+                ) {
                     defects.push(ClosureDefect::OperandImpliesAbsentOp {
                         object: stack.id.clone(),
                         tensor: tensor.name.clone(),
@@ -178,15 +198,7 @@ pub fn plan_component_ops(
                     });
                     continue;
                 }
-                if let Some(expected) = expected_shape(
-                    *role,
-                    hidden,
-                    q_rows,
-                    kv_rows,
-                    inter,
-                    attn.head_dim,
-                    attn.qk_norm_scope,
-                ) {
+                if let Some(expected) = expected_shape(*role, &geometry) {
                     if tensor.shape != expected {
                         defects.push(ClosureDefect::GeometryMismatch {
                             tensor: format!("{}/{}", stack.id, tensor.name),
@@ -276,6 +288,9 @@ pub fn plan_component_ops(
         let slot = &by_layer[&layer];
         let get = |role: OperandRole| &slot[&role];
         let policy = &attention_table[layer];
+        let bias = |role: OperandRole| {
+            (attn.attention_bias == Some(true)).then(|| operand(&stack_id, get(role)))
+        };
         let qk_norm = slot
             .contains_key(&OperandRole::AttnQNorm)
             .then(|| QkNormOp {
@@ -329,6 +344,16 @@ pub fn plan_component_ops(
                 output_gate: attn.output_gate.map(|spec| GateOp {
                     spec,
                     projection: operand(&stack_id, get(OperandRole::AttnOutputGate)),
+                }),
+                // Closure held, so `Some(true)` means all four are here
+                // and anything else means none is.
+                q_bias: bias(OperandRole::AttnQBias),
+                k_bias: bias(OperandRole::AttnKBias),
+                v_bias: bias(OperandRole::AttnVBias),
+                o_bias: bias(OperandRole::AttnOBias),
+                sinks: attn.sinks.map(|spec| SinkOp {
+                    spec,
+                    logits: operand(&stack_id, get(OperandRole::AttnSinks)),
                 }),
             },
             post_attention_norm,
@@ -401,6 +426,8 @@ fn required_roles(
     placement: NormPlacement,
     gated_ffn: bool,
     output_gate: bool,
+    attention_bias: bool,
+    sinks: bool,
 ) -> Vec<OperandRole> {
     let mut roles = vec![
         OperandRole::PreAttentionNorm,
@@ -422,6 +449,17 @@ fn required_roles(
     if output_gate {
         roles.push(OperandRole::AttnOutputGate);
     }
+    if attention_bias {
+        roles.extend([
+            OperandRole::AttnQBias,
+            OperandRole::AttnKBias,
+            OperandRole::AttnVBias,
+            OperandRole::AttnOBias,
+        ]);
+    }
+    if sinks {
+        roles.push(OperandRole::AttnSinks);
+    }
     roles
 }
 
@@ -432,11 +470,22 @@ fn absent_op(
     placement: NormPlacement,
     gated_ffn: bool,
     output_gate: bool,
+    attention_bias: bool,
+    sinks: bool,
 ) -> Option<&'static str> {
     match role {
         OperandRole::AttnOutputGate if !output_gate => {
             Some("attention output gate (judged semantics)")
         }
+        OperandRole::AttnQBias
+        | OperandRole::AttnKBias
+        | OperandRole::AttnVBias
+        | OperandRole::AttnOBias
+            if !attention_bias =>
+        {
+            Some("attention projection bias (declared `attention_bias`)")
+        }
+        OperandRole::AttnSinks if !sinks => Some("attention sinks (judged semantics)"),
         OperandRole::FfnGate if !gated_ffn => Some("gated FFN"),
         OperandRole::PreFfnNorm | OperandRole::PostFfnNorm
             if placement == NormPlacement::PreOnly =>
@@ -447,18 +496,30 @@ fn absent_op(
     }
 }
 
-/// Expected stored shape per role, from the surface's geometry. `None`
-/// for roles whose shape contract is not yet pinned.
-fn expected_shape(
-    role: OperandRole,
+/// The surface geometry every stack operand's shape is checked against.
+struct StackGeometry {
     hidden: usize,
     q_rows: usize,
     kv_rows: usize,
     intermediate: usize,
     head_dim: usize,
+    num_q_heads: usize,
     qk_scope: larql_models::config::QkNormScope,
-) -> Option<Vec<usize>> {
+}
+
+/// Expected stored shape per role, from the surface's geometry. `None`
+/// for roles whose shape contract is not yet pinned.
+fn expected_shape(role: OperandRole, g: &StackGeometry) -> Option<Vec<usize>> {
     use larql_models::config::QkNormScope;
+    let StackGeometry {
+        hidden,
+        q_rows,
+        kv_rows,
+        intermediate,
+        head_dim,
+        num_q_heads,
+        qk_scope,
+    } = *g;
     match role {
         OperandRole::AttnQ => Some(vec![q_rows, hidden]),
         OperandRole::AttnK | OperandRole::AttnV => Some(vec![kv_rows, hidden]),
@@ -477,5 +538,11 @@ fn expected_shape(
         OperandRole::FfnDown => Some(vec![hidden, intermediate]),
         // Linear(hidden -> q_heads*head_dim), per the judged spec.
         OperandRole::AttnOutputGate => Some(vec![q_rows, hidden]),
+        // A bias is one value per output row of its projection.
+        OperandRole::AttnQBias => Some(vec![q_rows]),
+        OperandRole::AttnKBias | OperandRole::AttnVBias => Some(vec![kv_rows]),
+        OperandRole::AttnOBias => Some(vec![hidden]),
+        // One logit per query head, per the judged spec.
+        OperandRole::AttnSinks => Some(vec![num_q_heads]),
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -220,6 +220,10 @@ pub struct FfnCall<'a> {
     pub up: WeightSlice<'a>,
     pub down: WeightSlice<'a>,
     pub activation: Activation,
+    /// How `gate` combines with `up`. Every backend must honour it or
+    /// refuse: computing `activation(gate) * up` for a `ClampedGlu` plan
+    /// runs a different model.
+    pub gate_policy: larql_models::ExpertGatePolicy,
 }
 
 /// One position's attention against interpreter-owned K/V state — the

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -22,7 +22,8 @@
 //! only ever be told what to compute.
 
 use larql_models::config::{
-    Activation, AttentionGateSpec, NormType, ParameterFreeQkNorm, PositionPolicy, QkNormScope,
+    Activation, AttentionGateSpec, AttentionSinkSpec, NormType, ParameterFreeQkNorm,
+    PositionPolicy, QkNormScope,
 };
 
 use super::super::super::graph::policy::AttentionSpan;
@@ -177,6 +178,24 @@ pub struct GateCall<'a> {
     pub weight: WeightSlice<'a>,
 }
 
+/// The judged attention-sink semantics plus the per-query-head logits,
+/// f32 like every other elementwise operand.
+pub struct SinkCall<'a> {
+    pub spec: AttentionSinkSpec,
+    /// `num_q_heads` logits.
+    pub logits: &'a [f32],
+}
+
+/// The additive projection biases, all four present or none — closure
+/// guarantees the pairing with the surface's `attention_bias`. Each is
+/// one value per output row of its projection.
+pub struct BiasCall<'a> {
+    pub q: &'a [f32],
+    pub k: &'a [f32],
+    pub v: &'a [f32],
+    pub o: &'a [f32],
+}
+
 /// One attention operation over a whole sequence, fully resolved.
 ///
 /// `inputs` are the attention *inputs* — already normalised by the
@@ -206,6 +225,12 @@ pub struct AttentionCall<'a> {
     pub span: AttentionSpan,
     pub window: Option<usize>,
     pub gate: Option<GateCall<'a>>,
+    /// Q/K/V/O biases: Q and K added right after projection (before
+    /// QK-norm and rope), V before caching, O after the output
+    /// projection. `None` = the op has no biases.
+    pub bias: Option<BiasCall<'a>>,
+    /// Attention sinks; `None` = ordinary softmax.
+    pub sinks: Option<SinkCall<'a>>,
 }
 
 /// One feed-forward operation over one vector, fully resolved.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -22,8 +22,8 @@
 //! only ever be told what to compute.
 
 use larql_models::config::{
-    Activation, AttentionGateSpec, AttentionSinkSpec, NormType, ParameterFreeQkNorm,
-    PositionPolicy, QkNormScope,
+    Activation, AttentionGateSpec, AttentionSinkSpec, ExpertRoutingPolicy, GateUpLayout,
+    MoeRouterKind, NormType, ParameterFreeQkNorm, PositionPolicy, QkNormScope,
 };
 
 use super::super::super::graph::policy::AttentionSpan;
@@ -251,6 +251,39 @@ pub struct FfnCall<'a> {
     pub gate_policy: larql_models::ExpertGatePolicy,
 }
 
+/// One routed feed-forward operation over one vector, fully resolved:
+/// the router in f32 (glue-sized), every expert's projections in the
+/// backend's declared FFN format, and every judged semantic as an
+/// argument. The backend routes, runs the selected experts and combines
+/// — nothing here is re-derived from the plan.
+pub struct RoutedFfnCall<'a> {
+    pub x: &'a [f32],
+    pub hidden: usize,
+    /// Per-expert intermediate width.
+    pub intermediate: usize,
+    pub experts: usize,
+    pub top_k: usize,
+    pub router_kind: MoeRouterKind,
+    pub routing_policy: ExpertRoutingPolicy,
+    pub activation: Activation,
+    pub gate_policy: larql_models::ExpertGatePolicy,
+    /// How each expert's fused `gate_up` rows split into gate and up.
+    pub gate_up_layout: GateUpLayout,
+    /// Router logits matrix `[experts, hidden]`, row-major.
+    pub router: &'a [f32],
+    /// Additive router bias `[experts]`.
+    pub router_bias: Option<&'a [f32]>,
+    /// One `[2·intermediate, hidden]` matrix per expert.
+    pub gate_up: &'a [WeightSlice<'a>],
+    /// Fused gate/up bias, `[experts · 2·intermediate]` flat, in the
+    /// operand's own row layout.
+    pub gate_up_bias: Option<&'a [f32]>,
+    /// One `[hidden, intermediate]` matrix per expert.
+    pub down: &'a [WeightSlice<'a>],
+    /// Down bias, `[experts · hidden]` flat.
+    pub down_bias: Option<&'a [f32]>,
+}
+
 /// One position's attention against interpreter-owned K/V state — the
 /// decode step.
 ///
@@ -366,6 +399,11 @@ pub trait PlanBackend: Sync {
     /// with no kernel for a judged variant must say so, not borrow
     /// another backend's arithmetic to fill the gap.
     fn ffn(&self, call: FfnCall<'_>) -> Result<Vec<f32>, VindexError>;
+
+    /// The routed FFN — a mixture of experts. Required of every backend
+    /// for the same reason as [`Self::ffn`]: a backend without the
+    /// arithmetic must refuse, never borrow it.
+    fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError>;
 
     /// Vocabulary projection plus the head's optional multiplier and
     /// softcap, in that order.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -264,6 +264,7 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
                 up: state.ffn_up.slice(),
                 down: state.ffn_down.slice(),
                 activation: layer.ffn.activation,
+                gate_policy: layer.ffn.gate_policy,
             })?;
             let ffn_out = match &state.post_ffn {
                 Some(norm) => norm.apply(self.backend, &ffn_out),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -21,7 +21,7 @@
 //! [`step`]: DecodeSession::step
 //! [`attention_step`]: super::backend::PlanBackend::attention_step
 
-use super::backend::{AttentionStepCall, FfnCall, MatrixClass, NormCall, PlanBackend};
+use super::backend::{AttentionStepCall, MatrixClass, NormCall, PlanBackend};
 use super::operands::OperandStore;
 use super::weights::{load_weight, LoadedWeight};
 use super::AttentionOperands;
@@ -60,9 +60,7 @@ struct LayerState {
     attention: AttentionOperands,
     post_attention: Option<LoadedNorm>,
     pre_ffn: LoadedNorm,
-    ffn_gate: Option<LoadedWeight>,
-    ffn_up: LoadedWeight,
-    ffn_down: LoadedWeight,
+    ffn: super::experts::FfnOperands,
     post_ffn: Option<LoadedNorm>,
     keys: Vec<Vec<f32>>,
     values: Vec<Vec<f32>>,
@@ -120,26 +118,9 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
                     .map(|op| LoadedNorm::load(op, store))
                     .transpose()?,
                 pre_ffn: LoadedNorm::load(&layer.pre_ffn_norm, store)?,
-                ffn_gate: layer
-                    .ffn
-                    .gate
-                    .as_ref()
-                    .map(|gate| {
-                        load_weight(
-                            store,
-                            gate,
-                            backend.weight_format(MatrixClass::FfnProjection),
-                        )
-                    })
-                    .transpose()?,
-                ffn_up: load_weight(
+                ffn: super::experts::FfnOperands::load(
+                    &layer.ffn,
                     store,
-                    &layer.ffn.up,
-                    backend.weight_format(MatrixClass::FfnProjection),
-                )?,
-                ffn_down: load_weight(
-                    store,
-                    &layer.ffn.down,
                     backend.weight_format(MatrixClass::FfnProjection),
                 )?,
                 post_ffn: layer
@@ -184,11 +165,7 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
         let mut weights: Vec<super::backend::WeightSlice<'_>> = Vec::new();
         for state in &session.layers {
             weights.extend(state.attention.weight_slices());
-            if let Some(gate) = &state.ffn_gate {
-                weights.push(gate.slice());
-            }
-            weights.push(state.ffn_up.slice());
-            weights.push(state.ffn_down.slice());
+            weights.extend(state.ffn.weight_slices());
         }
         if let Some((_, projection)) = &session.output {
             weights.push(projection.slice());
@@ -256,16 +233,9 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
             self.backend.residual_add(&mut h, &attn_out);
 
             let normed = state.pre_ffn.apply(self.backend, &h);
-            let ffn_out = self.backend.ffn(FfnCall {
-                x: &normed,
-                hidden: self.hidden,
-                intermediate: layer.ffn.intermediate_size,
-                gate: state.ffn_gate.as_ref().map(LoadedWeight::slice),
-                up: state.ffn_up.slice(),
-                down: state.ffn_down.slice(),
-                activation: layer.ffn.activation,
-                gate_policy: layer.ffn.gate_policy,
-            })?;
+            let ffn_out = state
+                .ffn
+                .apply(&layer.ffn, self.backend, &normed, self.hidden)?;
             let ffn_out = match &state.post_ffn {
                 Some(norm) => norm.apply(self.backend, &ffn_out),
                 None => ffn_out,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
@@ -48,12 +48,12 @@ use larql_models::config::{Activation, GateActivation, GateCombine, GatePlacemen
 
 use super::backend::{
     AttentionCall, AttentionStepCall, AttentionStepOut, DispatchStats, FfnCall, GateCall,
-    MatrixClass, NormCall, PlanBackend, ProjectCall, ProjectedQkv, WeightFormat, WeightFormats,
-    WeightSlice,
+    MatrixClass, NormCall, PlanBackend, ProjectCall, ProjectedQkv, RoutedFfnCall, WeightFormat,
+    WeightFormats, WeightSlice,
 };
 use super::production::{
-    add_output_bias, add_projection_biases, aggregate_heads, condition_qk_in_place,
-    ProductionBackend,
+    add_expert_bias, add_output_bias, add_projection_biases, aggregate_heads,
+    condition_qk_in_place, expert_inner, select_experts, ProductionBackend, FUSED_BRANCHES,
 };
 use crate::error::VindexError;
 use larql_compute::cpu::ops::geglu::{geglu_silu_alloc, silu};
@@ -491,6 +491,36 @@ impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
             value: v,
             output,
         })
+    }
+
+    /// The routed FFN on the device: router, then each selected expert's
+    /// fused gate/up and down through the same `gemv` seam as every other
+    /// matrix — in whatever representation the bank was loaded (native
+    /// MXFP4 when this backend declared it). Selection and the gate rule
+    /// are the production glue, so a divergence is device matmul
+    /// arithmetic alone.
+    fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        let mut logits = self.gemv(
+            WeightSlice::F32(call.router),
+            call.experts,
+            call.hidden,
+            call.x,
+        )?;
+        let selected = select_experts(&call, &mut logits)?;
+        let two_inter = FUSED_BRANCHES * call.intermediate;
+        let mut out = vec![0.0f32; call.hidden];
+        for (expert, weight) in selected {
+            let mut fused = self.gemv(call.gate_up[expert], two_inter, call.hidden, call.x)?;
+            add_expert_bias(&mut fused, call.gate_up_bias, expert);
+            let inner = expert_inner(&call, &fused);
+            let mut expert_out =
+                self.gemv(call.down[expert], call.hidden, call.intermediate, &inner)?;
+            add_expert_bias(&mut expert_out, call.down_bias, expert);
+            for (acc, v) in out.iter_mut().zip(&expert_out) {
+                *acc += weight * v;
+            }
+        }
+        Ok(out)
     }
 
     fn ffn(&self, call: FfnCall<'_>) -> Result<Vec<f32>, VindexError> {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
@@ -51,7 +51,10 @@ use super::backend::{
     MatrixClass, NormCall, PlanBackend, ProjectCall, ProjectedQkv, WeightFormat, WeightFormats,
     WeightSlice,
 };
-use super::production::{aggregate_heads, condition_qk_in_place, ProductionBackend};
+use super::production::{
+    add_output_bias, add_projection_biases, aggregate_heads, condition_qk_in_place,
+    ProductionBackend,
+};
 use crate::error::VindexError;
 use larql_compute::cpu::ops::geglu::{geglu_silu_alloc, silu};
 use ndarray::ArrayView2;
@@ -299,9 +302,10 @@ impl<M: MatMul + Send> DevicePlanBackend<M> {
             ],
             pre,
         )?;
-        let v = qkv.pop().expect("three matrices in, three vectors out");
+        let mut v = qkv.pop().expect("three matrices in, three vectors out");
         let mut k = qkv.pop().expect("three matrices in, three vectors out");
         let mut q = qkv.pop().expect("three matrices in, three vectors out");
+        add_projection_biases(call, &mut q, &mut k, &mut v);
         condition_qk_in_place(call, position, &mut q, &mut k)?;
         Ok((q, k, v))
     }
@@ -408,12 +412,14 @@ impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
                     *c *= 1.0 / (1.0 + (-g).exp());
                 }
             }
-            out.push(self.gemv(
+            let mut projected = self.gemv(
                 call.w_o,
                 call.hidden,
                 call.num_q_heads * call.head_dim,
                 &concat,
-            )?);
+            )?;
+            add_output_bias(&call, &mut projected);
+            out.push(projected);
         }
         Ok(out)
     }
@@ -440,9 +446,10 @@ impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
             .gate
             .as_ref()
             .map(|_| projected.pop().expect("gate matrix in, gate vector out"));
-        let v = projected.pop().expect("QKV in, three vectors out");
+        let mut v = projected.pop().expect("QKV in, three vectors out");
         let mut k = projected.pop().expect("QKV in, three vectors out");
         let mut q = projected.pop().expect("QKV in, three vectors out");
+        add_projection_biases(call, &mut q, &mut k, &mut v);
         condition_qk_in_place(call, step.position, &mut q, &mut k)?;
 
         let mut concat = aggregate_heads(
@@ -477,7 +484,8 @@ impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
                 *c *= 1.0 / (1.0 + (-g).exp());
             }
         }
-        let output = self.gemv(call.w_o, call.hidden, q_rows, &concat)?;
+        let mut output = self.gemv(call.w_o, call.hidden, q_rows, &concat)?;
+        add_output_bias(call, &mut output);
         Ok(AttentionStepOut {
             key: k,
             value: v,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
@@ -302,7 +302,7 @@ impl<M: MatMul + Send> DevicePlanBackend<M> {
         let v = qkv.pop().expect("three matrices in, three vectors out");
         let mut k = qkv.pop().expect("three matrices in, three vectors out");
         let mut q = qkv.pop().expect("three matrices in, three vectors out");
-        condition_qk_in_place(call, position, &mut q, &mut k);
+        condition_qk_in_place(call, position, &mut q, &mut k)?;
         Ok((q, k, v))
     }
 }
@@ -443,7 +443,7 @@ impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
         let v = projected.pop().expect("QKV in, three vectors out");
         let mut k = projected.pop().expect("QKV in, three vectors out");
         let mut q = projected.pop().expect("QKV in, three vectors out");
-        condition_qk_in_place(call, step.position, &mut q, &mut k);
+        condition_qk_in_place(call, step.position, &mut q, &mut k)?;
 
         let mut concat = aggregate_heads(
             call,
@@ -486,6 +486,7 @@ impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
     }
 
     fn ffn(&self, call: FfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        super::production::require_plain_gate("device", call.gate_policy)?;
         let inner = match call.gate {
             Some(gate_weight) => {
                 // Up and gate read the same input: one submission.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
@@ -1,0 +1,291 @@
+//! Loading a layer's FFN operands — dense or routed — in the backend's
+//! declared format, and building the resolved call.
+//!
+//! The routed case binds a **packed expert bank**: every expert's
+//! projections live in one operand (`[experts, rows, k]`, MXFP4 blocks
+//! plus a scales stream, or unquantised BF16). Per expert, the loader
+//! either binds the stored bytes as they are — an MXFP4 expert for a
+//! backend that declared MXFP4 is a copy into aligned memory and nothing
+//! else — or converts through f32 to the format the backend asked for,
+//! exactly as `load_weight` does for a dense matrix. One resolution path,
+//! so the batch executor and the decode session cannot drift.
+
+use larql_models::config::ExpertFormat;
+use larql_models::quant::mxfp4::{dequantize_expert, MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS};
+
+use super::backend::{FfnCall, RoutedFfnCall, WeightFormat, WeightSlice};
+use super::operands::{widen, OperandStore};
+use super::weights::{
+    bf16_bytes_to_f16, f32_bytes_to_f16, load_weight, quantize_mxfp4, quantize_nvfp4, AlignedBytes,
+    LoadedWeight,
+};
+use crate::error::VindexError;
+use crate::format::vindex3::opplan::{LayerFfn, PackedProjection, RoutedFfnOp};
+
+/// Stored dtype of MXFP4 block and scale streams.
+const DTYPE_U8: &str = "U8";
+/// Stored dtype of an unquantised packed bank.
+const DTYPE_BF16: &str = "BF16";
+/// Gate and up: the two branches sharing one fused operand.
+const FUSED_BRANCHES: usize = larql_models::quant::mxfp4::FUSED_HALVES;
+
+/// A layer's FFN operands, loaded once in the backend's declared format.
+pub(super) enum FfnOperands {
+    Dense {
+        gate: Option<LoadedWeight>,
+        up: LoadedWeight,
+        down: LoadedWeight,
+    },
+    Routed(RoutedOperands),
+}
+
+/// A routed layer's operands: router (f32 glue) and per-expert matrices.
+pub(super) struct RoutedOperands {
+    router: Vec<f32>,
+    router_bias: Option<Vec<f32>>,
+    gate_up: Vec<LoadedWeight>,
+    gate_up_bias: Option<Vec<f32>>,
+    down: Vec<LoadedWeight>,
+    down_bias: Option<Vec<f32>>,
+}
+
+impl FfnOperands {
+    pub(super) fn load(
+        ffn: &LayerFfn,
+        store: &OperandStore,
+        format: WeightFormat,
+    ) -> Result<Self, VindexError> {
+        match ffn {
+            LayerFfn::Dense(op) => Ok(Self::Dense {
+                gate: match &op.gate {
+                    Some(gate) => Some(load_weight(store, gate, format)?),
+                    None => None,
+                },
+                up: load_weight(store, &op.up, format)?,
+                down: load_weight(store, &op.down, format)?,
+            }),
+            LayerFfn::Routed(op) => Ok(Self::Routed(RoutedOperands::load(op, store, format)?)),
+        }
+    }
+
+    /// Every matrix operand, for residency preparation.
+    pub(super) fn weight_slices(&self) -> Vec<WeightSlice<'_>> {
+        match self {
+            Self::Dense { gate, up, down } => {
+                let mut slices = vec![up.slice(), down.slice()];
+                if let Some(gate) = gate {
+                    slices.push(gate.slice());
+                }
+                slices
+            }
+            Self::Routed(routed) => routed
+                .gate_up
+                .iter()
+                .chain(&routed.down)
+                .map(LoadedWeight::slice)
+                .collect(),
+        }
+    }
+
+    /// Run this layer's FFN over one normalised vector on `backend`.
+    pub(super) fn apply<B: super::backend::PlanBackend + ?Sized>(
+        &self,
+        ffn: &LayerFfn,
+        backend: &B,
+        x: &[f32],
+        hidden: usize,
+    ) -> Result<Vec<f32>, VindexError> {
+        match (self, ffn) {
+            (Self::Dense { gate, up, down }, LayerFfn::Dense(op)) => backend.ffn(FfnCall {
+                x,
+                hidden,
+                intermediate: op.intermediate_size,
+                gate: gate.as_ref().map(LoadedWeight::slice),
+                up: up.slice(),
+                down: down.slice(),
+                activation: op.activation,
+                gate_policy: op.gate_policy,
+            }),
+            (Self::Routed(routed), LayerFfn::Routed(op)) => {
+                let gate_up: Vec<WeightSlice<'_>> =
+                    routed.gate_up.iter().map(LoadedWeight::slice).collect();
+                let down: Vec<WeightSlice<'_>> =
+                    routed.down.iter().map(LoadedWeight::slice).collect();
+                backend.routed_ffn(RoutedFfnCall {
+                    x,
+                    hidden,
+                    intermediate: op.expert_intermediate_size,
+                    experts: op.experts,
+                    top_k: op.top_k,
+                    router_kind: op.router_kind,
+                    routing_policy: op.routing_policy,
+                    activation: op.activation,
+                    gate_policy: op.gate_policy,
+                    gate_up_layout: op.gate_up_layout.ok_or_else(|| {
+                        VindexError::Parse(
+                            "routed FFN op carries no gate_up layout; closure requires one"
+                                .to_string(),
+                        )
+                    })?,
+                    router: &routed.router,
+                    router_bias: routed.router_bias.as_deref(),
+                    gate_up: &gate_up,
+                    gate_up_bias: routed.gate_up_bias.as_deref(),
+                    down: &down,
+                    down_bias: routed.down_bias.as_deref(),
+                })
+            }
+            _ => Err(VindexError::Parse(
+                "FFN operands were loaded for a different op kind than the plan carries"
+                    .to_string(),
+            )),
+        }
+    }
+}
+
+impl RoutedOperands {
+    fn load(
+        op: &RoutedFfnOp,
+        store: &OperandStore,
+        format: WeightFormat,
+    ) -> Result<Self, VindexError> {
+        let hidden = op.router.shape.get(1).copied().unwrap_or(0);
+        let inter = op.expert_intermediate_size;
+        Ok(Self {
+            router: store.load(&op.router)?,
+            router_bias: op.router_bias.as_ref().map(|b| store.load(b)).transpose()?,
+            gate_up: load_packed(
+                store,
+                &op.gate_up,
+                op,
+                FUSED_BRANCHES * inter,
+                hidden,
+                format,
+            )?,
+            gate_up_bias: op
+                .gate_up
+                .bias
+                .as_ref()
+                .map(|b| store.load(b))
+                .transpose()?,
+            down: load_packed(store, &op.down, op, hidden, inter, format)?,
+            down_bias: op.down.bias.as_ref().map(|b| store.load(b)).transpose()?,
+        })
+    }
+}
+
+/// Load one packed projection as `experts` matrices of `[rows, k]` in
+/// `format`.
+fn load_packed(
+    store: &OperandStore,
+    projection: &PackedProjection,
+    op: &RoutedFfnOp,
+    rows: usize,
+    k: usize,
+    format: WeightFormat,
+) -> Result<Vec<LoadedWeight>, VindexError> {
+    let name = projection.weights.tensor.as_str();
+    let raw = store.load_raw(&projection.weights)?;
+    match op.expert_format {
+        ExpertFormat::PackedMxfp4 => {
+            let scales_ref = projection.scales.as_ref().ok_or_else(|| {
+                VindexError::Parse(format!(
+                    "`{name}`: MXFP4 expert projection carries no scales operand"
+                ))
+            })?;
+            let scales = store.load_raw(scales_ref)?;
+            expect_dtype(&raw.dtype, DTYPE_U8, name)?;
+            expect_dtype(&scales.dtype, DTYPE_U8, &scales_ref.tensor)?;
+            if !k.is_multiple_of(MXFP4_GROUP_ELEMS) {
+                return Err(VindexError::Parse(format!(
+                    "`{name}`: k={k} is not a multiple of the MXFP4 group"
+                )));
+            }
+            let groups = k / MXFP4_GROUP_ELEMS;
+            let block_stride = rows * groups * MXFP4_GROUP_BYTES;
+            let scale_stride = rows * groups;
+            expect_len(raw.bytes.len(), op.experts * block_stride, name)?;
+            expect_len(
+                scales.bytes.len(),
+                op.experts * scale_stride,
+                &scales_ref.tensor,
+            )?;
+            (0..op.experts)
+                .map(|e| {
+                    let packed = &raw.bytes[e * block_stride..(e + 1) * block_stride];
+                    let scale = &scales.bytes[e * scale_stride..(e + 1) * scale_stride];
+                    match format {
+                        // Native: the stored bytes are the operand.
+                        WeightFormat::Mxfp4 => Ok(LoadedWeight::Mxfp4 {
+                            packed: AlignedBytes::from_bytes(packed),
+                            scales: AlignedBytes::from_bytes(scale),
+                        }),
+                        // Everything else converts through f32, exactly as
+                        // a dense matrix would.
+                        other => {
+                            let values = dequantize_expert(packed, scale, rows, groups)
+                                .map_err(|e| VindexError::Parse(format!("`{name}`: {e}")))?;
+                            from_f32(values, rows, k, other, name)
+                        }
+                    }
+                })
+                .collect()
+        }
+        ExpertFormat::PackedBF16 => {
+            expect_dtype(&raw.dtype, DTYPE_BF16, name)?;
+            let stride = rows * k * 2;
+            expect_len(raw.bytes.len(), op.experts * stride, name)?;
+            (0..op.experts)
+                .map(|e| {
+                    let bytes = &raw.bytes[e * stride..(e + 1) * stride];
+                    match format {
+                        WeightFormat::F16 => Ok(LoadedWeight::F16(bf16_bytes_to_f16(bytes, name)?)),
+                        other => from_f32(widen(DTYPE_BF16, bytes, name)?, rows, k, other, name),
+                    }
+                })
+                .collect()
+        }
+        ExpertFormat::PerExpert => Err(VindexError::Parse(format!(
+            "`{name}`: per-expert tensors are not a packed projection; closure never plans one"
+        ))),
+    }
+}
+
+/// One expert's `[rows, k]` f32 matrix, converted to `format`.
+fn from_f32(
+    values: Vec<f32>,
+    rows: usize,
+    k: usize,
+    format: WeightFormat,
+    name: &str,
+) -> Result<LoadedWeight, VindexError> {
+    match format {
+        WeightFormat::F32 => Ok(LoadedWeight::F32(values)),
+        WeightFormat::F16 => {
+            let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+            Ok(LoadedWeight::F16(f32_bytes_to_f16(&bytes, name)?))
+        }
+        WeightFormat::Mxfp4 => quantize_mxfp4(&values, rows, k, name),
+        WeightFormat::Nvfp4 => quantize_nvfp4(&values, rows, k, name),
+    }
+}
+
+fn expect_dtype(found: &str, expected: &str, name: &str) -> Result<(), VindexError> {
+    if found == expected {
+        Ok(())
+    } else {
+        Err(VindexError::Parse(format!(
+            "`{name}`: expected stored dtype {expected}, found {found}"
+        )))
+    }
+}
+
+fn expect_len(found: usize, expected: usize, name: &str) -> Result<(), VindexError> {
+    if found == expected {
+        Ok(())
+    } else {
+        Err(VindexError::Parse(format!(
+            "`{name}`: {found} stored bytes, expected {expected} for the declared expert geometry"
+        )))
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/kernels.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/kernels.rs
@@ -127,6 +127,20 @@ pub fn softmax(scores: &mut [f32]) {
     }
 }
 
+/// Softmax against an attention sink, in the literal form of the judged
+/// semantics: the sink logit is appended to the row, the row is
+/// softmaxed whole, and the sink's column is dropped — so the surviving
+/// weights sum to `1 − p_sink`. Deliberately not the served path's
+/// denominator-only shortcut, so the two are independent transcriptions
+/// of one definition.
+pub fn softmax_with_sink(scores: &mut [f32], sink: f32) {
+    let mut row = Vec::with_capacity(scores.len() + 1);
+    row.extend_from_slice(scores);
+    row.push(sink);
+    softmax(&mut row);
+    scores.copy_from_slice(&row[..scores.len()]);
+}
+
 /// Rotate-half RoPE on one head slice at one position, matching the
 /// production convention: pair `i` with `i + head_dim/2`,
 /// `inv_freq[i] = theta^(-2i/head_dim)`.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/kernels.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/kernels.rs
@@ -157,6 +157,67 @@ pub fn rope_rotate(head: &mut [f32], position: usize, theta: f64) {
     }
 }
 
+/// Rotate-half RoPE on one head slice at one position with **given**
+/// per-pair inverse frequencies and an amplitude on `cos`/`sin` — the form
+/// every rotary scaling reduces to (`angle = pos · inv_freq[i]`,
+/// `cos·amplitude`, `sin·amplitude`). Plain rope is `theta^(-2i/d)` with
+/// amplitude 1; YaRN supplies a ramped blend and an amplitude that is not.
+pub fn rope_rotate_scaled(head: &mut [f32], position: usize, inv_freq: &[f64], amplitude: f32) {
+    let half = head.len() / 2;
+    debug_assert_eq!(inv_freq.len(), half);
+    for i in 0..half {
+        let angle = position as f64 * inv_freq[i];
+        let sin_t = angle.sin() as f32 * amplitude;
+        let cos_t = angle.cos() as f32 * amplitude;
+        let x0 = head[i];
+        let x1 = head[half + i];
+        head[i] = x0 * cos_t - x1 * sin_t;
+        head[half + i] = x0 * sin_t + x1 * cos_t;
+    }
+}
+
+/// YaRN's per-pair inverse frequencies and attention amplitude for one
+/// head of `head_dim` at base `theta` — the reference transcription of
+/// HF's `_compute_yarn_parameters`, sharing nothing with the served
+/// `larql-compute` rope module:
+///
+/// ```text
+/// dim(rot)      = d · ln(L / (rot · 2π)) / (2 · ln θ)        find_correction_dim
+/// low, high     = dim(β_fast), dim(β_slow)  [floor/ceil if truncate], clamped to [0, d−1]
+/// ramp[i]       = clamp((i − low) / (high − low), 0, 1)     (high nudged +0.001 if == low)
+/// inv_freq[i]   = extrap[i]/factor · ramp[i] + extrap[i] · (1 − ramp[i])
+/// amplitude     = YarnRopeScaling::attention_amplitude (the one authority)
+/// ```
+pub fn yarn_frequencies(
+    scaling: &larql_models::YarnRopeScaling,
+    head_dim: usize,
+    theta: f64,
+) -> (Vec<f64>, f32) {
+    let half = head_dim / 2;
+    let d = head_dim as f64;
+    let correction_dim = |rotations: f64| {
+        (d * (scaling.original_max_position_embeddings / (rotations * std::f64::consts::TAU)).ln())
+            / (2.0 * theta.ln())
+    };
+    let mut low = correction_dim(scaling.beta_fast);
+    let mut high = correction_dim(scaling.beta_slow);
+    if scaling.truncate {
+        low = low.floor();
+        high = high.ceil();
+    }
+    let low = low.max(0.0);
+    let high = high.min(d - 1.0);
+    let high = if high == low { high + 0.001 } else { high };
+    let inv_freq = (0..half)
+        .map(|i| {
+            let extrapolation = theta.powf(-2.0 * i as f64 / d);
+            let ramp = ((i as f64 - low) / (high - low)).clamp(0.0, 1.0);
+            extrapolation / scaling.factor * ramp + extrapolation * (1.0 - ramp)
+        })
+        .collect();
+    (inv_freq, scaling.attention_amplitude() as f32)
+}
+
 /// Tanh softcap: `cap * tanh(x / cap)`.
 pub fn softcap(x: f32, cap: f32) -> f32 {
     cap * (x / cap).tanh()

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -317,6 +317,7 @@ fn execute_layer<B: PlanBackend + ?Sized>(
             up: up.slice(),
             down: down.slice(),
             activation: layer.ffn.activation,
+            gate_policy: layer.ffn.gate_policy,
         })?;
         let ffn_out = match &layer.post_ffn_norm {
             Some(op) => apply_norm_op(op, store, &ffn_out, backend)?,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -33,8 +33,8 @@ mod tests;
 use super::{AttentionOp, ComponentOpPlan, LayerPlan, NormOp};
 use crate::error::VindexError;
 use backend::{
-    AttentionCall, FfnCall, GateCall, MatrixClass, NormCall, PlanBackend, ProjectCall, QkNormCall,
-    WeightFormat,
+    AttentionCall, BiasCall, FfnCall, GateCall, MatrixClass, NormCall, PlanBackend, ProjectCall,
+    QkNormCall, SinkCall, WeightFormat,
 };
 use operands::OperandStore;
 use rayon::prelude::*;
@@ -343,6 +343,10 @@ pub(super) struct AttentionOperands {
     w_o: LoadedWeight,
     qk_weights: Option<(Vec<f32>, Vec<f32>)>,
     gate: Option<LoadedWeight>,
+    /// Q/K/V/O biases, f32 (elementwise glue, not matrix traffic).
+    biases: Option<[Vec<f32>; 4]>,
+    /// Sink logits, f32.
+    sinks: Option<Vec<f32>>,
 }
 
 impl AttentionOperands {
@@ -364,6 +368,28 @@ impl AttentionOperands {
             },
             gate: match &op.output_gate {
                 Some(gate) => Some(load_weight(store, &gate.projection, format)?),
+                None => None,
+            },
+            biases: match (&op.q_bias, &op.k_bias, &op.v_bias, &op.o_bias) {
+                (Some(q), Some(k), Some(v), Some(o)) => Some([
+                    store.load(q)?,
+                    store.load(k)?,
+                    store.load(v)?,
+                    store.load(o)?,
+                ]),
+                (None, None, None, None) => None,
+                // Closure emits all four or none; a partial set is a
+                // plan the closure never produced.
+                _ => {
+                    return Err(VindexError::Parse(
+                        "attention op carries a partial Q/K/V/O bias set; operand closure \
+                         emits all four or none"
+                            .to_string(),
+                    ))
+                }
+            },
+            sinks: match &op.sinks {
+                Some(sinks) => Some(store.load(&sinks.logits)?),
                 None => None,
             },
         })
@@ -411,6 +437,19 @@ impl AttentionOperands {
             }),
             _ => None,
         };
+        let bias = self.biases.as_ref().map(|[q, k, v, o]| BiasCall {
+            q: q.as_slice(),
+            k: k.as_slice(),
+            v: v.as_slice(),
+            o: o.as_slice(),
+        });
+        let sinks = match (&op.sinks, &self.sinks) {
+            (Some(op_sinks), Some(logits)) => Some(SinkCall {
+                spec: op_sinks.spec,
+                logits: logits.as_slice(),
+            }),
+            _ => None,
+        };
         AttentionCall {
             inputs,
             hidden,
@@ -431,6 +470,8 @@ impl AttentionOperands {
             span: op.span,
             window: op.window,
             gate,
+            bias,
+            sinks,
         }
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -21,6 +21,7 @@
 pub mod backend;
 pub mod decode;
 pub mod device;
+mod experts;
 pub mod kernels;
 pub mod operands;
 pub mod production;
@@ -33,8 +34,8 @@ mod tests;
 use super::{AttentionOp, ComponentOpPlan, LayerPlan, NormOp};
 use crate::error::VindexError;
 use backend::{
-    AttentionCall, BiasCall, FfnCall, GateCall, MatrixClass, NormCall, PlanBackend, ProjectCall,
-    QkNormCall, SinkCall, WeightFormat,
+    AttentionCall, BiasCall, GateCall, MatrixClass, NormCall, PlanBackend, ProjectCall, QkNormCall,
+    SinkCall, WeightFormat,
 };
 use operands::OperandStore;
 use rayon::prelude::*;
@@ -301,24 +302,10 @@ fn execute_layer<B: PlanBackend + ?Sized>(
     // token would dominate the run on a real model without changing a
     // single number.
     let format = backend.weight_format(MatrixClass::FfnProjection);
-    let up = load_weight(store, &layer.ffn.up, format)?;
-    let down = load_weight(store, &layer.ffn.down, format)?;
-    let gate = match &layer.ffn.gate {
-        Some(gate_ref) => Some(load_weight(store, gate_ref, format)?),
-        None => None,
-    };
+    let ffn = experts::FfnOperands::load(&layer.ffn, store, format)?;
     h.par_iter_mut().try_for_each(|row| {
         let normed = apply_norm_op(&layer.pre_ffn_norm, store, row, backend)?;
-        let ffn_out = backend.ffn(FfnCall {
-            x: &normed,
-            hidden,
-            intermediate: layer.ffn.intermediate_size,
-            gate: gate.as_ref().map(LoadedWeight::slice),
-            up: up.slice(),
-            down: down.slice(),
-            activation: layer.ffn.activation,
-            gate_policy: layer.ffn.gate_policy,
-        })?;
+        let ffn_out = ffn.apply(&layer.ffn, backend, &normed, hidden)?;
         let ffn_out = match &layer.post_ffn_norm {
             Some(op) => apply_norm_op(op, store, &ffn_out, backend)?,
             None => ffn_out,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -18,11 +18,12 @@
 //! sharing code, which is exactly the agreement that proves nothing.
 
 use larql_models::config::{
-    Activation, GateActivation, GateCombine, GatePlacement, GateSource, NormType, PositionPolicy,
+    Activation, AttentionSinkSpec, GateActivation, GateCombine, GatePlacement, GateSource,
+    NormType, PositionPolicy,
 };
 use ndarray::Array2;
 
-use larql_compute::attention::softmax::softmax_in_place_f32;
+use larql_compute::attention::softmax::{softmax_in_place, softmax_in_place_f32};
 use larql_compute::cpu::ops::geglu::{geglu_silu_alloc, silu};
 use larql_compute::cpu::ops::moe::math::matmul_vec;
 use larql_compute::residual::{
@@ -188,6 +189,42 @@ pub(super) fn condition_qk_in_place(
     Ok(())
 }
 
+/// The Q/K/V projection biases, added right after projection — before
+/// [`condition_qk_in_place`] reads Q/K and before V is cached. Shared
+/// glue, so the production and device backends place them identically.
+pub(super) fn add_projection_biases(
+    call: &AttentionCall<'_>,
+    q: &mut [f32],
+    k: &mut [f32],
+    v: &mut [f32],
+) {
+    if let Some(bias) = &call.bias {
+        add_bias_in_place(q, bias.q);
+        add_bias_in_place(k, bias.k);
+        add_bias_in_place(v, bias.v);
+    }
+}
+
+/// The output-projection bias, added after `w_o`.
+pub(super) fn add_output_bias(call: &AttentionCall<'_>, out: &mut [f32]) {
+    if let Some(bias) = &call.bias {
+        add_bias_in_place(out, bias.o);
+    }
+}
+
+/// `x[i] += b[i]`; a length mismatch is a geometry bug closure refuses,
+/// so it panics rather than pads.
+fn add_bias_in_place(x: &mut [f32], b: &[f32]) {
+    assert_eq!(
+        x.len(),
+        b.len(),
+        "bias length must equal the projection's rows"
+    );
+    for (x, b) in x.iter_mut().zip(b) {
+        *x += b;
+    }
+}
+
 /// One query position's scores, softmax and weighted-V aggregation —
 /// the production softmax kernel over whatever K/V storage the caller
 /// abstracts through `key_of`/`value_of`. Shared by the production and
@@ -232,7 +269,16 @@ pub(super) fn aggregate_heads<'k>(
                 }
             })
             .collect();
-        softmax_in_place_f32(&mut scores);
+        match &call.sinks {
+            // The served path's own sink softmax; exhaustive on the judged
+            // semantics so a new variant must be implemented before it
+            // can execute here.
+            Some(sinks) => {
+                let AttentionSinkSpec::SoftmaxDenominator = sinks.spec;
+                softmax_in_place(&mut scores, Some(sinks.logits[q_head]));
+            }
+            None => softmax_in_place_f32(&mut scores),
+        }
         let head_out = &mut concat[q_head * head_dim..(q_head + 1) * head_dim];
         for (offset, key_position) in (start..=position).enumerate() {
             let v_slice = &value_of(key_position)[kv_head * head_dim..(kv_head + 1) * head_dim];
@@ -258,7 +304,8 @@ impl ProductionBackend {
         let kv_rows = call.num_kv_heads * head_dim;
         let mut q = matmul_vec(pre, call.w_q.as_f32()?, q_rows, call.hidden);
         let mut k = matmul_vec(pre, call.w_k.as_f32()?, kv_rows, call.hidden);
-        let v = matmul_vec(pre, call.w_v.as_f32()?, kv_rows, call.hidden);
+        let mut v = matmul_vec(pre, call.w_v.as_f32()?, kv_rows, call.hidden);
+        add_projection_biases(call, &mut q, &mut k, &mut v);
         condition_qk_in_place(call, position, &mut q, &mut k)?;
         Ok((q, k, v))
     }
@@ -289,7 +336,9 @@ impl ProductionBackend {
             }
         }
 
-        Ok(matmul_vec(&concat, call.w_o.as_f32()?, call.hidden, q_rows))
+        let mut out = matmul_vec(&concat, call.w_o.as_f32()?, call.hidden, q_rows);
+        add_output_bias(call, &mut out);
+        Ok(out)
     }
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -63,6 +63,26 @@ pub(super) fn unsupported_activation(shape: &str, activation: Activation) -> Vin
     ))
 }
 
+/// The gate policy every backend here honours today. A `ClampedGlu` plan
+/// (GPT-OSS's `swiglu_limit`) is carried by the container and refused
+/// until A-9.3 executes it — computing `activation(gate) * up` for it
+/// would run a different model without saying so.
+pub(super) fn require_plain_gate(
+    backend: &str,
+    policy: larql_models::ExpertGatePolicy,
+) -> Result<(), VindexError> {
+    match policy {
+        larql_models::ExpertGatePolicy::Gated => Ok(()),
+        larql_models::ExpertGatePolicy::ClampedGlu { limit, alpha } => {
+            Err(VindexError::Parse(format!(
+                "the {backend} backend does not execute ExpertGatePolicy::ClampedGlu {{ limit: \
+             {limit}, alpha: {alpha} }} yet (A-9.3); refusing rather than applying plain \
+             gating to a clamped-GLU FFN"
+            )))
+        }
+    }
+}
+
 /// Wrap one vector as a `[1, n]` matrix for the row-wise norm kernels.
 pub(super) fn as_row(x: &[f32]) -> Array2<f32> {
     Array2::from_shape_vec((1, x.len()), x.to_vec()).expect("row shape matches length")
@@ -105,7 +125,7 @@ pub(super) fn condition_qk_in_place(
     position: usize,
     q: &mut [f32],
     k: &mut [f32],
-) {
+) -> Result<(), VindexError> {
     let head_dim = call.head_dim;
     let qk_weight = call.qk_norm.as_ref().map(
         |QkNormCall {
@@ -143,14 +163,29 @@ pub(super) fn condition_qk_in_place(
             *value *= query_scale as f32;
         }
     }
-    if let PositionPolicy::Rope { theta } = call.position {
-        for head in q.chunks_exact_mut(head_dim) {
-            rope_rotate(head, position, theta);
+    match call.position {
+        PositionPolicy::Rope { theta } => {
+            for head in q.chunks_exact_mut(head_dim) {
+                rope_rotate(head, position, theta);
+            }
+            for head in k.chunks_exact_mut(head_dim) {
+                rope_rotate(head, position, theta);
+            }
         }
-        for head in k.chunks_exact_mut(head_dim) {
-            rope_rotate(head, position, theta);
+        // Represented, not yet executed here: YaRN is scaled frequencies
+        // AND an attention amplitude, and rotating at the bare theta would
+        // silently serve the wrong model. Refuse until A-9.3 lands it.
+        PositionPolicy::Yarn { .. } => {
+            return Err(VindexError::Parse(
+                "PositionPolicy::Yarn is carried by the container but this backend does not \
+                 execute YaRN rotary scaling yet (A-9.3); refusing rather than rotating at the \
+                 unscaled theta"
+                    .to_string(),
+            ));
         }
+        PositionPolicy::None => {}
     }
+    Ok(())
 }
 
 /// One query position's scores, softmax and weighted-V aggregation —
@@ -224,7 +259,7 @@ impl ProductionBackend {
         let mut q = matmul_vec(pre, call.w_q.as_f32()?, q_rows, call.hidden);
         let mut k = matmul_vec(pre, call.w_k.as_f32()?, kv_rows, call.hidden);
         let v = matmul_vec(pre, call.w_v.as_f32()?, kv_rows, call.hidden);
-        condition_qk_in_place(call, position, &mut q, &mut k);
+        condition_qk_in_place(call, position, &mut q, &mut k)?;
         Ok((q, k, v))
     }
 
@@ -365,6 +400,7 @@ impl PlanBackend for ProductionBackend {
     }
 
     fn ffn(&self, call: FfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        require_plain_gate("production", call.gate_policy)?;
         let up = matmul_vec(call.x, call.up.as_f32()?, call.intermediate, call.hidden);
         let inner: Vec<f32> = match call.gate {
             Some(gate_weight) => {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -37,7 +37,14 @@ use super::backend::{
     AttentionCall, AttentionStepCall, AttentionStepOut, FfnCall, GateCall, NormCall, PlanBackend,
     ProjectCall, ProjectedQkv, QkNormCall, RoutedFfnCall,
 };
-use super::kernels::rope_rotate;
+use super::kernels::{rope_rotate, rope_rotate_scaled};
+use larql_compute::attention::rope::{rope_freq_plan, RopeFreqScaling};
+
+/// The whole head rotates: `PositionPolicy` carries no partial-rotary
+/// fraction (no family through this path declares one).
+const FULL_ROTARY: f64 = 1.0;
+/// No position divisor (`rope_freq_plan` treats 0 as 1).
+const NO_POSITION_DIVISOR: f64 = 1.0;
 use crate::error::VindexError;
 use rayon::prelude::*;
 
@@ -175,16 +182,24 @@ pub(super) fn condition_qk_in_place(
                 rope_rotate(head, position, theta);
             }
         }
-        // Represented, not yet executed here: YaRN is scaled frequencies
-        // AND an attention amplitude, and rotating at the bare theta would
-        // silently serve the wrong model. Refuse until A-9.3 lands it.
-        PositionPolicy::Yarn { .. } => {
-            return Err(VindexError::Parse(
-                "PositionPolicy::Yarn is carried by the container but this backend does not \
-                 execute YaRN rotary scaling yet (A-9.3); refusing rather than rotating at the \
-                 unscaled theta"
-                    .to_string(),
-            ));
+        // YaRN through the served rope planner: the same ramp and
+        // amplitude the production forward applies (full rotary width, no
+        // position divisor — what `PositionPolicy::Yarn` carries).
+        PositionPolicy::Yarn { theta, scaling } => {
+            let plan = rope_freq_plan(
+                head_dim,
+                FULL_ROTARY,
+                theta,
+                NO_POSITION_DIVISOR,
+                RopeFreqScaling::Yarn(scaling),
+            );
+            let amplitude = plan.amplitude as f32;
+            for head in q.chunks_exact_mut(head_dim) {
+                rope_rotate_scaled(head, position, &plan.inv_freq, amplitude);
+            }
+            for head in k.chunks_exact_mut(head_dim) {
+                rope_rotate_scaled(head, position, &plan.inv_freq, amplitude);
+            }
         }
         PositionPolicy::None => {}
     }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -19,21 +19,23 @@
 
 use larql_models::config::{
     Activation, AttentionSinkSpec, GateActivation, GateCombine, GatePlacement, GateSource,
-    NormType, PositionPolicy,
+    GateUpBranch, MoeRouterKind, NormType, PositionPolicy,
 };
 use ndarray::Array2;
 
 use larql_compute::attention::softmax::{softmax_in_place, softmax_in_place_f32};
 use larql_compute::cpu::ops::geglu::{geglu_silu_alloc, silu};
 use larql_compute::cpu::ops::moe::math::matmul_vec;
+use larql_compute::ffn::expert_weight::router;
 use larql_compute::residual::{
     layer_norm_eps, rms_norm_eps, rms_norm_heads_no_weight_eps, rms_norm_qk_eps,
 };
+use larql_compute::MoeGateRule;
 
 use super::super::super::graph::policy::AttentionSpan;
 use super::backend::{
     AttentionCall, AttentionStepCall, AttentionStepOut, FfnCall, GateCall, NormCall, PlanBackend,
-    ProjectCall, ProjectedQkv, QkNormCall,
+    ProjectCall, ProjectedQkv, QkNormCall, RoutedFfnCall,
 };
 use super::kernels::rope_rotate;
 use crate::error::VindexError;
@@ -222,6 +224,63 @@ fn add_bias_in_place(x: &mut [f32], b: &[f32]) {
     );
     for (x, b) in x.iter_mut().zip(b) {
         *x += b;
+    }
+}
+
+/// Gate and up: the two branches sharing one fused operand.
+pub(super) const FUSED_BRANCHES: usize = larql_models::quant::mxfp4::FUSED_HALVES;
+
+/// Route one token through the served selection rule
+/// (`larql-compute`'s `router::select`) over the router logits — shared
+/// glue, so the production and device backends select identically and
+/// exactly as the served path does. Exhaustive on the router kind: Gemma
+/// 4's per-expert scale has its own arithmetic and must be implemented
+/// before it can execute here.
+pub(super) fn select_experts(
+    call: &RoutedFfnCall<'_>,
+    logits: &mut [f32],
+) -> Result<Vec<(usize, f32)>, VindexError> {
+    match call.router_kind {
+        MoeRouterKind::TopKSoftmax | MoeRouterKind::TopKThenSoftmax => {}
+        MoeRouterKind::Gemma4Hybrid => {
+            return Err(VindexError::Parse(
+                "MoeRouterKind::Gemma4Hybrid carries a per-expert scale this backend does not \
+                 execute; refusing rather than routing with the plain rule"
+                    .to_string(),
+            ))
+        }
+    }
+    if let Some(bias) = call.router_bias {
+        for (l, b) in logits.iter_mut().zip(bias) {
+            *l += b;
+        }
+    }
+    Ok(router::select(logits, call.top_k, call.routing_policy))
+}
+
+/// One selected expert's inner activation from its fused gate/up output
+/// (bias already added): rows read through the declared layout, combined
+/// by the served gate rule.
+pub(super) fn expert_inner(call: &RoutedFfnCall<'_>, fused: &[f32]) -> Vec<f32> {
+    let rule = MoeGateRule::from_arch(call.gate_policy, call.activation);
+    (0..call.intermediate)
+        .map(|i| {
+            let g = fused[call
+                .gate_up_layout
+                .row(GateUpBranch::Gate, i, call.intermediate)];
+            let u = fused[call
+                .gate_up_layout
+                .row(GateUpBranch::Up, i, call.intermediate)];
+            rule.combine(g, u)
+        })
+        .collect()
+}
+
+/// `x[i] += bias[expert-th row]` for a per-expert bias stored flat.
+pub(super) fn add_expert_bias(x: &mut [f32], bias: Option<&[f32]>, expert: usize) {
+    if let Some(bias) = bias {
+        let rows = x.len();
+        add_bias_in_place(x, &bias[expert * rows..(expert + 1) * rows]);
     }
 }
 
@@ -475,6 +534,34 @@ impl PlanBackend for ProductionBackend {
             call.hidden,
             call.intermediate,
         ))
+    }
+
+    fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        let mut logits = matmul_vec(call.x, call.router, call.experts, call.hidden);
+        let selected = select_experts(&call, &mut logits)?;
+        let two_inter = FUSED_BRANCHES * call.intermediate;
+        let mut out = vec![0.0f32; call.hidden];
+        for (expert, weight) in selected {
+            let mut fused = matmul_vec(
+                call.x,
+                call.gate_up[expert].as_f32()?,
+                two_inter,
+                call.hidden,
+            );
+            add_expert_bias(&mut fused, call.gate_up_bias, expert);
+            let inner = expert_inner(&call, &fused);
+            let mut expert_out = matmul_vec(
+                &inner,
+                call.down[expert].as_f32()?,
+                call.hidden,
+                call.intermediate,
+            );
+            add_expert_bias(&mut expert_out, call.down_bias, expert);
+            for (acc, v) in out.iter_mut().zip(&expert_out) {
+                *acc += weight * v;
+            }
+        }
+        Ok(out)
     }
 
     fn output_head(

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
@@ -22,7 +22,8 @@ use super::backend::{
     ProjectCall, ProjectedQkv, QkNormCall, RoutedFfnCall,
 };
 use super::kernels::{
-    activate, matvec, norm, rope_rotate, sigmoid, softcap, softmax, softmax_with_sink,
+    activate, matvec, norm, rope_rotate, rope_rotate_scaled, sigmoid, softcap, softmax,
+    softmax_with_sink, yarn_frequencies,
 };
 use crate::error::VindexError;
 use larql_models::config::NormType;
@@ -128,16 +129,17 @@ impl ReferenceBackend {
                     rope_rotate(head, position, theta);
                 }
             }
-            // Represented, not yet executed here: YaRN is scaled frequencies
-            // AND an attention amplitude, and rotating at the bare theta would
-            // silently serve the wrong model. Refuse until A-9.3 lands it.
-            PositionPolicy::Yarn { .. } => {
-                return Err(VindexError::Parse(
-                    "PositionPolicy::Yarn is carried by the container but this backend does not \
-                     execute YaRN rotary scaling yet (A-9.3); refusing rather than rotating at the \
-                     unscaled theta"
-                        .to_string(),
-                ));
+            // YaRN: the ramped frequency blend AND the amplitude on
+            // cos/sin, from the reference transcription of the block the
+            // container carries.
+            PositionPolicy::Yarn { theta, scaling } => {
+                let (inv_freq, amplitude) = yarn_frequencies(&scaling, head_dim, theta);
+                for head in q.chunks_exact_mut(head_dim) {
+                    rope_rotate_scaled(head, position, &inv_freq, amplitude);
+                }
+                for head in k.chunks_exact_mut(head_dim) {
+                    rope_rotate_scaled(head, position, &inv_freq, amplitude);
+                }
             }
             PositionPolicy::None => {}
         }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
@@ -12,13 +12,14 @@
 //! licence to change what the plan means.
 
 use larql_models::config::{
-    AttentionSinkSpec, GateActivation, GateCombine, GatePlacement, GateSource, QkNormScope,
+    AttentionSinkSpec, ExpertRoutingPolicy, GateActivation, GateCombine, GatePlacement, GateSource,
+    GateUpBranch, MoeRouterKind, QkNormScope,
 };
 
 use super::super::super::graph::policy::AttentionSpan;
 use super::backend::{
     AttentionCall, AttentionStepCall, AttentionStepOut, FfnCall, GateCall, NormCall, PlanBackend,
-    ProjectCall, ProjectedQkv, QkNormCall,
+    ProjectCall, ProjectedQkv, QkNormCall, RoutedFfnCall,
 };
 use super::kernels::{
     activate, matvec, norm, rope_rotate, sigmoid, softcap, softmax, softmax_with_sink,
@@ -227,6 +228,71 @@ impl ReferenceBackend {
     }
 }
 
+/// Gate and up: the two branches sharing one fused operand.
+const FUSED_BRANCHES: usize = larql_models::quant::mxfp4::FUSED_HALVES;
+
+/// The judged expert selection, in the literal form: rank the logits
+/// (ties to the lower index, as `torch.topk`), keep `top_k`, and weight
+/// them by a softmax whose denominator the routing policy chooses — every
+/// expert (`SoftmaxThenSelect`) or the selected ones only
+/// (`NormalisedOverSelected`; GPT-OSS's top-k-then-softmax is that same
+/// number). Exhaustive on the router kind: a rule with its own arithmetic
+/// (Gemma 4's per-expert scale) must be implemented before it executes.
+fn select_experts_reference(call: &RoutedFfnCall<'_>) -> Result<Vec<(usize, f32)>, VindexError> {
+    match call.router_kind {
+        MoeRouterKind::TopKSoftmax | MoeRouterKind::TopKThenSoftmax => {}
+        MoeRouterKind::Gemma4Hybrid => {
+            return Err(VindexError::Parse(
+                "MoeRouterKind::Gemma4Hybrid carries a per-expert scale this backend does not \
+                 execute; refusing rather than routing with the plain rule"
+                    .to_string(),
+            ))
+        }
+    }
+    let mut logits = matvec(call.router, call.experts, call.hidden, call.x);
+    if let Some(bias) = call.router_bias {
+        for (l, b) in logits.iter_mut().zip(bias) {
+            *l += b;
+        }
+    }
+    let mut ranked: Vec<(usize, f32)> = logits.iter().copied().enumerate().collect();
+    // Stable, so equal logits keep index order.
+    ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
+    let k = call.top_k.min(ranked.len());
+    let max = ranked.first().map_or(0.0, |r| r.1);
+    let denominator: f32 = match call.routing_policy {
+        ExpertRoutingPolicy::SoftmaxThenSelect => ranked.iter().map(|r| (r.1 - max).exp()).sum(),
+        ExpertRoutingPolicy::NormalisedOverSelected => {
+            ranked.iter().take(k).map(|r| (r.1 - max).exp()).sum()
+        }
+    };
+    Ok(ranked
+        .into_iter()
+        .take(k)
+        .map(|(e, l)| (e, (l - max).exp() / denominator))
+        .collect())
+}
+
+/// One expert's gate/up combine under the judged policy, transcribed from
+/// the family definitions: plain gating is `activation(gate) · up`;
+/// GPT-OSS's clamped GLU clamps gate above and up both ways at `limit`,
+/// scales the sigmoid argument by `alpha` and adds one to up.
+fn combine_gate_up_reference(
+    policy: larql_models::ExpertGatePolicy,
+    activation: larql_models::config::Activation,
+    g: f32,
+    u: f32,
+) -> f32 {
+    match policy {
+        larql_models::ExpertGatePolicy::Gated => activate(activation, g) * u,
+        larql_models::ExpertGatePolicy::ClampedGlu { limit, alpha } => {
+            let g = g.min(limit);
+            let u = u.clamp(-limit, limit);
+            (u + 1.0) * (g * sigmoid(alpha * g))
+        }
+    }
+}
+
 /// `x[i] += b[i]`; a bias of the wrong length is a geometry bug closure
 /// should have refused, so it panics rather than pads.
 fn add_in_place(x: &mut [f32], b: &[f32]) {
@@ -359,6 +425,63 @@ impl PlanBackend for ReferenceBackend {
             call.intermediate,
             &inner,
         ))
+    }
+
+    /// The routed FFN, stated literally: router logits, the judged
+    /// selection rule, each selected expert's fused gate/up read through
+    /// the declared row layout, the judged gate policy, its down
+    /// projection, and the weighted sum. Shares nothing with the served
+    /// MoE path — plain loops over widened f32 operands.
+    fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        let selected = select_experts_reference(&call)?;
+        let two_inter = FUSED_BRANCHES * call.intermediate;
+        let mut out = vec![0.0f32; call.hidden];
+        for (expert, weight) in selected {
+            let mut fused = matvec(
+                call.gate_up[expert].as_f32()?,
+                two_inter,
+                call.hidden,
+                call.x,
+            );
+            if let Some(bias) = call.gate_up_bias {
+                for (f, b) in fused
+                    .iter_mut()
+                    .zip(&bias[expert * two_inter..(expert + 1) * two_inter])
+                {
+                    *f += b;
+                }
+            }
+            let inner: Vec<f32> = (0..call.intermediate)
+                .map(|i| {
+                    let g =
+                        fused[call
+                            .gate_up_layout
+                            .row(GateUpBranch::Gate, i, call.intermediate)];
+                    let u = fused[call
+                        .gate_up_layout
+                        .row(GateUpBranch::Up, i, call.intermediate)];
+                    combine_gate_up_reference(call.gate_policy, call.activation, g, u)
+                })
+                .collect();
+            let mut expert_out = matvec(
+                call.down[expert].as_f32()?,
+                call.hidden,
+                call.intermediate,
+                &inner,
+            );
+            if let Some(bias) = call.down_bias {
+                for (o, b) in expert_out
+                    .iter_mut()
+                    .zip(&bias[expert * call.hidden..(expert + 1) * call.hidden])
+                {
+                    *o += b;
+                }
+            }
+            for (acc, v) in out.iter_mut().zip(&expert_out) {
+                *acc += weight * v;
+            }
+        }
+        Ok(out)
     }
 
     fn output_head(

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
@@ -107,13 +107,27 @@ impl ReferenceBackend {
                 *value *= query_scale as f32;
             }
         }
-        if let PositionPolicy::Rope { theta } = call.position {
-            for head in q.chunks_exact_mut(head_dim) {
-                rope_rotate(head, position, theta);
+        match call.position {
+            PositionPolicy::Rope { theta } => {
+                for head in q.chunks_exact_mut(head_dim) {
+                    rope_rotate(head, position, theta);
+                }
+                for head in k.chunks_exact_mut(head_dim) {
+                    rope_rotate(head, position, theta);
+                }
             }
-            for head in k.chunks_exact_mut(head_dim) {
-                rope_rotate(head, position, theta);
+            // Represented, not yet executed here: YaRN is scaled frequencies
+            // AND an attention amplitude, and rotating at the bare theta would
+            // silently serve the wrong model. Refuse until A-9.3 lands it.
+            PositionPolicy::Yarn { .. } => {
+                return Err(VindexError::Parse(
+                    "PositionPolicy::Yarn is carried by the container but this backend does not \
+                     execute YaRN rotary scaling yet (A-9.3); refusing rather than rotating at the \
+                     unscaled theta"
+                        .to_string(),
+                ));
             }
+            PositionPolicy::None => {}
         }
         Ok((q, k, v))
     }
@@ -286,6 +300,7 @@ impl PlanBackend for ReferenceBackend {
     }
 
     fn ffn(&self, call: FfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        super::production::require_plain_gate("reference", call.gate_policy)?;
         let up = matvec(call.up.as_f32()?, call.intermediate, call.hidden, call.x);
         let inner: Vec<f32> = match call.gate {
             Some(gate_weight) => {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
@@ -11,14 +11,18 @@
 //! is a bug in the production backend or a hole in the seam, never a
 //! licence to change what the plan means.
 
-use larql_models::config::{GateActivation, GateCombine, GatePlacement, GateSource, QkNormScope};
+use larql_models::config::{
+    AttentionSinkSpec, GateActivation, GateCombine, GatePlacement, GateSource, QkNormScope,
+};
 
 use super::super::super::graph::policy::AttentionSpan;
 use super::backend::{
     AttentionCall, AttentionStepCall, AttentionStepOut, FfnCall, GateCall, NormCall, PlanBackend,
     ProjectCall, ProjectedQkv, QkNormCall,
 };
-use super::kernels::{activate, matvec, norm, rope_rotate, sigmoid, softcap, softmax};
+use super::kernels::{
+    activate, matvec, norm, rope_rotate, sigmoid, softcap, softmax, softmax_with_sink,
+};
 use crate::error::VindexError;
 use larql_models::config::NormType;
 use larql_models::config::PositionPolicy;
@@ -99,7 +103,14 @@ impl ReferenceBackend {
         let kv_rows = call.num_kv_heads * head_dim;
         let mut q = matvec(call.w_q.as_f32()?, q_rows, call.hidden, pre);
         let mut k = matvec(call.w_k.as_f32()?, kv_rows, call.hidden, pre);
-        let v = matvec(call.w_v.as_f32()?, kv_rows, call.hidden, pre);
+        let mut v = matvec(call.w_v.as_f32()?, kv_rows, call.hidden, pre);
+        // Biases belong to the projections: added before anything reads
+        // the projected values (QK-norm, rope, the cache).
+        if let Some(bias) = &call.bias {
+            add_in_place(&mut q, bias.q);
+            add_in_place(&mut k, bias.k);
+            add_in_place(&mut v, bias.v);
+        }
 
         Self::apply_qk_norm(call, &mut q, &mut k)?;
         if let Some(query_scale) = call.query_scale {
@@ -176,7 +187,15 @@ impl ReferenceBackend {
                     score
                 })
                 .collect();
-            softmax(&mut scores);
+            match &call.sinks {
+                // Exhaustive on the judged semantics: a new variant must
+                // be implemented here before it can execute.
+                Some(sinks) => {
+                    let AttentionSinkSpec::SoftmaxDenominator = sinks.spec;
+                    softmax_with_sink(&mut scores, sinks.logits[q_head]);
+                }
+                None => softmax(&mut scores),
+            }
             let head_out = &mut concat[q_head * head_dim..(q_head + 1) * head_dim];
             for (offset, key_position) in (start..=position).enumerate() {
                 let v_slice = &value_of(key_position)[kv_head * head_dim..(kv_head + 1) * head_dim];
@@ -200,7 +219,24 @@ impl ReferenceBackend {
             }
         }
 
-        Ok(matvec(call.w_o.as_f32()?, call.hidden, q_rows, &concat))
+        let mut out = matvec(call.w_o.as_f32()?, call.hidden, q_rows, &concat);
+        if let Some(bias) = &call.bias {
+            add_in_place(&mut out, bias.o);
+        }
+        Ok(out)
+    }
+}
+
+/// `x[i] += b[i]`; a bias of the wrong length is a geometry bug closure
+/// should have refused, so it panics rather than pads.
+fn add_in_place(x: &mut [f32], b: &[f32]) {
+    assert_eq!(
+        x.len(),
+        b.len(),
+        "bias length must equal the projection's rows"
+    );
+    for (x, b) in x.iter_mut().zip(b) {
+        *x += b;
     }
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_backend_decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_backend_decode.rs
@@ -1,0 +1,354 @@
+//! Refusal and fallback arms of the backend seam and the decode loop.
+//!
+//! The seam's `as_f32` is fail-closed evidence of a wrong-format load;
+//! `dispatch_stats` defaults to "no device to account for". The decode
+//! session refuses a plan it cannot start (no embedding, an operand the
+//! store cannot resolve), refuses a token outside the table, propagates
+//! a backend refusal out of the step, and realises the *absent* arms of
+//! the program — two-norm placement, no final norm, no output head —
+//! rather than inventing an identity for them.
+
+use super::{dense_f32_model, VOCAB};
+use crate::error::VindexError;
+use crate::format::vindex3::encode::encode_system;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::backend::{
+    AttentionCall, AttentionStepCall, AttentionStepOut, FfnCall, NormCall, PlanBackend,
+    ProjectCall, RoutedFfnCall, WeightSlice,
+};
+use crate::format::vindex3::opplan::exec::decode::DecodeSession;
+use crate::format::vindex3::opplan::exec::execute_plan;
+use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::exec::production::ProductionBackend;
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan, LayerFfn};
+
+/// A short prompt over the dense fixture's vocabulary.
+const TOKENS: [u32; 4] = [3, 17, 60, 0];
+/// The first id past the table — one row too far, not wildly out.
+const OUT_OF_TABLE_TOKEN: u32 = VOCAB as u32;
+/// A tensor name no segment carries.
+const UNRESOLVABLE_TENSOR: &str = "no.such.tensor";
+/// Bytes standing in for a foreign-format slice; their content is never
+/// read because the refusal happens before any conversion.
+const FOREIGN_BYTES: [u8; 2] = [0x00, 0x3c];
+const NVFP4_TENSOR_SCALE: f32 = 1.0;
+const F32_VALUES: [f32; 2] = [0.5, -0.25];
+const FFN_REFUSAL: &str = "this backend carries no FFN kernel";
+const HEAD_REFUSAL: &str = "this backend carries no output-head kernel";
+
+/// The dense two-norm fixture (Llama-shaped): embedding, final norm and
+/// head present, `post_attention_norm` / `post_ffn_norm` absent.
+fn dense_fixture() -> (tempfile::TempDir, ComponentOpPlan, OperandStore) {
+    let dir = tempfile::tempdir().unwrap();
+    dense_f32_model(dir.path());
+    let inventory = larql_models::inventory::build_inventory(dir.path()).unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_system(
+        &[("dense-artifact".to_string(), inventory)],
+        container.path(),
+    )
+    .unwrap();
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let outcome = plan_component_ops(&inspection, container.path(), "target").unwrap();
+    assert!(outcome.closed(), "defects: {:?}", outcome.defects);
+    let plan = outcome.plan.unwrap();
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    (container, plan, store)
+}
+
+/// Step every token through a fresh session; return the last logits.
+fn decode_last_logits<B: PlanBackend>(
+    plan: &ComponentOpPlan,
+    store: &OperandStore,
+    backend: &B,
+) -> Option<Vec<f32>> {
+    let mut session = DecodeSession::new(plan, store, backend).unwrap();
+    let mut last = None;
+    for &token in TOKENS.iter() {
+        last = session.step(token).unwrap().logits;
+    }
+    assert_eq!(session.position(), TOKENS.len());
+    last
+}
+
+fn parse_message(err: VindexError) -> String {
+    match err {
+        VindexError::Parse(message) => message,
+        other => panic!("expected a Parse refusal, got {other:?}"),
+    }
+}
+
+// ── backend seam ──
+
+/// `as_f32` hands back exactly the f32 slice it was given and refuses
+/// every other representation: a backend that declared f32 receiving
+/// f16/MXFP4/NVFP4 is an interpreter bug, surfaced as an error rather
+/// than converted.
+#[test]
+fn as_f32_returns_f32_and_refuses_every_other_representation() {
+    let f32_slice = WeightSlice::F32(&F32_VALUES);
+    assert_eq!(f32_slice.as_f32().unwrap(), &F32_VALUES);
+
+    let foreign = [
+        ("f16", WeightSlice::F16(&FOREIGN_BYTES)),
+        (
+            "mxfp4",
+            WeightSlice::Mxfp4 {
+                packed: &FOREIGN_BYTES,
+                scales: &FOREIGN_BYTES,
+            },
+        ),
+        (
+            "nvfp4",
+            WeightSlice::Nvfp4 {
+                packed: &FOREIGN_BYTES,
+                scales: &FOREIGN_BYTES,
+                tensor_scale: NVFP4_TENSOR_SCALE,
+            },
+        ),
+    ];
+    for (label, slice) in foreign {
+        let message = parse_message(slice.as_f32().expect_err(label));
+        assert!(
+            message.contains("declared f32 weights"),
+            "{label}: {message}"
+        );
+    }
+}
+
+/// Backends with no device keep no dispatch accounting: the trait
+/// default answers `None`, and both CPU backends leave it in place.
+#[test]
+fn cpu_backends_report_no_dispatch_stats() {
+    assert_eq!(ReferenceBackend::new().dispatch_stats(), None);
+    assert_eq!(ProductionBackend::new().dispatch_stats(), None);
+    assert_eq!(RefusingBackend::new(RefusedOp::Ffn).dispatch_stats(), None);
+}
+
+// ── decode session ──
+
+/// Two-norm placement decodes: attention and FFN outputs join the
+/// residual un-normalised, and the stepped program still equals the
+/// batch traversal bit-for-bit — the absent post-norms are absent on
+/// both paths, not identities on one.
+#[test]
+fn a_two_norm_plan_decodes_and_matches_the_batch_traversal() {
+    let (_container, plan, store) = dense_fixture();
+    assert!(plan.layers[0].post_attention_norm.is_none());
+    assert!(plan.layers[0].post_ffn_norm.is_none());
+    let backend = ReferenceBackend::new();
+    let batch = execute_plan(&plan, &store, &TOKENS, &backend).unwrap();
+    let stepped = decode_last_logits(&plan, &store, &backend).expect("plan carries a head");
+    assert_eq!(batch.logits, Some(stepped));
+}
+
+/// A plan with no embedding op cannot start a session: external
+/// hidden-state input is a later rung, and the refusal names the
+/// component.
+#[test]
+fn a_session_refuses_a_plan_without_an_embedding_op() {
+    let (_container, mut plan, store) = dense_fixture();
+    plan.embedding = None;
+    let err = DecodeSession::new(&plan, &store, &ReferenceBackend::new())
+        .err()
+        .expect("no embedding op must refuse");
+    let message = parse_message(err);
+    assert!(message.contains("has no embedding op"), "{message}");
+    assert!(message.contains(&plan.component), "{message}");
+}
+
+/// A token past the embedding table is refused before any arithmetic,
+/// and the refused step consumes no position.
+#[test]
+fn a_token_outside_the_embedding_table_is_refused_without_advancing() {
+    let (_container, plan, store) = dense_fixture();
+    let backend = ReferenceBackend::new();
+    let mut session = DecodeSession::new(&plan, &store, &backend).unwrap();
+    session.step(TOKENS[0]).unwrap();
+    let refused = session
+        .step(OUT_OF_TABLE_TOKEN)
+        .err()
+        .expect("out-of-table token must refuse");
+    let message = parse_message(refused);
+    assert!(
+        message.contains(&format!("token id {OUT_OF_TABLE_TOKEN}")),
+        "{message}"
+    );
+    assert_eq!(session.position(), 1, "a refused step must not advance");
+}
+
+/// Without an output head a step yields no logits (never an empty or
+/// invented vector) but still advances the position.
+#[test]
+fn a_plan_without_an_output_head_yields_no_logits() {
+    let (_container, mut plan, store) = dense_fixture();
+    plan.output = None;
+    let logits = decode_last_logits(&plan, &store, &ReferenceBackend::new());
+    assert!(logits.is_none(), "headless plan produced logits");
+}
+
+/// Without a final norm the head reads the raw residual: the logits
+/// differ from the normed program's, so the absent norm was skipped and
+/// not quietly applied.
+#[test]
+fn a_plan_without_a_final_norm_feeds_the_raw_residual_to_the_head() {
+    let (_container, plan, store) = dense_fixture();
+    let backend = ReferenceBackend::new();
+    let normed = decode_last_logits(&plan, &store, &backend).unwrap();
+    let mut unnormed_plan = plan.clone();
+    unnormed_plan.final_norm = None;
+    let unnormed = decode_last_logits(&unnormed_plan, &store, &backend).unwrap();
+    assert_eq!(normed.len(), unnormed.len());
+    assert_ne!(
+        normed, unnormed,
+        "dropping the final norm must change the logits"
+    );
+}
+
+/// An operand the store cannot resolve fails the session at construction,
+/// at whichever site names it — attention, FFN, or the head — with the
+/// tensor in the message.
+#[test]
+fn a_session_fails_closed_on_an_unresolvable_operand_at_every_site() {
+    let (_container, plan, store) = dense_fixture();
+    let backend = ReferenceBackend::new();
+
+    let mut attention_broken = plan.clone();
+    attention_broken.layers[0].attention.q.tensor = UNRESOLVABLE_TENSOR.to_string();
+    let mut ffn_broken = plan.clone();
+    let LayerFfn::Dense(op) = &mut ffn_broken.layers[0].ffn else {
+        panic!("dense fixture");
+    };
+    op.up.tensor = UNRESOLVABLE_TENSOR.to_string();
+    let mut head_broken = plan;
+    head_broken
+        .output
+        .as_mut()
+        .expect("fixture carries a head")
+        .projection
+        .tensor = UNRESOLVABLE_TENSOR.to_string();
+
+    for (site, broken) in [
+        ("attention", attention_broken),
+        ("ffn", ffn_broken),
+        ("head", head_broken),
+    ] {
+        let err = DecodeSession::new(&broken, &store, &backend)
+            .err()
+            .unwrap_or_else(|| panic!("{site}: an unresolvable operand must refuse"));
+        let message = parse_message(err);
+        assert!(message.contains(UNRESOLVABLE_TENSOR), "{site}: {message}");
+    }
+}
+
+/// A backend that refuses the FFN refuses the step: the session
+/// propagates the refusal instead of substituting another backend's
+/// arithmetic.
+#[test]
+fn a_backend_ffn_refusal_propagates_out_of_the_step() {
+    let (_container, plan, store) = dense_fixture();
+    let backend = RefusingBackend::new(RefusedOp::Ffn);
+    let mut session = DecodeSession::new(&plan, &store, &backend).unwrap();
+    let refused = session
+        .step(TOKENS[0])
+        .err()
+        .expect("the FFN refusal must reach the caller");
+    let message = parse_message(refused);
+    assert_eq!(message, FFN_REFUSAL);
+}
+
+/// The same for the output head: every layer ran, and the head's
+/// refusal is what the step returns.
+#[test]
+fn a_backend_output_head_refusal_propagates_out_of_the_step() {
+    let (_container, plan, store) = dense_fixture();
+    let backend = RefusingBackend::new(RefusedOp::OutputHead);
+    let mut session = DecodeSession::new(&plan, &store, &backend).unwrap();
+    let refused = session
+        .step(TOKENS[0])
+        .err()
+        .expect("the head refusal must reach the caller");
+    let message = parse_message(refused);
+    assert_eq!(message, HEAD_REFUSAL);
+}
+
+/// Which operation a [`RefusingBackend`] has no kernel for.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RefusedOp {
+    Ffn,
+    OutputHead,
+}
+
+/// Reference arithmetic everywhere except one operation, which it
+/// refuses — the shape of a device backend missing one kernel.
+struct RefusingBackend {
+    inner: ReferenceBackend,
+    refuse: RefusedOp,
+}
+
+impl RefusingBackend {
+    fn new(refuse: RefusedOp) -> Self {
+        Self {
+            inner: ReferenceBackend::new(),
+            refuse,
+        }
+    }
+}
+
+impl PlanBackend for RefusingBackend {
+    fn name(&self) -> &str {
+        "refusing"
+    }
+
+    fn embed(&self, table: &[f32], hidden: usize, token: u32, scale: Option<f32>) -> Vec<f32> {
+        self.inner.embed(table, hidden, token, scale)
+    }
+
+    fn norm(&self, call: NormCall<'_>) -> Vec<f32> {
+        self.inner.norm(call)
+    }
+
+    fn project(&self, call: ProjectCall<'_>) -> Result<Vec<f32>, VindexError> {
+        self.inner.project(call)
+    }
+
+    fn attention(&self, call: AttentionCall<'_>) -> Result<Vec<Vec<f32>>, VindexError> {
+        self.inner.attention(call)
+    }
+
+    fn attention_step(&self, call: AttentionStepCall<'_>) -> Result<AttentionStepOut, VindexError> {
+        self.inner.attention_step(call)
+    }
+
+    fn ffn(&self, call: FfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        if self.refuse == RefusedOp::Ffn {
+            return Err(VindexError::Parse(FFN_REFUSAL.to_string()));
+        }
+        self.inner.ffn(call)
+    }
+
+    fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        self.inner.routed_ffn(call)
+    }
+
+    fn output_head(
+        &self,
+        projection: WeightSlice<'_>,
+        vocab: usize,
+        hidden: usize,
+        x: &[f32],
+        multiplier: Option<f64>,
+        softcapping: Option<f32>,
+    ) -> Result<Vec<f32>, VindexError> {
+        if self.refuse == RefusedOp::OutputHead {
+            return Err(VindexError::Parse(HEAD_REFUSAL.to_string()));
+        }
+        self.inner
+            .output_head(projection, vocab, hidden, x, multiplier, softcapping)
+    }
+
+    fn residual_add(&self, acc: &mut [f32], delta: &[f32]) {
+        self.inner.residual_add(acc, delta)
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_device.rs
@@ -1,0 +1,689 @@
+//! Device-backend arms not reached by the parity gates.
+//!
+//! The parity gates in `device.rs`, `decode.rs` and `routed.rs` drive
+//! `DevicePlanBackend` through whole plans, which reaches the happy
+//! paths of the f32/f16/MXFP4 realisations and the *first* refusal a
+//! kernelless device produces. What they cannot reach: the NVFP4
+//! realisation (no fixture declared it), the single-gemv refusals that
+//! sit behind a multi-gemv (a kernelless device dies at Q/K/V before the
+//! output projection is ever asked), the geometry checks in front of
+//! the device, the residency and diagnostic accessors, and the ungated
+//! and unsupported-activation FFN arms. Each test here drives one of
+//! those arms directly and asserts what the arm is *for*.
+
+use std::sync::{Arc, Mutex};
+
+use larql_compute::backend::MatMul;
+use larql_compute::cpu::ops::geglu::silu;
+use larql_models::config::{
+    Activation, ExpertGatePolicy, ExpertRoutingPolicy, GateUpLayout, MoeRouterKind,
+};
+use larql_models::quant::nvfp4::{
+    dequantize_into, round_trip, Nvfp4Matrix, NVFP4_GROUP_BYTES, NVFP4_GROUP_ELEMS,
+};
+use ndarray::{Array2, ArrayView2};
+
+use super::device::LoopDevice;
+use super::{dense_f32_model, lcg_values};
+use crate::format::vindex3::encode::encode_system;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::backend::{
+    FfnCall, MatrixClass, PlanBackend, ProjectCall, RoutedFfnCall, WeightFormat, WeightFormats,
+    WeightSlice,
+};
+use crate::format::vindex3::opplan::exec::decode::DecodeSession;
+use crate::format::vindex3::opplan::exec::device::DevicePlanBackend;
+use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use crate::format::vindex3::opplan::exec::weights::{quantize_mxfp4, quantize_nvfp4, LoadedWeight};
+use crate::format::vindex3::opplan::exec::{execute_plan, ExecutionTrace};
+use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
+
+/// A small matrix geometry aligned to both 4-bit group sizes (MXFP4's
+/// 32 and NVFP4's 16), so every format can carry it.
+const ROWS: usize = 4;
+const COLS: usize = 32;
+
+/// FFN geometry for the direct `ffn`/`routed_ffn` calls: `hidden` is
+/// the up/gate K dimension and `intermediate` the down K dimension, so
+/// both stay group-aligned.
+const FFN_HIDDEN: usize = 32;
+const FFN_INTERMEDIATE: usize = 32;
+
+/// Routed-FFN geometry: two experts, top-1, so the selected expert is
+/// determined by the router alone.
+const EXPERTS: usize = 2;
+const TOP_K: usize = 1;
+
+/// Bytes per f16 element, for sizing f16 weight slices.
+const F16_BYTES: usize = 2;
+
+/// Above the reassociation noise of two in-order loops that sum the
+/// same products (in practice they are bit-identical); far below any
+/// semantic effect.
+const LOOP_NOISE_CEILING: f32 = 1e-6;
+
+/// The NVFP4 realisation of the dense fixture must stay in the f32
+/// reference's neighbourhood: 4-bit weights are coarse, so this is a
+/// direction gate (cosine), not a closeness gate.
+const NVFP4_COSINE_FLOOR: f32 = 0.5;
+
+/// Tokens for the dense Llama fixture; distinct positions so the
+/// decode session's cache is exercised beyond one row.
+const DENSE_TOKENS: [u32; 5] = [3, 17, 42, 99, 7];
+
+/// A device with no gemv kernel of any format — every trait default.
+struct KernellessDevice;
+
+impl MatMul for KernellessDevice {
+    fn matmul(&self, _a: ArrayView2<f32>, _b: ArrayView2<f32>) -> Array2<f32> {
+        unimplemented!("the plan backend only dispatches gemv")
+    }
+
+    fn matmul_transb(&self, _a: ArrayView2<f32>, _b: ArrayView2<f32>) -> Array2<f32> {
+        unimplemented!("the plan backend only dispatches gemv")
+    }
+}
+
+/// `LoopDevice` plus an NVFP4 kernel: decode through the models-crate
+/// dequantiser (the independent reader of the format), then the same
+/// in-order loop. The seam is what is under test; the arithmetic is
+/// deliberately borrowed from the format's own reference decoder.
+struct Nvfp4LoopDevice;
+
+impl MatMul for Nvfp4LoopDevice {
+    fn matmul(&self, a: ArrayView2<f32>, b: ArrayView2<f32>) -> Array2<f32> {
+        LoopDevice.matmul(a, b)
+    }
+
+    fn matmul_transb(&self, a: ArrayView2<f32>, b: ArrayView2<f32>) -> Array2<f32> {
+        LoopDevice.matmul_transb(a, b)
+    }
+
+    fn f32_gemv_force(&self, w: ArrayView2<f32>, x: &[f32]) -> Option<Vec<f32>> {
+        LoopDevice.f32_gemv_force(w, x)
+    }
+
+    fn nvfp4_gemv(
+        &self,
+        packed: &[u8],
+        scales: &[u8],
+        tensor_scale: f32,
+        x: &[f32],
+        n: usize,
+        k: usize,
+    ) -> Option<Vec<f32>> {
+        if !k.is_multiple_of(NVFP4_GROUP_ELEMS) || x.len() != k {
+            return None;
+        }
+        let groups = k / NVFP4_GROUP_ELEMS;
+        if packed.len() < n * groups * NVFP4_GROUP_BYTES || scales.len() < n * groups {
+            return None;
+        }
+        let matrix = Nvfp4Matrix {
+            packed: packed[..n * groups * NVFP4_GROUP_BYTES].to_vec(),
+            scales: scales[..n * groups].to_vec(),
+            tensor_scale,
+        };
+        let mut w = vec![0.0f32; n * k];
+        dequantize_into(&matrix, n, k, &mut w).ok()?;
+        Some(matvec_rows(&w, n, k, x))
+    }
+}
+
+/// A device that has the f16 *multi* kernel but no single f16 gemv:
+/// Q/K/V (one multi submission) succeed and the output projection (a
+/// single gemv) is refused, which reaches the refusal behind the multi
+/// path that a fully kernelless device never gets to.
+struct MultiOnlyF16Device;
+
+impl MatMul for MultiOnlyF16Device {
+    fn matmul(&self, a: ArrayView2<f32>, b: ArrayView2<f32>) -> Array2<f32> {
+        LoopDevice.matmul(a, b)
+    }
+
+    fn matmul_transb(&self, a: ArrayView2<f32>, b: ArrayView2<f32>) -> Array2<f32> {
+        LoopDevice.matmul_transb(a, b)
+    }
+
+    fn f16_gemv_multi(
+        &self,
+        weights: &[(&[u8], usize, usize)],
+        x: &[f32],
+    ) -> Option<Vec<Vec<f32>>> {
+        weights
+            .iter()
+            .map(|&(w, n, k)| LoopDevice.f16_gemv_force(w, x, n, k))
+            .collect()
+    }
+}
+
+/// A device that records what `wire_resident` was handed: the byte
+/// length of every stream, in order.
+struct WireRecorder {
+    streams: Arc<Mutex<Vec<usize>>>,
+}
+
+impl MatMul for WireRecorder {
+    fn matmul(&self, _a: ArrayView2<f32>, _b: ArrayView2<f32>) -> Array2<f32> {
+        unimplemented!("the plan backend only dispatches gemv")
+    }
+
+    fn matmul_transb(&self, _a: ArrayView2<f32>, _b: ArrayView2<f32>) -> Array2<f32> {
+        unimplemented!("the plan backend only dispatches gemv")
+    }
+
+    fn wire_resident(&self, buffers: &[&[u8]]) {
+        self.streams
+            .lock()
+            .unwrap()
+            .extend(buffers.iter().map(|b| b.len()));
+    }
+}
+
+/// `out[n] = W[n, k] · x`, plain in-order loop.
+fn matvec_rows(w: &[f32], n: usize, k: usize, x: &[f32]) -> Vec<f32> {
+    (0..n)
+        .map(|row| (0..k).map(|col| w[row * k + col] * x[col]).sum())
+        .collect()
+}
+
+fn max_abs(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len());
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0, f32::max)
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na: f32 = a.iter().map(|v| v * v).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|v| v * v).sum::<f32>().sqrt();
+    dot / (na * nb)
+}
+
+/// Encode the dense Llama fixture and open its plan + store.
+fn dense_fixture() -> (tempfile::TempDir, ComponentOpPlan, OperandStore) {
+    let dir = tempfile::tempdir().unwrap();
+    dense_f32_model(dir.path());
+    let inventory = larql_models::inventory::build_inventory(dir.path()).unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_system(&[("dense-device".to_string(), inventory)], container.path()).unwrap();
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let outcome = plan_component_ops(&inspection, container.path(), "target").unwrap();
+    assert!(outcome.closed(), "defects: {:?}", outcome.defects);
+    let plan = outcome.plan.unwrap();
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    (container, plan, store)
+}
+
+/// Step every dense-fixture token through a fresh session; the last
+/// position's logits.
+fn decode_logits<B: PlanBackend>(
+    plan: &ComponentOpPlan,
+    store: &OperandStore,
+    backend: &B,
+) -> Vec<f32> {
+    let mut session = DecodeSession::new(plan, store, backend).unwrap();
+    let mut last = None;
+    for &token in DENSE_TOKENS.iter() {
+        last = session.step(token).unwrap().logits;
+    }
+    last.expect("plan carries an output head")
+}
+
+fn project_on<M: MatMul + Send>(
+    backend: &DevicePlanBackend<M>,
+    weight: WeightSlice<'_>,
+    x: &[f32],
+) -> Result<Vec<f32>, crate::error::VindexError> {
+    backend.project(ProjectCall {
+        weight,
+        out_dim: ROWS,
+        in_dim: COLS,
+        x,
+    })
+}
+
+fn ffn_call<'a>(
+    x: &'a [f32],
+    gate: Option<WeightSlice<'a>>,
+    up: WeightSlice<'a>,
+    down: WeightSlice<'a>,
+    activation: Activation,
+) -> FfnCall<'a> {
+    FfnCall {
+        x,
+        hidden: FFN_HIDDEN,
+        intermediate: FFN_INTERMEDIATE,
+        gate,
+        up,
+        down,
+        activation,
+        gate_policy: ExpertGatePolicy::Gated,
+    }
+}
+
+// ── Diagnostics and residency ────────────────────────────────────────
+
+/// `name` reports the injected name verbatim (it becomes the engine tag
+/// on a dump) and `dispatch_stats` counts one submission per device
+/// call: a lone `project` is one, a two-matrix f16 FFN is one multi
+/// submission plus one for `down`.
+#[test]
+fn the_name_is_verbatim_and_dispatch_stats_count_one_submission_per_device_call() {
+    const NAME: &str = "loop-device-stats";
+    const PROJECT_CALLS: u64 = 3;
+    /// Up+gate ride one multi submission; down is a second.
+    const SUBMISSIONS_PER_GATED_F16_FFN: u64 = 2;
+
+    let backend = DevicePlanBackend::new(LoopDevice, NAME, WeightFormat::F32);
+    assert_eq!(backend.name(), NAME);
+    let fresh = backend.dispatch_stats().unwrap();
+    assert_eq!((fresh.submissions, fresh.device_nanos), (0, 0));
+
+    let w = lcg_values(ROWS * COLS, 1);
+    let x = lcg_values(COLS, 2);
+    for _ in 0..PROJECT_CALLS {
+        project_on(&backend, WeightSlice::F32(&w), &x).unwrap();
+    }
+    let after_projects = backend.dispatch_stats().unwrap();
+    assert_eq!(after_projects.submissions, PROJECT_CALLS);
+
+    let f16 = vec![0u8; FFN_INTERMEDIATE * FFN_HIDDEN * F16_BYTES];
+    let x = lcg_values(FFN_HIDDEN, 3);
+    backend
+        .ffn(ffn_call(
+            &x,
+            Some(WeightSlice::F16(&f16)),
+            WeightSlice::F16(&f16),
+            WeightSlice::F16(&f16),
+            Activation::Silu,
+        ))
+        .unwrap();
+    let after_ffn = backend.dispatch_stats().unwrap();
+    assert_eq!(
+        after_ffn.submissions,
+        PROJECT_CALLS + SUBMISSIONS_PER_GATED_F16_FFN
+    );
+}
+
+/// `prepare` hands the device one stream per f16 weight and two per
+/// packed 4-bit weight (codes and scales), skipping f32 — the layout
+/// the residency hint must see for every byte the decode will touch.
+#[test]
+fn prepare_wires_one_stream_per_f16_weight_and_two_per_packed_weight() {
+    let streams = Arc::new(Mutex::new(Vec::new()));
+    let backend = DevicePlanBackend::new(
+        WireRecorder {
+            streams: Arc::clone(&streams),
+        },
+        "wire-recorder",
+        WeightFormat::F16,
+    );
+    let f32_weight = lcg_values(ROWS * COLS, 4);
+    let f16_bytes = vec![0u8; ROWS * COLS * F16_BYTES];
+    let LoadedWeight::Mxfp4 {
+        packed: mx_packed,
+        scales: mx_scales,
+    } = quantize_mxfp4(&f32_weight, ROWS, COLS, "mx").unwrap()
+    else {
+        unreachable!()
+    };
+    let LoadedWeight::Nvfp4 {
+        packed: nv_packed,
+        scales: nv_scales,
+        tensor_scale,
+    } = quantize_nvfp4(&f32_weight, ROWS, COLS, "nv").unwrap()
+    else {
+        unreachable!()
+    };
+    backend.prepare(&[
+        WeightSlice::F32(&f32_weight),
+        WeightSlice::F16(&f16_bytes),
+        WeightSlice::Mxfp4 {
+            packed: mx_packed.as_slice(),
+            scales: mx_scales.as_slice(),
+        },
+        WeightSlice::Nvfp4 {
+            packed: nv_packed.as_slice(),
+            scales: nv_scales.as_slice(),
+            tensor_scale,
+        },
+    ]);
+    let seen = streams.lock().unwrap().clone();
+    assert_eq!(
+        seen,
+        vec![
+            f16_bytes.len(),
+            mx_packed.as_slice().len(),
+            mx_scales.as_slice().len(),
+            nv_packed.as_slice().len(),
+            nv_scales.as_slice().len(),
+        ],
+        "f32 contributes no stream; f16 one; each packed format its codes then its scales"
+    );
+}
+
+// ── Geometry checks in front of the device ───────────────────────────
+
+/// An f32 weight whose length is not `out × in` is refused by the seam,
+/// naming the geometry, before any kernel sees it.
+#[test]
+fn a_misshapen_f32_weight_is_refused_naming_the_geometry() {
+    let backend = DevicePlanBackend::new(LoopDevice, "loop-device-shape", WeightFormat::F32);
+    let short = lcg_values(ROWS * COLS - 1, 5);
+    let x = lcg_values(COLS, 6);
+    let err = project_on(&backend, WeightSlice::F32(&short), &x).unwrap_err();
+    let message = err.to_string();
+    assert!(
+        message.contains(&format!("is not [{ROWS}, {COLS}]")),
+        "{message}"
+    );
+}
+
+/// An f16 slice shorter than the matrix is refused by the seam with the
+/// byte count — the device (which would also refuse) is never asked, so
+/// the message names the seam's check, not a kernel.
+#[test]
+fn a_short_f16_weight_is_refused_before_reaching_the_device() {
+    let backend = DevicePlanBackend::new(LoopDevice, "loop-device-f16-short", WeightFormat::F16);
+    let short = vec![0u8; ROWS * COLS * F16_BYTES - F16_BYTES];
+    let x = lcg_values(COLS, 7);
+    let err = project_on(&backend, WeightSlice::F16(&short), &x).unwrap_err();
+    let message = err.to_string();
+    assert!(
+        message.contains(&format!(
+            "{} weight bytes cannot hold [{ROWS} x {COLS}]",
+            short.len()
+        )),
+        "{message}"
+    );
+}
+
+// ── Single-gemv refusals behind the multi path ───────────────────────
+
+/// On a kernelless device the single-gemv seam refuses each format
+/// naming its kernel and the shape — the f16/MXFP4/NVFP4 arms a whole-
+/// plan run never reaches because it dies at the multi-gemv first.
+#[test]
+fn single_gemv_refusals_name_the_kernel_and_shape_for_every_packed_format() {
+    let backend = DevicePlanBackend::new(KernellessDevice, "kernelless-single", WeightFormat::F32);
+    let f32_weight = lcg_values(ROWS * COLS, 8);
+    let x = lcg_values(COLS, 9);
+    let f16_bytes = vec![0u8; ROWS * COLS * F16_BYTES];
+    let LoadedWeight::Mxfp4 {
+        packed: mx_packed,
+        scales: mx_scales,
+    } = quantize_mxfp4(&f32_weight, ROWS, COLS, "mx").unwrap()
+    else {
+        unreachable!()
+    };
+    let LoadedWeight::Nvfp4 {
+        packed: nv_packed,
+        scales: nv_scales,
+        tensor_scale,
+    } = quantize_nvfp4(&f32_weight, ROWS, COLS, "nv").unwrap()
+    else {
+        unreachable!()
+    };
+    let cases: [(&str, WeightSlice<'_>); 3] = [
+        ("f16_gemv", WeightSlice::F16(&f16_bytes)),
+        (
+            "mxfp4_gemv",
+            WeightSlice::Mxfp4 {
+                packed: mx_packed.as_slice(),
+                scales: mx_scales.as_slice(),
+            },
+        ),
+        (
+            "nvfp4_gemv",
+            WeightSlice::Nvfp4 {
+                packed: nv_packed.as_slice(),
+                scales: nv_scales.as_slice(),
+                tensor_scale,
+            },
+        ),
+    ];
+    for (kernel, weight) in cases {
+        let message = project_on(&backend, weight, &x).unwrap_err().to_string();
+        assert!(
+            message.contains(&format!("device {kernel} [{ROWS} x {COLS}] refused")),
+            "{kernel}: {message}"
+        );
+    }
+}
+
+/// A device that batches f16 matrices but has no single f16 kernel:
+/// Q/K/V succeed through the multi path and the output projection —
+/// a lone gemv — fails closed naming its own shape. Nothing widens or
+/// substitutes.
+#[test]
+fn a_multi_only_f16_device_fails_closed_at_the_output_projection() {
+    let (_c, plan, store) = dense_fixture();
+    let backend = DevicePlanBackend::new(MultiOnlyF16Device, "multi-only-f16", WeightFormat::F16);
+    let err = execute_plan(&plan, &store, &DENSE_TOKENS, &backend).unwrap_err();
+    let message = err.to_string();
+    let q_rows = super::Q_HEADS * super::HEAD_DIM;
+    assert!(
+        message.contains(&format!(
+            "device f16_gemv [{} x {q_rows}] refused",
+            super::HIDDEN
+        )),
+        "{message}"
+    );
+}
+
+/// The NVFP4 multi path refuses on a kernelless device naming the
+/// matrix count — the FFN's up+gate pair — and the FFN propagates it.
+#[test]
+fn an_nvfp4_multi_dispatch_refusal_names_the_matrix_count() {
+    /// Up and gate.
+    const FFN_PAIR: usize = 2;
+    let backend = DevicePlanBackend::new(KernellessDevice, "kernelless-nvfp4", WeightFormat::Nvfp4);
+    let values = lcg_values(FFN_INTERMEDIATE * FFN_HIDDEN, 10);
+    let LoadedWeight::Nvfp4 {
+        packed,
+        scales,
+        tensor_scale,
+    } = quantize_nvfp4(&values, FFN_INTERMEDIATE, FFN_HIDDEN, "nv").unwrap()
+    else {
+        unreachable!()
+    };
+    let weight = WeightSlice::Nvfp4 {
+        packed: packed.as_slice(),
+        scales: scales.as_slice(),
+        tensor_scale,
+    };
+    let x = lcg_values(FFN_HIDDEN, 11);
+    let err = backend
+        .ffn(ffn_call(&x, Some(weight), weight, weight, Activation::Silu))
+        .unwrap_err();
+    let message = err.to_string();
+    assert!(
+        message.contains(&format!("nvfp4_gemv_multi ({FFN_PAIR} matrices) refused")),
+        "{message}"
+    );
+}
+
+/// The routed FFN's first device call is the f32 router; a kernelless
+/// device refuses it and nothing routes.
+#[test]
+fn a_routed_ffn_whose_router_dispatch_is_refused_fails_closed() {
+    let backend = DevicePlanBackend::new(KernellessDevice, "kernelless-routed", WeightFormat::F32);
+    let router = lcg_values(EXPERTS * FFN_HIDDEN, 12);
+    let expert_gate_up: Vec<Vec<f32>> = (0..EXPERTS)
+        .map(|e| lcg_values(2 * FFN_INTERMEDIATE * FFN_HIDDEN, 20 + e as u64))
+        .collect();
+    let expert_down: Vec<Vec<f32>> = (0..EXPERTS)
+        .map(|e| lcg_values(FFN_HIDDEN * FFN_INTERMEDIATE, 30 + e as u64))
+        .collect();
+    let gate_up: Vec<WeightSlice<'_>> =
+        expert_gate_up.iter().map(|w| WeightSlice::F32(w)).collect();
+    let down: Vec<WeightSlice<'_>> = expert_down.iter().map(|w| WeightSlice::F32(w)).collect();
+    let x = lcg_values(FFN_HIDDEN, 13);
+    let err = backend
+        .routed_ffn(RoutedFfnCall {
+            x: &x,
+            hidden: FFN_HIDDEN,
+            intermediate: FFN_INTERMEDIATE,
+            experts: EXPERTS,
+            top_k: TOP_K,
+            router_kind: MoeRouterKind::TopKSoftmax,
+            routing_policy: ExpertRoutingPolicy::SoftmaxThenSelect,
+            activation: Activation::Silu,
+            gate_policy: ExpertGatePolicy::Gated,
+            gate_up_layout: GateUpLayout::ContiguousHalves,
+            router: &router,
+            router_bias: None,
+            gate_up: &gate_up,
+            gate_up_bias: None,
+            down: &down,
+            down_bias: None,
+        })
+        .unwrap_err();
+    let message = err.to_string();
+    assert!(
+        message.contains(&format!(
+            "device f32_gemv [{EXPERTS} x {FFN_HIDDEN}] refused"
+        )),
+        "{message}"
+    );
+}
+
+// ── FFN arms ─────────────────────────────────────────────────────────
+
+/// An ungated FFN is `down · silu(up · x)`: no gate matrix, no
+/// elementwise product — the shape the dense-Llama plan never carries.
+#[test]
+fn an_ungated_ffn_applies_silu_to_the_up_projection_alone() {
+    let backend = DevicePlanBackend::new(LoopDevice, "loop-device-ungated", WeightFormat::F32);
+    let up = lcg_values(FFN_INTERMEDIATE * FFN_HIDDEN, 14);
+    let down = lcg_values(FFN_HIDDEN * FFN_INTERMEDIATE, 15);
+    let x = lcg_values(FFN_HIDDEN, 16);
+    let got = backend
+        .ffn(ffn_call(
+            &x,
+            None,
+            WeightSlice::F32(&up),
+            WeightSlice::F32(&down),
+            Activation::Silu,
+        ))
+        .unwrap();
+    let inner: Vec<f32> = matvec_rows(&up, FFN_INTERMEDIATE, FFN_HIDDEN, &x)
+        .into_iter()
+        .map(silu)
+        .collect();
+    let expected = matvec_rows(&down, FFN_HIDDEN, FFN_INTERMEDIATE, &inner);
+    assert_eq!(got.len(), FFN_HIDDEN);
+    assert!(
+        max_abs(&got, &expected) < LOOP_NOISE_CEILING,
+        "ungated FFN diverges from down · silu(up · x)"
+    );
+}
+
+/// The device FFN refuses an activation it has no kernel for, in both
+/// the gated and the ungated shape, naming which shape refused.
+#[test]
+fn an_ffn_with_an_unsupported_activation_refuses_gated_and_ungated() {
+    let backend = DevicePlanBackend::new(LoopDevice, "loop-device-activation", WeightFormat::F32);
+    let up = lcg_values(FFN_INTERMEDIATE * FFN_HIDDEN, 17);
+    let down = lcg_values(FFN_HIDDEN * FFN_INTERMEDIATE, 18);
+    let x = lcg_values(FFN_HIDDEN, 19);
+    for (shape, gate) in [("gated", Some(WeightSlice::F32(&up))), ("ungated", None)] {
+        let err = backend
+            .ffn(ffn_call(
+                &x,
+                gate,
+                WeightSlice::F32(&up),
+                WeightSlice::F32(&down),
+                Activation::Gelu,
+            ))
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains(&format!("{shape}-FFN")) && message.contains("Gelu"),
+            "{shape}: {message}"
+        );
+    }
+}
+
+// ── The NVFP4 realisation ────────────────────────────────────────────
+
+/// A single NVFP4 projection through the seam equals the round-tripped
+/// matrix against the same input: the seam hands the device the codes,
+/// the E4M3 scales *and* the tensor scale intact, with the geometry.
+#[test]
+fn an_nvfp4_projection_matches_the_round_tripped_matrix() {
+    let backend =
+        DevicePlanBackend::new(Nvfp4LoopDevice, "nvfp4-loop-project", WeightFormat::Nvfp4);
+    let values = lcg_values(ROWS * COLS, 21);
+    let x = lcg_values(COLS, 22);
+    let LoadedWeight::Nvfp4 {
+        packed,
+        scales,
+        tensor_scale,
+    } = quantize_nvfp4(&values, ROWS, COLS, "nv").unwrap()
+    else {
+        unreachable!()
+    };
+    let got = project_on(
+        &backend,
+        WeightSlice::Nvfp4 {
+            packed: packed.as_slice(),
+            scales: scales.as_slice(),
+            tensor_scale,
+        },
+        &x,
+    )
+    .unwrap();
+    let reconstructed = round_trip(&values, ROWS, COLS).unwrap();
+    let expected = matvec_rows(&reconstructed, ROWS, COLS, &x);
+    assert!(
+        max_abs(&got, &expected) < LOOP_NOISE_CEILING,
+        "seam-routed NVFP4 gemv diverges from the reference reconstruction"
+    );
+    // The realisation is lossy but must not be degenerate: the tensor
+    // scale was applied (an all-zero output would mean it was dropped).
+    assert!(got.iter().any(|v| *v != 0.0));
+}
+
+/// The NVFP4 realisation runs the dense plan end to end — attention
+/// Q/K/V through the NVFP4 multi path, the FFN pair likewise, single
+/// projections through the NVFP4 gemv — stays in the reference's
+/// neighbourhood, and its decode session reproduces its own batch
+/// traversal bit for bit (the step path with no gate, on the device).
+#[test]
+fn an_nvfp4_device_backend_executes_and_decodes_the_dense_plan() {
+    let (_c, plan, store) = dense_fixture();
+    let backend = DevicePlanBackend::with_formats(
+        Nvfp4LoopDevice,
+        "nvfp4-loop-dense",
+        WeightFormats::uniform(WeightFormat::Nvfp4),
+    );
+    assert_eq!(
+        backend.weight_format(MatrixClass::FfnProjection),
+        WeightFormat::Nvfp4
+    );
+    let on_device: ExecutionTrace = execute_plan(&plan, &store, &DENSE_TOKENS, &backend).unwrap();
+    let on_reference =
+        execute_plan(&plan, &store, &DENSE_TOKENS, &ReferenceBackend::new()).unwrap();
+    let logits = on_device.logits.as_ref().unwrap();
+    assert!(logits.iter().all(|v| v.is_finite()));
+    let cos = cosine(logits, on_reference.logits.as_ref().unwrap());
+    assert!(
+        cos > NVFP4_COSINE_FLOOR,
+        "nvfp4 logits decorrelated from reference: cos {cos}"
+    );
+
+    let stepped = decode_logits(&plan, &store, &backend);
+    assert_eq!(
+        logits.as_slice(),
+        stepped.as_slice(),
+        "nvfp4 decode-session logits differ from the batch traversal"
+    );
+    // Every matrix went through the device: the batch pass and the
+    // decode pass both submitted work.
+    assert!(backend.dispatch_stats().unwrap().submissions > 0);
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
@@ -1,0 +1,578 @@
+//! Expert-bank binding and production-backend arms not reached by the parity gates.
+//!
+//! Two groups. **Expert-bank binding** (`experts.rs`): the packed bank's
+//! refusal arms — a projection without scales, a stored dtype or byte
+//! count that disagrees with the declared geometry, an unaligned `k`, a
+//! per-expert format that is not packed — plus the conversion arms a
+//! non-f32 backend takes (MXFP4 → f16/NVFP4, BF16 → f16/f32/MXFP4/NVFP4)
+//! and the residency listing. **Production backend** (`production.rs`):
+//! the arms the routed and dense fixtures never select — weighted QK
+//! norm, `Windowed` span, LayerNorm, the plain projection, embedding
+//! scale, the Gemma 4 router refusal, the bias-free router, the
+//! ungated FFN, and every kernel refusal.
+//!
+//! The routed fixture is the GPT-OSS miniature of `routed.rs` with one
+//! twist: every source value is bf16-representable, so an unquantised
+//! BF16 copy of the bank (written under unclassified names, into the bank
+//! object) quantises at load to **exactly** the bytes the checkpoint's own
+//! MXFP4 packing holds — the BF16 → MXFP4 arm is checked byte for byte,
+//! not against a tolerance.
+
+mod fixture;
+
+use larql_models::config::{
+    Activation, ExpertFormat, MoeRouterKind, NormType, ParameterFreeQkNorm, PositionPolicy,
+    QkNormScope,
+};
+use larql_models::ExpertGatePolicy;
+
+use self::fixture::*;
+use super::{dense_f32_model, lcg_values, norm_values};
+use crate::format::vindex3::graph::policy::AttentionSpan;
+use crate::format::vindex3::opplan::exec::backend::{
+    AttentionCall, AttentionStepCall, FfnCall, NormCall, PlanBackend, ProjectCall, QkNormCall,
+    RoutedFfnCall, WeightFormat, WeightSlice,
+};
+use crate::format::vindex3::opplan::exec::experts::FfnOperands;
+use crate::format::vindex3::opplan::exec::production::{
+    aggregate_heads, condition_qk_in_place, qk_norm_in_place, select_experts, ProductionBackend,
+};
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use crate::format::vindex3::opplan::{FfnOp, LayerFfn};
+
+// ═══════════════════════════ experts.rs ═══════════════════════════
+
+/// The residency listing of a routed layer is every expert's gate_up and
+/// down matrix — one slice per (expert, projection), in the declared
+/// format — so `prepare` can wire the whole bank.
+#[test]
+fn routed_operands_list_every_expert_matrix_for_residency() {
+    let fx = routed_fixture();
+    let operands = load(&fx.op, &fx.store, WeightFormat::F32);
+    let kinds = slice_kinds(&operands);
+    assert_eq!(kinds.len(), FUSED_BRANCHES * EXPERTS);
+    assert!(kinds.iter().all(|k| *k == "f32"), "{kinds:?}");
+}
+
+/// A routed op without a `gate_up_layout` refuses at apply time — the
+/// layout is what makes the fused rows readable — naming the missing fact.
+#[test]
+fn a_routed_op_without_a_gate_up_layout_refuses_at_apply() {
+    let fx = routed_fixture();
+    let operands = load(&fx.op, &fx.store, WeightFormat::F32);
+    let mut op = fx.op.clone();
+    op.gate_up_layout = None;
+    let x = norm_values(HIDDEN, INPUT_SEED);
+    let err = operands
+        .apply(&routed(&op), &ProductionBackend::new(), &x, HIDDEN)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("no gate_up layout"), "{err}");
+}
+
+/// Operands loaded for a routed op refuse to serve a dense op: the two
+/// kinds share nothing, and a mismatch is an interpreter bug, not a
+/// fallback.
+#[test]
+fn operands_loaded_for_one_ffn_kind_refuse_the_other_at_apply() {
+    let fx = routed_fixture();
+    let operands = load(&fx.op, &fx.store, WeightFormat::F32);
+    let dense = LayerFfn::Dense(Box::new(FfnOp {
+        intermediate_size: INTER,
+        activation: Activation::Silu,
+        gate_policy: ExpertGatePolicy::Gated,
+        gate: None,
+        up: fx.op.router.clone(),
+        down: fx.op.router.clone(),
+    }));
+    let x = norm_values(HIDDEN, INPUT_SEED);
+    let err = operands
+        .apply(&dense, &ProductionBackend::new(), &x, HIDDEN)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("different op kind"), "{err}");
+}
+
+/// An MXFP4 projection whose op carries no scales operand refuses,
+/// naming the projection — the blocks alone are not a matrix.
+#[test]
+fn an_mxfp4_projection_without_scales_refuses() {
+    let fx = routed_fixture();
+    let mut op = fx.op.clone();
+    op.gate_up.scales = None;
+    let err = load_err(&op, &fx.store, WeightFormat::F32);
+    assert!(err.contains("no scales operand"), "{err}");
+    assert!(err.contains(GATE_UP_BLOCKS), "{err}");
+}
+
+/// An MXFP4 projection whose `k` is not a multiple of the 32-element
+/// group refuses before touching the bytes: `k` follows from the router's
+/// declared width, and a stray width must not be silently grouped.
+#[test]
+fn an_mxfp4_projection_with_an_unaligned_k_refuses() {
+    let fx = routed_fixture();
+    let mut op = fx.op.clone();
+    op.router.shape[1] = HIDDEN + 1;
+    let err = load_err(&op, &fx.store, WeightFormat::F32);
+    assert!(err.contains("not a multiple of the MXFP4 group"), "{err}");
+}
+
+/// A scales stream of the wrong length for the declared expert geometry
+/// refuses, naming the scales tensor: here gate_up's scales are pointed
+/// at down's (half the size).
+#[test]
+fn a_scales_stream_of_the_wrong_length_refuses() {
+    let fx = routed_fixture();
+    let mut op = fx.op.clone();
+    op.gate_up.scales = op.down.scales.clone();
+    let err = load_err(&op, &fx.store, WeightFormat::F32);
+    assert!(err.contains("stored bytes, expected"), "{err}");
+    assert!(
+        err.contains(DOWN_BLOCKS.replace(BLOCKS_SUFFIX, SCALES_SUFFIX).as_str()),
+        "{err}"
+    );
+}
+
+/// A block stream whose byte count disagrees with the declared expert
+/// geometry refuses (the op's intermediate width was edited, the bytes
+/// were not).
+#[test]
+fn a_block_stream_disagreeing_with_the_declared_geometry_refuses() {
+    let fx = routed_fixture();
+    let mut op = fx.op.clone();
+    op.expert_intermediate_size = INTER + MXFP4_GROUP_ELEMS;
+    let err = load_err(&op, &fx.store, WeightFormat::F32);
+    assert!(err.contains("stored bytes, expected"), "{err}");
+    assert!(err.contains(GATE_UP_BLOCKS), "{err}");
+}
+
+/// A stream stored in a dtype other than the one its format demands
+/// refuses, naming both dtypes: an MXFP4 scales operand pointed at the
+/// F32 bias, and a BF16 projection pointed at the U8 blocks.
+#[test]
+fn a_stream_stored_in_the_wrong_dtype_refuses() {
+    let fx = routed_fixture();
+    let mut op = fx.op.clone();
+    op.gate_up.scales = op.gate_up.bias.clone();
+    let err = load_err(&op, &fx.store, WeightFormat::F32);
+    assert!(err.contains("expected stored dtype U8, found F32"), "{err}");
+
+    let mut op = fx.op.clone();
+    op.expert_format = ExpertFormat::PackedBF16;
+    let err = load_err(&op, &fx.store, WeightFormat::F32);
+    assert!(
+        err.contains("expected stored dtype BF16, found U8"),
+        "{err}"
+    );
+}
+
+/// `PerExpert` is not a packed projection; closure never plans one, and
+/// the loader refuses rather than guessing a layout.
+#[test]
+fn a_per_expert_format_is_refused_as_not_packed() {
+    let fx = routed_fixture();
+    let mut op = fx.op.clone();
+    op.expert_format = ExpertFormat::PerExpert;
+    let err = load_err(&op, &fx.store, WeightFormat::F32);
+    assert!(err.contains("not a packed projection"), "{err}");
+}
+
+/// A backend that declares f16 for the FFN class receives the MXFP4 bank
+/// converted through f32 to f16 (e2m1 × 2ⁿ is exact in f16 at these
+/// magnitudes), and computes the same routed output as the f32 backend;
+/// an NVFP4 declaration receives NVFP4 streams.
+#[test]
+fn an_mxfp4_bank_converts_through_f32_for_f16_and_nvfp4_backends() {
+    let fx = routed_fixture();
+    let x = norm_values(HIDDEN, INPUT_SEED);
+    let ffn = routed(&fx.op);
+    let f32_out = load(&fx.op, &fx.store, WeightFormat::F32)
+        .apply(&ffn, &ProductionBackend::new(), &x, HIDDEN)
+        .unwrap();
+
+    let f16 = load(&fx.op, &fx.store, WeightFormat::F16);
+    assert!(slice_kinds(&f16).iter().all(|k| *k == "f16"));
+    let f16_out = f16
+        .apply(&ffn, &loop_device(WeightFormat::F16), &x, HIDDEN)
+        .unwrap();
+    let delta = max_abs_diff(&f32_out, &f16_out);
+    assert!(delta < NOISE_CEILING, "f16 realisation drifted {delta:e}");
+
+    let nvfp4 = load(&fx.op, &fx.store, WeightFormat::Nvfp4);
+    let kinds = slice_kinds(&nvfp4);
+    assert_eq!(kinds.len(), FUSED_BRANCHES * EXPERTS);
+    assert!(kinds.iter().all(|k| *k == "nvfp4"), "{kinds:?}");
+}
+
+/// A BF16 bank binds in every declared format: f16 exactly (bf16 ⊂ f16),
+/// f32 by widening, and MXFP4/NVFP4 by quantising — where the MXFP4
+/// bytes equal the checkpoint's own packing of the same values, byte for
+/// byte, because the sources are bf16-representable.
+#[test]
+fn a_bf16_bank_binds_in_every_declared_format() {
+    let fx = routed_fixture();
+    let (_dir, _container, store) = bf16_carrier_store();
+    let op = bf16_op(&fx.op);
+    let ffn = routed(&op);
+    let x = norm_values(HIDDEN, INPUT_SEED);
+
+    let f32_bank = load(&op, &store, WeightFormat::F32);
+    assert!(slice_kinds(&f32_bank).iter().all(|k| *k == "f32"));
+    let f32_out = f32_bank
+        .apply(&ffn, &ProductionBackend::new(), &x, HIDDEN)
+        .unwrap();
+
+    let f16_bank = load(&op, &store, WeightFormat::F16);
+    assert!(slice_kinds(&f16_bank).iter().all(|k| *k == "f16"));
+    let f16_out = f16_bank
+        .apply(&ffn, &loop_device(WeightFormat::F16), &x, HIDDEN)
+        .unwrap();
+    let delta = max_abs_diff(&f32_out, &f16_out);
+    assert!(delta < NOISE_CEILING, "f16 realisation drifted {delta:e}");
+
+    let from_bf16 = mxfp4_bytes(&load(&op, &store, WeightFormat::Mxfp4));
+    let native = mxfp4_bytes(&load(&fx.op, &store, WeightFormat::Mxfp4));
+    assert_eq!(from_bf16.len(), FUSED_BRANCHES * EXPERTS);
+    assert_eq!(
+        from_bf16, native,
+        "BF16 bank quantised at load must equal the checkpoint's MXFP4 packing"
+    );
+
+    let nvfp4 = slice_kinds(&load(&op, &store, WeightFormat::Nvfp4));
+    assert!(nvfp4.iter().all(|k| *k == "nvfp4"), "{nvfp4:?}");
+}
+
+/// A BF16 bank whose byte count disagrees with the declared geometry
+/// refuses, naming the projection.
+#[test]
+fn a_bf16_bank_disagreeing_with_the_declared_geometry_refuses() {
+    let fx = routed_fixture();
+    let (_dir, _container, store) = bf16_carrier_store();
+    let mut op = bf16_op(&fx.op);
+    op.expert_intermediate_size = INTER + 1;
+    let err = load_err(&op, &store, WeightFormat::F32);
+    assert!(err.contains("stored bytes, expected"), "{err}");
+    assert!(err.contains(GATE_UP_BF16), "{err}");
+}
+
+/// A dense op without a gate binds two operands, and its ungated SiLU
+/// runs through the production `silu` — agreeing with the reference's
+/// scalar transcription.
+#[test]
+fn a_gate_less_dense_op_binds_two_operands_and_runs_ungated() {
+    let dir = tempfile::tempdir().unwrap();
+    dense_f32_model(dir.path());
+    let container = encoded(dir.path(), "dense");
+    let (plan, store) = closed_plan(container.path());
+    let mut op = plan.layers[0].ffn.dense().expect("dense layer").clone();
+    op.gate = None;
+    let ffn = LayerFfn::Dense(Box::new(op));
+    let operands = FfnOperands::load(&ffn, &store, WeightFormat::F32).unwrap();
+    assert_eq!(operands.weight_slices().len(), 2, "up and down only");
+    let x = norm_values(super::HIDDEN, INPUT_SEED);
+    let production = operands
+        .apply(&ffn, &ProductionBackend::new(), &x, super::HIDDEN)
+        .unwrap();
+    let reference = operands
+        .apply(&ffn, &ReferenceBackend::new(), &x, super::HIDDEN)
+        .unwrap();
+    let delta = max_abs_diff(&production, &reference);
+    assert!(delta < NOISE_CEILING, "ungated FFN drifted {delta:e}");
+}
+
+// ═══════════════════════════ production.rs ═══════════════════════════
+
+/// A `[2, 2]` identity-shaped weight for the tiny direct calls.
+const TINY: usize = 2;
+const TINY_WEIGHT: [f32; TINY * TINY] = [1.0, 0.0, 0.0, 2.0];
+const TINY_X: [f32; TINY] = [3.0, 4.0];
+
+/// The backend names itself for parity reports, and the embedding scale
+/// is applied when the plan carries one — a scaled row is the unscaled
+/// row times the scale, not a re-lookup.
+#[test]
+fn the_production_backend_names_itself_and_scales_embeddings() {
+    const SCALE: f32 = 0.5;
+    let backend = ProductionBackend::new();
+    assert_eq!(backend.name(), "production-larql-compute");
+    let table = lcg_values(TINY * TINY, INPUT_SEED);
+    let plain = backend.embed(&table, TINY, 1, None);
+    let scaled = backend.embed(&table, TINY, 1, Some(SCALE));
+    assert_eq!(plain.as_slice(), &table[TINY..]);
+    let expected: Vec<f32> = plain.iter().map(|v| v * SCALE).collect();
+    assert_eq!(scaled, expected);
+}
+
+/// LayerNorm binds the production layer-norm kernel (bias absent, not
+/// zeroed) and `project` binds `matmul_vec`: `[1, 3]` normalises to
+/// `[-1, 1]` up to eps, and the diagonal weight doubles the second lane.
+#[test]
+fn layer_norm_and_projection_bind_the_production_kernels() {
+    let backend = ProductionBackend::new();
+    let normed = backend.norm(NormCall {
+        kind: NormType::LayerNorm,
+        x: &[1.0, 3.0],
+        weight: &[1.0, 1.0],
+        weight_offset: 0.0,
+        eps: 0.0,
+    });
+    assert!(
+        max_abs_diff(&normed, &[-1.0, 1.0]) < NOISE_CEILING,
+        "{normed:?}"
+    );
+    let projected = backend
+        .project(ProjectCall {
+            weight: WeightSlice::F32(&TINY_WEIGHT),
+            out_dim: TINY,
+            in_dim: TINY,
+            x: &TINY_X,
+        })
+        .unwrap();
+    assert_eq!(projected, vec![3.0, 8.0]);
+}
+
+/// A hand-built attention call over `inputs`, with no optional judgment.
+fn plain_attention<'a>(inputs: &'a [Vec<f32>], w: &'a [f32]) -> AttentionCall<'a> {
+    AttentionCall {
+        inputs,
+        hidden: HEAD_DIM,
+        num_q_heads: 1,
+        num_kv_heads: 1,
+        head_dim: HEAD_DIM,
+        w_q: WeightSlice::F32(w),
+        w_k: WeightSlice::F32(w),
+        w_v: WeightSlice::F32(w),
+        w_o: WeightSlice::F32(w),
+        qk_norm: None,
+        parameter_free_qk_norm: ParameterFreeQkNorm { q: false, k: false },
+        qk_norm_eps: EPS,
+        query_scale: None,
+        score_scale: 1.0 / (HEAD_DIM as f64).sqrt(),
+        logit_softcapping: None,
+        position: PositionPolicy::None,
+        span: AttentionSpan::Full,
+        window: None,
+        gate: None,
+        bias: None,
+        sinks: None,
+    }
+}
+
+/// A weighted QK norm with unit weight (or zero weight and unit offset —
+/// the Gemma spelling) is the parameter-free norm: the weighted kernel is
+/// bound and the offset is applied, through both the raw helper and the
+/// call-level conditioning.
+#[test]
+fn a_unit_weight_qk_norm_equals_the_parameter_free_form() {
+    let raw = lcg_values(Q_HEADS * HEAD_DIM, INPUT_SEED);
+    let ones = vec![1.0f32; HEAD_DIM];
+    let zeros = vec![0.0f32; HEAD_DIM];
+
+    let mut parameter_free = raw.clone();
+    qk_norm_in_place(
+        &mut parameter_free,
+        None,
+        true,
+        Q_HEADS,
+        HEAD_DIM,
+        QkNormScope::PerHead,
+        EPS,
+    );
+    assert!(
+        max_abs_diff(&parameter_free, &raw) > NOISE_CEILING,
+        "norm must move the vector"
+    );
+    let mut weighted = raw.clone();
+    qk_norm_in_place(
+        &mut weighted,
+        Some((&ones, 0.0)),
+        false,
+        Q_HEADS,
+        HEAD_DIM,
+        QkNormScope::PerHead,
+        EPS,
+    );
+    assert!(max_abs_diff(&weighted, &parameter_free) < NOISE_CEILING);
+    let mut offset = raw.clone();
+    qk_norm_in_place(
+        &mut offset,
+        Some((&zeros, 1.0)),
+        false,
+        Q_HEADS,
+        HEAD_DIM,
+        QkNormScope::PerHead,
+        EPS,
+    );
+    assert!(max_abs_diff(&offset, &parameter_free) < NOISE_CEILING);
+
+    // Through the call: Q under a unit-weight norm, K under a zero-weight /
+    // unit-offset norm, one head each — both equal the parameter-free form.
+    let inputs = vec![raw[..HEAD_DIM].to_vec()];
+    let identity = vec![0.0f32; HEAD_DIM * HEAD_DIM];
+    let mut call = plain_attention(&inputs, &identity);
+    call.qk_norm = Some(QkNormCall {
+        scope: QkNormScope::PerHead,
+        weight_offset: 0.0,
+        q_weight: &ones,
+        k_weight: &ones,
+    });
+    let mut q = raw[..HEAD_DIM].to_vec();
+    let mut k = raw[HEAD_DIM..].to_vec();
+    condition_qk_in_place(&call, 0, &mut q, &mut k).unwrap();
+    assert!(max_abs_diff(&q, &parameter_free[..HEAD_DIM]) < NOISE_CEILING);
+    assert!(max_abs_diff(&k, &parameter_free[HEAD_DIM..]) < NOISE_CEILING);
+}
+
+/// A `Windowed` span carries no sequence bound: with a window count set
+/// it still aggregates over the whole prefix, exactly as `Full` does.
+#[test]
+fn a_windowed_span_aggregates_the_whole_prefix() {
+    const POSITIONS: usize = 3;
+    let rows: Vec<Vec<f32>> = (0..POSITIONS)
+        .map(|p| lcg_values(HEAD_DIM, INPUT_SEED + p as u64))
+        .collect();
+    let query = &rows[POSITIONS - 1];
+    let identity = vec![0.0f32; HEAD_DIM * HEAD_DIM];
+    let mut full = plain_attention(&rows, &identity);
+    full.span = AttentionSpan::Full;
+    let mut windowed = plain_attention(&rows, &identity);
+    windowed.span = AttentionSpan::Windowed;
+    windowed.window = Some(1);
+    let mut sliding = plain_attention(&rows, &identity);
+    sliding.span = AttentionSpan::Sliding;
+    sliding.window = Some(1);
+    let key_of = |p: usize| rows[p].as_slice();
+    let full_out = aggregate_heads(&full, POSITIONS - 1, query, key_of, key_of);
+    let windowed_out = aggregate_heads(&windowed, POSITIONS - 1, query, key_of, key_of);
+    let sliding_out = aggregate_heads(&sliding, POSITIONS - 1, query, key_of, key_of);
+    assert_eq!(windowed_out, full_out);
+    // Control: the same window count under `Sliding` does bound the span.
+    assert!(max_abs_diff(&sliding_out, &full_out) > NOISE_CEILING);
+}
+
+/// A routed call over `logits.len()` experts with the given router bias.
+fn routed_call<'a>(x: &'a [f32], router: &'a [f32], bias: Option<&'a [f32]>) -> RoutedFfnCall<'a> {
+    RoutedFfnCall {
+        x,
+        hidden: x.len(),
+        intermediate: INTER,
+        experts: router.len() / x.len(),
+        top_k: TOP_K,
+        router_kind: MoeRouterKind::TopKThenSoftmax,
+        routing_policy: larql_models::config::ExpertRoutingPolicy::NormalisedOverSelected,
+        activation: Activation::Silu,
+        gate_policy: ExpertGatePolicy::Gated,
+        gate_up_layout: larql_models::config::GateUpLayout::Interleaved,
+        router,
+        router_bias: bias,
+        gate_up: &[],
+        gate_up_bias: None,
+        down: &[],
+        down_bias: None,
+    }
+}
+
+/// The Gemma 4 hybrid router is refused (its per-expert scale is not
+/// implemented here), and a call without a router bias routes on the
+/// raw logits — identical to a zero bias.
+#[test]
+fn gemma4_routing_is_refused_and_a_missing_router_bias_adds_nothing() {
+    let x = norm_values(HIDDEN, INPUT_SEED);
+    let router = lcg_values(EXPERTS * HIDDEN, INPUT_SEED + 1);
+    let logits: Vec<f32> = lcg_values(EXPERTS, INPUT_SEED + 2);
+    let zeros = vec![0.0f32; EXPERTS];
+
+    let mut hybrid = routed_call(&x, &router, None);
+    hybrid.router_kind = MoeRouterKind::Gemma4Hybrid;
+    let err = select_experts(&hybrid, &mut logits.clone())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("Gemma4Hybrid"), "{err}");
+
+    let unbiased = select_experts(&routed_call(&x, &router, None), &mut logits.clone()).unwrap();
+    let zero_biased =
+        select_experts(&routed_call(&x, &router, Some(&zeros)), &mut logits.clone()).unwrap();
+    assert_eq!(unbiased.len(), TOP_K);
+    assert_eq!(unbiased, zero_biased);
+}
+
+/// A decode step whose output projection arrives in a representation the
+/// backend did not declare fails closed after projection — the error names
+/// the representation mismatch rather than converting.
+#[test]
+fn a_decode_step_fails_closed_on_a_non_f32_output_projection() {
+    let inputs = vec![lcg_values(HEAD_DIM, INPUT_SEED)];
+    let identity = vec![0.0f32; HEAD_DIM * HEAD_DIM];
+    let mut op = plain_attention(&inputs, &identity);
+    op.w_o = WeightSlice::F16(&[]);
+    let err = ProductionBackend::new()
+        .attention_step(AttentionStepCall {
+            op,
+            position: 0,
+            keys: &[],
+            values: &[],
+        })
+        .err()
+        .expect("a non-f32 output projection must refuse")
+        .to_string();
+    assert!(err.contains("declared f32 weights"), "{err}");
+}
+
+/// A dense FFN call over the tiny diagonal weights.
+fn tiny_ffn<'a>(gate: bool, activation: Activation, policy: ExpertGatePolicy) -> FfnCall<'a> {
+    FfnCall {
+        x: &TINY_X,
+        hidden: TINY,
+        intermediate: TINY,
+        gate: gate.then_some(WeightSlice::F32(&TINY_WEIGHT)),
+        up: WeightSlice::F32(&TINY_WEIGHT),
+        down: WeightSlice::F32(&TINY_WEIGHT),
+        activation,
+        gate_policy: policy,
+    }
+}
+
+/// The production FFN refuses what `larql-compute` has no kernel for —
+/// a non-SiLU activation, gated or not, and the clamped-GLU gate policy —
+/// naming the shape and the activation or policy, and runs the ungated
+/// SiLU it does have.
+#[test]
+fn the_production_ffn_refuses_unkernelled_variants_and_runs_ungated_silu() {
+    let backend = ProductionBackend::new();
+    let err = backend
+        .ffn(tiny_ffn(true, Activation::Gelu, ExpertGatePolicy::Gated))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("gated-FFN kernel for activation Gelu"),
+        "{err}"
+    );
+    let err = backend
+        .ffn(tiny_ffn(false, Activation::Relu, ExpertGatePolicy::Gated))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("ungated-FFN kernel for activation Relu"),
+        "{err}"
+    );
+    let clamped = ExpertGatePolicy::ClampedGlu {
+        limit: SWIGLU_LIMIT,
+        alpha: 1.0,
+    };
+    let err = backend
+        .ffn(tiny_ffn(true, Activation::Silu, clamped))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("ClampedGlu"), "{err}");
+
+    let ungated = backend
+        .ffn(tiny_ffn(false, Activation::Silu, ExpertGatePolicy::Gated))
+        .unwrap();
+    let reference = ReferenceBackend::new()
+        .ffn(tiny_ffn(false, Activation::Silu, ExpertGatePolicy::Gated))
+        .unwrap();
+    assert!(
+        max_abs_diff(&ungated, &reference) < NOISE_CEILING,
+        "{ungated:?} vs {reference:?}"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/fixture.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/fixture.rs
@@ -1,0 +1,399 @@
+//! The routed miniature, its carrier variant, and the load/compare
+//! helpers shared by the expert-bank and production-backend gates.
+
+use std::path::Path;
+
+use larql_models::config::ExpertFormat;
+
+use super::super::device::LoopDevice;
+use super::super::{lcg_values, norm_values, ShardBuilder};
+use crate::format::vindex3::encode::encode_system;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::backend::{WeightFormat, WeightFormats, WeightSlice};
+use crate::format::vindex3::opplan::exec::device::DevicePlanBackend;
+use crate::format::vindex3::opplan::exec::experts::FfnOperands;
+use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::exec::weights::{quantize_mxfp4, LoadedWeight};
+use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan, LayerFfn, RoutedFfnOp};
+
+// ── Routed miniature geometry: MXFP4 needs k ≡ 0 (mod 32) on both projections ──
+pub(super) const HIDDEN: usize = 32;
+pub(super) const INTER: usize = 32;
+pub(super) const EXPERTS: usize = 4;
+pub(super) const TOP_K: usize = 2;
+pub(super) const Q_HEADS: usize = 2;
+pub(super) const KV_HEADS: usize = 1;
+pub(super) const HEAD_DIM: usize = 16;
+pub(super) const VOCAB: usize = 29;
+pub(super) const LAYERS: usize = 2;
+pub(super) const WINDOW: usize = 4;
+/// GPT-OSS's published clamp.
+pub(super) const SWIGLU_LIMIT: f32 = 7.0;
+/// Gate and up share one fused operand.
+pub(super) const FUSED_BRANCHES: usize = larql_models::quant::mxfp4::FUSED_HALVES;
+/// MXFP4 group geometry, as the packer lays it out.
+pub(super) const MXFP4_GROUP_ELEMS: usize = larql_models::quant::mxfp4::MXFP4_GROUP_ELEMS;
+pub(super) const MXFP4_GROUP_BYTES: usize = larql_models::quant::mxfp4::MXFP4_GROUP_BYTES;
+/// Bank-relative suffixes of the classified MXFP4 streams and of the
+/// unclassified BF16 copies (which land in the bank object because they
+/// share its prefix, but block closure — so they are only ever reached by
+/// an op edited to point at them).
+pub(super) const GATE_UP_BLOCKS: &str = "mlp.experts.gate_up_proj_blocks";
+pub(super) const DOWN_BLOCKS: &str = "mlp.experts.down_proj_blocks";
+pub(super) const GATE_UP_BF16: &str = "mlp.experts.gate_up_proj_bf16";
+pub(super) const DOWN_BF16: &str = "mlp.experts.down_proj_bf16";
+pub(super) const BLOCKS_SUFFIX: &str = "_blocks";
+pub(super) const SCALES_SUFFIX: &str = "_scales";
+pub(super) const BF16_SUFFIX: &str = "_bf16";
+pub(super) const DTYPE_U8: &str = "U8";
+pub(super) const DTYPE_BF16: &str = "BF16";
+/// Seed of the normalised FFN input the routed tests apply.
+pub(super) const INPUT_SEED: u64 = 9_001;
+
+/// Loop-vs-BLAS reassociation on 32-wide operands, and the bf16 → f16 /
+/// e2m1 → f16 conversions are exact, so f16 realisations sit here too.
+pub(super) const NOISE_CEILING: f32 = 1e-5;
+/// A hand-built call's epsilon.
+pub(super) const EPS: f64 = 1e-5;
+
+/// Round-to-nearest-even bf16 of `v`, back as the f32 it denotes.
+pub(super) fn bf16_round(v: f32) -> f32 {
+    f32::from_bits(u32::from(bf16_bits(v)) << 16)
+}
+
+/// The bf16 bit pattern nearest `v` (ties to even).
+pub(super) fn bf16_bits(v: f32) -> u16 {
+    let bits = v.to_bits();
+    let rounding = 0x7FFF + ((bits >> 16) & 1);
+    ((bits.wrapping_add(rounding)) >> 16) as u16
+}
+
+/// The GPT-OSS miniature with bf16-representable source values. With
+/// `bf16_copies`, each layer's expert bank additionally carries an
+/// unquantised BF16 copy of both projections under unclassified names.
+pub(super) fn miniature_gpt_oss(dir: &Path, bf16_copies: bool) {
+    let config = serde_json::json!({
+        "architectures": ["GptOssForCausalLM"],
+        "model_type": "gpt_oss",
+        "torch_dtype": "float32",
+        "hidden_size": HIDDEN,
+        "num_hidden_layers": LAYERS,
+        "intermediate_size": INTER,
+        "num_attention_heads": Q_HEADS,
+        "num_key_value_heads": KV_HEADS,
+        "head_dim": HEAD_DIM,
+        "vocab_size": VOCAB,
+        "num_local_experts": EXPERTS,
+        "num_experts_per_tok": TOP_K,
+        "sliding_window": WINDOW,
+        "layer_types": ["sliding_attention", "full_attention"],
+        "rope_theta": 10000.0,
+        "rope_scaling": {
+            "rope_type": "yarn",
+            "factor": 32.0,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "original_max_position_embeddings": 4096,
+            "truncate": false
+        },
+        "rms_norm_eps": 1e-5,
+        "attention_bias": true,
+        "swiglu_limit": SWIGLU_LIMIT,
+        "tie_word_embeddings": false,
+        "quantization_config": {
+            "quant_method": "mxfp4",
+            "modules_to_not_convert": [
+                "model.layers.*.self_attn",
+                "model.layers.*.mlp.router",
+                "model.embed_tokens",
+                "lm_head"
+            ]
+        }
+    });
+    std::fs::write(dir.join("config.json"), config.to_string()).unwrap();
+
+    let q_rows = Q_HEADS * HEAD_DIM;
+    let kv_rows = KV_HEADS * HEAD_DIM;
+    let mut shard = ShardBuilder::new();
+    shard.push(
+        "model.embed_tokens.weight",
+        &[VOCAB, HIDDEN],
+        &lcg_values(VOCAB * HIDDEN, 1),
+    );
+    shard.push("model.norm.weight", &[HIDDEN], &norm_values(HIDDEN, 2));
+    shard.push(
+        "lm_head.weight",
+        &[VOCAB, HIDDEN],
+        &lcg_values(VOCAB * HIDDEN, 3),
+    );
+    for layer in 0..LAYERS {
+        let seed = 700 + layer as u64 * 40;
+        let prefix = format!("model.layers.{layer}");
+        let scaled = |n: usize, s: u64, g: f32| -> Vec<f32> {
+            lcg_values(n, s).into_iter().map(|v| v * g).collect()
+        };
+        for (suffix, shape, values) in [
+            (
+                "self_attn.q_proj.weight",
+                vec![q_rows, HIDDEN],
+                scaled(q_rows * HIDDEN, seed, 1.0),
+            ),
+            (
+                "self_attn.k_proj.weight",
+                vec![kv_rows, HIDDEN],
+                scaled(kv_rows * HIDDEN, seed + 1, 1.0),
+            ),
+            (
+                "self_attn.v_proj.weight",
+                vec![kv_rows, HIDDEN],
+                scaled(kv_rows * HIDDEN, seed + 2, 1.0),
+            ),
+            (
+                "self_attn.o_proj.weight",
+                vec![HIDDEN, q_rows],
+                scaled(HIDDEN * q_rows, seed + 3, 1.0),
+            ),
+            (
+                "self_attn.q_proj.bias",
+                vec![q_rows],
+                scaled(q_rows, seed + 4, 2.0),
+            ),
+            (
+                "self_attn.k_proj.bias",
+                vec![kv_rows],
+                scaled(kv_rows, seed + 5, 2.0),
+            ),
+            (
+                "self_attn.v_proj.bias",
+                vec![kv_rows],
+                scaled(kv_rows, seed + 6, 2.0),
+            ),
+            (
+                "self_attn.o_proj.bias",
+                vec![HIDDEN],
+                scaled(HIDDEN, seed + 7, 2.0),
+            ),
+            (
+                "self_attn.sinks",
+                vec![Q_HEADS],
+                scaled(Q_HEADS, seed + 8, 4.0),
+            ),
+            (
+                "input_layernorm.weight",
+                vec![HIDDEN],
+                norm_values(HIDDEN, seed + 9),
+            ),
+            (
+                "post_attention_layernorm.weight",
+                vec![HIDDEN],
+                norm_values(HIDDEN, seed + 10),
+            ),
+            (
+                "mlp.router.weight",
+                vec![EXPERTS, HIDDEN],
+                scaled(EXPERTS * HIDDEN, seed + 11, 4.0),
+            ),
+            (
+                "mlp.router.bias",
+                vec![EXPERTS],
+                scaled(EXPERTS, seed + 12, 1.0),
+            ),
+            (
+                "mlp.experts.gate_up_proj_bias",
+                vec![EXPERTS, FUSED_BRANCHES * INTER],
+                scaled(EXPERTS * FUSED_BRANCHES * INTER, seed + 13, 1.0),
+            ),
+            (
+                "mlp.experts.down_proj_bias",
+                vec![EXPERTS, HIDDEN],
+                scaled(EXPERTS * HIDDEN, seed + 14, 1.0),
+            ),
+        ] {
+            shard.push(&format!("{prefix}.{suffix}"), &shape, &values);
+        }
+        // Packed MXFP4 experts from bf16-representable sources, so a BF16
+        // copy of the same bank requantises to these exact bytes.
+        for (suffix, bf16_suffix, rows, k, s) in [
+            (
+                GATE_UP_BLOCKS,
+                GATE_UP_BF16,
+                FUSED_BRANCHES * INTER,
+                HIDDEN,
+                seed + 15,
+            ),
+            (DOWN_BLOCKS, DOWN_BF16, HIDDEN, INTER, seed + 16),
+        ] {
+            let groups = k / MXFP4_GROUP_ELEMS;
+            let mut blocks = Vec::new();
+            let mut scales = Vec::new();
+            let mut bf16 = Vec::new();
+            for e in 0..EXPERTS {
+                let values: Vec<f32> = scaled(rows * k, s + e as u64 * 100, 2.0)
+                    .into_iter()
+                    .map(bf16_round)
+                    .collect();
+                let LoadedWeight::Mxfp4 { packed, scales: sc } =
+                    quantize_mxfp4(&values, rows, k, suffix).unwrap()
+                else {
+                    unreachable!()
+                };
+                blocks.extend_from_slice(&packed.as_slice()[..rows * groups * MXFP4_GROUP_BYTES]);
+                scales.extend_from_slice(&sc.as_slice()[..rows * groups]);
+                bf16.extend(values.iter().flat_map(|v| bf16_bits(*v).to_le_bytes()));
+            }
+            shard.push_bytes(
+                &format!("{prefix}.{suffix}"),
+                DTYPE_U8,
+                &[EXPERTS, rows, groups, MXFP4_GROUP_BYTES],
+                &blocks,
+            );
+            shard.push_bytes(
+                &format!("{prefix}.{}", suffix.replace(BLOCKS_SUFFIX, SCALES_SUFFIX)),
+                DTYPE_U8,
+                &[EXPERTS, rows, groups],
+                &scales,
+            );
+            if bf16_copies {
+                shard.push_bytes(
+                    &format!("{prefix}.{bf16_suffix}"),
+                    DTYPE_BF16,
+                    &[EXPERTS, rows, k],
+                    &bf16,
+                );
+            }
+        }
+    }
+    shard.write(dir);
+}
+
+/// Encode `dir` into a fresh container.
+pub(super) fn encoded(dir: &Path, artifact: &str) -> tempfile::TempDir {
+    let inventory = larql_models::inventory::build_inventory(dir).unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_system(&[(artifact.to_string(), inventory)], container.path()).unwrap();
+    container
+}
+
+/// A closed plan and the store over the same container.
+pub(super) fn closed_plan(container: &Path) -> (ComponentOpPlan, OperandStore) {
+    let inspection = inspect_container(container, false).unwrap();
+    let outcome = plan_component_ops(&inspection, container, "target").unwrap();
+    assert!(outcome.closed(), "{:?}", outcome.defects);
+    let store = OperandStore::open(container, &inspection).unwrap();
+    (outcome.plan.unwrap(), store)
+}
+
+/// The routed miniature: its closed plan, its store, and layer 0's op.
+pub(super) struct RoutedFixture {
+    _dir: tempfile::TempDir,
+    _container: tempfile::TempDir,
+    pub(super) store: OperandStore,
+    pub(super) op: RoutedFfnOp,
+}
+
+pub(super) fn routed_fixture() -> RoutedFixture {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_gpt_oss(dir.path(), false);
+    let container = encoded(dir.path(), "mini-gpt-oss");
+    let (plan, store) = closed_plan(container.path());
+    let op = plan.layers[0]
+        .ffn
+        .routed()
+        .expect("layer 0 is routed")
+        .clone();
+    RoutedFixture {
+        _dir: dir,
+        _container: container,
+        store,
+        op,
+    }
+}
+
+/// The store of a container whose bank also carries the BF16 copies —
+/// not closable (the copies are unclassified), so the op comes from
+/// [`routed_fixture`] and is edited to point at them.
+pub(super) fn bf16_carrier_store() -> (tempfile::TempDir, tempfile::TempDir, OperandStore) {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_gpt_oss(dir.path(), true);
+    let container = encoded(dir.path(), "mini-gpt-oss");
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    (dir, container, store)
+}
+
+/// `op` re-pointed at the BF16 copies, declared `PackedBF16`.
+pub(super) fn bf16_op(op: &RoutedFfnOp) -> RoutedFfnOp {
+    let mut op = op.clone();
+    op.expert_format = ExpertFormat::PackedBF16;
+    for projection in [&mut op.gate_up, &mut op.down] {
+        projection.weights.tensor = projection
+            .weights
+            .tensor
+            .replace(BLOCKS_SUFFIX, BF16_SUFFIX);
+        projection.scales = None;
+    }
+    op
+}
+
+pub(super) fn routed(op: &RoutedFfnOp) -> LayerFfn {
+    LayerFfn::Routed(Box::new(op.clone()))
+}
+
+pub(super) fn load(op: &RoutedFfnOp, store: &OperandStore, format: WeightFormat) -> FfnOperands {
+    FfnOperands::load(&routed(op), store, format).unwrap()
+}
+
+pub(super) fn load_err(op: &RoutedFfnOp, store: &OperandStore, format: WeightFormat) -> String {
+    FfnOperands::load(&routed(op), store, format)
+        .err()
+        .expect("loading must refuse")
+        .to_string()
+}
+
+/// A device backend that binds the FFN class in `format` and everything
+/// else in f32 (the loop device has f32, f16 and MXFP4 gemvs).
+pub(super) fn loop_device(format: WeightFormat) -> DevicePlanBackend<LoopDevice> {
+    DevicePlanBackend::with_formats(
+        LoopDevice,
+        "loop-device-coverage",
+        WeightFormats {
+            attention: WeightFormat::F32,
+            ffn: format,
+            head: WeightFormat::F32,
+        },
+    )
+}
+
+pub(super) fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len());
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0, f32::max)
+}
+
+/// The variant name of every matrix the operands expose.
+pub(super) fn slice_kinds(operands: &FfnOperands) -> Vec<&'static str> {
+    operands.weight_slices().iter().map(slice_kind).collect()
+}
+
+/// The two MXFP4 streams of every matrix, for byte comparison.
+pub(super) fn mxfp4_bytes(operands: &FfnOperands) -> Vec<(Vec<u8>, Vec<u8>)> {
+    operands
+        .weight_slices()
+        .iter()
+        .map(|s| match s {
+            WeightSlice::Mxfp4 { packed, scales } => (packed.to_vec(), scales.to_vec()),
+            other => panic!("expected an MXFP4 slice, got {}", slice_kind(other)),
+        })
+        .collect()
+}
+
+pub(super) fn slice_kind(slice: &WeightSlice<'_>) -> &'static str {
+    match slice {
+        WeightSlice::F32(_) => "f32",
+        WeightSlice::F16(_) => "f16",
+        WeightSlice::Mxfp4 { .. } => "mxfp4",
+        WeightSlice::Nvfp4 { .. } => "nvfp4",
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/golden.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/golden.rs
@@ -39,11 +39,38 @@ pub(super) const G_LAYERS: usize = 2;
 pub(super) const G_WINDOW: usize = 3;
 pub(super) const G_TOKENS: [u32; 5] = [3, 17, 28, 0, 11];
 
+/// Optional attention operands the miniature can carry (A-9.1): Q/K/V/O
+/// projection biases (with `attention_bias: true` declared) and
+/// per-query-head sink logits. `perturb` names one of those tensors by
+/// suffix; the writer scales it by [`PERTURB_GAIN`], so a test can ask
+/// whether that single operand is load-bearing.
+#[derive(Default, Clone, Copy)]
+pub(super) struct MiniatureExtras {
+    pub attention_bias: bool,
+    pub sinks: bool,
+    pub perturb: Option<&'static str>,
+}
+
+/// Multiplier applied to a perturbed extra operand.
+pub(super) const PERTURB_GAIN: f32 = 3.0;
+
+/// The five extra attention operands, by layer-relative suffix.
+pub(super) const BIAS_SUFFIXES: [&str; 4] = [
+    "self_attn.q_proj.bias",
+    "self_attn.k_proj.bias",
+    "self_attn.v_proj.bias",
+    "self_attn.o_proj.bias",
+];
+pub(super) const SINKS_SUFFIX: &str = "self_attn.sinks";
+
 /// The two-layer miniature Glimmer checkpoint (F32, judged family).
 pub(super) fn miniature_glimmer(dir: &Path) {
-    std::fs::write(
-        dir.join("config.json"),
-        serde_json::json!({
+    miniature_glimmer_with(dir, MiniatureExtras::default());
+}
+
+/// The miniature with the A-9.1 extras.
+pub(super) fn miniature_glimmer_with(dir: &Path, extras: MiniatureExtras) {
+    let mut config = serde_json::json!({
             "architectures": ["MuseGlimmerForConditionalGeneration"],
             "torch_dtype": "float32",
             "model_type": "muse_glimmer_text",
@@ -64,10 +91,11 @@ pub(super) fn miniature_glimmer(dir: &Path) {
             "post_norm_eps": 1e-8,
             "attn_logit_softcapping": 50.0,
             "final_logit_softcapping": 20.0
-        })
-        .to_string(),
-    )
-    .unwrap();
+    });
+    if extras.attention_bias {
+        config["attention_bias"] = serde_json::json!(true);
+    }
+    std::fs::write(dir.join("config.json"), config.to_string()).unwrap();
 
     let q_rows = G_Q_HEADS * G_HEAD_DIM;
     let kv_rows = G_KV_HEADS * G_HEAD_DIM;
@@ -150,6 +178,26 @@ pub(super) fn miniature_glimmer(dir: &Path) {
         ] {
             shard.push(&format!("{prefix}.{suffix}"), &shape, &values);
         }
+        // Extras: values well away from zero so an unapplied bias or sink
+        // is a visible absence, not a rounding-level one.
+        let mut extra = |suffix: &str, len: usize, seed: u64| {
+            let mut values: Vec<f32> = lcg_values(len, seed).into_iter().map(|v| v * 4.0).collect();
+            if extras.perturb == Some(suffix) {
+                for v in &mut values {
+                    *v *= PERTURB_GAIN;
+                }
+            }
+            shard.push(&format!("{prefix}.{suffix}"), &[len], &values);
+        };
+        if extras.attention_bias {
+            extra(BIAS_SUFFIXES[0], q_rows, seed + 12);
+            extra(BIAS_SUFFIXES[1], kv_rows, seed + 13);
+            extra(BIAS_SUFFIXES[2], kv_rows, seed + 14);
+            extra(BIAS_SUFFIXES[3], G_HIDDEN, seed + 15);
+        }
+        if extras.sinks {
+            extra(SINKS_SUFFIX, G_Q_HEADS, seed + 16);
+        }
     }
     shard.write(dir);
 }
@@ -192,6 +240,22 @@ impl RawWeights {
 
     fn get(&self, name: &str) -> &[f32] {
         &self.tensors[name]
+    }
+
+    /// An operand the checkpoint may or may not carry (the A-9.1 extras).
+    fn maybe(&self, name: &str) -> Option<&[f32]> {
+        self.tensors.get(name).map(Vec::as_slice)
+    }
+}
+
+/// `x[i] += b[i]` when the operand exists — the golden statement of "a
+/// projection bias is added to the projection's output".
+fn add_if_present(x: &mut [f32], b: Option<&[f32]>) {
+    if let Some(b) = b {
+        assert_eq!(x.len(), b.len());
+        for (x, b) in x.iter_mut().zip(b) {
+            *x += b;
+        }
     }
 }
 
@@ -289,12 +353,16 @@ pub(super) fn golden_forward(dir: &Path) -> GoldenTrace {
                 G_HIDDEN,
                 &pre,
             );
-            let v = mv(
+            let mut v = mv(
                 w.get(&name("self_attn.v_proj.weight")),
                 kv_rows,
                 G_HIDDEN,
                 &pre,
             );
+            // A-9.1: projection biases, before anything reads Q/K/V.
+            add_if_present(&mut q, w.maybe(&name("self_attn.q_proj.bias")));
+            add_if_present(&mut k, w.maybe(&name("self_attn.k_proj.bias")));
+            add_if_present(&mut v, w.maybe(&name("self_attn.v_proj.bias")));
 
             // Parameter-free QK norm: RMS per head, no weights.
             for head in q.chunks_exact_mut(G_HEAD_DIM) {
@@ -363,11 +431,22 @@ pub(super) fn golden_forward(dir: &Path) -> GoldenTrace {
                         50.0 * (scaled / 50.0).tanh()
                     })
                     .collect();
-                let max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+                // A-9.1: a sink is one more logit per query head that
+                // takes softmax mass and has no value row — stated here
+                // in the denominator form (the reference executor uses
+                // the append-and-drop form; two transcriptions).
+                let sink = w.maybe(&name("self_attn.sinks")).map(|s| s[q_head]);
+                let mut max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+                if let Some(sink) = sink {
+                    max = max.max(sink);
+                }
                 let mut sum = 0.0;
                 for s in scores.iter_mut() {
                     *s = (*s - max).exp();
                     sum += *s;
+                }
+                if let Some(sink) = sink {
+                    sum += (sink - max).exp();
                 }
                 for s in scores.iter_mut() {
                     *s /= sum;
@@ -398,12 +477,14 @@ pub(super) fn golden_forward(dir: &Path) -> GoldenTrace {
             if position == h.len() - 1 {
                 trace.attention_after_gate = concat.clone();
             }
-            attn_out.push(mv(
+            let mut projected = mv(
                 w.get(&name("self_attn.o_proj.weight")),
                 G_HIDDEN,
                 q_rows,
                 &concat,
-            ));
+            );
+            add_if_present(&mut projected, w.maybe(&name("self_attn.o_proj.bias")));
+            attn_out.push(projected);
         }
 
         // Four-norm placement: post-attention norm (eps 1e-8) on the

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -15,6 +15,7 @@ mod device;
 mod golden;
 mod kernels;
 mod parity;
+mod routed;
 mod seam;
 mod sinks_bias;
 mod smoke;
@@ -69,6 +70,21 @@ impl ShardBuilder {
             name.to_string(),
             serde_json::json!({
                 "dtype": "F32",
+                "shape": shape,
+                "data_offsets": [start, self.payload.len()],
+            }),
+        );
+    }
+
+    /// Write one tensor of any dtype from raw little-endian bytes — for
+    /// packed MXFP4 (`U8`) expert banks.
+    pub(super) fn push_bytes(&mut self, name: &str, dtype: &str, shape: &[usize], bytes: &[u8]) {
+        let start = self.payload.len();
+        self.payload.extend_from_slice(bytes);
+        self.header.insert(
+            name.to_string(),
+            serde_json::json!({
+                "dtype": dtype,
                 "shape": shape,
                 "data_offsets": [start, self.payload.len()],
             }),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -10,6 +10,9 @@
 //! placement, RoPE convention, residual order — not shared arithmetic.
 
 mod controls;
+mod coverage_backend_decode;
+mod coverage_device;
+mod coverage_experts_production;
 mod decode;
 mod device;
 mod golden;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -16,6 +16,7 @@ mod golden;
 mod kernels;
 mod parity;
 mod seam;
+mod sinks_bias;
 mod smoke;
 mod streaming;
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/routed.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/routed.rs
@@ -1,0 +1,568 @@
+//! A-9.2 gates: a mixture of experts expressed **entirely inside the
+//! generic graph** — expert bank as an object, router and expert operands
+//! as roles, one routed FFN op — and executed by every backend against
+//! the served production forward.
+//!
+//! The fixture is a miniature of the GPT-OSS *family* (its judged
+//! architecture, not a shape lookalike): packed MXFP4 experts with scales
+//! and biases, a biased router with top-k-then-softmax, clamped GLU,
+//! attention sinks and Q/K/V/O biases. So one fixture exercises A-9.1 and
+//! A-9.2 on the real family and the oracle is the served CPU path
+//! (`load_model_dir` + `ExpertWeightFfn`), sharing no code with the plan
+//! executor.
+//!
+//! ```text
+//! parity      served forward ≡ reference ≡ production ≡ device (native MXFP4 experts)
+//! causal      perturb router weight / one expert's gate_up / down / bias → output moves
+//! closure     both ways: MoE judgment ⇒ router + bank operands; stray bank operand ⇒ op;
+//!             expert operand in the stack ⇒ misplaced; wrong expert count ⇒ geometry
+//! absence     dense plans still serialise byte-identically (the golden gate above)
+//! universality the executor reaches the bank only through the op plan's OperandRefs
+//! ```
+
+use std::path::Path;
+
+use larql_compute::forward::hooks::RecordHook;
+
+use super::device::LoopDevice;
+use super::{lcg_values, norm_values, ShardBuilder};
+use crate::format::vindex3::encode::{encode_system, SYSTEM_GRAPH_JSON};
+use crate::format::vindex3::graph::{ObjectKind, OperandRole};
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::backend::{WeightFormat, WeightFormats};
+use crate::format::vindex3::opplan::exec::device::DevicePlanBackend;
+use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::exec::production::ProductionBackend;
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use crate::format::vindex3::opplan::exec::weights::{quantize_mxfp4, LoadedWeight};
+use crate::format::vindex3::opplan::exec::{execute_plan, ExecutionTrace};
+use crate::format::vindex3::opplan::{plan_component_ops, ClosureDefect, LayerFfn, OpPlanOutcome};
+
+// ── Geometry: MXFP4 needs k ≡ 0 (mod 32) on both projections ──
+const HIDDEN: usize = 32;
+const INTER: usize = 32;
+const EXPERTS: usize = 4;
+const TOP_K: usize = 2;
+const Q_HEADS: usize = 2;
+const KV_HEADS: usize = 1;
+const HEAD_DIM: usize = 16;
+const VOCAB: usize = 29;
+const LAYERS: usize = 2;
+const WINDOW: usize = 4;
+const TOKENS: [u32; 5] = [3, 17, 28, 0, 11];
+/// GPT-OSS's published clamp.
+const SWIGLU_LIMIT: f64 = 7.0;
+
+/// Naive-loop vs BLAS/f32 on a 32-wide model: reassociation only.
+const TOLERANCE: f32 = 2e-5;
+/// A perturbed operand must move the layer that consumes it well above
+/// that; measured deltas sit around 1e-2..1e0.
+const CAUSAL_FLOOR: f32 = 1e-3;
+
+/// Which extra operand to perturb (scale by [`PERTURB_GAIN`]) in the
+/// checkpoint, by layer-relative suffix.
+const PERTURB_GAIN: f32 = 3.0;
+const ROUTER_WEIGHT: &str = "mlp.router.weight";
+const GATE_UP_BLOCKS: &str = "mlp.experts.gate_up_proj_blocks";
+const DOWN_BLOCKS: &str = "mlp.experts.down_proj_blocks";
+const DOWN_BIAS: &str = "mlp.experts.down_proj_bias";
+
+/// The miniature GPT-OSS checkpoint. `perturb` names one operand whose
+/// f32 source values are scaled before packing (blocks) or writing.
+fn miniature_gpt_oss(dir: &Path, perturb: Option<&str>) {
+    let config = serde_json::json!({
+        "architectures": ["GptOssForCausalLM"],
+        "model_type": "gpt_oss",
+        "torch_dtype": "float32",
+        "hidden_size": HIDDEN,
+        "num_hidden_layers": LAYERS,
+        "intermediate_size": INTER,
+        "num_attention_heads": Q_HEADS,
+        "num_key_value_heads": KV_HEADS,
+        "head_dim": HEAD_DIM,
+        "vocab_size": VOCAB,
+        "num_local_experts": EXPERTS,
+        "num_experts_per_tok": TOP_K,
+        "sliding_window": WINDOW,
+        "layer_types": ["sliding_attention", "full_attention"],
+        "rope_theta": 10000.0,
+        "rms_norm_eps": 1e-5,
+        "attention_bias": true,
+        "swiglu_limit": SWIGLU_LIMIT,
+        "tie_word_embeddings": false,
+        "quantization_config": {
+            "quant_method": "mxfp4",
+            "modules_to_not_convert": [
+                "model.layers.*.self_attn",
+                "model.layers.*.mlp.router",
+                "model.embed_tokens",
+                "lm_head"
+            ]
+        }
+    });
+    std::fs::write(dir.join("config.json"), config.to_string()).unwrap();
+
+    let q_rows = Q_HEADS * HEAD_DIM;
+    let kv_rows = KV_HEADS * HEAD_DIM;
+    let mut shard = ShardBuilder::new();
+    shard.push(
+        "model.embed_tokens.weight",
+        &[VOCAB, HIDDEN],
+        &lcg_values(VOCAB * HIDDEN, 1),
+    );
+    shard.push("model.norm.weight", &[HIDDEN], &norm_values(HIDDEN, 2));
+    shard.push(
+        "lm_head.weight",
+        &[VOCAB, HIDDEN],
+        &lcg_values(VOCAB * HIDDEN, 3),
+    );
+    for layer in 0..LAYERS {
+        let seed = 700 + layer as u64 * 40;
+        let prefix = format!("model.layers.{layer}");
+        let gain = |suffix: &str| {
+            if perturb == Some(suffix) {
+                PERTURB_GAIN
+            } else {
+                1.0
+            }
+        };
+        let scaled = |n: usize, s: u64, g: f32| -> Vec<f32> {
+            lcg_values(n, s).into_iter().map(|v| v * g).collect()
+        };
+        // Dense: attention (+ biases, sinks), norms, router.
+        for (suffix, shape, values) in [
+            (
+                "self_attn.q_proj.weight",
+                vec![q_rows, HIDDEN],
+                scaled(q_rows * HIDDEN, seed, 1.0),
+            ),
+            (
+                "self_attn.k_proj.weight",
+                vec![kv_rows, HIDDEN],
+                scaled(kv_rows * HIDDEN, seed + 1, 1.0),
+            ),
+            (
+                "self_attn.v_proj.weight",
+                vec![kv_rows, HIDDEN],
+                scaled(kv_rows * HIDDEN, seed + 2, 1.0),
+            ),
+            (
+                "self_attn.o_proj.weight",
+                vec![HIDDEN, q_rows],
+                scaled(HIDDEN * q_rows, seed + 3, 1.0),
+            ),
+            (
+                "self_attn.q_proj.bias",
+                vec![q_rows],
+                scaled(q_rows, seed + 4, 2.0),
+            ),
+            (
+                "self_attn.k_proj.bias",
+                vec![kv_rows],
+                scaled(kv_rows, seed + 5, 2.0),
+            ),
+            (
+                "self_attn.v_proj.bias",
+                vec![kv_rows],
+                scaled(kv_rows, seed + 6, 2.0),
+            ),
+            (
+                "self_attn.o_proj.bias",
+                vec![HIDDEN],
+                scaled(HIDDEN, seed + 7, 2.0),
+            ),
+            (
+                "self_attn.sinks",
+                vec![Q_HEADS],
+                scaled(Q_HEADS, seed + 8, 4.0),
+            ),
+            (
+                "input_layernorm.weight",
+                vec![HIDDEN],
+                norm_values(HIDDEN, seed + 9),
+            ),
+            (
+                "post_attention_layernorm.weight",
+                vec![HIDDEN],
+                norm_values(HIDDEN, seed + 10),
+            ),
+            (
+                ROUTER_WEIGHT,
+                vec![EXPERTS, HIDDEN],
+                scaled(EXPERTS * HIDDEN, seed + 11, 4.0 * gain(ROUTER_WEIGHT)),
+            ),
+            (
+                "mlp.router.bias",
+                vec![EXPERTS],
+                scaled(EXPERTS, seed + 12, 1.0),
+            ),
+            (
+                "mlp.experts.gate_up_proj_bias",
+                vec![EXPERTS, 2 * INTER],
+                scaled(EXPERTS * 2 * INTER, seed + 13, 1.0),
+            ),
+            (
+                DOWN_BIAS,
+                vec![EXPERTS, HIDDEN],
+                scaled(EXPERTS * HIDDEN, seed + 14, 1.0 * gain(DOWN_BIAS)),
+            ),
+        ] {
+            shard.push(&format!("{prefix}.{suffix}"), &shape, &values);
+        }
+        // Packed MXFP4 experts: quantise each expert's f32 matrix with the
+        // executor's own quantiser (the checkpoint's packing convention;
+        // the models-crate decoder is the independent reader).
+        for (suffix, rows, k, s) in [
+            (GATE_UP_BLOCKS, 2 * INTER, HIDDEN, seed + 15),
+            (DOWN_BLOCKS, HIDDEN, INTER, seed + 16),
+        ] {
+            let groups = k / 32;
+            let mut blocks = Vec::new();
+            let mut scales = Vec::new();
+            for e in 0..EXPERTS {
+                let values = scaled(rows * k, s + e as u64 * 100, 2.0 * gain(suffix));
+                let LoadedWeight::Mxfp4 { packed, scales: sc } =
+                    quantize_mxfp4(&values, rows, k, suffix).unwrap()
+                else {
+                    unreachable!()
+                };
+                blocks.extend_from_slice(&packed.as_slice()[..rows * groups * 16]);
+                scales.extend_from_slice(&sc.as_slice()[..rows * groups]);
+            }
+            shard.push_bytes(
+                &format!("{prefix}.{suffix}"),
+                "U8",
+                &[EXPERTS, rows, groups, 16],
+                &blocks,
+            );
+            let scales_name = suffix.replace("_blocks", "_scales");
+            shard.push_bytes(
+                &format!("{prefix}.{scales_name}"),
+                "U8",
+                &[EXPERTS, rows, groups],
+                &scales,
+            );
+        }
+    }
+    shard.write(dir);
+}
+
+struct OracleTrace {
+    post_attention: Vec<Vec<Vec<f32>>>,
+    post_layer: Vec<Vec<Vec<f32>>>,
+    logits: Vec<f32>,
+}
+
+/// The served CPU forward: `load_model_dir` dequantises the packed experts
+/// at load, `ExpertWeightFfn` routes and runs them, the layer hook taps
+/// the same boundaries the executor traces.
+fn oracle(dir: &Path) -> OracleTrace {
+    let weights = larql_models::load_model_dir(dir).unwrap();
+    let view = larql_models::WeightsView::dense(&weights);
+    let ffn = larql_compute::ffn::ExpertWeightFfn { weights: &weights };
+    let mut hook = RecordHook::for_layers(0..LAYERS);
+    let mut h = larql_compute::forward::embed_tokens_pub(&weights, &TOKENS);
+    for layer in 0..LAYERS {
+        let (h_next, _, _, _) = larql_compute::forward::layer::run_layer_with_capture_hooked(
+            view, &h, layer, &ffn, false, false, None, None, &mut hook,
+        )
+        .unwrap();
+        h = h_next;
+    }
+    let last = h
+        .slice(ndarray::s![TOKENS.len() - 1..TOKENS.len(), ..])
+        .to_owned();
+    let logits = larql_compute::forward::predict::raw::hidden_to_raw_logits(&weights, &last);
+    let to_rows = |a: &ndarray::Array2<f32>| -> Vec<Vec<f32>> {
+        a.outer_iter().map(|row| row.to_vec()).collect()
+    };
+    OracleTrace {
+        post_attention: (0..LAYERS)
+            .map(|l| to_rows(&hook.post_attention[&l]))
+            .collect(),
+        post_layer: (0..LAYERS).map(|l| to_rows(&hook.post_layer[&l])).collect(),
+        logits,
+    }
+}
+
+fn encoded(dir: &Path) -> tempfile::TempDir {
+    let inventory = larql_models::inventory::build_inventory(dir).unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_system(&[("mini-gpt-oss".to_string(), inventory)], container.path()).unwrap();
+    container
+}
+
+fn closure(container: &Path) -> OpPlanOutcome {
+    let inspection = inspect_container(container, false).unwrap();
+    plan_component_ops(&inspection, container, "target").unwrap()
+}
+
+fn traces(container: &Path) -> (ExecutionTrace, ExecutionTrace, ExecutionTrace) {
+    let inspection = inspect_container(container, false).unwrap();
+    let outcome = closure(container);
+    assert!(outcome.closed(), "{:?}", outcome.defects);
+    let plan = outcome.plan.unwrap();
+    let store = OperandStore::open(container, &inspection).unwrap();
+    let reference = execute_plan(&plan, &store, &TOKENS, &ReferenceBackend::new()).unwrap();
+    let production = execute_plan(&plan, &store, &TOKENS, &ProductionBackend::new()).unwrap();
+    // The device declares native MXFP4 for the FFN class: the expert bank
+    // is bound as its stored bytes and read by the device's mxfp4 gemv.
+    let device = DevicePlanBackend::with_formats(
+        LoopDevice,
+        "loop-device-routed",
+        WeightFormats {
+            attention: WeightFormat::F32,
+            ffn: WeightFormat::Mxfp4,
+            head: WeightFormat::F32,
+        },
+    );
+    let on_device = execute_plan(&plan, &store, &TOKENS, &device).unwrap();
+    (reference, production, on_device)
+}
+
+fn max_abs(a: &[Vec<f32>], b: &[Vec<f32>]) -> f32 {
+    a.iter()
+        .zip(b)
+        .flat_map(|(ra, rb)| ra.iter().zip(rb).map(|(x, y)| (x - y).abs()))
+        .fold(0.0, f32::max)
+}
+
+fn assert_matches_oracle(trace: &ExecutionTrace, oracle: &OracleTrace, label: &str) {
+    for layer in 0..LAYERS {
+        let attn = max_abs(
+            &trace.layers[layer].post_attention,
+            &oracle.post_attention[layer],
+        );
+        assert!(
+            attn < TOLERANCE,
+            "{label}: layer {layer} post_attention {attn:e}"
+        );
+        let post = max_abs(&trace.layers[layer].post_layer, &oracle.post_layer[layer]);
+        assert!(
+            post < TOLERANCE,
+            "{label}: layer {layer} post_layer {post:e}"
+        );
+    }
+    let logits = max_abs(
+        std::slice::from_ref(trace.logits.as_ref().unwrap()),
+        std::slice::from_ref(&oracle.logits),
+    );
+    assert!(logits < TOLERANCE, "{label}: logits {logits:e}");
+}
+
+// ── Parity: served forward ≡ every backend ──
+
+#[test]
+fn a_routed_plan_matches_the_served_forward_on_every_backend() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_gpt_oss(dir.path(), None);
+    let oracle = oracle(dir.path());
+    let container = encoded(dir.path());
+    let (reference, production, device) = traces(container.path());
+    assert_matches_oracle(&reference, &oracle, "reference vs served");
+    assert_matches_oracle(&production, &oracle, "production vs served");
+    assert_matches_oracle(&device, &oracle, "device(mxfp4) vs served");
+}
+
+// ── The graph: the bank is an object, the plan is routed, nothing else ──
+
+#[test]
+fn the_expert_bank_is_a_first_class_object_and_the_ffn_is_routed() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_gpt_oss(dir.path(), None);
+    let container = encoded(dir.path());
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let bank = inspection
+        .graph
+        .objects
+        .iter()
+        .find(|o| o.kind == ObjectKind::ExpertBank)
+        .expect("an expert-bank object");
+    assert_eq!(
+        bank.source_bindings.len(),
+        LAYERS,
+        "one binding per routed layer"
+    );
+    assert!(
+        bank.representations[0].encoding.contains("MXFP4"),
+        "{:?}",
+        bank.representations
+    );
+    let stack = inspection
+        .graph
+        .objects
+        .iter()
+        .find(|o| o.kind == ObjectKind::DecoderStack)
+        .unwrap();
+    assert!(
+        !stack.representations[0].encoding.contains("MXFP4"),
+        "{:?}",
+        stack.representations
+    );
+    // The container writes no MoE side-channel: the graph is the whole story.
+    let listing: Vec<String> = std::fs::read_dir(container.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        !listing.iter().any(|f| f.contains("moe_manifest")),
+        "{listing:?}"
+    );
+    let outcome = closure(container.path());
+    assert!(outcome.closed(), "{:?}", outcome.defects);
+    let plan = outcome.plan.unwrap();
+    for layer in &plan.layers {
+        let LayerFfn::Routed(op) = &layer.ffn else {
+            panic!("layer {} planned dense", layer.layer)
+        };
+        assert_eq!(op.experts, EXPERTS);
+        assert_eq!(op.top_k, TOP_K);
+        assert_eq!(op.gate_up.weights.object, bank.id);
+        assert_eq!(op.down.weights.object, bank.id);
+        assert!(op.gate_up.scales.is_some() && op.down.scales.is_some());
+        assert!(op.gate_up.bias.is_some() && op.down.bias.is_some());
+        assert_eq!(op.router.object, stack.id);
+        assert!(op.router_bias.is_some());
+        assert!(matches!(
+            op.gate_policy,
+            larql_models::ExpertGatePolicy::ClampedGlu { .. }
+        ));
+    }
+}
+
+// ── Causal: router and every expert-bank operand are load-bearing ──
+
+#[test]
+fn router_and_expert_operands_are_load_bearing() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_gpt_oss(dir.path(), None);
+    let base = traces(encoded(dir.path()).path()).0;
+    for suffix in [ROUTER_WEIGHT, GATE_UP_BLOCKS, DOWN_BLOCKS, DOWN_BIAS] {
+        let dir = tempfile::tempdir().unwrap();
+        miniature_gpt_oss(dir.path(), Some(suffix));
+        let moved = traces(encoded(dir.path()).path()).0;
+        let layer0 = max_abs(&base.layers[0].post_layer, &moved.layers[0].post_layer);
+        let logits = max_abs(
+            std::slice::from_ref(base.logits.as_ref().unwrap()),
+            std::slice::from_ref(moved.logits.as_ref().unwrap()),
+        );
+        eprintln!("perturb {suffix}: layer0 post_layer {layer0:e}, logits {logits:e}");
+        assert!(
+            layer0 > CAUSAL_FLOOR,
+            "perturbing `{suffix}` moved layer 0 by only {layer0:e} — carried but not executed"
+        );
+        assert!(
+            logits > TOLERANCE,
+            "perturbing `{suffix}`: logits moved only {logits:e}"
+        );
+    }
+}
+
+// ── Closure, fail-closed both ways ──
+
+fn mutate_graph(container: &Path, mutate: impl FnOnce(&mut serde_json::Value)) {
+    let path = container.join(SYSTEM_GRAPH_JSON);
+    let mut graph: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    mutate(&mut graph);
+    std::fs::write(&path, graph.to_string()).unwrap();
+}
+
+#[test]
+fn bank_operands_without_a_moe_judgment_refuse() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_gpt_oss(dir.path(), None);
+    let container = encoded(dir.path());
+    mutate_graph(container.path(), |graph| {
+        let target = graph["components"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|c| c["id"] == "target")
+            .unwrap();
+        target["execution"]["ffn"]
+            .as_object_mut()
+            .unwrap()
+            .remove("moe");
+    });
+    let outcome = closure(container.path());
+    assert!(!outcome.closed());
+    // Every router and expert operand now implies an op the surface lacks
+    // — 8 per layer — and the dense FFN operands are missing.
+    let implied = outcome
+        .defects
+        .iter()
+        .filter(|d| matches!(d, ClosureDefect::OperandImpliesAbsentOp { required_primitive, .. } if required_primitive.contains("routed FFN")))
+        .count();
+    assert_eq!(implied, 8 * LAYERS, "{:?}", outcome.defects);
+    assert!(outcome.defects.iter().any(|d| matches!(
+        d,
+        ClosureDefect::MissingOperand {
+            role: OperandRole::FfnUp,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn a_moe_judgment_with_the_wrong_expert_count_refuses_on_geometry() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_gpt_oss(dir.path(), None);
+    let container = encoded(dir.path());
+    mutate_graph(container.path(), |graph| {
+        let target = graph["components"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|c| c["id"] == "target")
+            .unwrap();
+        target["execution"]["ffn"]["moe"]["experts"] = serde_json::json!(EXPERTS + 1);
+    });
+    let outcome = closure(container.path());
+    assert!(!outcome.closed());
+    let geometry = outcome
+        .defects
+        .iter()
+        .filter(|d| matches!(d, ClosureDefect::GeometryMismatch { .. }))
+        .count();
+    // router weight + router bias + 6 bank operands, per layer.
+    assert_eq!(geometry, 8 * LAYERS, "{:?}", outcome.defects);
+}
+
+#[test]
+fn an_expert_operand_left_in_the_stack_is_misplaced() {
+    // Undo the carve-out in the persisted graph: drop the bank object so
+    // the stack's binding owns the expert tensors again.
+    let dir = tempfile::tempdir().unwrap();
+    miniature_gpt_oss(dir.path(), None);
+    let inventory = larql_models::inventory::build_inventory(dir.path()).unwrap();
+    let mut graph = crate::format::vindex3::graph::build_from_inventories(&[(
+        "mini-gpt-oss".to_string(),
+        inventory.clone(),
+    )])
+    .graph;
+    graph.objects.retain(|o| o.kind != ObjectKind::ExpertBank);
+    let container = tempfile::tempdir().unwrap();
+    crate::format::vindex3::encode::encode_graph(
+        &graph,
+        &[("mini-gpt-oss".to_string(), inventory)],
+        container.path(),
+    )
+    .unwrap();
+    let outcome = closure(container.path());
+    assert!(!outcome.closed());
+    let misplaced = outcome
+        .defects
+        .iter()
+        .filter(|d| {
+            matches!(
+                d,
+                ClosureDefect::MisplacedOperand {
+                    belongs_in: ObjectKind::ExpertBank,
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(misplaced, 6 * LAYERS, "{:?}", outcome.defects);
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/routed.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/routed.rs
@@ -11,6 +11,9 @@
 //! (`load_model_dir` + `ExpertWeightFfn`), sharing no code with the plan
 //! executor.
 //!
+//! It also carries GPT-OSS's YaRN block, so A-9.3 (scaled frequencies +
+//! attention amplitude in the interpreter) is gated by the same oracle.
+//!
 //! ```text
 //! parity      served forward ≡ reference ≡ production ≡ device (native MXFP4 experts)
 //! causal      perturb router weight / one expert's gate_up / down / bias → output moves
@@ -58,6 +61,9 @@ const TOLERANCE: f32 = 2e-5;
 /// A perturbed operand must move the layer that consumes it well above
 /// that; measured deltas sit around 1e-2..1e0.
 const CAUSAL_FLOOR: f32 = 1e-3;
+/// YaRN's control moves less on this fixture (see the test); ten times the
+/// parity tolerance still separates "executed" from "noise" cleanly.
+const YARN_CAUSAL_FLOOR: f32 = 10.0 * TOLERANCE;
 
 /// Which extra operand to perturb (scale by [`PERTURB_GAIN`]) in the
 /// checkpoint, by layer-relative suffix.
@@ -86,6 +92,17 @@ fn miniature_gpt_oss(dir: &Path, perturb: Option<&str>) {
         "sliding_window": WINDOW,
         "layer_types": ["sliding_attention", "full_attention"],
         "rope_theta": 10000.0,
+        // GPT-OSS's published YaRN block: the ramp AND the 1.3466 amplitude
+        // (A-9.3) — every layer rotates at scaled frequencies and every
+        // logit is rescaled.
+        "rope_scaling": {
+            "rope_type": "yarn",
+            "factor": 32.0,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "original_max_position_embeddings": 4096,
+            "truncate": false
+        },
         "rms_norm_eps": 1e-5,
         "attention_bias": true,
         "swiglu_limit": SWIGLU_LIMIT,
@@ -565,4 +582,63 @@ fn an_expert_operand_left_in_the_stack_is_misplaced() {
         })
         .count();
     assert_eq!(misplaced, 6 * LAYERS, "{:?}", outcome.defects);
+}
+
+// ── A-9.3: the carried YaRN block is executed, not merely carried ──
+
+#[test]
+fn the_plan_executes_yarn_and_its_factor_is_load_bearing() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_gpt_oss(dir.path(), None);
+    let container = encoded(dir.path());
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let plan = closure(container.path()).plan.unwrap();
+    assert!(plan.layers.iter().all(|l| l
+        .attention
+        .position
+        .yarn()
+        .is_some_and(|y| y.factor == 32.0)));
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    let base = execute_plan(&plan, &store, &TOKENS, &ReferenceBackend::new()).unwrap();
+
+    // Mutate only the persisted graph: a different factor is a different
+    // frequency ramp AND a different amplitude — position 0 moves too.
+    mutate_graph(container.path(), |graph| {
+        let target = graph["components"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|c| c["id"] == "target")
+            .unwrap();
+        for layer in target["attention"].as_array_mut().unwrap() {
+            layer["position"]["scaling"]["factor"] = serde_json::json!(4.0);
+        }
+    });
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let plan = closure(container.path()).plan.unwrap();
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    let moved = execute_plan(&plan, &store, &TOKENS, &ReferenceBackend::new()).unwrap();
+    // Position 0 has no rotation, only the amplitude: if it moves, the
+    // amplitude is executed, not just the ramp.
+    let position0 = (base.layers[0].post_attention[0].iter())
+        .zip(&moved.layers[0].post_attention[0])
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    let layer0 = max_abs(
+        &base.layers[0].post_attention,
+        &moved.layers[0].post_attention,
+    );
+    eprintln!("yarn factor 32→4: layer0 post_attention {layer0:e}, position 0 {position0:e}");
+    // The effect is bounded by the fixture's attention temperature: on
+    // 32-wide random weights the logits are near-uniform, so a 1.18×
+    // amplitude change moves post-attention by ~4e-4 — an order of
+    // magnitude above parity noise, which is the causal claim.
+    assert!(
+        layer0 > YARN_CAUSAL_FLOOR,
+        "YaRN factor carried but not executed: {layer0:e}"
+    );
+    assert!(
+        position0 > YARN_CAUSAL_FLOOR,
+        "YaRN amplitude not executed at position 0: {position0:e}"
+    );
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/seam.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/seam.rs
@@ -23,7 +23,7 @@ use crate::format::vindex3::encode::encode_system;
 use crate::format::vindex3::inspect::inspect_container;
 use crate::format::vindex3::opplan::exec::backend::{
     AttentionCall, AttentionStepCall, AttentionStepOut, FfnCall, NormCall, PlanBackend,
-    ProjectCall, WeightSlice,
+    ProjectCall, RoutedFfnCall, WeightSlice,
 };
 use crate::format::vindex3::opplan::exec::operands::OperandStore;
 use crate::format::vindex3::opplan::exec::production::ProductionBackend;
@@ -90,6 +90,11 @@ impl PlanBackend for RecordingBackend {
         self.inner.ffn(call)
     }
 
+    fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        self.record("routed_ffn");
+        self.inner.routed_ffn(call)
+    }
+
     fn output_head(
         &self,
         projection: WeightSlice<'_>,
@@ -146,6 +151,10 @@ impl PlanBackend for PerturbedBackend {
 
     fn ffn(&self, call: FfnCall<'_>) -> Result<Vec<f32>, VindexError> {
         self.0.ffn(call)
+    }
+
+    fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        self.0.routed_ffn(call)
     }
 
     fn output_head(

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/sinks_bias.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/sinks_bias.rs
@@ -1,0 +1,307 @@
+//! A-9.1 gates: attention sinks and Q/K/V/O projection biases travel
+//! checkpoint → surface → operand closure → `AttentionCall` → every
+//! backend, and each is **load-bearing** — the same discipline that
+//! caught YaRN's two loss mechanisms in A-9.0.
+//!
+//! ```text
+//! parity     golden (denominator sink, plain adds) ≡ reference ≡ production ≡ device
+//! causal     perturb q/k/v/o bias, perturb sinks  → output moves (5 positive controls)
+//! absence    the bias-free plan serialises exactly as before; closure refuses a
+//!            bias operand nobody declared, a sink operand nobody judged, and a
+//!            declaration nothing backs (fail-closed both ways)
+//! ```
+//!
+//! Glimmer's judged family carries neither, so the sink judgment is added
+//! to the *persisted graph* — the container is the authority the
+//! executor reads (the `controls` module's rule), and a judgment absent
+//! from it must refuse.
+
+use super::golden::{
+    executor_trace_from, golden_forward, max_abs, miniature_glimmer, miniature_glimmer_with,
+    MiniatureExtras, BIAS_SUFFIXES, G_LAYERS, G_TOKENS, SINKS_SUFFIX,
+};
+use crate::format::vindex3::encode::{encode_system, SYSTEM_GRAPH_JSON};
+use crate::format::vindex3::graph::OperandRole;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::backend::WeightFormat;
+use crate::format::vindex3::opplan::exec::device::DevicePlanBackend;
+use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::exec::production::ProductionBackend;
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use crate::format::vindex3::opplan::exec::{execute_plan, ExecutionTrace};
+use crate::format::vindex3::opplan::{plan_component_ops, ClosureDefect, OpPlanOutcome};
+
+/// Reassociation-only tolerance between independent f32 transcriptions.
+const GOLDEN_TOLERANCE: f32 = 1e-5;
+/// A perturbed operand must move the layer that consumes it by far more
+/// than fp noise: 100× the parity tolerance (measured deltas sit near
+/// 1e-1 on the 12-wide fixture). The logits only have to move above the
+/// parity tolerance — the miniature's head compresses hard
+/// (`output_multiplier` 0.196, softcap 20), so end-to-end deltas are
+/// small even for a large layer-level change; the site is where the
+/// causal claim is made, the logits prove it propagates.
+const CAUSAL_FLOOR: f32 = 1e-3;
+
+/// Encode `dir` and hand back the container.
+fn encoded(dir: &std::path::Path) -> tempfile::TempDir {
+    let inventory = larql_models::inventory::build_inventory(dir).unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_system(&[("mini-glimmer".to_string(), inventory)], container.path()).unwrap();
+    container
+}
+
+/// Write the sink judgment into the persisted surface — the fact Glimmer's
+/// family does not carry, stated where the executor reads it.
+fn judge_sinks(container: &std::path::Path) {
+    let path = container.join(SYSTEM_GRAPH_JSON);
+    let mut graph: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    let target = graph["components"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|c| c["id"] == "target")
+        .unwrap();
+    target["execution"]["attention"]["sinks"] = serde_json::json!("softmax_denominator");
+    std::fs::write(&path, graph.to_string()).unwrap();
+}
+
+/// A fixture carrying both extras, encoded and judged.
+fn full_fixture(perturb: Option<&'static str>) -> (tempfile::TempDir, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_glimmer_with(
+        dir.path(),
+        MiniatureExtras {
+            attention_bias: true,
+            sinks: true,
+            perturb,
+        },
+    );
+    let container = encoded(dir.path());
+    judge_sinks(container.path());
+    (dir, container)
+}
+
+fn closure(container: &std::path::Path) -> OpPlanOutcome {
+    let inspection = inspect_container(container, false).unwrap();
+    plan_component_ops(&inspection, container, "target").unwrap()
+}
+
+// ── Parity: the golden semantics through every backend ──
+
+#[test]
+fn biases_and_sinks_match_the_independent_golden_semantics() {
+    let (dir, container) = full_fixture(None);
+    let golden = golden_forward(dir.path());
+    let executed = executor_trace_from(container.path());
+    for layer in 0..G_LAYERS {
+        let attn = max_abs(
+            &executed.layers[layer].post_attention,
+            &golden.layers[layer].post_attention,
+        );
+        assert!(
+            attn < GOLDEN_TOLERANCE,
+            "layer {layer} post_attention {attn:e}"
+        );
+        let post = max_abs(
+            &executed.layers[layer].post_layer,
+            &golden.layers[layer].post_layer,
+        );
+        assert!(post < GOLDEN_TOLERANCE, "layer {layer} post_layer {post:e}");
+    }
+    let worst = executed
+        .logits
+        .unwrap()
+        .iter()
+        .zip(&golden.logits)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    assert!(worst < GOLDEN_TOLERANCE, "logits {worst:e}");
+}
+
+fn assert_traces_agree(a: &ExecutionTrace, b: &ExecutionTrace, label: &str) {
+    for (index, (da, db)) in a.layers.iter().zip(&b.layers).enumerate() {
+        let delta = max_abs(&da.post_layer, &db.post_layer);
+        assert!(delta < GOLDEN_TOLERANCE, "{label}: layer {index} {delta:e}");
+    }
+    let logits = max_abs(
+        std::slice::from_ref(a.logits.as_ref().unwrap()),
+        std::slice::from_ref(b.logits.as_ref().unwrap()),
+    );
+    assert!(logits < GOLDEN_TOLERANCE, "{label}: logits {logits:e}");
+}
+
+#[test]
+fn every_backend_agrees_on_biases_and_sinks() {
+    let (_dir, container) = full_fixture(None);
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let outcome = closure(container.path());
+    assert!(outcome.closed(), "{:?}", outcome.defects);
+    let plan = outcome.plan.unwrap();
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    let reference = execute_plan(&plan, &store, &G_TOKENS, &ReferenceBackend::new()).unwrap();
+    let production = execute_plan(&plan, &store, &G_TOKENS, &ProductionBackend::new()).unwrap();
+    let device = DevicePlanBackend::new(
+        super::device::LoopDevice,
+        "loop-device-sinks-bias",
+        WeightFormat::F32,
+    );
+    let on_device = execute_plan(&plan, &store, &G_TOKENS, &device).unwrap();
+    assert_traces_agree(&production, &reference, "production vs reference");
+    assert_traces_agree(&on_device, &reference, "device vs reference");
+}
+
+// ── Causal: each operand moves the output ──
+
+#[test]
+fn each_bias_and_the_sinks_are_load_bearing() {
+    let (_dir, baseline) = full_fixture(None);
+    let base = executor_trace_from(baseline.path());
+    for suffix in BIAS_SUFFIXES.iter().copied().chain([SINKS_SUFFIX]) {
+        let (_dir, container) = full_fixture(Some(suffix));
+        let moved = executor_trace_from(container.path());
+        let delta = max_abs(
+            std::slice::from_ref(base.logits.as_ref().unwrap()),
+            std::slice::from_ref(moved.logits.as_ref().unwrap()),
+        );
+        let attn0 = max_abs(
+            &base.layers[0].post_attention,
+            &moved.layers[0].post_attention,
+        );
+        eprintln!("perturb {suffix}: layer0 post_attention {attn0:e}, logits {delta:e}");
+        assert!(
+            attn0 > CAUSAL_FLOOR,
+            "perturbing `{suffix}` moved layer 0's attention output by only {attn0:e} — the \
+             operand is carried but not executed"
+        );
+        assert!(
+            delta > GOLDEN_TOLERANCE,
+            "perturbing `{suffix}` moved layer 0 by {attn0:e} but the logits by only {delta:e}"
+        );
+    }
+}
+
+// ── Absence: nothing changes for a model without them, and closure is
+//    fail-closed in both directions ──
+
+#[test]
+fn a_bias_free_plan_serialises_without_the_new_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_glimmer(dir.path());
+    let container = encoded(dir.path());
+    let outcome = closure(container.path());
+    let plan = serde_json::to_value(outcome.plan.unwrap()).unwrap();
+    let text = plan.to_string();
+    for key in ["q_bias", "k_bias", "v_bias", "o_bias", "\"sinks\""] {
+        assert!(!text.contains(key), "bias-free plan carries `{key}`");
+    }
+    let surface = std::fs::read_to_string(container.path().join(SYSTEM_GRAPH_JSON)).unwrap();
+    assert!(!surface.contains("attention_bias") && !surface.contains("\"sinks\""));
+}
+
+#[test]
+fn bias_operands_without_a_declaration_refuse() {
+    // Tensors present, `attention_bias` undeclared: the operands imply an
+    // op the surface does not carry.
+    let dir = tempfile::tempdir().unwrap();
+    miniature_glimmer_with(
+        dir.path(),
+        MiniatureExtras {
+            attention_bias: true,
+            ..Default::default()
+        },
+    );
+    let mut config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dir.path().join("config.json")).unwrap())
+            .unwrap();
+    config.as_object_mut().unwrap().remove("attention_bias");
+    std::fs::write(dir.path().join("config.json"), config.to_string()).unwrap();
+    let container = encoded(dir.path());
+    let outcome = closure(container.path());
+    assert!(!outcome.closed());
+    let implied = outcome
+        .defects
+        .iter()
+        .filter(|d| matches!(d, ClosureDefect::OperandImpliesAbsentOp { tensor, .. } if tensor.contains("_proj.bias")))
+        .count();
+    assert_eq!(implied, 4 * G_LAYERS, "{:?}", outcome.defects);
+}
+
+#[test]
+fn a_declaration_without_bias_operands_refuses() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_glimmer(dir.path());
+    let mut config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dir.path().join("config.json")).unwrap())
+            .unwrap();
+    config["attention_bias"] = serde_json::json!(true);
+    std::fs::write(dir.path().join("config.json"), config.to_string()).unwrap();
+    let container = encoded(dir.path());
+    let outcome = closure(container.path());
+    assert!(!outcome.closed());
+    for role in [
+        OperandRole::AttnQBias,
+        OperandRole::AttnKBias,
+        OperandRole::AttnVBias,
+        OperandRole::AttnOBias,
+    ] {
+        let missing = outcome
+            .defects
+            .iter()
+            .filter(|d| matches!(d, ClosureDefect::MissingOperand { role: r, .. } if *r == role))
+            .count();
+        assert_eq!(missing, G_LAYERS, "{role:?}: {:?}", outcome.defects);
+    }
+}
+
+#[test]
+fn a_sink_operand_without_a_judgment_refuses() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_glimmer_with(
+        dir.path(),
+        MiniatureExtras {
+            sinks: true,
+            ..Default::default()
+        },
+    );
+    let container = encoded(dir.path());
+    // Not judged: the operand implies an op the surface does not carry.
+    let outcome = closure(container.path());
+    assert!(!outcome.closed());
+    let implied = outcome
+        .defects
+        .iter()
+        .filter(|d| matches!(d, ClosureDefect::OperandImpliesAbsentOp { tensor, .. } if tensor.ends_with(SINKS_SUFFIX)))
+        .count();
+    assert_eq!(implied, G_LAYERS, "{:?}", outcome.defects);
+    // Judged: it closes, and the plan carries the sinks per layer.
+    judge_sinks(container.path());
+    let outcome = closure(container.path());
+    assert!(outcome.closed(), "{:?}", outcome.defects);
+    let plan = outcome.plan.unwrap();
+    assert!(plan.layers.iter().all(|l| l.attention.sinks.is_some()));
+}
+
+#[test]
+fn a_sink_judgment_without_the_operand_refuses() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_glimmer(dir.path());
+    let container = encoded(dir.path());
+    judge_sinks(container.path());
+    let outcome = closure(container.path());
+    assert!(!outcome.closed());
+    let missing = outcome
+        .defects
+        .iter()
+        .filter(|d| {
+            matches!(
+                d,
+                ClosureDefect::MissingOperand {
+                    role: OperandRole::AttnSinks,
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(missing, G_LAYERS, "{:?}", outcome.defects);
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights.rs
@@ -78,6 +78,16 @@ impl AlignedBytes {
         }
     }
 
+    /// A page-aligned copy of `bytes` — how a natively stored quantised
+    /// operand (an MXFP4 expert's blocks or scales) is bound without a
+    /// numeric transform: the bytes are the checkpoint's, only the
+    /// alignment is ours.
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut aligned = Self::zeroed(bytes.len());
+        aligned.as_mut_slice()[..bytes.len()].copy_from_slice(bytes);
+        aligned
+    }
+
     /// The full padded allocation — page-aligned pointer, page-multiple
     /// length, zero beyond `logical_len`.
     pub fn as_slice(&self) -> &[u8] {

--- a/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
@@ -116,6 +116,9 @@ pub struct AttentionOp {
 pub struct FfnOp {
     pub intermediate_size: usize,
     pub activation: Activation,
+    /// How the gate combines with the up branch (plain gated, or GPT-OSS's
+    /// clamped GLU). Transcribed from `FfnSurface.gate_policy`.
+    pub gate_policy: larql_models::ExpertGatePolicy,
     /// Present iff the surface says the FFN is gated.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gate: Option<OperandRef>,

--- a/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
@@ -30,13 +30,13 @@ pub mod exec;
 mod tests;
 
 use larql_models::config::{
-    Activation, AttentionGateSpec, AttentionSinkSpec, NormType, ParameterFreeQkNorm,
-    PositionPolicy, QkNormScope,
+    Activation, AttentionGateSpec, AttentionSinkSpec, ExpertFormat, ExpertRoutingPolicy,
+    GateUpLayout, MoeRouterKind, NormType, ParameterFreeQkNorm, PositionPolicy, QkNormScope,
 };
 use serde::Serialize;
 
 use super::graph::policy::AttentionSpan;
-use super::graph::OperandRole;
+use super::graph::{ObjectKind, OperandRole};
 
 pub use build::plan_component_ops;
 
@@ -149,6 +149,79 @@ pub struct FfnOp {
     pub down: OperandRef,
 }
 
+/// One packed expert projection: the bytes for every expert in one
+/// operand (`[experts, rows, …]`), plus the companion streams its
+/// representation needs. `scales` is present iff the expert format keeps
+/// its dequantisation scales in a separate stream (MXFP4); `bias` iff the
+/// checkpoint carries per-expert biases.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PackedProjection {
+    pub weights: OperandRef,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scales: Option<OperandRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bias: Option<OperandRef>,
+}
+
+/// One layer's routed FFN op — a mixture of experts, entirely inside the
+/// generic graph: the router operands live in the decoder stack, the
+/// expert operands in the component's expert-bank object, and every
+/// semantic the executor needs is transcribed here from `FfnSurface.moe`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RoutedFfnOp {
+    pub experts: usize,
+    pub top_k: usize,
+    pub expert_intermediate_size: usize,
+    pub router_kind: MoeRouterKind,
+    pub routing_policy: ExpertRoutingPolicy,
+    pub activation: Activation,
+    /// How each expert's gate combines with its up branch.
+    pub gate_policy: larql_models::ExpertGatePolicy,
+    pub expert_format: ExpertFormat,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gate_up_layout: Option<GateUpLayout>,
+    /// Router logits: `[experts, hidden]`.
+    pub router: OperandRef,
+    /// Additive router bias `[experts]`, iff the surface declares one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub router_bias: Option<OperandRef>,
+    /// Fused gate+up per expert: `[experts, 2·inter, hidden]` in the
+    /// declared layout (packed as the format dictates).
+    pub gate_up: PackedProjection,
+    /// Down per expert: `[experts, hidden, inter]`.
+    pub down: PackedProjection,
+}
+
+/// One layer's FFN: dense or routed. Untagged, so a dense layer serialises
+/// exactly as its [`FfnOp`] always has — a dense plan is byte-identical
+/// before and after routed FFNs existed.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum LayerFfn {
+    /// Both boxed: the two ops differ several-fold in size and a plan
+    /// holds one per layer; the untagged serialisation is unaffected.
+    Dense(Box<FfnOp>),
+    Routed(Box<RoutedFfnOp>),
+}
+
+impl LayerFfn {
+    /// The dense op, when this layer's FFN is dense.
+    pub fn dense(&self) -> Option<&FfnOp> {
+        match self {
+            Self::Dense(op) => Some(op.as_ref()),
+            Self::Routed(_) => None,
+        }
+    }
+
+    /// The routed op, when this layer's FFN is a mixture of experts.
+    pub fn routed(&self) -> Option<&RoutedFfnOp> {
+        match self {
+            Self::Routed(op) => Some(op.as_ref()),
+            Self::Dense(_) => None,
+        }
+    }
+}
+
 /// The generic program of one decoder layer. Norm placement is explicit
 /// op positions, not a count: under two-norm placement the
 /// `post_attention_layernorm` operand *is* [`Self::pre_ffn_norm`] and the
@@ -164,7 +237,7 @@ pub struct LayerPlan {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post_attention_norm: Option<NormOp>,
     pub pre_ffn_norm: NormOp,
-    pub ffn: FfnOp,
+    pub ffn: LayerFfn,
     /// Normalises FFN output before its residual add (four-norm only).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post_ffn_norm: Option<NormOp>,
@@ -221,6 +294,13 @@ pub enum ClosureDefect {
     MissingAttentionTable { component: String },
     /// A stack tensor no operand role classifies.
     UnclassifiedOperand { object: String, tensor: String },
+    /// An operand classified into a role that lives in another object
+    /// kind — an expert operand in the stack, a router in the bank.
+    MisplacedOperand {
+        object: String,
+        tensor: String,
+        belongs_in: ObjectKind,
+    },
     /// An operand exists whose op the surface does not carry — the
     /// container physically requires a primitive its semantics lack.
     OperandImpliesAbsentOp {
@@ -268,6 +348,15 @@ impl std::fmt::Display for ClosureDefect {
             Self::UnclassifiedOperand { object, tensor } => {
                 write!(f, "unclassified executable operand: {object}/{tensor}")
             }
+            Self::MisplacedOperand {
+                object,
+                tensor,
+                belongs_in,
+            } => write!(
+                f,
+                "misplaced operand: {object}/{tensor} belongs in the {} object",
+                belongs_in.name()
+            ),
             Self::OperandImpliesAbsentOp {
                 object,
                 tensor,

--- a/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
@@ -30,7 +30,8 @@ pub mod exec;
 mod tests;
 
 use larql_models::config::{
-    Activation, AttentionGateSpec, NormType, ParameterFreeQkNorm, PositionPolicy, QkNormScope,
+    Activation, AttentionGateSpec, AttentionSinkSpec, NormType, ParameterFreeQkNorm,
+    PositionPolicy, QkNormScope,
 };
 use serde::Serialize;
 
@@ -76,6 +77,14 @@ pub struct GateOp {
     pub projection: OperandRef,
 }
 
+/// The optional attention sinks: the judged semantics plus the operand
+/// holding the per-query-head logits.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SinkOp {
+    pub spec: AttentionSinkSpec,
+    pub logits: OperandRef,
+}
+
 /// One layer's attention op: geometry and scaling from the surface,
 /// span/window/position from the per-layer policy table — never from an
 /// index pattern.
@@ -109,6 +118,20 @@ pub struct AttentionOp {
     pub o: OperandRef,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_gate: Option<GateOp>,
+    /// Additive projection biases; all four present iff the surface
+    /// declares `attention_bias`. Absent from the serialised op otherwise,
+    /// so a bias-free plan serialises exactly as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub q_bias: Option<OperandRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k_bias: Option<OperandRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub v_bias: Option<OperandRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub o_bias: Option<OperandRef>,
+    /// Attention sinks, present iff the surface carries the judgment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sinks: Option<SinkOp>,
 }
 
 /// One layer's FFN op.

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/coverage_opplan.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/coverage_opplan.rs
@@ -1,0 +1,138 @@
+//! Op-plan builder arms not reached by the plan/closure gates.
+//!
+//! The [`LayerFfn`] projections are exclusive views — a dense layer has
+//! no routed op and a routed layer has no dense op — and the misplaced-
+//! operand defect renders the object kind it belongs in. Neither is
+//! observable through the dense fixtures the sibling gates encode.
+
+use larql_models::config::{
+    Activation, ExpertFormat, ExpertRoutingPolicy, GateUpLayout, MoeRouterKind,
+};
+use larql_models::ExpertGatePolicy;
+
+use super::encoded_fixture;
+use crate::format::vindex3::graph::ObjectKind;
+use crate::format::vindex3::opplan::{
+    plan_component_ops, ClosureDefect, LayerFfn, OperandRef, PackedProjection, RoutedFfnOp,
+};
+
+/// Geometry of the hand-built routed op — small, but every dimension is
+/// distinct so an accessor returning the wrong field would be visible.
+const ROUTED_EXPERTS: usize = 4;
+const ROUTED_TOP_K: usize = 2;
+const ROUTED_HIDDEN: usize = 32;
+const ROUTED_INTER: usize = 48;
+const STACK_OBJECT: &str = "target.decoder_stack";
+const BANK_OBJECT: &str = "target.expert_bank";
+const ROUTER_TENSOR: &str = "0.mlp.router.weight";
+const GATE_UP_TENSOR: &str = "0.mlp.experts.gate_up_proj";
+const DOWN_TENSOR: &str = "0.mlp.experts.down_proj";
+const F32_DTYPE: &str = "F32";
+
+fn operand(object: &str, tensor: &str, shape: Vec<usize>) -> OperandRef {
+    OperandRef {
+        object: object.to_string(),
+        tensor: tensor.to_string(),
+        dtype: F32_DTYPE.to_string(),
+        shape,
+    }
+}
+
+/// A routed FFN op exactly as the builder would emit it for a per-expert
+/// (unpacked, unbiased) mixture — the shape the accessors are asked about.
+fn routed_layer() -> LayerFfn {
+    LayerFfn::Routed(Box::new(RoutedFfnOp {
+        experts: ROUTED_EXPERTS,
+        top_k: ROUTED_TOP_K,
+        expert_intermediate_size: ROUTED_INTER,
+        router_kind: MoeRouterKind::TopKSoftmax,
+        routing_policy: ExpertRoutingPolicy::SoftmaxThenSelect,
+        activation: Activation::Silu,
+        gate_policy: ExpertGatePolicy::Gated,
+        expert_format: ExpertFormat::PerExpert,
+        gate_up_layout: Some(GateUpLayout::ContiguousHalves),
+        router: operand(
+            STACK_OBJECT,
+            ROUTER_TENSOR,
+            vec![ROUTED_EXPERTS, ROUTED_HIDDEN],
+        ),
+        router_bias: None,
+        gate_up: PackedProjection {
+            weights: operand(
+                BANK_OBJECT,
+                GATE_UP_TENSOR,
+                vec![ROUTED_EXPERTS, 2 * ROUTED_INTER, ROUTED_HIDDEN],
+            ),
+            scales: None,
+            bias: None,
+        },
+        down: PackedProjection {
+            weights: operand(
+                BANK_OBJECT,
+                DOWN_TENSOR,
+                vec![ROUTED_EXPERTS, ROUTED_HIDDEN, ROUTED_INTER],
+            ),
+            scales: None,
+            bias: None,
+        },
+    }))
+}
+
+/// A routed layer answers `routed()` with its own op and `dense()` with
+/// nothing — the two projections are exclusive, never a lossy view of
+/// each other.
+#[test]
+fn a_routed_layer_exposes_its_routed_op_and_no_dense_op() {
+    let layer = routed_layer();
+    let routed = layer.routed().expect("routed layer carries a routed op");
+    assert_eq!(routed.experts, ROUTED_EXPERTS);
+    assert_eq!(routed.top_k, ROUTED_TOP_K);
+    assert_eq!(routed.expert_intermediate_size, ROUTED_INTER);
+    assert_eq!(routed.router.tensor, ROUTER_TENSOR);
+    assert_eq!(routed.gate_up.weights.object, BANK_OBJECT);
+    assert!(
+        layer.dense().is_none(),
+        "a routed layer must not present a dense op"
+    );
+}
+
+/// The planned dense fixture: every layer answers `dense()` and none
+/// answers `routed()` — the accessor reads the variant, not a default.
+#[test]
+fn a_planned_dense_layer_exposes_no_routed_op() {
+    let fixture = encoded_fixture();
+    let plan = plan_component_ops(&fixture.inspection, &fixture.root, "target")
+        .unwrap()
+        .plan
+        .unwrap();
+    assert!(!plan.layers.is_empty());
+    for layer in &plan.layers {
+        assert!(
+            layer.ffn.routed().is_none(),
+            "layer {}: dense plan presented a routed op",
+            layer.layer
+        );
+        assert!(layer.ffn.dense().is_some(), "layer {}", layer.layer);
+    }
+}
+
+/// A misplaced-operand defect names the tensor, the object it was found
+/// in, and the kind of object it belongs in — by the kind's own name,
+/// so the report is a work item without a lookup.
+#[test]
+fn a_misplaced_operand_defect_renders_where_the_operand_belongs() {
+    let defect = ClosureDefect::MisplacedOperand {
+        object: STACK_OBJECT.to_string(),
+        tensor: GATE_UP_TENSOR.to_string(),
+        belongs_in: ObjectKind::ExpertBank,
+    };
+    let rendered = defect.to_string();
+    assert_eq!(
+        rendered,
+        format!(
+            "misplaced operand: {STACK_OBJECT}/{GATE_UP_TENSOR} belongs in the {} object",
+            ObjectKind::ExpertBank.name()
+        )
+    );
+    assert!(rendered.contains("expert_bank"), "{rendered}");
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/mod.rs
@@ -2,6 +2,7 @@
 //! explicit, and closure blocks on every shortfall.
 
 mod closure;
+mod coverage_opplan;
 mod plan;
 mod unjudged;
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/plan.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/plan.rs
@@ -99,7 +99,7 @@ fn drafter_plan_uses_two_norm_placement_and_qk_norms() {
     assert!(plan.output.is_none());
     assert!(plan.final_norm.is_some());
     assert_eq!(layer0.attention.num_kv_heads, 4);
-    assert_eq!(layer0.ffn.activation, Activation::Silu);
+    assert_eq!(layer0.ffn.dense().unwrap().activation, Activation::Silu);
 
     // 11 operands: 4 attn + 2 qk norms + 2 norms + 3 mlp.
     assert_eq!(layer0.operands_accounted, 11);

--- a/crates/larql-vindex/src/format/vindex3/plan/carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/carriage.rs
@@ -119,11 +119,48 @@ pub const CARRIAGE_RULES: &[CarriageRule] = &[
     CarriageRule {
         leaf: "rope_type",
         reaches: Carriage::Represented,
-        // PositionPolicy is `Rope { theta } | None`. It can state that a
-        // layer is rotary or has no position encoding, and nothing else —
-        // so the only rope *class* it can represent is the unscaled one.
-        site: "Component.attention[].position — PositionPolicy expresses unscaled rope only",
+        // PositionPolicy is `Rope { theta } | Yarn { theta, scaling } |
+        // None`: unscaled rotary, YaRN-scaled rotary (frequencies AND the
+        // attention amplitude), or no position encoding. Any other declared
+        // rope class (llama3, dynamic, ...) still has no variant and
+        // mismatches here — represented, not lowered: the interpreter and
+        // the lowering refuse a YaRN layer until A-9.3/A-9.4 execute it.
+        site: "Component.attention[].position (PositionPolicy::Rope | Yarn)",
         probe: Some(probe_rope_type),
+    },
+    // The YaRN block's own leaves, each carried on `PositionPolicy::Yarn`
+    // and answered from it. A checkpoint that declares them without
+    // declaring `rope_type: yarn` gets no answer, which is right — the
+    // leaves mean nothing outside that block.
+    CarriageRule {
+        leaf: "factor",
+        reaches: Carriage::Represented,
+        site: "Component.attention[].position (PositionPolicy::Yarn.scaling.factor)",
+        probe: Some(probe_yarn_factor),
+    },
+    CarriageRule {
+        leaf: "beta_fast",
+        reaches: Carriage::Represented,
+        site: "Component.attention[].position (PositionPolicy::Yarn.scaling.beta_fast)",
+        probe: Some(probe_yarn_beta_fast),
+    },
+    CarriageRule {
+        leaf: "beta_slow",
+        reaches: Carriage::Represented,
+        site: "Component.attention[].position (PositionPolicy::Yarn.scaling.beta_slow)",
+        probe: Some(probe_yarn_beta_slow),
+    },
+    CarriageRule {
+        leaf: "truncate",
+        reaches: Carriage::Represented,
+        site: "Component.attention[].position (PositionPolicy::Yarn.scaling.truncate)",
+        probe: Some(probe_yarn_truncate),
+    },
+    CarriageRule {
+        leaf: "original_max_position_embeddings",
+        reaches: Carriage::Represented,
+        site: "Component.attention[].position (PositionPolicy::Yarn.scaling.original_max_position_embeddings)",
+        probe: Some(probe_yarn_original_max),
     },
     // ── Span policy ─────────────────────────────────────────────────
     CarriageRule {
@@ -175,6 +212,17 @@ pub const CARRIAGE_RULES: &[CarriageRule] = &[
         reaches: Carriage::Lowered,
         site: "ExecutionSurface.ffn.activation → FfnOp.activation",
         probe: Some(probe_activation),
+    },
+    CarriageRule {
+        leaf: "swiglu_limit",
+        reaches: Carriage::Represented,
+        // GPT-OSS's clamped GLU: `gate.min(limit)`, `up.clamp(±limit)`,
+        // `(up + 1) * gate * sigmoid(alpha * gate)`. Carried as a gate
+        // *policy* rather than an activation variant, and judged here by
+        // the limit it carries. Represented, not lowered: the interpreter
+        // and the lowering refuse a ClampedGlu FFN until A-9.3/A-9.4.
+        site: "ExecutionSurface.ffn.gate_policy (ExpertGatePolicy::ClampedGlu.limit) → FfnOp.gate_policy",
+        probe: Some(probe_swiglu_limit),
     },
     // ── Attention/output scaling ────────────────────────────────────
     CarriageRule {
@@ -266,13 +314,48 @@ fn probe_layer_rope_theta(component: &Component) -> Option<Value> {
     ))
 }
 
-/// The rope *class* the schema can express. `PositionPolicy` has no
-/// scaling variant, so an all-rotary (or NoPE) table can only mean
-/// unscaled rope — which is exactly the claim to compare against a
-/// declared `rope_type`.
+/// The rope *class* the table actually carries, in the checkpoint's own
+/// spelling: `yarn` when any rotating layer holds a YaRN block, else
+/// `default`. A table can not mix the two — the block is a checkpoint-wide
+/// fact — so the first rotating layer answers for all.
 fn probe_rope_type(component: &Component) -> Option<Value> {
-    component.attention.as_ref()?;
-    Some(json!("default"))
+    let table = component.attention.as_ref()?;
+    let scaled = table.iter().any(|l| l.position.yarn().is_some());
+    Some(json!(if scaled { "yarn" } else { "default" }))
+}
+
+/// The YaRN block the table carries, when it carries one. `None` when the
+/// table has no scaled layer — the caller's leaf then has nothing to be
+/// judged against, which is the right answer for a checkpoint that
+/// declares the leaf outside a `yarn` block.
+fn yarn_block(component: &Component) -> Option<larql_models::YarnRopeScaling> {
+    component
+        .attention
+        .as_ref()?
+        .iter()
+        .find_map(|l| l.position.yarn())
+}
+
+fn probe_yarn_factor(component: &Component) -> Option<Value> {
+    Some(json!(yarn_block(component)?.factor))
+}
+
+fn probe_yarn_beta_fast(component: &Component) -> Option<Value> {
+    Some(json!(yarn_block(component)?.beta_fast))
+}
+
+fn probe_yarn_beta_slow(component: &Component) -> Option<Value> {
+    Some(json!(yarn_block(component)?.beta_slow))
+}
+
+fn probe_yarn_truncate(component: &Component) -> Option<Value> {
+    Some(json!(yarn_block(component)?.truncate))
+}
+
+fn probe_yarn_original_max(component: &Component) -> Option<Value> {
+    Some(json!(
+        yarn_block(component)?.original_max_position_embeddings
+    ))
 }
 
 /// Per-layer span kinds in the checkpoint's own vocabulary, so the
@@ -307,6 +390,17 @@ fn probe_post_norm_eps(component: &Component) -> Option<Value> {
 fn probe_activation(component: &Component) -> Option<Value> {
     let activation = component.execution.as_ref()?.ffn.activation;
     serde_json::to_value(activation).ok()
+}
+
+/// The clamp bound the FFN surface carries, when its gate policy is the
+/// clamped GLU. A plain-gated surface has no limit to answer with — a
+/// checkpoint declaring `swiglu_limit` that resolved to plain gating is
+/// then reported as unrepresented, which is the truth.
+fn probe_swiglu_limit(component: &Component) -> Option<Value> {
+    match component.execution.as_ref()?.ffn.gate_policy {
+        larql_models::ExpertGatePolicy::ClampedGlu { limit, .. } => Some(json!(limit)),
+        larql_models::ExpertGatePolicy::Gated => None,
+    }
 }
 
 fn probe_query_scale(component: &Component) -> Option<Value> {

--- a/crates/larql-vindex/src/format/vindex3/plan/carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/carriage.rs
@@ -258,16 +258,14 @@ pub const CARRIAGE_RULES: &[CarriageRule] = &[
     // ── Facts that stop at the parser, reviewed ─────────────────────
     CarriageRule {
         leaf: "attention_bias",
-        reaches: Carriage::Parsed,
-        // VINDEX3 has no `attention_bias` field; what it has instead is
-        // operand closure, which refuses any bias tensor it cannot
-        // classify into a declared op. For a model that declares `false`
-        // the two agree trivially. For one that declares `true` the bias
-        // operands themselves block at G5b — a stronger check than a
-        // boolean, and the reason this is judged rather than a hole.
-        // MOE1 gives the projections explicit bias operands.
-        site: "no schema field — carried instead as operand evidence, gated by G5b closure",
-        probe: None,
+        reaches: Carriage::Represented,
+        // A-9.1: the surface states it, and operand closure enforces it
+        // both ways — `true` requires all four bias operands, anything
+        // else refuses any bias operand it finds — so the boolean and the
+        // operand evidence cannot drift apart. The executors add the four
+        // biases; the Metal lowering refuses them until A-9.4.
+        site: "ExecutionSurface.attention.attention_bias → AttentionOp.{q,k,v,o}_bias (closure-paired)",
+        probe: Some(probe_attention_bias),
     },
     CarriageRule {
         leaf: "max_position_embeddings",
@@ -401,6 +399,12 @@ fn probe_swiglu_limit(component: &Component) -> Option<Value> {
         larql_models::ExpertGatePolicy::ClampedGlu { limit, .. } => Some(json!(limit)),
         larql_models::ExpertGatePolicy::Gated => None,
     }
+}
+
+fn probe_attention_bias(component: &Component) -> Option<Value> {
+    Some(json!(
+        component.execution.as_ref()?.attention.attention_bias?
+    ))
 }
 
 fn probe_query_scale(component: &Component) -> Option<Value> {

--- a/crates/larql-vindex/src/format/vindex3/plan/compare.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/compare.rs
@@ -183,7 +183,13 @@ fn layer_rope_theta_findings(inventory: &ArchitectureInventory) -> Option<Findin
             declared_array
                 .get(l.layer)
                 .and_then(Value::as_f64)
-                .is_some_and(|declared| PositionPolicy::from_declared_theta(declared) != l.position)
+                // Compare what the array declares — the base, or the NoPE
+                // sentinel — not the whole variant: a YaRN block on top of
+                // the same theta is a separate fact with its own carriage.
+                .is_some_and(|declared| {
+                    PositionPolicy::from_declared_theta(declared).rope_theta()
+                        != l.position.rope_theta()
+                })
         })
         .map(|l| l.layer)
         .collect();

--- a/crates/larql-vindex/src/format/vindex3/plan/semantics.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/semantics.rs
@@ -33,6 +33,20 @@ pub const EXECUTION_SEMANTIC_KEYS: &[&str] = &[
     "final_logit_softcapping",
     "attn_logit_softcapping",
     "partial_rotary_factor",
+    // The YaRN block's leaves. Each changes what attention computes —
+    // `factor` sets the frequency blend AND the amplitude on every logit,
+    // the betas and `truncate` set the correction band, and
+    // `original_max_position_embeddings` is the window those bounds are
+    // defined against — so each is judged against `PositionPolicy::Yarn`
+    // by its own carriage rule, not credited for being parsed. Under a
+    // non-YaRN `rope_type` (llama3, linear) the probes answer `None` and
+    // the leaves report unrepresented, which is the truth until those
+    // classes have a variant.
+    "factor",
+    "beta_fast",
+    "beta_slow",
+    "truncate",
+    "original_max_position_embeddings",
     // GPT-OSS clamps both halves of the fused gate/up projection at
     // ±this value before the GLU. It changes what the FFN computes, so
     // it is execution-semantic wherever it is declared.
@@ -57,6 +71,15 @@ pub const TENSOR_SEMANTIC_KEYS: &[&str] = &[
     "patch_temporal",
     "pos_emb_height",
     "pos_emb_width",
+    // The stored representation: what the checkpoint's raw-byte tensors
+    // *are*. `quantization_config.quant_method` (`mxfp4` on GPT-OSS) and
+    // its `modules_to_not_convert` exclusion list decide the encoding a
+    // `U8` blocks/scales pair is placed under. Read by the inventory's
+    // representation reader; proven carried by the placed object's
+    // `representations[].encoding` (which names MXFP4, not U8), the same
+    // way every other tensor semantic is proven by placement.
+    "quant_method",
+    "modules_to_not_convert",
 ];
 
 /// Keys that declare a cross-component contract: hidden-state taps, block

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/carriage.rs
@@ -32,17 +32,16 @@ fn finding_for<'a>(findings: &'a [Finding], suffix: &str) -> &'a Finding {
         .unwrap_or_else(|| panic!("no finding for `{suffix}`"))
 }
 
-/// **The positive control.** GPT-OSS declares `rope_scaling = {rope_type:
-/// "yarn", factor: 32}` for a 131k context. Every leaf of that block is
-/// `consumed` — the parser genuinely reads it — but `PositionPolicy` is
-/// `Rope { theta } | None` and carries no scaling, so the model would
-/// execute as plain rope and the old gate said nothing at all.
-///
-/// The carriage probe answers what the schema can actually express
-/// (`default`), the comparison against the declaration fails, and the
-/// plan refuses.
+/// **The positive control.** A `yarn` block that is *incomplete* — GPT-OSS
+/// declares `factor: 32` but this checkpoint omits
+/// `original_max_position_embeddings`, which YaRN's correction bounds are
+/// defined against — resolves to no scaling at all (`yarn_rope_scaling`
+/// refuses a malformed block), so the position policy carries plain rope.
+/// The carriage probe answers `default`, the comparison against the
+/// declaration fails, and the plan refuses: a `yarn` the container cannot
+/// honour is a dropped fact, whatever the reason.
 #[test]
-fn declared_yarn_scaling_blocks_because_the_schema_cannot_express_it() {
+fn an_incomplete_yarn_block_resolves_to_plain_rope_and_blocks() {
     let findings = plan_with(|config| {
         config["text_config"]["rope_parameters"]["rope_type"] = serde_json::json!("yarn");
         config["text_config"]["rope_parameters"]["factor"] = serde_json::json!(32.0);
@@ -59,6 +58,47 @@ fn declared_yarn_scaling_blocks_because_the_schema_cannot_express_it() {
         "a dropped fact reaches the parser and no further"
     );
     assert!(finding.blocks(), "a dropped execution semantic must block");
+}
+
+/// **The positive arm of A-9.0.** A complete `yarn` block — GPT-OSS's, with
+/// its `original_max_position_embeddings` — becomes `PositionPolicy::Yarn`
+/// on every rotating layer, and the probe reads `yarn` back out of the
+/// built table. Every leaf of the block is judged against what the policy
+/// carries, not merely credited for having been parsed.
+#[test]
+fn a_complete_yarn_block_is_carried_as_position_policy_yarn() {
+    let findings = plan_with(|config| {
+        let rp = &mut config["text_config"]["rope_parameters"];
+        rp["rope_type"] = serde_json::json!("yarn");
+        rp["factor"] = serde_json::json!(32.0);
+        rp["beta_fast"] = serde_json::json!(32.0);
+        rp["beta_slow"] = serde_json::json!(1.0);
+        rp["truncate"] = serde_json::json!(false);
+        rp["original_max_position_embeddings"] = serde_json::json!(4096);
+    });
+    let rope_type = finding_for(&findings, "rope_parameters.rope_type");
+    assert_eq!(
+        rope_type.category,
+        FindingCategory::Representable,
+        "{rope_type:?}"
+    );
+    assert_eq!(rope_type.resolved, Some(serde_json::json!("yarn")));
+    assert_eq!(rope_type.carriage, Some(Carriage::Represented));
+    assert!(!rope_type.blocks());
+
+    for (leaf, declared) in [
+        ("factor", serde_json::json!(32.0)),
+        ("beta_fast", serde_json::json!(32.0)),
+        ("beta_slow", serde_json::json!(1.0)),
+        ("truncate", serde_json::json!(false)),
+        ("original_max_position_embeddings", serde_json::json!(4096)),
+    ] {
+        let f = finding_for(&findings, &format!("rope_parameters.{leaf}"));
+        assert_eq!(f.category, FindingCategory::Representable, "{leaf}: {f:?}");
+        assert_eq!(f.declared, Some(declared), "{leaf}");
+        assert_eq!(f.carriage, Some(Carriage::Represented), "{leaf}");
+        assert!(!f.blocks(), "{leaf}");
+    }
 }
 
 /// **The negative control, on the same key.** Muse-Glimmer declares
@@ -83,15 +123,16 @@ fn declared_default_rope_type_is_carried_not_blocked() {
 /// keep a key out of the report entirely, so a fact nobody had checked
 /// looked identical to one that was carried.
 ///
-/// GPT-OSS's `swiglu_limit` (a ±7 clamp on the fused gate/up halves
-/// before the GLU) is the live occupant — `FfnSurface` has no field for
-/// it, and MOE1 is where it gets one.
+/// `partial_rotary_factor` is the live occupant: consumed by the parser,
+/// execution-semantic (it changes which dimensions rotate), and judged by
+/// no rule yet. (`swiglu_limit` held this slot until A-9.0 gave it a gate
+/// policy — see the two tests below.)
 #[test]
 fn an_execution_semantic_key_with_no_carriage_rule_blocks() {
     let findings = plan_with(|config| {
-        config["text_config"]["swiglu_limit"] = serde_json::json!(7.0);
+        config["text_config"]["partial_rotary_factor"] = serde_json::json!(0.5);
     });
-    let finding = finding_for(&findings, "swiglu_limit");
+    let finding = finding_for(&findings, "partial_rotary_factor");
 
     assert_eq!(finding.category, FindingCategory::Unrepresented);
     assert_eq!(finding.class, SemanticClass::ExecutionSemantic);
@@ -102,6 +143,44 @@ fn an_execution_semantic_key_with_no_carriage_rule_blocks() {
         finding.detail
     );
     assert!(finding.blocks());
+}
+
+/// `swiglu_limit` on an architecture whose FFN gate is plain gating: the
+/// surface carries `ExpertGatePolicy::Gated`, so there is no limit to
+/// answer with, and the declared clamp is reported as unrepresented —
+/// which is the truth about this fixture, and blocks.
+#[test]
+fn swiglu_limit_on_a_plain_gated_ffn_is_unrepresented_and_blocks() {
+    let findings = plan_with(|config| {
+        config["text_config"]["swiglu_limit"] = serde_json::json!(7.0);
+    });
+    let finding = finding_for(&findings, "swiglu_limit");
+
+    assert_eq!(
+        finding.category,
+        FindingCategory::Unrepresented,
+        "{finding:?}"
+    );
+    assert_eq!(finding.class, SemanticClass::ExecutionSemantic);
+    assert!(
+        finding.detail.contains("no built component answered"),
+        "{}",
+        finding.detail
+    );
+    assert!(finding.blocks());
+}
+
+/// The rule itself is on the books, reaching `Represented` at the gate
+/// policy — so a GPT-OSS-shaped surface, whose architecture resolves
+/// `ExpertGatePolicy::ClampedGlu { limit: swiglu_limit, .. }`, answers the
+/// probe with the limit and the fact is judged carried. (An end-to-end
+/// GPT-OSS fixture is A-9.2's; here the rule and its probe are pinned.)
+#[test]
+fn swiglu_limit_has_a_carriage_rule_at_the_gate_policy() {
+    let rule = rule_for("swiglu_limit").expect("swiglu_limit is judged");
+    assert_eq!(rule.reaches, Carriage::Represented);
+    assert!(rule.site.contains("gate_policy"), "{}", rule.site);
+    assert!(rule.probe.is_some());
 }
 
 /// A fact that honestly stops at the parser is *reported*, not hidden.

--- a/crates/larql-vindex/src/format/vindex3/verify_system/payload.rs
+++ b/crates/larql-vindex/src/format/vindex3/verify_system/payload.rs
@@ -83,7 +83,7 @@ pub fn verify_payloads(
             continue;
         };
 
-        let mut planned = match plan_object_tensors(object, &inventories) {
+        let mut planned = match plan_object_tensors(object, &inventories, &graph.objects) {
             Ok(planned) => planned,
             Err(e) => {
                 payloads.push(failed_check(id, format!("source no longer plans: {e}")));


### PR DESCRIPTION
## A-9 — gpt-oss-20b through VINDEX3: the same graph → plan → CPU interpreter / Metal lowering as Glimmer, no family branch

Closes the A-9 rung of the attention execution ladder (ROADMAP §"Attention execution ladder", rows A-9 / A-10). The proof VINDEX3 is an engine architecture and not a Glimmer implementation: a hostile second family (pure routed MXFP4 MoE + attention sinks + Q/K/V/O biases + YaRN with amplitude + clamped GLU) is **represented** in the generic semantic graph, **planned** into the same op plan, and **executed** by both the CPU interpreter and the Metal lowering — with no `if model == gpt_oss` anywhere on the path.

### The congruence chain on the real 20B

```text
served HF forward (larql-models + larql-compute, exact BF16+MXFP4 bytes)
    ↕  cos 1.000000000 · rel_rms 1e-6 (layers 0–16) … 3e-6 (17–23)
VINDEX3 CPU interpreter        (`vindex3 exec --dump-layers`)
    ↕  cos 1.000000000 · rel_rms ≤ 1e-6, all 24 layers, "no capture drifts"
VINDEX3 Metal lowering         (`vindex3 exec --backend metal-lowered --dump-layers`, f16 attention, native MXFP4 experts)
```

Same 81 oracle ids on every arm; the dumps are byte-compatible so `shannon layer-diff` compares them directly.

The earlier generated-token flip is **measured, not explained**: with all-NVFP4 attention the layer-0 rel_rms is 0.058 (cos 0.998); switching attention/head to f16 collapses it to 0.000000 and the whole stack to ≤ 1e-6. Any divergence attributable to the common MXFP4 expert path is below the ~1e-6 residual of the congruent f16-attention run.

### Rungs (one commit each, file coordinates in ROADMAP)

| Rung | What landed |
|---|---|
| A-9.0 | `PositionPolicy::Yarn{theta, scaling}` (amplitude from ONE authority), `ExpertGatePolicy::ClampedGlu`, `quantization_config` classified as a representation fact; `larql vindex3 plan` on the HF checkpoint admissible (50 representable / 0 mismatched / 0 blocking). Two parser finds fixed+pinned (transformers-5 `rope_parameters` YaRN dropped; YaRN leaves not classified execution-semantic). Executors REFUSE Yarn/ClampedGlu until they execute them. |
| A-9.1 | Attention sinks (`AttentionSinkSpec::SoftmaxDenominator`) + Q/K/V/O biases as judged, carried, closed-both-ways, executed semantics; golden parity, 3-backend parity, 5 causal controls, absence gate. gpt-oss ops defects 384 → 264, zero attention defects. |
| A-9.2 | MoE inside the generic graph: `ObjectKind::ExpertBank` carved by binding specificity, `FfnSurface.moe`, router/expert roles, `RoutedFfnOp` → reference/production/device (native MXFP4 bytes bound). Miniature gpt-oss-family fixture: served ≡ reference ≡ production ≡ device at 2e-5, 4 causal controls, closure fail-closed both ways. Real gpt-oss: 264 → 0 defects, container with NO `moe_manifest.json`. |
| A-9.3 | YaRN executes in the interpreter (scaled frequencies + amplitude); real gpt-oss-20b runs end-to-end on CPU (7.5 tok/s decode); teacher-forced 14/16 vs the Q4_K-spine oracle, both misses at the two lowest margins. |
| A-9.4 | Metal lowering: YaRN amplitude, sinks, biases (attention half; fragment gate <1e-4 + 4 controls) and the routed FFN (expert-bank segments registered as zero-copy regions → the served descriptor MoE encode; ClampedGlu via the existing kernel). gpt-oss-20b lowers end-to-end: argmax = oracle id 1, 15/16 trajectory identical to the interpreter, 18.5 tok/s. |
| A-9.5 | Lowered `--dump-layers` (encode_stack Checkpoints → per-position `[seq,hidden]` planes) closes the interpreter ↔ Metal chain above. |

Also: `larql run --emit-ids` on the routed Metal path + the banked oracle fixture (#268 already on main); `shannon layer-dump --tokens`; `vindex3_cmd/lowered.rs` split into `lowered/{mod,resident,routed,dump}` under the 800-line cap.

### CI gates

Run locally with each crate's own workflow flags before pushing:

- fmt + clippy: larql-models, larql-vindex, larql-compute (both feature sets), larql-compute-metal, larql-cli (gpu and `--no-default-features`), plus x86_64 cross-clippy on models/vindex/cli — clean.
- tests: models 788, compute 1079, vindex 2811, cli 751 (both feature shapes), compute-metal 822 — green.
- coverage policy: **larql-models PASSES** (was red on main on `quant/nvfp4.rs`; this PR lifts it and its own three touched files), **larql-compute PASSES** (was red on main on `backend/matmul.rs` 45%; trait-default tests lift it to 97%), **larql-vindex** — see below.
- larql-compute-metal coverage stays as on main: its failing files (`buffers/residency.rs`, `diag/nvfp4_call_profile.rs`, TOTAL) are device-bound and CI's macOS runner has no Metal device; this PR's lowering additions are device-bound too.

### What's next

A-10 (ROADMAP): the bracketed cost-of-abstraction ladder — served routed Metal path vs `vindex3 exec --backend metal-lowered` (f16 and NVFP4 attention) at short/512/1K/2K/4K with the KV-B1 hygiene.
