### PR TITLE
fix(docs): update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents (Claude Code, Codex, opencode, etc.) when working with code in this repository.
 
 ## What this project is
 
 LARQL decompiles transformer model weights into a **vindex** — a directory of mmap'd files that can be queried like a graph database. **LQL** (Lazarus Query Language) is the SQL-like surface for browsing, mutating, and recompiling that knowledge. The core claim: the model *is* the database, so edits are structural (patch overlays on gate/down matrices), not fine-tuning.
 
-Three extraction levels gate which LQL statements work: `browse` (DESCRIBE/WALK/SELECT), `inference` (+INFER), `all` (+COMPILE). Patches (`.vlp` JSON files) stack onto a readonly base vindex — INSERT/DELETE/UPDATE auto-start a patch; base files are never mutated.
+Extraction tiers gate which LQL statements work: `browse` (DESCRIBE/WALK/SELECT), `inference` (+INFER), `all` (+COMPILE); `attention` is a tier for the client-only slice for `run --ffn URL`. Patches (`.vlp` JSON files) stack onto a readonly base vindex — INSERT/DELETE/UPDATE auto-start a patch; base files are never mutated.
 
 ## Workspace layout
 
@@ -20,6 +20,11 @@ larql-models      model config, architecture traits, weight loading, quant/dequa
                   config+weights+loader (encoders/vision_tower.rs), projector
                   weights+loader (connectors/projector.rs), shared
                   test_fixtures (behind `test-utils` feature)
+larql-vindex-spec the v1 manifest schema contract — ExtractLevel/StorageDtype/quant
+                  enums, shard cap. Dependency-light leaf several crates depend on.
+larql-execution   execution-refusal semantics shared across runtime crates;
+                  deliberately empty of larql-* deps (contract leaf, same precedent
+                  as larql-vindex-spec).
     ↓
 larql-compute     CPU substrate: BLAS kernels, residual norms, attention spine
                   (rope/gqa/block/decode/gpu), forward-pass primitives (embed,
@@ -30,13 +35,15 @@ larql-compute     CPU substrate: BLAS kernels, residual norms, attention spine
                   substrate callers), forward_overrides env-var registry,
                   PerLayerDecodeState, vision encoder CPU forward
                   (encoders/vision_tower.rs), projector CPU forward
-                  (connectors/projector.rs). ADR-0022 moved substrate down from
+                  (connectors/projector.rs). CPU-only — Metal lives in the peer
+                  below (larql-compute ADR-019). ADR-0022 moved substrate down from
                   larql-inference; the substrate is now self-contained.
     ↓
-larql-compute-metal  Metal GPU backend (first-class peer, NOT a thin layer).
-                     Implements ComputeBackend / KvDispatch / AsyncComputeBackend
-                     for MetalBackend; ships custom MSL shaders, multi-layer
-                     pipelining, stage-bisected kernels.
+larql-compute-metal  Metal GPU backend (first-class PEER of larql-compute — same
+                     trait surface, owns its kernels, NOT downstream of it).
+                     Ships custom MSL shaders, multi-layer pipelining,
+                     stage-bisected kernels. Default features workspace-wide pull
+                     it in and it only compiles on macOS.
     ↓
 larql-vindex      vindex lifecycle: extract, load, query, mutate, patch, save,
                   Vindexfile. Implements `KvIndex for VectorIndex` (Step 3a).
@@ -47,24 +54,38 @@ larql-inference   engines (Standard, MarkovResidual, Apollo, etc.), chat,
                   layer_executor, layer_graph orchestration. KvEngine trait
                   (with supports_multimodal + prefill_from_hidden per
                   ADR-0023), AnyEngine dispatch enum (KvEngine | RetrievalEngine).
