### PR TITLE
test(metal): clear the compute-metal coverage debt — the last red on main (97.05% total)

### DIFF
--- a/crates/larql-compute-metal/tests/matmul_trait_support/mod.rs
+++ b/crates/larql-compute-metal/tests/matmul_trait_support/mod.rs
@@ -1,0 +1,157 @@
+//! Fixtures and CPU oracles shared by `test_matmul_trait_arms.rs`.
+//!
+//! Every oracle here is a plain left-to-right loop over the *dequantised*
+//! weights, so a GPU arm agreeing with it proves the kernel read the
+//! format and the reduction — not that two GPU paths agree with each
+//! other. Tolerances are named at the use site.
+
+#![allow(dead_code)]
+
+use larql_models::quant::mxfp4::{
+    dequantize_expert, MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS, MXFP4_TABLE,
+};
+
+/// Multiplier for the xorshift32 seed mix; keeps fixtures deterministic
+/// per seed while decorrelating neighbouring seeds.
+const SEED_MIX: u32 = 2_654_435_761;
+
+/// E8M0 byte encoding the multiplier `1.0` (`2^(127-127)`).
+const E8M0_ONE: u8 = 127;
+/// Spread of E8M0 exponents below `E8M0_ONE` that the MXFP4 fixture
+/// cycles through, so the scale stream carries distinct bytes per group
+/// and a kernel indexing it wrongly cannot agree with the oracle.
+const E8M0_EXPONENT_SPREAD: u8 = 6;
+
+/// Deterministic uniform values in `[-1, 1)` — an xorshift32 stream.
+pub fn uniform_values(len: usize, seed: u32) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(SEED_MIX).wrapping_add(1);
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            (state as f32 / u32::MAX as f32) * 2.0 - 1.0
+        })
+        .collect()
+}
+
+/// `out[r] = sum_c w[r, c] * x[c]` over a row-major `rows × k` matrix,
+/// accumulated left to right in f32 — the oracle every GPU arm is
+/// judged against.
+pub fn cpu_gemv(w: &[f32], x: &[f32], rows: usize, k: usize) -> Vec<f32> {
+    assert_eq!(w.len(), rows * k, "oracle: weight length");
+    assert_eq!(x.len(), k, "oracle: input length");
+    (0..rows)
+        .map(|r| {
+            w[r * k..(r + 1) * k]
+                .iter()
+                .zip(x)
+                .map(|(a, b)| a * b)
+                .sum()
+        })
+        .collect()
+}
+
+/// Largest `|ref - got|` divided by `max |ref|`, so rows whose dot
+/// product is naturally small are not judged against an absolute
+/// epsilon. Panics on a length mismatch — a wrong output length is a
+/// failure, not a small error.
+pub fn rel_error(reference: &[f32], got: &[f32]) -> f32 {
+    assert_eq!(reference.len(), got.len(), "output length mismatch");
+    let scale = reference.iter().fold(0.0f32, |m, v| m.max(v.abs()));
+    if scale == 0.0 {
+        return 0.0;
+    }
+    reference
+        .iter()
+        .zip(got)
+        .map(|(r, g)| (r - g).abs())
+        .fold(0.0f32, f32::max)
+        / scale
+}
+
+/// Index of the largest finite score, ties to the lowest index.
+pub fn cpu_argmax(scores: &[f32]) -> (u32, f32) {
+    let (mut best_i, mut best_v) = (0usize, f32::NEG_INFINITY);
+    for (i, &v) in scores.iter().enumerate() {
+        if v.is_finite() && v > best_v {
+            best_i = i;
+            best_v = v;
+        }
+    }
+    (best_i as u32, best_v)
+}
+
+/// `(index, score)` of the `top_k` largest scores, sorted descending.
+pub fn cpu_topk(scores: &[f32], top_k: usize) -> Vec<(u32, f32)> {
+    let mut ranked: Vec<(u32, f32)> = scores
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| (i as u32, v))
+        .collect();
+    ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    ranked.truncate(top_k);
+    ranked
+}
+
+/// Smallest gap between consecutive entries of a descending-sorted
+/// score list. A fixture whose top scores are closer than the GPU
+/// reduction tolerance cannot pin an argmax, so tests assert this is
+/// comfortably larger than the tolerance before trusting the index.
+pub fn min_gap_between_top(scores: &[f32], top_k: usize) -> f32 {
+    let ranked = cpu_topk(scores, top_k + 1);
+    ranked
+        .windows(2)
+        .map(|w| w[0].1 - w[1].1)
+        .fold(f32::INFINITY, f32::min)
+}
+
+/// A packed MXFP4 matrix plus its scale stream and the dequantised
+/// weights it denotes.
+pub struct Mxfp4Fixture {
+    pub packed: Vec<u8>,
+    pub scales: Vec<u8>,
+    pub dequantised: Vec<f32>,
+}
+
+/// Build an MXFP4 matrix whose nibble stream cycles through every code
+/// of the table and whose E8M0 scales differ per group. Derived from
+/// `seed` so the two fixtures in a `_multi` batch are different
+/// matrices. `k` must be a multiple of `MXFP4_GROUP_ELEMS`.
+pub fn mxfp4_fixture(rows: usize, k: usize, seed: u32) -> Mxfp4Fixture {
+    assert!(
+        k.is_multiple_of(MXFP4_GROUP_ELEMS),
+        "fixture: k must be group-aligned"
+    );
+    let groups = k / MXFP4_GROUP_ELEMS;
+    let mut state = seed.wrapping_mul(SEED_MIX).wrapping_add(1);
+    let mut next_byte = move || {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        (state >> 24) as u8
+    };
+    let packed: Vec<u8> = (0..rows * groups * MXFP4_GROUP_BYTES)
+        .map(|_| next_byte())
+        .collect();
+    let scales: Vec<u8> = (0..rows * groups)
+        .map(|i| E8M0_ONE - ((i as u8).wrapping_add(next_byte()) % E8M0_EXPONENT_SPREAD))
+        .collect();
+    let dequantised = dequantize_expert(&packed, &scales, rows, groups).expect("dequantise");
+    // Fixture sanity: the codes actually span the table, so a kernel
+    // with a wrong LUT cannot agree with the oracle by accident.
+    let mut seen = [false; MXFP4_TABLE.len()];
+    for &b in &packed {
+        seen[(b & 0x0F) as usize] = true;
+        seen[(b >> 4) as usize] = true;
+    }
+    assert!(
+        seen.iter().all(|&s| s),
+        "fixture: nibble stream must exercise every MXFP4 code"
+    );
+    Mxfp4Fixture {
+        packed,
+        scales,
+        dequantised,
+    }
+}

