### PR TITLE
vindex3 plan: honest plumbing for Qwen3.5/hybrid-linear-attention config facts

### DIFF
--- a/crates/larql-models/src/architectures/gemma3.rs
+++ b/crates/larql-models/src/architectures/gemma3.rs
@@ -260,6 +260,18 @@ mod tests {
             mask_token_id: None,
             use_double_wide_mlp: None,
             vocab_size_per_layer_input: None,
+            linear_conv_kernel_dim: None,
+            linear_key_head_dim: None,
+            linear_value_head_dim: None,
+            linear_num_key_heads: None,
+            linear_num_value_heads: None,
+            mamba_ssm_dtype: None,
+            attn_output_gate: None,
+            output_gate_type: None,
+            mtp_num_hidden_layers: None,
+            mtp_use_dedicated_embeddings: None,
+            mrope_interleaved: None,
+            mrope_section: None,
         }
     }
 

--- a/crates/larql-models/src/architectures/granite.rs
+++ b/crates/larql-models/src/architectures/granite.rs
@@ -255,6 +255,18 @@ mod tests {
             mask_token_id: None,
             use_double_wide_mlp: None,
             vocab_size_per_layer_input: None,
+            linear_conv_kernel_dim: None,
+            linear_key_head_dim: None,
+            linear_value_head_dim: None,
+            linear_num_key_heads: None,
+            linear_num_value_heads: None,
+            mamba_ssm_dtype: None,
+            attn_output_gate: None,
+            output_gate_type: None,
+            mtp_num_hidden_layers: None,
+            mtp_use_dedicated_embeddings: None,
+            mrope_interleaved: None,
+            mrope_section: None,
         }
     }
 

--- a/crates/larql-models/src/config/layer_types.rs
+++ b/crates/larql-models/src/config/layer_types.rs
@@ -36,6 +36,20 @@ pub const LAYER_TYPE_FULL_ATTENTION: &str = "full_attention";
 /// the two were aliased.
 pub const LAYER_TYPE_WINDOW_ATTENTION: &str = "window_attention";
 
+/// A layer computing attention via a recurrent linear-attention mechanism
+/// (gated linear attention / delta-rule / SSM-adjacent short-conv state)
+/// instead of softmax over an explicit K/V sequence — the span kind
+/// hybrid linear-attention architectures (Kimi-Linear, Qwen3-Next,
+/// Qwen3.5) interleave with [`LAYER_TYPE_FULL_ATTENTION`].
+///
+/// Declared here as a vocabulary fact only. Recording *that* a layer is
+/// `linear_attention` is honest plumbing — a linear-attention forward
+/// pass is real, separate compute this crate has not implemented, so
+/// nothing downstream treats this spelling as executable (see
+/// `larql-vindex`'s `AttentionSpan`, which deliberately has no variant
+/// for it yet — R2/Kimi-Linear rung, `docs/k3-funnel.md`).
+pub const LAYER_TYPE_LINEAR_ATTENTION: &str = "linear_attention";
+
 /// Whether `layer_types` marks `layer` as sliding-window.
 ///
 /// Returns `None` when the config declares no `layer_types`, leaving the

--- a/crates/larql-models/src/config/mod.rs
+++ b/crates/larql-models/src/config/mod.rs
@@ -42,7 +42,8 @@ pub use experts::{
     ExpertFormat, ExpertGatePolicy, ExpertRoutingPolicy, GateUpBranch, GateUpLayout,
 };
 pub use layer_types::{
-    LAYER_TYPE_FULL_ATTENTION, LAYER_TYPE_SLIDING_ATTENTION, LAYER_TYPE_WINDOW_ATTENTION,
+    LAYER_TYPE_FULL_ATTENTION, LAYER_TYPE_LINEAR_ATTENTION, LAYER_TYPE_SLIDING_ATTENTION,
+    LAYER_TYPE_WINDOW_ATTENTION,
 };
 pub use model_config::ModelConfig;
 pub use moe_router::MoeRouterKind;

--- a/crates/larql-models/src/config/model_config.rs
+++ b/crates/larql-models/src/config/model_config.rs
@@ -171,4 +171,57 @@ pub struct ModelConfig {
     /// — the width of a table that exists only when `per_layer_embed_dim`
     /// is set. Read verbatim, judged against that width.
     pub vocab_size_per_layer_input: Option<u64>,
+
+    // ── Hybrid linear-attention + multi-token-prediction (declared,
+    //    R2/Kimi-Linear-rung prep — see `docs/k3-funnel.md`) ──
+    //
+    // Qwen3.5-style hybrid architectures interleave full-attention layers
+    // with linear-attention (gated recurrent / short-conv, SSM-adjacent)
+    // layers and add a multi-token-prediction head. None of this is
+    // executable yet: there is no `AttentionOp`/component variant for a
+    // linear-attention layer and no MTP-head object in the VINDEX3 schema.
+    // These fields are read and retained verbatim — not judged, not
+    // guessed at — so a future R2 pass has the declared values in hand
+    // instead of the parser having silently dropped them.
+    /// Convolution kernel width in the linear-attention block's short conv
+    /// (`linear_conv_kernel_dim`).
+    pub linear_conv_kernel_dim: Option<usize>,
+    /// Per-head key dimension in the linear-attention block
+    /// (`linear_key_head_dim`) — distinct from the full-attention `head_dim`.
+    pub linear_key_head_dim: Option<usize>,
+    /// Per-head value dimension in the linear-attention block
+    /// (`linear_value_head_dim`).
+    pub linear_value_head_dim: Option<usize>,
+    /// Number of key heads in the linear-attention block
+    /// (`linear_num_key_heads`).
+    pub linear_num_key_heads: Option<usize>,
+    /// Number of value heads in the linear-attention block
+    /// (`linear_num_value_heads`).
+    pub linear_num_value_heads: Option<usize>,
+    /// Dtype the linear-attention block's SSM/recurrent state is computed
+    /// in (`mamba_ssm_dtype`), verbatim.
+    pub mamba_ssm_dtype: Option<String>,
+    /// Whether attention output is gated before `o_proj` (`attn_output_gate`).
+    /// Distinct from the judged [`AttentionGateSpec`](super::AttentionGateSpec)
+    /// an architecture returns from `attention_output_gate()` — this is the
+    /// checkpoint's raw declaration, carried through even where no family
+    /// has judged what the gate computes yet.
+    pub attn_output_gate: Option<bool>,
+    /// Attention output gate nonlinearity, verbatim (`output_gate_type`,
+    /// e.g. `"swish"`).
+    pub output_gate_type: Option<String>,
+    /// Number of hidden layers in the multi-token-prediction head
+    /// (`mtp_num_hidden_layers`). `None`/absent = no MTP head declared.
+    pub mtp_num_hidden_layers: Option<usize>,
+    /// Whether the MTP head uses its own embedding table rather than
+    /// sharing the backbone's (`mtp_use_dedicated_embeddings`).
+    pub mtp_use_dedicated_embeddings: Option<bool>,
+    /// Whether mRoPE sections interleave across the `mrope_section` split
+    /// (`rope_parameters.mrope_interleaved`) — Qwen-VL-style multi-axis
+    /// position encoding [`PositionPolicy`](super::PositionPolicy) does
+    /// not express.
+    pub mrope_interleaved: Option<bool>,
+    /// mRoPE per-axis section widths (`rope_parameters.mrope_section`),
+    /// verbatim.
+    pub mrope_section: Option<Vec<usize>>,
 }

