### PR TITLE
test(vindex3): close the coverage gap the Gemma 2 PR left below the floor

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/plan/tests/carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/carriage.rs
@@ -269,6 +269,30 @@ fn f32_agreement_still_separates_genuinely_different_epsilons() {
     assert!(!pre.blocks() && !post.blocks());
 }
 
+/// `query_pre_attn_scalar` is the derived-value counterpart to
+/// `rms_norm_eps`'s f32-narrowing case above: the checkpoint declares the
+/// raw scalar (256), VINDEX3's execution surface stores the score scale
+/// execution actually reads (`256^-0.5`) — a different JSON value, carried
+/// through `canonical_declared` rather than compared as raw JSON. The
+/// finding stays representable, and says so explicitly rather than
+/// silently matching.
+#[test]
+fn query_pre_attn_scalar_agrees_via_the_canonical_score_scale_derivation() {
+    let findings = plan_with(|config| {
+        config["text_config"]["query_pre_attn_scalar"] = serde_json::json!(256.0);
+    });
+    let finding = finding_for(&findings, "query_pre_attn_scalar");
+
+    assert_eq!(finding.category, FindingCategory::Representable);
+    assert_eq!(finding.declared, Some(serde_json::json!(256.0)));
+    assert!(!finding.blocks());
+    assert!(
+        finding.detail.contains("canonical conversion"),
+        "{}",
+        finding.detail
+    );
+}
+
 /// An alias is benign only while the canonical spelling it defers to is
 /// genuinely declared and consumed. GPT-OSS ships both
 /// `experts_per_token` and `num_experts_per_tok`; the parser reads the
@@ -348,6 +372,16 @@ fn carriage_stages_are_ordered() {
     assert!(Carriage::Parsed < Carriage::Represented);
     assert!(Carriage::Represented < Carriage::Lowered);
     assert!(Carriage::Lowered < Carriage::Executed);
+}
+
+/// The stage name every finding's `detail` prints — all four, not just
+/// the ones a rule happens to reach in the fixtures above.
+#[test]
+fn carriage_stage_names_print_as_the_report_shows_them() {
+    assert_eq!(Carriage::Parsed.name(), "parsed");
+    assert_eq!(Carriage::Represented.name(), "represented");
+    assert_eq!(Carriage::Lowered.name(), "lowered");
+    assert_eq!(Carriage::Executed.name(), "executed");
 }
 
 /// Every rule claiming carriage past the parser must ship a probe: the

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/system.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/system.rs
@@ -146,6 +146,38 @@ fn an_unjudged_key_still_blocks() {
         .any(|f| f.class == SemanticClass::Unknown && f.blocks()));
 }
 
+/// The sibling case: a key some future parser reads (`Consumed`, not
+/// `Unconsumed`) but the semantics registry has never classified. Parser
+/// consumption is not representation authority, so this blocks exactly
+/// like the unread case above — a key the parser happened to notice must
+/// not silently outrank a key it never saw.
+#[test]
+fn a_consumed_but_unclassified_key_still_blocks() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut inventory = known_dense(dir.path());
+    inventory
+        .config_keys
+        .push(larql_models::inventory::ConfigKeyFact {
+            path: "some_future_field_a_parser_reads_but_nobody_classified".to_string(),
+            value: serde_json::json!(42),
+            status: larql_models::inventory::KeyStatus::Consumed,
+        });
+    let named = vec![("llama-artifact".to_string(), inventory)];
+    let plan = plan_system(&named);
+    assert!(!plan.admissible);
+    let finding = plan.artifacts[0]
+        .findings
+        .iter()
+        .find(|f| f.subject == "some_future_field_a_parser_reads_but_nobody_classified")
+        .expect("finding for the unjudged consumed key");
+    assert_eq!(finding.category, FindingCategory::Unrepresented);
+    assert_eq!(finding.class, SemanticClass::Unknown);
+    assert!(finding.blocks());
+    assert!(finding
+        .detail
+        .contains("parser consumption is not representation"));
+}
+
 /// Attention policy reports as representable per component, with the NoPE
 /// count visible.
 #[test]


### PR DESCRIPTION
#273 merged clean, but by the time it landed, `main` had picked up more uncovered pre-existing code in the same two files (mostly #276's `probe_embed_scale`/`probe_residual_scale`), which combined with a couple of genuinely-uncovered lines of #273's own code to drop both files below the repo's 90% per-file floor.

Three targeted tests, no source changes — see commit message for exactly which lines each one closes.

`carriage.rs`: 88.56% → 92.37%. `plan/mod.rs`: 88.10% → 91.67%. Coverage policy passes; full larql-vindex suite (2581 tests) green.