--- a/crates/larql-compute-metal/tests/test_backend_arms.rs
+++ b/crates/larql-compute-metal/tests/test_backend_arms.rs
@@ -1,0 +1,242 @@
+//! Cover the `backend/mod.rs` arms no production path reaches:
+//!
+//! | arm | what is proven |
+//! |---|---|
+//! | `device_ref` | returns a handle to the same physical device the backend was built on (same registry id as `system_default`), not a fresh or wrong device |
+//! | `empty_roundtrip` / `empty_encoder_roundtrip` | each completes (returns) and neither allocates into the weight cache — they are pure driver round-trips |
+//! | `kv_cache_mut_for_layers` | builds a per-layer cache whose layer count and `(num_kv_heads, head_dim)` follow the layers, at the decode default capacity for every layer; a second call with the same geometry reuses the cache (state survives) rather than rebuilding; a changed geometry rebuilds |
+//! | `prepare_ple_inputs` size guard | a table whose length is not a multiple of `num_layers * ple_dim` trips the debug assertion, naming all three numbers |
+//!
+//! Everything here is read-only against the device: no kernels run
+//! except the empty command buffers, so the file is cheap and safe to
+//! run in parallel with the rest of the suite.
+
+#![cfg(target_os = "macos")]
+
+use larql_compute::attention::rope::RopeFreqPlan;
+use larql_compute::{
+    Activation, FfnType, FullPipelineLayer, NormType, QuantAux, QuantFormat, QuantWeight,
+};
+use larql_compute_metal::MetalBackend;
+
+/// Decode-path default KV capacity — `decode::DEFAULT_KV_CACHE_MAX_SEQ`
+/// is `pub(crate)`, so it is restated here; the test pins that
+/// `kv_cache_mut_for_layers` sizes every layer to it.
+const EXPECTED_DEFAULT_KV_ROWS: usize = 4096;
+/// Two layers with *different* KV geometry, so a uniform-shape fallback
+/// would be caught.
+const LAYER_A_KV_HEADS: usize = 2;
+const LAYER_A_HEAD_DIM: usize = 64;
+const LAYER_B_KV_HEADS: usize = 4;
+const LAYER_B_HEAD_DIM: usize = 32;
+/// A third geometry used to force a rebuild.
+const LAYER_C_KV_HEADS: usize = 1;
+const LAYER_C_HEAD_DIM: usize = 128;
+/// Occupancy written into the cache to detect a rebuild (a rebuild
+/// resets it to zero).
+const PROBE_OCCUPANCY: usize = 3;
+/// Enough round-trips that a per-call leak into the weight cache would
+/// show as growth.
+const ROUNDTRIP_REPEATS: usize = 4;
+/// PLE table geometry for the size-guard arm.
+const PLE_LAYERS: usize = 3;
+const PLE_DIM: usize = 8;
+/// One element short of a whole `(layer, dim)` row — not a multiple.
+const PLE_BAD_LEN: usize = PLE_LAYERS * PLE_DIM * 2 - 1;
+
+fn backend() -> Option<MetalBackend> {
+    let gpu = MetalBackend::new();
+    if gpu.is_none() {
+        eprintln!("no Metal device; skipping");
+    }
+    gpu
+}
+
+/// The KV-cache arm only reads `num_kv_heads`, `head_dim` and
+/// `sliding_window`; every other field is inert filler. Weights are
+/// empty slices — `QuantWeight::new` only checks aux-vs-format.
+fn layer_with_kv_geometry<'a>(
+    num_kv_heads: usize,
+    head_dim: usize,
+    norm: &'a [f32],
+) -> FullPipelineLayer<'a> {
+    let empty: &'a [u8] = &[];
+    let weight = || QuantWeight::new(QuantFormat::Q4_K, empty, QuantAux::None);
+    FullPipelineLayer {
+        wq: weight(),
+        wk: weight(),
+        wv: weight(),
+        wo: weight(),
+        gate: weight(),
+        up: weight(),
+        down: weight(),
+        input_norm: norm,
+        post_attn_norm: norm,
+        pre_ffn_norm: None,
+        post_ffn_norm: None,
+        attn_sinks: None,
+        attn_q_bias: None,
+        attn_k_bias: None,
+        attn_v_bias: None,
+        attn_o_bias: None,
+        attn_softcap: 0.0,
+        input_norm_bias: None,
+        post_attn_norm_bias: None,
+        norm_offset: 0.0,
+        qk_norm_offset: 0.0,
+        eps: 1e-6,
+        has_post_norms: false,
+        norm_type: NormType::RmsNorm,
+        ffn_type: FfnType::Gated,
+        activation: Activation::Silu,
+        attn_scale: 1.0 / (head_dim as f32).sqrt(),
+        head_dim,
+        num_q_heads: num_kv_heads,
+        num_kv_heads,
+        rope_base: 10_000.0,
+        rotary_dim: 0,
+        rope_freq: RopeFreqPlan::unscaled(head_dim, 0_usize, 10_000.0_f64),
+        sliding_window: 0,
+        has_v_norm: false,
+        layer_scalar: 0.0,
+        q_norm_weight: None,
+        k_norm_weight: None,
+        ffn_up_bias: None,
+        ffn_down_bias: None,
+        moe: None,
+        ffn_is_remote: false,
+        moe_combined_output_norm: false,
+        moe_outer_post_norm: None,
+        ple_input_gate: None,
+        ple_projection: None,
+        ple_post_norm: None,
+        kv_shared_source: None,
+        residual_multiplier: 1.0,
+    }
+}
+
+/// `device_ref` hands back the device the backend runs on.
+#[test]
+fn device_ref_is_the_system_default_device() {
+    let Some(gpu) = backend() else { return };
+    let system = metal::Device::system_default().expect("device exists: backend was built on it");
+    let dev = gpu.device_ref();
+    assert_eq!(
+        dev.registry_id(),
+        system.registry_id(),
+        "device_ref must return the backend's own device ({}), got {}",
+        system.name(),
+        dev.name()
+    );
+}
+
+/// Both empty round-trips complete, repeatedly, without touching the
+/// weight cache.
+#[test]
+fn empty_roundtrips_complete_without_growing_the_weight_cache() {
+    let Some(gpu) = backend() else { return };
+    let before = gpu.cache_size();
+    for _ in 0..ROUNDTRIP_REPEATS {
+        gpu.empty_roundtrip();
+        gpu.empty_encoder_roundtrip();
+    }
+    assert_eq!(
+        gpu.cache_size(),
+        before,
+        "empty round-trips must not allocate into the weight cache"
+    );
+}
+
+/// `kv_cache_mut_for_layers` follows per-layer geometry, sizes every
+/// layer to the decode default, reuses on identical geometry and
+/// rebuilds on changed geometry.
+#[test]
+fn kv_cache_mut_for_layers_follows_per_layer_geometry_and_reuses_on_repeat() {
+    let Some(gpu) = backend() else { return };
+    let norm_a = vec![1.0f32; LAYER_A_KV_HEADS * LAYER_A_HEAD_DIM];
+    let norm_b = vec![1.0f32; LAYER_B_KV_HEADS * LAYER_B_HEAD_DIM];
+    let layers = [
+        layer_with_kv_geometry(LAYER_A_KV_HEADS, LAYER_A_HEAD_DIM, &norm_a),
+        layer_with_kv_geometry(LAYER_B_KV_HEADS, LAYER_B_HEAD_DIM, &norm_b),
+    ];
+
+    {
+        let mut guard = gpu.kv_cache_mut_for_layers(&layers);
+        let kv = guard.as_mut().expect("first access must build the cache");
+        assert_eq!(
+            kv.layers.len(),
+            layers.len(),
+            "one cache layer per pipeline layer"
+        );
+        for (i, (cache_layer, layer)) in kv.layers.iter().zip(&layers).enumerate() {
+            assert_eq!(
+                (cache_layer.num_kv_heads, cache_layer.head_dim),
+                (layer.num_kv_heads, layer.head_dim),
+                "layer {i} geometry must follow the pipeline layer"
+            );
+            assert_eq!(
+                cache_layer.max_seq, EXPECTED_DEFAULT_KV_ROWS,
+                "layer {i} must be sized to the decode default capacity"
+            );
+        }
+        kv.layers[0].current_len = PROBE_OCCUPANCY;
+    }
+
+    // Same geometry again: the cache must be reused, so the probe survives.
+    {
+        let guard = gpu.kv_cache_mut_for_layers(&layers);
+        let kv = guard.as_ref().expect("cache persists");
+        assert_eq!(
+            kv.layers[0].current_len, PROBE_OCCUPANCY,
+            "identical geometry must reuse the cache, not rebuild it"
+        );
+    }
+
+    // Changed geometry: a rebuild, visible as the probe resetting.
+    let norm_c = vec![1.0f32; LAYER_C_KV_HEADS * LAYER_C_HEAD_DIM];
+    let changed = [layer_with_kv_geometry(
+        LAYER_C_KV_HEADS,
+        LAYER_C_HEAD_DIM,
+        &norm_c,
+    )];
+    let guard = gpu.kv_cache_mut_for_layers(&changed);
+    let kv = guard.as_ref().expect("rebuilt cache");
+    assert_eq!(kv.layers.len(), changed.len());
+    assert_eq!(
+        (kv.layers[0].num_kv_heads, kv.layers[0].head_dim),
+        (LAYER_C_KV_HEADS, LAYER_C_HEAD_DIM)
+    );
+    assert_eq!(
+        kv.layers[0].current_len, 0,
+        "a changed geometry must rebuild, resetting occupancy"
+    );
+}
+
+/// A PLE table that is not a whole number of `(layer, dim)` rows trips
+/// the size guard, and the message names the three numbers involved.
+/// Debug-only: the guard is a `debug_assert!`.
+#[test]
+#[cfg(debug_assertions)]
+fn prepare_ple_inputs_rejects_a_table_that_is_not_a_multiple_of_rows() {
+    let Some(gpu) = backend() else { return };
+    let data = vec![0.0f32; PLE_BAD_LEN];
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        gpu.prepare_ple_inputs(&data, PLE_LAYERS, PLE_DIM);
+    }));
+    let err = outcome.expect_err("a non-multiple table length must trip the size guard");
+    let msg = err
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_default();
+    for needle in [
+        PLE_BAD_LEN.to_string(),
+        PLE_LAYERS.to_string(),
+        PLE_DIM.to_string(),
+    ] {
+        assert!(
+            msg.contains(&needle),
+            "guard message must name {needle}; got {msg:?}"
+        );
+    }
+}

