### PR TITLE
feat(vindex3): G4.0 — Gemma 4 26B-A4B plans admissibly (42 → 0 blocking): per-layer geometry, proportional rope, K≡V, per-layer-type judgement

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1935,6 +1935,88 @@ representation sets, placement, quality contracts. Engine work (A-1…A-10)
 continues throughout but is **not permitted to move schema** — a schema
 change is a V3-F0/V3.0 event, argued as such.
 
+**V3-F0 witness 3 — Gemma 4 26B-A4B (hybrid MoE), mapped 2026-08-18.**
+Rung 0 measured: `larql vindex3 plan` on `google/gemma-4-26B-A4B-it` (HF
+snapshot, BF16, 2 shards) is **inadmissible: 68 representable / 3 mismatched
+/ 39 unrepresented → 42 blocking** (gpt-oss started at 4). Objects already
+place: `decoder_stack` 3.3 GB, `embedding` 1.5 GB, `expert_bank` 45.7 GB
+(the A-9.2 bank machinery recognises the 128-expert packed BF16 banks
+unaided), `final_norm`, `perception_tower` 1.1 GB. The 42 sort into one root
+cause, four semantic families, and classification debt:
+
+```text
+ROOT CAUSE  per-layer attention geometry. graph/surface.rs:238 requires ONE head geometry per
+            component ("a per-layer variation is a schema gap to surface, not to average away") and
+            Gemma 4 has head_dim 256 / kv 8 on 25 sliding layers, global_head_dim 512 / kv 2 on the
+            5 full layers → target.execution_surface incomplete → the text component never builds →
+            every probe that reads a BUILT component reports "no built component answered":
+            rms_norm_eps, hidden_activation, attention_bias, final_logit_softcapping, both rope_thetas.
+            These clear together once geometry is per-layer.
+FAMILY 1    position. rope_parameters.{full,sliding}_attention is per LAYER TYPE (transformers-5
+            shape, the same trap A-9.0 hit): full theta 1e6 resolved as 10000 (mismatched — a
+            resolution bug, not a schema gap); rope_type "proportional" (mismatched vs default) with
+            partial_rotary_factor 0.25 (unrepresented): rotate the first 0.25·head_dim dims, inverse
+            frequencies over the FULL head_dim (global_head_dim on full layers), zero frequency on the
+            rest — HF _compute_proportional_rope_parameters. Needs a PositionPolicy variant.
+FAMILY 2    K ≡ V. attention_k_eq_v=true: v_proj is ABSENT on the 5 full layers (present on the 25
+            sliding) — the V operand is the K object. Parsed but unclassified today.
+FAMILY 3    hybrid FFN. EVERY layer has dense mlp.{gate,up,down} (inter 2112) AND experts.{gate_up,
+            down}_proj (128 × inter 704, top-8) with router.{proj,scale,per_expert_scale} and FIVE
+            FFN norms. HF Gemma4TextDecoderLayer: h = pre_ffn_norm(r); d = post_ffn_norm_1(mlp(h));
+            router over the RESIDUAL r (norm WITHOUT scale, × scale × H^-0.5, softmax, top-k,
+            renormalise, × per_expert_scale[idx]); m = post_ffn_norm_2(experts(pre_ffn_norm_2(r)));
+            out = r + post_ffn_norm(d + m); then × layer_scalar. enable_moe_block / num_experts /
+            top_k_experts / moe_intermediate_size are parsed but unclassified.
+FAMILY 4    output. final_logit_softcapping 30 (OutputOp.softcapping EXISTS — opplan/mod.rs:271,
+            surface.rs:211 — will answer once the component builds); tie_word_embeddings (no
+            output_head object placed — the head must bind the embedding object; verify).
+CLASSIFY    num_kv_shared_layers 0 (rule missing; 0 = none — but >0 on E2B/E4B is attention
+            reading ANOTHER LAYER's KV state, a cross-op state dependency: THE F0 question this
+            family poses to the ontology; refuse until represented), hidden_size_per_layer_input 0
+            and vocab_size_per_layer_input (PLE; 0 = absent), use_double_wide_mlp, global_head_dim,
+            num_global_key_value_heads, use_bidirectional_attention "vision"; root: audio_config
+            null, {audio,boa,boi,eoa,eoi,image,video}_token_id, vision_soft_tokens_per_image
+            (interface_semantic); vision_config: hidden_activation gelu_pytorch_tanh vs gelu_tanh
+            is an ALIAS mismatch (plan/compare.rs must compare through Activation), attention_bias /
+            rope_theta 100 / rope_type / global_head_dim 72 / pooling_kernel_size /
+            position_embedding_size / default_output_length / standardize / use_clipped_linears are
+            tower execution facts to carry on perception_tower (not executed by the text plan);
+            id2label / label2id / problem_type / return_dict / output_* / is_encoder_decoder /
+            chunk_size_feed_forward / _name_or_path are metadata_only.
+```
+
+Rungs, mirroring A-9 (each closes with its gate; served-side authority for
+every fact is `architectures/gemma4.rs`, which already judges all of it):
+
+```text
+G4.0  admissibility as REPRESENTATION: AttentionLayerPolicy (graph/policy.rs:74) gains per-layer
+      {head_dim, num_kv_heads}; surface_from_resolved stops requiring uniformity and AttentionOp reads
+      the layer's geometry (KV allocation follows); PositionPolicy::Proportional{theta, rotary_fraction}
+      (config/position.rs) + carriage rules for partial_rotary_factor and rope_type=proportional
+      (plan/carriage.rs; the leaves are already in plan/semantics.rs:35) + the per-layer-type
+      rope_parameters resolution fix pinned; AttentionLayerPolicy.v_from_k (closure: v_from_k ⇒ no V
+      operand, else required); the CLASSIFY list judged (config_keys.rs / semantics.rs registries);
+      vision alias compare. Executors REFUSE Proportional / v_from_k / hybrid until they execute them.
+      Gate: plan admissible, 0 blocking; every dropped fact pinned by a test that re-drops it.
+G4.1  hybrid FFN in the generic graph: LayerFfn::Hybrid{dense, routed, combine} (opplan/mod.rs:200) —
+      or Dense+Routed as two ops in the layer program with an explicit combine — plus roles for
+      router.scale, per_expert_scale, layer_scalar, pre_ffn_norm_2, post_ffn_norm_1/_2 (graph/roles.rs),
+      MoeRouterKind::SoftmaxThenTopK + NormalisedOverSelected + per-expert scale, the scale-less router
+      norm, ExpertFormat packed BF16 [E,2I,H]/[E,H,I]. Closure both ways on a miniature gemma4-family
+      fixture; `vindex3 ops` on the real container: N → 0 defects.
+G4.2  interpreter executes it (reference / production / device): per-layer geometry, proportional rope,
+      K≡V, hybrid FFN + router scales + layer_scalar, softcapped tied head. Gate: served CPU forward
+      (`shannon layer-dump --tokens` on the HF checkpoint) ≡ `vindex3 exec --dump-layers`, all 30
+      layers, plus causal controls per new operand.
+G4.3  Metal lowering: per-layer KV geometry (a (512, 16, 2, span) planner row — serial where
+      unmeasured), proportional rope table, K bound as V, hybrid encode = gated-ffn + descriptor MoE +
+      norms + sum + layer_scalar in one CB, softcap head. Gate: layer-diff lowered vs interpreter
+      ≤ 1e-6 (the A-9.5 instrument, no new plumbing).
+G4.4  banked id oracle (`larql run --emit-ids` on the served path) + bracketed ladder; then the F0
+      verdict: did Gemma 4 add vocabulary only? (Expected yes for 26B; num_kv_shared_layers>0 on
+      E2B/E4B is the open relationship question and is scored separately.)
+```
+
 **Immediate queue this implies:** (1) the third hostile architecture through
 the generic chain; (2) multi-representation binding, WALK/DESCRIBE on V3
 authority, the opset/version model, refusal semantics in the spec (the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1989,7 +1989,39 @@ Rungs, mirroring A-9 (each closes with its gate; served-side authority for
 every fact is `architectures/gemma4.rs`, which already judges all of it):
 
 ```text
-G4.0  admissibility as REPRESENTATION: AttentionLayerPolicy (graph/policy.rs:74) gains per-layer
+G4.0  DONE 2026-08-19 (branch feat/vindex3-gemma4): `larql vindex3 plan` on the real 26B-A4B is
+      ADMISSIBLE — 111 representable / 0 mismatched / 0 unrepresented / 0 blocking (from 42). What
+      landed, all as vocabulary in existing categories (F1 still holding): AttentionLayerPolicy
+      gains per-layer HeadGeometry{head_dim, num_kv_heads} and v_from_k; the surface no longer
+      requires uniform geometry and the op plan judges each layer's shapes against ITS geometry
+      (kv_rows 24 ≠ 16 in the fixture — a coincident product hid the K/V check once);
+      PositionPolicy::PartialRope{theta, rotary_fraction, basis: RotaryWidth|HeadWidth} with
+      ROPE_TYPE_PROPORTIONAL, judged by the gemma4 arch on its full layers; carriage probes now
+      take a ProbeContext (the attention span the fact's PATH names + the declared value for alias
+      resolution) so per-layer-TYPE facts are judged against their own layers, and the resolution
+      comparator does the same; ParameterFreeQkNorm.v (Gemma 4's scale-less v_norm) and
+      AttentionOp.v_from_k (V = the K operand, closure-paired: no V operand on such a layer, a
+      stray one refused); rules for attention_k_eq_v, enable_moe_block, top_k_experts,
+      global_head_dim, num_global_key_value_heads, num_kv_shared_layers / hidden_size_per_layer_input
+      / use_double_wide_mlp / use_clipped_linears (represented as ABSENT only — 0/false agree,
+      anything else blocks); two new recorded readers (inventory/interfaces.rs for the root
+      multimodal join incl. audio_config:null and use_bidirectional_attention; text_features.rs for
+      the PLE-vocab / double-wide knobs — a stopgap until they become ModelConfig fields, avoided
+      now because the parallel Granite landing touches every ModelConfig constructor); label-map
+      containers (id2label/label2id) and HF return/chunk plumbing classified metadata; a nested
+      tower with no layer_types gets a Full × N table so its rope facts are judged; the tower's
+      attention_bias reaches its surface. Executors (reference/production/device, the Metal
+      lowering) REFUSE PartialRope, v_from_k and the V norm, typed, naming G4.2/G4.3. Pinned by
+      plan/tests/gemma4.rs (9, each re-dropping its fact), opplan/tests/gemma4_closure.rs (K≡V both
+      ways), exec/tests/gemma4_refusals.rs, and the invariant that every execution-semantic leaf
+      has a carriage rule. TWO FINDS the gate forced: (1) the comparator treated
+      rope_parameters.full_attention.rope_theta as the checkpoint-wide base and compared it to
+      every layer — a false mismatch on any per-layer-type checkpoint; (2) HF `proportional`
+      takes inverse frequencies over the FULL head width (base^(2i/512) on the global layers)
+      while the served path's partial rotary takes them over the rotary width (base^(2i/128)) —
+      different angles on the 5 global layers; the served gemma4 forward has NOT been certified
+      against HF at attention level, and G4.2's layer-dump parity gate will arbitrate it.
+      As mapped: admissibility as REPRESENTATION: AttentionLayerPolicy (graph/policy.rs:74) gains per-layer
       {head_dim, num_kv_heads}; surface_from_resolved stops requiring uniformity and AttentionOp reads
       the layer's geometry (KV allocation follows); PositionPolicy::Proportional{theta, rotary_fraction}
       (config/position.rs) + carriage rules for partial_rotary_factor and rope_type=proportional

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/mod.rs
@@ -151,6 +151,33 @@ impl<'a> LoweredSession<'a> {
                 l.ffn.dense().map(|f| f.gate_policy)
             )));
         }
+        // K≡V layers and the parameter-free V norm (Gemma 4): carried by
+        // the plan, not lowered until G4.3.
+        if let Some(l) = plan
+            .layers
+            .iter()
+            .find(|l| l.attention.v_from_k || l.attention.parameter_free_qk_norm.v)
+        {
+            return Err(VindexError::Parse(format!(
+                "layer {} carries v_from_k={} / parameter-free v_norm={}, which the Metal \
+                 lowering does not execute yet (G4.3); refusing",
+                l.layer, l.attention.v_from_k, l.attention.parameter_free_qk_norm.v
+            )));
+        }
+        // A partial rotary (Gemma 4's proportional rope on its global
+        // layers): carried by the plan, not lowered until G4.3 — the rope
+        // kernel rotates the whole head at plain frequencies.
+        if let Some(l) = plan
+            .layers
+            .iter()
+            .find(|l| matches!(l.attention.position, PositionPolicy::PartialRope { .. }))
+        {
+            return Err(VindexError::Parse(format!(
+                "layer {} carries {:?}, which the Metal lowering does not execute yet (G4.3); \
+                 refusing rather than rotating the whole head",
+                l.layer, l.attention.position
+            )));
+        }
         let embedding = plan
             .embedding
             .as_ref()
@@ -562,6 +589,10 @@ impl<'a> LoweredSession<'a> {
                         LoweredPosition::Scaled { theta, amplitude }
                     }
                     PositionPolicy::None => LoweredPosition::None,
+                    // Refused in `new`; a plan carrying it never gets here.
+                    PositionPolicy::PartialRope { .. } => {
+                        unreachable!("PartialRope is refused before the session is built")
+                    }
                 },
                 // A window applies only to a sliding span; a full layer
                 // attends the whole prefix whatever the plan records.

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/resident.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/resident.rs
@@ -151,6 +151,10 @@ pub(super) fn rope_table_key(position: &PositionPolicy) -> Option<u64> {
             Some(h.finish() | 1)
         }
         PositionPolicy::None => None,
+        // Refused in `LoweredSession::new`; never reaches the table.
+        PositionPolicy::PartialRope { .. } => {
+            unreachable!("PartialRope is refused before the session is built")
+        }
     }
 }
 
@@ -170,6 +174,9 @@ pub(super) fn rope_inv_freq_table(position: &PositionPolicy, head_dim: usize) ->
             inv_freq.iter().map(|f| *f as f32).collect()
         }
         PositionPolicy::None => Vec::new(),
+        PositionPolicy::PartialRope { .. } => {
+            unreachable!("PartialRope is refused before the session is built")
+        }
     }
 }
 

--- a/crates/larql-models/src/architectures/gemma4.rs
+++ b/crates/larql-models/src/architectures/gemma4.rs
@@ -16,7 +16,8 @@
 //! 3. Default pattern of 6 (every 6th layer is full)
 
 use crate::config::{
-    Activation, ExpertFormat, GateUpLayout, ModelArchitecture, ModelConfig, PostNormEps,
+    Activation, ExpertFormat, GateUpLayout, ModelArchitecture, ModelConfig, PositionPolicy,
+    PostNormEps, RotaryFrequencyBasis,
 };
 use crate::tensor_keys::qk_norm;
 
@@ -225,6 +226,29 @@ impl ModelArchitecture for Gemma4Arch {
 
     fn is_sliding_window_layer(&self, layer: usize) -> bool {
         !self.is_global_layer(layer)
+    }
+
+    /// Global layers rotate only `partial_rotary_factor` of each
+    /// `global_head_dim`-wide head, with the inverse frequencies taken over
+    /// the FULL head width — HF's `proportional` rope class, which
+    /// `Gemma4RotaryEmbedding` selects for `full_attention` and computes
+    /// with `head_dim_key = "global_head_dim"`. Sliding layers are plain
+    /// rotary at the local base. The class is the architecture's judgement
+    /// (no Gemma 4 checkpoint declares plain partial rotary); the VINDEX3
+    /// carriage gate compares it against the declared `rope_type`, so a
+    /// checkpoint saying otherwise blocks rather than being mis-served.
+    fn position_policy_for_layer(&self, layer: usize) -> PositionPolicy {
+        let theta = self.rope_base_for_layer(layer);
+        match self.config.partial_rotary_factor {
+            Some(rotary_fraction) if self.is_global_layer(layer) && rotary_fraction < 1.0 => {
+                PositionPolicy::PartialRope {
+                    theta,
+                    rotary_fraction,
+                    basis: RotaryFrequencyBasis::HeadWidth,
+                }
+            }
+            _ => PositionPolicy::Rope { theta },
+        }
     }
 
     fn rope_base_for_layer(&self, layer: usize) -> f64 {

--- a/crates/larql-models/src/architectures/muse_glimmer.rs
+++ b/crates/larql-models/src/architectures/muse_glimmer.rs
@@ -63,7 +63,11 @@ impl ModelArchitecture for MuseGlimmerArch {
     }
 
     fn parameter_free_qk_norm(&self) -> ParameterFreeQkNorm {
-        ParameterFreeQkNorm { q: true, k: true }
+        ParameterFreeQkNorm {
+            q: true,
+            k: true,
+            v: false,
+        }
     }
 
     /// Layer norms are *centred*: `RMSNorm(x) * (1.0 + weight)`.

--- a/crates/larql-models/src/config/mod.rs
+++ b/crates/larql-models/src/config/mod.rs
@@ -47,9 +47,11 @@ pub use layer_types::{
 pub use model_config::ModelConfig;
 pub use moe_router::MoeRouterKind;
 pub use norm::{EmbeddingNorm, NormSpec, NormType, ParameterFreeQkNorm, PostNormEps, QkNormScope};
-pub use position::PositionPolicy;
+pub use position::{PositionPolicy, RotaryFrequencyBasis};
 pub use rope::{Llama3RopeScaling, RopeScaling, YarnRopeScaling};
-pub use rope_types::{ROPE_TYPE_DEFAULT, ROPE_TYPE_LINEAR, ROPE_TYPE_LLAMA3, ROPE_TYPE_YARN};
+pub use rope_types::{
+    ROPE_TYPE_DEFAULT, ROPE_TYPE_LINEAR, ROPE_TYPE_LLAMA3, ROPE_TYPE_PROPORTIONAL, ROPE_TYPE_YARN,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/larql-models/src/config/norm.rs
+++ b/crates/larql-models/src/config/norm.rs
@@ -107,15 +107,21 @@ impl PostNormEps {
     }
 }
 
-/// Parameter-free QK normalisation: RMS-normalise Q and/or K with no
-/// learned weight tensors. Distinct from weighted QK-norm (whose weights
-/// exist in the stack and carry [`QkNormScope`]) — a judged semantic
-/// fact, evidenced by an implementation that normalises while the
-/// operand estate ships no `q_norm`/`k_norm` weights.
+/// Parameter-free projection normalisation: RMS-normalise Q, K and/or V
+/// per head with no learned weight tensors. Distinct from weighted QK-norm
+/// (whose weights exist in the stack and carry [`QkNormScope`]) — a judged
+/// semantic fact, evidenced by an implementation that normalises while the
+/// operand estate ships no weights for it. `v` is Gemma 4's `v_norm`
+/// (`Gemma4RMSNorm(with_scale=False)` on the value states, every layer,
+/// alongside WEIGHTED q/k norms) — a family can mix the two, so V is its
+/// own flag rather than a "qk" pair. Defaults for inventories written
+/// before V was recorded.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ParameterFreeQkNorm {
     pub q: bool,
     pub k: bool,
+    #[serde(default)]
+    pub v: bool,
 }
 
 /// The vector over which a QK-norm's RMS statistic is reduced.

--- a/crates/larql-models/src/config/position.rs
+++ b/crates/larql-models/src/config/position.rs
@@ -38,8 +38,32 @@ pub enum PositionPolicy {
         theta: f64,
         scaling: YarnRopeScaling,
     },
+    /// Rotary on the first `rotary_fraction` of each head only, the rest of
+    /// the head unrotated. `basis` says which width the inverse frequencies
+    /// are taken over: the rotary width (the plain partial rotary of
+    /// Phi/GPT-NeoX — HF `default` + `partial_rotary_factor`) or the full
+    /// head width (HF `proportional`, Gemma 4's full-attention layers over
+    /// `global_head_dim`). The two rotate the same dims at DIFFERENT angles
+    /// — `base^(2i/128)` vs `base^(2i/512)` on Gemma 4 — so the basis is
+    /// part of the policy, not a detail a consumer may pick.
+    PartialRope {
+        theta: f64,
+        rotary_fraction: f64,
+        basis: RotaryFrequencyBasis,
+    },
     /// No positional encoding — the layer attends position-agnostically.
     None,
+}
+
+/// The width the inverse-frequency series of a partial rotary is taken
+/// over. See [`PositionPolicy::PartialRope`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RotaryFrequencyBasis {
+    /// `base^(2i / rotary_width)` — the plain partial rotary.
+    RotaryWidth,
+    /// `base^(2i / head_dim)` — HF `proportional`.
+    HeadWidth,
 }
 
 impl PositionPolicy {
@@ -68,8 +92,42 @@ impl PositionPolicy {
     /// no default.
     pub fn rope_theta(self) -> Option<f64> {
         match self {
-            Self::Rope { theta } | Self::Yarn { theta, .. } => Some(theta),
+            Self::Rope { theta } | Self::Yarn { theta, .. } | Self::PartialRope { theta, .. } => {
+                Some(theta)
+            }
             Self::None => None,
+        }
+    }
+
+    /// The rotated fraction of each head when the policy is a partial
+    /// rotary; `None` for a full rotary, YaRN and NoPE — "no partial rotary
+    /// declared", which is not the same claim as a fraction of 1.0.
+    pub fn rotary_fraction(self) -> Option<f64> {
+        match self {
+            Self::PartialRope {
+                rotary_fraction, ..
+            } => Some(rotary_fraction),
+            Self::Rope { .. } | Self::Yarn { .. } | Self::None => None,
+        }
+    }
+
+    /// The HF `rope_type` spelling this policy answers to when it is not
+    /// the default class: `yarn`, or `proportional` for a head-width-basis
+    /// partial rotary. `None` for the default class (plain rotary, plain
+    /// partial rotary) and for NoPE.
+    pub fn declared_rope_type(self) -> Option<&'static str> {
+        match self {
+            Self::Yarn { .. } => Some(super::rope_types::ROPE_TYPE_YARN),
+            Self::PartialRope {
+                basis: RotaryFrequencyBasis::HeadWidth,
+                ..
+            } => Some(super::rope_types::ROPE_TYPE_PROPORTIONAL),
+            Self::PartialRope {
+                basis: RotaryFrequencyBasis::RotaryWidth,
+                ..
+            }
+            | Self::Rope { .. }
+            | Self::None => None,
         }
     }
 
@@ -78,7 +136,7 @@ impl PositionPolicy {
     pub fn yarn(self) -> Option<YarnRopeScaling> {
         match self {
             Self::Yarn { scaling, .. } => Some(scaling),
-            Self::Rope { .. } | Self::None => None,
+            Self::Rope { .. } | Self::PartialRope { .. } | Self::None => None,
         }
     }
 
@@ -186,6 +244,58 @@ mod tests {
         assert_eq!(yarn.yarn(), Some(scaling));
         assert_eq!(PositionPolicy::Rope { theta: 1e4 }.yarn(), None);
         assert_eq!(PositionPolicy::None.yarn(), None);
+    }
+
+    fn gemma4_partial() -> PositionPolicy {
+        PositionPolicy::PartialRope {
+            theta: 1_000_000.0,
+            rotary_fraction: 0.25,
+            basis: RotaryFrequencyBasis::HeadWidth,
+        }
+    }
+
+    /// A partial rotary offers its theta and its fraction, answers to
+    /// HF's `proportional` spelling only on the head-width basis, and
+    /// carries no YaRN block; the plain-partial basis is the default class.
+    #[test]
+    fn a_partial_rotary_answers_for_its_fraction_and_class() {
+        let proportional = gemma4_partial();
+        assert_eq!(proportional.rope_theta(), Some(1_000_000.0));
+        assert_eq!(proportional.rotary_fraction(), Some(0.25));
+        assert_eq!(proportional.declared_rope_type(), Some("proportional"));
+        assert_eq!(proportional.yarn(), None);
+        assert!(proportional.is_rotary());
+        let plain_partial = PositionPolicy::PartialRope {
+            theta: 10_000.0,
+            rotary_fraction: 0.5,
+            basis: RotaryFrequencyBasis::RotaryWidth,
+        };
+        assert_eq!(plain_partial.declared_rope_type(), None);
+        assert_eq!(plain_partial.rotary_fraction(), Some(0.5));
+        // Full rotary, YaRN and NoPE declare no fraction; YaRN answers `yarn`.
+        assert_eq!(PositionPolicy::Rope { theta: 1e4 }.rotary_fraction(), None);
+        assert_eq!(PositionPolicy::None.rotary_fraction(), None);
+        assert_eq!(
+            PositionPolicy::Rope { theta: 1e4 }.declared_rope_type(),
+            None
+        );
+        assert_eq!(PositionPolicy::None.declared_rope_type(), None);
+        let yarn = PositionPolicy::Yarn {
+            theta: 150000.0,
+            scaling: gpt_oss_yarn(),
+        };
+        assert_eq!(yarn.declared_rope_type(), Some("yarn"));
+        assert_eq!(yarn.rotary_fraction(), None);
+    }
+
+    /// The partial rotary round-trips with its basis tagged.
+    #[test]
+    fn a_partial_rotary_round_trips_with_its_basis() {
+        let json = serde_json::to_string(&gemma4_partial()).unwrap();
+        assert!(json.contains("\"kind\":\"partial_rope\""), "{json}");
+        assert!(json.contains("\"basis\":\"head_width\""), "{json}");
+        let back: PositionPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, gemma4_partial());
     }
 
     #[test]

--- a/crates/larql-models/src/config/rope_types.rs
+++ b/crates/larql-models/src/config/rope_types.rs
@@ -21,3 +21,12 @@ pub const ROPE_TYPE_LLAMA3: &str = "llama3";
 /// Ramped interpolation/extrapolation frequency blend **plus** an amplitude on
 /// `cos`/`sin`. GPT-OSS and DeepSeek.
 pub const ROPE_TYPE_YARN: &str = "yarn";
+
+/// Partial rotary whose inverse frequencies are taken over the FULL head
+/// width (`base^(2i/head_dim)`, first `partial_rotary_factor · head_dim`
+/// dims rotated, the rest at zero frequency) — HF
+/// `_compute_proportional_rope_parameters`. Gemma 4 declares it on its
+/// full-attention layers, over `global_head_dim`. Distinct from the plain
+/// partial rotary (`default` + `partial_rotary_factor`), whose frequencies
+/// are taken over the rotary width: same rotated dims, different angles.
+pub const ROPE_TYPE_PROPORTIONAL: &str = "proportional";

--- a/crates/larql-models/src/inventory/components.rs
+++ b/crates/larql-models/src/inventory/components.rs
@@ -54,6 +54,42 @@ pub struct ComponentTopology {
     /// Patch/positional geometry for perception towers.
     #[serde(skip_serializing_if = "PatchGeometry::is_empty")]
     pub patch: PatchGeometry,
+    /// The tower's own execution facts beyond the shared surface —
+    /// read and recorded so a checkpoint's declaration has a home, even
+    /// while no plan executes the tower. Defaults for inventories written
+    /// before they were recorded.
+    #[serde(default, skip_serializing_if = "TowerExecution::is_empty")]
+    pub tower: TowerExecution,
+}
+
+/// A perception tower's declared execution facts that the shared
+/// [`ComponentTopology`] surface does not carry (Gemma 4 vision: whether
+/// projections carry biases, the pooling kernel of its output projector,
+/// the size of its position-embedding table, how many soft tokens an image
+/// yields, input standardisation, clipped linears, and a global head width
+/// that may differ from `head_dim`).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TowerExecution {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention_bias: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pooling_kernel_size: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position_embedding_size: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_output_length: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub standardize: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_clipped_linears: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub global_head_dim: Option<usize>,
+}
+
+impl TowerExecution {
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
 }
 
 /// Perception-tower patch geometry. All optional; absent fields are absent
@@ -177,6 +213,10 @@ impl<'a> Cursor<'a> {
     fn string_at(&mut self, rel_path: &str) -> Option<String> {
         self.get(rel_path)?.as_str().map(str::to_string)
     }
+
+    fn bool_at(&mut self, rel_path: &str) -> Option<bool> {
+        self.get(rel_path)?.as_bool()
+    }
 }
 
 fn read_component(root_key: &str, object: &Value) -> ComponentReading {
@@ -231,6 +271,15 @@ fn read_component(root_key: &str, object: &Value) -> ComponentReading {
             pos_emb_width: cursor.usize_at("pos_emb_width"),
             image_size: cursor.usize_at("image_size"),
             num_channels: cursor.usize_at("num_channels"),
+        },
+        tower: TowerExecution {
+            attention_bias: cursor.bool_at("attention_bias"),
+            pooling_kernel_size: cursor.usize_at("pooling_kernel_size"),
+            position_embedding_size: cursor.usize_at("position_embedding_size"),
+            default_output_length: cursor.usize_at("default_output_length"),
+            standardize: cursor.bool_at("standardize"),
+            use_clipped_linears: cursor.bool_at("use_clipped_linears"),
+            global_head_dim: cursor.usize_at("global_head_dim"),
         },
     };
     ComponentReading {

--- a/crates/larql-models/src/inventory/config_keys.rs
+++ b/crates/larql-models/src/inventory/config_keys.rs
@@ -142,7 +142,24 @@ pub const METADATA_LEAF_KEYS: &[&str] = &[
     "initializer_range",
     "use_cache",
     "attention_dropout",
+    // HF `PretrainedConfig` plumbing that changes what a call RETURNS or
+    // how a training/eval loop chunks work, never what a forward computes:
+    // classification-head labels on a config that has no head, output
+    // switches, the encoder-decoder flag, and the feed-forward chunk size
+    // (identical numbers at any chunking; Gemma 4's vision tower ships 0).
+    "problem_type",
+    "return_dict",
+    "output_attentions",
+    "output_hidden_states",
+    "is_encoder_decoder",
+    "chunk_size_feed_forward",
 ];
+
+/// Containers whose every leaf is metadata: HF label maps
+/// (`id2label.0 = "LABEL_0"`), whose leaves are numbered and so cannot be
+/// named in [`METADATA_LEAF_KEYS`]. Only listed as a whole because nothing
+/// under them can move a forward pass.
+pub const METADATA_CONTAINER_KEYS: &[&str] = &["id2label", "label2id"];
 
 /// Config fields that declare a cross-component interface. The one known
 /// occupant is the DFlash-style drafter contract: `target_layer_ids` names
@@ -180,6 +197,22 @@ pub fn find_interfaces(facts: &[ConfigKeyFact]) -> Vec<InterfaceFact> {
         .collect()
 }
 
+/// Every leaf under a [`METADATA_CONTAINER_KEYS`] container, as metadata.
+fn flatten_metadata_into(value: &Value, prefix: String, out: &mut Vec<ConfigKeyFact>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                flatten_metadata_into(child, format!("{prefix}.{key}"), out);
+            }
+        }
+        leaf => out.push(ConfigKeyFact {
+            status: KeyStatus::Metadata,
+            path: prefix,
+            value: leaf.clone(),
+        }),
+    }
+}
+
 /// Last dot-separated segment of a flattened path.
 fn leaf_name(path: &str) -> &str {
     path.rsplit('.').next().unwrap_or(path)
@@ -203,7 +236,10 @@ fn flatten_into(
                 } else {
                     format!("{prefix}.{key}")
                 };
-                if child.is_object() {
+                if child.is_object() && METADATA_CONTAINER_KEYS.contains(&key.as_str()) {
+                    // A label map: every leaf metadata, whatever it is named.
+                    flatten_metadata_into(child, path, out);
+                } else if child.is_object() {
                     // Recurse always — every leaf must surface individually —
                     // but consumed-credit survives only through containers the
                     // parser itself recurses into. Presence-only containers

--- a/crates/larql-models/src/inventory/interfaces.rs
+++ b/crates/larql-models/src/inventory/interfaces.rs
@@ -1,0 +1,120 @@
+//! The multimodal interface reader: the root-level facts that bind a text
+//! decoder to its perception towers — which special-token ids delimit an
+//! image / audio / video span, how many soft tokens an image yields, and
+//! whether the text model attends bidirectionally across a span — plus
+//! the declaration that a component is ABSENT (`audio_config: null`).
+//!
+//! The third recorded reader (after the nested-component topology and the
+//! stored-representation readers): it records the full path of every key
+//! it reads into [`InterfaceReading::consumed_paths`], and key
+//! classification credits exactly that set. Interface facts are neither
+//! tensor semantics (nothing is stored) nor forward-pass execution
+//! semantics of one component — they are the contract BETWEEN components,
+//! which is why they have their own home rather than a slot on
+//! `ModelConfig`.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Root-level special-token roles, in the spelling HF multimodal configs
+/// use. Each names the token that opens, closes or stands in for one
+/// perception span. `image_token_id` and `video_token_id` are also read by
+/// the text parser; recording them here too keeps the interface complete
+/// in one place.
+pub const TOKEN_ROLE_KEYS: &[&str] = &[
+    "image_token_id",
+    "video_token_id",
+    "audio_token_id",
+    "boi_token_id",
+    "eoi_token_id",
+    "boa_token_id",
+    "eoa_token_id",
+    // A second spelling HF Gemma 4 ships beside `eoa_token_id`, same value.
+    "eoa_token_index",
+];
+
+/// Root-level count of soft tokens one image expands to.
+pub const SOFT_TOKENS_PER_IMAGE_KEY: &str = "vision_soft_tokens_per_image";
+
+/// Component keys whose declared ABSENCE (`null`) is itself an interface
+/// fact: the checkpoint says it has no such tower.
+pub const OPTIONAL_COMPONENT_KEYS: &[&str] = &["audio_config"];
+
+/// The text-side masking policy over perception spans
+/// (`text_config.use_bidirectional_attention`, Gemma 4: `"vision"`).
+pub const BIDIRECTIONAL_ATTENTION_PATH: (&str, &str) =
+    ("text_config", "use_bidirectional_attention");
+
+/// What the checkpoint declares about the joins between its components.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct MultimodalInterface {
+    /// `(key, token id)` for every declared special-token role, in
+    /// [`TOKEN_ROLE_KEYS`] order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub token_roles: Vec<(String, u64)>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub soft_tokens_per_image: Option<u64>,
+    /// Components the checkpoint declares it does NOT have.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub absent_components: Vec<String>,
+    /// The span kind the text model attends bidirectionally over, verbatim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bidirectional_attention: Option<String>,
+}
+
+impl MultimodalInterface {
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+/// One reading: the interface plus the paths it consumed.
+#[derive(Debug, Clone)]
+pub struct InterfaceReading {
+    pub interface: MultimodalInterface,
+    pub consumed_paths: BTreeSet<String>,
+}
+
+/// Read the interface facts a config declares. `None` when it declares
+/// none — a text-only checkpoint has no interface to record.
+pub fn read_interface(config: &Value) -> Option<InterfaceReading> {
+    let mut consumed_paths = BTreeSet::new();
+    let mut interface = MultimodalInterface::default();
+    for key in TOKEN_ROLE_KEYS {
+        if let Some(id) = config.get(key).and_then(Value::as_u64) {
+            consumed_paths.insert((*key).to_string());
+            interface.token_roles.push(((*key).to_string(), id));
+        }
+    }
+    if let Some(n) = config
+        .get(SOFT_TOKENS_PER_IMAGE_KEY)
+        .and_then(Value::as_u64)
+    {
+        consumed_paths.insert(SOFT_TOKENS_PER_IMAGE_KEY.to_string());
+        interface.soft_tokens_per_image = Some(n);
+    }
+    for key in OPTIONAL_COMPONENT_KEYS {
+        if config.get(key).is_some_and(Value::is_null) {
+            consumed_paths.insert((*key).to_string());
+            interface.absent_components.push((*key).to_string());
+        }
+    }
+    let (container, leaf) = BIDIRECTIONAL_ATTENTION_PATH;
+    if let Some(kind) = config
+        .get(container)
+        .and_then(|c| c.get(leaf))
+        .and_then(Value::as_str)
+    {
+        consumed_paths.insert(format!("{container}.{leaf}"));
+        interface.bidirectional_attention = Some(kind.to_string());
+    }
+    (!interface.is_empty()).then_some(InterfaceReading {
+        interface,
+        consumed_paths,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/larql-models/src/inventory/interfaces/tests.rs
+++ b/crates/larql-models/src/inventory/interfaces/tests.rs
@@ -1,0 +1,62 @@
+//! The multimodal interface reader.
+
+use super::*;
+use serde_json::Value;
+
+fn gemma4_shaped() -> Value {
+    serde_json::json!({
+        "audio_config": null,
+        "audio_token_id": 258881,
+        "boa_token_id": 256000,
+        "boi_token_id": 255999,
+        "eoa_token_id": 258883,
+        "eoa_token_index": 258883,
+        "eoi_token_id": 258882,
+        "image_token_id": 258880,
+        "video_token_id": 258884,
+        "vision_soft_tokens_per_image": 280,
+        "text_config": { "use_bidirectional_attention": "vision" }
+    })
+}
+
+/// Every declared interface fact is read, recorded, and credited by
+/// full path — nothing is credited that was not read.
+#[test]
+fn reads_every_declared_interface_fact_and_credits_exactly_those_paths() {
+    let reading = read_interface(&gemma4_shaped()).expect("declares an interface");
+    let i = &reading.interface;
+    assert_eq!(i.token_roles.len(), 8);
+    assert!(i
+        .token_roles
+        .contains(&("image_token_id".to_string(), 258880)));
+    assert_eq!(i.soft_tokens_per_image, Some(280));
+    assert_eq!(i.absent_components, vec!["audio_config".to_string()]);
+    assert_eq!(i.bidirectional_attention.as_deref(), Some("vision"));
+    for path in [
+        "audio_config",
+        "eoa_token_index",
+        "vision_soft_tokens_per_image",
+        "text_config.use_bidirectional_attention",
+    ] {
+        assert!(reading.consumed_paths.contains(path), "{path}");
+    }
+    assert_eq!(reading.consumed_paths.len(), 11);
+}
+
+/// A present (non-null) `audio_config` is a component, not an absence:
+/// it is left to the component reader and not credited here.
+#[test]
+fn a_present_optional_component_is_not_recorded_as_absent() {
+    let mut config = gemma4_shaped();
+    config["audio_config"] = serde_json::json!({ "hidden_size": 8 });
+    let reading = read_interface(&config).unwrap();
+    assert!(reading.interface.absent_components.is_empty());
+    assert!(!reading.consumed_paths.contains("audio_config"));
+}
+
+/// A text-only config declares no interface: `None`, no credit.
+#[test]
+fn a_text_only_config_has_no_interface() {
+    let config = serde_json::json!({ "model_type": "llama", "hidden_size": 64 });
+    assert!(read_interface(&config).is_none());
+}

--- a/crates/larql-models/src/inventory/mod.rs
+++ b/crates/larql-models/src/inventory/mod.rs
@@ -19,10 +19,12 @@
 
 pub mod components;
 pub mod config_keys;
+pub mod interfaces;
 pub mod report;
 pub mod representation;
 pub mod resolved;
 pub mod tensors;
+pub mod text_features;
 
 #[cfg(test)]
 mod tests;
@@ -74,6 +76,20 @@ pub fn build_inventory(model_dir: &Path) -> Result<ArchitectureInventory, ModelE
         recorded_reads.extend(r.consumed_paths);
         r.representation
     });
+    // The multimodal-interface reader is the third: special-token roles,
+    // soft-token counts, declared-absent towers and the bidirectional
+    // masking policy are credited only because it read and stored them.
+    let interface_reading = interfaces::read_interface(&config);
+    let multimodal_interface = interface_reading.map(|r| {
+        recorded_reads.extend(r.consumed_paths);
+        r.interface
+    });
+    // The declared-absent text features are the fourth reader (see the
+    // module doc for why they are not `ModelConfig` fields yet).
+    let text_features = text_features::read_text_features(&config).map(|r| {
+        recorded_reads.extend(r.consumed_paths);
+        r.features
+    });
     let config_facts = config_keys::classify_config(&config, &recorded_reads);
     let interfaces = config_keys::find_interfaces(&config_facts);
     let tensor_inventory = tensors::scan_tensors(model_dir)?;
@@ -92,6 +108,8 @@ pub fn build_inventory(model_dir: &Path) -> Result<ArchitectureInventory, ModelE
         resolved: topology,
         nested_components,
         stored_representation,
+        multimodal_interface,
+        text_features,
         config_keys: config_facts,
         interfaces,
         tensors: tensor_inventory,

--- a/crates/larql-models/src/inventory/report.rs
+++ b/crates/larql-models/src/inventory/report.rs
@@ -64,6 +64,15 @@ pub struct ArchitectureInventory {
     /// declaration alone.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stored_representation: Option<crate::inventory::representation::StoredRepresentation>,
+    /// The joins between components — special-token roles, soft-token
+    /// counts, declared-absent towers, bidirectional masking — as the
+    /// interface reader recorded them. `None` on a text-only checkpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub multimodal_interface: Option<crate::inventory::interfaces::MultimodalInterface>,
+    /// Text-decoder features the graph represents only as absent, read
+    /// verbatim so a checkpoint turning them on blocks on the value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text_features: Option<crate::inventory::text_features::TextFeatures>,
     /// Every leaf in `config.json`, flattened to a dot path, classified.
     pub config_keys: Vec<ConfigKeyFact>,
     /// Declared cross-component interfaces (see
@@ -234,6 +243,14 @@ pub struct LayerPolicy {
     pub position: crate::config::PositionPolicy,
     pub head_dim: usize,
     pub num_kv_heads: usize,
+    /// The value projection IS the key projection on this layer: no
+    /// `v_proj` tensor exists and V is the raw K projection (before the
+    /// key's norm and rotation) — Gemma 4 `attention_k_eq_v` on its full
+    /// layers. Per layer, because the same checkpoint keeps `v_proj` on
+    /// its sliding layers. Defaults for inventories written before it was
+    /// recorded.
+    #[serde(default)]
+    pub v_from_k: bool,
     /// Source-name prefix of this layer's packed expert bank (the parent of
     /// its `gate_up`/`down` operands), when the layer's FFN is routed —
     /// `model.layers.3.mlp.experts`. `None` = a dense-FFN layer. Per layer,

--- a/crates/larql-models/src/inventory/resolved.rs
+++ b/crates/larql-models/src/inventory/resolved.rs
@@ -104,6 +104,7 @@ pub fn resolve(config: &Value, identity: &Identity) -> (Detection, ResolvedTopol
                 position: arch.position_policy_for_layer(layer),
                 head_dim: arch.head_dim_for_layer(layer),
                 num_kv_heads: arch.num_kv_heads_for_layer(layer),
+                v_from_k: arch.v_shares_k(layer),
                 expert_bank: expert_bank_prefix(arch.as_ref(), layer),
             }
         })
@@ -126,7 +127,11 @@ pub fn resolve(config: &Value, identity: &Identity) -> (Detection, ResolvedTopol
         attn_logit_softcapping: arch.attn_logit_softcapping(),
         qk_norm_scope: arch.qk_norm_scope(),
         qk_norm_weight_offset: arch.qk_norm_weight_offset(),
-        parameter_free_qk_norm: arch.parameter_free_qk_norm(),
+        parameter_free_qk_norm: {
+            let mut norms = arch.parameter_free_qk_norm();
+            norms.v = arch.has_v_norm();
+            norms
+        },
         attention_output_gate: arch.attention_output_gate(),
         attention_sinks: arch.attention_sinks(),
         attention_bias: arch.attention_bias(),

--- a/crates/larql-models/src/inventory/tests/build.rs
+++ b/crates/larql-models/src/inventory/tests/build.rs
@@ -170,3 +170,50 @@ fn routed_inventory_records_representation_and_binds_spelled_banks() {
     assert_eq!(inv.resolved.layers[1].expert_bank, None);
     assert!(inv.resolved.execution.unwrap().moe.is_some());
 }
+
+/// A multimodal checkpoint's root interface facts and its declared-absent
+/// text features are read by the inventory's recorded readers, stored,
+/// and credited as consumed — nothing at the root is "read by nothing".
+#[test]
+fn interface_and_text_feature_readers_store_and_credit_what_they_read() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture(dir.path());
+    // Extend the Glimmer-shaped fixture's config with the Gemma-4-style
+    // root interface and text knobs.
+    let path = dir.path().join("config.json");
+    let mut config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    config["audio_config"] = serde_json::Value::Null;
+    config["boi_token_id"] = serde_json::json!(255999);
+    config["vision_soft_tokens_per_image"] = serde_json::json!(280);
+    config["text_config"]["use_bidirectional_attention"] = serde_json::json!("vision");
+    config["text_config"]["use_double_wide_mlp"] = serde_json::json!(false);
+    config["text_config"]["vocab_size_per_layer_input"] = serde_json::json!(128);
+    std::fs::write(&path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+    let inv = build_inventory(dir.path()).unwrap();
+    let interface = inv.multimodal_interface.expect("interface read");
+    assert_eq!(
+        interface.absent_components,
+        vec!["audio_config".to_string()]
+    );
+    assert_eq!(interface.soft_tokens_per_image, Some(280));
+    assert_eq!(interface.bidirectional_attention.as_deref(), Some("vision"));
+    assert!(interface
+        .token_roles
+        .contains(&("boi_token_id".to_string(), 255999)));
+    let features = inv.text_features.expect("text features read");
+    assert_eq!(features.double_wide_mlp, Some(false));
+    assert_eq!(features.per_layer_input_vocab, Some(128));
+    for path in [
+        "audio_config",
+        "boi_token_id",
+        "vision_soft_tokens_per_image",
+        "text_config.use_bidirectional_attention",
+        "text_config.use_double_wide_mlp",
+        "text_config.vocab_size_per_layer_input",
+    ] {
+        let fact = inv.config_keys.iter().find(|f| f.path == path).unwrap();
+        assert_eq!(fact.status, KeyStatus::Consumed, "{path}");
+    }
+}

--- a/crates/larql-models/src/inventory/tests/config_keys.rs
+++ b/crates/larql-models/src/inventory/tests/config_keys.rs
@@ -220,3 +220,34 @@ fn a_non_object_root_is_one_unconsumed_fact() {
     assert_eq!(facts[0].status, KeyStatus::Unconsumed);
     assert_eq!(facts[0].value, json!("not an object"));
 }
+
+/// A label-map container (`id2label`, `label2id`) is metadata to its
+/// leaves, however they are named — a numbered leaf cannot be named in
+/// the leaf registry, and nothing under a label map moves a forward pass.
+/// A nested map inside one is flattened the same way.
+#[test]
+fn label_map_containers_are_metadata_to_every_leaf() {
+    let config = json!({
+        "vision_config": {
+            "id2label": { "0": "LABEL_0", "1": "LABEL_1", "nested": { "2": "LABEL_2" } },
+            "label2id": { "LABEL_0": 0 },
+            "problem_type": null,
+            "chunk_size_feed_forward": 0
+        }
+    });
+    let facts = classify_config(&config, &Default::default());
+    for path in [
+        "vision_config.id2label.0",
+        "vision_config.id2label.1",
+        "vision_config.id2label.nested.2",
+        "vision_config.label2id.LABEL_0",
+        "vision_config.problem_type",
+        "vision_config.chunk_size_feed_forward",
+    ] {
+        let fact = facts
+            .iter()
+            .find(|f| f.path == path)
+            .unwrap_or_else(|| panic!("{path}"));
+        assert_eq!(fact.status, KeyStatus::Metadata, "{path}");
+    }
+}

--- a/crates/larql-models/src/inventory/text_features.rs
+++ b/crates/larql-models/src/inventory/text_features.rs
@@ -1,0 +1,66 @@
+//! Declared text-decoder features the graph represents only as ABSENT.
+//!
+//! Gemma 3n/4-E style knobs — the double-wide MLP on KV-shared layers and
+//! the per-layer-input embedding vocabulary — that the current checkpoints
+//! of interest declare OFF (`false` / a vocabulary with a zero-width
+//! table). They must be READ so a checkpoint that turns them on blocks on
+//! the value rather than vanishing, but they are not (yet) `ModelConfig`
+//! fields: adding fields there touches every literal constructor across
+//! six crates, which a parallel architecture landing is also doing. This
+//! reader stores exactly what it reads and records the paths, like the
+//! representation and interface readers; the facts migrate to
+//! `ModelConfig` once that landing merges (see ROADMAP, V3-F0 witness 3).
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The text component container these live under.
+pub const TEXT_CONFIG_KEY: &str = "text_config";
+pub const DOUBLE_WIDE_MLP_KEY: &str = "use_double_wide_mlp";
+pub const PER_LAYER_INPUT_VOCAB_KEY: &str = "vocab_size_per_layer_input";
+
+/// What the checkpoint declares, verbatim.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TextFeatures {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub double_wide_mlp: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub per_layer_input_vocab: Option<u64>,
+}
+
+impl TextFeatures {
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+/// One reading: the features plus the paths it consumed.
+#[derive(Debug, Clone)]
+pub struct TextFeaturesReading {
+    pub features: TextFeatures,
+    pub consumed_paths: BTreeSet<String>,
+}
+
+/// Read the declared features. `None` when the checkpoint declares none.
+pub fn read_text_features(config: &Value) -> Option<TextFeaturesReading> {
+    let text = config.get(TEXT_CONFIG_KEY)?;
+    let mut consumed_paths = BTreeSet::new();
+    let mut features = TextFeatures::default();
+    if let Some(flag) = text.get(DOUBLE_WIDE_MLP_KEY).and_then(Value::as_bool) {
+        consumed_paths.insert(format!("{TEXT_CONFIG_KEY}.{DOUBLE_WIDE_MLP_KEY}"));
+        features.double_wide_mlp = Some(flag);
+    }
+    if let Some(vocab) = text.get(PER_LAYER_INPUT_VOCAB_KEY).and_then(Value::as_u64) {
+        consumed_paths.insert(format!("{TEXT_CONFIG_KEY}.{PER_LAYER_INPUT_VOCAB_KEY}"));
+        features.per_layer_input_vocab = Some(vocab);
+    }
+    (!features.is_empty()).then_some(TextFeaturesReading {
+        features,
+        consumed_paths,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/larql-models/src/inventory/text_features/tests.rs
+++ b/crates/larql-models/src/inventory/text_features/tests.rs
@@ -1,0 +1,29 @@
+//! The declared-text-features reader.
+
+use super::*;
+
+/// Both knobs are read verbatim and credited by full path; a config that
+/// declares neither yields no reading and no credit.
+#[test]
+fn reads_the_declared_knobs_and_credits_exactly_those_paths() {
+    let config = serde_json::json!({
+        "text_config": { "use_double_wide_mlp": false, "vocab_size_per_layer_input": 262144 }
+    });
+    let reading = read_text_features(&config).expect("declares features");
+    assert_eq!(reading.features.double_wide_mlp, Some(false));
+    assert_eq!(reading.features.per_layer_input_vocab, Some(262144));
+    assert_eq!(
+        reading.consumed_paths,
+        [
+            "text_config.use_double_wide_mlp",
+            "text_config.vocab_size_per_layer_input"
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    );
+    assert!(
+        read_text_features(&serde_json::json!({ "text_config": { "hidden_size": 8 } })).is_none()
+    );
+    assert!(read_text_features(&serde_json::json!({ "hidden_size": 8 })).is_none());
+}

--- a/crates/larql-vindex/src/format/vindex3/graph/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/build.rs
@@ -15,7 +15,7 @@ use larql_models::inventory::{ArchitectureInventory, TensorGroup};
 use super::component::{Component, ComponentRole};
 use super::edge::HiddenStateEdge;
 use super::object::{Fidelity, LogicalObject, ObjectKind, Representation, SourceBinding};
-use super::policy::{AttentionLayerPolicy, AttentionSpan};
+use super::policy::{AttentionLayerPolicy, AttentionSpan, HeadGeometry};
 use super::surface::{
     attach_stack_evidence, gate_evidence, head_from_resolved, surface_from_nested,
     surface_from_resolved,
@@ -379,6 +379,11 @@ fn attention_table(inventory: &ArchitectureInventory) -> Vec<AttentionLayerPolic
             },
             window: layer.window,
             position: layer.position,
+            geometry: Some(HeadGeometry {
+                head_dim: layer.head_dim,
+                num_kv_heads: layer.num_kv_heads,
+            }),
+            v_from_k: layer.v_from_k,
         })
         .collect()
 }
@@ -393,14 +398,27 @@ fn attention_table(inventory: &ArchitectureInventory) -> Vec<AttentionLayerPolic
 /// parsed into [`ComponentTopology`] and then dropped before the graph,
 /// with nothing reporting the loss.
 ///
-/// `None` when the component declares no `layer_types` (there is no
-/// interleave to record) or when it names a span the vocabulary does not
-/// contain — refusing rather than resolving an unknown spelling to a
-/// default, which is the failure this vocabulary exists to prevent.
+/// A component that declares a layer count but no `layer_types` attends
+/// fully on every layer — that is what the absence of an interleave means
+/// in the HF configs that omit it (Gemma 4's vision tower: 27 layers, one
+/// rope base, no `layer_types`), and recording it lets the tower's rope
+/// facts be judged against a table instead of vanishing. `None` when the
+/// component declares neither a count nor an interleave, or when it names
+/// a span the vocabulary does not contain — refusing rather than
+/// resolving an unknown spelling to a default, which is the failure this
+/// vocabulary exists to prevent.
 fn nested_attention_table(
     topology: &larql_models::inventory::components::ComponentTopology,
 ) -> Option<Vec<AttentionLayerPolicy>> {
-    let layer_types = topology.layer_types.as_ref()?;
+    let uniform_full;
+    let layer_types: &Vec<String> = match (&topology.layer_types, topology.num_layers) {
+        (Some(declared), _) => declared,
+        (None, Some(n)) => {
+            uniform_full = vec![AttentionSpan::Full.declared_name().to_string(); n];
+            &uniform_full
+        }
+        (None, None) => return None,
+    };
     // A rope base the component declares for itself; absent means the
     // component states no position policy, which is a fact, not a zero.
     let position = match topology.rope_theta {
@@ -416,6 +434,10 @@ fn nested_attention_table(
                 // a spatial window's extent is not a position count.
                 window: None,
                 position,
+                // A nested topology states one head geometry for the
+                // whole tower; the surface carries it.
+                geometry: None,
+                v_from_k: false,
             })
         })
         .collect()

--- a/crates/larql-vindex/src/format/vindex3/graph/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/mod.rs
@@ -50,7 +50,7 @@ pub use complete::{execution_completeness, CompletenessDefect};
 pub use component::{Component, ComponentRole};
 pub use edge::HiddenStateEdge;
 pub use object::{most_specific_owner, LogicalObject, ObjectKind, Representation, SourceBinding};
-pub use policy::AttentionLayerPolicy;
+pub use policy::{AttentionLayerPolicy, HeadGeometry};
 pub use roles::{NormPlacement, OperandRole};
 pub use surface::ExecutionSurface;
 

--- a/crates/larql-vindex/src/format/vindex3/graph/policy.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/policy.rs
@@ -79,4 +79,30 @@ pub struct AttentionLayerPolicy {
     pub window: Option<usize>,
     /// How the layer encodes position — including intentional absence.
     pub position: PositionPolicy,
+    /// This layer's head geometry when the family varies it by layer
+    /// (Gemma 4: `head_dim` 256 / 8 KV heads on sliding layers,
+    /// `global_head_dim` 512 / 2 KV heads on full layers). `None` = the
+    /// container predates per-layer geometry and every layer has the
+    /// component surface's geometry — an absence with one meaning, not
+    /// a default: the graph builder always records `Some` today, so a
+    /// `None` on a fresh encode is a bug, not a fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub geometry: Option<HeadGeometry>,
+    /// The value projection IS the key projection on this layer (Gemma 4
+    /// `attention_k_eq_v`, full layers only): no V operand exists and V is
+    /// the raw K projection, before the key's norm and rotation. Closure
+    /// pairs it both ways — a V operand on such a layer is a stray, a
+    /// missing V on any other layer is missing. Defaults for containers
+    /// written before it was recorded.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub v_from_k: bool,
+}
+
+/// One layer's attention head geometry. Query-head count is a component
+/// fact (no judged family varies it by layer); the KV side and the head
+/// width are what Gemma 4 varies, so those are the per-layer facts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeadGeometry {
+    pub head_dim: usize,
+    pub num_kv_heads: usize,
 }

--- a/crates/larql-vindex/src/format/vindex3/graph/surface.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/surface.rs
@@ -235,25 +235,10 @@ pub fn surface_from_resolved(
             "resolved.execution (pre-v3 inventory — re-run inspect-hf)".to_string(),
         ]);
     };
-    // The surface carries one head geometry for the whole component; a
-    // per-layer variation is a schema gap to surface, not to average away.
-    let mut missing = Vec::new();
-    for layer in &resolved.layers {
-        if layer.head_dim != resolved.head_dim || layer.num_kv_heads != resolved.num_kv_heads {
-            missing.push(format!(
-                "uniform head geometry (layer {} has head_dim {} / kv {}, component says {} / {})",
-                layer.layer,
-                layer.head_dim,
-                layer.num_kv_heads,
-                resolved.head_dim,
-                resolved.num_kv_heads
-            ));
-            break;
-        }
-    }
-    if !missing.is_empty() {
-        return Err(missing);
-    }
+    // The surface carries the component's declared head geometry; a
+    // family that varies it by layer (Gemma 4's global layers) records
+    // each layer's geometry on its `AttentionLayerPolicy`, and the op
+    // plan reads the layer's, so nothing here is averaged away.
     Ok(ExecutionSurface {
         attention: AttentionSurface {
             num_q_heads: resolved.num_q_heads,
@@ -435,7 +420,10 @@ pub fn surface_from_nested(
             parameter_free_qk_norm: ParameterFreeQkNorm::default(),
             output_gate: None,
             sinks: None,
-            attention_bias: None,
+            // What the tower declares about its projection biases, when
+            // it declares anything (Gemma 4 vision: `false`); the loader's
+            // tensor-presence check answers otherwise, as for text.
+            attention_bias: nested.tower.attention_bias,
         },
         ffn: FfnSurface {
             intermediate_size,

--- a/crates/larql-vindex/src/format/vindex3/graph/tests/surface.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/tests/surface.rs
@@ -135,19 +135,49 @@ fn missing_resolution_is_an_incomplete_surface_not_a_default() {
     ));
 }
 
-/// Per-layer head-geometry variation is a schema gap the surface refuses
-/// to average away.
+/// Per-layer head-geometry variation (Gemma 4's global layers) is
+/// carried on the layer's policy, not averaged into the surface and not
+/// refused: the surface builds with the component's declared geometry
+/// and the varying layer's policy states its own.
 #[test]
-fn non_uniform_head_geometry_refuses_a_surface() {
+fn non_uniform_head_geometry_is_carried_per_layer() {
     let (_a, _b, mut named) = glimmer_pair();
-    named[0].1.resolved.layers[0].head_dim = 16;
+    let varied_head_dim = 16;
+    let varied_kv_heads = 1;
+    let uniform_head_dim = named[0].1.resolved.layers[1].head_dim;
+    let uniform_kv_heads = named[0].1.resolved.layers[1].num_kv_heads;
+    named[0].1.resolved.layers[0].head_dim = varied_head_dim;
+    named[0].1.resolved.layers[0].num_kv_heads = varied_kv_heads;
     let built = build_from_inventories(&named);
-    let incomplete = built
-        .incomplete_surfaces
+    assert!(
+        !built
+            .incomplete_surfaces
+            .iter()
+            .any(|s| s.component == "target"),
+        "per-layer geometry must not refuse the surface: {:?}",
+        built.incomplete_surfaces
+    );
+    let target = built
+        .graph
+        .components
         .iter()
-        .find(|s| s.component == "target")
-        .expect("non-uniform geometry must refuse");
-    assert!(incomplete.missing[0].contains("uniform head geometry"));
+        .find(|c| c.id == "target")
+        .unwrap();
+    let table = target.attention.as_ref().expect("policy table");
+    let g0 = table[0].geometry.expect("layer 0 geometry recorded");
+    let g1 = table[1].geometry.expect("layer 1 geometry recorded");
+    assert_eq!(
+        (g0.head_dim, g0.num_kv_heads),
+        (varied_head_dim, varied_kv_heads)
+    );
+    assert_eq!(
+        (g1.head_dim, g1.num_kv_heads),
+        (uniform_head_dim, uniform_kv_heads)
+    );
+    // The surface still states the component's declared geometry.
+    let surface = target.execution.as_ref().expect("surface built");
+    assert_eq!(surface.attention.head_dim, uniform_head_dim);
+    assert_eq!(surface.attention.num_kv_heads, uniform_kv_heads);
 }
 
 /// Every nested-derivation refusal names its missing fact — a bare
@@ -173,6 +203,7 @@ fn nested_refusals_name_every_missing_fact() {
         rope_type: None,
         max_position_embeddings: None,
         patch: Default::default(),
+        tower: Default::default(),
     };
     let missing = surface_from_nested(&bare, false).unwrap_err();
     for fact in [

--- a/crates/larql-vindex/src/format/vindex3/graph/tests/validate.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/tests/validate.rs
@@ -20,6 +20,8 @@ fn component(id: &str, role: ComponentRole, layers: usize) -> Component {
                 span: AttentionSpan::Sliding,
                 window: Some(16),
                 position: PositionPolicy::Rope { theta: 10000.0 },
+                geometry: None,
+                v_from_k: false,
             };
             layers
         ]),
@@ -137,6 +139,8 @@ fn graph_round_trips_through_json_with_nope_policies() {
         span: AttentionSpan::Full,
         window: None,
         position: PositionPolicy::None,
+        geometry: None,
+        v_from_k: false,
     };
     let json = serde_json::to_string_pretty(&graph).unwrap();
     let back: SystemGraph = serde_json::from_str(&json).unwrap();

--- a/crates/larql-vindex/src/format/vindex3/opplan/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/build.rs
@@ -131,18 +131,28 @@ pub fn plan_component_ops(
     // ── Stack closure ──
     let hidden = component.hidden_size;
     let attn = &surface.attention;
-    let q_rows = attn.num_q_heads * attn.head_dim;
-    let kv_rows = attn.num_kv_heads * attn.head_dim;
     let inter = surface.ffn.intermediate_size;
     let gated_ffn = surface.ffn.ffn_type == FfnType::Gated;
-    let geometry = StackGeometry {
-        hidden,
-        q_rows,
-        kv_rows,
-        intermediate: inter,
-        head_dim: attn.head_dim,
-        num_q_heads: attn.num_q_heads,
-        qk_scope: attn.qk_norm_scope,
+    // Head geometry is a per-layer fact when the family varies it
+    // (Gemma 4's global layers); the layer's policy is the authority and
+    // the surface is what a pre-geometry container meant by "every
+    // layer".
+    let layer_geometry = |layer: usize| {
+        let (head_dim, num_kv_heads) = attention_table[layer]
+            .geometry
+            .map_or((attn.head_dim, attn.num_kv_heads), |g| {
+                (g.head_dim, g.num_kv_heads)
+            });
+        StackGeometry {
+            hidden,
+            q_rows: attn.num_q_heads * head_dim,
+            kv_rows: num_kv_heads * head_dim,
+            intermediate: inter,
+            head_dim,
+            num_q_heads: attn.num_q_heads,
+            num_kv_heads,
+            qk_scope: attn.qk_norm_scope,
+        }
     };
 
     // Judged routed-FFN semantics the plan can express today: pure routed
@@ -213,7 +223,8 @@ pub fn plan_component_ops(
             .get(&ObjectKind::ExpertBank)
             .map(|(o, _)| o.id.clone())
             .unwrap_or_default();
-        for layer in 0..component.num_layers {
+        for (layer, policy) in attention_table.iter().enumerate() {
+            let geometry = layer_geometry(layer);
             let present = by_layer.get(&layer);
             let bank = bank_by_layer.get(&layer);
             // A layer is routed by operand evidence — it has an expert
@@ -231,6 +242,7 @@ pub fn plan_component_ops(
                 sinks: attn.sinks.is_some(),
                 routed,
                 moe: surface.ffn.moe,
+                v_from_k: policy.v_from_k,
             };
             for role in required_roles(&ops) {
                 let holder = if role.is_expert_bank() { bank } else { present };
@@ -360,6 +372,7 @@ pub fn plan_component_ops(
         let slot = &by_layer[&layer];
         let get = |role: OperandRole| &slot[&role];
         let policy = &attention_table[layer];
+        let geometry = layer_geometry(layer);
         let bias = |role: OperandRole| {
             (attn.attention_bias == Some(true)).then(|| operand(&stack_id, get(role)))
         };
@@ -442,9 +455,9 @@ pub fn plan_component_ops(
                 get(OperandRole::PreAttentionNorm),
             ),
             attention: AttentionOp {
-                num_q_heads: attn.num_q_heads,
-                num_kv_heads: attn.num_kv_heads,
-                head_dim: attn.head_dim,
+                num_q_heads: geometry.num_q_heads,
+                num_kv_heads: geometry.num_kv_heads,
+                head_dim: geometry.head_dim,
                 query_scale: attn.query_scale,
                 score_scale: attn.score_scale,
                 logit_softcapping: attn.logit_softcapping,
@@ -455,7 +468,17 @@ pub fn plan_component_ops(
                 parameter_free_qk_norm: attn.parameter_free_qk_norm,
                 q: operand(&stack_id, get(OperandRole::AttnQ)),
                 k: operand(&stack_id, get(OperandRole::AttnK)),
-                v: operand(&stack_id, get(OperandRole::AttnV)),
+                // On a K≡V layer the value operand IS the key operand:
+                // the op reads one matrix twice, and says so.
+                v: operand(
+                    &stack_id,
+                    get(if policy.v_from_k {
+                        OperandRole::AttnK
+                    } else {
+                        OperandRole::AttnV
+                    }),
+                ),
+                v_from_k: policy.v_from_k,
                 o: operand(&stack_id, get(OperandRole::AttnO)),
                 output_gate: attn.output_gate.map(|spec| GateOp {
                     spec,
@@ -542,6 +565,9 @@ struct LayerOps {
     /// judgment); dense otherwise.
     routed: bool,
     moe: Option<MoeSurface>,
+    /// V is the K projection on this layer: no V operand is required, and
+    /// one present is a stray.
+    v_from_k: bool,
 }
 
 /// Roles every layer must supply, given the surface's ops.
@@ -551,9 +577,11 @@ fn required_roles(ops: &LayerOps) -> Vec<OperandRole> {
         OperandRole::PostAttentionNorm,
         OperandRole::AttnQ,
         OperandRole::AttnK,
-        OperandRole::AttnV,
         OperandRole::AttnO,
     ];
+    if !ops.v_from_k {
+        roles.push(OperandRole::AttnV);
+    }
     if ops.placement == NormPlacement::PrePost {
         roles.push(OperandRole::PreFfnNorm);
         roles.push(OperandRole::PostFfnNorm);
@@ -614,6 +642,9 @@ fn absent_op(role: OperandRole, ops: &LayerOps) -> Option<&'static str> {
             Some("attention projection bias (declared `attention_bias`)")
         }
         OperandRole::AttnSinks if !ops.sinks => Some("attention sinks (judged semantics)"),
+        OperandRole::AttnV if ops.v_from_k => {
+            Some("value projection (this layer's V is its K projection — `attention_k_eq_v`)")
+        }
         OperandRole::FfnGate if !ops.routed && !ops.gated_ffn => Some("gated FFN"),
         OperandRole::FfnGate | OperandRole::FfnUp | OperandRole::FfnDown if ops.routed => {
             Some("dense FFN (this layer is routed)")
@@ -649,7 +680,8 @@ fn absent_op(role: OperandRole, ops: &LayerOps) -> Option<&'static str> {
     }
 }
 
-/// The surface geometry every stack operand's shape is checked against.
+/// The geometry one layer's stack operands are checked against — the
+/// layer's own head geometry under the component's query-head count.
 struct StackGeometry {
     hidden: usize,
     q_rows: usize,
@@ -657,6 +689,7 @@ struct StackGeometry {
     intermediate: usize,
     head_dim: usize,
     num_q_heads: usize,
+    num_kv_heads: usize,
     qk_scope: larql_models::config::QkNormScope,
 }
 
@@ -675,6 +708,7 @@ fn expected_shape(
         intermediate,
         head_dim,
         num_q_heads,
+        num_kv_heads: _,
         qk_scope,
     } = *g;
     match role {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -344,6 +344,17 @@ impl AttentionOperands {
         store: &OperandStore,
         format: WeightFormat,
     ) -> Result<Self, VindexError> {
+        // Carried by the container, not executed yet (V3-F0 witness 3,
+        // G4.2): a K≡V layer and the parameter-free V norm. Loading `v`
+        // as the K matrix and running the plain path would silently skip
+        // the V norm — refuse, typed, before any bytes move.
+        if op.v_from_k || op.parameter_free_qk_norm.v {
+            return Err(VindexError::Parse(format!(
+                "attention op carries v_from_k={} / parameter-free v_norm={}, which no \
+                 executor runs yet (G4.2) — refusing rather than executing a different model",
+                op.v_from_k, op.parameter_free_qk_norm.v
+            )));
+        }
         Ok(Self {
             w_q: load_weight(store, &op.q, format)?,
             w_k: load_weight(store, &op.k, format)?,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -73,6 +73,17 @@ pub(super) fn unsupported_activation(shape: &str, activation: Activation) -> Vin
     ))
 }
 
+/// Refuse a position policy no backend here executes yet. A
+/// `PartialRope` plan (Gemma 4's proportional rotary on its global layers)
+/// is carried by the container and refused until G4.2 executes it —
+/// rotating the whole head at the plain frequencies would run a different
+/// model without saying so.
+pub(super) fn unsupported_position(policy: PositionPolicy) -> VindexError {
+    VindexError::Parse(format!(
+        "no executor for position policy {policy:?} — carried by the container, refused          until the interpreter executes it (V3-F0 witness 3, G4.2)"
+    ))
+}
+
 /// The gate policy every backend here honours today. A `ClampedGlu` plan
 /// (GPT-OSS's `swiglu_limit`) is carried by the container and refused
 /// until A-9.3 executes it — computing `activation(gate) * up` for it
@@ -202,6 +213,7 @@ pub(super) fn condition_qk_in_place(
             }
         }
         PositionPolicy::None => {}
+        policy @ PositionPolicy::PartialRope { .. } => return Err(unsupported_position(policy)),
     }
     Ok(())
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
@@ -142,6 +142,9 @@ impl ReferenceBackend {
                 }
             }
             PositionPolicy::None => {}
+            policy @ PositionPolicy::PartialRope { .. } => {
+                return Err(super::production::unsupported_position(policy));
+            }
         }
         Ok((q, k, v))
     }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
@@ -344,7 +344,11 @@ fn plain_attention<'a>(inputs: &'a [Vec<f32>], w: &'a [f32]) -> AttentionCall<'a
         w_v: WeightSlice::F32(w),
         w_o: WeightSlice::F32(w),
         qk_norm: None,
-        parameter_free_qk_norm: ParameterFreeQkNorm { q: false, k: false },
+        parameter_free_qk_norm: ParameterFreeQkNorm {
+            q: false,
+            k: false,
+            v: false,
+        },
         qk_norm_eps: EPS,
         query_scale: None,
         score_scale: 1.0 / (HEAD_DIM as f64).sqrt(),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/gemma4_refusals.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/gemma4_refusals.rs
@@ -1,0 +1,84 @@
+//! V3-F0 witness 3, G4.0: the semantics Gemma 4 declares are CARRIED by
+//! the container and REFUSED by every executor until G4.2 executes them.
+//! Each refusal is typed, names the rung, and fires before any bytes
+//! move — running the plain path would be a different model.
+
+use larql_models::config::{ParameterFreeQkNorm, PositionPolicy, RotaryFrequencyBasis};
+
+use super::lcg_values;
+use crate::format::vindex3::graph::policy::AttentionSpan;
+use crate::format::vindex3::opplan::exec::backend::{AttentionCall, PlanBackend, WeightSlice};
+use crate::format::vindex3::opplan::exec::production::ProductionBackend;
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+
+const HEAD_DIM: usize = 8;
+const EPS: f64 = 1e-5;
+const POSITIONS: usize = 2;
+const ROTARY_FRACTION: f64 = 0.25;
+const THETA: f64 = 1_000_000.0;
+/// The rung the refusal must name.
+const RUNG: &str = "G4.2";
+
+fn call<'a>(inputs: &'a [Vec<f32>], w: &'a [f32], position: PositionPolicy) -> AttentionCall<'a> {
+    AttentionCall {
+        inputs,
+        hidden: HEAD_DIM,
+        num_q_heads: 1,
+        num_kv_heads: 1,
+        head_dim: HEAD_DIM,
+        w_q: WeightSlice::F32(w),
+        w_k: WeightSlice::F32(w),
+        w_v: WeightSlice::F32(w),
+        w_o: WeightSlice::F32(w),
+        qk_norm: None,
+        parameter_free_qk_norm: ParameterFreeQkNorm {
+            q: false,
+            k: false,
+            v: false,
+        },
+        qk_norm_eps: EPS,
+        query_scale: None,
+        score_scale: 1.0 / (HEAD_DIM as f64).sqrt(),
+        logit_softcapping: None,
+        position,
+        span: AttentionSpan::Full,
+        window: None,
+        gate: None,
+        bias: None,
+        sinks: None,
+    }
+}
+
+/// A proportional partial rotary is refused by the reference and
+/// production backends alike, naming the policy and the rung — and the
+/// same call with plain rotary runs, so it is the policy being refused.
+#[test]
+fn a_partial_rotary_is_refused_typed_by_both_cpu_backends() {
+    let inputs: Vec<Vec<f32>> = (0..POSITIONS)
+        .map(|p| lcg_values(HEAD_DIM, p as u64 + 1))
+        .collect();
+    let w = lcg_values(HEAD_DIM * HEAD_DIM, 7);
+    let partial = PositionPolicy::PartialRope {
+        theta: THETA,
+        rotary_fraction: ROTARY_FRACTION,
+        basis: RotaryFrequencyBasis::HeadWidth,
+    };
+    for (name, backend) in [
+        (
+            "reference",
+            Box::new(ReferenceBackend::new()) as Box<dyn PlanBackend>,
+        ),
+        ("production", Box::new(ProductionBackend::new())),
+    ] {
+        let err = backend
+            .attention(call(&inputs, &w, partial))
+            .expect_err("PartialRope must be refused");
+        let message = err.to_string();
+        assert!(message.contains("PartialRope"), "{name}: {message}");
+        assert!(message.contains(RUNG), "{name}: {message}");
+        // Control: the plain rotary at the same base runs.
+        backend
+            .attention(call(&inputs, &w, PositionPolicy::Rope { theta: THETA }))
+            .unwrap_or_else(|e| panic!("{name}: plain rope must run: {e}"));
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -15,6 +15,7 @@ mod coverage_device;
 mod coverage_experts_production;
 mod decode;
 mod device;
+mod gemma4_refusals;
 mod golden;
 mod kernels;
 mod parity;

--- a/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
@@ -114,7 +114,14 @@ pub struct AttentionOp {
     pub parameter_free_qk_norm: ParameterFreeQkNorm,
     pub q: OperandRef,
     pub k: OperandRef,
+    /// The value projection; the SAME operand as `k` when `v_from_k`.
     pub v: OperandRef,
+    /// V is the raw K projection (Gemma 4 `attention_k_eq_v` on full
+    /// layers): `v` names the K operand, and the executor must take V from
+    /// that projection BEFORE the key's norm and rotation. Untagged
+    /// default so plans without it serialise byte-identically.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub v_from_k: bool,
     pub o: OperandRef,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_gate: Option<GateOp>,

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/closure.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/closure.rs
@@ -149,6 +149,57 @@ fn a_geometry_mismatch_blocks() {
     )));
 }
 
+/// Closure judges each layer against ITS OWN head geometry: a layer whose
+/// policy declares a different `head_dim` / KV-head count expects the
+/// matching projection shapes, and the mismatch names that layer's
+/// tensors with the per-layer expectation — the component surface's
+/// geometry is not what closure reads.
+#[test]
+fn closure_checks_shapes_against_the_layers_own_geometry() {
+    let dir = tempfile::tempdir().unwrap();
+    let tensors = dense_tensors();
+    let borrowed: Vec<(&str, &[usize])> = tensors
+        .iter()
+        .map(|(name, shape)| (*name, shape.as_slice()))
+        .collect();
+    let mut inventory = custom_artifact(dir.path(), &dense_config(), &borrowed);
+    // The config says head_dim 8 / 2 KV heads; declare layer 0 at four
+    // times the head width and one KV head, as a Gemma-4-style global
+    // layer would, without touching the stored tensors. (Not 16 / 1: that
+    // gives kv_rows 16 = 2 × 8, and a coincident product would hide the
+    // K/V check.)
+    let varied_head_dim = 32;
+    let varied_kv_heads = 1;
+    inventory.resolved.layers[0].head_dim = varied_head_dim;
+    inventory.resolved.layers[0].num_kv_heads = varied_kv_heads;
+    let named = vec![("dense-artifact".to_string(), inventory)];
+    let out = tempfile::tempdir().unwrap();
+    encode_system(&named, out.path()).unwrap();
+    let inspection = inspect_container(out.path(), false).unwrap();
+    let outcome = plan_component_ops(&inspection, out.path(), "target").unwrap();
+    assert!(outcome.plan.is_none());
+    let hidden = 64;
+    let q_heads = 8;
+    // q/o expect q_heads × 32 rows; k/v expect 1 × 32 rows.
+    let expect_q = vec![q_heads * varied_head_dim, hidden];
+    let expect_kv = vec![varied_kv_heads * varied_head_dim, hidden];
+    for (needle, expected) in [
+        ("q_proj", &expect_q),
+        ("k_proj", &expect_kv),
+        ("v_proj", &expect_kv),
+    ] {
+        assert!(
+            outcome.defects.iter().any(|d| matches!(
+                d,
+                ClosureDefect::GeometryMismatch { tensor, expected: e, actual: _ }
+                    if tensor.contains(needle) && e == expected
+            )),
+            "{needle} must be judged against the layer's geometry: {:?}",
+            outcome.defects
+        );
+    }
+}
+
 /// A single-sided QK-norm pair blocks with the missing half named.
 #[test]
 fn a_single_sided_qk_norm_blocks() {

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/gemma4_closure.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/gemma4_closure.rs
@@ -1,0 +1,73 @@
+//! V3-F0 witness 3, G4.0: operand closure honours the per-layer K≡V
+//! judgment both ways — the full layer needs no V operand and refuses a
+//! stray one; the sliding layers still need theirs. (The hybrid FFN is
+//! G4.1's rung; its unjudged-semantic defect is expected here and is not
+//! what these tests read.)
+
+use crate::format::vindex3::encode::encode_system;
+use crate::format::vindex3::graph::OperandRole;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::{plan_component_ops, ClosureDefect, OpPlanOutcome};
+use crate::format::vindex3::plan::tests_support::{gemma4_shaped_target_with, GEMMA4_FULL_LAYER};
+
+const SLIDING_LAYER: usize = 0;
+
+fn plan_variant(mutate_tensors: impl FnOnce(&mut Vec<(String, Vec<usize>)>)) -> OpPlanOutcome {
+    let dir = tempfile::tempdir().unwrap();
+    let inventory = gemma4_shaped_target_with(dir.path(), |_| {}, mutate_tensors);
+    let named = vec![("gemma4-artifact".to_string(), inventory)];
+    let out = tempfile::tempdir().unwrap();
+    encode_system(&named, out.path()).unwrap();
+    let inspection = inspect_container(out.path(), false).unwrap();
+    plan_component_ops(&inspection, out.path(), "target").unwrap()
+}
+
+fn missing_v(outcome: &OpPlanOutcome, layer: usize) -> bool {
+    outcome.defects.iter().any(|d| {
+        matches!(d, ClosureDefect::MissingOperand { layer: l, role: OperandRole::AttnV } if *l == layer)
+    })
+}
+
+/// The full layer ships no `v_proj` and closure does not ask for one;
+/// every sliding layer's V is still required.
+#[test]
+fn a_k_eq_v_layer_needs_no_v_operand_and_a_sliding_layer_still_does() {
+    let outcome = plan_variant(|_| {});
+    assert!(
+        !missing_v(&outcome, GEMMA4_FULL_LAYER),
+        "{:?}",
+        outcome.defects
+    );
+    assert!(!missing_v(&outcome, SLIDING_LAYER), "{:?}", outcome.defects);
+
+    let outcome = plan_variant(|tensors| {
+        tensors.retain(|(name, _)| {
+            name != &format!("model.language_model.layers.{SLIDING_LAYER}.self_attn.v_proj.weight")
+        });
+    });
+    assert!(missing_v(&outcome, SLIDING_LAYER), "{:?}", outcome.defects);
+}
+
+/// A `v_proj` on the K≡V layer is a stray: an operand whose op the layer
+/// does not carry, named as the value projection.
+#[test]
+fn a_v_operand_on_a_k_eq_v_layer_is_a_stray() {
+    let hidden = 64;
+    let kv_rows = 24;
+    let outcome = plan_variant(|tensors| {
+        tensors.push((
+            format!("model.language_model.layers.{GEMMA4_FULL_LAYER}.self_attn.v_proj.weight"),
+            vec![kv_rows, hidden],
+        ));
+    });
+    assert!(
+        outcome.defects.iter().any(|d| matches!(
+            d,
+            ClosureDefect::OperandImpliesAbsentOp { tensor, required_primitive, .. }
+                if tensor.contains(&format!("{GEMMA4_FULL_LAYER}.self_attn.v_proj"))
+                    && required_primitive.contains("value projection")
+        )),
+        "{:?}",
+        outcome.defects
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/mod.rs
@@ -3,6 +3,7 @@
 
 mod closure;
 mod coverage_opplan;
+mod gemma4_closure;
 mod plan;
 mod unjudged;
 

--- a/crates/larql-vindex/src/format/vindex3/plan/carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/carriage.rs
@@ -38,6 +38,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use super::super::graph::policy::AttentionSpan;
 use super::super::graph::Component;
 
 /// How far a declared fact travels from `config.json` into execution.
@@ -93,7 +94,37 @@ pub struct CarriageRule {
     /// Required for [`Carriage::Represented`] and deeper, and unused for
     /// [`Carriage::Parsed`] — a rule that stops at the parser has nothing
     /// to read back.
-    pub probe: Option<fn(&Component) -> Option<Value>>,
+    pub probe: Option<fn(&Component, &ProbeContext<'_>) -> Option<Value>>,
+}
+
+/// What a probe may know about the fact it is answering for, beyond the
+/// component: the attention span the fact's path names, when a family
+/// declares a fact per layer TYPE (`rope_parameters.full_attention.*` vs
+/// `rope_parameters.sliding_attention.*` — Gemma 3/4), and the declared
+/// value, so a probe can answer in the checkpoint's own spelling when
+/// several spellings name one judged variant (`gelu_pytorch_tanh` and
+/// `gelu_new` are both `Activation::GeluTanh`). A probe never lets the
+/// declared value *choose* what it reports — it only resolves aliases of
+/// what the schema already holds.
+pub struct ProbeContext<'a> {
+    pub span: Option<AttentionSpan>,
+    pub declared: &'a Value,
+}
+
+impl ProbeContext<'_> {
+    /// The per-layer-type scope a flattened config path names, if any.
+    pub fn span_of(path: &str) -> Option<AttentionSpan> {
+        [
+            AttentionSpan::Full,
+            AttentionSpan::Sliding,
+            AttentionSpan::Windowed,
+        ]
+        .into_iter()
+        .find(|span| {
+            path.split('.')
+                .any(|segment| segment == span.declared_name())
+        })
+    }
 }
 
 /// The rules. Every leaf classified
@@ -109,6 +140,12 @@ pub const CARRIAGE_RULES: &[CarriageRule] = &[
         reaches: Carriage::Lowered,
         site: "Component.attention[].position (PositionPolicy::Rope) → AttentionOp.position",
         probe: Some(probe_rope_theta),
+    },
+    CarriageRule {
+        leaf: "partial_rotary_factor",
+        reaches: Carriage::Lowered,
+        site: "Component.attention[].position (PositionPolicy::PartialRope.rotary_fraction) → AttentionOp.position",
+        probe: Some(probe_partial_rotary_factor),
     },
     CarriageRule {
         leaf: "layer_rope_theta",
@@ -268,6 +305,77 @@ pub const CARRIAGE_RULES: &[CarriageRule] = &[
         probe: Some(probe_attention_bias),
     },
     CarriageRule {
+        leaf: "num_kv_shared_layers",
+        reaches: Carriage::Represented,
+        // Gemma 4 E2B/E4B: the last N layers read the KV state of the last
+        // non-shared layer of their type instead of projecting their own —
+        // attention reading ANOTHER op's state, a cross-layer dependency
+        // the graph does not represent (V3-F0's open ontology question,
+        // scored by that witness). The table represents "no layer shares"
+        // and nothing else, so `0` agrees and any other count is dropped
+        // at the boundary and blocks — refused, never mis-served as
+        // per-layer projections.
+        site: "Component.attention[] — no KV-sharing relationship exists; only 0 is representable",
+        probe: Some(probe_kv_shared_layers),
+    },
+    // ── Gemma 4 (V3-F0 witness 3) ──────────────────────────────────
+    CarriageRule {
+        leaf: "attention_k_eq_v",
+        reaches: Carriage::Represented,
+        site: "Component.attention[].v_from_k → AttentionOp.v_from_k (closure-paired: no V operand on such a layer)",
+        probe: Some(probe_k_eq_v),
+    },
+    CarriageRule {
+        leaf: "enable_moe_block",
+        reaches: Carriage::Represented,
+        site: "ExecutionSurface.ffn.moe (Some = a routed block is judged) → LayerFfn::Routed / hybrid",
+        probe: Some(probe_moe_enabled),
+    },
+    CarriageRule {
+        leaf: "top_k_experts",
+        reaches: Carriage::Lowered,
+        site: "ExecutionSurface.ffn.moe.top_k → RoutedFfnOp routing",
+        probe: Some(probe_moe_top_k),
+    },
+    CarriageRule {
+        leaf: "global_head_dim",
+        reaches: Carriage::Lowered,
+        site: "Component.attention[].geometry.head_dim on the full layers → AttentionOp.head_dim",
+        probe: Some(probe_full_layer_head_dim),
+    },
+    CarriageRule {
+        leaf: "num_global_key_value_heads",
+        reaches: Carriage::Lowered,
+        site: "Component.attention[].geometry.num_kv_heads on the full layers → AttentionOp.num_kv_heads",
+        probe: Some(probe_full_layer_kv_heads),
+    },
+    CarriageRule {
+        leaf: "hidden_size_per_layer_input",
+        reaches: Carriage::Represented,
+        // Per-layer-input embeddings (Gemma 3n/4 E2B): a second embedding
+        // table gated into every layer. No object or op exists for it; the
+        // graph represents its ABSENCE only, so `0` agrees and any width
+        // is dropped at the boundary and blocks.
+        site: "no schema field — the graph represents PLE as absent; only 0 is representable",
+        probe: Some(probe_zero),
+    },
+    CarriageRule {
+        leaf: "use_double_wide_mlp",
+        reaches: Carriage::Represented,
+        // Doubles the MLP width on KV-shared layers; no KV-shared layer is
+        // representable (see `num_kv_shared_layers`), so only `false` is.
+        site: "no schema field — only `false` is representable",
+        probe: Some(probe_false),
+    },
+    CarriageRule {
+        leaf: "use_clipped_linears",
+        reaches: Carriage::Represented,
+        // A tower option that clips projection outputs; no op carries a
+        // clip, so only `false` is representable.
+        site: "no schema field on the tower surface — only `false` is representable",
+        probe: Some(probe_false),
+    },
+    CarriageRule {
         leaf: "max_position_embeddings",
         reaches: Carriage::Parsed,
         // A serving/KV-allocation bound, not a forward-pass semantic: no
@@ -290,19 +398,36 @@ pub fn rule_for(leaf: &str) -> Option<&'static CarriageRule> {
 // against the schema rather than believed. They return `None` when the
 // component has no surface or table to answer from.
 
-/// The uniform rope base across the attention table, when there is one.
+/// The layers a per-layer-type fact speaks for: those of the span the
+/// fact's path names, or every layer for a checkpoint-wide fact.
+fn layers_in_scope<'a>(
+    component: &'a Component,
+    ctx: &ProbeContext<'_>,
+) -> Option<impl Iterator<Item = &'a super::super::graph::AttentionLayerPolicy>> {
+    let table = component.attention.as_ref()?;
+    let span = ctx.span;
+    Some(
+        table
+            .iter()
+            .filter(move |l| span.is_none_or(|s| l.span == s)),
+    )
+}
+
+/// The uniform rope base across the layers in scope, when there is one:
+/// the whole table for `rope_theta`, one layer type for
+/// `rope_parameters.full_attention.rope_theta` (Gemma 4 declares 1e6 on
+/// its full layers and 1e4 on its sliding ones — two facts, two probes).
 /// A per-layer split (Muse-Glimmer's `layer_rope_theta`) answers `None`
 /// here and is checked by [`probe_layer_rope_theta`] instead.
-fn probe_rope_theta(component: &Component) -> Option<Value> {
-    let table = component.attention.as_ref()?;
-    let mut thetas = table.iter().filter_map(|l| l.position.rope_theta());
+fn probe_rope_theta(component: &Component, ctx: &ProbeContext<'_>) -> Option<Value> {
+    let mut thetas = layers_in_scope(component, ctx)?.filter_map(|l| l.position.rope_theta());
     let first = thetas.next()?;
     thetas.all(|t| t == first).then(|| json!(first))
 }
 
 /// Every layer's rope base in layer order, with NoPE layers as `0` —
 /// the same sentinel spelling the checkpoints use.
-fn probe_layer_rope_theta(component: &Component) -> Option<Value> {
+fn probe_layer_rope_theta(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     let table = component.attention.as_ref()?;
     Some(Value::Array(
         table
@@ -312,14 +437,94 @@ fn probe_layer_rope_theta(component: &Component) -> Option<Value> {
     ))
 }
 
-/// The rope *class* the table actually carries, in the checkpoint's own
-/// spelling: `yarn` when any rotating layer holds a YaRN block, else
-/// `default`. A table can not mix the two — the block is a checkpoint-wide
-/// fact — so the first rotating layer answers for all.
-fn probe_rope_type(component: &Component) -> Option<Value> {
+/// The rope *class* the layers in scope carry, in the checkpoint's own
+/// spelling: `yarn` when any rotating layer holds a YaRN block,
+/// `proportional` when any holds a head-width-basis partial rotary
+/// (Gemma 4's full layers), else `default`. Within one scope the class
+/// is uniform, so the first classed layer answers for all.
+fn probe_rope_type(component: &Component, ctx: &ProbeContext<'_>) -> Option<Value> {
+    let mut layers = layers_in_scope(component, ctx)?;
+    let class = layers
+        .find_map(|l| l.position.declared_rope_type())
+        .unwrap_or(larql_models::config::ROPE_TYPE_DEFAULT);
+    Some(json!(class))
+}
+
+/// The KV-sharing count the table represents: none. Every layer in the
+/// graph projects its own K/V, so the only declaration the schema agrees
+/// with is `0`.
+fn probe_kv_shared_layers(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
+    component.attention.as_ref()?;
+    Some(json!(0))
+}
+
+/// Whether any layer takes V from its K projection.
+fn probe_k_eq_v(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     let table = component.attention.as_ref()?;
-    let scaled = table.iter().any(|l| l.position.yarn().is_some());
-    Some(json!(if scaled { "yarn" } else { "default" }))
+    Some(json!(table.iter().any(|l| l.v_from_k)))
+}
+
+fn probe_moe_enabled(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
+    Some(json!(component.execution.as_ref()?.ffn.moe.is_some()))
+}
+
+fn probe_moe_top_k(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
+    Some(json!(component.execution.as_ref()?.ffn.moe?.top_k))
+}
+
+/// The head width the full-attention layers carry — the fact
+/// `global_head_dim` declares — when every full layer agrees. A layer
+/// without its own geometry has the surface's (that is what the absence
+/// means), so a uniform tower answers with its surface head width.
+fn probe_full_layer_head_dim(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
+    let table = component.attention.as_ref()?;
+    let surface = component.execution.as_ref()?;
+    let mut dims = table
+        .iter()
+        .filter(|l| l.span == AttentionSpan::Full)
+        .map(|l| {
+            l.geometry
+                .map_or(surface.attention.head_dim, |g| g.head_dim)
+        });
+    let first = dims.next()?;
+    dims.all(|d| d == first).then(|| json!(first))
+}
+
+/// The KV-head count the full-attention layers carry.
+fn probe_full_layer_kv_heads(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
+    let table = component.attention.as_ref()?;
+    let surface = component.execution.as_ref()?;
+    let mut heads = table
+        .iter()
+        .filter(|l| l.span == AttentionSpan::Full)
+        .map(|l| {
+            l.geometry
+                .map_or(surface.attention.num_kv_heads, |g| g.num_kv_heads)
+        });
+    let first = heads.next()?;
+    heads.all(|h| h == first).then(|| json!(first))
+}
+
+/// A fact the schema represents only as absent: the built component
+/// answers `0`, so a declared `0` agrees and anything else blocks.
+fn probe_zero(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
+    component.execution.as_ref()?;
+    Some(json!(0))
+}
+
+/// A switch the schema represents only as off.
+fn probe_false(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
+    component.execution.as_ref()?;
+    Some(json!(false))
+}
+
+/// The rotary fraction the layers in scope carry — `partial_rotary_factor`
+/// is a per-layer-type leaf on Gemma 4 (`full_attention` only).
+fn probe_partial_rotary_factor(component: &Component, ctx: &ProbeContext<'_>) -> Option<Value> {
+    let mut fractions =
+        layers_in_scope(component, ctx)?.filter_map(|l| l.position.rotary_fraction());
+    let first = fractions.next()?;
+    fractions.all(|f| f == first).then(|| json!(first))
 }
 
 /// The YaRN block the table carries, when it carries one. `None` when the
@@ -334,23 +539,23 @@ fn yarn_block(component: &Component) -> Option<larql_models::YarnRopeScaling> {
         .find_map(|l| l.position.yarn())
 }
 
-fn probe_yarn_factor(component: &Component) -> Option<Value> {
+fn probe_yarn_factor(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(yarn_block(component)?.factor))
 }
 
-fn probe_yarn_beta_fast(component: &Component) -> Option<Value> {
+fn probe_yarn_beta_fast(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(yarn_block(component)?.beta_fast))
 }
 
-fn probe_yarn_beta_slow(component: &Component) -> Option<Value> {
+fn probe_yarn_beta_slow(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(yarn_block(component)?.beta_slow))
 }
 
-fn probe_yarn_truncate(component: &Component) -> Option<Value> {
+fn probe_yarn_truncate(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(yarn_block(component)?.truncate))
 }
 
-fn probe_yarn_original_max(component: &Component) -> Option<Value> {
+fn probe_yarn_original_max(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(
         yarn_block(component)?.original_max_position_embeddings
     ))
@@ -359,7 +564,7 @@ fn probe_yarn_original_max(component: &Component) -> Option<Value> {
 /// Per-layer span kinds in the checkpoint's own vocabulary, so the
 /// comparison is against the declared spelling rather than a rendering
 /// this probe invents.
-fn probe_layer_types(component: &Component) -> Option<Value> {
+fn probe_layer_types(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     let table = component.attention.as_ref()?;
     Some(Value::Array(
         table
@@ -370,23 +575,32 @@ fn probe_layer_types(component: &Component) -> Option<Value> {
 }
 
 /// The uniform sliding window across sliding layers, when there is one.
-fn probe_sliding_window(component: &Component) -> Option<Value> {
+fn probe_sliding_window(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     let table = component.attention.as_ref()?;
     let mut windows = table.iter().filter_map(|l| l.window);
     let first = windows.next()?;
     windows.all(|w| w == first).then(|| json!(first))
 }
 
-fn probe_pre_norm_eps(component: &Component) -> Option<Value> {
+fn probe_pre_norm_eps(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(component.execution.as_ref()?.norm.pre.eps))
 }
 
-fn probe_post_norm_eps(component: &Component) -> Option<Value> {
+fn probe_post_norm_eps(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(component.execution.as_ref()?.norm.post?.eps))
 }
 
-fn probe_activation(component: &Component) -> Option<Value> {
+/// The judged activation, in the checkpoint's own spelling when that
+/// spelling is an alias of the judged variant (`gelu_pytorch_tanh` →
+/// `GeluTanh`); the schema's spelling otherwise, so a genuine
+/// disagreement still reads as one.
+fn probe_activation(component: &Component, ctx: &ProbeContext<'_>) -> Option<Value> {
     let activation = component.execution.as_ref()?.ffn.activation;
+    if let Some(declared) = ctx.declared.as_str() {
+        if larql_models::config::Activation::from_hf_name(declared) == Some(activation) {
+            return Some(json!(declared));
+        }
+    }
     serde_json::to_value(activation).ok()
 }
 
@@ -394,34 +608,34 @@ fn probe_activation(component: &Component) -> Option<Value> {
 /// clamped GLU. A plain-gated surface has no limit to answer with — a
 /// checkpoint declaring `swiglu_limit` that resolved to plain gating is
 /// then reported as unrepresented, which is the truth.
-fn probe_swiglu_limit(component: &Component) -> Option<Value> {
+fn probe_swiglu_limit(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     match component.execution.as_ref()?.ffn.gate_policy {
         larql_models::ExpertGatePolicy::ClampedGlu { limit, .. } => Some(json!(limit)),
         larql_models::ExpertGatePolicy::Gated => None,
     }
 }
 
-fn probe_attention_bias(component: &Component) -> Option<Value> {
+fn probe_attention_bias(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(
         component.execution.as_ref()?.attention.attention_bias?
     ))
 }
 
-fn probe_query_scale(component: &Component) -> Option<Value> {
+fn probe_query_scale(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(component.execution.as_ref()?.attention.query_scale?))
 }
 
-fn probe_score_scale(component: &Component) -> Option<Value> {
+fn probe_score_scale(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(component.execution.as_ref()?.attention.score_scale))
 }
 
-fn probe_attn_softcap(component: &Component) -> Option<Value> {
+fn probe_attn_softcap(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(
         component.execution.as_ref()?.attention.logit_softcapping?
     ))
 }
 
-fn probe_final_softcap(component: &Component) -> Option<Value> {
+fn probe_final_softcap(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(
         component
             .execution
@@ -432,7 +646,7 @@ fn probe_final_softcap(component: &Component) -> Option<Value> {
     ))
 }
 
-fn probe_output_multiplier(component: &Component) -> Option<Value> {
+fn probe_output_multiplier(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     Some(json!(
         component
             .execution

--- a/crates/larql-vindex/src/format/vindex3/plan/compare.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/compare.rs
@@ -17,6 +17,7 @@ use super::semantics::component_of;
 
 /// Sliding layer label used in the inventory's per-layer table.
 const ATTENTION_SLIDING: &str = "sliding";
+const ATTENTION_FULL: &str = "full";
 
 /// Extractor of the resolved counterpart for one declared scalar.
 type ResolvedScalar = fn(&ArchitectureInventory) -> Option<u64>;
@@ -59,23 +60,57 @@ fn declared(facts: &[ConfigKeyFact], leaf: &str) -> Option<(String, Value)> {
         .map(|f| (f.path.clone(), f.value.clone()))
 }
 
-/// Declared RoPE base, in the parser's own specificity order. Returns the
-/// path that supplied it so a mismatch names its source.
-fn declared_rope_theta(facts: &[ConfigKeyFact]) -> Option<(String, f64)> {
-    const CANDIDATES: &[&str] = &[
-        "text_config.rope_parameters.full_attention.rope_theta",
-        "rope_parameters.full_attention.rope_theta",
+/// The declared RoPE bases, each with the layers it speaks for: the
+/// checkpoint-wide base (flat `rope_theta`, transformers-5's flat
+/// `rope_parameters.rope_theta`) speaks for every layer; the per-layer-type
+/// bases (`rope_parameters.full_attention.rope_theta` /
+/// `…sliding_attention.rope_theta` — Gemma 3/4) each speak for their span
+/// only. Returns `(path, theta, span-or-None)` per declaration so a
+/// mismatch names its source and is judged against the right layers —
+/// Gemma 4 declares 1e6 on full layers and 1e4 on sliding ones, and
+/// comparing either against the whole table is a false mismatch.
+fn declared_rope_thetas(facts: &[ConfigKeyFact]) -> Vec<(String, f64, Option<&'static str>)> {
+    const PER_SPAN: &[(&str, &str)] = &[
+        (
+            "text_config.rope_parameters.full_attention.rope_theta",
+            ATTENTION_FULL,
+        ),
+        ("rope_parameters.full_attention.rope_theta", ATTENTION_FULL),
+        (
+            "text_config.rope_parameters.sliding_attention.rope_theta",
+            ATTENTION_SLIDING,
+        ),
+        (
+            "rope_parameters.sliding_attention.rope_theta",
+            ATTENTION_SLIDING,
+        ),
+    ];
+    const WHOLE_TABLE: &[&str] = &[
         "text_config.rope_parameters.rope_theta",
         "rope_parameters.rope_theta",
         "text_config.rope_theta",
         "rope_theta",
     ];
-    CANDIDATES.iter().find_map(|path| {
-        facts
-            .iter()
-            .find(|f| f.path == *path)
-            .and_then(|f| f.value.as_f64().map(|v| (f.path.clone(), v)))
-    })
+    let mut out: Vec<(String, f64, Option<&'static str>)> = PER_SPAN
+        .iter()
+        .filter_map(|(path, span)| {
+            facts
+                .iter()
+                .find(|f| f.path == *path)
+                .and_then(|f| f.value.as_f64().map(|v| (f.path.clone(), v, Some(*span))))
+        })
+        .collect();
+    // A whole-table base only speaks when no per-span base was declared —
+    // the per-span form is the more specific spelling of the same fact.
+    if out.is_empty() {
+        out.extend(WHOLE_TABLE.iter().find_map(|path| {
+            facts
+                .iter()
+                .find(|f| f.path == *path)
+                .and_then(|f| f.value.as_f64().map(|v| (f.path.clone(), v, None)))
+        }));
+    }
+    out
 }
 
 /// Run every comparator over one inventory.
@@ -101,7 +136,7 @@ pub fn compare(inventory: &ArchitectureInventory) -> Vec<Finding> {
         ));
     }
 
-    findings.extend(rope_theta_finding(inventory));
+    findings.extend(rope_theta_findings(inventory));
     findings.extend(layer_rope_theta_findings(inventory));
     findings.extend(layer_types_finding(inventory));
     findings
@@ -134,12 +169,11 @@ fn value_finding(
     }
 }
 
-/// Uniform declared θ vs the resolved policy of every layer.
-fn rope_theta_finding(inventory: &ArchitectureInventory) -> Option<Finding> {
-    let (path, declared_theta) = declared_rope_theta(&inventory.config_keys)?;
+/// Each declared θ vs the resolved policy of the layers it speaks for.
+fn rope_theta_findings(inventory: &ArchitectureInventory) -> Vec<Finding> {
     let layers = &inventory.resolved.layers;
     if layers.is_empty() {
-        return None;
+        return Vec::new();
     }
     // A per-layer declaration overrides the uniform one; that comparator
     // owns the answer then.
@@ -148,19 +182,29 @@ fn rope_theta_finding(inventory: &ArchitectureInventory) -> Option<Finding> {
         .iter()
         .any(|f| f.path.ends_with("layer_rope_theta"))
     {
-        return None;
+        return Vec::new();
     }
-    let disagreeing = layers
-        .iter()
-        .filter(|l| l.position.rope_theta() != Some(declared_theta))
-        .count();
-    Some(value_finding(
-        &path,
-        disagreeing == 0,
-        SemanticClass::ExecutionSemantic,
-        declared_theta.into(),
-        serde_json::to_value(layers[0].position).ok(),
-    ))
+    declared_rope_thetas(&inventory.config_keys)
+        .into_iter()
+        .filter_map(|(path, declared_theta, span)| {
+            let in_scope: Vec<_> = layers
+                .iter()
+                .filter(|l| span.is_none_or(|s| l.attention == s))
+                .collect();
+            let first = in_scope.first()?;
+            let disagreeing = in_scope
+                .iter()
+                .filter(|l| l.position.rope_theta() != Some(declared_theta))
+                .count();
+            Some(value_finding(
+                &path,
+                disagreeing == 0,
+                SemanticClass::ExecutionSemantic,
+                declared_theta.into(),
+                serde_json::to_value(first.position).ok(),
+            ))
+        })
+        .collect()
 }
 
 /// Per-layer declared θ array vs the resolved per-layer position policy.

--- a/crates/larql-vindex/src/format/vindex3/plan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/mod.rs
@@ -244,8 +244,12 @@ fn carriage_finding(
             detail: format!("stops at the parser by judgement — {}", rule.site),
         };
     }
+    let ctx = carriage::ProbeContext {
+        span: carriage::ProbeContext::span_of(&fact.path),
+        declared: &fact.value,
+    };
     let carried = component_for_key(built, &component_name)
-        .and_then(|component| rule.probe.and_then(|probe| probe(component)));
+        .and_then(|component| rule.probe.and_then(|probe| probe(component, &ctx)));
     match carried {
         // The schema holds a value: compare it to the declaration. This
         // is where a dropped fact dies — GPT-OSS declares `yarn` and the

--- a/crates/larql-vindex/src/format/vindex3/plan/semantics.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/semantics.rs
@@ -51,6 +51,23 @@ pub const EXECUTION_SEMANTIC_KEYS: &[&str] = &[
     // ±this value before the GLU. It changes what the FFN computes, so
     // it is execution-semantic wherever it is declared.
     "swiglu_limit",
+    // Gemma 4 (V3-F0 witness 3). Each changes what a layer computes:
+    // V taken from the K projection on the layers a family says so;
+    // whether a routed expert block runs beside the dense MLP and how
+    // many experts each token routes to; the head geometry the full
+    // layers use instead of the component's (`global_head_dim`,
+    // `num_global_key_value_heads`); the per-layer-input (PLE) width and
+    // the double-wide MLP on shared-KV layers, both of which the graph
+    // represents only as ABSENT (`0` / `false`), so any other declaration
+    // blocks; and the tower's clipped-linears flag, likewise `false` only.
+    "attention_k_eq_v",
+    "enable_moe_block",
+    "top_k_experts",
+    "global_head_dim",
+    "num_global_key_value_heads",
+    "hidden_size_per_layer_input",
+    "use_double_wide_mlp",
+    "use_clipped_linears",
 ];
 
 /// Keys that describe stored operands: widths, depths, head geometry,
@@ -80,6 +97,26 @@ pub const TENSOR_SEMANTIC_KEYS: &[&str] = &[
     // way every other tensor semantic is proven by placement.
     "quant_method",
     "modules_to_not_convert",
+    // Routed-expert bank geometry: proven carried by the placed
+    // `expert_bank` object and the operand closure over its shapes
+    // (`[E, 2I, H]` / `[E, H, I]`), the same way every other tensor
+    // semantic is proven by placement.
+    "num_experts",
+    "num_local_experts",
+    "n_routed_experts",
+    "moe_intermediate_size",
+    // Gemma 4's per-layer-input vocabulary: the width of a table that is
+    // absent when `hidden_size_per_layer_input` is 0 (that leaf's rule
+    // holds the gate); a non-zero PLE width would place the table.
+    "vocab_size_per_layer_input",
+    // Perception-tower stored geometry: the output projector's pooling
+    // kernel, its position-embedding table size, and its declared global
+    // head width (equal to `head_dim` on Gemma 4 vision).
+    "pooling_kernel_size",
+    "position_embedding_size",
+    // Input standardisation: its parameters are the placed `std_scale` /
+    // `std_bias` tensors; the flag says they apply.
+    "standardize",
 ];
 
 /// Keys that declare a cross-component contract: hidden-state taps, block
@@ -90,6 +127,21 @@ pub const INTERFACE_SEMANTIC_KEYS: &[&str] = &[
     "mask_token_id",
     "image_token_id",
     "video_token_id",
+    // The rest of a multimodal join (Gemma 4): the tokens that open,
+    // close or stand in for an audio / image span, how many soft tokens
+    // an image expands to (declared twice — root and tower), the span
+    // kind the text model attends bidirectionally over, and a tower the
+    // checkpoint declares it does NOT have (`audio_config: null`).
+    "audio_token_id",
+    "boi_token_id",
+    "eoi_token_id",
+    "boa_token_id",
+    "eoa_token_id",
+    "eoa_token_index",
+    "vision_soft_tokens_per_image",
+    "default_output_length",
+    "use_bidirectional_attention",
+    "audio_config",
 ];
 
 /// Identity facts inert for a forward pass wherever they appear.

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/carriage.rs
@@ -118,30 +118,42 @@ fn declared_default_rope_type_is_carried_not_blocked() {
     assert!(!finding.blocks());
 }
 
-/// An execution-semantic key with no carriage rule blocks. This is the
-/// state the module exists to abolish: "parsed" was previously enough to
-/// keep a key out of the report entirely, so a fact nobody had checked
-/// looked identical to one that was carried.
-///
-/// `partial_rotary_factor` is the live occupant: consumed by the parser,
-/// execution-semantic (it changes which dimensions rotate), and judged by
-/// no rule yet. (`swiglu_limit` held this slot until A-9.0 gave it a gate
-/// policy — see the two tests below.)
+/// Every execution-semantic leaf the registry knows has a carriage rule.
+/// The plan blocks an unruled execution-semantic leaf ("parser
+/// consumption is not representation authority" — the safety net stays
+/// in `carriage_finding`), and this pins that the net catches nothing
+/// today: `partial_rotary_factor` was the last live occupant until G4.0
+/// judged it against `PositionPolicy::PartialRope`, and
+/// `num_kv_shared_layers` until G4.0 gave it a rule; a leaf added to the
+/// registry without a rule fails here before it fails on a checkpoint.
 #[test]
-fn an_execution_semantic_key_with_no_carriage_rule_blocks() {
+fn every_execution_semantic_leaf_has_a_carriage_rule() {
+    use crate::format::vindex3::plan::semantics::EXECUTION_SEMANTIC_KEYS;
+    let unruled: Vec<&str> = EXECUTION_SEMANTIC_KEYS
+        .iter()
+        .copied()
+        .filter(|leaf| rule_for(leaf).is_none())
+        .collect();
+    assert!(
+        unruled.is_empty(),
+        "execution-semantic leaves with no carriage rule: {unruled:?}"
+    );
+}
+
+/// A judged partial rotary is carried, per layer type: Gemma 4 declares
+/// `partial_rotary_factor` under `rope_parameters.full_attention` and the
+/// probe answers from the full layers' policy alone.
+#[test]
+fn a_partial_rotary_factor_is_judged_against_the_full_layers() {
     let findings = plan_with(|config| {
         config["text_config"]["partial_rotary_factor"] = serde_json::json!(0.5);
     });
     let finding = finding_for(&findings, "partial_rotary_factor");
-
-    assert_eq!(finding.category, FindingCategory::Unrepresented);
+    // Glimmer's resolver knows no partial rotary, so the fact is declared
+    // and dropped — the honest verdict, and it blocks.
     assert_eq!(finding.class, SemanticClass::ExecutionSemantic);
-    assert_eq!(finding.carriage, Some(Carriage::Parsed));
-    assert!(
-        finding.detail.contains("no carriage rule"),
-        "the refusal must name the missing judgement: {}",
-        finding.detail
-    );
+    assert_eq!(finding.category, FindingCategory::Unrepresented);
+    assert!(finding.detail.contains("PartialRope"), "{}", finding.detail);
     assert!(finding.blocks());
 }
 

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/gemma4.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/gemma4.rs
@@ -1,0 +1,450 @@
+//! V3-F0 witness 3 — Gemma 4 through the plan gate (G4.0): every hostile
+//! semantic the family declares is REPRESENTED, judged against what the
+//! built graph holds, and each finding is pinned by re-dropping the fact
+//! it guards. The miniature mirrors the real 26B-A4B checkpoint's config
+//! shape and tensor spelling (`plan::tests_support::gemma4_shaped_target`).
+
+use larql_models::config::{PositionPolicy, RotaryFrequencyBasis};
+
+use crate::format::vindex3::plan::tests_support::{
+    gemma4_shaped_target, gemma4_shaped_target_with, GEMMA4_FIXTURE_LAYERS, GEMMA4_FULL_LAYER,
+    GEMMA4_FULL_THETA, GEMMA4_GLOBAL_HEAD_DIM, GEMMA4_GLOBAL_KV_HEADS, GEMMA4_HEAD_DIM,
+    GEMMA4_KV_HEADS, GEMMA4_PARTIAL_ROTARY, GEMMA4_SLIDING_THETA, GEMMA4_TOP_K,
+};
+use crate::format::vindex3::plan::{plan_system, Finding, FindingCategory, SystemPlan};
+
+fn plan_of(inventory: larql_models::inventory::ArchitectureInventory) -> SystemPlan {
+    plan_system(&[("gemma4-artifact".to_string(), inventory)])
+}
+
+fn findings(plan: &SystemPlan) -> Vec<&Finding> {
+    plan.artifacts
+        .iter()
+        .flat_map(|a| a.findings.iter())
+        .collect()
+}
+
+fn finding_for<'a>(plan: &'a SystemPlan, subject: &str) -> &'a Finding {
+    findings(plan)
+        .into_iter()
+        .find(|f| f.subject == subject)
+        .unwrap_or_else(|| panic!("no finding for `{subject}`"))
+}
+
+/// The theta a rope finding resolved to: the resolution comparator
+/// reports the whole per-layer policy, the carriage probe the bare base;
+/// both name the same number.
+fn resolved_theta(finding: &Finding) -> Option<f64> {
+    let resolved = finding.resolved.as_ref()?;
+    resolved
+        .get("theta")
+        .and_then(serde_json::Value::as_f64)
+        .or_else(|| resolved.as_f64())
+}
+
+/// The gate itself: the whole family plans admissibly — every declared
+/// fact representable, none dropped, none disagreeing.
+#[test]
+fn the_gemma4_shaped_checkpoint_plans_admissibly() {
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_of(gemma4_shaped_target(dir.path()));
+    let blocking: Vec<String> = findings(&plan)
+        .into_iter()
+        .filter(|f| f.blocks())
+        .map(|f| format!("{}: {}", f.subject, f.detail))
+        .collect();
+    assert!(plan.admissible, "blocking findings: {blocking:#?}");
+    assert_eq!(plan.summary.mismatched, 0);
+    assert_eq!(plan.summary.unrepresented, 0);
+}
+
+/// Per-layer head geometry: the graph records each layer's own
+/// `head_dim` / KV-head count, the full layer's differing from the
+/// component's, and `global_head_dim` / `num_global_key_value_heads` are
+/// judged against the full layers alone.
+#[test]
+fn per_layer_head_geometry_is_carried_and_the_global_facts_judged_against_full_layers() {
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_of(gemma4_shaped_target(dir.path()));
+    let target = plan
+        .graph
+        .components
+        .iter()
+        .find(|c| c.id == "target")
+        .expect("text component");
+    let table = target.attention.as_ref().expect("policy table");
+    assert_eq!(table.len(), GEMMA4_FIXTURE_LAYERS);
+    for (i, layer) in table.iter().enumerate() {
+        let g = layer.geometry.expect("geometry recorded on every layer");
+        let expected = if i == GEMMA4_FULL_LAYER {
+            (GEMMA4_GLOBAL_HEAD_DIM, GEMMA4_GLOBAL_KV_HEADS)
+        } else {
+            (GEMMA4_HEAD_DIM, GEMMA4_KV_HEADS)
+        };
+        assert_eq!((g.head_dim, g.num_kv_heads), expected, "layer {i}");
+    }
+    let ghd = finding_for(&plan, "text_config.global_head_dim");
+    assert_eq!(ghd.category, FindingCategory::Representable);
+    assert_eq!(
+        ghd.resolved,
+        Some(serde_json::json!(GEMMA4_GLOBAL_HEAD_DIM))
+    );
+    let gkv = finding_for(&plan, "text_config.num_global_key_value_heads");
+    assert_eq!(
+        gkv.resolved,
+        Some(serde_json::json!(GEMMA4_GLOBAL_KV_HEADS))
+    );
+}
+
+/// Per-layer-type rope: each declared theta is judged against the layers
+/// of its own type. Re-drop: change the resolved full layer's theta and
+/// only the `full_attention` declaration mismatches; the sliding one
+/// still agrees.
+#[test]
+fn per_layer_type_rope_thetas_are_judged_against_their_own_layers() {
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_of(gemma4_shaped_target(dir.path()));
+    let full = finding_for(
+        &plan,
+        "text_config.rope_parameters.full_attention.rope_theta",
+    );
+    let sliding = finding_for(
+        &plan,
+        "text_config.rope_parameters.sliding_attention.rope_theta",
+    );
+    assert_eq!(
+        full.category,
+        FindingCategory::Representable,
+        "{}",
+        full.detail
+    );
+    assert_eq!(
+        sliding.category,
+        FindingCategory::Representable,
+        "{}",
+        sliding.detail
+    );
+    assert_eq!(resolved_theta(full), Some(GEMMA4_FULL_THETA));
+    assert_eq!(resolved_theta(sliding), Some(GEMMA4_SLIDING_THETA));
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut dropped = gemma4_shaped_target(dir.path());
+    let wrong_theta = 123.0;
+    dropped.resolved.layers[GEMMA4_FULL_LAYER].position =
+        PositionPolicy::Rope { theta: wrong_theta };
+    let plan = plan_of(dropped);
+    let full = finding_for(
+        &plan,
+        "text_config.rope_parameters.full_attention.rope_theta",
+    );
+    let sliding = finding_for(
+        &plan,
+        "text_config.rope_parameters.sliding_attention.rope_theta",
+    );
+    assert_eq!(
+        full.category,
+        FindingCategory::Mismatched,
+        "{}",
+        full.detail
+    );
+    assert_eq!(
+        sliding.category,
+        FindingCategory::Representable,
+        "{}",
+        sliding.detail
+    );
+    assert!(!plan.admissible);
+}
+
+/// The proportional partial rotary is a policy variant on the full
+/// layers, and both its leaves (`rope_type: proportional`,
+/// `partial_rotary_factor`) are judged against it. Re-drop: resolve the
+/// full layer as plain rotary and `rope_type` mismatches (`default` vs
+/// `proportional`) while `partial_rotary_factor` becomes unrepresented.
+#[test]
+fn proportional_partial_rotary_is_a_policy_the_full_layers_carry() {
+    let dir = tempfile::tempdir().unwrap();
+    let inventory = gemma4_shaped_target(dir.path());
+    assert_eq!(
+        inventory.resolved.layers[GEMMA4_FULL_LAYER].position,
+        PositionPolicy::PartialRope {
+            theta: GEMMA4_FULL_THETA,
+            rotary_fraction: GEMMA4_PARTIAL_ROTARY,
+            basis: RotaryFrequencyBasis::HeadWidth,
+        }
+    );
+    assert_eq!(
+        inventory.resolved.layers[0].position,
+        PositionPolicy::Rope {
+            theta: GEMMA4_SLIDING_THETA
+        }
+    );
+    let plan = plan_of(inventory);
+    let kind = finding_for(
+        &plan,
+        "text_config.rope_parameters.full_attention.rope_type",
+    );
+    assert_eq!(
+        kind.category,
+        FindingCategory::Representable,
+        "{}",
+        kind.detail
+    );
+    assert_eq!(kind.resolved, Some(serde_json::json!("proportional")));
+    let fraction = finding_for(
+        &plan,
+        "text_config.rope_parameters.full_attention.partial_rotary_factor",
+    );
+    assert_eq!(
+        fraction.category,
+        FindingCategory::Representable,
+        "{}",
+        fraction.detail
+    );
+    assert_eq!(
+        fraction.resolved,
+        Some(serde_json::json!(GEMMA4_PARTIAL_ROTARY))
+    );
+    // The sliding declaration is the default class and says so.
+    let sliding_kind = finding_for(
+        &plan,
+        "text_config.rope_parameters.sliding_attention.rope_type",
+    );
+    assert_eq!(sliding_kind.resolved, Some(serde_json::json!("default")));
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut dropped = gemma4_shaped_target(dir.path());
+    dropped.resolved.layers[GEMMA4_FULL_LAYER].position = PositionPolicy::Rope {
+        theta: GEMMA4_FULL_THETA,
+    };
+    let plan = plan_of(dropped);
+    let kind = finding_for(
+        &plan,
+        "text_config.rope_parameters.full_attention.rope_type",
+    );
+    assert_eq!(
+        kind.category,
+        FindingCategory::Mismatched,
+        "{}",
+        kind.detail
+    );
+    let fraction = finding_for(
+        &plan,
+        "text_config.rope_parameters.full_attention.partial_rotary_factor",
+    );
+    assert_eq!(
+        fraction.category,
+        FindingCategory::Unrepresented,
+        "{}",
+        fraction.detail
+    );
+    assert!(!plan.admissible);
+}
+
+/// K≡V is carried per layer and judged. Re-drop: resolve every layer as
+/// projecting its own V and the declaration mismatches.
+#[test]
+fn k_eq_v_is_carried_on_the_full_layer_and_judged() {
+    let dir = tempfile::tempdir().unwrap();
+    let inventory = gemma4_shaped_target(dir.path());
+    let shares: Vec<bool> = inventory
+        .resolved
+        .layers
+        .iter()
+        .map(|l| l.v_from_k)
+        .collect();
+    let mut expected = vec![false; GEMMA4_FIXTURE_LAYERS];
+    expected[GEMMA4_FULL_LAYER] = true;
+    assert_eq!(shares, expected);
+    // The parameter-free V norm rides every layer.
+    assert!(
+        inventory
+            .resolved
+            .execution
+            .as_ref()
+            .unwrap()
+            .parameter_free_qk_norm
+            .v
+    );
+    let plan = plan_of(inventory);
+    let k_eq_v = finding_for(&plan, "text_config.attention_k_eq_v");
+    assert_eq!(
+        k_eq_v.category,
+        FindingCategory::Representable,
+        "{}",
+        k_eq_v.detail
+    );
+    assert_eq!(k_eq_v.resolved, Some(serde_json::json!(true)));
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut dropped = gemma4_shaped_target(dir.path());
+    for layer in &mut dropped.resolved.layers {
+        layer.v_from_k = false;
+    }
+    let plan = plan_of(dropped);
+    let k_eq_v = finding_for(&plan, "text_config.attention_k_eq_v");
+    assert_eq!(
+        k_eq_v.category,
+        FindingCategory::Mismatched,
+        "{}",
+        k_eq_v.detail
+    );
+}
+
+/// The knobs the graph represents only as absent agree at their absent
+/// value and block at any other: PLE width, the double-wide MLP,
+/// KV-shared layers. Each is a declared fact, so the mismatch names the
+/// declared value rather than dropping it.
+#[test]
+fn absent_only_knobs_agree_when_off_and_block_when_on() {
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_of(gemma4_shaped_target(dir.path()));
+    for subject in [
+        "text_config.hidden_size_per_layer_input",
+        "text_config.use_double_wide_mlp",
+        "text_config.num_kv_shared_layers",
+        "text_config.vocab_size_per_layer_input",
+    ] {
+        let f = finding_for(&plan, subject);
+        assert_eq!(
+            f.category,
+            FindingCategory::Representable,
+            "{subject}: {}",
+            f.detail
+        );
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let ple_width = 256;
+    let shared_layers = 2;
+    let plan = plan_of(gemma4_shaped_target_with(
+        dir.path(),
+        |config| {
+            config["text_config"]["hidden_size_per_layer_input"] = serde_json::json!(ple_width);
+            config["text_config"]["use_double_wide_mlp"] = serde_json::json!(true);
+            config["text_config"]["num_kv_shared_layers"] = serde_json::json!(shared_layers);
+        },
+        |_| {},
+    ));
+    for subject in [
+        "text_config.hidden_size_per_layer_input",
+        "text_config.use_double_wide_mlp",
+        "text_config.num_kv_shared_layers",
+    ] {
+        let f = finding_for(&plan, subject);
+        assert_eq!(
+            f.category,
+            FindingCategory::Mismatched,
+            "{subject}: {}",
+            f.detail
+        );
+        assert!(f.blocks());
+    }
+    assert!(!plan.admissible);
+}
+
+/// The hybrid-MoE declarations are judged against the routed surface:
+/// `enable_moe_block` against the presence of a MoE judgment, `top_k_experts`
+/// against its top-k. Re-drop: withdraw the block and both change.
+#[test]
+fn the_hybrid_moe_declarations_are_judged_against_the_routed_surface() {
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_of(gemma4_shaped_target(dir.path()));
+    let enabled = finding_for(&plan, "text_config.enable_moe_block");
+    assert_eq!(enabled.resolved, Some(serde_json::json!(true)));
+    let top_k = finding_for(&plan, "text_config.top_k_experts");
+    assert_eq!(top_k.resolved, Some(serde_json::json!(GEMMA4_TOP_K)));
+
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_of(gemma4_shaped_target_with(
+        dir.path(),
+        |config| {
+            config["text_config"]["enable_moe_block"] = serde_json::json!(false);
+        },
+        |tensors| {
+            tensors.retain(|(name, _)| !name.contains(".experts.") && !name.contains(".router."));
+        },
+    ));
+    let enabled = finding_for(&plan, "text_config.enable_moe_block");
+    assert_eq!(enabled.resolved, Some(serde_json::json!(false)));
+    assert_eq!(enabled.category, FindingCategory::Representable);
+}
+
+/// The vision tower declares no `layer_types`: its table is full
+/// attention on every declared layer, so its rope base and class are
+/// judged (they were dropped when no table existed), and its
+/// `attention_bias` reaches the tower surface.
+#[test]
+fn a_tower_without_layer_types_gets_a_full_table_and_its_facts_are_judged() {
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_of(gemma4_shaped_target(dir.path()));
+    let vision = plan
+        .graph
+        .components
+        .iter()
+        .find(|c| c.id == "vision")
+        .expect("vision component");
+    let table = vision.attention.as_ref().expect("tower table");
+    assert_eq!(table.len(), 2);
+    assert!(table
+        .iter()
+        .all(|l| l.span == crate::format::vindex3::graph::policy::AttentionSpan::Full));
+    for subject in [
+        "vision_config.rope_parameters.rope_theta",
+        "vision_config.rope_parameters.rope_type",
+        "vision_config.attention_bias",
+        "vision_config.hidden_activation",
+        "vision_config.global_head_dim",
+    ] {
+        let f = finding_for(&plan, subject);
+        assert_eq!(
+            f.category,
+            FindingCategory::Representable,
+            "{subject}: {}",
+            f.detail
+        );
+    }
+    assert_eq!(
+        finding_for(&plan, "vision_config.rope_parameters.rope_theta").resolved,
+        Some(serde_json::json!(100.0))
+    );
+    // The activation alias resolves in the checkpoint's own spelling.
+    assert_eq!(
+        finding_for(&plan, "vision_config.hidden_activation").resolved,
+        Some(serde_json::json!("gelu_pytorch_tanh"))
+    );
+}
+
+/// The multimodal interface and the tower's metadata are read and
+/// classified: nothing at the root or under `id2label` is "read by
+/// nothing".
+#[test]
+fn the_multimodal_interface_and_tower_metadata_are_read_and_classified() {
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_of(gemma4_shaped_target(dir.path()));
+    for subject in [
+        "audio_config",
+        "audio_token_id",
+        "eoa_token_index",
+        "vision_soft_tokens_per_image",
+        "text_config.use_bidirectional_attention",
+        "vision_config.id2label.0",
+        "vision_config.label2id.LABEL_0",
+        "vision_config.chunk_size_feed_forward",
+        "vision_config.pooling_kernel_size",
+        "vision_config.use_clipped_linears",
+    ] {
+        let f = finding_for(&plan, subject);
+        assert_eq!(
+            f.category,
+            FindingCategory::Representable,
+            "{subject}: {}",
+            f.detail
+        );
+        assert!(
+            !f.detail.contains("read by nothing"),
+            "{subject} must be read: {}",
+            f.detail
+        );
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod carriage;
 mod compare;
+mod gemma4;
 mod semantics;
 mod system;
 

--- a/crates/larql-vindex/src/format/vindex3/plan/tests_support.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests_support.rs
@@ -243,6 +243,223 @@ pub fn glimmer_shaped_target_with(
     inventory_from(dir, &config, &serde_json::Value::Object(header))
 }
 
+/// Gemma 4 26B-A4B in miniature — the V3-F0 witness-3 family, one
+/// declared fact per hostile semantic: per-layer head geometry
+/// (`head_dim` 8 / 2 KV heads on sliding layers, `global_head_dim` 24 /
+/// 1 KV head on the full layer — 24 not 16, so kv_rows 24 ≠ 16 and no
+/// product collides), per-layer-type rope (`proportional` + partial
+/// rotary on full, plain on sliding), K≡V on the full layer (no `v_proj`
+/// there), a hybrid dense+routed FFN with router scales, five FFN norms
+/// and `layer_scalar`, tied softcapped head, the PLE/double-wide/KV-shared
+/// knobs declared OFF, the multimodal interface at the root, and a vision
+/// tower without `layer_types`. Tensor names and shapes follow the real
+/// checkpoint's `model.language_model.…` spelling.
+pub const GEMMA4_FIXTURE_LAYERS: usize = 4;
+pub const GEMMA4_FULL_LAYER: usize = 3;
+pub const GEMMA4_HIDDEN: usize = 64;
+pub const GEMMA4_Q_HEADS: usize = 8;
+pub const GEMMA4_HEAD_DIM: usize = 8;
+pub const GEMMA4_KV_HEADS: usize = 2;
+pub const GEMMA4_GLOBAL_HEAD_DIM: usize = 24;
+pub const GEMMA4_GLOBAL_KV_HEADS: usize = 1;
+pub const GEMMA4_INTER: usize = 128;
+pub const GEMMA4_EXPERTS: usize = 4;
+pub const GEMMA4_TOP_K: usize = 2;
+pub const GEMMA4_MOE_INTER: usize = 32;
+pub const GEMMA4_VOCAB: usize = 128;
+pub const GEMMA4_FULL_THETA: f64 = 1_000_000.0;
+pub const GEMMA4_SLIDING_THETA: f64 = 10_000.0;
+pub const GEMMA4_PARTIAL_ROTARY: f64 = 0.25;
+
+pub fn gemma4_shaped_target(dir: &Path) -> ArchitectureInventory {
+    gemma4_shaped_target_with(dir, |_| {}, |_| {})
+}
+
+/// The same fixture with `mutate_config` applied to its config and
+/// `mutate_tensors` to its `(name, shape)` list before writing.
+pub fn gemma4_shaped_target_with(
+    dir: &Path,
+    mutate_config: impl FnOnce(&mut serde_json::Value),
+    mutate_tensors: impl FnOnce(&mut Vec<(String, Vec<usize>)>),
+) -> ArchitectureInventory {
+    let layer_types: Vec<&str> = (0..GEMMA4_FIXTURE_LAYERS)
+        .map(|i| {
+            if i == GEMMA4_FULL_LAYER {
+                "full_attention"
+            } else {
+                "sliding_attention"
+            }
+        })
+        .collect();
+    // Built in three pieces: one `json!` of this depth trips the macro's
+    // recursion limit.
+    let text_config = serde_json::json!({
+        "model_type": "gemma4_text",
+        "hidden_size": GEMMA4_HIDDEN,
+            "num_hidden_layers": GEMMA4_FIXTURE_LAYERS,
+            "intermediate_size": GEMMA4_INTER,
+            "num_attention_heads": GEMMA4_Q_HEADS,
+            "num_key_value_heads": GEMMA4_KV_HEADS,
+            "head_dim": GEMMA4_HEAD_DIM,
+            "global_head_dim": GEMMA4_GLOBAL_HEAD_DIM,
+            "num_global_key_value_heads": GEMMA4_GLOBAL_KV_HEADS,
+            "attention_k_eq_v": true,
+            "attention_bias": false,
+            "enable_moe_block": true,
+            "num_experts": GEMMA4_EXPERTS,
+            "top_k_experts": GEMMA4_TOP_K,
+            "moe_intermediate_size": GEMMA4_MOE_INTER,
+            "hidden_activation": "gelu_pytorch_tanh",
+            "final_logit_softcapping": 30.0,
+            "hidden_size_per_layer_input": 0,
+            "vocab_size_per_layer_input": GEMMA4_VOCAB,
+            "use_double_wide_mlp": false,
+            "num_kv_shared_layers": 0,
+            "use_bidirectional_attention": "vision",
+            "vocab_size": GEMMA4_VOCAB,
+            "sliding_window": 16,
+            "rms_norm_eps": 1e-6,
+            "rope_parameters": {
+                "full_attention": {
+                    "partial_rotary_factor": GEMMA4_PARTIAL_ROTARY,
+                    "rope_theta": GEMMA4_FULL_THETA,
+                    "rope_type": "proportional"
+                },
+                "sliding_attention": { "rope_theta": GEMMA4_SLIDING_THETA, "rope_type": "default" }
+            },
+        "layer_types": layer_types,
+        "tie_word_embeddings": true
+    });
+    let vision_config = serde_json::json!({
+        "model_type": "gemma4_vision",
+            "hidden_size": 32,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "head_dim": 8,
+            "global_head_dim": 8,
+            "intermediate_size": 64,
+            "hidden_activation": "gelu_pytorch_tanh",
+            "rms_norm_eps": 1e-6,
+            "rope_parameters": { "rope_theta": 100.0, "rope_type": "default" },
+            "attention_bias": false,
+            "patch_size": 16,
+            "pooling_kernel_size": 3,
+            "position_embedding_size": 64,
+            "default_output_length": 4,
+            "standardize": true,
+            "use_clipped_linears": false,
+            "id2label": { "0": "LABEL_0" },
+            "label2id": { "LABEL_0": 0 },
+            "problem_type": null,
+            "return_dict": true,
+            "output_attentions": false,
+            "output_hidden_states": false,
+        "is_encoder_decoder": false,
+        "chunk_size_feed_forward": 0
+    });
+    let mut config = serde_json::json!({
+        "architectures": ["Gemma4ForConditionalGeneration"],
+        "dtype": "bfloat16",
+        "model_type": "gemma4",
+        "audio_config": null,
+        "audio_token_id": 258881,
+        "boa_token_id": 256000,
+        "boi_token_id": 255999,
+        "eoa_token_id": 258883,
+        "eoa_token_index": 258883,
+        "eoi_token_id": 258882,
+        "image_token_id": 258880,
+        "video_token_id": 258884,
+        "vision_soft_tokens_per_image": 4,
+        "tie_word_embeddings": true,
+        "text_config": text_config,
+        "vision_config": vision_config
+    });
+    mutate_config(&mut config);
+
+    let h = GEMMA4_HIDDEN;
+    let mut tensors: Vec<(String, Vec<usize>)> = vec![
+        (
+            "model.language_model.embed_tokens.weight".into(),
+            vec![GEMMA4_VOCAB, h],
+        ),
+        ("model.language_model.norm.weight".into(), vec![h]),
+        (
+            "model.embed_vision.embedding_projection.weight".into(),
+            vec![h, 32],
+        ),
+        (
+            "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight".into(),
+            vec![32, 32],
+        ),
+    ];
+    for layer in 0..GEMMA4_FIXTURE_LAYERS {
+        let stack = format!("model.language_model.layers.{layer}");
+        let full = layer == GEMMA4_FULL_LAYER;
+        let (head_dim, kv_heads) = if full {
+            (GEMMA4_GLOBAL_HEAD_DIM, GEMMA4_GLOBAL_KV_HEADS)
+        } else {
+            (GEMMA4_HEAD_DIM, GEMMA4_KV_HEADS)
+        };
+        let q_rows = GEMMA4_Q_HEADS * head_dim;
+        let kv_rows = kv_heads * head_dim;
+        tensors.push((format!("{stack}.self_attn.q_proj.weight"), vec![q_rows, h]));
+        tensors.push((format!("{stack}.self_attn.k_proj.weight"), vec![kv_rows, h]));
+        if !full {
+            tensors.push((format!("{stack}.self_attn.v_proj.weight"), vec![kv_rows, h]));
+        }
+        tensors.push((format!("{stack}.self_attn.o_proj.weight"), vec![h, q_rows]));
+        tensors.push((format!("{stack}.self_attn.q_norm.weight"), vec![head_dim]));
+        tensors.push((format!("{stack}.self_attn.k_norm.weight"), vec![head_dim]));
+        for norm in [
+            "input_layernorm",
+            "post_attention_layernorm",
+            "pre_feedforward_layernorm",
+            "post_feedforward_layernorm",
+            "pre_feedforward_layernorm_2",
+            "post_feedforward_layernorm_1",
+            "post_feedforward_layernorm_2",
+        ] {
+            tensors.push((format!("{stack}.{norm}.weight"), vec![h]));
+        }
+        tensors.push((format!("{stack}.layer_scalar"), vec![1]));
+        tensors.push((
+            format!("{stack}.mlp.gate_proj.weight"),
+            vec![GEMMA4_INTER, h],
+        ));
+        tensors.push((format!("{stack}.mlp.up_proj.weight"), vec![GEMMA4_INTER, h]));
+        tensors.push((
+            format!("{stack}.mlp.down_proj.weight"),
+            vec![h, GEMMA4_INTER],
+        ));
+        tensors.push((
+            format!("{stack}.router.proj.weight"),
+            vec![GEMMA4_EXPERTS, h],
+        ));
+        tensors.push((format!("{stack}.router.scale"), vec![h]));
+        tensors.push((
+            format!("{stack}.router.per_expert_scale"),
+            vec![GEMMA4_EXPERTS],
+        ));
+        tensors.push((
+            format!("{stack}.experts.gate_up_proj"),
+            vec![GEMMA4_EXPERTS, 2 * GEMMA4_MOE_INTER, h],
+        ));
+        tensors.push((
+            format!("{stack}.experts.down_proj"),
+            vec![GEMMA4_EXPERTS, h, GEMMA4_MOE_INTER],
+        ));
+    }
+    mutate_tensors(&mut tensors);
+    let mut header = serde_json::Map::new();
+    let mut offset = 0u64;
+    for (name, shape) in &tensors {
+        push_tensor(&mut header, &mut offset, name, shape);
+    }
+    inventory_from(dir, &config, &serde_json::Value::Object(header))
+}
+
 /// A drafter-shaped artifact declaring `target_layer_ids` taps into a
 /// deeper producer.
 pub fn drafter_shaped(dir: &Path) -> ArchitectureInventory {

--- a/scripts/gptoss-vindex3-cost-ladder.sh
+++ b/scripts/gptoss-vindex3-cost-ladder.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# A-10 — the cost of abstraction: gpt-oss-20b through the generic VINDEX3
+# plan (`vindex3 exec --backend metal-lowered*`) against the mature served
+# routed Metal path (`bench --routed-from`), bracketed, per context.
+#
+#   ./scripts/gptoss-vindex3-cost-ladder.sh bench/prompts/gpt-oss/ctx-1024.txt 300
+#
+# Per prompt, two blocks, each `served / candidate / served`:
+#
+#   block F16    candidate = metal-lowered-ffn   (f16 attention + head, native MXFP4 experts;
+#                            the arm certified interpreter-≡-Metal at rel_rms ≤ 1e-6)
+#   block NVFP4  candidate = metal-lowered       (NVFP4 attention; the representation that
+#                            flipped one generated token — priced here, not argued)
+#
+# The unit of measurement is the bracket, not the arm (kv-ladder-bracket.sh
+# has the rationale): a candidate counts only if the two served baselines
+# around it agree within BRACKET_TOL_PCT, and every arm must complete its
+# full decode budget. Rest before every arm.
+#
+# What this ladder is NOT: an id-parity gate. The served path decodes over
+# the Q4_K spine while the container carries BF16 attention, so the two
+# trajectories are "same semantics, different representation" (A-9.3) and
+# are expected to agree at the start and drift at low-margin steps. The
+# ids fingerprint is printed so a *within-arm* change is visible, and the
+# lowered arms print their attention route witness so routing and timing
+# stay separate assertions.
+#
+# Statistic caveat, deliberately visible: `bench` reports the mean over all
+# post-warmup decode steps; `vindex3 exec --generate` reports the last-half
+# mean and has no warmup flag yet. Both are per-token decode means over a
+# steady tail at n=256, but they are not the same estimator — treat a
+# single-digit-% delta as "within instrument", not as a ranking, until
+# `vindex3 exec` grows `--warmup` and both read the same window.
+#
+# Shared input, checked (feedback: a parity gate blind to shared input has
+# cost a rope bug before): the served arm tokenises the prompt text; the
+# lowered arms take ids. The ids come from `larql run --emit-ids` over the
+# same text on the same spine, and the prompt-token COUNT of the two is
+# compared before any arm runs — a mismatch voids the prompt.
+
+set -u
+
+SPINE="${LARQL_LADDER_MODEL:-/Users/christopherhay/chris-models/gpt-oss-20b-q4k.vindex}"
+ROUTED="${LARQL_LADDER_ROUTED:-/Users/christopherhay/chris-models/gpt-oss-20b-experts-mxfp4.v3}"
+# The A-9 container: system graph + expert banks, encoded from the HF checkpoint.
+CONTAINER="${LARQL_LADDER_CONTAINER:?set LARQL_LADDER_CONTAINER to the gpt-oss VINDEX3 container}"
+BIN="${LARQL_LADDER_BIN:-./target/release/larql}"
+
+# Pinned by bench/prompts/README.md; changing either changes the number.
+WARMUP=16
+TOKENS=256
+MIN_STEPS=$((TOKENS - 1))
+BRACKET_TOL_PCT=1.0
+
+PROMPT_FILE="${1:?usage: gptoss-vindex3-cost-ladder.sh <prompt-file> [rest-seconds]}"
+REST="${2:-300}"
+
+[ -r "$PROMPT_FILE" ] || { echo "no such prompt file: $PROMPT_FILE" >&2; exit 2; }
+[ -x "$BIN" ] || { echo "no larql binary at $BIN (cargo build --release)" >&2; exit 2; }
+[ -d "$CONTAINER" ] || { echo "no container at $CONTAINER" >&2; exit 2; }
+PROMPT="$(cat "$PROMPT_FILE")"
+
+# ── shared input: ids for the lowered arms, count-checked against the served tokeniser ──
+IDS_FILE="${PROMPT_FILE%.txt}.ids"
+emit=$(LARQL_GPU_ROUTE=1 "$BIN" run "$SPINE" --metal --emit-ids --routed-from "$ROUTED" -n 1 "$PROMPT" 2>&1)
+served_count=$(echo "$emit" | sed -n 's/^\[ids\] prompt \([0-9]*\) tokens: .*/\1/p' | head -1)
+echo "$emit" | sed -n 's/^\[ids\] prompt [0-9]* tokens: \(\[.*\]\)$/\1/p' | head -1 | tr -d '[] ' > "$IDS_FILE"
+ids_count=$(tr ',' '\n' < "$IDS_FILE" | grep -c .)
+if [ -z "$served_count" ] || [ "$served_count" != "$ids_count" ]; then
+  echo "VOID: served prompt tokens (${served_count:-none}) != ids written (${ids_count}) — shared input not established" >&2
+  exit 1
+fi
+
+served_arm() {
+  LARQL_GPU_ROUTE=1 "$BIN" bench "$SPINE" --routed-from "$ROUTED" \
+    --prompt "$PROMPT" --warmup "$WARMUP" -n "$TOKENS" 2>&1 \
+    | awk '/^ *larql-metal/{
+        note=""; for (i=7; i<=NF; i++) note = note $i " ";
+        gsub(/ms$/, "", $3);
+        print $3, $6, note
+      }'
+}
+
+# $1 = metal-lowered-ffn | metal-lowered. Prints "mean steps note".
+lowered_arm() {
+  out=$("$BIN" vindex3 exec "$CONTAINER" --tokens "$(cat "$IDS_FILE")" \
+        --backend "$1" --generate "$TOKENS" 2>&1)
+  mean=$(echo "$out" | sed -n 's/^steady (last half): \([0-9.]*\) ms\/token.*/\1/p' | head -1)
+  # `generated ids: [a, b, …]` — count = steps completed (first token from prefill).
+  steps=$(echo "$out" | sed -n 's/^generated ids: \[\(.*\)\]$/\1/p' | tr ',' '\n' | grep -c .)
+  ids=$(echo "$out" | grep '^generated ids' | md5 | cut -c1-8)
+  wit=$(echo "$out" | sed -n 's/^attention dispatches: //p' | tr ' ' '_')
+  metal=$(echo "$out" | grep -c '\[metal\]')
+  [ -n "$mean" ] && echo "$mean $((steps > 0 ? steps - 1 : 0)) ids=$ids wit=$wit metal=$metal"
+}
+
+run_block() {
+  local label="$1" candidate="$2"
+  echo "════ BLOCK $label   served / $candidate / served   ${REST}s rest before every arm"
+  echo "     prompt $PROMPT_FILE ($served_count tokens)   warmup $WARMUP   n $TOKENS"
+  local MEANS=() VOID=0
+  for arm in served candidate served; do
+    sleep "$REST"
+    if [ "$arm" = served ]; then
+      read -r mean steps note <<<"$(served_arm)"
+    else
+      read -r mean steps note <<<"$(lowered_arm "$candidate")"
+    fi
+    if [ -z "${mean:-}" ]; then
+      echo "  $(printf '%-10s' "$arm") NO ROW — arm failed to produce a reading"
+      VOID=1; continue
+    fi
+    flag=""
+    if [ "${steps:-0}" -lt "$MIN_STEPS" ]; then
+      flag="  ← TRUNCATED: $steps < $MIN_STEPS steps"; VOID=1
+    fi
+    printf "  %-10s mean %8s ms   steps %5s   %s%s\n" "$arm" "$mean" "$steps" "${note:-}" "$flag"
+    MEANS+=("$mean")
+  done
+  if [ "${#MEANS[@]}" -ne 3 ]; then echo "  VERDICT: VOID — block did not produce three arms"; return 1; fi
+  awk -v o1="${MEANS[0]}" -v c="${MEANS[1]}" -v o2="${MEANS[2]}" \
+      -v tol="$BRACKET_TOL_PCT" -v void="$VOID" -v lab="$label" '
+  BEGIN {
+    spread = (o1 > o2 ? o1 - o2 : o2 - o1) / (o1 < o2 ? o1 : o2) * 100
+    printf "  brackets %.2f%% apart (tolerance %.1f%%)\n", spread, tol
+    if (void)         { print "  VERDICT: VOID — an arm did not complete its decode budget"; exit 1 }
+    if (spread > tol) { print "  VERDICT: VOID — brackets disagree; do NOT average across them"; exit 1 }
+    base = (o1 + o2) / 2
+    printf "  VERDICT: VALID — %s %.2f vs served %.2f ms/token", lab, c, base
+    printf "  (%+.1f%% latency = the cost of abstraction for this arm)\n", (c - base) / base * 100
+  }'
+}
+
+run_block F16   metal-lowered-ffn
+run_block NVFP4 metal-lowered


### PR DESCRIPTION
## V3-F0 witness 3 — Gemma 4 26B-A4B through the VINDEX3 plan gate (G4.0)

The third hostile architecture for the freeze criterion (ROADMAP §"VINDEX3 evolution", V3-F0). Rung 0 measured: `larql vindex3 plan` on `google/gemma-4-26B-A4B-it` was **inadmissible with 42 blocking findings** (gpt-oss started at 4). After this PR: **111 representable / 0 mismatched / 0 unrepresented / 0 blocking**, and every new fact landed as *vocabulary in an existing category* — F1 (no new foundational relationship) still holds.

### What Gemma 4 declares that the graph could not carry

| Family | Fact | Now |
|---|---|---|
| geometry | `head_dim` 256 / 8 KV heads on 25 sliding layers, `global_head_dim` 512 / 2 KV heads on the 5 full layers — the surface required one geometry per component | `AttentionLayerPolicy.geometry: HeadGeometry{head_dim, num_kv_heads}` per layer; the op plan judges each layer's shapes against *its* geometry; `AttentionOp` already carried per-op geometry so executors follow |
| position | `rope_parameters.{full,sliding}_attention` per layer *type*; `rope_type: proportional` + `partial_rotary_factor 0.25` on the full layers | `PositionPolicy::PartialRope{theta, rotary_fraction, basis: RotaryWidth \| HeadWidth}` (HF `proportional` = frequencies over the full head width); carriage probes take a `ProbeContext` (the span the fact's path names + the declared value for alias resolution) so per-type facts are judged against their own layers; the resolution comparator does the same |
| K ≡ V | `attention_k_eq_v`: no `v_proj` on the full layers, V is the raw K projection; a parameter-free `v_norm` on every layer | `AttentionLayerPolicy.v_from_k` + `AttentionOp.v_from_k` (V names the K operand), closure paired both ways (no V operand on such a layer, a stray one refused); `ParameterFreeQkNorm.v` |
| hybrid MoE | `enable_moe_block`, 128 experts top-8 beside a dense MLP | classified + judged against the routed surface (execution is G4.1) |
| absent-only knobs | `num_kv_shared_layers`, `hidden_size_per_layer_input`, `use_double_wide_mlp`, `use_clipped_linears` | rules that agree at `0`/`false` and block at anything else — represented as ABSENT, never mis-served |
| interface | `audio_config: null`, seven span token ids, `vision_soft_tokens_per_image`, `use_bidirectional_attention` | a recorded multimodal-interface reader (`inventory/interfaces.rs`) |
| tower | no `layer_types`; `rope_theta 100`; `attention_bias`; pooling/position-table/standardise facts; `id2label` etc. | Full × N table so its rope is judged; `attention_bias` on the tower surface; the rest classified (execution / tensor / metadata) |

Executors (reference / production / device) and the Metal lowering **refuse** `PartialRope`, `v_from_k` and the V norm, typed and naming G4.2/G4.3, until they execute them.

### Two finds the gate forced

1. The rope-theta resolution comparator took `rope_parameters.full_attention.rope_theta` as *the* checkpoint-wide base and compared it to every layer — a false mismatch on any per-layer-type checkpoint. Fixed and pinned.
2. HF `proportional` takes inverse frequencies over the **full** head width (`base^(2i/512)` on the global layers) whereas the served path's partial rotary takes them over the rotary width (`base^(2i/128)`) — different angles on the 5 global layers. VINDEX3 now carries HF's semantics; the served gemma4 forward has not been certified against HF at attention level, and G4.2's layer-dump parity gate will arbitrate it.

### Tests

`plan/tests/gemma4.rs` (9 — each re-drops the fact it guards on a Gemma-4-shaped miniature that mirrors the real config shape and tensor spelling), `opplan/tests/gemma4_closure.rs` (K≡V both ways), `exec/tests/gemma4_refusals.rs`, plus the invariant that every execution-semantic leaf has a carriage rule. Gates run locally with each crate's CI flags: fmt/clippy clean on models, vindex, cli (both feature shapes), inference; tests green (models 801, vindex 2870, cli 751, inference 1760, compute-metal lib 421); coverage policy passes for models (91.06%) and vindex (94.21%).

Also: `scripts/gptoss-vindex3-cost-ladder.sh` (the A-10 harness, own commit) and the roadmap map/record for G4.0.

### Next

G4.1 — the hybrid FFN in the generic graph (`LayerFfn::Hybrid` or dense+routed with an explicit combine, roles for `router.scale` / `per_expert_scale` / `layer_scalar` / the three extra norms), then G4.2 interpreter execution with the HF layer-dump parity gate.