--- a/crates/larql-models/src/detect/parser.rs
+++ b/crates/larql-models/src/detect/parser.rs
@@ -400,6 +400,42 @@ pub(super) fn parse_model_config(config: &serde_json::Value) -> ModelConfig {
         .and_then(|_| text_config["block_size"].as_u64().map(|v| v as usize));
     let mask_token_id = text_config["mask_token_id"].as_u64();
 
+    // Hybrid linear-attention + multi-token-prediction (declared,
+    // R2/Kimi-Linear-rung prep). Read verbatim — no semantics judged here.
+    let linear_conv_kernel_dim = text_config["linear_conv_kernel_dim"]
+        .as_u64()
+        .map(|v| v as usize);
+    let linear_key_head_dim = text_config["linear_key_head_dim"]
+        .as_u64()
+        .map(|v| v as usize);
+    let linear_value_head_dim = text_config["linear_value_head_dim"]
+        .as_u64()
+        .map(|v| v as usize);
+    let linear_num_key_heads = text_config["linear_num_key_heads"]
+        .as_u64()
+        .map(|v| v as usize);
+    let linear_num_value_heads = text_config["linear_num_value_heads"]
+        .as_u64()
+        .map(|v| v as usize);
+    let mamba_ssm_dtype = text_config["mamba_ssm_dtype"].as_str().map(str::to_string);
+    let attn_output_gate = text_config["attn_output_gate"].as_bool();
+    let output_gate_type = text_config["output_gate_type"].as_str().map(str::to_string);
+    let mtp_num_hidden_layers = text_config["mtp_num_hidden_layers"]
+        .as_u64()
+        .map(|v| v as usize);
+    let mtp_use_dedicated_embeddings = text_config["mtp_use_dedicated_embeddings"].as_bool();
+    // mRoPE sectioning (Qwen-VL-style multi-axis position encoding),
+    // declared under the same `rope_parameters` block the flat-form
+    // rope_theta/rope_type/partial_rotary_factor already read.
+    let mrope_interleaved = rope_params.and_then(|rp| rp["mrope_interleaved"].as_bool());
+    let mrope_section = rope_params.and_then(|rp| {
+        rp["mrope_section"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_u64().map(|n| n as usize))
+                .collect()
+        })
+    });
+
     ModelConfig {
         model_type,
         norm_eps,
@@ -462,5 +498,17 @@ pub(super) fn parse_model_config(config: &serde_json::Value) -> ModelConfig {
         mask_token_id,
         use_double_wide_mlp,
         vocab_size_per_layer_input,
+        linear_conv_kernel_dim,
+        linear_key_head_dim,
+        linear_value_head_dim,
+        linear_num_key_heads,
+        linear_num_value_heads,
+        mamba_ssm_dtype,
+        attn_output_gate,
+        output_gate_type,
+        mtp_num_hidden_layers,
+        mtp_use_dedicated_embeddings,
+        mrope_interleaved,
+        mrope_section,
     }
 }

--- a/crates/larql-models/src/detect/tests/mod.rs
+++ b/crates/larql-models/src/detect/tests/mod.rs
@@ -12,6 +12,7 @@ mod gemma4;
 mod gpt2_aliases;
 mod kv_recompute;
 mod norm_eps;
+mod qwen35_hybrid;
 mod real_configs;
 mod rope_scaling;
 mod routing;

--- a/crates/larql-models/src/detect/tests/qwen35_hybrid.rs
+++ b/crates/larql-models/src/detect/tests/qwen35_hybrid.rs
@@ -1,0 +1,135 @@
+//! Qwen3.5-style hybrid linear-attention configs — `model_type: "qwen3_5"`
+//! (or `"qwen3_5_text"` when nested under `text_config`) matches the
+//! `qwen`-prefix family route and is served by [`QwenArch`], so no new
+//! registry entry is needed. What *is* new: `text_config` declares hybrid
+//! linear-attention block geometry, a multi-token-prediction head, and
+//! mRoPE sectioning that `ModelConfig` did not carry before — this module
+//! pins that every one of those facts reaches `ModelConfig` verbatim
+//! (R2/Kimi-Linear-rung prep, `docs/k3-funnel.md`).
+
+use crate::detect::*;
+
+fn qwen35_shaped_config() -> serde_json::Value {
+    serde_json::json!({
+        "architectures": ["Qwen3_5ForConditionalGeneration"],
+        "model_type": "qwen3_5",
+        "text_config": {
+            "model_type": "qwen3_5_text",
+            "hidden_size": 5120,
+            "num_hidden_layers": 8,
+            "intermediate_size": 17408,
+            "num_attention_heads": 24,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "vocab_size": 248320,
+            "full_attention_interval": 4,
+            "layer_types": [
+                "linear_attention", "linear_attention", "linear_attention", "full_attention",
+                "linear_attention", "linear_attention", "linear_attention", "full_attention",
+            ],
+            "linear_conv_kernel_dim": 4,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 48,
+            "mamba_ssm_dtype": "float32",
+            "attn_output_gate": true,
+            "output_gate_type": "swish",
+            "mtp_num_hidden_layers": 1,
+            "mtp_use_dedicated_embeddings": false,
+            "partial_rotary_factor": 0.25,
+            "rope_parameters": {
+                "rope_theta": 10000000,
+                "rope_type": "default",
+                "partial_rotary_factor": 0.25,
+                "mrope_interleaved": true,
+                "mrope_section": [11, 11, 10]
+            }
+        }
+    })
+}
+
+/// The declared-but-previously-unparsed hybrid fields all land on
+/// `ModelConfig`, verbatim.
+#[test]
+fn hybrid_linear_attention_fields_are_parsed_verbatim() {
+    let arch = detect_from_json(&qwen35_shaped_config());
+    let cfg = arch.config();
+
+    assert_eq!(cfg.model_type, "qwen3_5_text");
+    assert_eq!(cfg.linear_conv_kernel_dim, Some(4));
+    assert_eq!(cfg.linear_key_head_dim, Some(128));
+    assert_eq!(cfg.linear_value_head_dim, Some(128));
+    assert_eq!(cfg.linear_num_key_heads, Some(16));
+    assert_eq!(cfg.linear_num_value_heads, Some(48));
+    assert_eq!(cfg.mamba_ssm_dtype.as_deref(), Some("float32"));
+    assert_eq!(cfg.attn_output_gate, Some(true));
+    assert_eq!(cfg.output_gate_type.as_deref(), Some("swish"));
+    assert_eq!(cfg.mtp_num_hidden_layers, Some(1));
+    assert_eq!(cfg.mtp_use_dedicated_embeddings, Some(false));
+    assert_eq!(cfg.mrope_interleaved, Some(true));
+    assert_eq!(cfg.mrope_section, Some(vec![11, 11, 10]));
+    assert_eq!(
+        cfg.layer_types.as_deref(),
+        Some(
+            [
+                "linear_attention",
+                "linear_attention",
+                "linear_attention",
+                "full_attention",
+                "linear_attention",
+                "linear_attention",
+                "linear_attention",
+                "full_attention",
+            ]
+            .map(str::to_string)
+            .as_slice()
+        )
+    );
+}
+
+/// `qwen3_5*` routes through the existing `qwen`-prefix match — no new
+/// registry entry, matching the family's own Qwen2/2.5/3 convention.
+#[test]
+fn qwen35_uses_the_qwen_prefix_route() {
+    let arch = detect_from_json(&qwen35_shaped_config());
+    assert_eq!(arch.family(), "qwen3_5_text");
+}
+
+/// `partial_rotary_factor` is read from both the flat `text_config` spot
+/// and the nested `rope_parameters` spot the real checkpoint declares it
+/// under — the flat form wins when `rope_parameters.full_attention` is
+/// absent (Gemma 4's structured nesting is a different shape).
+#[test]
+fn partial_rotary_factor_is_read_from_the_declared_spot() {
+    let arch = detect_from_json(&qwen35_shaped_config());
+    assert_eq!(arch.config().partial_rotary_factor, Some(0.25));
+}
+
+/// An absent hybrid block (an ordinary dense Qwen3 config) leaves every
+/// new field `None` — presence, not a family default, is what turns them
+/// into a fact.
+#[test]
+fn a_dense_qwen_config_declares_none_of_the_hybrid_fields() {
+    let config = serde_json::json!({
+        "model_type": "qwen3",
+        "hidden_size": 4096,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+    });
+    let arch = detect_from_json(&config);
+    let cfg = arch.config();
+    assert_eq!(cfg.linear_conv_kernel_dim, None);
+    assert_eq!(cfg.linear_key_head_dim, None);
+    assert_eq!(cfg.linear_value_head_dim, None);
+    assert_eq!(cfg.linear_num_key_heads, None);
+    assert_eq!(cfg.linear_num_value_heads, None);
+    assert_eq!(cfg.mamba_ssm_dtype, None);
+    assert_eq!(cfg.attn_output_gate, None);
+    assert_eq!(cfg.output_gate_type, None);
+    assert_eq!(cfg.mtp_num_hidden_layers, None);
+    assert_eq!(cfg.mtp_use_dedicated_embeddings, None);
+    assert_eq!(cfg.mrope_interleaved, None);
+    assert_eq!(cfg.mrope_section, None);
+}