--- a/crates/larql-compute-metal/tests/test_matmul_trait_arms.rs
+++ b/crates/larql-compute-metal/tests/test_matmul_trait_arms.rs
@@ -1,0 +1,540 @@
+//! Arm-by-arm contract tests for `impl MatMul for MetalBackend`
+//! (`src/trait_impl/matmul.rs`).
+//!
+//! Each arm is asserted for what it is:
+//!
+//! | arm | proven by |
+//! |---|---|
+//! | `f32_gemv` / `f16_gemv` | parity with a CPU loop over the (dequantised) weights; `None` below the FLOP threshold while the `_force` twin runs |
+//! | `f16_gemv_multi` | bit-identical to the sequential `f16_gemv_force` calls; empty batch → `Some([])`; short/mismatched operands → `None` |
+//! | `wire_resident` | observably a no-op: a gemv after wiring is bit-identical to one before; degenerate inputs return without dispatch |
+//! | `mxfp4_gemv(_multi)` / `nvfp4_gemv(_multi)` | parity with the dequantised matrix; `_multi` equals the singles; geometry guards → `None` |
+//! | `*_topk1` / `f16_gemv_topk` | equal to the CPU argmax / top-k of the same gemv, on a fixture whose top gaps exceed the tolerance |
+//! | `matmul_batch` | each op dispatched through `matmul` or `matmul_transb` by its flag, against ndarray `dot` |
+//!
+//! Shapes are deliberately awkward (row counts that are not a multiple of
+//! the kernels' rows-per-threadgroup) so tail-row guards are exercised.
+
+#![cfg(target_os = "macos")]
+
+extern crate blas_src;
+
+mod matmul_trait_support;
+
+use matmul_trait_support::{
+    cpu_argmax, cpu_gemv, cpu_topk, min_gap_between_top, mxfp4_fixture, rel_error, uniform_values,
+};
+
+use larql_compute::backend::matmul::{MatMul, MatMulOp};
+use larql_compute::prelude::*;
+use larql_compute::CpuBackend;
+use larql_compute_metal::calibration::MIN_FLOP_FLOOR;
+use larql_compute_metal::shaders::f32_gemv::K_TOPK;
+use larql_compute_metal::MetalBackend;
+use larql_models::quant::half::{decode_f16, encode_f16};
+use larql_models::quant::mxfp4::MXFP4_GROUP_ELEMS;
+use larql_models::quant::nvfp4::{self, NVFP4_GROUP_ELEMS};
+use ndarray::Array2;
+
+/// Row count that is not a multiple of any kernel's rows-per-threadgroup
+/// (4 or 8), so the tail-row guard runs.
+const ROWS: usize = 37;
+/// Reduction length: a multiple of both the MXFP4 (32) and NVFP4 (16)
+/// group sizes.
+const K: usize = 256;
+/// A second row count for the `_multi` batches, so the batch carries
+/// matrices of different height.
+const ROWS_ALT: usize = 21;
+/// Rows needed for `2 * rows * K` to clear `MIN_FLOP_FLOOR` — the lowest
+/// threshold `set_flop_threshold` will accept.
+const ROWS_ABOVE_FLOOR: usize = MIN_FLOP_FLOOR / (2 * K) + 1;
+/// Bytes per f16 element.
+const F16_BYTES: usize = 2;
+/// Reduction-order tolerance: the GPU accumulates lane-parallel then
+/// `simd_sum`; the oracle accumulates left to right. Both in f32.
+const REDUCTION_REL_TOL: f32 = 1e-4;
+/// Minimum score gap the top-k fixture must exhibit for the argmax /
+/// top-k index comparison to be meaningful (well above the tolerance).
+const MIN_TOPK_GAP: f32 = 1e-2;
+/// `top_k` requested from `f16_gemv_topk` — inside the kernel's
+/// per-threadgroup capacity.
+const TOPK_REQUESTED: usize = 5;
+/// Seeds for the deterministic fixtures.
+const SEED_W: u32 = 11;
+const SEED_W_ALT: u32 = 13;
+const SEED_X: u32 = 17;
+/// Matmul geometry for `matmul_batch`.
+const MM_M: usize = 3;
+const MM_K: usize = 5;
+const MM_N: usize = 7;
+
+fn gpu() -> Option<MetalBackend> {
+    let gpu = MetalBackend::new();
+    if gpu.is_none() {
+        eprintln!("no Metal device; skipping");
+    }
+    gpu
+}
+
+fn x_vec() -> Vec<f32> {
+    uniform_values(K, SEED_X)
+}
+
+fn f32_matrix(rows: usize, seed: u32) -> (Array2<f32>, Vec<f32>) {
+    let w = uniform_values(rows * K, seed);
+    (Array2::from_shape_vec((rows, K), w.clone()).unwrap(), w)
+}
+
+/// f16 weights are compared against their own decoded values, so the
+/// comparison isolates the kernel from the f16 rounding of the fixture.
+fn f16_matrix(rows: usize, seed: u32) -> (Vec<u8>, Vec<f32>) {
+    let bytes = encode_f16(&uniform_values(rows * K, seed));
+    let decoded = decode_f16(&bytes);
+    (bytes, decoded)
+}
+
+// ───────────────────────── f32 gemv ─────────────────────────
+
+/// `f32_gemv` above the FLOP threshold matches the CPU loop, and the
+/// shape used really clears the floor the backend clamps to.
+#[test]
+fn f32_gemv_above_threshold_matches_cpu_reference() {
+    let Some(gpu) = gpu() else { return };
+    gpu.set_flop_threshold(MIN_FLOP_FLOOR);
+    assert!(2 * ROWS_ABOVE_FLOOR * K >= gpu.flop_threshold());
+    let (w, w_flat) = f32_matrix(ROWS_ABOVE_FLOOR, SEED_W);
+    let x = x_vec();
+    let reference = cpu_gemv(&w_flat, &x, ROWS_ABOVE_FLOOR, K);
+    let got = gpu
+        .f32_gemv(w.view(), &x)
+        .expect("above threshold dispatches");
+    assert!(rel_error(&reference, &got) < REDUCTION_REL_TOL);
+}
+
+/// Below the threshold `f32_gemv` declines (`None`) while `f32_gemv_force`
+/// runs the same kernel and agrees with the CPU loop.
+#[test]
+fn f32_gemv_declines_below_threshold_while_force_runs() {
+    let Some(gpu) = gpu() else { return };
+    gpu.set_flop_threshold(MIN_FLOP_FLOOR);
+    assert!(2 * ROWS * K < gpu.flop_threshold());
+    let (w, w_flat) = f32_matrix(ROWS, SEED_W);
+    let x = x_vec();
+    assert!(gpu.f32_gemv(w.view(), &x).is_none());
+    let reference = cpu_gemv(&w_flat, &x, ROWS, K);
+    let got = gpu
+        .f32_gemv_force(w.view(), &x)
+        .expect("force ignores the threshold");
+    assert!(rel_error(&reference, &got) < REDUCTION_REL_TOL);
+}
+
+/// Both f32 variants reject an input vector whose length is not `k`.
+#[test]
+fn f32_gemv_variants_reject_mismatched_input_length() {
+    let Some(gpu) = gpu() else { return };
+    let (w, _) = f32_matrix(ROWS, SEED_W);
+    let short_x = vec![0.0f32; K - 1];
+    assert!(gpu.f32_gemv(w.view(), &short_x).is_none());
+    assert!(gpu.f32_gemv_force(w.view(), &short_x).is_none());
+}
+
+// ───────────────────────── f16 gemv ─────────────────────────
+
+/// `f16_gemv` above threshold and `f16_gemv_force` below it both match
+/// the CPU loop over the decoded f16 weights; the gated arm declines on
+/// the small shape.
+#[test]
+fn f16_gemv_matches_decoded_weights_and_honours_threshold_gate() {
+    let Some(gpu) = gpu() else { return };
+    gpu.set_flop_threshold(MIN_FLOP_FLOOR);
+    let x = x_vec();
+
+    let (big, big_dec) = f16_matrix(ROWS_ABOVE_FLOOR, SEED_W);
+    let got = gpu
+        .f16_gemv(&big, &x, ROWS_ABOVE_FLOOR, K)
+        .expect("above threshold dispatches");
+    let reference = cpu_gemv(&big_dec, &x, ROWS_ABOVE_FLOOR, K);
+    assert!(rel_error(&reference, &got) < REDUCTION_REL_TOL);
+
+    let (small, small_dec) = f16_matrix(ROWS, SEED_W);
+    assert!(gpu.f16_gemv(&small, &x, ROWS, K).is_none());
+    let forced = gpu
+        .f16_gemv_force(&small, &x, ROWS, K)
+        .expect("force ignores the threshold");
+    let reference = cpu_gemv(&small_dec, &x, ROWS, K);
+    assert!(rel_error(&reference, &forced) < REDUCTION_REL_TOL);
+}
+
+/// Short weight bytes or a mismatched input length yield `None` on both
+/// f16 variants.
+#[test]
+fn f16_gemv_variants_reject_short_weights_and_mismatched_input() {
+    let Some(gpu) = gpu() else { return };
+    let (w, _) = f16_matrix(ROWS, SEED_W);
+    let x = x_vec();
+    let short_w = &w[..w.len() - F16_BYTES];
+    let short_x = &x[..K - 1];
+    assert!(gpu.f16_gemv(short_w, &x, ROWS, K).is_none());
+    assert!(gpu.f16_gemv_force(short_w, &x, ROWS, K).is_none());
+    assert!(gpu.f16_gemv(&w, short_x, ROWS, K).is_none());
+    assert!(gpu.f16_gemv_force(&w, short_x, ROWS, K).is_none());
+}
+
+/// One submission of N dispatches is bit-identical to N sequential
+/// `f16_gemv_force` calls, and each agrees with the CPU loop.
+#[test]
+fn f16_gemv_multi_is_bit_identical_to_sequential_force_gemvs() {
+    let Some(gpu) = gpu() else { return };
+    let x = x_vec();
+    let (w_a, dec_a) = f16_matrix(ROWS, SEED_W);
+    let (w_b, dec_b) = f16_matrix(ROWS_ALT, SEED_W_ALT);
+    let batch = gpu
+        .f16_gemv_multi(&[(&w_a, ROWS, K), (&w_b, ROWS_ALT, K)], &x)
+        .expect("valid batch dispatches");
+    assert_eq!(batch.len(), 2);
+    let single_a = gpu.f16_gemv_force(&w_a, &x, ROWS, K).unwrap();
+    let single_b = gpu.f16_gemv_force(&w_b, &x, ROWS_ALT, K).unwrap();
+    assert_eq!(batch[0], single_a, "batch[0] must be bit-identical");
+    assert_eq!(batch[1], single_b, "batch[1] must be bit-identical");
+    assert!(rel_error(&cpu_gemv(&dec_a, &x, ROWS, K), &batch[0]) < REDUCTION_REL_TOL);
+    assert!(rel_error(&cpu_gemv(&dec_b, &x, ROWS_ALT, K), &batch[1]) < REDUCTION_REL_TOL);
+}
+
+/// An empty batch is `Some(empty)`; any short or mismatched operand
+/// fails the whole batch with `None` before anything is dispatched.
+#[test]
+fn f16_gemv_multi_empty_batch_and_operand_guards() {
+    let Some(gpu) = gpu() else { return };
+    let x = x_vec();
+    assert_eq!(gpu.f16_gemv_multi(&[], &x), Some(Vec::new()));
+    let (w, _) = f16_matrix(ROWS, SEED_W);
+    let short_w = &w[..w.len() - F16_BYTES];
+    assert!(gpu
+        .f16_gemv_multi(&[(&w, ROWS, K), (short_w, ROWS, K)], &x)
+        .is_none());
+    assert!(gpu.f16_gemv_multi(&[(&w, ROWS, K)], &x[..K - 1]).is_none());
+}
+
+// ───────────────────────── wire_resident ─────────────────────────
+
+/// Wiring a set of weight buffers changes no number: the gemv over the
+/// first buffer is bit-identical before and after, and the kernel's
+/// scratch 1×1 dispatch leaks nothing into the caller's bytes.
+#[test]
+fn wire_resident_is_a_no_op_on_numbers() {
+    let Some(gpu) = gpu() else { return };
+    let x = x_vec();
+    let (w_a, _) = f16_matrix(ROWS, SEED_W);
+    let (w_b, _) = f16_matrix(ROWS_ALT, SEED_W_ALT);
+    let before = gpu.f16_gemv_force(&w_a, &x, ROWS, K).unwrap();
+    let w_a_bytes_before = w_a.clone();
+    gpu.wire_resident(&[&w_a, &w_b]);
+    assert_eq!(w_a, w_a_bytes_before, "wiring must not write the weights");
+    let after = gpu.f16_gemv_force(&w_a, &x, ROWS, K).unwrap();
+    assert_eq!(before, after, "gemv must be bit-identical across wiring");
+}
+
+/// Degenerate inputs — no buffers, or a first buffer shorter than one
+/// f16 element — return without dispatching and without panicking.
+#[test]
+fn wire_resident_returns_early_on_degenerate_inputs() {
+    let Some(gpu) = gpu() else { return };
+    gpu.wire_resident(&[]);
+    let one_byte = [0u8; 1];
+    gpu.wire_resident(&[&one_byte]);
+}
+
+// ───────────────────────── MXFP4 ─────────────────────────
+
+/// `mxfp4_gemv` agrees with the CPU loop over the dequantised matrix, on
+/// a fixture whose nibble stream spans every code and whose scales differ
+/// per group.
+#[test]
+fn mxfp4_gemv_matches_dequantised_reference() {
+    let Some(gpu) = gpu() else { return };
+    let x = x_vec();
+    let fx = mxfp4_fixture(ROWS, K, SEED_W);
+    let reference = cpu_gemv(&fx.dequantised, &x, ROWS, K);
+    let got = gpu
+        .mxfp4_gemv(&fx.packed, &fx.scales, &x, ROWS, K)
+        .expect("aligned geometry dispatches");
+    assert!(rel_error(&reference, &got) < REDUCTION_REL_TOL);
+}
+
+/// The MXFP4 batch equals the single-matrix calls element for element
+/// (same kernel, same arguments) and an empty batch is `Some(empty)`.
+#[test]
+fn mxfp4_gemv_multi_equals_single_gemvs() {
+    let Some(gpu) = gpu() else { return };
+    let x = x_vec();
+    let fa = mxfp4_fixture(ROWS, K, SEED_W);
+    let fb = mxfp4_fixture(ROWS_ALT, K, SEED_W_ALT);
+    let batch = gpu
+        .mxfp4_gemv_multi(
+            &[
+                (&fa.packed, &fa.scales, ROWS, K),
+                (&fb.packed, &fb.scales, ROWS_ALT, K),
+            ],
+            &x,
+        )
+        .expect("valid batch dispatches");
+    let single_a = gpu.mxfp4_gemv(&fa.packed, &fa.scales, &x, ROWS, K).unwrap();
+    let single_b = gpu
+        .mxfp4_gemv(&fb.packed, &fb.scales, &x, ROWS_ALT, K)
+        .unwrap();
+    assert_eq!(batch, vec![single_a, single_b]);
+    assert_eq!(gpu.mxfp4_gemv_multi(&[], &x), Some(Vec::new()));
+}
+
+/// Unaligned `k`, a short input, short packed bytes or short scales each
+/// yield `None` rather than an out-of-bounds read.
+#[test]
+fn mxfp4_gemv_rejects_bad_geometry() {
+    let Some(gpu) = gpu() else { return };
+    let x = x_vec();
+    let fx = mxfp4_fixture(ROWS, K, SEED_W);
+    let unaligned_k = K - 1;
+    assert!(gpu
+        .mxfp4_gemv(&fx.packed, &fx.scales, &x, ROWS, unaligned_k)
+        .is_none());
+    assert!(gpu
+        .mxfp4_gemv(&fx.packed, &fx.scales, &x[..K - MXFP4_GROUP_ELEMS], ROWS, K)
+        .is_none());
+    assert!(gpu
+        .mxfp4_gemv(&fx.packed[..fx.packed.len() - 1], &fx.scales, &x, ROWS, K)
+        .is_none());
+    assert!(gpu
+        .mxfp4_gemv(&fx.packed, &fx.scales[..fx.scales.len() - 1], &x, ROWS, K)
+        .is_none());
+}
+
+// ───────────────────────── NVFP4 ─────────────────────────
+
+fn nvfp4_matrix(rows: usize, seed: u32) -> (nvfp4::Nvfp4Matrix, Vec<f32>) {
+    let m = nvfp4::quantize(&uniform_values(rows * K, seed), rows, K).expect("quantise");
+    let mut dequantised = vec![0.0f32; rows * K];
+    nvfp4::dequantize_into(&m, rows, K, &mut dequantised).expect("dequantise");
+    (m, dequantised)
+}
+
+/// `nvfp4_gemv` agrees with the dequantised matrix; the batch equals the
+/// singles; an empty batch is `Some(empty)`.
+#[test]
+fn nvfp4_gemv_and_multi_match_dequantised_reference() {
+    let Some(gpu) = gpu() else { return };
+    let x = x_vec();
+    let (ma, da) = nvfp4_matrix(ROWS, SEED_W);
+    let (mb, db) = nvfp4_matrix(ROWS_ALT, SEED_W_ALT);
+    let single_a = gpu
+        .nvfp4_gemv(&ma.packed, &ma.scales, ma.tensor_scale, &x, ROWS, K)
+        .expect("aligned geometry dispatches");
+    let single_b = gpu
+        .nvfp4_gemv(&mb.packed, &mb.scales, mb.tensor_scale, &x, ROWS_ALT, K)
+        .expect("aligned geometry dispatches");
+    assert!(rel_error(&cpu_gemv(&da, &x, ROWS, K), &single_a) < REDUCTION_REL_TOL);
+    assert!(rel_error(&cpu_gemv(&db, &x, ROWS_ALT, K), &single_b) < REDUCTION_REL_TOL);
+    let batch = gpu
+        .nvfp4_gemv_multi(
+            &[
+                (&ma.packed, &ma.scales, ma.tensor_scale, ROWS, K),
+                (&mb.packed, &mb.scales, mb.tensor_scale, ROWS_ALT, K),
+            ],
+            &x,
+        )
+        .expect("valid batch dispatches");
+    assert_eq!(batch, vec![single_a, single_b]);
+    assert_eq!(gpu.nvfp4_gemv_multi(&[], &x), Some(Vec::new()));
+}
+
+/// NVFP4 geometry guards: unaligned `k`, short input, short packed, short
+/// scales each yield `None`.
+#[test]
+fn nvfp4_gemv_rejects_bad_geometry() {
+    let Some(gpu) = gpu() else { return };
+    let x = x_vec();
+    let (m, _) = nvfp4_matrix(ROWS, SEED_W);
+    let ts = m.tensor_scale;
+    assert!(gpu
+        .nvfp4_gemv(&m.packed, &m.scales, ts, &x, ROWS, K - 1)
+        .is_none());
+    assert!(gpu
+        .nvfp4_gemv(
+            &m.packed,
+            &m.scales,
+            ts,
+            &x[..K - NVFP4_GROUP_ELEMS],
+            ROWS,
+            K
+        )
+        .is_none());
+    assert!(gpu
+        .nvfp4_gemv(&m.packed[..m.packed.len() - 1], &m.scales, ts, &x, ROWS, K)
+        .is_none());
+    assert!(gpu
+        .nvfp4_gemv(&m.packed, &m.scales[..m.scales.len() - 1], ts, &x, ROWS, K)
+        .is_none());
+}
+
+// ───────────────────────── top-k ─────────────────────────
+
+/// `f32_gemv_topk1` returns the CPU argmax of the same gemv with its
+/// score, on a fixture whose top gap is well above the tolerance.
+#[test]
+fn f32_gemv_topk1_equals_cpu_argmax() {
+    let Some(gpu) = gpu() else { return };
+    let (w, w_flat) = f32_matrix(ROWS, SEED_W);
+    let x = x_vec();
+    let scores = cpu_gemv(&w_flat, &x, ROWS, K);
+    assert!(
+        min_gap_between_top(&scores, 1) > MIN_TOPK_GAP,
+        "fixture gap"
+    );
+    let (idx, val) = cpu_argmax(&scores);
+    let (got_idx, got_val) = MatMul::f32_gemv_topk1(&gpu, w.view(), &x).expect("valid shape");
+    assert_eq!(got_idx, idx);
+    assert!((got_val - val).abs() < REDUCTION_REL_TOL * val.abs().max(1.0));
+}
+
+/// `f32_gemv_topk1` on a non-contiguous view (the transpose of a
+/// row-major matrix) materialises a standard-layout copy and returns the
+/// same argmax as the contiguous copy of that view.
+#[test]
+fn f32_gemv_topk1_handles_non_contiguous_view() {
+    let Some(gpu) = gpu() else { return };
+    // Square so the transpose keeps `k == K` for the shared input vector.
+    let (w_square, _) = f32_matrix(K, SEED_W);
+    let w_t = w_square.t();
+    assert!(w_t.as_slice().is_none(), "fixture: view is non-contiguous");
+    let x = x_vec();
+    let contiguous = w_t.as_standard_layout().into_owned();
+    let w_t_flat = contiguous.as_slice().unwrap();
+    let scores = cpu_gemv(w_t_flat, &x, K, K);
+    assert!(
+        min_gap_between_top(&scores, 1) > MIN_TOPK_GAP,
+        "fixture gap"
+    );
+    let (idx, _) = cpu_argmax(&scores);
+    let (got_idx, _) = MatMul::f32_gemv_topk1(&gpu, w_t, &x).expect("valid shape");
+    assert_eq!(got_idx, idx);
+    let (from_contiguous, _) =
+        MatMul::f32_gemv_topk1(&gpu, contiguous.view(), &x).expect("valid shape");
+    assert_eq!(got_idx, from_contiguous);
+}
+
+/// `f32_gemv_topk1` rejects a mismatched input and an empty matrix.
+#[test]
+fn f32_gemv_topk1_rejects_mismatched_input_and_zero_rows() {
+    let Some(gpu) = gpu() else { return };
+    let (w, _) = f32_matrix(ROWS, SEED_W);
+    let x = x_vec();
+    assert!(MatMul::f32_gemv_topk1(&gpu, w.view(), &x[..K - 1]).is_none());
+    let empty = Array2::<f32>::zeros((0, K));
+    assert!(MatMul::f32_gemv_topk1(&gpu, empty.view(), &x).is_none());
+}
+
+/// `f16_gemv_topk1` equals the CPU argmax over the decoded f16 weights,
+/// and `f16_gemv_topk` returns the CPU top-k in descending order with
+/// matching indices.
+#[test]
+fn f16_gemv_topk1_and_topk_equal_cpu_ranking() {
+    let Some(gpu) = gpu() else { return };
+    let (w, dec) = f16_matrix(ROWS, SEED_W);
+    let x = x_vec();
+    let scores = cpu_gemv(&dec, &x, ROWS, K);
+    assert!(
+        min_gap_between_top(&scores, TOPK_REQUESTED) > MIN_TOPK_GAP,
+        "fixture gap"
+    );
+    let (idx, val) = cpu_argmax(&scores);
+    let (got_idx, got_val) = MatMul::f16_gemv_topk1(&gpu, &w, &x, ROWS, K).expect("valid shape");
+    assert_eq!(got_idx, idx);
+    assert!((got_val - val).abs() < REDUCTION_REL_TOL * val.abs().max(1.0));
+
+    let expected = cpu_topk(&scores, TOPK_REQUESTED);
+    let got = MatMul::f16_gemv_topk(&gpu, &w, &x, ROWS, K, TOPK_REQUESTED)
+        .expect("top_k within capacity");
+    assert_eq!(got.len(), TOPK_REQUESTED);
+    for (g, e) in got.iter().zip(&expected) {
+        assert_eq!(g.0, e.0, "top-k index order");
+        assert!((g.1 - e.1).abs() < REDUCTION_REL_TOL * e.1.abs().max(1.0));
+    }
+}
+
+/// The f16 top-k arms decline on short weights, mismatched input, zero
+/// rows, `top_k == 0` and `top_k > K_TOPK`.
+#[test]
+fn f16_gemv_topk_arms_reject_bad_shapes_and_capacity() {
+    let Some(gpu) = gpu() else { return };
+    let (w, _) = f16_matrix(ROWS, SEED_W);
+    let x = x_vec();
+    let short_w = &w[..w.len() - F16_BYTES];
+    assert!(MatMul::f16_gemv_topk1(&gpu, short_w, &x, ROWS, K).is_none());
+    assert!(MatMul::f16_gemv_topk1(&gpu, &w, &x[..K - 1], ROWS, K).is_none());
+    assert!(MatMul::f16_gemv_topk1(&gpu, &w, &x, 0, K).is_none());
+    assert!(MatMul::f16_gemv_topk(&gpu, short_w, &x, ROWS, K, 1).is_none());
+    assert!(MatMul::f16_gemv_topk(&gpu, &w, &x, ROWS, K, 0).is_none());
+    assert!(MatMul::f16_gemv_topk(&gpu, &w, &x, ROWS, K, K_TOPK + 1).is_none());
+}
+
+// ───────────────────────── matmul_batch ─────────────────────────
+
+/// Each op is routed by its `transpose_b` flag: the first against
+/// `a · b`, the second against `a · bᵀ`. Non-square `b` makes the two
+/// routes have different shapes, so a flag ignored would not type-check
+/// against the oracle.
+#[test]
+fn matmul_batch_dispatches_each_op_by_transpose_flag() {
+    let Some(gpu) = gpu() else { return };
+    let a = Array2::from_shape_vec((MM_M, MM_K), uniform_values(MM_M * MM_K, SEED_W)).unwrap();
+    let b = Array2::from_shape_vec((MM_K, MM_N), uniform_values(MM_K * MM_N, SEED_W_ALT)).unwrap();
+    let b_t = b.t().to_owned();
+    let ops = vec![
+        MatMulOp {
+            a: a.clone(),
+            b: b.clone(),
+            transpose_b: false,
+        },
+        MatMulOp {
+            a: a.clone(),
+            b: b_t,
+            transpose_b: true,
+        },
+    ];
+    let outs = gpu.matmul_batch(&ops);
+    assert_eq!(outs.len(), 2);
+    let expected = a.dot(&b);
+    for out in &outs {
+        assert_eq!(out.shape(), &[MM_M, MM_N]);
+        let err = rel_error(expected.as_slice().unwrap(), out.as_slice().unwrap());
+        assert!(err < REDUCTION_REL_TOL, "matmul_batch arm error {err}");
+    }
+}
+
+// ───────────────────────── Q4_K stride-32 ─────────────────────────
+
+/// Hidden size that is a multiple of the Q4_K super-block (256).
+const Q4K_HIDDEN: usize = 512;
+/// Q4_K-vs-Q4_K (same quantised weights) disagreement is reduction
+/// order only; the CPU path dequantises in a different grouping, so the
+/// bound is looser than the f32 arms but far below any Q4_K ulp.
+const Q4K_ABS_TOL: f32 = 0.5;
+
+/// The stride-32 Q4_K matvec matches the CPU Q4_K matvec over the same
+/// bytes, and declines a hidden size that is not a super-block multiple.
+#[test]
+fn q4k_matvec_stride32_matches_cpu_and_rejects_unaligned_hidden() {
+    let Some(gpu) = gpu() else { return };
+    let w = uniform_values(ROWS * Q4K_HIDDEN, SEED_W);
+    let x = uniform_values(Q4K_HIDDEN, SEED_X);
+    let q4k = larql_compute::cpu::ops::q4_common::quantize_q4_k(&w);
+    let cpu = CpuBackend
+        .q4k_matvec(&q4k, &x, ROWS, Q4K_HIDDEN)
+        .expect("CPU Q4_K matvec");
+    let got = MetalBackend::q4k_matvec_stride32(&gpu, &q4k, &x, ROWS, Q4K_HIDDEN)
+        .expect("aligned hidden dispatches");
+    for (i, (c, g)) in cpu.iter().zip(&got).enumerate() {
+        assert!((c - g).abs() < Q4K_ABS_TOL, "row {i}: cpu={c} gpu={g}");
+    }
+    assert!(MetalBackend::q4k_matvec_stride32(&gpu, &q4k, &x, ROWS, Q4K_HIDDEN - 1).is_none());
+    assert!(MetalBackend::q4k_matvec_stride32(&gpu, &q4k, &x, ROWS, 0).is_none());
+}

