### PR TITLE
fix(lql): encode mutation prompts with model architecture

### DIFF
--- a/crates/larql-lql/src/executor/mutation/insert/balance.rs
+++ b/crates/larql-lql/src/executor/mutation/insert/balance.rs
@@ -44,7 +44,7 @@ impl Session {
         // every magic number has a single home with its measurement-link
         // comment.
 
-        let (path, _config, _patched) = self.require_vindex()?;
+        let (path, config, _patched) = self.require_vindex()?;
         let mut cb = larql_vindex::SilentLoadCallbacks;
         let weights = larql_vindex::load_model_weights(path, &mut cb)
             .map_err(|e| LqlError::exec("balance: load weights", e))?;
@@ -52,10 +52,8 @@ impl Session {
             .map_err(|e| LqlError::exec("balance: load tokenizer", e))?;
 
         let prompt = canonical_prompt(relation, entity);
-        let enc = tokenizer
-            .encode(prompt.as_str(), true)
-            .map_err(|e| LqlError::exec("balance: tokenize", e))?;
-        let prompt_ids: Vec<u32> = enc.get_ids().to_vec();
+        let prompt_ids =
+            crate::executor::query::encode_vindex_prompt(config, &tokenizer, prompt.as_str())?;
 
         // Snapshot/restore applies only to the AMPLIFY path: when
         // UP_SCALE saturates (residual blow-up, softmax collapse in
@@ -179,11 +177,13 @@ impl Session {
             return Ok(());
         }
 
-        let (path, _config, _patched) = self.require_vindex()?;
+        let (path, config, _patched) = self.require_vindex()?;
+        let path = path.to_path_buf();
+        let config = config.clone();
         let mut cb = larql_vindex::SilentLoadCallbacks;
-        let weights = larql_vindex::load_model_weights(path, &mut cb)
+        let weights = larql_vindex::load_model_weights(&path, &mut cb)
             .map_err(|e| LqlError::exec("cross-balance: load weights", e))?;
-        let tokenizer = larql_vindex::load_vindex_tokenizer(path)
+        let tokenizer = larql_vindex::load_vindex_tokenizer(&path)
             .map_err(|e| LqlError::exec("cross-balance: load tokenizer", e))?;
 
         for _iter in 0..CROSS_ITERS {
@@ -196,10 +196,11 @@ impl Session {
                 .cloned()
                 .collect();
             for fact in &priors_to_check {
-                let enc = tokenizer
-                    .encode(fact.canonical_prompt.as_str(), true)
-                    .map_err(|e| LqlError::exec("cross-balance: tokenize", e))?;
-                let fact_ids: Vec<u32> = enc.get_ids().to_vec();
+                let fact_ids = crate::executor::query::encode_vindex_prompt(
+                    &config,
+                    &tokenizer,
+                    fact.canonical_prompt.as_str(),
+                )?;
                 let (_, _, patched) = self.require_vindex()?;
                 let walk =
                     larql_inference::vindex::WalkFfn::new_unlimited_with_trace(&weights, patched);

--- a/crates/larql-lql/src/executor/mutation/insert/capture.rs
+++ b/crates/larql-lql/src/executor/mutation/insert/capture.rs
@@ -77,10 +77,8 @@ impl Session {
         let weights = larql_vindex::load_model_weights(path, &mut cb)
             .map_err(|e| LqlError::exec("failed to load weights", e))?;
 
-        let encoding = tokenizer
-            .encode(prompt.as_str(), true)
-            .map_err(|e| LqlError::exec("tokenize error", e))?;
-        let token_ids: Vec<u32> = encoding.get_ids().to_vec();
+        let token_ids =
+            crate::executor::query::encode_vindex_prompt(config, &tokenizer, prompt.as_str())?;
 
         // Capture through the BASE index (no patch overlay), with
         // UNLIMITED top_k to match what INFER does at query time.
@@ -170,10 +168,11 @@ impl Session {
 
             let mut captured = Vec::with_capacity(decoy_prompts.len());
             for decoy_prompt in &decoy_prompts {
-                let enc = tokenizer
-                    .encode(decoy_prompt.as_str(), true)
-                    .map_err(|e| LqlError::exec("tokenize decoy", e))?;
-                let ids: Vec<u32> = enc.get_ids().to_vec();
+                let ids = crate::executor::query::encode_vindex_prompt(
+                    config,
+                    &tokenizer,
+                    decoy_prompt.as_str(),
+                )?;
                 // Also unlimited top_k here so decoy residuals match
                 // the full-power baseline INFER will produce.
                 let ffn = larql_inference::vindex::WalkFfn::new_unlimited_with_trace(

--- a/crates/larql-lql/src/executor/mutation/insert/knn.rs
+++ b/crates/larql-lql/src/executor/mutation/insert/knn.rs
@@ -67,10 +67,8 @@ impl Session {
 
             let rel_words = relation.replace(['-', '_'], " ");
             let prompt = format!("The {rel_words} of {entity} is");
-            let encoding = tokenizer
-                .encode(prompt.as_str(), true)
-                .map_err(|e| LqlError::exec("tokenize error", e))?;
-            let token_ids: Vec<u32> = encoding.get_ids().to_vec();
+            let token_ids =
+                crate::executor::query::encode_vindex_prompt(config, &tokenizer, prompt.as_str())?;
 
             // `InferenceWeights::load` branches on `config.quant` — callers
             // do not need to know the on-disk format.

--- a/crates/larql-lql/src/executor/mutation/rebalance.rs
+++ b/crates/larql-lql/src/executor/mutation/rebalance.rs
@@ -46,11 +46,13 @@ impl Session {
         }
 
         let n_facts = self.installed_edges.len();
-        let (path, _config, _patched) = self.require_vindex()?;
+        let (path, config, _patched) = self.require_vindex()?;
+        let path = path.to_path_buf();
+        let config = config.clone();
         let mut cb = larql_vindex::SilentLoadCallbacks;
-        let weights = larql_vindex::load_model_weights(path, &mut cb)
+        let weights = larql_vindex::load_model_weights(&path, &mut cb)
             .map_err(|e| LqlError::exec("rebalance: load weights", e))?;
-        let tokenizer = larql_vindex::load_vindex_tokenizer(path)
+        let tokenizer = larql_vindex::load_vindex_tokenizer(&path)
             .map_err(|e| LqlError::exec("rebalance: load tokenizer", e))?;
 
         // DOWN_SCALE / UP_SCALE / PROBE_TOP_K live in `executor::tuning`
@@ -65,10 +67,11 @@ impl Session {
             let facts_snapshot = self.installed_edges.clone();
 
             for (i, fact) in facts_snapshot.iter().enumerate() {
-                let enc = tokenizer
-                    .encode(fact.canonical_prompt.as_str(), true)
-                    .map_err(|e| LqlError::exec("rebalance: tokenize", e))?;
-                let ids: Vec<u32> = enc.get_ids().to_vec();
+                let ids = crate::executor::query::encode_vindex_prompt(
+                    &config,
+                    &tokenizer,
+                    fact.canonical_prompt.as_str(),
+                )?;
 
                 let (_, _, patched) = self.require_vindex()?;
                 let walk =

--- a/crates/larql-lql/src/executor/query/mod.rs
+++ b/crates/larql-lql/src/executor/query/mod.rs
@@ -18,8 +18,10 @@ use crate::error::LqlError;
 /// add it (Gemma 4). Every text-prompt query path must route through
 /// this (or [`encode_dense_prompt`]) rather than calling
 /// `tokenizer.encode` directly — a silently missing BOS is enough to
-/// turn gemma-4 prose into token salad. Legacy vindexes without a
-/// recorded `model_config` fall back to the tokenizer's own output.
+/// turn gemma-4 prose into token salad. Mutation paths that capture or
+/// calibrate residuals must use the same helper so their coordinates match
+/// query-time inference. Legacy vindexes without a recorded `model_config`
+/// fall back to the tokenizer's own output.
 pub(super) fn encode_vindex_prompt(
     config: &larql_vindex::VindexConfig,
     tokenizer: &larql_inference::tokenizers::Tokenizer,
@@ -61,4 +63,66 @@ pub(super) fn resolve_bands(config: &larql_vindex::VindexConfig) -> larql_vindex
             knowledge: (0, last),
             output: (0, last),
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tokenizer_without_bos_postprocessor() -> larql_inference::tokenizers::Tokenizer {
+        let json = serde_json::json!({
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [],
+            "normalizer": null,
+            "pre_tokenizer": {"type": "Whitespace"},
+            "post_processor": null,
+            "decoder": null,
+            "model": {
+                "type": "WordLevel",
+                "vocab": {"[UNK]": 0, "<bos>": 2, "hello": 3},
+                "unk_token": "[UNK]"
+            }
+        });
+        larql_inference::tokenizers::Tokenizer::from_bytes(
+            serde_json::to_vec(&json).expect("tokenizer json"),
+        )
+        .expect("tokenizer")
+    }
+
+    #[test]
+    fn encode_vindex_prompt_prepends_gemma4_bos() {
+        let config = larql_vindex::VindexConfig {
+            family: "gemma4".into(),
+            num_layers: 2,
+            hidden_size: 8,
+            intermediate_size: 16,
+            vocab_size: 32,
+            model_config: Some(larql_vindex::VindexModelConfig {
+                model_type: "gemma4_text".into(),
+                head_dim: 4,
+                num_q_heads: 2,
+                num_kv_heads: 1,
+                rope_base: 10_000.0,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let tokenizer = tokenizer_without_bos_postprocessor();
+
+        let ids = encode_vindex_prompt(&config, &tokenizer, "hello").expect("encode");
+
+        assert_eq!(ids, vec![2, 3]);
+    }
+
+    #[test]
+    fn encode_vindex_prompt_preserves_legacy_fallback() {
+        let config = larql_vindex::VindexConfig::default();
+        let tokenizer = tokenizer_without_bos_postprocessor();
+
+        let ids = encode_vindex_prompt(&config, &tokenizer, "hello").expect("encode");
+
+        assert_eq!(ids, vec![3]);
+    }
 }


### PR DESCRIPTION
## Summary

Mutation-time prompts were tokenized directly through `tokenizer.encode(..., true)`, while query-time inference uses the model architecture-aware encoding path.

For architectures such as Gemma 4, whose tokenizer may not add BOS through its post-processor, this caused mutation residuals to be captured and calibrated in a different token coordinate system from the one used by `INFER`.

This change routes mutation prompts through the shared architecture-aware encoder.

## Changes

- Use `encode_vindex_prompt` for:
  - KNN residual capture
  - COMPOSE canonical residual capture
  - COMPOSE decoy capture
  - local post-install balancing
  - cross-fact regression checks
  - global `REBALANCE`
- Document that mutation capture and calibration must use the same prompt encoding as query-time inference.
- Add regression coverage verifying:
  - Gemma 4 receives the architecture-required BOS token when the tokenizer has no BOS post-processor.
  - legacy vindexes without a recorded model configuration retain the existing tokenizer fallback.

Target-token and entity-token encoding remain unchanged; only prompts forwarded through the model are affected.

## Why

A missing BOS token changes every downstream residual. An edit captured without BOS may therefore fail to activate, or be balanced against a prompt representation different from the one later used during inference.

Keeping prompt encoding architecture-aware and shared ensures that mutation-time and query-time residuals remain comparable.

## Compatibility

- No schema or patch-format changes.
- Existing behavior is preserved for legacy vindexes whose architecture cannot be reconstructed.
- The change applies generically through the architecture abstraction rather than branching on Gemma 4 inside the mutation code.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --offline -p larql-lql --lib encode_vindex_prompt` — 2 passed
- `cargo test --offline -p larql-lql --test cov_mutation_synthetic` — 19 passed
- `cargo test --offline -p larql-lql --test cov_tier_a_synthetic insert_compose_alphabetic_tokenizer_pushes_template_decoys` — passed

## Scope

This PR is intentionally limited to mutation prompt capture and calibration. Other direct-tokenization consumers can be audited separately to keep this fix focused and reviewable.