--- a/crates/larql-models/src/inventory/config_keys.rs
+++ b/crates/larql-models/src/inventory/config_keys.rs
@@ -118,6 +118,20 @@ pub const CONSUMED_LEAF_KEYS: &[&str] = &[
     "target_layer_ids",
     "block_size",
     "mask_token_id",
+    // hybrid linear-attention + multi-token-prediction (declared,
+    // R2/Kimi-Linear-rung prep — see `docs/k3-funnel.md`)
+    "linear_conv_kernel_dim",
+    "linear_key_head_dim",
+    "linear_value_head_dim",
+    "linear_num_key_heads",
+    "linear_num_value_heads",
+    "mamba_ssm_dtype",
+    "attn_output_gate",
+    "output_gate_type",
+    "mtp_num_hidden_layers",
+    "mtp_use_dedicated_embeddings",
+    "mrope_interleaved",
+    "mrope_section",
 ];
 
 /// Containers the parser recurses into: leaves inside keep consumed-leaf

--- a/crates/larql-models/src/inventory/report.rs
+++ b/crates/larql-models/src/inventory/report.rs
@@ -39,7 +39,16 @@ use serde::{Deserialize, Serialize};
 /// parity would later expose. Adds the judged attention-gate spec and
 /// parameter-free QK norm. A v3 inventory fails to parse rather than
 /// answering with a folded scale.
-pub const INVENTORY_SCHEMA: u32 = 4;
+///
+/// v5: [`LayerPolicy`] carries `declared_span` — the checkpoint's own
+/// `layer_types` entry for the layer, verbatim, alongside the resolved
+/// `"sliding"`/`"full"` boolean. Closes the gap a hybrid linear-attention
+/// interleave (Qwen3.5, Kimi-Linear-style) fell into: `is_sliding_window_
+/// layer` only ever answers a boolean, so every layer that was not
+/// literally `"sliding_attention"` resolved to `"full"` with nothing
+/// downstream able to tell a genuine full-attention layer from a
+/// defaulted one. A v4 inventory deserialises with `declared_span: None`.
+pub const INVENTORY_SCHEMA: u32 = 5;
 
 /// Machine-readable architecture inventory of one HF checkpoint directory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -245,8 +254,23 @@ pub struct AttentionSummary {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LayerPolicy {
     pub layer: usize,
-    /// `"sliding"` or `"full"`.
+    /// `"sliding"` or `"full"` — the boolean split
+    /// `ModelArchitecture::is_sliding_window_layer` resolves to.
+    /// [`Self::declared_span`] is the finer-grained fact when the
+    /// checkpoint states one.
     pub attention: String,
+    /// The checkpoint's own `layer_types` entry for this layer, verbatim,
+    /// when it declares one. `None` when the config states no per-layer
+    /// array (an implicit stride, or a plain single-attention-type model)
+    /// — [`Self::attention`] is then the only source of truth.
+    ///
+    /// Carries a vocabulary [`Self::attention`] cannot: a hybrid
+    /// linear-attention interleave (`"linear_attention"`) is neither
+    /// `"sliding"` nor `"full"`, and the boolean split alone cannot tell
+    /// a defaulted layer from a genuine one. See `docs/k3-funnel.md`
+    /// §4.7.8.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared_span: Option<String>,
     /// Window size when sliding, `None` on full-attention layers.
     pub window: Option<usize>,
     /// How this layer encodes position — rotary at a base, or not at all.

--- a/crates/larql-models/src/inventory/resolved.rs
+++ b/crates/larql-models/src/inventory/resolved.rs
@@ -96,6 +96,11 @@ pub fn resolve(config: &Value, identity: &Identity) -> (Detection, ResolvedTopol
                     ATTENTION_FULL
                 }
                 .to_string(),