--- a/crates/larql-compute-metal/tests/test_nvfp4_call_profile.rs
+++ b/crates/larql-compute-metal/tests/test_nvfp4_call_profile.rs
@@ -1,0 +1,277 @@
+//! Drive `diag/nvfp4_call_profile.rs` end to end on a real device.
+//!
+//! The module splits one NVFP4 gemv call into host/GPU phases
+//! (`profile_nvfp4_gemv`) and measures the per-dispatch cost of a
+//! pipelined burst (`nvfp4_pipelined_cost`). Both are diagnostics, so
+//! this file does not assert any latency number — those vary with the
+//! machine and with contention. What it does pin:
+//!
+//! | arm | claim |
+//! |---|---|
+//! | 1 | every phase of a profiled call is finite and non-negative |
+//! | 2 | the wall-clock phases (input, acquire, encode, commit, wait, readback) sum to no more than `total` — they are sub-intervals of it, so a profile whose parts exceed its whole is mis-attributed |
+//! | 3 | `commit_to_gpu_start` is derived as `commit→done − gpu_span`, so it is bounded above by `commit + wait` plus timer slack |
+//! | 4 | the GPU reported a completed span — `gpu_span > 0` — which is what distinguishes "we read real GPU timestamps" from a selector that returned zeros |
+//! | 5 | profiling leaves the backend usable: a second call hits the weight cache rather than inserting new entries (cache size does not grow), and a real `nvfp4_gemv` afterwards still matches the CPU reference |
+//! | 6 | `nvfp4_pipelined_cost` returns a finite, positive per-dispatch microsecond cost for `depth = 1` and for a deep burst, and the same cache-hit/correctness invariants hold |
+//!
+//! The `None` arms in both functions fire only when the pooled input
+//! buffer's `contents()` is null. Shared-storage Metal buffers never
+//! report a null contents pointer, so those arms are not reachable from
+//! a test and are documented as such in the coverage report rather than
+//! faked.
+
+#![cfg(target_os = "macos")]
+
+use larql_compute::backend::matmul::MatMul;
+use larql_compute_metal::MetalBackend;
+use larql_models::quant::nvfp4::{self, NVFP4_GROUP_ELEMS};
+
+/// Deliberately not a multiple of the kernel's rows-per-threadgroup, so
+/// the profiled dispatch exercises the tail-row guard like a real call.
+const ROWS: usize = 13;
+/// Groups per row — enough that the scale stream is a real stream.
+const GROUPS_PER_ROW: usize = 24;
+const K: usize = NVFP4_GROUP_ELEMS * GROUPS_PER_ROW;
+/// A burst deep enough that queueing, if it pipelines at all, is visible.
+const PIPELINE_DEPTH: usize = 8;
+/// Single dispatch — the degenerate burst the deep one is compared to.
+const SINGLE_DISPATCH: usize = 1;
+/// Two `Instant` reads bracketing each phase are not free; the sum of
+/// sub-intervals may exceed `total` by their own overhead. Generous
+/// because the test must not flake under contention.
+const TIMER_SLACK_US: f64 = 50.0;
+/// Relative error budget for the post-profile gemv against the CPU
+/// reference — reduction-order noise only.
+const GEMV_REL_ERROR_BUDGET: f32 = 1e-4;
+
+fn fixture_values(rows: usize, k: usize, seed: u32) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(2654435761).wrapping_add(1);
+    let mut next = move || {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        (state as f32 / u32::MAX as f32) * 2.0 - 1.0
+    };
+    (0..rows * k)
+        .map(|i| {
+            let group = (i % k) / NVFP4_GROUP_ELEMS;
+            let octave = (group % 12) as i32;
+            next() * (2.0f32).powi(-2 * octave)
+        })
+        .collect()
+}
+
+fn input_vector(k: usize) -> Vec<f32> {
+    (0..k).map(|i| ((i as f32) * 0.017).sin()).collect()
+}
+
+fn cpu_reference(matrix: &nvfp4::Nvfp4Matrix, rows: usize, k: usize, x: &[f32]) -> Vec<f32> {
+    let mut weights = vec![0.0f32; rows * k];
+    nvfp4::dequantize_into(matrix, rows, k, &mut weights).expect("dequantise");
+    (0..rows)
+        .map(|r| {
+            weights[r * k..(r + 1) * k]
+                .iter()
+                .zip(x)
+                .map(|(w, v)| w * v)
+                .sum()
+        })
+        .collect()
+}
+
+fn rel_error(reference: &[f32], got: &[f32]) -> f32 {
+    let scale = reference.iter().fold(0.0f32, |m, v| m.max(v.abs()));
+    if scale == 0.0 {
+        return 0.0;
+    }
+    reference
+        .iter()
+        .zip(got)
+        .map(|(r, g)| (r - g).abs())
+        .fold(0.0f32, f32::max)
+        / scale
+}
+
+struct Fixture {
+    matrix: nvfp4::Nvfp4Matrix,
+    x: Vec<f32>,
+    reference: Vec<f32>,
+}
+
+fn fixture() -> Fixture {
+    let values = fixture_values(ROWS, K, 7);
+    let x = input_vector(K);
+    let matrix = nvfp4::quantize(&values, ROWS, K).expect("quantise");
+    let reference = cpu_reference(&matrix, ROWS, K, &x);
+    Fixture {
+        matrix,
+        x,
+        reference,
+    }
+}
+
+/// The gemv the profiled kernel mirrors must still be right after the
+/// diagnostic has run — proves the diagnostic recycled rather than
+/// corrupted the shared pool and pipelines.
+fn assert_gemv_still_matches_reference(gpu: &MetalBackend, fx: &Fixture) {
+    let got = gpu
+        .nvfp4_gemv(
+            &fx.matrix.packed,
+            &fx.matrix.scales,
+            fx.matrix.tensor_scale,
+            &fx.x,
+            ROWS,
+            K,
+        )
+        .expect("Metal backend must have an NVFP4 kernel");
+    let err = rel_error(&fx.reference, &got);
+    assert!(
+        err < GEMV_REL_ERROR_BUDGET,
+        "nvfp4_gemv after profiling disagrees with the CPU reference by {err}"
+    );
+}
+
+fn assert_finite_non_negative(name: &str, value: f64) {
+    assert!(
+        value.is_finite() && value >= 0.0,
+        "{name} must be a finite non-negative microsecond count, got {value}"
+    );
+}
+
+/// Arms 1–5: one profiled call reports an internally consistent phase
+/// breakdown with real GPU timestamps and leaves the backend intact.
+#[test]
+fn profile_nvfp4_gemv_reports_consistent_phases_and_real_gpu_span() {
+    let Some(gpu) = MetalBackend::new() else {
+        eprintln!("no Metal device; skipping");
+        return;
+    };
+    let fx = fixture();
+
+    // Warm the pool so the measured call is a steady-state call, not a
+    // first-touch allocation — that is what the module claims to model.
+    let warm = gpu
+        .profile_nvfp4_gemv(
+            &fx.matrix.packed,
+            &fx.matrix.scales,
+            fx.matrix.tensor_scale,
+            &fx.x,
+            ROWS,
+            K,
+        )
+        .expect("warm-up profile");
+    assert_finite_non_negative("warm total", warm.total);
+
+    let cache_before = gpu.cache_size();
+    let p = gpu
+        .profile_nvfp4_gemv(
+            &fx.matrix.packed,
+            &fx.matrix.scales,
+            fx.matrix.tensor_scale,
+            &fx.x,
+            ROWS,
+            K,
+        )
+        .expect("profile on a live device returns Some");
+
+    // Arm 1.
+    assert_finite_non_negative("input_stage", p.input_stage);
+    assert_finite_non_negative("buffer_acquire", p.buffer_acquire);
+    assert_finite_non_negative("encode", p.encode);
+    assert_finite_non_negative("commit", p.commit);
+    assert_finite_non_negative("wait", p.wait);
+    assert_finite_non_negative("readback", p.readback);
+    assert_finite_non_negative("total", p.total);
+    assert!(p.gpu_span.is_finite(), "gpu_span must be finite");
+    assert!(
+        p.commit_to_gpu_start.is_finite(),
+        "commit_to_gpu_start must be finite"
+    );
+
+    // Arm 2.
+    let phase_sum = p.input_stage + p.buffer_acquire + p.encode + p.commit + p.wait + p.readback;
+    assert!(
+        phase_sum <= p.total + TIMER_SLACK_US,
+        "wall phases ({phase_sum} us) exceed the whole call ({} us)",
+        p.total
+    );
+    assert!(p.total > 0.0, "a real call cannot take zero wall time");
+
+    // Arm 3: commit→done is commit + wait, and the derived queue latency
+    // is that minus the GPU span.
+    assert!(
+        p.commit_to_gpu_start <= p.commit + p.wait + TIMER_SLACK_US,
+        "derived queue latency {} us exceeds commit+wait {} us",
+        p.commit_to_gpu_start,
+        p.commit + p.wait
+    );
+
+    // Arm 4.
+    assert!(
+        p.gpu_span > 0.0,
+        "GPUStartTime/GPUEndTime must bracket a completed dispatch; got span {} us",
+        p.gpu_span
+    );
+
+    // Arm 5.
+    assert!(
+        gpu.cache_size() <= cache_before,
+        "a warmed profile must hit the weight cache, not insert; cache grew {} -> {}",
+        cache_before,
+        gpu.cache_size()
+    );
+    assert_gemv_still_matches_reference(&gpu, &fx);
+}
+
+/// Arm 6: the pipelined-burst measurement returns a positive finite
+/// per-dispatch cost at both the degenerate depth and a deep burst, hits
+/// the weight cache on the second call, and leaves the gemv correct.
+#[test]
+fn nvfp4_pipelined_cost_reports_positive_per_dispatch_cost_and_recycles_scratch() {
+    let Some(gpu) = MetalBackend::new() else {
+        eprintln!("no Metal device; skipping");
+        return;
+    };
+    let fx = fixture();
+
+    let single = gpu
+        .nvfp4_pipelined_cost(
+            &fx.matrix.packed,
+            &fx.matrix.scales,
+            fx.matrix.tensor_scale,
+            &fx.x,
+            ROWS,
+            K,
+            SINGLE_DISPATCH,
+        )
+        .expect("depth-1 burst on a live device returns Some");
+    assert!(
+        single.is_finite() && single > 0.0,
+        "depth-1 per-dispatch cost must be finite and positive, got {single}"
+    );
+
+    let cache_before = gpu.cache_size();
+    let deep = gpu
+        .nvfp4_pipelined_cost(
+            &fx.matrix.packed,
+            &fx.matrix.scales,
+            fx.matrix.tensor_scale,
+            &fx.x,
+            ROWS,
+            K,
+            PIPELINE_DEPTH,
+        )
+        .expect("deep burst on a live device returns Some");
+    assert!(
+        deep.is_finite() && deep > 0.0,
+        "deep-burst per-dispatch cost must be finite and positive, got {deep}"
+    );
+    assert!(
+        gpu.cache_size() <= cache_before,
+        "a second burst must hit the weight cache, not insert; cache grew {} -> {}",
+        cache_before,
+        gpu.cache_size()
+    );
+    assert_gemv_still_matches_reference(&gpu, &fx);
+}