-                  Substrate moves to larql-compute; this crate is the
-                  inference-shaped layer that composes substrate primitives +
-                  engine state.
+                  The inference-shaped layer that composes substrate primitives +
+                  engine state; the substrate itself lives in larql-compute.
+    ↓
+larql-kv          pluggable KV-cache engines — 9 implementations (standard,
+                  markov-rs, boundary-per-layer, turbo-quant, apollo, …),
+                  state-policy classified (canonical vs derivative), W10 mask
+                  cascade. Depends on larql-inference (its dev-dep cycle stays
+                  out of the substrate).
+larql-boundary    confidence-gated BOUNDARY ref codec (used by larql-kv)
     ↓
 larql-lql         lexer/parser/executor/REPL + USE REMOTE client
     ↓
 larql-server      HTTP + gRPC server serving vindexes
-larql-cli         top-level `larql` binary (every subcommand lives in commands/).
+larql-router      layer-shard router for distributed larql-server; pairs with
+                  larql-router-protocol (generated tonic/prost + QUIC wrapper)
+larql-factory     Vindex Factory driver: recipe schema, build_id, structural
+                  validation, capability manifest, card generator
+larql-cli         top-level `larql` binary (subcommands live in
+                  commands/{primary,extraction,query,dev,diagnostics}).
                   Multi-modal: `--image` + `--mm-weights` flags on `larql run`,
                   image decode/resize (image_input.rs), plan assembly
                   (run_cmd_image.rs). 3-image regression test in
                   tests/multimodal_e2e.rs (#[ignore], NOT FOR CI).
 larql-python      PyO3 bindings (maturin-built, module name `larql._native`)
+larql-demos       runnable examples, one per shipped capability
 
 # Portable (no LARQL deps; extract to sibling repo later, name stable)
 model-compute         bounded native kernels (arithmetic/datetime) and optional
                       wasmtime-hosted WASM modules (features: `native`/`wasm`)
 ```
+
+**`crates/larql-experts` is its own nested workspace** (own Cargo.toml with `[workspace]` members) — it builds the `wasm32-wasip1` expert modules that `model-compute`'s `wasm` feature hosts. Root `cargo build --workspace` does not include it.
 
 **Metal is a first-class peer** (ADR-0022, 2026-05-18). `larql-compute-metal`
 is the same shape as a future `larql-compute-vulkan` / `larql-compute-cuda` —
@@ -84,9 +105,9 @@ that stamps a compiled edge into gate/up/down tensors lives at
 it's the lowest-level step of the `COMPILE` verb and isn't a separate crate
 until a second consumer needs it.
 
-The CLI is a thin dispatcher: each `larql <cmd>` lives in [crates/larql-cli/src/commands/extraction/](crates/larql-cli/src/commands/extraction/) or [crates/larql-cli/src/commands/query/](crates/larql-cli/src/commands/query/) and is wired into the `Commands` enum in [crates/larql-cli/src/main.rs](crates/larql-cli/src/main.rs). `larql serve` exec's into `larql-server`. `larql repl` and `larql lql` delegate to `larql_lql::run_repl`/`run_statement`.
+The CLI is a thin dispatcher: each `larql <cmd>` lives in [crates/larql-cli/src/commands/{primary,extraction,query,dev,diagnostics}/](crates/larql-cli/src/commands/) and is wired into the `Commands` enum in [crates/larql-cli/src/main.rs](crates/larql-cli/src/main.rs) under help headings (Run / Build / Query / LQL / Server / Research / Factory). Legacy research subcommands (`larql walk`, `larql weight-extract`, …) trampoline to `larql dev <subcmd>` via an argv rewrite in `main()`. `larql serve` exec's into `larql-server`. `larql repl` and `larql lql` delegate to `larql_lql::run_repl`/`run_statement`.
 
-LQL parser and executor are split symmetrically: [crates/larql-lql/src/parser/](crates/larql-lql/src/parser/) and [crates/larql-lql/src/executor/](crates/larql-lql/src/executor/) both have matching `lifecycle.rs`, `query.rs`, `mutation.rs`, `introspection.rs`, `trace.rs`. When adding a statement, touch the AST in [crates/larql-lql/src/ast.rs](crates/larql-lql/src/ast.rs), then both sides.
+LQL parser and executor are split: [crates/larql-lql/src/parser/](crates/larql-lql/src/parser/) and [crates/larql-lql/src/executor/](crates/larql-lql/src/executor/) both cover lifecycle/query/mutation/introspection/trace, but the executor has since grown subdirectories (`lifecycle/`, `mutation/`, `query/`). When adding a statement, touch the AST in [crates/larql-lql/src/ast.rs](crates/larql-lql/src/ast.rs), then both sides.
 
 ## Build, test, run
 
@@ -94,13 +115,17 @@ LQL parser and executor are split symmetrically: [crates/larql-lql/src/parser/](
 cargo build --release                             # optimised build
 cargo build --release --features gpu              # GPU backend (Metal today; Vulkan/CUDA later)
 cargo test                                        # entire workspace
-cargo test -p larql-lql                           # single crate (272 tests)
+cargo test -p larql-lql                           # single crate
 cargo test -p larql-inference --features gpu      # +GPU tests (Metal on Apple Silicon)
 cargo test -p <crate> <test_name>                 # single test
-make ci                                           # fmt-check + clippy -D warnings + test
+make ci                                           # fmt-check + clippy -D warnings + test-full
 make fmt                                          # cargo fmt --all
 make lint                                         # cargo clippy --workspace --tests -- -D warnings
 ```
+
+- Non-macOS builds need `--no-default-features`. The default gpu feature pulls in larql-compute-metal, which only compiles on macOS; CI uses `--no-default-features` on Linux/Windows.
+- `make test` is intentionally fast — `cargo test --workspace --lib --bins` (no integration tests). Use `make test-full` for `cargo test --workspace`, `make test-models` for the `#[ignore]`d model-backed goldens in larql-inference (`-- --ignored`), and `make larql-<crate>-ci` for the per-crate gate CI runs (fmt-check + lint + test + bench-test + coverage). Beyond per-crate workflows, `.github/workflows/quality.yml` adds cargo-audit/deny, MSRV, buf lint, and a dead-doc-link gate (scripts/check_doc_links.py).
+- Re-bench across architectures before landing perf claims — `make bench-cross-arch` runs Gemma 3 4B, Gemma 4 31B, Llama 2, Mistral 7B, Gemma 4 26B (ADR-017): an A/B promoted on Gemma 3 4B alone must be re-bench'd here.
 
 CLI (after `cargo build --release`): `./target/release/larql extract-index … | repl | lql '…' | convert | hf | build | serve | verify`. See [docs/cli.md](docs/cli.md) for the full surface.
 
@@ -117,10 +142,10 @@ Or via the Makefile: `make python-setup | python-build | python-test | python-cl
 
 ## Key architectural invariants
 
-- **Base vindexes are immutable.** All mutation flows through `PatchedVindex` (overlay) — see [crates/larql-vindex/src/patch/core.rs](crates/larql-vindex/src/patch/). `INSERT/DELETE/UPDATE` auto-start a patch; `SAVE PATCH` persists it as `.vlp` JSON. Never write through to base files.
+- **Base vindexes are immutable.** All mutation flows through `PatchedVindex` (overlay, defined in [crates/larql-vindex/src/patch/overlay.rs](crates/larql-vindex/src/patch/overlay.rs)). `INSERT/DELETE/UPDATE` auto-start a patch; `SAVE PATCH` persists it as `.vlp` JSON. Never write through to base files.
 - **`COMPILE CURRENT INTO VINDEX`** bakes patches into a new standalone vindex by hardlinking base weight files (APFS fast path) and rewriting only `down_weights.bin` column-wise. No sidecar at load time.
 - **Storage is mmap-first.** Gate vectors, embeddings, down weights are zero-copy `mmap`'d. f16 is the default dtype (`--f16` halves size with negligible accuracy loss). Don't load entire tensors into RAM unless an operation requires it.
-- **Three extraction levels, not features.** `browse` (~3 GB), `inference` (~6 GB), `all` (~10 GB) — gated by `ExtractLevel` enum in [crates/larql-vindex/src/config/types.rs](crates/larql-vindex-spec/src/lib.rs). Check level before attempting an operation; fail loudly if weights aren't present.
+- **Extraction tiers, not features.** `browse` (~3 GB), `attention` (client-side slice for `run --ffn URL`), `inference` (~6 GB), `all` (~10 GB) — gated by `ExtractLevel`, canonical in [crates/larql-vindex-spec/src/lib.rs](crates/larql-vindex-spec/src/lib.rs) (mirrored in [crates/larql-vindex/src/config/index.rs](crates/larql-vindex/src/config/index.rs)). Check level before attempting an operation; fail loudly if weights aren't present.
 - **Walk FFN is sparse-by-design and can beat dense** (517ms vs 535ms on Gemma 4B) because gate KNN (K≈10) skips most of the 10,240 features per layer. If you touch FFN code, preserve this invariant — see [docs/ffn-graph-layer.md](docs/ffn-graph-layer.md).
 - **MXFP4 quantized MoE (GPT-OSS) has degraded DESCRIBE/WALK** due to 4-bit precision; `INFER` is the supported path. Don't assume all model families are equivalent — see [docs/specs/vindex-operations-spec.md](crates/larql-vindex/docs/operations-spec.md).
 - **A tensor the extractor doesn't name is silently dropped.** There is no coverage audit: extraction writes what `ModelArchitecture` returns keys for, and anything else in the checkpoint vanishes without a warning. This cost GPT-OSS 5 of its 11 per-layer attention tensors (four projection biases + `self_attn.sinks`) for months, while the module header claimed both existed — fixed 2026-07-29, but the *class* of bug is still open. When adding an architecture, diff the source tensor inventory against the written `weight_manifest.json`; when adding a tensor kind, check both `write_f32.rs` and `write_kquant/norms.rs` ask for it. See [docs/k3-funnel.md](docs/k3-funnel.md) §4.6.
@@ -133,11 +158,13 @@ Or via the Makefile: `make python-setup | python-build | python-test | python-cl
 
 ## Where to find things
 
-- LQL language spec: [docs/specs/lql-spec.md](crates/larql-lql/docs/spec.md) (v0.3)
+- LQL language spec: [docs/specs/lql-spec.md](crates/larql-lql/docs/spec.md) (v0.4)
 - Vindex file format: [docs/specs/vindex-format-spec.md](crates/larql-vindex/docs/format-spec.md)
 - Operations + patches: [docs/specs/vindex-operations-spec.md](crates/larql-vindex/docs/operations-spec.md)
 - Ecosystem (HF publish, Vindexfile): [docs/specs/vindex-ecosystem-spec.md](crates/larql-vindex/docs/ecosystem-spec.md)
 - Inference engine internals: [docs/inference-engine.md](docs/inference-engine.md), [docs/ffn-graph-layer.md](docs/ffn-graph-layer.md)
 - Trace format (.bin/.bndx/.ctxt): [docs/specs/trace-format-spec.md](crates/larql-inference/docs/trace-format.md), [docs/residual-trace.md](docs/residual-trace.md)
+- ADRs: [docs/adr/](docs/adr/) (0001–0026 — wire format, grid, compute-trait extraction ADR-0022, multimodal seam ADR-0023, ...). Some crates have their own specifc ADRs in `crates/<crate-name>/doc/adr`.
+- KV-cache engines: [crates/larql-kv/README.md](crates/larql-kv/README.md), [crates/larql-kv/docs/state-policy.md](crates/larql-kv/docs/state-policy.md); Vindex Factory: [docs/vindex-factory.md](docs/vindex-factory.md)
 - Experimental work: `~/chris-source/chris-experiments/` — numbered 01-45, grouped into foundations, compilation, routing, and shannon series
 - Python bindings docs: [crates/larql-python/README.md](crates/larql-python/README.md), [docs/larql-python.md](docs/larql-python.md)


### PR DESCRIPTION
- generalize for more ai coding tools
- new `attention` extraction level
- new crates (where missing or didn't exist yet?) `larql-vindex-spec`, `larql-execution`, `larql-kv`, `larql-boundary`, `larql-router`, `larql-factory`, `larql-demos`
- extra crate `larql-experts`
- new organization of lql/cli commands
- notes about testing
- some OS specifics
- more links to relevant documents
- other things that moved, changed,...

Assisted-by: OpenCode:DeepSeek-V4-Flash