### PR TITLE
fix(vindex3): classify_group refuses component-external mtp.* namespace before substring scan

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/graph/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/build.rs
@@ -101,6 +101,37 @@ const GROUP_PATTERNS: &[(GroupClass, &[&str])] = &[
     (GroupClass::Stack, &["layers", "blocks"]),
 ];
 
+/// Top-level path segments that name a tensor namespace declared *outside*
+/// any component this builder places — evidence the checkpoint carries a
+/// distinct sub-model the placement vocabulary has no `GroupClass`/
+/// `ObjectKind` for yet. Qwen3.5's multi-token-prediction draft head is the
+/// first observed case: `mtp.fc`, `mtp.layers.*`, `mtp.norm`,
+/// `mtp.pre_fc_norm_hidden`, `mtp.pre_fc_norm_embedding` all live under a
+/// `mtp.` prefix that sits beside — not inside — the primary text model's
+/// own `model.language_model.*` tensors.
+///
+/// This check must run *before* the substring [`GROUP_PATTERNS`] scan, not
+/// after: `mtp.layers` contains `"layers"`, `mtp.norm` and
+/// `mtp.pre_fc_norm_hidden` contain `"norm"`, and `mtp.pre_fc_norm_embedding`
+/// contains `"embedding"`, so each would otherwise silently name-classify as
+/// `Stack`/`Norm`/`Embedding` and merge into the primary text component's
+/// own `DecoderStack`/`FinalNorm`/`Embedding` object — corrupting that
+/// object's tensor accounting with a different sub-model's weights. Only
+/// `mtp.fc` matches no existing pattern and already surfaced honestly; every
+/// other `mtp.*` group was being lost to this shadowing. A namespace here
+/// classifies as [`GroupClass::Unknown`] and surfaces in `unplaced` with the
+/// same "no placement rule" reason a truly-unrecognised prefix gets — there
+/// is no `ObjectKind` for an MTP draft head yet, so honestly refusing to
+/// place it is the correct behaviour, not a stand-in for one.
+const COMPONENT_EXTERNAL_NAMESPACES: &[&str] = &["mtp"];
+
+/// Whether `prefix`'s first `.`-separated path segment names a
+/// [`COMPONENT_EXTERNAL_NAMESPACES`] entry.
+fn is_component_external_namespace(prefix: &str) -> bool {
+    let first_segment = prefix.split('.').next().unwrap_or(prefix);
+    COMPONENT_EXTERNAL_NAMESPACES.contains(&first_segment)
+}
+
 /// Intermediate classification of one tensor-group prefix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GroupClass {