### PR DESCRIPTION
The `larql-compute-metal` coverage policy was the last red check on main (`buffers/residency.rs`, `diag/nvfp4_call_profile.rs`, `backend/mod.rs`, `trait_impl/matmul.rs`, TOTAL < 96%). This PR lifts the remaining three files with isolated Metal tests that assert each arm for what it is:

- `trait_impl/matmul.rs` 78.26% → 99.15% — 21 tests: f32/f16/MXFP4/NVFP4 gemv and `_multi` against CPU references (dequantised matrices), top-k/argmax equal to CPU ranking, CPU-vs-GPU flop-threshold gates (`None` below, `_force` runs), shape refusals, `matmul_batch` by transpose flag, `wire_resident` as a numeric no-op.
- `diag/nvfp4_call_profile.rs` 0% → 98.45% — both profile entry points driven on a real device with phase/derived-timing/cache/GPU-span assertions.
- `backend/mod.rs` 88.09% → 98.92% — device identity, empty round-trips, per-layer KV-cache geometry + reuse/rebuild, the PLE debug guard.

Policy locally (same runner class as CI — local == CI for this crate): **97.05% total, 108/109 files at the 90% floor** (the remaining uncovered lines are null-buffer / shader-library fault arms, reported in the test docs rather than faked). fmt/clippy clean; full Metal suite green.