+                declared_span: cfg
+                    .layer_types
+                    .as_ref()
+                    .and_then(|types| types.get(layer))
+                    .cloned(),
                 window: if sliding {
                     arch.sliding_window_size()
                 } else {

--- a/crates/larql-models/src/inventory/tests/resolved.rs
+++ b/crates/larql-models/src/inventory/tests/resolved.rs
@@ -148,6 +148,50 @@ fn layer_table_reflects_declared_layer_types() {
     assert_eq!(topology.num_kv_heads, 2);
     assert_eq!(topology.head_dim, 128);
     assert_eq!(topology.vocab_size, Some(202048));
+
+    // Every layer's own declared spelling is carried alongside the
+    // boolean split, verbatim.
+    assert_eq!(
+        topology.layers[0].declared_span.as_deref(),
+        Some("sliding_attention")
+    );
+    assert_eq!(
+        topology.layers[3].declared_span.as_deref(),
+        Some("full_attention")
+    );
+}
+
+/// A hybrid interleave outside the sliding/full vocabulary (a
+/// linear-attention layer): `attention` still resolves to the boolean
+/// split `is_sliding_window_layer` answers (`false`, since it is not
+/// literally `"sliding_attention"`), but `declared_span` preserves the
+/// checkpoint's own spelling verbatim — the fact `attention` alone
+/// cannot express and that a consumer needs in order to tell a genuine
+/// full-attention layer from a defaulted one.
+#[test]
+fn a_hybrid_linear_attention_layer_keeps_its_own_declared_spelling() {
+    let config = serde_json::json!({
+        "model_type": "qwen3_5_text",
+        "hidden_size": 64,
+        "num_hidden_layers": 4,
+        "intermediate_size": 256,
+        "num_attention_heads": 8,
+        "num_key_value_heads": 2,
+        "layer_types": ["linear_attention", "linear_attention", "linear_attention", "full_attention"]
+    });
+    let identity = read_identity(&config);
+    let (_, topology) = resolve(&config, &identity);
+
+    assert_eq!(topology.layers[0].attention, "full");
+    assert_eq!(
+        topology.layers[0].declared_span.as_deref(),
+        Some("linear_attention")
+    );
+    assert_eq!(topology.layers[3].attention, "full");
+    assert_eq!(
+        topology.layers[3].declared_span.as_deref(),
+        Some("full_attention")
+    );
 }
 
 /// A config with no `layer_types` and no override resolves all-full — that

--- a/crates/larql-models/src/loading/gguf/orient.rs
+++ b/crates/larql-models/src/loading/gguf/orient.rs
@@ -328,6 +328,18 @@ fn synth_gpt2_config(
         mask_token_id: None,
         use_double_wide_mlp: None,
         vocab_size_per_layer_input: None,
+        linear_conv_kernel_dim: None,
+        linear_key_head_dim: None,
+        linear_value_head_dim: None,
+        linear_num_key_heads: None,
+        linear_num_value_heads: None,
+        mamba_ssm_dtype: None,
+        attn_output_gate: None,
+        output_gate_type: None,
+        mtp_num_hidden_layers: None,
+        mtp_use_dedicated_embeddings: None,
+        mrope_interleaved: None,
+        mrope_section: None,
     }
 }
 
@@ -559,6 +571,18 @@ mod tests {
             mask_token_id: None,
             use_double_wide_mlp: None,
             vocab_size_per_layer_input: None,
+            linear_conv_kernel_dim: None,
+            linear_key_head_dim: None,
+            linear_value_head_dim: None,
+            linear_num_key_heads: None,
+            linear_num_value_heads: None,
+            mamba_ssm_dtype: None,
+            attn_output_gate: None,
+            output_gate_type: None,
+            mtp_num_hidden_layers: None,
+            mtp_use_dedicated_embeddings: None,
+            mrope_interleaved: None,
+            mrope_section: None,
         };
         let arch = crate::architectures::gpt2::Gpt2Arch::from_config(cfg);
 

--- a/crates/larql-server/tests/test_expert_endpoint.rs
+++ b/crates/larql-server/tests/test_expert_endpoint.rs
@@ -119,6 +119,18 @@ impl TestMoeArch {
                 mask_token_id: None,
                 use_double_wide_mlp: None,
                 vocab_size_per_layer_input: None,
+                linear_conv_kernel_dim: None,
+                linear_key_head_dim: None,
+                linear_value_head_dim: None,
+                linear_num_key_heads: None,
+                linear_num_value_heads: None,
+                mamba_ssm_dtype: None,
+                attn_output_gate: None,
+                output_gate_type: None,
+                mtp_num_hidden_layers: None,
+                mtp_use_dedicated_embeddings: None,
+                mrope_interleaved: None,
+                mrope_section: None,
             },
         }
     }

--- a/crates/larql-vindex/src/config/model.rs
+++ b/crates/larql-vindex/src/config/model.rs
@@ -339,6 +339,28 @@ mod tests {
             // 4.1 3B/8B/30B included) declares `false`, so no vindex-served
             // model needs this today.
             "mlp_bias",
+            // Hybrid linear-attention + multi-token-prediction geometry
+            // (Qwen3.5/Kimi-Linear-style — R2/Kimi-Linear rung,
+            // docs/k3-funnel.md). No forward pass anywhere in this crate,
+            // VINDEX1/2 or VINDEX3, executes a linear-attention layer or
+            // an MTP head yet — there is no served model this gap could
+            // silently mis-serve. `larql vindex3 plan` reports every one
+            // of these `unrepresented` (see
+            // `format::vindex3::plan::semantics::EXECUTION_SEMANTIC_KEYS`)
+            // rather than answering for it, which is what this list
+            // exists to force a decision about.
+            "linear_conv_kernel_dim",
+            "linear_key_head_dim",
+            "linear_value_head_dim",
+            "linear_num_key_heads",
+            "linear_num_value_heads",
+            "mamba_ssm_dtype",
+            "attn_output_gate",
+            "output_gate_type",
+            "mtp_num_hidden_layers",
+            "mtp_use_dedicated_embeddings",
+            "mrope_interleaved",
+            "mrope_section",
         ];
 
         let src = include_str!("../../../larql-models/src/config/model_config.rs");

--- a/crates/larql-vindex/src/format/vindex3/graph/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/build.rs
@@ -390,6 +390,13 @@ fn attention_table(inventory: &ArchitectureInventory) -> Vec<AttentionLayerPolic
                 num_kv_heads: layer.num_kv_heads,
             }),
             v_from_k: layer.v_from_k,
+            // Carried alongside the boolean-derived `span` verbatim, so a
+            // declared spelling the vocabulary cannot express (a hybrid
+            // linear-attention interleave) is recorded rather than
+            // silently lost behind whatever `span` defaulted to. See
+            // `AttentionLayerPolicy::declared_span` and
+            // `plan::carriage::probe_layer_types`.
+            declared_span: layer.declared_span.clone(),
         })
         .collect()
 }
@@ -444,6 +451,7 @@ fn nested_attention_table(
                 // whole tower; the surface carries it.
                 geometry: None,
                 v_from_k: false,
+                declared_span: Some(entry.clone()),
             })
         })
         .collect()