@@ -114,6 +145,9 @@ enum GroupClass {
 }
 
 fn classify_group(prefix: &str) -> GroupClass {
+    if is_component_external_namespace(prefix) {
+        return GroupClass::Unknown;
+    }
     for (class, patterns) in GROUP_PATTERNS {
         if patterns.iter().any(|p| prefix.contains(p)) {
             return *class;

--- a/crates/larql-vindex/src/format/vindex3/graph/tests/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/tests/build.rs
@@ -332,3 +332,84 @@ fn the_gemma4_multimodal_embedder_is_a_perception_adapter() {
         .iter()
         .any(|b| b.tensor_prefix.contains("embed_vision")));
 }
+
+/// Qwen3.5's MTP draft head declares its own tensor namespace (`mtp.fc`,
+/// `mtp.layers.*`, `mtp.norm`, `mtp.pre_fc_norm_hidden`,
+/// `mtp.pre_fc_norm_embedding`) sitting beside the primary text model's own
+/// tensors. Every one of these prefixes shares a substring with a
+/// [`GROUP_PATTERNS`]-style rule — `mtp.layers` contains `"layers"`,
+/// `mtp.norm`/`mtp.pre_fc_norm_hidden` contain `"norm"`,
+/// `mtp.pre_fc_norm_embedding` contains `"embedding"` — so before the
+/// `mtp`-namespace check existed, only `mtp.fc` (which matches nothing)
+/// surfaced honestly; the rest were silently absorbed into the primary
+/// text component's `decoder_stack`/`final_norm`/`embedding` objects.
+///
+/// This asserts the whole `mtp.*` family surfaces in `unplaced` with the
+/// standard reason, and that none of it leaks into the primary text
+/// component's objects.
+#[test]
+fn mtp_namespace_groups_are_unplaced_not_merged_into_the_primary_text_component() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut inventory = known_dense(dir.path());
+    // known_dense's own tensor list has no "layers"/"norm"/"embed_tokens"
+    // group beyond `model.embed_tokens` — add the primary decoder stack and
+    // final norm groups a real checkpoint would carry, so the mtp groups
+    // have a real target object to (incorrectly) fall into if the fix
+    // regresses.
+    for (prefix, tensors, bytes) in [
+        ("model.language_model.layers", 8usize, 4096u64),
+        ("model.language_model.norm", 1, 128),
+        // The MTP draft head's own namespace — must NOT merge into any of
+        // the objects above.
+        ("mtp.fc", 1, 512),
+        ("mtp.layers", 11, 2048),
+        ("mtp.norm", 1, 128),
+        ("mtp.pre_fc_norm_hidden", 1, 128),
+        ("mtp.pre_fc_norm_embedding", 1, 128),
+    ] {
+        inventory
+            .tensors
+            .groups
+            .push(larql_models::inventory::TensorGroup {
+                prefix: prefix.to_string(),
+                tensors,
+                bytes,
+            });
+    }
+    let named = vec![("only-artifact".to_string(), inventory)];
+    let built = build_from_inventories(&named);
+
+    for mtp_prefix in [
+        "mtp.fc",
+        "mtp.layers",
+        "mtp.norm",
+        "mtp.pre_fc_norm_hidden",
+        "mtp.pre_fc_norm_embedding",
+    ] {
+        let unplaced = built
+            .unplaced
+            .iter()
+            .find(|u| u.prefix == mtp_prefix)
+            .unwrap_or_else(|| panic!("{mtp_prefix} was placed anyway: {:?}", built.unplaced));
+        assert!(
+            unplaced
+                .reason
+                .contains("no placement rule owns this group"),
+            "{mtp_prefix}: {}",
+            unplaced.reason
+        );
+    }
+
+    // None of the mtp.* bytes leaked into the primary text component's
+    // objects — the regression this test guards against.
+    for object in &built.graph.objects {
+        for binding in &object.source_bindings {
+            assert!(
+                !binding.tensor_prefix.starts_with("mtp"),
+                "object `{}` absorbed mtp-namespace group `{}`",
+                object.id,
+                binding.tensor_prefix
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What

`crates/larql-vindex/src/format/vindex3/graph/build.rs`'s `classify_group` classifies each tensor-group prefix into a `GroupClass` by pure substring match against `GROUP_PATTERNS`, first-match-wins. Anything that matches nothing ends up honestly in `unplaced` ("no placement rule owns this group — judge it before conversion"); everything else is silently merged into the primary text component's `DecoderStack`/`FinalNorm`/`Embedding` object.

`Qwen/Qwen3.8-27B`'s MTP draft head declares its own tensor namespace — `mtp.fc`, `mtp.layers`, `mtp.norm`, `mtp.pre_fc_norm_hidden`, `mtp.pre_fc_norm_embedding` (verified against the real `model.safetensors.index.json`, 15 tensors, 5 groups). Only `mtp.fc` matched nothing and surfaced correctly. The other four were silently absorbed purely because they contain the substrings `"layers"`, `"norm"`, and `"embedding"`:

- `mtp.layers` (11 tensors, 744,510,464 bytes — one MTP layer's full attn+mlp+norm anatomy) → merged into the primary decoder stack, inflating its reported size from 48,706,393,088 to 49,450,903,552 bytes.
- `mtp.pre_fc_norm_embedding` → merged into the embedding table.
- `mtp.norm` **and** `mtp.pre_fc_norm_hidden` → both merged into final norm, which should hold exactly one tensor and briefly held three (30,720 bytes vs the real 10,240).

None of this showed up as a finding anywhere — that silent absence was the bug.

## Fix

Added `COMPONENT_EXTERNAL_NAMESPACES: &[&str] = &["mtp"]` and `is_component_external_namespace()`, checked against the group prefix's first `.`-segment *before* the `GROUP_PATTERNS` substring scan runs. Any `mtp.*` group now returns `GroupClass::Unknown` immediately — the same honest `unplaced` treatment `mtp.fc` already had. No new `GroupClass`/`ObjectKind` introduced. Confirmed via repo-wide grep this is the only place `classify_group`/`GROUP_PATTERNS` is used, and no other tensor namespace currently needs this treatment.

## Result (independently re-verified against the real checkpoint)

`vindex3 plan` on `Qwen/Qwen3.8-27B`: `49 representable / 1 mismatched / 29 unrepresented / 30 blocking` → `49 representable / 1 mismatched / 33 unrepresented / 34 blocking`. All five `mtp.*` groups now surface consistently as `unrepresented` ("no placement rule owns this group — judge it before conversion"). `decoder_stack`/`embedding`/`final_norm` byte counts confirmed back to their real values, `layer_types`/attention-policy/representable findings (49 of them) confirmed byte-identical before/after — unaffected by this change, as required.

This branch is independent of #274 (the `layer_types`/hybrid-attention-config plumbing PR) — it was branched from a later `main` and doesn't include that fix, so its own before/after numbers differ slightly from #274's; both are internally consistent and don't conflict.

## Validation

- New regression test `mtp_namespace_groups_are_unplaced_not_merged_into_the_primary_text_component` (`graph/tests/build.rs`), following the existing `an_unclassifiable_group_is_reported_unplaced_with_its_own_reason` convention — independently re-run, passes on its own.
- `cargo test -p larql-vindex`: 2502 passed (including the new test), 0 failed.
- `cargo clippy -p larql-vindex --tests --no-deps -- -D warnings`: clean. (The dependency-inclusive `clippy -p larql-vindex --tests -- -D warnings` fails only on a pre-existing, unrelated lint in `larql-models/src/architectures/gemma2.rs` from a newer clippy than this branch was last linted against — file untouched by this PR.)
- `cargo fmt --check -p larql-vindex`: clean.

## Explicitly out of scope

MTP tensor *placement*/representation (real R2 work — this PR only makes the gap honest, doesn't close it). Vision/multimodal, hybrid-linear-attention config plumbing (#274, separate).