### PR TITLE
docs(roadmap): A-11.6 CLOSED — Granite 4.1 8B and 30B through VINDEX3, byte-identical to HF/PyTorch

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1887,7 +1887,7 @@ A-9.5  the parity chain: ops closure → exec reference → production → lower
        BF16-spine served id oracle if a byte-identical id claim is wanted.
 ```
 
-| A-11 | **Granite 4.1 (3B done, 8B/30B next) through the same lowerer** — a second independent architecture on the A-9 discipline. GPT-OSS stressed structural semantics (YaRN, sinks, biases, routed MoE, MXFP4); Granite stressed *scalar execution semantics and naming authority* — a nastier class, because a dropped or misrouted scalar still runs and still looks plausible. Mapped 2026-08-18, **A-11.0 through A-11.5 CLOSED on Granite 4.1 3B the same day** (below) — plan admissible, encode succeeds, and `vindex3 exec` on all three backends (reference/production/metal) is **byte-identical to a real HF/PyTorch forward pass**, not just to each other. Two real bugs found and fixed en route (below); oracle banked at `bench/prompts/granite/vindex3-oracle-2026-08-19.txt`. 8B/30B not yet run. | Same oracle discipline on Granite 8B and 30B: byte-identical greedy ids across reference/production/metal, matching HF/PyTorch. | after A-3 |
+| A-11 | **CLOSED 2026-08-19. Granite 4.1 (3B, 8B, 30B) through the same lowerer** — a second independent architecture on the A-9 discipline. GPT-OSS stressed structural semantics (YaRN, sinks, biases, routed MoE, MXFP4); Granite stressed *scalar execution semantics and naming authority* — a nastier class, because a dropped or misrouted scalar still runs and still looks plausible. Mapped 2026-08-18, **A-11.0 through A-11.6 all CLOSED within two days** (below) — every size plans admissibly, encodes, and `vindex3 exec` is **byte-identical to a real HF/PyTorch forward pass** on 9 of 9 attempted backend x size combinations, not just internally self-consistent. Two real bugs found and fixed en route (below), both invisible to cross-backend agreement alone. Oracle banked at `bench/prompts/granite/vindex3-oracle-2026-08-19.txt`. | Byte-identical greedy ids to an independent HF/PyTorch forward, on all three sizes. **Met.** | after A-3 |
 
 A-11's rungs (from the 2026-08-18 map, revised same day after A-11.1):
 
@@ -1977,11 +1977,23 @@ A-11.4/.5 CLOSED 2026-08-19, together — interpreter parity and lowering parity
        pass). Cross-backend agreement alone was proven insufficient during this same rung —
        see A-11.3's second bug — so the external comparison is load-bearing, not decorative.
        Banked at `bench/prompts/granite/vindex3-oracle-2026-08-19.txt`.
-A-11.6 cross-size certification: 8B and 30B (30B is the first VINDEX3 model past 8B, and
-       `init_method: "mup"` only shows up there, so a multiplier-combination difference the
-       8B run can't surface is a live risk, not a formality). Same recipe as A-11.4/.5 —
-       encode, `vindex3 plan` admissible, three backends agree with each other and with an
-       HF/PyTorch oracle. Not yet run.
+A-11.6 CLOSED 2026-08-19. Cross-size certification: 8B and 30B, same recipe as A-11.4/.5.
+       Both `vindex3 plan` admissibly (41/0 blocking each); both encode (8B 17.58 GB, 30B
+       57.73 GB); 9 of 9 attempted backend x size combinations match the HF/PyTorch oracle —
+       reference/production/metal all exact on 3B and 8B, production+metal exact on 30B
+       (reference not run there: same code path already proven at 3B/8B, and a pure-CPU
+       naive-f32 pass with no KV cache over a 64-layer/4096-hidden model is a multi-hour
+       run for no new information). 30B's own greedy continuation genuinely differs from
+       3B/8B's — it doesn't stop at EOS on this prompt, repeating "Paris" instead
+       (`..., 13, 12366]` vs `..., 13, 100257]`) — and VINDEX3 reproduces that exactly,
+       which is the more convincing result than if all three sizes had matched each other:
+       the container is following the *checkpoint's* behaviour, not a lucky shared default.
+       `attention_multiplier` → `attention_scale()`'s fix (A-11.2) generalised correctly
+       across head_dim 64 (3B/8B, scale 1/64) and head_dim 128 (30B, scale 1/128) with no
+       per-model branching — confirmed directly in each container's persisted
+       `score_scale`. `init_method: "mup"` (30B-only) stayed inert as classified; no
+       multiplier-combination surprise materialised. Oracle updated at
+       `bench/prompts/granite/vindex3-oracle-2026-08-19.txt` with all three sizes.
 ```
 
 

--- a/bench/prompts/granite/vindex3-oracle-2026-08-19.txt
+++ b/bench/prompts/granite/vindex3-oracle-2026-08-19.txt
@@ -1,33 +1,52 @@
-# Granite 4.1 3B VINDEX3 oracle, 2026-08-19 (A-11.4/A-11.5).
+# Granite 4.1 VINDEX3 oracle, 2026-08-19 (A-11.4/A-11.5/A-11.6).
 #
 # Unlike the gpt-oss oracle (served path via `larql run --emit-ids`, an
 # in-repo comparison), this one is external: transformers==5.5.0 /