--- a/crates/larql-vindex/src/format/vindex3/graph/policy.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/policy.rs
@@ -70,7 +70,7 @@ impl AttentionSpan {
 /// This is architectural liveness information — a KV planner reading it
 /// knows that positions beyond `window` on a sliding layer are
 /// *architecturally* dead, before any semantic analysis runs.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AttentionLayerPolicy {
     pub span: AttentionSpan,
     /// Window size when [`AttentionSpan::Sliding`]; `None` on full and
@@ -96,6 +96,20 @@ pub struct AttentionLayerPolicy {
     /// written before it was recorded.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub v_from_k: bool,
+    /// The checkpoint's own `layer_types` entry for this layer, verbatim,
+    /// when it declares one. `None` when the config states no per-layer
+    /// array.
+    ///
+    /// Carried alongside [`Self::span`], never folded into it: `span` is
+    /// this schema's *executable* three-way vocabulary, and a checkpoint
+    /// declaring a spelling outside it (a hybrid linear-attention layer)
+    /// still needs its raw declaration recorded rather than silently
+    /// collapsed to whatever `span` defaulted to. Consumers that need to
+    /// know whether `span` is a genuine resolution or a fallback default
+    /// compare this field against `span` via [`AttentionSpan::from_declared`]
+    /// — see `plan::carriage::probe_layer_types`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared_span: Option<String>,
 }
 
 /// One layer's attention head geometry. Query-head count is a component

--- a/crates/larql-vindex/src/format/vindex3/graph/tests/validate.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/tests/validate.rs
@@ -22,6 +22,7 @@ fn component(id: &str, role: ComponentRole, layers: usize) -> Component {
                 position: PositionPolicy::Rope { theta: 10000.0 },
                 geometry: None,
                 v_from_k: false,
+                declared_span: None,
             };
             layers
         ]),
@@ -141,6 +142,7 @@ fn graph_round_trips_through_json_with_nope_policies() {
         position: PositionPolicy::None,
         geometry: None,
         v_from_k: false,
+        declared_span: None,
     };
     let json = serde_json::to_string_pretty(&graph).unwrap();
     let back: SystemGraph = serde_json::from_str(&json).unwrap();

--- a/crates/larql-vindex/src/format/vindex3/plan/carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/carriage.rs
@@ -540,6 +540,90 @@ pub const CARRIAGE_RULES: &[CarriageRule] = &[
         site: "no schema field — a KV-allocation bound, read by no generic op",
         probe: None,
     },
+    // ── Hybrid linear-attention + multi-token-prediction (declared, not
+    //    yet executed — R2/Kimi-Linear rung, see docs/k3-funnel.md) ──
+    //
+    // No `AttentionOp` variant computes a linear-attention layer and no
+    // MTP-head object exists in the schema, so every one of these always
+    // refuses via the shared `probe_unrepresented` — the same idiom
+    // `norm_topk_prob`/`high_freq_factor` above use for "no schema field
+    // yet". Each still gets its own rule (rather than falling through
+    // `carriage_finding`'s generic no-rule message) so
+    // `every_execution_semantic_leaf_has_a_carriage_rule` covers it: a
+    // future field added to the registry without a rule fails there
+    // before it fails on a checkpoint.
+    CarriageRule {
+        leaf: "linear_conv_kernel_dim",
+        reaches: Carriage::Represented,
+        site: "no schema field — the linear-attention block's short-conv geometry is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "linear_key_head_dim",
+        reaches: Carriage::Represented,
+        site: "no schema field — the linear-attention block's head geometry is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "linear_value_head_dim",
+        reaches: Carriage::Represented,
+        site: "no schema field — the linear-attention block's head geometry is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "linear_num_key_heads",
+        reaches: Carriage::Represented,
+        site: "no schema field — the linear-attention block's head geometry is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "linear_num_value_heads",
+        reaches: Carriage::Represented,
+        site: "no schema field — the linear-attention block's head geometry is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "mamba_ssm_dtype",
+        reaches: Carriage::Represented,
+        site: "no schema field — the linear-attention block's recurrent/SSM-adjacent state precision is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "attn_output_gate",
+        reaches: Carriage::Represented,
+        site: "no schema field — the attention output gate is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "output_gate_type",
+        reaches: Carriage::Represented,
+        site: "no schema field — the attention output gate is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "mtp_num_hidden_layers",
+        reaches: Carriage::Represented,
+        site: "no schema field — the multi-token-prediction head is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "mtp_use_dedicated_embeddings",
+        reaches: Carriage::Represented,
+        site: "no schema field — the multi-token-prediction head is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "mrope_interleaved",
+        reaches: Carriage::Represented,
+        site: "no schema field — mRoPE multi-axis sectioning is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
+    CarriageRule {
+        leaf: "mrope_section",
+        reaches: Carriage::Represented,
+        site: "no schema field — mRoPE multi-axis sectioning is not represented yet",
+        probe: Some(probe_unrepresented),
+    },
 ];
 
 /// The rule governing a config leaf, if any.