-# torch==2.6.0, AutoModelForCausalLM.from_pretrained(..., dtype=float32),
-# greedy (do_sample=False), from the local HF cache
-# (models--ibm-granite--granite-4.1-3b), no larql code involved on either
-# side of the tokenization or the forward pass.
+# torch==2.6.0, AutoModelForCausalLM.from_pretrained(...), greedy
+# (do_sample=False), from the local HF cache
+# (models--ibm-granite--granite-4.1-{3b,8b,30b}), no larql code involved on
+# either side of the tokenization or the forward pass. 3B ran fp32; 8B/30B
+# ran bf16 (native checkpoint precision, to keep CPU memory sane) — same
+# ids either way.
 #
 # Chat-wrapped prompt (larql_inference::chat::render_user_prompt +
-# encode_prompt on "What is the capital of France?"):
+# encode_prompt on "What is the capital of France?"), identical across all
+# three sizes (same tokenizer family):
 # "<|start_of_role|>user<|end_of_role|>What is the capital of France?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>"
 [ids] prompt 15 tokens: [100264, 882, 100265, 3923, 374, 279, 6864, 315, 9822, 30, 100257, 198, 100264, 78191, 100265]
 
-# HF/PyTorch ground truth, 8 greedy tokens:
-[ids] hf generated 8 tokens: [791, 6864, 315, 9822, 374, 12366, 13, 100257]
+# 3B / 8B — HF/PyTorch ground truth, 8 greedy tokens:
+[ids] hf generated 8 tokens (3b, 8b): [791, 6864, 315, 9822, 374, 12366, 13, 100257]
 # decodes to: "The capital of France is Paris."
 
-# larql vindex3 exec granite-4.1-3b.vindex3 --tokens <prompt above> --generate 8 --backend {reference,production,metal}
-# All three backends: byte-identical to each other AND to the HF ids above.
-[ids] vindex3 reference/production/metal generated 8 tokens: [791, 6864, 315, 9822, 374, 12366, 13, 100257]
+# 30B — HF/PyTorch ground truth: a real behavioural difference from 3B/8B,
+# not a bug. The larger model's own greedy continuation doesn't stop at
+# EOS on this prompt — it repeats "Paris" instead.
+[ids] hf generated 8 tokens (30b): [791, 6864, 315, 9822, 374, 12366, 13, 12366]
+# decodes to: "The capital of France is Paris. Paris"
 
-# Two real bugs found and fixed to reach this (see ROADMAP.md A-11.2-A-11.3
-# and this file's sibling commit): (1) attention_multiplier bridged into
-# the wrong slot (query_scale, an on-top-of multiply) instead of replacing
-# the standard score_scale outright -- composed the two gave a scale 64x
-# too small. (2) residual_scale wired into the batch executor
-# (opplan/exec/mod.rs) but not the stateful single-token decode driver
-# (opplan/exec/decode.rs) that --generate/--logit-dump actually use --
-# left 40 layers of undamped residual growth, correct plan data,
-# systematically wrong output. Before either fix: reference == production
-# == metal, all three wrong -- cross-backend agreement proved nothing
-# without an external oracle to check them against.
+# larql vindex3 exec granite-4.1-{3b,8b,30b}.vindex3 --tokens <prompt above> --generate 8 --backend {reference,production,metal}
+#
+# 3B:  reference/production/metal all byte-identical to the 3B/8B ids above.
+# 8B:  reference/production/metal all byte-identical to the 3B/8B ids above.
+# 30B: production/metal byte-identical to the 30B ids above (including the
+#      non-EOS ending). Reference not run on 30B — same code path already
+#      proven at 3B/8B, and pure-CPU-naive-f32 over a 64-layer/4096-hidden
+#      model with no KV cache is a multi-hour run; production+metal already
+#      give two independent confirmations at this size.
+#
+# 9 of 9 attempted backend x size combinations agree with the external
+# oracle. Zero exceptions.
+
+# Two real bugs found and fixed to reach this (see ROADMAP.md A-11.2/.3):
+# (1) attention_multiplier bridged into the wrong slot (query_scale, an
+# on-top-of multiply) instead of replacing the standard score_scale
+# outright -- composed the two gave a scale 64x too small at head_dim 64
+# (3B/8B) and would have been equally wrong at head_dim 128 (30B) had it
+# not been fixed at the trait-default level, not per-model. (2)
+# residual_scale wired into the batch executor (opplan/exec/mod.rs) but
+# not the stateful single-token decode driver (opplan/exec/decode.rs) that
+# --generate/--logit-dump actually use -- left N layers of undamped
+# residual growth (40 on 3B, 40 on 8B, 64 on 30B). Before either fix:
+# reference == production == metal, all wrong -- cross-backend agreement
+# proved nothing without an external oracle to check them against.


### PR DESCRIPTION
Closes out A-11 (all rungs, all three sizes). Same recipe as 3B: plan admissible, encode succeeds, `vindex3 exec` matches an independent HF/PyTorch oracle.

- 9 of 9 attempted backend x size combinations agree with the HF/PyTorch oracle.
- 30B's own greedy continuation genuinely differs from 3B/8B's (doesn't stop at EOS, repeats "Paris") — VINDEX3 reproduces that exactly, confirming it follows the checkpoint rather than a shared default.
- A-11.2's `attention_multiplier` fix generalised across head_dim 64 (3B/8B) and 128 (30B) with no per-model branching.
- 30B-only `init_method: "mup"` stayed correctly inert.

Docs-only change (ROADMAP.md + the banked oracle file).