@@ -764,8 +848,24 @@ fn probe_yarn_original_max(component: &Component, _ctx: &ProbeContext<'_>) -> Op
 /// Per-layer span kinds in the checkpoint's own vocabulary, so the
 /// comparison is against the declared spelling rather than a rendering
 /// this probe invents.
+///
+/// Refuses (returns `None`) rather than vouching for the interleave when
+/// any layer's own [`declared_span`](super::super::graph::policy::AttentionLayerPolicy::declared_span)
+/// disagrees with what `span` resolved to. `AttentionLayerPolicy::span`
+/// is built off a boolean sliding/full split that silently defaults any
+/// spelling outside its three-way vocabulary (a hybrid linear-attention
+/// layer, e.g.) to `Full` — echoing `span.declared_name()` back in that
+/// state would report the declared interleave as carried when the graph
+/// actually dropped it. See `docs/k3-funnel.md` §4.7.8.
 fn probe_layer_types(component: &Component, _ctx: &ProbeContext<'_>) -> Option<Value> {
     let table = component.attention.as_ref()?;
+    let all_faithful = table.iter().all(|l| match l.declared_span.as_deref() {
+        Some(raw) => AttentionSpan::from_declared(raw) == Some(l.span),
+        None => true,
+    });
+    if !all_faithful {
+        return None;
+    }
     Some(Value::Array(
         table
             .iter()

--- a/crates/larql-vindex/src/format/vindex3/plan/compare.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/compare.rs
@@ -12,6 +12,7 @@ use larql_models::config::PositionPolicy;
 use larql_models::inventory::{ArchitectureInventory, ConfigKeyFact};
 use serde_json::Value;
 
+use super::super::graph::policy::AttentionSpan;
 use super::report::{Finding, FindingCategory, SemanticClass};
 use super::semantics::component_of;
 
@@ -266,22 +267,34 @@ fn layer_rope_theta_findings(inventory: &ArchitectureInventory) -> Option<Findin
 
 /// Declared `layer_types` interleave vs the resolved per-layer table.
 fn layer_types_finding(inventory: &ArchitectureInventory) -> Option<Finding> {
-    const SLIDING_DECLARATION: &str = "sliding_attention";
     let fact = inventory
         .config_keys
         .iter()
         .find(|f| semantics_is_layer_types(&f.path))?;
     let declared_array = fact.value.as_array()?;
     let layers = &inventory.resolved.layers;
+    // A layer disagrees when its own declared spelling names something
+    // outside the schema's executable span vocabulary (a hybrid
+    // linear-attention layer, e.g.), or when it names something the
+    // vocabulary does have and the resolved boolean split answers the
+    // opposite. Checking sliding-ness alone — the previous shape — let a
+    // spelling like `linear_attention` pass silently as "agrees, full
+    // attention" purely because neither side claims sliding: the same
+    // collapse the carriage gate exists to catch, one function over.
     let disagreeing = layers
         .iter()
         .filter(|l| {
             declared_array
                 .get(l.layer)
                 .and_then(Value::as_str)
-                .is_some_and(|declared| {
-                    declared.eq_ignore_ascii_case(SLIDING_DECLARATION)
-                        != (l.attention == ATTENTION_SLIDING)
+                .is_none_or(|declared| match AttentionSpan::from_declared(declared) {
+                    Some(AttentionSpan::Sliding) => l.attention != ATTENTION_SLIDING,
+                    Some(_) => l.attention == ATTENTION_SLIDING,
+                    // Outside the vocabulary entirely: the resolved
+                    // boolean split cannot represent it either way, so
+                    // this is a disagreement regardless of what
+                    // `attention` happens to say.
+                    None => true,
                 })
         })
         .count();

--- a/crates/larql-vindex/src/format/vindex3/plan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/mod.rs
@@ -470,6 +470,22 @@ fn attention_policy_findings(artifact: &str, built: &BuiltGraph) -> Vec<Finding>
                 .iter()
                 .filter(|l| l.position == larql_models::config::PositionPolicy::None)
                 .count();
+            // A layer whose own declared spelling disagrees with what
+            // `span` resolved to: the boolean sliding/full split has no
+            // vocabulary for it (a hybrid linear-attention layer, e.g.)
+            // and silently defaulted it to `Full`. Counted apart from
+            // `full` so this summary does not read as a faithful count
+            // when part of it is a fallback default — see
+            // `plan::carriage::probe_layer_types`.
+            let defaulted = table
+                .iter()
+                .filter(|l| {
+                    l.declared_span.as_deref().is_some_and(|raw| {
+                        super::graph::policy::AttentionSpan::from_declared(raw) != Some(l.span)
+                    })
+                })
+                .count();
+            let full = table.len() - sliding - defaulted;
             Some(Finding {
                 category: FindingCategory::Representable,
                 class: SemanticClass::ExecutionSemantic,
@@ -478,14 +494,21 @@ fn attention_policy_findings(artifact: &str, built: &BuiltGraph) -> Vec<Finding>
                 declared: None,
                 resolved: None,
                 carriage: None,
-                detail: format!(
-                    "per-layer policy recorded on component `{}`: {} sliding / {} full, \
-                     {} NoPE layer(s)",
-                    component.id,
-                    sliding,
-                    table.len() - sliding,
-                    nope,
-                ),
+                detail: if defaulted > 0 {
+                    format!(
+                        "per-layer policy recorded on component `{}`: {sliding} sliding / \
+                         {full} full / {defaulted} declared span(s) this schema has no \
+                         execution vocabulary for (defaulted to full — see \
+                         text_config.layer_types), {nope} NoPE layer(s)",
+                        component.id,
+                    )
+                } else {
+                    format!(
+                        "per-layer policy recorded on component `{}`: {sliding} sliding / \
+                         {full} full, {nope} NoPE layer(s)",
+                        component.id,
+                    )
+                },
             })
         })
         .collect()

--- a/crates/larql-vindex/src/format/vindex3/plan/semantics.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/semantics.rs
@@ -104,6 +104,38 @@ pub const EXECUTION_SEMANTIC_KEYS: &[&str] = &[
     "hidden_size_per_layer_input",
     "use_double_wide_mlp",
     "use_clipped_linears",
+    // Hybrid linear-attention block geometry (Qwen3.5/Kimi-Linear-style):
+    // changes what the linear-attention layers compute, even though no
+    // `AttentionOp` variant executes them yet — see
+    // `crate::format::vindex3::graph::policy::AttentionSpan` and
+    // `docs/k3-funnel.md`'s R2/Kimi-Linear rung. Deliberately
+    // execution-semantic, not tensor-semantic: a consumed tensor-semantic
+    // key is reported representable unconditionally (proven by the graph
+    // holding the operand), which would be false here — nothing places
+    // these tensors.
+    "linear_conv_kernel_dim",
+    "linear_key_head_dim",
+    "linear_value_head_dim",
+    "linear_num_key_heads",
+    "linear_num_value_heads",
+    // Precision the linear-attention block's recurrent/SSM-adjacent state
+    // is computed in — an execution-relevant fact distinct from the
+    // checkpoint's overall storage `dtype`.
+    "mamba_ssm_dtype",
+    // Attention output gate: whether one exists, and its nonlinearity.
+    // Distinct from the judged `AttentionGateSpec` a family may one day
+    // return from `attention_output_gate()` — these are the checkpoint's
+    // raw declaration.
+    "attn_output_gate",
+    "output_gate_type",
+    // Multi-token-prediction head shape. No MTP-head object exists in the
+    // VINDEX3 schema yet (`mtp.fc` has no placement rule either).
+    "mtp_num_hidden_layers",
+    "mtp_use_dedicated_embeddings",
+    // mRoPE sectioning (Qwen-VL-style multi-axis position encoding).
+    // `PositionPolicy` expresses unscaled single-axis rope only.
+    "mrope_interleaved",
+    "mrope_section",
 ];
 
 /// Keys that describe stored operands: widths, depths, head geometry,
@@ -245,6 +277,13 @@ pub const ALIAS_KEYS: &[(&str, &str)] = &[
         "initial_context_length",
         "rope_scaling.original_max_position_embeddings",
     ),
+    // The regular-interval spelling of a hybrid interleave ("every Nth
+    // layer is full attention"): a compressed encoding of exactly the
+    // fact the explicit `layer_types` array states per layer. Qwen3.5
+    // declares both; the parser reads the array. Benign only while
+    // `layer_types` is genuinely present and consumed in the same
+    // config — the gate verifies that, same as every other alias.
+    ("full_attention_interval", "layer_types"),
 ];
 
 /// Reviewed-and-safe-to-drop keys. Empty by design until a key has actually

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/hybrid_linear_attention.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/hybrid_linear_attention.rs
@@ -1,0 +1,228 @@
+//! Hybrid linear-attention interleaves (Qwen3.5/Kimi-Linear-style):
+//! `layer_types` declaring a span kind outside VINDEX3's executable
+//! vocabulary must block honestly — not fabricate a collapsed "all full"
+//! resolution — and must not take unrelated per-layer facts (rope theta)
+//! down with it.
+
+use super::support::{glimmer_shaped_target_with, FIXTURE_LAYERS};
+use crate::format::vindex3::plan::{plan_system, Finding, FindingCategory, SemanticClass};
+
+/// The Glimmer-shaped fixture with its `layer_types` swapped for a
+/// Qwen3.5-style hybrid interleave — three `linear_attention` layers to
+/// one `full_attention` layer — plus the declared-but-unexecuted hybrid
+/// linear-attention / MTP / mRoPE fields a real Qwen3.5 `config.json`
+/// carries alongside it.
+fn hybrid_findings() -> Vec<Finding> {
+    let dir = tempfile::tempdir().unwrap();
+    let inventory = glimmer_shaped_target_with(dir.path(), |config| {
+        let layer_types: Vec<&str> = (0..FIXTURE_LAYERS)
+            .map(|i| {
+                if i % 4 == 3 {
+                    "full_attention"
+                } else {
+                    "linear_attention"
+                }
+            })
+            .collect();
+        config["text_config"]["layer_types"] = serde_json::json!(layer_types);
+        config["text_config"]["full_attention_interval"] = serde_json::json!(4);
+        config["text_config"]["linear_conv_kernel_dim"] = serde_json::json!(4);
+        config["text_config"]["linear_key_head_dim"] = serde_json::json!(16);
+        config["text_config"]["linear_value_head_dim"] = serde_json::json!(16);
+        config["text_config"]["linear_num_key_heads"] = serde_json::json!(2);
+        config["text_config"]["linear_num_value_heads"] = serde_json::json!(4);
+        config["text_config"]["mamba_ssm_dtype"] = serde_json::json!("float32");
+        config["text_config"]["attn_output_gate"] = serde_json::json!(true);
+        config["text_config"]["output_gate_type"] = serde_json::json!("swish");
+        config["text_config"]["mtp_num_hidden_layers"] = serde_json::json!(1);
+        config["text_config"]["mtp_use_dedicated_embeddings"] = serde_json::json!(false);
+        config["text_config"]["rope_parameters"]["mrope_interleaved"] = serde_json::json!(true);
+        config["text_config"]["rope_parameters"]["mrope_section"] = serde_json::json!([2, 2, 1]);
+    });
+    let named = vec![("target-artifact".to_string(), inventory)];
+    plan_system(&named)
+        .artifacts
+        .into_iter()
+        .flat_map(|a| a.findings)
+        .collect()
+}
+
+fn finding_for<'a>(findings: &'a [Finding], suffix: &str) -> &'a Finding {
+    findings
+        .iter()
+        .find(|f| f.subject.ends_with(suffix))
+        .unwrap_or_else(|| panic!("no finding for `{suffix}`"))
+}
+
+/// The core fix: a declared span outside the executable vocabulary
+/// (`linear_attention`) must not resolve to a fabricated "all full"
+/// value. It stays `Unrepresented` — an honest statement that the schema
+/// has no home for it yet — rather than a `Representable`/`Mismatched`
+/// verdict built on a resolved value nothing actually computed.
+///
+/// Two independent findings carry `text_config.layer_types`: the
+/// declared-vs-resolved comparator (`compare::layer_types_finding`,
+/// `carriage: None`) and the carriage gate's probe
+/// (`carriage::probe_layer_types`, `carriage: Some(_)`). Both must
+/// refuse to call the interleave carried — neither may echo the
+/// collapsed "all full" default as if it were a real resolution.
+#[test]
+fn hybrid_layer_types_blocks_honestly_on_both_findings() {
+    let findings = hybrid_findings();
+    let layer_types_findings: Vec<&Finding> = findings
+        .iter()
+        .filter(|f| f.subject == "text_config.layer_types")
+        .collect();
+    assert_eq!(
+        layer_types_findings.len(),
+        2,
+        "expected the comparator finding and the carriage finding"
+    );
+
+    let fabricated_all_full = serde_json::json!(vec!["full_attention"; FIXTURE_LAYERS]);
+    for finding in &layer_types_findings {
+        assert_ne!(
+            finding.category,
+            FindingCategory::Representable,
+            "{finding:?}"
+        );
+        assert_eq!(finding.class, SemanticClass::ExecutionSemantic);
+        assert!(finding.blocks(), "{finding:?}");
+        assert_ne!(
+            finding.resolved,
+            Some(fabricated_all_full.clone()),
+            "must not fabricate a collapsed all-full resolution: {finding:?}"
+        );
+    }
+
+    // The carriage-gate finding specifically: parsed, but nothing built
+    // could vouch for the declared interleave.
+    let carriage_finding = layer_types_findings
+        .iter()
+        .find(|f| f.carriage.is_some())
+        .expect("a carriage-sourced finding");
+    assert_eq!(carriage_finding.category, FindingCategory::Unrepresented);
+
+    // The comparator finding: an honest disagreement count, not a
+    // fabricated exact match.
+    let comparator_finding = layer_types_findings
+        .iter()
+        .find(|f| f.carriage.is_none())
+        .expect("a comparator-sourced finding");
+    assert_eq!(comparator_finding.category, FindingCategory::Mismatched);
+
+    // The full declared interleave is still visible on at least one
+    // finding — "the container records what's actually declared" is
+    // satisfied regardless of what the graph could resolve.
+    let declared_array: Vec<&str> = (0..FIXTURE_LAYERS)
+        .map(|i| {
+            if i % 4 == 3 {
+                "full_attention"
+            } else {
+                "linear_attention"
+            }
+        })
+        .collect();
+    assert!(
+        layer_types_findings
+            .iter()
+            .any(|f| f.declared == Some(serde_json::json!(declared_array))),
+        "the full declared interleave must survive to the report"
+    );
+}
+
+/// **Regression guard.** The span fix must not take unrelated per-layer
+/// facts down with it: rope theta is carried independently of span, and
+/// must stay representable even while `layer_types` blocks.
+#[test]
+fn unrelated_per_layer_facts_still_carry_with_a_hybrid_interleave() {
+    let findings = hybrid_findings();
+    for subject in [
+        "text_config.rope_parameters.rope_theta",
+        "text_config.layer_rope_theta",
+    ] {
+        let finding = finding_for(&findings, subject);
+        assert_eq!(
+            finding.category,
+            FindingCategory::Representable,
+            "{subject}: {}",
+            finding.detail
+        );
+        assert!(!finding.blocks(), "{subject}");
+    }
+}
+
+/// Every newly-parsed hybrid linear-attention / MTP / mRoPE field is
+/// retained (the parser reads it — no more silent drop) but stays
+/// honestly `unrepresented`: there is no `AttentionOp`/component variant
+/// for a linear-attention layer, no MTP-head object, and no multi-axis
+/// position policy in the schema yet, so nothing here claims a
+/// representation that does not exist. Each gets its own `CarriageRule`
+/// (the shared `probe_unrepresented` idiom `norm_topk_prob` and
+/// `high_freq_factor` already use for "no schema field yet") rather than
+/// falling through the generic no-rule message — so
+/// `every_execution_semantic_leaf_has_a_carriage_rule` covers these too.
+#[test]
+fn declared_hybrid_fields_are_parsed_but_stay_honestly_unrepresented() {
+    let findings = hybrid_findings();
+    for subject in [
+        "text_config.linear_conv_kernel_dim",
+        "text_config.linear_key_head_dim",
+        "text_config.linear_value_head_dim",
+        "text_config.linear_num_key_heads",
+        "text_config.linear_num_value_heads",
+        "text_config.mamba_ssm_dtype",
+        "text_config.attn_output_gate",
+        "text_config.output_gate_type",
+        "text_config.mtp_num_hidden_layers",
+        "text_config.mtp_use_dedicated_embeddings",
+        "text_config.rope_parameters.mrope_interleaved",
+        "text_config.rope_parameters.mrope_section",
+    ] {
+        let finding = finding_for(&findings, subject);
+        assert_eq!(finding.class, SemanticClass::ExecutionSemantic, "{subject}");
+        assert_eq!(
+            finding.category,
+            FindingCategory::Unrepresented,
+            "{subject}: {}",
+            finding.detail
+        );
+        assert!(
+            finding.detail.contains("no schema field"),
+            "{subject}: {} — must not be silently dropped, must name the missing judgement",
+            finding.detail
+        );
+        assert!(finding.blocks(), "{subject}");
+    }
+}
+
+/// `full_attention_interval` is a redundant spelling of the same
+/// interleave `layer_types` states explicitly, and the parser reads the
+/// array — so this leaf grades `Alias` and does not block, even while
+/// the interleave it aliases is itself unrepresented.
+#[test]
+fn full_attention_interval_is_a_non_blocking_alias() {
+    let findings = hybrid_findings();
+    let finding = finding_for(&findings, "text_config.full_attention_interval");
+    assert_eq!(finding.class, SemanticClass::Alias);
+    assert!(!finding.blocks());
+}
+
+/// The informational per-component attention-policy summary discloses
+/// the gap rather than reporting a silently fabricated full count.
+#[test]
+fn attention_policy_summary_discloses_the_unexecutable_span() {
+    let findings = hybrid_findings();
+    let finding = findings
+        .iter()
+        .find(|f| f.subject == "attention_policy")
+        .expect("attention policy finding");
+    assert_eq!(finding.category, FindingCategory::Representable);
+    assert!(
+        finding
+            .detail
+            .contains("this schema has no execution vocabulary for"),
+        "{}",
+        finding.detail
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/mod.rs
@@ -3,6 +3,7 @@
 mod carriage;
 mod compare;
 mod gemma4;
+mod hybrid_linear_attention;
 mod semantics;
 mod system;
 


### PR DESCRIPTION
## What

Scoped, config-plumbing-only pass triggered by running `larql vindex3 plan` against the newly-released `Qwen/Qwen3.8-27B` (`model_type: qwen3_5`) — a hybrid linear-attention architecture (48 `linear_attention` + 16 `full_attention` layers, gated attention output, 1-layer MTP head), same problem class as R2's Kimi-Linear target. No compute, no kernels, no vision — see `docs/qwen3.8-competitive-landscape.md` (companion PR) for the full architecture writeup.

## Why

`plan` was telling two kinds of lies about this checkpoint:

1. `text_config.layer_types` resolved every `linear_attention` layer to `full_attention` and then the declared-vs-resolved comparator reported **"declared interleave honoured (0 sliding / 64 full)"** — a false positive, in both the carriage-gate probe and the comparator independently.
2. Twelve genuinely-declared hybrid-attention/MTP/mRoPE facts were invisible to `ModelConfig` entirely, so `plan` reported them as generic `unknown, read by nothing` instead of naming what's actually missing.

## What changed

- `ModelConfig` gains 12 new `Option` fields (`linear_conv_kernel_dim`, `linear_{key,value}_head_dim`, `linear_num_{key,value}_heads`, `mamba_ssm_dtype`, `attn_output_gate`, `output_gate_type`, `mtp_num_hidden_layers`, `mtp_use_dedicated_embeddings`, `mrope_interleaved`, `mrope_section`), parsed verbatim in `detect/parser.rs`, registered in `inventory/config_keys.rs`'s `CONSUMED_LEAF_KEYS`. `partial_rotary_factor` was already parsed for both spellings — no change needed there.
- `layer_types` carriage fixed at the root cause: `LayerPolicy`/`AttentionLayerPolicy` gained an additive `declared_span: Option<String>` carrying the checkpoint's own spelling verbatim; both the carriage-gate probe and the comparator now compare through `AttentionSpan::from_declared` and refuse to vouch for a layer whose declared spelling falls outside Sliding/Full/Windowed.
- Deliberately **no** new `AttentionSpan::LinearAttention` variant — `opplan/exec/{production,reference}.rs` match `AttentionSpan` exhaustively in real softmax-attention code, so adding one would force deciding the linear-attention arithmetic this PR is scoped to defer to real R2 work.

## Result (independently re-verified against the real checkpoint, not just the agent's self-report)

`vindex3 plan` on `Qwen/Qwen3.8-27B`: **49 representable / 1 mismatched / 29 unrepresented / 30 blocking → 48 representable / 1 mismatched / 30 unrepresented / 30 blocking.**

Blocking count is unchanged — that's the expected outcome, not a shortfall. The goal was turning silent gaps into honest, labeled ones, not passing the gate outright:

- `layer_types` moved from a **false** `representable` to an honest `mismatched` ("48 layers resolve a different attention kind than declared").
- The 12 newly-parsed fields moved from silent `unknown` to labeled `execution_semantic` blocks ("parsed, but no carriage rule states whether VINDEX3 represents it").
- `full_attention_interval` dropped off the blocking list entirely, recognized as a redundant alias of `layer_types`.

## New finding surfaced, not fixed

`graph::build::classify_group`'s substring matching silently merges `mtp.layers`/`mtp.norm`/`mtp.pre_fc_norm_{hidden,embedding}` into the main decoder's `decoder_stack`/`final_norm`/`embedding` tensor groups (only `mtp.fc` gets its own "no placement rule" finding). This is a real, pre-existing, architecture-generic tensor-placement gap — flagged for separate follow-up, not touched here since fixing it means changing classification logic shared by every architecture.

## Validation

- `cargo test -p larql-models -p larql-vindex -p larql-vindex-spec -p larql-cli` — green, 0 failures.
- `cargo clippy --tests -- -D warnings` — clean on all four crates (one pre-existing, unrelated dead-code warning in `larql-cli`'s `vindex3_cmd/lowered.rs` untouched).

## Explicitly out of scope

Vision (Qwen3-VL DeepStack ViT — separately, completely unrepresented, execution-surface build fails outright). Actual linear-attention/GDN compute, MTP compute, and the `mtp.*` tensor-placement gap above — all real R2 work, deferred until there's a reference implementation to verify against.