### PR TITLE
feat(vindex3): the V3 runtime stack (VI3-INF-0..3, KV-1, SERVE-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2466,6 +2466,7 @@ dependencies = [
  "larql-compute",
  "larql-compute-metal",
  "larql-inference",
+ "larql-kv",
  "larql-models",
  "larql-router",
  "larql-router-protocol",

--- a/crates/larql-inference/src/lib.rs
+++ b/crates/larql-inference/src/lib.rs
@@ -75,6 +75,7 @@ pub mod test_utils;
 pub mod tokenizer;
 pub mod trace;
 pub mod vindex;
+pub mod vindex3;
 
 // Re-export dependencies for downstream crates.
 pub use larql_models;
@@ -280,6 +281,15 @@ pub use trace::{
 pub use vindex::{
     generate_kquant_cpu_remote, open_inference_vindex, predict_kquant, FfnL1Cache, WalkFfn,
     WalkFfnConfig,
+};
+// The VINDEX3 runtime seam (VI3-INF-0): a container's executable plan
+// served through `LogitsSession` — no ModelWeights, no family
+// detection, no V2 fallback. Deliberately NOT folded into
+// `open_inference_vindex`: the two formats have different authority
+// models and converge only above the session trait.
+pub use vindex3::{
+    continue_session, generate_session, LogitsSession, SessionGeneration, Vindex3Runtime,
+    Vindex3Session,
 };
 
 /// Stable, application-facing inference imports.

--- a/crates/larql-inference/src/vindex3/generate.rs
+++ b/crates/larql-inference/src/vindex3/generate.rs
@@ -1,0 +1,88 @@
+//! Generation above the [`LogitsSession`] seam.
+//!
+//! The existing sampler and EOS machinery
+//! ([`Sampler`](crate::layer_graph::generate::sampling::Sampler),
+//! [`EosConfig`](crate::layer_graph::generate::eos::EosConfig)) drive
+//! any [`LogitsSession`] — they never learn what a layer is. Token ids
+//! go in and come out as ids: a tokenizer is part of the fixture on
+//! the V3 path (only one side of a parity comparison may choose it),
+//! so detokenisation composes *outside* this driver.
+
+use crate::error::InferenceError;
+use crate::layer_graph::generate::eos::EosConfig;
+use crate::layer_graph::generate::sampling::{Sampler, SamplingConfig};
+
+use super::session::LogitsSession;
+
+/// Built outside the generic driver so the refusal exists (and is
+/// counted) once, not once per session instantiation.
+fn sampler_exhausted_error() -> InferenceError {
+    InferenceError::Parse("sampler produced no token — logits were empty or non-finite".to_string())
+}
+
+/// What one generation run produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionGeneration {
+    /// Prompt length consumed by prefill, in tokens.
+    pub prompt_len: usize,
+    /// Generated token ids, in emission order. A stop token is never
+    /// included — generation ends *before* emitting it.
+    pub tokens: Vec<u32>,
+}
+
+/// Generate up to `max_new_tokens` ids from `session`, sampling with
+/// `sampling` and stopping on `eos`. `on_token` fires once per emitted
+/// id, in order — the streaming surface at this seam.
+///
+/// EOS is judged on token ids only (`EosConfig::is_eos` with no
+/// decoded text): stop *strings* need a tokenizer, which lives above
+/// this driver.
+pub fn generate_session<S: LogitsSession + ?Sized>(
+    session: &mut S,
+    prompt: &[u32],
+    max_new_tokens: usize,
+    sampling: SamplingConfig,
+    eos: &EosConfig,
+    on_token: impl FnMut(u32),
+) -> Result<SessionGeneration, InferenceError> {
+    let logits = session.prefill(prompt)?;
+    continue_session(session, logits, max_new_tokens, sampling, eos, on_token)
+}
+
+/// Continue generation from logits already in hand — the resume-aware
+/// driver (VI3-SERVE-1). The caller has typically batch-prefilled the
+/// session's continuation state
+/// ([`Vindex3Runtime::prefill_into`](super::Vindex3Runtime::prefill_into))
+/// and holds the prefill's last-position logits; this drives sampling
+/// and stepping from there. [`generate_session`] is prefill followed
+/// by exactly this function, so the two paths cannot drift.
+///
+/// The result's `prompt_len` is the session's position at entry — the
+/// positions the continuation stands on, however they were consumed.
+pub fn continue_session<S: LogitsSession + ?Sized>(
+    session: &mut S,
+    mut logits: Vec<f32>,
+    max_new_tokens: usize,
+    sampling: SamplingConfig,
+    eos: &EosConfig,
+    mut on_token: impl FnMut(u32),
+) -> Result<SessionGeneration, InferenceError> {
+    let prompt_len = session.position();
+    let mut sampler = Sampler::new(sampling);
+    let mut tokens = Vec::new();
+    while tokens.len() < max_new_tokens {
+        let id = sampler
+            .sample_with_history(&logits, &tokens)
+            .ok_or_else(sampler_exhausted_error)?;
+        if eos.is_eos(id, "") {
+            break;
+        }
+        tokens.push(id);
+        on_token(id);
+        if tokens.len() == max_new_tokens {
+            break;
+        }
+        logits = session.step(id)?;
+    }
+    Ok(SessionGeneration { prompt_len, tokens })
+}

--- a/crates/larql-inference/src/vindex3/mod.rs
+++ b/crates/larql-inference/src/vindex3/mod.rs
@@ -1,0 +1,59 @@
+//! VINDEX3 inference runtime — the seam where the executable model
+//! program meets the generation machinery (VI3-INF-0/1).
+//!
+//! A VINDEX3 container is not "reorganised weights to reconstruct a
+//! transformer from" — it is a closed executable program
+//! (`ComponentOpPlan`) plus its operands. The canonical interpreter in
+//! `larql-vindex` owns model *meaning* (operation order, residual
+//! placement, optional operations, span policy); a `PlanBackend` owns
+//! only the arithmetic. This module gives that program a home inside
+//! the inference runtime **without translating it back into a
+//! V2-shaped model**: no [`ModelWeights`](crate::ModelWeights), no
+//! family detection, no `ModelArchitecture` reconstruction.
+//!
+//! The seam is deliberately tiny. Generation needs logits and state
+//! progression, so that is the whole contract:
+//!
+//! ```text
+//! generate (sampler / EOS / streaming)
+//!        │
+//!   LogitsSession        ← format-neutral: prefill, step, position
+//!        │
+//!  Vindex3Session        ← wraps the canonical DecodeSession
+//!        │
+//!   PlanBackend          ← reference / production / Metal arithmetic
+//! ```
+//!
+//! What deliberately does **not** exist here: a `load_vindex3() ->
+//! ModelWeights` bridge, or a `match version {2 => …, 3 => …}` inside
+//! `open_inference_vindex`. The two formats have different authority
+//! models and converge only above [`LogitsSession`].
+//!
+//! Rung status: VI3-INF-0/1 — [`LogitsSession::prefill`] feeds the
+//! prompt tokenwise through [`LogitsSession::step`] (a semantic
+//! integration gate, not a fast path). VI3-INF-2 — continuation state
+//! is a caller-side [`KvState`] provider (`session_with_kv`),
+//! `prepare`d with the plan's explicit per-layer KV geometry
+//! ([`LayerKvGeometry`]): row width and sliding/full window come from
+//! the executable program, never from `ModelArchitecture` inference.
+//! VI3-INF-3 — batch prefill populates the **same** caller provider
+//! ([`Vindex3Runtime::prefill_into`]), which also owns the logical
+//! continuation position, and `session_with_kv` resumes from it; no
+//! batch-state → decode-state translation exists anywhere.
+
+mod generate;
+mod runtime;
+mod session;
+
+#[cfg(test)]
+mod tests;
+
+pub use generate::{continue_session, generate_session, SessionGeneration};
+pub use runtime::Vindex3Runtime;
+pub use session::{LogitsSession, Vindex3Session};
+
+// The continuation-state seam, re-exported so engine authors reach it
+// from the runtime module without deep `larql_vindex` paths.
+pub use larql_vindex::format::vindex3::opplan::exec::kv::{
+    plan_kv_geometry, KvState, LayerKvGeometry, RowKvState,
+};

--- a/crates/larql-inference/src/vindex3/runtime.rs
+++ b/crates/larql-inference/src/vindex3/runtime.rs
@@ -1,0 +1,121 @@
+//! Opening a VINDEX3 container as an inference runtime.
+
+use std::path::Path;
+
+use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+use larql_vindex::format::vindex3::opplan::exec::kv::KvState;
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::prefill_plan;
+use larql_vindex::format::vindex3::opplan::{plan_component_ops, ClosureDefect, ComponentOpPlan};
+
+use crate::error::InferenceError;
+
+use super::session::Vindex3Session;
+
+/// Inspect the container, plan `component`'s operations, and open the
+/// operand store — solely from the container's own contents. Kept
+/// outside the generic impl so the whole opening path (and its
+/// refusals) is one instantiation regardless of backend.
+fn open_component(
+    container: &Path,
+    component: &str,
+) -> Result<(ComponentOpPlan, OperandStore), InferenceError> {
+    let inspection = inspect_container(container, false)?;
+    let outcome = plan_component_ops(&inspection, container, component)?;
+    if !outcome.closed() {
+        return Err(unclosed_component(component, &outcome.defects));
+    }
+    let plan = outcome.plan.ok_or_else(|| {
+        InferenceError::Parse(format!("component `{component}` produced no plan"))
+    })?;
+    let store = OperandStore::open(container, &inspection)?;
+    Ok((plan, store))
+}
+
+/// Built outside the generic impl so the refusal exists (and is
+/// counted) once, not once per backend instantiation. Defensive:
+/// unreachable while every encoded text component carries a head,
+/// kept so a headless component fails closed instead of panicking.
+pub(super) fn headless_prefill_error() -> InferenceError {
+    InferenceError::Parse(
+        "prefill produced no logits — the component carries no output head".to_string(),
+    )
+}
+
+/// A component whose stack does not fully classify into the declared
+/// operations refuses to open, with the defects in the error. An
+/// unclosed program must not be "best-effort" executed.
+fn unclosed_component(component: &str, defects: &[ClosureDefect]) -> InferenceError {
+    let listed: Vec<String> = defects.iter().map(|d| d.to_string()).collect();
+    InferenceError::Parse(format!(
+        "component `{component}` does not close: {}",
+        listed.join("; ")
+    ))
+}
+
+/// One opened container component: the executable plan, its operand
+/// store, and the arithmetic backend. Owns what a [`Vindex3Session`]
+/// borrows, so sessions can be created, dropped, and re-created (fresh
+/// conversations) without re-planning the container.
+pub struct Vindex3Runtime<B: PlanBackend> {
+    plan: ComponentOpPlan,
+    store: OperandStore,
+    backend: B,
+}
+
+impl<B: PlanBackend> Vindex3Runtime<B> {
+    /// Open `component` from the container, refusing any closure
+    /// defect (see [`unclosed_component`]'s doc).
+    pub fn open(container: &Path, component: &str, backend: B) -> Result<Self, InferenceError> {
+        let (plan, store) = open_component(container, component)?;
+        Ok(Self {
+            plan,
+            store,
+            backend,
+        })
+    }
+
+    /// Open an incremental session at position zero. Each call loads
+    /// the operands in the backend's declared weight format.
+    pub fn session(&self) -> Result<Vindex3Session<'_, B>, InferenceError> {
+        Vindex3Session::new(&self.plan, &self.store, &self.backend)
+    }
+
+    /// Open a session whose continuation state lives in — and outlives
+    /// the session as — the caller's [`KvState`] provider (VI3-INF-2).
+    /// The session continues from `kv.position()`, so this is also the
+    /// resume path after [`prefill_into`](Self::prefill_into). See
+    /// [`Vindex3Session::with_kv_state`] for the provider contract.
+    pub fn session_with_kv<'a>(
+        &'a self,
+        kv: &'a mut dyn KvState,
+    ) -> Result<Vindex3Session<'a, B>, InferenceError> {
+        Vindex3Session::with_kv_state(&self.plan, &self.store, &self.backend, kv)
+    }
+
+    /// Batch-prefill `tokens` into the caller's provider (VI3-INF-3)
+    /// and return the last position's logits, so generation can sample
+    /// the first continuation token before resuming decode over the
+    /// **same** provider via [`session_with_kv`](Self::session_with_kv).
+    /// A provider already holding state is extended from its logical
+    /// position — a long prompt can prefill in chunks.
+    pub fn prefill_into(
+        &self,
+        tokens: &[u32],
+        kv: &mut dyn KvState,
+    ) -> Result<Vec<f32>, InferenceError> {
+        let out = prefill_plan(&self.plan, &self.store, tokens, &self.backend, kv)?;
+        out.logits.ok_or_else(headless_prefill_error)
+    }
+
+    /// The component's executable plan — the model-meaning authority.
+    pub fn plan(&self) -> &ComponentOpPlan {
+        &self.plan
+    }
+
+    /// The arithmetic backend this runtime executes with.
+    pub fn backend(&self) -> &B {
+        &self.backend
+    }
+}

--- a/crates/larql-inference/src/vindex3/session.rs
+++ b/crates/larql-inference/src/vindex3/session.rs
@@ -1,0 +1,125 @@
+//! The format-neutral session contract and its VINDEX3 realisation.
+
+use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+use larql_vindex::format::vindex3::opplan::exec::decode::DecodeSession;
+use larql_vindex::format::vindex3::opplan::exec::kv::KvState;
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
+
+use crate::error::InferenceError;
+
+/// The three refusal messages, built outside the generic impls so each
+/// exists (and is counted) once, not once per backend instantiation.
+fn headless_plan_error(component: &str) -> InferenceError {
+    InferenceError::Parse(format!(
+        "component `{component}` carries no output head — a logits session cannot serve it"
+    ))
+}
+
+fn empty_prompt_error() -> InferenceError {
+    InferenceError::Parse("prefill requires at least one prompt token".to_string())
+}
+
+/// Defensive: unreachable while construction refuses headless plans,
+/// kept so a future plan mutation fails closed instead of panicking.
+pub(super) fn missing_logits_error() -> InferenceError {
+    InferenceError::Parse(
+        "decode step produced no logits despite the plan's output head".to_string(),
+    )
+}
+
+/// Logits and state progression — everything generation needs from a
+/// model runtime, and nothing else. Deliberately not another
+/// transformer abstraction: an implementation may be a VINDEX3 plan
+/// interpreter, a V2 layer graph, or anything that can advance one
+/// token and price a vocabulary.
+pub trait LogitsSession {
+    /// Consume the prompt and return the logits for its last position.
+    /// Errors on an empty prompt — there is no position to price.
+    fn prefill(&mut self, tokens: &[u32]) -> Result<Vec<f32>, InferenceError>;
+
+    /// Advance one token and return the logits for the position just
+    /// consumed.
+    fn step(&mut self, token: u32) -> Result<Vec<f32>, InferenceError>;
+
+    /// Positions consumed so far.
+    fn position(&self) -> usize;
+}
+
+/// [`LogitsSession`] over the canonical VINDEX3 incremental executor.
+///
+/// Borrows the plan, operand store, and backend — typically owned by a
+/// [`Vindex3Runtime`](super::Vindex3Runtime), which hands sessions
+/// out. Construction loads every operand once, in the backend's
+/// declared weight format (weights stay resident for the session's
+/// lifetime, which is what lets a pointer-keyed device buffer cache
+/// hold the model on the GPU).
+pub struct Vindex3Session<'a, B: PlanBackend> {
+    inner: DecodeSession<'a, B>,
+}
+
+impl<'a, B: PlanBackend> Vindex3Session<'a, B> {
+    /// Load the plan's operands and open an incremental session at
+    /// position zero. The plan must carry an output head — a session
+    /// that cannot produce logits cannot serve generation.
+    pub fn new(
+        plan: &'a ComponentOpPlan,
+        store: &OperandStore,
+        backend: &'a B,
+    ) -> Result<Self, InferenceError> {
+        if plan.output.is_none() {
+            return Err(headless_plan_error(&plan.component));
+        }
+        Ok(Self {
+            inner: DecodeSession::new(plan, store, backend)?,
+        })
+    }
+
+    /// Like [`new`](Self::new), but continuation state lives in — and
+    /// outlives the session as — the caller's [`KvState`] provider
+    /// (VI3-INF-2). The session continues from `kv.position()`: an
+    /// empty provider starts fresh, a batch-prefilled or previously
+    /// decoded one resumes (VI3-INF-3) — the provider is the only
+    /// position authority. It is `prepare`d with the plan's per-layer
+    /// KV geometry, so residency and windowing policy read explicit
+    /// program properties, never a family registry.
+    pub fn with_kv_state(
+        plan: &'a ComponentOpPlan,
+        store: &OperandStore,
+        backend: &'a B,
+        kv: &'a mut dyn KvState,
+    ) -> Result<Self, InferenceError> {
+        if plan.output.is_none() {
+            return Err(headless_plan_error(&plan.component));
+        }
+        Ok(Self {
+            inner: DecodeSession::with_kv_state(plan, store, backend, kv)?,
+        })
+    }
+}
+
+impl<B: PlanBackend> LogitsSession for Vindex3Session<'_, B> {
+    /// Tokenwise prompt ingestion (VI3-INF-0): every position passes
+    /// through the stack to fill the session's KV state; only the last
+    /// position's logits are returned. Slow on long prompts by design
+    /// at this rung — the batch interpreter becomes the prefill path
+    /// at VI3-INF-3.
+    fn prefill(&mut self, tokens: &[u32]) -> Result<Vec<f32>, InferenceError> {
+        let (&last, rest) = tokens.split_last().ok_or_else(empty_prompt_error)?;
+        for &token in rest {
+            self.step(token)?;
+        }
+        self.step(last)
+    }
+
+    fn step(&mut self, token: u32) -> Result<Vec<f32>, InferenceError> {
+        self.inner
+            .step(token)?
+            .logits
+            .ok_or_else(missing_logits_error)
+    }
+
+    fn position(&self) -> usize {
+        self.inner.position()
+    }
+}

--- a/crates/larql-inference/src/vindex3/tests/mod.rs
+++ b/crates/larql-inference/src/vindex3/tests/mod.rs
@@ -1,0 +1,534 @@
+//! VI3-INF-0 and VI3-INF-2 gates.
+//!
+//! Two layers of evidence, deliberately separate:
+//!
+//! - **Driver semantics** against a scripted [`LogitsSession`] double —
+//!   sampling, EOS, callback order, budget handling — with no container
+//!   in sight, so a failure names the driver.
+//! - **Seam parity** against the direct [`DecodeSession`] harness on a
+//!   real encoded container: the runtime path must reproduce the
+//!   existing V3 decode harness **bit-for-bit** (logits) and id-for-id
+//!   (greedy tokens). The harness side opens its own plan and store —
+//!   the two arms share only the container bytes and the backend
+//!   arithmetic.
+//!
+//! A control precedes the parity claim (the instrument must fail on
+//! known-different input): a diverged prompt stream must produce
+//! diverged logits, or bit-equality above proves nothing.
+
+use std::path::Path;
+
+use larql_vindex::format::vindex3::fixtures::{
+    dense_f32_model, encode_fixture_container, miniature_glimmer, G_TOKENS,
+};
+use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+use larql_vindex::format::vindex3::opplan::exec::decode::DecodeSession;
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use larql_vindex::format::vindex3::opplan::plan_component_ops;
+
+use super::{
+    generate_session, plan_kv_geometry, KvState, LogitsSession, RowKvState, Vindex3Runtime,
+    Vindex3Session,
+};
+use crate::error::InferenceError;
+use crate::layer_graph::generate::eos::EosConfig;
+use crate::layer_graph::generate::sampling::SamplingConfig;
+
+/// The rung's target: sixteen greedy tokens through the runtime.
+const NEW_TOKENS: usize = 16;
+/// Component id the miniature systems encode their text stack under.
+const COMPONENT: &str = "target";
+
+// ── Driver semantics against a scripted session ──
+
+/// Scripted [`LogitsSession`]: returns pre-baked logit rows in order,
+/// so driver tests control exactly what the sampler sees.
+struct ScriptedSession {
+    rows: Vec<Vec<f32>>,
+    cursor: usize,
+    position: usize,
+}
+
+impl ScriptedSession {
+    fn new(rows: Vec<Vec<f32>>) -> Self {
+        Self {
+            rows,
+            cursor: 0,
+            position: 0,
+        }
+    }
+
+    fn next_row(&mut self) -> Result<Vec<f32>, InferenceError> {
+        let row =
+            self.rows.get(self.cursor).cloned().ok_or_else(|| {
+                InferenceError::Parse("scripted session ran out of rows".to_string())
+            })?;
+        self.cursor += 1;
+        Ok(row)
+    }
+}
+
+impl LogitsSession for ScriptedSession {
+    fn prefill(&mut self, tokens: &[u32]) -> Result<Vec<f32>, InferenceError> {
+        if tokens.is_empty() {
+            return Err(InferenceError::Parse("empty prompt".to_string()));
+        }
+        self.position += tokens.len();
+        self.next_row()
+    }
+
+    fn step(&mut self, _token: u32) -> Result<Vec<f32>, InferenceError> {
+        self.position += 1;
+        self.next_row()
+    }
+
+    fn position(&self) -> usize {
+        self.position
+    }
+}
+
+/// A logit row whose argmax is `id` (out of 4 vocabulary entries).
+fn row_peaking_at(id: usize) -> Vec<f32> {
+    let mut row = vec![0.0f32; 4];
+    row[id] = 1.0;
+    row
+}
+
+#[test]
+fn the_driver_emits_greedy_ids_in_callback_order() {
+    let mut session = ScriptedSession::new(vec![
+        row_peaking_at(2),
+        row_peaking_at(0),
+        row_peaking_at(3),
+    ]);
+    let mut streamed = Vec::new();
+    let result = generate_session(
+        &mut session,
+        &[7, 8],
+        3,
+        SamplingConfig::greedy(),
+        &EosConfig::empty(),
+        |id| streamed.push(id),
+    )
+    .unwrap();
+    assert_eq!(result.tokens, vec![2, 0, 3]);
+    assert_eq!(streamed, result.tokens);
+    assert_eq!(result.prompt_len, 2);
+    // Prompt (2) + steps for all but the last emitted token (2).
+    assert_eq!(session.position(), 4);
+}
+
+#[test]
+fn a_stop_token_ends_generation_before_being_emitted() {
+    let mut session = ScriptedSession::new(vec![row_peaking_at(1), row_peaking_at(3)]);
+    let result = generate_session(
+        &mut session,
+        &[7],
+        4,
+        SamplingConfig::greedy(),
+        &EosConfig::empty().with_eos_id(3),
+        |_| {},
+    )
+    .unwrap();
+    // Token 1 emitted; the stop token 3 ended the run without appearing.
+    assert_eq!(result.tokens, vec![1]);
+}
+
+#[test]
+fn a_zero_token_budget_prefills_but_emits_nothing() {
+    let mut session = ScriptedSession::new(vec![row_peaking_at(1)]);
+    let mut fired = false;
+    let result = generate_session(
+        &mut session,
+        &[7, 8, 9],
+        0,
+        SamplingConfig::greedy(),
+        &EosConfig::empty(),
+        |_| fired = true,
+    )
+    .unwrap();
+    assert!(result.tokens.is_empty());
+    assert!(!fired);
+    // The prompt was still consumed — a follow-up call can continue.
+    assert_eq!(session.position(), 3);
+}
+
+#[test]
+fn non_finite_logits_surface_as_an_error_not_a_token() {
+    let mut session = ScriptedSession::new(vec![vec![f32::NAN, f32::NAN]]);
+    let err = generate_session(
+        &mut session,
+        &[7],
+        2,
+        SamplingConfig::greedy(),
+        &EosConfig::empty(),
+        |_| {},
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("sampler produced no token"),
+        "{err}"
+    );
+}
+
+// ── Seam parity against the direct DecodeSession harness ──
+
+/// Encode `write_checkpoint`'s model into a fresh container.
+fn container_with(write_checkpoint: impl FnOnce(&Path)) -> tempfile::TempDir {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(
+        write_checkpoint,
+        checkpoint.path(),
+        container.path(),
+        "seam-fixture",
+    );
+    container
+}
+
+/// Ties keep the first index — the same rule the V3 exec harness and
+/// the greedy sampler use.
+fn argmax(logits: &[f32]) -> u32 {
+    logits
+        .iter()
+        .enumerate()
+        .fold((0usize, f32::NEG_INFINITY), |best, (index, &value)| {
+            if value > best.1 {
+                (index, value)
+            } else {
+                best
+            }
+        })
+        .0 as u32
+}
+
+/// The existing V3 decode harness, verbatim in shape: a direct
+/// [`DecodeSession`] fed the prompt tokenwise, then greedy argmax.
+/// Returns the emitted ids and every logits row the greedy loop saw
+/// (prompt-final first).
+fn harness_decode<B: PlanBackend>(
+    container: &Path,
+    backend: &B,
+    prompt: &[u32],
+    new_tokens: usize,
+) -> (Vec<u32>, Vec<Vec<f32>>) {
+    let inspection = inspect_container(container, false).unwrap();
+    let outcome = plan_component_ops(&inspection, container, COMPONENT).unwrap();
+    assert!(outcome.closed(), "harness fixture must close");
+    let plan = outcome.plan.unwrap();
+    let store = OperandStore::open(container, &inspection).unwrap();
+    let mut session = DecodeSession::new(&plan, &store, backend).unwrap();
+
+    let mut logits = None;
+    for &token in prompt {
+        logits = session.step(token).unwrap().logits;
+    }
+    let mut logits = logits.expect("plan carries an output head");
+    let mut rows = vec![logits.clone()];
+    let mut ids = Vec::new();
+    while ids.len() < new_tokens {
+        let next = argmax(&logits);
+        ids.push(next);
+        if ids.len() == new_tokens {
+            break;
+        }
+        logits = session.step(next).unwrap().logits.unwrap();
+        rows.push(logits.clone());
+    }
+    (ids, rows)
+}
+
+/// The parity gate per backend: prefill+step logits bit-for-bit, then
+/// sixteen greedy ids through `generate_session` id-for-id.
+fn assert_seam_parity<B: PlanBackend>(backend_for_harness: &B, backend_for_runtime: B) {
+    let container = container_with(miniature_glimmer);
+    let (harness_ids, harness_rows) =
+        harness_decode(container.path(), backend_for_harness, &G_TOKENS, NEW_TOKENS);
+    assert_eq!(harness_ids.len(), NEW_TOKENS);
+
+    let runtime = Vindex3Runtime::open(container.path(), COMPONENT, backend_for_runtime).unwrap();
+
+    // Logits stream, bit-for-bit: prefill equals the harness's
+    // prompt-final row; each subsequent step equals the harness's row
+    // for the same emitted id.
+    let mut session = runtime.session().unwrap();
+    let prefill = session.prefill(&G_TOKENS).unwrap();
+    assert_eq!(prefill, harness_rows[0], "prefill logits diverge");
+    assert_eq!(session.position(), G_TOKENS.len());
+    for (row, &id) in harness_rows[1..].iter().zip(&harness_ids) {
+        let stepped = session.step(id).unwrap();
+        assert_eq!(&stepped, row, "step logits diverge after id {id}");
+    }
+
+    // Sixteen greedy tokens through the generation driver, on a fresh
+    // session from the same runtime.
+    let mut streamed = Vec::new();
+    let mut session = runtime.session().unwrap();
+    let result = generate_session(
+        &mut session,
+        &G_TOKENS,
+        NEW_TOKENS,
+        SamplingConfig::greedy(),
+        &EosConfig::empty(),
+        |id| streamed.push(id),
+    )
+    .unwrap();
+    assert_eq!(result.tokens, harness_ids, "greedy ids diverge");
+    assert_eq!(streamed, harness_ids);
+    assert_eq!(result.prompt_len, G_TOKENS.len());
+    assert_eq!(session.position(), G_TOKENS.len() + NEW_TOKENS - 1);
+}
+
+#[test]
+fn reference_runtime_matches_the_decode_harness_bit_for_bit() {
+    assert_seam_parity(&ReferenceBackend::new(), ReferenceBackend::new());
+}
+
+#[test]
+fn production_runtime_matches_the_decode_harness_bit_for_bit() {
+    assert_seam_parity(&ProductionBackend::new(), ProductionBackend::new());
+}
+
+/// Control: the instrument must fail on known-different input. A
+/// reversed prompt is a different program input, so its prefill logits
+/// must differ from the harness's — otherwise the bit-equality above
+/// is vacuous.
+#[test]
+fn the_parity_instrument_detects_a_diverged_prompt() {
+    let container = container_with(miniature_glimmer);
+    let backend = ReferenceBackend::new();
+    let (_, harness_rows) = harness_decode(container.path(), &backend, &G_TOKENS, 1);
+
+    let runtime = Vindex3Runtime::open(container.path(), COMPONENT, backend).unwrap();
+    let mut session = runtime.session().unwrap();
+    let mut reversed = G_TOKENS.to_vec();
+    reversed.reverse();
+    assert_ne!(reversed, G_TOKENS.to_vec());
+    let prefill = session.prefill(&reversed).unwrap();
+    assert_ne!(
+        prefill, harness_rows[0],
+        "instrument cannot distinguish different prompts"
+    );
+}
+
+/// The dense Llama-shaped anatomy through the same seam — a second,
+/// independent plan shape (two norms, RoPE everywhere, no gates).
+#[test]
+fn dense_runtime_matches_the_decode_harness_bit_for_bit() {
+    let container = container_with(dense_f32_model);
+    let backend = ReferenceBackend::new();
+    let prompt = [5u32, 99, 42];
+    let (harness_ids, _) = harness_decode(container.path(), &backend, &prompt, NEW_TOKENS);
+
+    let runtime =
+        Vindex3Runtime::open(container.path(), COMPONENT, ReferenceBackend::new()).unwrap();
+    assert_eq!(runtime.plan().component, COMPONENT);
+    assert!(!runtime.backend().name().is_empty());
+    let mut session = runtime.session().unwrap();
+    let result = generate_session(
+        &mut session,
+        &prompt,
+        NEW_TOKENS,
+        SamplingConfig::greedy(),
+        &EosConfig::empty(),
+        |_| {},
+    )
+    .unwrap();
+    assert_eq!(result.tokens, harness_ids);
+}
+
+// ── Continuation state behind the KvState seam (VI3-INF-2) ──
+
+/// Caller-owned continuation state must change nothing about the
+/// generated ids, and must still hold every row after the session is
+/// gone — with per-layer geometry matching the plan's own statement
+/// ([`plan_kv_geometry`]), which is the whole point of the seam: KV
+/// policy reads the program, not a family registry.
+#[test]
+fn a_caller_owned_kv_state_generates_identically_and_outlives_the_session() {
+    let container = container_with(miniature_glimmer);
+    let runtime =
+        Vindex3Runtime::open(container.path(), COMPONENT, ReferenceBackend::new()).unwrap();
+
+    let mut default_session = runtime.session().unwrap();
+    let baseline = generate_session(
+        &mut default_session,
+        &G_TOKENS,
+        NEW_TOKENS,
+        SamplingConfig::greedy(),
+        &EosConfig::empty(),
+        |_| {},
+    )
+    .unwrap();
+
+    let mut kv = RowKvState::default();
+    {
+        let mut session = runtime.session_with_kv(&mut kv).unwrap();
+        let provided = generate_session(
+            &mut session,
+            &G_TOKENS,
+            NEW_TOKENS,
+            SamplingConfig::greedy(),
+            &EosConfig::empty(),
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(provided, baseline, "caller-owned KV diverged the ids");
+    }
+
+    // The session is gone; the caller still holds the conversation's
+    // continuation state, one row pair per consumed position, at the
+    // width the plan declares per layer.
+    let geometry = plan_kv_geometry(runtime.plan());
+    let consumed = G_TOKENS.len() + NEW_TOKENS - 1;
+    for (layer, geo) in geometry.iter().enumerate() {
+        assert_eq!(kv.keys(layer).len(), consumed);
+        assert_eq!(kv.values(layer).len(), consumed);
+        assert!(kv.keys(layer).iter().all(|row| row.len() == geo.kv_dim));
+    }
+    // …and the miniature's sliding+full split is explicit in that
+    // geometry — no ModelArchitecture consulted anywhere in this test.
+    assert_eq!(geometry[0].window, Some(3));
+    assert_eq!(geometry[1].window, None);
+}
+
+/// VI3-INF-3 through the runtime, per backend: batch prefill into the
+/// caller's provider, sample the first token from the prefill logits,
+/// resume decode over the SAME provider — and the emitted ids must
+/// match the tokenwise harness id-for-id, with the prefill logits
+/// bit-identical to the harness's prompt-final row. The provider owns
+/// the logical position throughout; nothing passes a start position.
+fn assert_prefill_resume_matches_harness<B: PlanBackend>(
+    backend_for_harness: &B,
+    backend_for_runtime: B,
+) {
+    let container = container_with(miniature_glimmer);
+    let (harness_ids, harness_rows) =
+        harness_decode(container.path(), backend_for_harness, &G_TOKENS, NEW_TOKENS);
+
+    let runtime = Vindex3Runtime::open(container.path(), COMPONENT, backend_for_runtime).unwrap();
+    let mut kv = RowKvState::default();
+    let prefill_logits = runtime.prefill_into(&G_TOKENS, &mut kv).unwrap();
+    assert_eq!(prefill_logits, harness_rows[0], "prefill logits diverge");
+    assert_eq!(kv.position(), G_TOKENS.len());
+
+    // The exact SERVE-1 stack: prefill_into → session_with_kv →
+    // continue_session, streaming callback and all.
+    let mut streamed = Vec::new();
+    let mut session = runtime.session_with_kv(&mut kv).unwrap();
+    assert_eq!(session.position(), G_TOKENS.len(), "resume position");
+    let result = super::continue_session(
+        &mut session,
+        prefill_logits,
+        NEW_TOKENS,
+        SamplingConfig::greedy(),
+        &EosConfig::empty(),
+        |id| streamed.push(id),
+    )
+    .unwrap();
+    assert_eq!(result.tokens, harness_ids, "prefill+resume ids diverge");
+    assert_eq!(streamed, harness_ids);
+    assert_eq!(result.prompt_len, G_TOKENS.len());
+    drop(session);
+    assert_eq!(kv.position(), G_TOKENS.len() + NEW_TOKENS - 1);
+}
+
+#[test]
+fn reference_batch_prefill_resumes_to_the_harness_ids() {
+    assert_prefill_resume_matches_harness(&ReferenceBackend::new(), ReferenceBackend::new());
+}
+
+#[test]
+fn production_batch_prefill_resumes_to_the_harness_ids() {
+    assert_prefill_resume_matches_harness(&ProductionBackend::new(), ProductionBackend::new());
+}
+
+// ── Refusals ──
+
+#[test]
+fn an_empty_prompt_is_refused() {
+    let container = container_with(miniature_glimmer);
+    let runtime =
+        Vindex3Runtime::open(container.path(), COMPONENT, ReferenceBackend::new()).unwrap();
+    let mut session = runtime.session().unwrap();
+    let err = session.prefill(&[]).unwrap_err();
+    assert!(
+        err.to_string().contains("at least one prompt token"),
+        "{err}"
+    );
+}
+
+#[test]
+fn an_unknown_component_refuses_to_open() {
+    let container = container_with(miniature_glimmer);
+    let err = match Vindex3Runtime::open(
+        container.path(),
+        "no-such-component",
+        ReferenceBackend::new(),
+    ) {
+        Ok(_) => panic!("an unknown component must refuse to open"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("no-such-component"), "{err}");
+}
+
+/// An unclosed component must refuse to open with the defects in the
+/// error — never "best-effort" execute. Provoked the same way the
+/// vindex closure gates do it: strip the component's execution surface
+/// from the container's own graph, which planning reports as a
+/// `MissingSurface` defect.
+#[test]
+fn an_unclosed_component_refuses_to_open_naming_its_defects() {
+    let container = container_with(miniature_glimmer);
+    let graph_path = container
+        .path()
+        .join(larql_vindex::format::vindex3::encode::SYSTEM_GRAPH_JSON);
+    let mut graph: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&graph_path).unwrap()).unwrap();
+    for component in graph["components"].as_array_mut().unwrap() {
+        component.as_object_mut().unwrap().remove("execution");
+    }
+    std::fs::write(&graph_path, graph.to_string()).unwrap();
+
+    let err = match Vindex3Runtime::open(container.path(), COMPONENT, ReferenceBackend::new()) {
+        Ok(_) => panic!("an unclosed component must refuse to open"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("does not close"), "{err}");
+}
+
+/// The step path's defensive refusal (a step yielding no logits) is
+/// unreachable while construction refuses headless plans — pinned here
+/// so the fail-closed message stays a work item, not a mystery, if a
+/// future change ever reaches it.
+#[test]
+fn the_defensive_missing_logits_refusal_names_the_invariant() {
+    let err = super::session::missing_logits_error();
+    assert!(err.to_string().contains("output head"), "{err}");
+}
+
+/// Same discipline for the prefill path's defensive refusal.
+#[test]
+fn the_defensive_headless_prefill_refusal_names_the_invariant() {
+    let err = super::runtime::headless_prefill_error();
+    assert!(err.to_string().contains("no output head"), "{err}");
+}
+
+#[test]
+fn a_plan_without_an_output_head_is_refused() {
+    let container = container_with(miniature_glimmer);
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let outcome = plan_component_ops(&inspection, container.path(), COMPONENT).unwrap();
+    let mut plan = outcome.plan.unwrap();
+    plan.output = None;
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    let backend = ReferenceBackend::new();
+    let err = match Vindex3Session::new(&plan, &store, &backend) {
+        Ok(_) => panic!("a headless plan must be refused"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("no output head"), "{err}");
+}

--- a/crates/larql-kv/src/lib.rs
+++ b/crates/larql-kv/src/lib.rs
@@ -23,9 +23,11 @@ pub mod engines;
 pub mod generation;
 pub mod model_walk;
 pub mod profiler;
+pub mod vindex3;
 pub mod vindex_compare;
 
 pub use cache::KvCache;
+pub use vindex3::CanonicalKvState;
 
 pub use engines::apollo;
 pub use engines::boundary_kv;

--- a/crates/larql-kv/src/vindex3/mod.rs
+++ b/crates/larql-kv/src/vindex3/mod.rs
@@ -1,0 +1,234 @@
+//! VI3-KV-1: the canonical [`KvCache`] behind the VINDEX3 [`KvState`]
+//! contract — deliberately unambitious.
+//!
+//! One target, nothing else: the ordinary canonical `larql-kv` cache
+//! satisfies the V3 continuation-state contract with **no change in
+//! semantics**. No windowing (that is VI3-KV-2 — the executor's span
+//! logic owns position exclusion, so wiring `LayerKvGeometry::window`
+//! into [`KvCache::max_window`] here would *change* semantics, not
+//! adapt them). No quantisation, no residual state, no residency
+//! optimisation.
+//!
+//! The two contracts already say the same thing: [`KvCache`] stores
+//! "post-RoPE K, post-V-norm V" per layer with `next_position` as the
+//! absolute append count ("increments per append, not per eviction"),
+//! and the V3 step contract appends exactly the post-norm, post-rope
+//! rows the backend returned, with the provider owning the logical
+//! continuation position. This module is the proof that the overlap
+//! is real: the KV-1 gates demand [`RowKvState`] and
+//! [`CanonicalKvState`] stay **bit-identical** through prefill,
+//! resume, and decode — chaining `V3 batch == V3 tokenwise ==
+//! RowKvState == larql-kv canonical cache` onto the existing
+//! executor ≡ production-forward parity.
+//!
+//! Geometry comes from the executable plan and nowhere else: the
+//! adapter records what [`KvState::prepare`] announces —
+//! `larql-kv` needs no `ModelArchitecture` inference to know a
+//! VINDEX3 model's continuation geometry (row width, sliding/full
+//! split). That closure is an explicit gate, not an incidental fact.
+//!
+//! Adapter shape: the cache's matrices are the **storage authority**.
+//! Today's `KvState` read contract serves `&[Vec<f32>]` rows (it
+//! mirrors `AttentionStepCall`, a recorded debt), so the adapter keeps
+//! per-layer row views — materialised *from* the matrices after every
+//! write, never alongside them, so the served bits are the stored
+//! bits by construction.
+
+use larql_vindex::format::vindex3::opplan::exec::kv::{KvState, LayerKvGeometry};
+use ndarray::Array2;
+
+use crate::cache::KvCache;
+
+#[cfg(test)]
+mod tests;
+
+/// Per-layer row views, derived from the cache's matrices.
+#[derive(Default, Clone)]
+struct LayerRows {
+    keys: Vec<Vec<f32>>,
+    values: Vec<Vec<f32>>,
+}
+
+impl LayerRows {
+    /// Rebuild both views from one layer's matrices.
+    fn from_matrices(kv: Option<&(Array2<f32>, Array2<f32>)>) -> Self {
+        match kv {
+            Some((k, v)) => Self {
+                keys: k.rows().into_iter().map(|row| row.to_vec()).collect(),
+                values: v.rows().into_iter().map(|row| row.to_vec()).collect(),
+            },
+            None => Self::default(),
+        }
+    }
+}
+
+/// The canonical [`KvCache`] as a VINDEX3 continuation-state provider.
+///
+/// Owns the cache; [`cache`](Self::cache) and
+/// [`into_cache`](Self::into_cache) hand the state to the existing KV
+/// machinery (engines, surgery, injection), and
+/// [`from_cache`](Self::from_cache) brings it back — the same
+/// conversation state crossing the `larql-kv` boundary intact.
+pub struct CanonicalKvState {
+    cache: KvCache,
+    geometry: Vec<LayerKvGeometry>,
+    rows: Vec<LayerRows>,
+}
+
+impl Default for CanonicalKvState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CanonicalKvState {
+    /// An empty provider; the first `prepare` sizes it from the plan.
+    pub fn new() -> Self {
+        Self {
+            cache: KvCache::with_layers(0),
+            geometry: Vec::new(),
+            rows: Vec::new(),
+        }
+    }
+
+    /// Adopt an existing canonical cache (engine-held, injected,
+    /// transplanted) as V3 continuation state. Row views are rebuilt
+    /// from the cache's matrices — the matrices stay the authority —
+    /// and the next `prepare` validates the plan's geometry against
+    /// them. The cache must be unwindowed: a clipped cache has evicted
+    /// rows this contract requires (windowing is VI3-KV-2).
+    pub fn from_cache(cache: KvCache) -> Self {
+        assert!(
+            cache.max_window.is_none(),
+            "canonical V3 continuation state requires an unwindowed cache"
+        );
+        let rows = cache
+            .layers
+            .iter()
+            .map(|kv| LayerRows::from_matrices(kv.as_ref()))
+            .collect();
+        Self {
+            cache,
+            geometry: Vec::new(),
+            rows,
+        }
+    }
+
+    /// The held cache — the storage authority, readable by everything
+    /// that already speaks [`KvCache`].
+    pub fn cache(&self) -> &KvCache {
+        &self.cache
+    }
+
+    /// Surrender the cache to the existing KV machinery.
+    pub fn into_cache(self) -> KvCache {
+        self.cache
+    }
+
+    /// The plan-declared geometry this provider was prepared with —
+    /// row width and sliding/full window per layer, read from the
+    /// executable program, never from `ModelArchitecture`.
+    pub fn geometry(&self) -> &[LayerKvGeometry] {
+        &self.geometry
+    }
+}
+
+impl KvState for CanonicalKvState {
+    fn prepare(&mut self, layers: &[LayerKvGeometry]) {
+        if self.geometry.is_empty() {
+            if self.cache.layers.is_empty() {
+                self.cache = KvCache::with_layers(layers.len());
+                self.rows = vec![LayerRows::default(); layers.len()];
+            } else {
+                // The from_cache path: the held state must be state
+                // for a program of this shape.
+                assert_eq!(
+                    self.cache.layers.len(),
+                    layers.len(),
+                    "adopted cache holds {} layers but the plan declares {}",
+                    self.cache.layers.len(),
+                    layers.len()
+                );
+                for (layer, geometry) in layers.iter().enumerate() {
+                    if let Some((k, _)) = self.cache.get_layer(layer) {
+                        assert_eq!(
+                            k.shape()[1],
+                            geometry.kv_dim,
+                            "adopted cache rows at layer {layer} are {} wide; the plan says {}",
+                            k.shape()[1],
+                            geometry.kv_dim
+                        );
+                    }
+                }
+            }
+            self.geometry = layers.to_vec();
+        } else {
+            // A resumed provider: same program, same geometry.
+            assert_eq!(
+                self.geometry, layers,
+                "resumed KV state was prepared for a different program geometry"
+            );
+        }
+    }
+
+    fn append(&mut self, layer: usize, key: Vec<f32>, value: Vec<f32>) {
+        let kv_dim = self.geometry[layer].kv_dim;
+        assert_eq!(
+            key.len(),
+            kv_dim,
+            "K row at layer {layer} is {} wide; the plan says {kv_dim}",
+            key.len()
+        );
+        assert_eq!(
+            value.len(),
+            kv_dim,
+            "V row at layer {layer} is {} wide; the plan says {kv_dim}",
+            value.len()
+        );
+
+        // Write into the matrices first…
+        let (k, v) = match self.cache.get_layer(layer) {
+            Some((k, v)) => {
+                let mut k_new = Array2::zeros((k.shape()[0] + 1, kv_dim));
+                k_new.slice_mut(ndarray::s![..k.shape()[0], ..]).assign(k);
+                k_new
+                    .row_mut(k.shape()[0])
+                    .assign(&ndarray::ArrayView1::from(key.as_slice()));
+                let mut v_new = Array2::zeros((v.shape()[0] + 1, kv_dim));
+                v_new.slice_mut(ndarray::s![..v.shape()[0], ..]).assign(v);
+                v_new
+                    .row_mut(v.shape()[0])
+                    .assign(&ndarray::ArrayView1::from(value.as_slice()));
+                (k_new, v_new)
+            }
+            None => (
+                Array2::from_shape_vec((1, kv_dim), key).expect("row width asserted above"),
+                Array2::from_shape_vec((1, kv_dim), value).expect("row width asserted above"),
+            ),
+        };
+        self.cache.set_layer(layer, (k, v));
+
+        // …then materialise the served view from what the cache now
+        // holds, so the view provably carries the stored bits.
+        let (k, v) = self.cache.get_layer(layer).expect("layer was just written");
+        let last = k.shape()[0] - 1;
+        self.rows[layer].keys.push(k.row(last).to_vec());
+        self.rows[layer].values.push(v.row(last).to_vec());
+    }
+
+    fn keys(&self, layer: usize) -> &[Vec<f32>] {
+        &self.rows[layer].keys
+    }
+
+    fn values(&self, layer: usize) -> &[Vec<f32>] {
+        &self.rows[layer].values
+    }
+
+    fn position(&self) -> usize {
+        self.cache.next_position
+    }
+
+    fn set_position(&mut self, position: usize) {
+        self.cache.next_position = position;
+    }
+}

--- a/crates/larql-kv/src/vindex3/tests/mod.rs
+++ b/crates/larql-kv/src/vindex3/tests/mod.rs
@@ -1,0 +1,270 @@
+//! VI3-KV-1 gates: the canonical cache IS the V3 continuation state.
+//!
+//! The headline gate compares [`RowKvState`] and [`CanonicalKvState`]
+//! after every significant boundary — geometry accepted, prefill
+//! state, logical position, per-layer K/V rows, prefill logits, first
+//! resumed logits, N continuation logits, generated ids, final state —
+//! and demands **bit identity** throughout. With INF-3's gates that
+//! chains:
+//!
+//! ```text
+//! V3 batch == V3 tokenwise == RowKvState == larql-kv canonical cache
+//! ```
+//!
+//! and `tests/parity.rs` in larql-vindex chains the production forward
+//! onto the same equality.
+//!
+//! The second architectural gate is geometry closure: the adapter
+//! knows the miniature's sliding(3)/full split and row width from the
+//! executable plan alone — `larql-kv` consults no `ModelArchitecture`
+//! anywhere on this path.
+
+use larql_vindex::format::vindex3::fixtures::{
+    encode_fixture_container, miniature_glimmer, G_HEAD_DIM, G_KV_HEADS, G_LAYERS, G_TOKENS,
+    G_WINDOW,
+};
+use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::opplan::exec::decode::DecodeSession;
+use larql_vindex::format::vindex3::opplan::exec::kv::{
+    plan_kv_geometry, KvState, LayerKvGeometry, RowKvState,
+};
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::prefill_plan;
+use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use larql_vindex::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
+
+use crate::cache::KvCache;
+
+use super::CanonicalKvState;
+
+const CONTINUATION_STEPS: usize = 8;
+
+fn fixture() -> (tempfile::TempDir, ComponentOpPlan, OperandStore) {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(
+        miniature_glimmer,
+        checkpoint.path(),
+        container.path(),
+        "kv1-fixture",
+    );
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let outcome = plan_component_ops(&inspection, container.path(), "target").unwrap();
+    assert!(
+        outcome.closed(),
+        "fixture must close: {:?}",
+        outcome.defects
+    );
+    let plan = outcome.plan.unwrap();
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    (container, plan, store)
+}
+
+/// Ties keep the first index — the harness rule.
+fn argmax(logits: &[f32]) -> u32 {
+    logits
+        .iter()
+        .enumerate()
+        .fold((0usize, f32::NEG_INFINITY), |best, (index, &value)| {
+            if value > best.1 {
+                (index, value)
+            } else {
+                best
+            }
+        })
+        .0 as u32
+}
+
+/// Compare two providers' observable state bit-for-bit.
+fn assert_state_equal(a: &dyn KvState, b: &dyn KvState, layers: usize, boundary: &str) {
+    assert_eq!(a.position(), b.position(), "{boundary}: positions diverge");
+    for layer in 0..layers {
+        assert_eq!(
+            a.keys(layer),
+            b.keys(layer),
+            "{boundary}: K rows diverge at layer {layer}"
+        );
+        assert_eq!(
+            a.values(layer),
+            b.values(layer),
+            "{boundary}: V rows diverge at layer {layer}"
+        );
+    }
+}
+
+/// The cache's matrices — not the adapter's row views — must hold the
+/// same bits as the reference provider: the matrices are the storage
+/// authority, and this is the check that keeps the view honest.
+fn assert_cache_matrices_equal(cache: &KvCache, reference: &RowKvState, layers: usize) {
+    for layer in 0..layers {
+        let (k, v) = cache.get_layer(layer).expect("layer holds state");
+        let k_rows: Vec<Vec<f32>> = k.rows().into_iter().map(|row| row.to_vec()).collect();
+        let v_rows: Vec<Vec<f32>> = v.rows().into_iter().map(|row| row.to_vec()).collect();
+        assert_eq!(
+            k_rows,
+            reference.keys(layer),
+            "matrix K diverges at {layer}"
+        );
+        assert_eq!(
+            v_rows,
+            reference.values(layer),
+            "matrix V diverges at {layer}"
+        );
+    }
+}
+
+#[test]
+fn canonical_cache_matches_rowkvstate_at_every_boundary() {
+    let (_c, plan, store) = fixture();
+    let backend = ReferenceBackend::new();
+    let layers = plan.layers.len();
+
+    // Prefill both providers from the same program.
+    let mut row_state = RowKvState::default();
+    let row_prefill = prefill_plan(&plan, &store, &G_TOKENS, &backend, &mut row_state).unwrap();
+    let mut canonical = CanonicalKvState::new();
+    let canonical_prefill =
+        prefill_plan(&plan, &store, &G_TOKENS, &backend, &mut canonical).unwrap();
+
+    // Geometry accepted.
+    assert_eq!(canonical.geometry(), plan_kv_geometry(&plan).as_slice());
+    // Prefill state, logical position, prefill logits.
+    assert_state_equal(&row_state, &canonical, layers, "after prefill");
+    assert_cache_matrices_equal(canonical.cache(), &row_state, layers);
+    assert_eq!(row_prefill.logits, canonical_prefill.logits);
+
+    // Resume decode over each provider; greedy ids from the shared
+    // prefill logits onward.
+    let mut ids_a = vec![argmax(row_prefill.logits.as_ref().unwrap())];
+    let mut ids_b = ids_a.clone();
+    {
+        let mut session_a =
+            DecodeSession::with_kv_state(&plan, &store, &backend, &mut row_state).unwrap();
+        let mut session_b =
+            DecodeSession::with_kv_state(&plan, &store, &backend, &mut canonical).unwrap();
+        for step in 0..CONTINUATION_STEPS {
+            let logits_a = session_a
+                .step(*ids_a.last().unwrap())
+                .unwrap()
+                .logits
+                .unwrap();
+            let logits_b = session_b
+                .step(*ids_b.last().unwrap())
+                .unwrap()
+                .logits
+                .unwrap();
+            // First resumed logits, then every continuation step.
+            assert_eq!(logits_a, logits_b, "continuation step {step} diverges");
+            ids_a.push(argmax(&logits_a));
+            ids_b.push(argmax(&logits_b));
+        }
+    }
+    // Generated ids and final state.
+    assert_eq!(ids_a, ids_b, "generated ids diverge");
+    assert_state_equal(&row_state, &canonical, layers, "final");
+    assert_cache_matrices_equal(canonical.cache(), &row_state, layers);
+    assert_eq!(
+        canonical.position(),
+        G_TOKENS.len() + CONTINUATION_STEPS,
+        "final logical position"
+    );
+}
+
+/// The architectural closure, as its own gate: `larql-kv` knows a
+/// VINDEX3 model's continuation geometry — row width AND the
+/// sliding(3)/full split — from the executable plan alone. No
+/// `ModelArchitecture` appears anywhere in this test or in the
+/// adapter.
+#[test]
+fn continuation_geometry_reaches_larql_kv_from_the_plan_alone() {
+    let (_c, plan, store) = fixture();
+    let backend = ReferenceBackend::new();
+    let mut canonical = CanonicalKvState::new();
+    prefill_plan(&plan, &store, &G_TOKENS, &backend, &mut canonical).unwrap();
+
+    assert_eq!(
+        canonical.geometry(),
+        &[
+            LayerKvGeometry {
+                kv_dim: G_KV_HEADS * G_HEAD_DIM,
+                window: Some(G_WINDOW),
+            },
+            LayerKvGeometry {
+                kv_dim: G_KV_HEADS * G_HEAD_DIM,
+                window: None,
+            },
+        ],
+        "the sliding/full split must arrive from the plan and be preserved"
+    );
+    // Canonical means canonical: the geometry's window is knowledge,
+    // not policy — the held cache stays unwindowed (VI3-KV-2 is where
+    // windowing becomes a provider policy under its own gates).
+    assert!(canonical.cache().max_window.is_none());
+}
+
+/// The same conversation state crossing the `KvCache` boundary and
+/// coming back: prefill through the adapter, surrender the cache to
+/// the existing KV world, adopt it again, and resume decode — every
+/// continuation step bit-identical to a session that never crossed.
+#[test]
+fn state_crosses_the_kvcache_boundary_intact() {
+    let (_c, plan, store) = fixture();
+    let backend = ReferenceBackend::new();
+
+    // Oracle: prefill + decode over one uninterrupted provider.
+    let mut oracle_state = RowKvState::default();
+    let oracle_prefill =
+        prefill_plan(&plan, &store, &G_TOKENS, &backend, &mut oracle_state).unwrap();
+    let mut oracle_ids = vec![argmax(oracle_prefill.logits.as_ref().unwrap())];
+    let mut oracle_logits = Vec::new();
+    let mut oracle =
+        DecodeSession::with_kv_state(&plan, &store, &backend, &mut oracle_state).unwrap();
+    for _ in 0..CONTINUATION_STEPS {
+        let logits = oracle
+            .step(*oracle_ids.last().unwrap())
+            .unwrap()
+            .logits
+            .unwrap();
+        oracle_ids.push(argmax(&logits));
+        oracle_logits.push(logits);
+    }
+
+    // Arm: prefill through the adapter, cross the boundary both ways.
+    let mut canonical = CanonicalKvState::new();
+    let prefill = prefill_plan(&plan, &store, &G_TOKENS, &backend, &mut canonical).unwrap();
+    let cache = canonical.into_cache();
+    assert_eq!(cache.next_position, G_TOKENS.len());
+    for layer in 0..G_LAYERS {
+        assert_eq!(cache.cached_len(layer), G_TOKENS.len());
+        let (k, _) = cache.get_layer(layer).unwrap();
+        assert_eq!(k.shape()[1], G_KV_HEADS * G_HEAD_DIM);
+    }
+
+    let mut adopted = CanonicalKvState::from_cache(cache);
+    let mut ids = vec![argmax(prefill.logits.as_ref().unwrap())];
+    let mut resumed = DecodeSession::with_kv_state(&plan, &store, &backend, &mut adopted).unwrap();
+    assert_eq!(resumed.position(), G_TOKENS.len());
+    for (step, expected) in oracle_logits.iter().enumerate() {
+        let logits = resumed.step(*ids.last().unwrap()).unwrap().logits.unwrap();
+        assert_eq!(&logits, expected, "step {step} diverges after the crossing");
+        ids.push(argmax(&logits));
+    }
+    assert_eq!(ids, oracle_ids);
+}
+
+#[test]
+#[should_panic(expected = "unwindowed")]
+fn a_windowed_cache_is_refused_as_canonical_state() {
+    let _ = CanonicalKvState::from_cache(KvCache::with_window(2, 3));
+}
+
+#[test]
+#[should_panic(expected = "the plan says")]
+fn a_misfit_row_width_is_refused() {
+    let mut canonical = CanonicalKvState::new();
+    canonical.prepare(&[LayerKvGeometry {
+        kv_dim: 4,
+        window: None,
+    }]);
+    canonical.append(0, vec![0.0; 3], vec![0.0; 3]);
+}

--- a/crates/larql-server/Cargo.toml
+++ b/crates/larql-server/Cargo.toml
@@ -18,6 +18,9 @@ path = "src/main.rs"
 [dependencies]
 larql-vindex = { path = "../larql-vindex" }
 larql-inference = { path = "../larql-inference" }
+# Continuation-state providers for the VINDEX3 serving path
+# (VI3-SERVE-1): the canonical KvCache behind the V3 KvState contract.
+larql-kv = { path = "../larql-kv" }
 larql-models = { path = "../larql-models" }
 larql-router-protocol = { path = "../larql-router-protocol" }
 # Optional Metal backend for shard-side GPU experts (macOS).  When the

--- a/crates/larql-server/examples/bench_expert_server.rs
+++ b/crates/larql-server/examples/bench_expert_server.rs
@@ -119,6 +119,7 @@ fn bench_remote<F: FnMut() -> Result<(), String>>(
 fn make_app_state(model: LoadedModel) -> Arc<AppState> {
     Arc::new(AppState {
         models: vec![Arc::new(model)],
+        v3_models: Vec::new(),
         started_at: Instant::now(),
         requests_served: AtomicU64::new(0),
         api_key: None,

--- a/crates/larql-server/src/bootstrap.rs
+++ b/crates/larql-server/src/bootstrap.rs
@@ -74,7 +74,7 @@ pub fn parse_layer_range(s: &str) -> Result<(usize, usize), BoxError> {
     Ok((start, end + 1))
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct LoadVindexOptions {
     pub no_infer: bool,
     pub ffn_only: bool,
@@ -138,6 +138,38 @@ pub fn parse_unit_manifest(
     let manifest: UnitManifest = serde_json::from_slice(&bytes)
         .map_err(|e| -> BoxError { format!("--units: parse {}: {e}", path.display()).into() })?;
     manifest.into_unit_set()
+}
+
+/// One bound model artifact — which runtime family serves it. The
+/// V2/V3 decision is made HERE, at binding time, from the container's
+/// own generation marker; nothing downstream re-detects it.
+pub enum LoadedArtifact {
+    V2(Box<LoadedModel>),
+    V3(Box<crate::vindex3::V3Model>),
+}
+
+/// Detect the artifact's container generation and bind it with the
+/// matching loader. A VINDEX3 container binds as an executable
+/// program ([`crate::vindex3::load_v3_model`]) — it structurally
+/// cannot take the V2 path, whose `load_vindex_config` refuses
+/// non-V2 generations.
+pub fn load_artifact(path_str: &str, opts: LoadVindexOptions) -> Result<LoadedArtifact, BoxError> {
+    let path = if larql_vindex::is_hf_path(path_str) {
+        larql_vindex::resolve_hf_vindex(path_str)?
+    } else {
+        PathBuf::from(path_str)
+    };
+    match larql_vindex::format::generation::detect_generation(&path)? {
+        larql_vindex::format::generation::ContainerGeneration::V3 => {
+            info!("Loading VINDEX3 container: {}", path.display());
+            Ok(LoadedArtifact::V3(Box::new(crate::vindex3::load_v3_model(
+                &path,
+            )?)))
+        }
+        larql_vindex::format::generation::ContainerGeneration::V2 => Ok(LoadedArtifact::V2(
+            Box::new(load_single_vindex(path_str, opts)?),
+        )),
+    }
 }
 
 pub fn load_single_vindex(
@@ -816,6 +848,7 @@ pub async fn serve(cli: Cli) -> Result<(), BoxError> {
     );
 
     let mut models: Vec<Arc<LoadedModel>> = Vec::new();
+    let mut v3_models: Vec<Arc<crate::vindex3::V3Model>> = Vec::new();
 
     let layer_range = cli.layers.as_deref().map(parse_layer_range).transpose()?;
     let expert_filter = cli.experts.as_deref().map(parse_layer_range).transpose()?;
@@ -919,19 +952,22 @@ pub async fn serve(cli: Cli) -> Result<(), BoxError> {
             // `LoadVindexOptions` is `Clone` (was `Copy` until `unit_filter`
             // added an `Arc<HashSet<...>>` field) — clone per iteration so
             // the loop owns each call's argument.
-            match load_single_vindex(&p.to_string_lossy(), load_opts.clone()) {
-                Ok(m) => models.push(Arc::new(m)),
+            match load_artifact(&p.to_string_lossy(), load_opts.clone()) {
+                Ok(LoadedArtifact::V2(m)) => models.push(Arc::new(*m)),
+                Ok(LoadedArtifact::V3(m)) => v3_models.push(Arc::new(*m)),
                 Err(e) => warn!("  Skipping {}: {}", p.display(), e),
             }
         }
     } else if let Some(ref vindex_path) = cli.vindex_path {
-        let m = load_single_vindex(vindex_path, load_opts)?;
-        models.push(Arc::new(m));
+        match load_artifact(vindex_path, load_opts)? {
+            LoadedArtifact::V2(m) => models.push(Arc::new(*m)),
+            LoadedArtifact::V3(m) => v3_models.push(Arc::new(*m)),
+        }
     } else {
         return Err("must provide a vindex path or --dir".into());
     }
 
-    if models.is_empty() {
+    if models.is_empty() && v3_models.is_empty() {
         return Err("no vindexes loaded".into());
     }
 
@@ -1021,6 +1057,7 @@ pub async fn serve(cli: Cli) -> Result<(), BoxError> {
 
     let state = Arc::new(AppState {
         models: models.clone(),
+        v3_models: v3_models.clone(),
         started_at: std::time::Instant::now(),
         requests_served: std::sync::atomic::AtomicU64::new(0),
         api_key: cli.api_key.clone(),
@@ -1047,8 +1084,10 @@ pub async fn serve(cli: Cli) -> Result<(), BoxError> {
         }
         routes::multi_model_router(Arc::clone(&state))
     } else {
-        let m = &models[0];
-        info!("Single-model mode: {}", m.config.model);
+        match models.first() {
+            Some(m) => info!("Single-model mode: {}", m.config.model),
+            None => info!("Single-model mode: {} (VINDEX3)", v3_models[0].id),
+        }
         routes::single_model_router(Arc::clone(&state))
     };
 

--- a/crates/larql-server/src/lib.rs
+++ b/crates/larql-server/src/lib.rs
@@ -26,4 +26,5 @@ pub mod session;
 pub mod shard_loader;
 pub mod shard_query;
 pub mod state;
+pub mod vindex3;
 pub mod wire;

--- a/crates/larql-server/src/routes/models.rs
+++ b/crates/larql-server/src/routes/models.rs
@@ -62,7 +62,7 @@ pub async fn handle_models(State(state): State<Arc<AppState>>) -> Json<serde_jso
     let created = server_boot_unix_secs(&state);
     let multi = state.is_multi_model();
 
-    let data: Vec<serde_json::Value> = state
+    let mut data: Vec<serde_json::Value> = state
         .models
         .iter()
         .map(|m| {
@@ -83,6 +83,25 @@ pub async fn handle_models(State(state): State<Arc<AppState>>) -> Json<serde_jso
             })
         })
         .collect();
+
+    // VINDEX3 runtimes (VI3-SERVE-1). `generation: 3` is a
+    // larql-specific extra; no `features` count — a V3 container is an
+    // executable program, not a feature index.
+    data.extend(state.v3_models.iter().map(|m| {
+        serde_json::json!({
+            "id": m.id,
+            "object": MODEL_OBJECT,
+            "created": created,
+            "owned_by": OWNED_BY,
+            "path": if multi {
+                format!("{}/{}", API_PREFIX, m.id)
+            } else {
+                API_PREFIX.to_string()
+            },
+            "generation": 3,
+            "loaded": true,
+        })
+    }));
 
     Json(serde_json::json!({
         "object": LIST_OBJECT,

--- a/crates/larql-server/src/routes/openai/completions.rs
+++ b/crates/larql-server/src/routes/openai/completions.rs
@@ -61,8 +61,8 @@ use crate::state::{AppState, LoadedModel};
 
 use super::util::{contains_any, error_chunk, new_id_suffix, trim_at_stop, unix_now, StopSpec};
 
-const TEXT_COMPLETION_OBJECT: &str = "text_completion";
-const DEFAULT_MAX_TOKENS: usize = 16;
+pub(super) const TEXT_COMPLETION_OBJECT: &str = "text_completion";
+pub(super) const DEFAULT_MAX_TOKENS: usize = 16;
 
 #[derive(Deserialize)]
 #[serde(untagged)]
@@ -190,11 +190,16 @@ pub async fn handle_completions(
         ));
     }
 
-    let model = state.model_or_err(req.model.as_deref())?;
-    if model.infer_disabled {
-        return Err(OpenAIError::service_unavailable(
-            "inference disabled (--no-infer / --embed-only / --ffn-only)",
-        ));
+    // The one V2/V3 decision point: the registry resolves the request's
+    // model to a runtime binding; below this match nothing re-detects
+    // the container generation.
+    let served = state.served_or_err(req.model.as_deref())?;
+    if let crate::state::ServedModel::V2(model) = &served {
+        if model.infer_disabled {
+            return Err(OpenAIError::service_unavailable(
+                "inference disabled (--no-infer / --embed-only / --ffn-only)",
+            ));
+        }
     }
 
     let prompts: Vec<String> = match req.prompt {
@@ -219,16 +224,13 @@ pub async fn handle_completions(
         .map(|s| s.as_slice().to_vec())
         .unwrap_or_default();
     let echo = req.echo.unwrap_or(false);
+    let stream = req.stream.unwrap_or(false);
 
-    // Model id for the response (matches the request when given,
-    // otherwise the loaded model's id).
-    let model_id = req.model.clone().unwrap_or_else(|| model.id.clone());
-    let model_arc = model.clone();
-
-    if req.stream.unwrap_or(false) {
+    if stream {
         // Streaming mode: SSE response. `echo` and batched prompts are
         // not supported in stream mode (OpenAI's stream contract is
-        // one prompt → one stream of chunks).
+        // one prompt → one stream of chunks). Validated here, before
+        // runtime dispatch, so both runtimes share one contract.
         if echo {
             return Err(OpenAIError::invalid_request(
                 "echo=true is not supported with stream=true",
@@ -240,6 +242,34 @@ pub async fn handle_completions(
                  send one prompt per request",
             ));
         }
+    }
+
+    // Model id for the response (matches the request when given,
+    // otherwise the loaded model's id).
+    let model_id = req.model.clone().unwrap_or_else(|| match &served {
+        crate::state::ServedModel::V2(m) => m.id.clone(),
+        crate::state::ServedModel::V3(m) => m.id.clone(),
+    });
+
+    let model_arc = match served {
+        crate::state::ServedModel::V3(v3) => {
+            return super::v3_completions::respond(
+                v3.clone(),
+                prompts,
+                max_tokens,
+                sampling_params,
+                stop_strings,
+                echo,
+                stream,
+                model_id,
+                state.infer_timeout,
+            )
+            .await;
+        }
+        crate::state::ServedModel::V2(model) => model.clone(),
+    };
+
+    if stream {
         let prompt = prompts.into_iter().next().unwrap();
         return Ok(stream_completions(
             model_arc,
@@ -409,7 +439,7 @@ fn stream_completions(
     Sse::new(stream).keep_alive(KeepAlive::default())
 }
 
-fn build_text_completion_chunk(
+pub(super) fn build_text_completion_chunk(
     id: &str,
     model: &str,
     text: Option<&str>,
@@ -444,7 +474,7 @@ fn build_text_completion_chunk(
 /// non-deterministic across platforms: the synthetic CI model emits
 /// different tokens on Ubuntu vs macOS, which is exactly what made
 /// `completions.rs` coverage flap. Keeping this logic pure pins it.)
-fn finalize_completion(
+pub(super) fn finalize_completion(
     tokens: &[(String, f64)],
     stop_strings: &[String],
 ) -> (String, Vec<(String, f64)>, &'static str) {

--- a/crates/larql-server/src/routes/openai/mod.rs
+++ b/crates/larql-server/src/routes/openai/mod.rs
@@ -29,6 +29,7 @@ pub mod embeddings;
 pub mod error;
 pub mod schema;
 pub mod util;
+mod v3_completions;
 
 pub use error::OpenAIError;
 

--- a/crates/larql-server/src/routes/openai/v3_completions.rs
+++ b/crates/larql-server/src/routes/openai/v3_completions.rs
@@ -1,0 +1,296 @@
+//! `/v1/completions` served by a VINDEX3 runtime (VI3-SERVE-1).
+//!
+//! Reached only through [`AppState::served`] resolving the request's
+//! model to a [`V3Model`] — the one place the V2/V3 distinction is
+//! decided. Everything wire-shaped is **shared** with the V2 path
+//! (`build_text_completion_chunk`, `finalize_completion`, the SSE
+//! assembly, the response structs), so the two runtimes cannot drift
+//! apart in what a client sees; only the token source differs:
+//!
+//! ```text
+//! V2: ModelWeights + VectorIndex → generate_streaming
+//! V3: Vindex3Runtime → CanonicalKvState → prefill_into
+//!       → session_with_kv → continue_session
+//! ```
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use futures::stream::Stream;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::StreamExt;
+
+use crate::error::ServerError;
+use crate::vindex3::{generate_v3, V3Model};
+
+use super::completions::{
+    build_text_completion_chunk, finalize_completion, CompletionChoice, CompletionsResponse,
+    CompletionsUsage, TEXT_COMPLETION_OBJECT,
+};
+use super::error::OpenAIError;
+use super::util::{build_sampling_eos, contains_any, error_chunk, new_id_suffix, unix_now};
+
+/// Serve one already-validated completions request on a V3 runtime.
+/// The caller (the shared `/v1/completions` handler) has done all
+/// request validation; this function only generates and shapes.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn respond(
+    model: Arc<V3Model>,
+    prompts: Vec<String>,
+    max_tokens: usize,
+    sampling_params: super::util::SamplingParams,
+    stop_strings: Vec<String>,
+    echo: bool,
+    stream: bool,
+    model_id: String,
+    timeout: std::time::Duration,
+) -> Result<Response, OpenAIError> {
+    if stream {
+        // Validation mirroring the V2 stream contract happened in the
+        // shared handler; one prompt is guaranteed here.
+        let prompt = prompts.into_iter().next().expect("validated non-empty");
+        return Ok(stream_v3_completions(
+            model,
+            prompt,
+            max_tokens,
+            sampling_params,
+            stop_strings,
+            model_id,
+        )
+        .into_response());
+    }
+
+    let handle = tokio::task::spawn_blocking(move || -> Result<_, ServerError> {
+        run_v3_completions_loop(
+            &model,
+            &prompts,
+            max_tokens,
+            sampling_params,
+            &stop_strings,
+            echo,
+        )
+    });
+    let (choices, prompt_tokens, completion_tokens) = join_generation(handle, timeout).await?;
+
+    Ok(Json(CompletionsResponse {
+        id: format!("cmpl-{}", new_id_suffix()),
+        object: TEXT_COMPLETION_OBJECT,
+        created: unix_now(),
+        model: model_id,
+        choices,
+        usage: CompletionsUsage {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens: prompt_tokens + completion_tokens,
+        },
+    })
+    .into_response())
+}
+
+/// Await a blocking generation task under the server-side timeout —
+/// the same 504-and-detach contract the V2 buffered path applies
+/// (BUG-infer-deadlock §5.6): on timeout the JoinHandle is dropped,
+/// the blocking thread finishes in the background, and the client
+/// gets 504 rather than an indefinitely held connection.
+async fn join_generation<T>(
+    handle: tokio::task::JoinHandle<Result<T, ServerError>>,
+    timeout: std::time::Duration,
+) -> Result<T, OpenAIError> {
+    if timeout.is_zero() {
+        return Ok(handle
+            .await
+            .map_err(|e| ServerError::Internal(e.to_string()))??);
+    }
+    match tokio::time::timeout(timeout, handle).await {
+        Ok(join_result) => Ok(join_result.map_err(|e| ServerError::Internal(e.to_string()))??),
+        Err(_elapsed) => {
+            tracing::warn!(
+                target: "larql_server::openai::completions",
+                "v3 completion timed out after {}s; responding 504",
+                timeout.as_secs(),
+            );
+            Err(OpenAIError::from(ServerError::Timeout(format!(
+                "completion exceeded server-side timeout of {}s",
+                timeout.as_secs(),
+            ))))
+        }
+    }
+}
+
+/// Buffered generation over every prompt; returns
+/// `(choices, prompt_tokens_sum, completion_tokens_sum)` — the same
+/// shape the V2 loop feeds the shared response struct.
+fn run_v3_completions_loop(
+    model: &V3Model,
+    prompts: &[String],
+    max_tokens: usize,
+    sampling_params: super::util::SamplingParams,
+    stop_strings: &[String],
+    echo: bool,
+) -> Result<(Vec<CompletionChoice>, usize, usize), ServerError> {
+    let mut choices = Vec::with_capacity(prompts.len());
+    let mut prompt_tokens_sum = 0;
+    let mut completion_tokens_sum = 0;
+    for (index, prompt) in prompts.iter().enumerate() {
+        let prompt_ids = encode_prompt(model, prompt)?;
+        let (sampling, eos) = build_sampling_eos(sampling_params, stop_strings);
+        let generation = generate_v3(model, &prompt_ids, max_tokens, sampling, &eos, |_, _| {})?;
+
+        // The V2 path's text-level EOS/stop-trim semantics, verbatim —
+        // `finalize_completion` is shared, so the two runtimes agree
+        // on finish_reason and trimming by construction.
+        let scored: Vec<(String, f64)> =
+            generation.texts.iter().map(|t| (t.clone(), 1.0)).collect();
+        let (mut text, kept, mut finish_reason) = finalize_completion(&scored, stop_strings);
+        if generation.stopped_early {
+            finish_reason = "stop";
+        }
+        if echo {
+            text = format!("{prompt}{text}");
+        }
+        prompt_tokens_sum += generation.prompt_tokens;
+        completion_tokens_sum += kept.len();
+        choices.push(CompletionChoice {
+            text,
+            index,
+            finish_reason,
+            logprobs: None,
+        });
+    }
+    Ok((choices, prompt_tokens_sum, completion_tokens_sum))
+}
+
+/// SSE streaming over the V3 stack — chunk shape, stop handling, and
+/// termination identical to the V2 `stream_completions`.
+fn stream_v3_completions(
+    model: Arc<V3Model>,
+    prompt: String,
+    max_tokens: usize,
+    sampling_params: super::util::SamplingParams,
+    stop_strings: Vec<String>,
+    model_id: String,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let (tx, rx) = tokio::sync::mpsc::channel::<String>(64);
+    let cmpl_id = format!("cmpl-{}", new_id_suffix());
+
+    tokio::task::spawn_blocking(move || {
+        let prompt_ids = match encode_prompt(&model, &prompt) {
+            Ok(ids) => ids,
+            Err(e) => {
+                let _ = tx.blocking_send(error_chunk(&e.to_string()));
+                return;
+            }
+        };
+        let (sampling, eos) = build_sampling_eos(sampling_params, &stop_strings);
+
+        let cmpl_id_cb = cmpl_id.clone();
+        let model_id_cb = model_id.clone();
+        let tx_cb = tx.clone();
+        let stop_strings_cb = stop_strings.clone();
+        let mut completion_text = String::new();
+        let mut early_stop = false;
+        let result = generate_v3(
+            &model,
+            &prompt_ids,
+            max_tokens,
+            sampling,
+            &eos,
+            |_id, text| {
+                if early_stop {
+                    return;
+                }
+                let chunk =
+                    build_text_completion_chunk(&cmpl_id_cb, &model_id_cb, Some(text), None);
+                if tx_cb.blocking_send(chunk).is_err() {
+                    early_stop = true;
+                    return;
+                }
+                completion_text.push_str(text);
+                if !stop_strings_cb.is_empty() && contains_any(&completion_text, &stop_strings_cb) {
+                    early_stop = true;
+                }
+            },
+        );
+        let finish_reason: &'static str = match result {
+            Ok(generation) if early_stop || generation.stopped_early => "stop",
+            Ok(_) => "length",
+            Err(e) => {
+                let _ = tx.blocking_send(error_chunk(&e.to_string()));
+                return;
+            }
+        };
+        let final_chunk =
+            build_text_completion_chunk(&cmpl_id, &model_id, None, Some(finish_reason));
+        let _ = tx.blocking_send(final_chunk);
+    });
+
+    let stream = ReceiverStream::new(rx)
+        .map(|data| Event::default().data(data))
+        .chain(tokio_stream::once(Event::default().data("[DONE]")))
+        .map(Ok::<_, Infallible>);
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+fn encode_prompt(model: &V3Model, prompt: &str) -> Result<Vec<u32>, ServerError> {
+    let encoding = model
+        .tokenizer
+        .encode(prompt, true)
+        .map_err(|e| ServerError::BadRequest(format!("tokenize: {e}")))?;
+    let ids: Vec<u32> = encoding.get_ids().to_vec();
+    if ids.is_empty() {
+        return Err(ServerError::BadRequest(
+            "prompt tokenises to empty".to_string(),
+        ));
+    }
+    Ok(ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn join_generation_awaits_with_timeout_disabled() {
+        let handle = tokio::task::spawn_blocking(|| Ok::<_, ServerError>(7usize));
+        let value = join_generation(handle, std::time::Duration::ZERO)
+            .await
+            .unwrap();
+        assert_eq!(value, 7);
+    }
+
+    #[tokio::test]
+    async fn join_generation_returns_within_the_timeout() {
+        let handle = tokio::task::spawn_blocking(|| Ok::<_, ServerError>("done"));
+        let value = join_generation(handle, std::time::Duration::from_secs(30))
+            .await
+            .unwrap();
+        assert_eq!(value, "done");
+    }
+
+    #[tokio::test]
+    async fn join_generation_responds_504_when_the_task_overruns() {
+        let handle = tokio::task::spawn_blocking(|| {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            Ok::<_, ServerError>(())
+        });
+        let err = join_generation(handle, std::time::Duration::from_millis(5))
+            .await
+            .unwrap_err();
+        let body = format!("{err:?}");
+        assert!(body.contains("timeout"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn join_generation_surfaces_the_task_error() {
+        let handle =
+            tokio::task::spawn_blocking(|| Err::<(), _>(ServerError::Internal("boom".to_string())));
+        let err = join_generation(handle, std::time::Duration::from_secs(30))
+            .await
+            .unwrap_err();
+        assert!(format!("{err:?}").contains("boom"));
+    }
+}

--- a/crates/larql-server/src/routes/stream.rs
+++ b/crates/larql-server/src/routes/stream.rs
@@ -720,6 +720,7 @@ mod tests {
     fn test_state(models: Vec<Arc<LoadedModel>>) -> Arc<AppState> {
         Arc::new(AppState {
             models,
+            v3_models: Vec::new(),
             started_at: std::time::Instant::now(),
             requests_served: AtomicU64::new(0),
             api_key: None,

--- a/crates/larql-server/src/state.rs
+++ b/crates/larql-server/src/state.rs
@@ -269,6 +269,12 @@ impl LoadedModel {
 pub struct AppState {
     /// Loaded models, keyed by model ID.
     pub models: Vec<Arc<LoadedModel>>,
+    /// Loaded VINDEX3 runtimes (VI3-SERVE-1), keyed by model ID.
+    /// A separate registry, deliberately: a V3 container binds as an
+    /// executable program ([`crate::vindex3::V3Model`]), never as a
+    /// reconstituted `ModelWeights`, and the two shapes share nothing
+    /// below the serving surface.
+    pub v3_models: Vec<Arc<crate::vindex3::V3Model>>,
     /// Server start time for uptime reporting.
     pub started_at: std::time::Instant,
     /// Request counter.
@@ -289,6 +295,15 @@ pub struct AppState {
     pub infer_timeout: std::time::Duration,
 }
 
+/// One request's resolved model binding: which runtime serves it.
+/// Produced only by [`AppState::served`]; the enum exists so the
+/// version distinction lives at model resolution, not inside
+/// generation code.
+pub enum ServedModel<'a> {
+    V2(&'a Arc<LoadedModel>),
+    V3(&'a Arc<crate::vindex3::V3Model>),
+}
+
 impl AppState {
     /// Get model by ID, or the only model if single-model serving.
     pub fn model(&self, id: Option<&str>) -> Option<&Arc<LoadedModel>> {
@@ -301,7 +316,47 @@ impl AppState {
 
     /// Whether this is multi-model serving.
     pub fn is_multi_model(&self) -> bool {
-        self.models.len() > 1
+        self.models.len() + self.v3_models.len() > 1
+    }
+
+    /// Resolve a request's model across BOTH registries. This is the
+    /// single place the V2/V3 distinction is decided — routes match
+    /// the returned binding once, at the top, and no version check
+    /// leaks below it.
+    pub fn served(&self, id: Option<&str>) -> Option<ServedModel<'_>> {
+        match id {
+            Some(id) => self
+                .models
+                .iter()
+                .find(|m| m.id == id)
+                .map(ServedModel::V2)
+                .or_else(|| {
+                    self.v3_models
+                        .iter()
+                        .find(|m| m.id == id)
+                        .map(ServedModel::V3)
+                }),
+            None if self.models.len() + self.v3_models.len() == 1 => self
+                .models
+                .first()
+                .map(ServedModel::V2)
+                .or_else(|| self.v3_models.first().map(ServedModel::V3)),
+            None => None,
+        }
+    }
+
+    /// [`served`](Self::served), or a `NotFound` error.
+    pub fn served_or_err(
+        &self,
+        id: Option<&str>,
+    ) -> Result<ServedModel<'_>, crate::error::ServerError> {
+        self.served(id).ok_or_else(|| {
+            let msg = match id {
+                Some(mid) => format!("model '{}' not found", mid),
+                None => "no model loaded".into(),
+            };
+            crate::error::ServerError::NotFound(msg)
+        })
     }
 
     pub fn bump_requests(&self) {

--- a/crates/larql-server/src/vindex3.rs
+++ b/crates/larql-server/src/vindex3.rs
@@ -1,0 +1,132 @@
+//! VI3-SERVE-1: a VINDEX3 container served over the normal API.
+//!
+//! One vertical slice, deliberately boring:
+//!
+//! ```text
+//! VINDEX3 container → Vindex3Runtime → CanonicalKvState
+//!     → prefill_into() → session_with_kv() → continue_session()
+//!     → existing SSE/JSON shaping
+//! ```
+//!
+//! What deliberately does **not** happen here: no `load_vindex3() ->
+//! ModelWeights`, no `VectorIndex`, no `ModelArchitecture` — a V3
+//! container binds as an executable program and is served through the
+//! runtime stack INF-0..3 and KV-1 gated bit-for-bit. The V2/V3
+//! distinction is decided once, at model binding
+//! ([`crate::bootstrap::load_artifact`] /
+//! [`crate::state::AppState::served`]); generation code below the
+//! binding never asks which format it is running.
+//!
+//! Per-request cost note: every request opens a fresh session, which
+//! loads the plan's operands (`DecodeSession::new` keeps weights
+//! resident per session, not per server). Fine for the semantic gate
+//! this rung is; a shared resident session/operand pool is later,
+//! perf-shaped work.
+
+use std::path::{Path, PathBuf};
+
+use larql_inference::layer_graph::generate::detok::Detokenizer;
+use larql_inference::vindex3::{continue_session, Vindex3Runtime};
+use larql_inference::{EosConfig, SamplingConfig};
+use larql_kv::CanonicalKvState;
+use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+use larql_vindex::tokenizers;
+
+use crate::error::ServerError;
+use crate::state::model_id_from_name;
+
+/// Component id a container's text stack is served under.
+const SERVED_COMPONENT: &str = "target";
+
+/// One bound VINDEX3 container: the opened runtime plus the serving
+/// glue (tokenizer, id). Holds no `ModelWeights` and no `VectorIndex`
+/// — structurally, the old inference path is unreachable from here.
+pub struct V3Model {
+    /// Model ID (derived from the container directory name).
+    pub id: String,
+    /// Container directory on disk.
+    pub path: PathBuf,
+    /// The opened executable program + operand store + backend.
+    pub runtime: Vindex3Runtime<ProductionBackend>,
+    /// Tokenizer for the text-facing API (`tokenizer.json` in the
+    /// container directory).
+    pub tokenizer: tokenizers::Tokenizer,
+}
+
+/// Bind a VINDEX3 container for serving: open the component's plan
+/// and operand store (refusing closure defects), and load the
+/// container's tokenizer — the text API cannot serve ids-only.
+pub fn load_v3_model(path: &Path) -> Result<V3Model, Box<dyn std::error::Error + Send + Sync>> {
+    let runtime = Vindex3Runtime::open(path, SERVED_COMPONENT, ProductionBackend::new())
+        .map_err(|e| format!("open VINDEX3 container: {e}"))?;
+    let tokenizer = larql_vindex::load_vindex_tokenizer(path)
+        .map_err(|e| format!("VINDEX3 container has no servable tokenizer.json: {e}"))?;
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "vindex3".to_string());
+    Ok(V3Model {
+        id: model_id_from_name(&name),
+        path: path.to_path_buf(),
+        runtime,
+        tokenizer,
+    })
+}
+
+/// What one V3 generation produced, shaped for the OpenAI routes:
+/// per-token surface text in emission order plus the ids behind them.
+pub struct V3Generation {
+    pub ids: Vec<u32>,
+    pub texts: Vec<String>,
+    pub prompt_tokens: usize,
+    /// True when generation ended before the token budget — the EOS
+    /// signal the routes fold into `finish_reason`.
+    pub stopped_early: bool,
+}
+
+/// The SERVE-1 stack for one request: fresh caller-owned continuation
+/// state, batch prefill, resume, drive the sampler — streaming each
+/// token's `(id, text)` through `on_token` as it is emitted.
+pub fn generate_v3(
+    model: &V3Model,
+    prompt_ids: &[u32],
+    max_tokens: usize,
+    sampling: SamplingConfig,
+    eos: &EosConfig,
+    mut on_token: impl FnMut(u32, &str),
+) -> Result<V3Generation, ServerError> {
+    let mut kv = CanonicalKvState::new();
+    let prefill_logits = model
+        .runtime
+        .prefill_into(prompt_ids, &mut kv)
+        .map_err(|e| ServerError::Internal(format!("v3 prefill: {e}")))?;
+    let mut session = model
+        .runtime
+        .session_with_kv(&mut kv)
+        .map_err(|e| ServerError::Internal(format!("v3 session: {e}")))?;
+
+    let mut detok = Detokenizer::new(&model.tokenizer);
+    detok.seed(prompt_ids);
+    let mut texts = Vec::new();
+    let result = continue_session(
+        &mut session,
+        prefill_logits,
+        max_tokens,
+        sampling,
+        eos,
+        |id| {
+            let text = detok.push(id);
+            on_token(id, &text);
+            texts.push(text);
+        },
+    )
+    .map_err(|e| ServerError::Internal(format!("v3 decode: {e}")))?;
+
+    let stopped_early = result.tokens.len() < max_tokens;
+    Ok(V3Generation {
+        ids: result.tokens,
+        texts,
+        prompt_tokens: prompt_ids.len(),
+        stopped_early,
+    })
+}

--- a/crates/larql-server/tests/common/mod.rs
+++ b/crates/larql-server/tests/common/mod.rs
@@ -468,6 +468,7 @@ pub fn model_with_q4k_weights(
 pub fn state(models: Vec<Arc<LoadedModel>>) -> Arc<AppState> {
     Arc::new(AppState {
         models,
+        v3_models: Vec::new(),
         started_at: std::time::Instant::now(),
         requests_served: AtomicU64::new(0),
         api_key: None,
@@ -480,6 +481,7 @@ pub fn state(models: Vec<Arc<LoadedModel>>) -> Arc<AppState> {
 pub fn state_with_key(models: Vec<Arc<LoadedModel>>, key: &str) -> Arc<AppState> {
     Arc::new(AppState {
         models,
+        v3_models: Vec::new(),
         started_at: std::time::Instant::now(),
         requests_served: AtomicU64::new(0),
         api_key: Some(key.to_string()),
@@ -492,6 +494,7 @@ pub fn state_with_key(models: Vec<Arc<LoadedModel>>, key: &str) -> Arc<AppState>
 pub fn state_with_cache(models: Vec<Arc<LoadedModel>>, cache_size: u64) -> Arc<AppState> {
     Arc::new(AppState {
         models,
+        v3_models: Vec::new(),
         started_at: std::time::Instant::now(),
         requests_served: AtomicU64::new(0),
         api_key: None,

--- a/crates/larql-server/tests/test_expert_endpoint.rs
+++ b/crates/larql-server/tests/test_expert_endpoint.rs
@@ -328,6 +328,7 @@ fn make_loaded_model(
 async fn spawn_server_with_model(model: LoadedModel) -> String {
     let state = Arc::new(AppState {
         models: vec![Arc::new(model)],
+        v3_models: Vec::new(),
         started_at: std::time::Instant::now(),
         requests_served: std::sync::atomic::AtomicU64::new(0),
         api_key: None,

--- a/crates/larql-server/tests/test_http_core.rs
+++ b/crates/larql-server/tests/test_http_core.rs
@@ -351,6 +351,7 @@ async fn http_warmup_no_model_returns_404() {
     // single_model_router with empty model list → model(None) returns None → 404.
     let st = Arc::new(AppState {
         models: vec![],
+        v3_models: Vec::new(),
         started_at: std::time::Instant::now(),
         requests_served: AtomicU64::new(0),
         api_key: None,

--- a/crates/larql-server/tests/test_unit_state.rs
+++ b/crates/larql-server/tests/test_unit_state.rs
@@ -116,6 +116,7 @@ fn make_tiny_model(id: &str) -> Arc<LoadedModel> {
 fn make_tiny_state(models: Vec<Arc<LoadedModel>>) -> Arc<AppState> {
     Arc::new(AppState {
         models,
+        v3_models: Vec::new(),
         started_at: std::time::Instant::now(),
         requests_served: AtomicU64::new(0),
         api_key: None,

--- a/crates/larql-server/tests/test_vindex3_serve.rs
+++ b/crates/larql-server/tests/test_vindex3_serve.rs
@@ -1,0 +1,363 @@
+//! VI3-SERVE-1 gates: a VINDEX3 container over the normal server API.
+//!
+//! The authoritative arm (A) is the direct runtime stack —
+//! `Vindex3Runtime` → `CanonicalKvState` → `prefill_into` →
+//! `session_with_kv` → `continue_session` — assembled by hand in this
+//! file. Arm B is an HTTP request through the server's model registry
+//! into `/v1/completions`. The gate demands the streamed tokens match
+//! arm A token-for-token: same first token, same ordering, same
+//! count, same finish behaviour.
+//!
+//! The negative control pins the architectural regression this rung
+//! exists to prevent: the served container **cannot** be opened by
+//! the V2 path at all (`load_vindex_config` refuses the generation,
+//! `load_single_vindex` errors), and the serving state holds zero V2
+//! models while requests succeed — so the server provably did not
+//! reconstitute an old-style model behind the scenes.
+
+mod common;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use larql_inference::layer_graph::generate::detok::Detokenizer;
+use larql_inference::test_utils::synthetic_tokenizer_json;
+use larql_inference::vindex3::{continue_session, Vindex3Runtime};
+use larql_inference::{EosConfig, SamplingConfig};
+use larql_kv::CanonicalKvState;
+use larql_server::bootstrap::{
+    load_artifact, load_single_vindex, LoadVindexOptions, LoadedArtifact,
+};
+use larql_server::state::AppState;
+use larql_vindex::format::load::load_vindex_config;
+use larql_vindex::format::vindex3::fixtures::{
+    encode_fixture_container, miniature_glimmer, G_VOCAB,
+};
+use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+
+const NEW_TOKENS: usize = 16;
+const PROMPT: &str = "[3]";
+const COMPONENT: &str = "target";
+
+/// Encode the miniature container and give it a servable tokenizer
+/// (`[N]` ↔ id N, no pre-tokenizer).
+fn v3_container() -> tempfile::TempDir {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(
+        miniature_glimmer,
+        checkpoint.path(),
+        container.path(),
+        "serve-fixture",
+    );
+    std::fs::write(
+        container.path().join("tokenizer.json"),
+        synthetic_tokenizer_json(G_VOCAB),
+    )
+    .unwrap();
+    container
+}
+
+/// Arm A: the direct runtime stack, by hand. Returns per-token
+/// `(id, text)` pairs in emission order.
+fn direct_arm(container: &Path, max_tokens: usize) -> Vec<(u32, String)> {
+    let runtime = Vindex3Runtime::open(container, COMPONENT, ProductionBackend::new()).unwrap();
+    let tokenizer = larql_vindex::load_vindex_tokenizer(container).unwrap();
+    let prompt_ids: Vec<u32> = tokenizer.encode(PROMPT, true).unwrap().get_ids().to_vec();
+    assert!(!prompt_ids.is_empty());
+
+    let mut kv = CanonicalKvState::new();
+    let prefill = runtime.prefill_into(&prompt_ids, &mut kv).unwrap();
+    let mut session = runtime.session_with_kv(&mut kv).unwrap();
+    let mut detok = Detokenizer::new(&tokenizer);
+    detok.seed(&prompt_ids);
+    let mut pairs = Vec::new();
+    continue_session(
+        &mut session,
+        prefill,
+        max_tokens,
+        SamplingConfig::greedy(),
+        &EosConfig::builtin(),
+        |id| {
+            let text = detok.push(id);
+            pairs.push((id, text));
+        },
+    )
+    .unwrap();
+    pairs
+}
+
+/// A serving state holding ONLY the V3 model — bound through the same
+/// `load_artifact` the real bootstrap uses.
+fn v3_state(container: &Path) -> Arc<AppState> {
+    let artifact =
+        load_artifact(&container.to_string_lossy(), LoadVindexOptions::default()).unwrap();
+    let v3 = match artifact {
+        LoadedArtifact::V3(m) => Arc::new(*m),
+        LoadedArtifact::V2(_) => panic!("a VINDEX3 container must bind as V3"),
+    };
+    Arc::new(AppState {
+        models: Vec::new(),
+        v3_models: vec![v3],
+        started_at: std::time::Instant::now(),
+        requests_served: std::sync::atomic::AtomicU64::new(0),
+        api_key: None,
+        sessions: larql_server::session::SessionManager::new(3600),
+        describe_cache: larql_server::cache::DescribeCache::new(0),
+        infer_timeout: std::time::Duration::from_secs(60),
+    })
+}
+
+/// Parse an SSE body into its JSON data chunks (excluding `[DONE]`).
+fn sse_chunks(body: &str) -> Vec<serde_json::Value> {
+    body.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter(|data| *data != "[DONE]")
+        .map(|data| serde_json::from_str(data).expect("SSE chunk is JSON"))
+        .collect()
+}
+
+#[tokio::test]
+async fn v3_stream_over_the_api_matches_the_direct_runtime_token_for_token() {
+    let container = v3_container();
+    let expected = direct_arm(container.path(), NEW_TOKENS);
+    assert_eq!(expected.len(), NEW_TOKENS, "fixture must fill the budget");
+
+    let state = v3_state(container.path());
+    assert!(
+        state.models.is_empty(),
+        "no V2 model may exist while V3 serves"
+    );
+    let app = larql_server::routes::single_model_router(state);
+    let resp = common::post_json(
+        app,
+        "/v1/completions",
+        serde_json::json!({
+            "prompt": PROMPT,
+            "max_tokens": NEW_TOKENS,
+            "stream": true,
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(content_type.contains("event-stream"), "{content_type}");
+
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(body.contains("[DONE]"));
+
+    let chunks = sse_chunks(&body);
+    // One chunk per token plus the final finish_reason chunk.
+    assert_eq!(chunks.len(), NEW_TOKENS + 1, "chunk count");
+    for (chunk, (_, text)) in chunks[..NEW_TOKENS].iter().zip(&expected) {
+        assert_eq!(chunk["choices"][0]["text"], text.as_str());
+        assert_eq!(
+            chunk["choices"][0]["finish_reason"],
+            serde_json::Value::Null
+        );
+        assert_eq!(chunk["object"], "text_completion");
+    }
+    // Same first token, same ordering (asserted above), same EOS
+    // behaviour: the greedy run never hits a stop, so "length".
+    assert_eq!(chunks[NEW_TOKENS]["choices"][0]["finish_reason"], "length");
+}
+
+#[tokio::test]
+async fn v3_buffered_response_matches_the_direct_runtime() {
+    let container = v3_container();
+    let expected = direct_arm(container.path(), NEW_TOKENS);
+    let expected_text: String = expected.iter().map(|(_, t)| t.as_str()).collect();
+
+    let app = larql_server::routes::single_model_router(v3_state(container.path()));
+    let resp = common::post_json(
+        app,
+        "/v1/completions",
+        serde_json::json!({"prompt": PROMPT, "max_tokens": NEW_TOKENS}),
+    )
+    .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let json = common::body_json(resp.into_body()).await;
+    assert_eq!(json["choices"][0]["text"], expected_text.as_str());
+    assert_eq!(json["choices"][0]["finish_reason"], "length");
+    assert_eq!(json["usage"]["prompt_tokens"], 1);
+    assert_eq!(json["usage"]["completion_tokens"], NEW_TOKENS);
+    assert_eq!(json["object"], "text_completion");
+}
+
+#[tokio::test]
+async fn v3_stream_honours_client_stop_strings() {
+    let container = v3_container();
+    let expected = direct_arm(container.path(), NEW_TOKENS);
+    // Stop on the third token's surface text: chunks 1..=3 stream,
+    // then the final chunk closes with "stop".
+    let stop = expected[2].1.clone();
+    assert!(!stop.trim().is_empty(), "stop token must have surface text");
+
+    let app = larql_server::routes::single_model_router(v3_state(container.path()));
+    let resp = common::post_json(
+        app,
+        "/v1/completions",
+        serde_json::json!({
+            "prompt": PROMPT,
+            "max_tokens": NEW_TOKENS,
+            "stream": true,
+            "stop": stop,
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    let chunks = sse_chunks(&body);
+    assert_eq!(chunks.len(), 3 + 1, "stream must stop after the match");
+    assert_eq!(chunks[3]["choices"][0]["finish_reason"], "stop");
+}
+
+/// The negative control: the container this server is happily serving
+/// CANNOT be opened by the V2 path at all — so V3 serving is provably
+/// not "reconstitute an old model, run old inference" in disguise.
+#[test]
+fn the_served_container_cannot_take_the_v2_path() {
+    let container = v3_container();
+
+    let config = load_vindex_config(container.path());
+    assert!(
+        config.is_err(),
+        "V2 config loader must refuse a V3 container"
+    );
+
+    let v2_load = load_single_vindex(
+        &container.path().to_string_lossy(),
+        LoadVindexOptions::default(),
+    );
+    assert!(
+        v2_load.is_err(),
+        "V2 model loader must refuse a V3 container"
+    );
+
+    let artifact = load_artifact(
+        &container.path().to_string_lossy(),
+        LoadVindexOptions::default(),
+    )
+    .unwrap();
+    assert!(
+        matches!(artifact, LoadedArtifact::V3(_)),
+        "binding must resolve to the V3 runtime"
+    );
+}
+
+#[tokio::test]
+async fn v3_model_appears_in_the_models_listing() {
+    let container = v3_container();
+    let app = larql_server::routes::single_model_router(v3_state(container.path()));
+    let resp = common::get(app, "/v1/models").await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let json = common::body_json(resp.into_body()).await;
+    assert_eq!(json["object"], "list");
+    let data = json["data"].as_array().unwrap();
+    assert_eq!(data.len(), 1);
+    assert_eq!(data[0]["object"], "model");
+    assert_eq!(data[0]["generation"], 3);
+    assert_eq!(data[0]["loaded"], true);
+    assert!(data[0]["id"].as_str().is_some_and(|s| !s.is_empty()));
+}
+
+#[tokio::test]
+async fn v3_buffered_supports_echo_and_batched_prompts() {
+    let container = v3_container();
+    let app = larql_server::routes::single_model_router(v3_state(container.path()));
+    let resp = common::post_json(
+        app,
+        "/v1/completions",
+        serde_json::json!({
+            "prompt": ["[3]", "[5]"],
+            "max_tokens": 2,
+            "echo": true,
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let json = common::body_json(resp.into_body()).await;
+    let choices = json["choices"].as_array().unwrap();
+    assert_eq!(choices.len(), 2);
+    assert!(choices[0]["text"].as_str().unwrap().starts_with("[3]"));
+    assert!(choices[1]["text"].as_str().unwrap().starts_with("[5]"));
+    assert_eq!(json["usage"]["prompt_tokens"], 2);
+    assert_eq!(json["usage"]["completion_tokens"], 4);
+}
+
+#[tokio::test]
+async fn v3_buffered_trims_at_client_stop_strings() {
+    let container = v3_container();
+    let expected = direct_arm(container.path(), NEW_TOKENS);
+    let stop = expected[2].1.clone();
+
+    let app = larql_server::routes::single_model_router(v3_state(container.path()));
+    let resp = common::post_json(
+        app,
+        "/v1/completions",
+        serde_json::json!({
+            "prompt": PROMPT,
+            "max_tokens": NEW_TOKENS,
+            "stop": stop,
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let json = common::body_json(resp.into_body()).await;
+    assert_eq!(json["choices"][0]["finish_reason"], "stop");
+    let text = json["choices"][0]["text"].as_str().unwrap();
+    let full: String = expected.iter().map(|(_, t)| t.as_str()).collect();
+    assert!(text.len() < full.len(), "stop must trim the completion");
+}
+
+#[tokio::test]
+async fn v3_stream_reports_an_untokenizable_prompt_as_an_error_chunk() {
+    let container = v3_container();
+    let app = larql_server::routes::single_model_router(v3_state(container.path()));
+    // An empty prompt string passes the handler's list-level check but
+    // tokenises to zero ids — the in-stream failure path.
+    let resp = common::post_json(
+        app,
+        "/v1/completions",
+        serde_json::json!({
+            "prompt": "",
+            "max_tokens": 4,
+            "stream": true,
+        }),
+    )
+    .await;
+    // Headers are already SSE by the time tokenisation runs, so the
+    // failure arrives as an in-stream error chunk, mirroring V2.
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(body.contains("error"), "{body}");
+    assert!(body.contains("[DONE]"));
+}
+
+/// …and the other arm of the same binding decision: an ordinary V2
+/// vindex must resolve to the V2 runtime through the identical
+/// `load_artifact` call, so the dispatch is proven in both directions.
+#[test]
+fn a_v2_vindex_binds_as_v2_through_the_same_artifact_loader() {
+    let fixture = common::synthetic_vindex::build();
+    let artifact =
+        load_artifact(&fixture.dir.to_string_lossy(), LoadVindexOptions::default()).unwrap();
+    assert!(
+        matches!(artifact, LoadedArtifact::V2(_)),
+        "a V2 vindex must bind as V2"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/fixtures.rs
+++ b/crates/larql-vindex/src/format/vindex3/fixtures.rs
@@ -1,0 +1,411 @@
+//! Miniature whole-model checkpoints, public so integration tests in
+//! sibling crates can build a real VINDEX3 container without
+//! duplicating the frozen geometry.
+//!
+//! Two fixtures, both deterministic (LCG over the flat index — no RNG
+//! state, no clock):
+//!
+//! - [`dense_f32_model`]: a dense Llama-shaped checkpoint. The plain
+//!   anatomy — two norms per layer, RoPE everywhere, no gates.
+//! - [`miniature_glimmer`]: the judged-semantics miniature (sigmoid
+//!   attention gate, four-norm placement, per-layer sliding/full +
+//!   RoPE/NoPE split, softcapping) with deliberately awkward
+//!   dimensions so no broadcasting accident can hide.
+//!
+//! The executor's own oracle tests live in
+//! `opplan/exec/tests` and consume these same writers; a sibling crate
+//! building a container from one of them is therefore executing the
+//! exact program those parity gates certify.
+//!
+//! This is a sibling of [`super::test_support`] (conformance fixture A),
+//! which covers a single routed-MoE *layer bank*; the writers here emit
+//! *complete model programs* — embedding, attention stack, output head —
+//! the shape a [`DecodeSession`](super::opplan::exec::decode::DecodeSession)
+//! needs.
+
+use std::io::Write;
+use std::path::Path;
+
+use larql_models::inventory::build_inventory;
+
+use super::encode::encode_system;
+
+/// Deterministic small weights: LCG over the flat index, scaled to
+/// ±0.05 so activations stay in a well-conditioned range.
+pub fn lcg_values(n: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    (0..n)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let unit = ((state >> 33) as f64) / ((1u64 << 31) as f64);
+            ((unit - 0.5) * 0.1) as f32
+        })
+        .collect()
+}
+
+/// Norm weights near 1.0 (never all-zero: that would mask norm bugs).
+pub fn norm_values(n: usize, seed: u64) -> Vec<f32> {
+    lcg_values(n, seed).into_iter().map(|v| 1.0 + v).collect()
+}
+
+/// Write one F32 tensor into a safetensors header/payload pair.
+pub struct ShardBuilder {
+    header: serde_json::Map<String, serde_json::Value>,
+    payload: Vec<u8>,
+}
+
+impl Default for ShardBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ShardBuilder {
+    pub fn new() -> Self {
+        Self {
+            header: serde_json::Map::new(),
+            payload: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, name: &str, shape: &[usize], values: &[f32]) {
+        assert_eq!(shape.iter().product::<usize>(), values.len());
+        let start = self.payload.len();
+        for v in values {
+            self.payload.extend_from_slice(&v.to_le_bytes());
+        }
+        self.header.insert(
+            name.to_string(),
+            serde_json::json!({
+                "dtype": "F32",
+                "shape": shape,
+                "data_offsets": [start, self.payload.len()],
+            }),
+        );
+    }
+
+    /// Write one tensor of any dtype from raw little-endian bytes — for
+    /// packed MXFP4 (`U8`) expert banks.
+    pub fn push_bytes(&mut self, name: &str, dtype: &str, shape: &[usize], bytes: &[u8]) {
+        let start = self.payload.len();
+        self.payload.extend_from_slice(bytes);
+        self.header.insert(
+            name.to_string(),
+            serde_json::json!({
+                "dtype": dtype,
+                "shape": shape,
+                "data_offsets": [start, self.payload.len()],
+            }),
+        );
+    }
+
+    pub fn write(self, dir: &Path) {
+        let header_bytes = serde_json::to_vec(&serde_json::Value::Object(self.header)).unwrap();
+        let mut file = std::fs::File::create(dir.join("model.safetensors")).unwrap();
+        file.write_all(&(header_bytes.len() as u64).to_le_bytes())
+            .unwrap();
+        file.write_all(&header_bytes).unwrap();
+        file.write_all(&self.payload).unwrap();
+    }
+}
+
+// ── Dense Llama-shaped fixture geometry ──
+pub const DENSE_HIDDEN: usize = 64;
+pub const DENSE_INTERMEDIATE: usize = 256;
+pub const DENSE_VOCAB: usize = 128;
+pub const DENSE_Q_HEADS: usize = 8;
+pub const DENSE_KV_HEADS: usize = 2;
+pub const DENSE_HEAD_DIM: usize = 8;
+pub const DENSE_LAYERS: usize = 2;
+
+/// A dense Llama-shaped checkpoint with real F32 weights — loadable by
+/// the production path and encodable into a VINDEX3 container.
+pub fn dense_f32_model(dir: &Path) {
+    std::fs::write(
+        dir.join("config.json"),
+        serde_json::json!({
+            "architectures": ["LlamaForCausalLM"],
+            "torch_dtype": "float32",
+            "model_type": "llama",
+            "hidden_size": DENSE_HIDDEN,
+            "num_hidden_layers": DENSE_LAYERS,
+            "intermediate_size": DENSE_INTERMEDIATE,
+            "num_attention_heads": DENSE_Q_HEADS,
+            "num_key_value_heads": DENSE_KV_HEADS,
+            "head_dim": DENSE_HEAD_DIM,
+            "vocab_size": DENSE_VOCAB,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let q_rows = DENSE_Q_HEADS * DENSE_HEAD_DIM;
+    let kv_rows = DENSE_KV_HEADS * DENSE_HEAD_DIM;
+    let mut shard = ShardBuilder::new();
+    shard.push(
+        "model.embed_tokens.weight",
+        &[DENSE_VOCAB, DENSE_HIDDEN],
+        &lcg_values(DENSE_VOCAB * DENSE_HIDDEN, 1),
+    );
+    shard.push(
+        "model.norm.weight",
+        &[DENSE_HIDDEN],
+        &norm_values(DENSE_HIDDEN, 2),
+    );
+    shard.push(
+        "lm_head.weight",
+        &[DENSE_VOCAB, DENSE_HIDDEN],
+        &lcg_values(DENSE_VOCAB * DENSE_HIDDEN, 3),
+    );
+    for layer in 0..DENSE_LAYERS {
+        let seed = 100 + layer as u64 * 10;
+        let prefix = format!("model.layers.{layer}");
+        shard.push(
+            &format!("{prefix}.self_attn.q_proj.weight"),
+            &[q_rows, DENSE_HIDDEN],
+            &lcg_values(q_rows * DENSE_HIDDEN, seed),
+        );
+        shard.push(
+            &format!("{prefix}.self_attn.k_proj.weight"),
+            &[kv_rows, DENSE_HIDDEN],
+            &lcg_values(kv_rows * DENSE_HIDDEN, seed + 1),
+        );
+        shard.push(
+            &format!("{prefix}.self_attn.v_proj.weight"),
+            &[kv_rows, DENSE_HIDDEN],
+            &lcg_values(kv_rows * DENSE_HIDDEN, seed + 2),
+        );
+        shard.push(
+            &format!("{prefix}.self_attn.o_proj.weight"),
+            &[DENSE_HIDDEN, q_rows],
+            &lcg_values(DENSE_HIDDEN * q_rows, seed + 3),
+        );
+        shard.push(
+            &format!("{prefix}.input_layernorm.weight"),
+            &[DENSE_HIDDEN],
+            &norm_values(DENSE_HIDDEN, seed + 4),
+        );
+        shard.push(
+            &format!("{prefix}.post_attention_layernorm.weight"),
+            &[DENSE_HIDDEN],
+            &norm_values(DENSE_HIDDEN, seed + 5),
+        );
+        shard.push(
+            &format!("{prefix}.mlp.gate_proj.weight"),
+            &[DENSE_INTERMEDIATE, DENSE_HIDDEN],
+            &lcg_values(DENSE_INTERMEDIATE * DENSE_HIDDEN, seed + 6),
+        );
+        shard.push(
+            &format!("{prefix}.mlp.up_proj.weight"),
+            &[DENSE_INTERMEDIATE, DENSE_HIDDEN],
+            &lcg_values(DENSE_INTERMEDIATE * DENSE_HIDDEN, seed + 7),
+        );
+        shard.push(
+            &format!("{prefix}.mlp.down_proj.weight"),
+            &[DENSE_HIDDEN, DENSE_INTERMEDIATE],
+            &lcg_values(DENSE_HIDDEN * DENSE_INTERMEDIATE, seed + 8),
+        );
+    }
+    shard.write(dir);
+}
+
+// ── The awkward miniature-Glimmer geometry, shared only as *numbers* ──
+pub const G_HIDDEN: usize = 12;
+pub const G_Q_HEADS: usize = 3;
+pub const G_KV_HEADS: usize = 1;
+pub const G_HEAD_DIM: usize = 4;
+pub const G_FFN: usize = 20;
+pub const G_VOCAB: usize = 29;
+pub const G_LAYERS: usize = 2;
+pub const G_WINDOW: usize = 3;
+pub const G_TOKENS: [u32; 5] = [3, 17, 28, 0, 11];
+
+/// Optional attention operands the miniature can carry (A-9.1): Q/K/V/O
+/// projection biases (with `attention_bias: true` declared) and
+/// per-query-head sink logits. `perturb` names one of those tensors by
+/// suffix; the writer scales it by [`PERTURB_GAIN`], so a test can ask
+/// whether that single operand is load-bearing.
+#[derive(Default, Clone, Copy)]
+pub struct MiniatureExtras {
+    pub attention_bias: bool,
+    pub sinks: bool,
+    pub perturb: Option<&'static str>,
+}
+
+/// Multiplier applied to a perturbed extra operand.
+pub const PERTURB_GAIN: f32 = 3.0;
+
+/// The four projection-bias operands, by layer-relative suffix.
+pub const BIAS_SUFFIXES: [&str; 4] = [
+    "self_attn.q_proj.bias",
+    "self_attn.k_proj.bias",
+    "self_attn.v_proj.bias",
+    "self_attn.o_proj.bias",
+];
+pub const SINKS_SUFFIX: &str = "self_attn.sinks";
+
+/// The two-layer miniature Glimmer checkpoint (F32, judged family):
+///
+/// ```text
+/// layer 0: Sliding(3) + RoPE(500000) + gated attention
+/// layer 1: Full     + NoPE          + gated attention
+/// ```
+pub fn miniature_glimmer(dir: &Path) {
+    miniature_glimmer_with(dir, MiniatureExtras::default());
+}
+
+/// The miniature with the A-9.1 extras.
+pub fn miniature_glimmer_with(dir: &Path, extras: MiniatureExtras) {
+    let mut config = serde_json::json!({
+            "architectures": ["MuseGlimmerForConditionalGeneration"],
+            "torch_dtype": "float32",
+            "model_type": "muse_glimmer_text",
+            "hidden_size": G_HIDDEN,
+            "num_hidden_layers": G_LAYERS,
+            "intermediate_size": G_FFN,
+            "num_attention_heads": G_Q_HEADS,
+            "num_key_value_heads": G_KV_HEADS,
+            "head_dim": G_HEAD_DIM,
+            "vocab_size": G_VOCAB,
+            "sliding_window": G_WINDOW,
+            "rms_norm_eps": 1e-5,
+            "rope_parameters": { "rope_theta": 500000.0, "rope_type": "default" },
+            "layer_types": ["sliding_attention", "full_attention"],
+            "layer_rope_theta": [500000.0, 0.0],
+            "qk_scale_factor": 3.87,
+            "output_multiplier": 0.196,
+            "post_norm_eps": 1e-8,
+            "attn_logit_softcapping": 50.0,
+            "final_logit_softcapping": 20.0
+    });
+    if extras.attention_bias {
+        config["attention_bias"] = serde_json::json!(true);
+    }
+    std::fs::write(dir.join("config.json"), config.to_string()).unwrap();
+
+    let q_rows = G_Q_HEADS * G_HEAD_DIM;
+    let kv_rows = G_KV_HEADS * G_HEAD_DIM;
+    let mut shard = ShardBuilder::new();
+    shard.push(
+        "model.embed_tokens.weight",
+        &[G_VOCAB, G_HIDDEN],
+        &lcg_values(G_VOCAB * G_HIDDEN, 1),
+    );
+    shard.push("model.norm.weight", &[G_HIDDEN], &norm_values(G_HIDDEN, 2));
+    shard.push(
+        "lm_head.weight",
+        &[G_VOCAB, G_HIDDEN],
+        &lcg_values(G_VOCAB * G_HIDDEN, 3),
+    );
+    for layer in 0..G_LAYERS {
+        let seed = 900 + layer as u64 * 30;
+        let prefix = format!("model.layers.{layer}");
+        for (suffix, shape, values) in [
+            (
+                "self_attn.q_proj.weight",
+                vec![q_rows, G_HIDDEN],
+                lcg_values(q_rows * G_HIDDEN, seed),
+            ),
+            (
+                "self_attn.k_proj.weight",
+                vec![kv_rows, G_HIDDEN],
+                lcg_values(kv_rows * G_HIDDEN, seed + 1),
+            ),
+            (
+                "self_attn.v_proj.weight",
+                vec![kv_rows, G_HIDDEN],
+                lcg_values(kv_rows * G_HIDDEN, seed + 2),
+            ),
+            (
+                "self_attn.o_proj.weight",
+                vec![G_HIDDEN, q_rows],
+                lcg_values(G_HIDDEN * q_rows, seed + 3),
+            ),
+            (
+                "self_attn.gate_proj.weight",
+                vec![q_rows, G_HIDDEN],
+                lcg_values(q_rows * G_HIDDEN, seed + 4),
+            ),
+            (
+                "input_layernorm.weight",
+                vec![G_HIDDEN],
+                norm_values(G_HIDDEN, seed + 5),
+            ),
+            (
+                "post_attention_layernorm.weight",
+                vec![G_HIDDEN],
+                norm_values(G_HIDDEN, seed + 6),
+            ),
+            (
+                "pre_feedforward_layernorm.weight",
+                vec![G_HIDDEN],
+                norm_values(G_HIDDEN, seed + 7),
+            ),
+            (
+                "post_feedforward_layernorm.weight",
+                vec![G_HIDDEN],
+                norm_values(G_HIDDEN, seed + 8),
+            ),
+            (
+                "mlp.gate_proj.weight",
+                vec![G_FFN, G_HIDDEN],
+                lcg_values(G_FFN * G_HIDDEN, seed + 9),
+            ),
+            (
+                "mlp.up_proj.weight",
+                vec![G_FFN, G_HIDDEN],
+                lcg_values(G_FFN * G_HIDDEN, seed + 10),
+            ),
+            (
+                "mlp.down_proj.weight",
+                vec![G_HIDDEN, G_FFN],
+                lcg_values(G_HIDDEN * G_FFN, seed + 11),
+            ),
+        ] {
+            shard.push(&format!("{prefix}.{suffix}"), &shape, &values);
+        }
+        // Extras: values well away from zero so an unapplied bias or sink
+        // is a visible absence, not a rounding-level one.
+        let mut extra = |suffix: &str, len: usize, seed: u64| {
+            let mut values: Vec<f32> = lcg_values(len, seed).into_iter().map(|v| v * 4.0).collect();
+            if extras.perturb == Some(suffix) {
+                for v in &mut values {
+                    *v *= PERTURB_GAIN;
+                }
+            }
+            shard.push(&format!("{prefix}.{suffix}"), &[len], &values);
+        };
+        if extras.attention_bias {
+            extra(BIAS_SUFFIXES[0], q_rows, seed + 12);
+            extra(BIAS_SUFFIXES[1], kv_rows, seed + 13);
+            extra(BIAS_SUFFIXES[2], kv_rows, seed + 14);
+            extra(BIAS_SUFFIXES[3], G_HIDDEN, seed + 15);
+        }
+        if extras.sinks {
+            extra(SINKS_SUFFIX, G_Q_HEADS, seed + 16);
+        }
+    }
+    shard.write(dir);
+}
+
+/// Write a checkpoint fixture and encode it into a VINDEX3 container in
+/// one call — the shape every "open a real container" test needs.
+///
+/// `write_checkpoint` is one of the writers above (or a caller's own);
+/// the encoded system holds that single model under `name`.
+pub fn encode_fixture_container(
+    write_checkpoint: impl FnOnce(&Path),
+    checkpoint_dir: &Path,
+    container_dir: &Path,
+    name: &str,
+) {
+    write_checkpoint(checkpoint_dir);
+    let inventory = build_inventory(checkpoint_dir).unwrap();
+    encode_system(&[(name.to_string(), inventory)], container_dir).unwrap();
+}

--- a/crates/larql-vindex/src/format/vindex3/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/mod.rs
@@ -38,6 +38,10 @@
 
 pub mod build;
 pub mod encode;
+/// Miniature whole-model checkpoint writers, public so sibling crates'
+/// integration tests can encode a real container without duplicating
+/// the frozen fixture geometry the executor's parity gates certify.
+pub mod fixtures;
 pub mod graph;
 pub mod import;
 pub mod index;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -2,8 +2,10 @@
 //!
 //! A [`DecodeSession`] loads every operand **once** — in the format the
 //! backend declares — and then advances one token per [`step`], feeding
-//! the backend's [`attention_step`] against the session's per-layer K/V
-//! cache. Each step therefore computes exactly one position through the
+//! the backend's [`attention_step`] against a per-layer K/V
+//! continuation state ([`KvState`], default [`RowKvState`], or a
+//! caller-owned provider via [`with_kv_state`](DecodeSession::with_kv_state)).
+//! Each step therefore computes exactly one position through the
 //! whole stack instead of re-running the forward over the grown
 //! sequence, and every weight keeps a stable address for the session's
 //! lifetime, which is what lets a pointer-keyed device buffer cache
@@ -22,6 +24,7 @@
 //! [`attention_step`]: super::backend::PlanBackend::attention_step
 
 use super::backend::{AttentionStepCall, MatrixClass, NormCall, PlanBackend};
+use super::kv::{plan_kv_geometry, KvState, RowKvState};
 use super::operands::OperandStore;
 use super::weights::{load_weight, LoadedWeight};
 use super::AttentionOperands;
@@ -64,8 +67,30 @@ struct LayerState {
     post_ffn: Option<LoadedNorm>,
     /// The layer's output scalar, when the plan carries one.
     layer_scale: Option<f32>,
-    keys: Vec<Vec<f32>>,
-    values: Vec<Vec<f32>>,
+}
+
+/// Who holds the session's continuation state (VI3-INF-2): the default
+/// [`RowKvState`] owned in place, or a caller's provider borrowed for
+/// the session's lifetime so the state outlives the session.
+enum KvSlot<'a> {
+    Owned(RowKvState),
+    Borrowed(&'a mut dyn KvState),
+}
+
+impl KvSlot<'_> {
+    fn state(&self) -> &dyn KvState {
+        match self {
+            KvSlot::Owned(state) => state,
+            KvSlot::Borrowed(state) => &**state,
+        }
+    }
+
+    fn state_mut(&mut self) -> &mut dyn KvState {
+        match self {
+            KvSlot::Owned(state) => state,
+            KvSlot::Borrowed(state) => &mut **state,
+        }
+    }
 }
 
 /// What one decode step produces.
@@ -84,18 +109,47 @@ pub struct DecodeSession<'a, B: PlanBackend> {
     layers: Vec<LayerState>,
     final_norm: Option<LoadedNorm>,
     output: Option<(OutputOp, LoadedWeight)>,
-    position: usize,
+    kv: KvSlot<'a>,
 }
 
 impl<'a, B: PlanBackend> DecodeSession<'a, B> {
     /// Load every operand the plan consumes, once, in the backend's
     /// declared weight format. The embedding table stays f32 — it is a
-    /// row lookup, not matrix traffic.
+    /// row lookup, not matrix traffic. Continuation state is the
+    /// default in-place [`RowKvState`].
     pub fn new(
         plan: &'a ComponentOpPlan,
         store: &OperandStore,
         backend: &'a B,
     ) -> Result<Self, VindexError> {
+        Self::build(plan, store, backend, KvSlot::Owned(RowKvState::default()))
+    }
+
+    /// Like [`new`](Self::new), but the caller provides — and keeps
+    /// owning — the continuation state, so K/V policy composes outside
+    /// the executor and the state outlives the session. The session
+    /// continues from `kv.position()`: an empty provider starts a
+    /// fresh sequence, and one populated by
+    /// [`prefill_plan`](super::prefill_plan) — or by an earlier
+    /// session — resumes exactly where it left off. The provider is
+    /// the *only* position authority; no separate start argument
+    /// exists to disagree with it.
+    pub fn with_kv_state(
+        plan: &'a ComponentOpPlan,
+        store: &OperandStore,
+        backend: &'a B,
+        kv: &'a mut dyn KvState,
+    ) -> Result<Self, VindexError> {
+        Self::build(plan, store, backend, KvSlot::Borrowed(kv))
+    }
+
+    fn build(
+        plan: &'a ComponentOpPlan,
+        store: &OperandStore,
+        backend: &'a B,
+        mut kv: KvSlot<'a>,
+    ) -> Result<Self, VindexError> {
+        kv.state_mut().prepare(&plan_kv_geometry(plan));
         let embedding = plan.embedding.as_ref().ok_or_else(|| {
             VindexError::Parse(format!(
                 "component `{}` has no embedding op — external hidden-state input is a later rung",
@@ -135,8 +189,6 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
                     .as_ref()
                     .map(|op| store.load(op).and_then(|v| super::layer_scalar_of(&v)))
                     .transpose()?,
-                keys: Vec::new(),
-                values: Vec::new(),
             });
         }
         let final_norm = plan
@@ -167,7 +219,7 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
             layers,
             final_norm,
             output,
-            position: 0,
+            kv,
         };
         let mut weights: Vec<super::backend::WeightSlice<'_>> = Vec::new();
         for state in &session.layers {
@@ -181,9 +233,10 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
         Ok(session)
     }
 
-    /// Positions consumed so far.
+    /// Positions consumed so far — read from the continuation state,
+    /// which is the single position authority (VI3-INF-3).
     pub fn position(&self) -> usize {
-        self.position
+        self.kv.state().position()
     }
 
     /// Advance one token: embed it, run it through every layer against
@@ -215,7 +268,8 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
             });
         }
 
-        for (state, layer) in self.layers.iter_mut().zip(&self.plan.layers) {
+        let position = self.kv.state().position();
+        for (index, (state, layer)) in self.layers.iter_mut().zip(&self.plan.layers).enumerate() {
             // Attention input is normalised once and handed over; the
             // judged gate reads the same vector (same as the batch path).
             let inputs = [state.pre_attention.apply(self.backend, &h)];
@@ -227,12 +281,11 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
             );
             let out = self.backend.attention_step(AttentionStepCall {
                 op: call,
-                position: self.position,
-                keys: &state.keys,
-                values: &state.values,
+                position,
+                keys: self.kv.state().keys(index),
+                values: self.kv.state().values(index),
             })?;
-            state.keys.push(out.key);
-            state.values.push(out.value);
+            self.kv.state_mut().append(index, out.key, out.value);
             let mut attn_out = match &state.post_attention {
                 Some(norm) => norm.apply(self.backend, &out.output),
                 None => out.output,
@@ -274,7 +327,7 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
             )?),
             None => None,
         };
-        self.position += 1;
+        self.kv.state_mut().set_position(position + 1);
         Ok(StepOutput { logits })
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/kv.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/kv.rs
@@ -1,0 +1,154 @@
+//! Caller-owned continuation state for the executor's traversals
+//! (VI3-INF-2/3).
+//!
+//! [`DecodeSession`](super::decode::DecodeSession) used to own its K/V
+//! rows as private per-layer `Vec<Vec<f32>>`. That was right for
+//! proving decode semantics and wrong as the production
+//! continuation-state architecture: the state a conversation carries
+//! between steps is *policy* (residency, quantisation, windowing,
+//! checkpointing), and policy composes outside the executor. This
+//! module is the seam: the session drives a [`KvState`] provider and
+//! owns none of the rows.
+//!
+//! The provider learns its geometry **from the plan** —
+//! [`plan_kv_geometry`] reads each layer's KV row width and attention
+//! window out of the executable program itself. No head-count
+//! inference from a family registry, no `ModelArchitecture` questions:
+//! sliding/full and head dims are explicit properties of the program.
+//!
+//! Contract notes:
+//!
+//! - Rows are stored exactly as the backend returned them (post-norm,
+//!   post-rope) and returned position-ordered from position 0. A
+//!   provider must hold **every** appended row — the span logic, not
+//!   the store, excludes positions a window masks out (the cache may
+//!   hold a position the span must exclude; dropping it is a policy
+//!   the executor has not been taught to coordinate with).
+//! - The `&[Vec<f32>]` row-slice shape mirrors
+//!   [`AttentionStepCall`](super::backend::AttentionStepCall) and
+//!   changes only with it; a flat or device-resident representation is
+//!   a later rung tied to that backend contract.
+
+use super::super::ComponentOpPlan;
+
+/// One layer's continuation-state geometry, read from the plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LayerKvGeometry {
+    /// Row width of one position's K (and V): `num_kv_heads * head_dim`.
+    pub kv_dim: usize,
+    /// The layer's attention window in positions; `None` = full span.
+    /// Informational for sizing/policy — see the module contract: the
+    /// store still holds every row.
+    pub window: Option<usize>,
+}
+
+/// Every layer's [`LayerKvGeometry`], in layer order, from the plan.
+pub fn plan_kv_geometry(plan: &ComponentOpPlan) -> Vec<LayerKvGeometry> {
+    plan.layers
+        .iter()
+        .map(|layer| LayerKvGeometry {
+            kv_dim: layer.attention.num_kv_heads * layer.attention.head_dim,
+            window: layer.attention.window,
+        })
+        .collect()
+}
+
+/// Per-layer K/V continuation state, owned by the caller for its
+/// entire lifetime — execution modes merely consume and update it.
+/// The batch prefill ([`prefill_plan`](super::prefill_plan)) and the
+/// incremental [`DecodeSession`](super::decode::DecodeSession) drive
+/// the **same** provider; there is no batch-state → decode-state
+/// translation anywhere.
+///
+/// Every traversal calls [`prepare`](Self::prepare) before driving the
+/// provider, reads earlier rows, and appends new positions' pairs.
+/// The decode step appends layer 0..n for position p, then again for
+/// p+1; the batch prefill appends all positions for layer 0, then all
+/// for layer 1 — a provider must not assume one interleaving.
+pub trait KvState {
+    /// Announce the traversal's geometry before any append. An
+    /// announcement, **not** a reset: a provider already holding rows
+    /// (a prefilled state being resumed) keeps them.
+    fn prepare(&mut self, layers: &[LayerKvGeometry]);
+
+    /// Append one position's K and V rows for `layer`.
+    fn append(&mut self, layer: usize, key: Vec<f32>, value: Vec<f32>);
+
+    /// All K rows appended for `layer`, position-ordered from 0.
+    fn keys(&self, layer: usize) -> &[Vec<f32>];
+
+    /// All V rows appended for `layer`, position-ordered from 0.
+    fn values(&self, layer: usize) -> &[Vec<f32>];
+
+    /// The logical continuation position: the next position this state
+    /// continues from. Owned explicitly by the provider — **never**
+    /// derived from a physical row count, because a windowed or
+    /// compressed provider may one day retain fewer rows than the
+    /// positions it logically represents. A session resuming over this
+    /// state starts here; there is no separate start-position argument
+    /// anywhere that could disagree with it.
+    fn position(&self) -> usize;
+
+    /// Record that the state now continues from `position`. The
+    /// driving traversal is the only writer, and calls are monotonic —
+    /// once per consumed position on the decode path, once at the end
+    /// of a batch prefill.
+    fn set_position(&mut self, position: usize);
+}
+
+/// The default provider: plain per-layer row vectors — exactly the
+/// state [`DecodeSession`](super::decode::DecodeSession) used to own
+/// privately, now behind the seam. The decode-vs-batch parity gates
+/// pin that this indirection changed nothing.
+#[derive(Default)]
+pub struct RowKvState {
+    layers: Vec<LayerRows>,
+    position: usize,
+}
+
+#[derive(Default)]
+struct LayerRows {
+    keys: Vec<Vec<f32>>,
+    values: Vec<Vec<f32>>,
+}
+
+impl KvState for RowKvState {
+    fn prepare(&mut self, layers: &[LayerKvGeometry]) {
+        if self.layers.is_empty() {
+            self.layers = layers.iter().map(|_| LayerRows::default()).collect();
+        } else {
+            // A held state is being resumed; it must be state for a
+            // program of this shape. Fail loud — silently reshaping
+            // continuation state would be a wrong-conversation bug.
+            assert_eq!(
+                self.layers.len(),
+                layers.len(),
+                "resumed KV state holds {} layers but the plan declares {}",
+                self.layers.len(),
+                layers.len()
+            );
+        }
+    }
+
+    fn append(&mut self, layer: usize, key: Vec<f32>, value: Vec<f32>) {
+        let rows = &mut self.layers[layer];
+        rows.keys.push(key);
+        rows.values.push(value);
+    }
+
+    fn keys(&self, layer: usize) -> &[Vec<f32>] {
+        &self.layers[layer].keys
+    }
+
+    fn values(&self, layer: usize) -> &[Vec<f32>] {
+        &self.layers[layer].values
+    }
+
+    fn position(&self) -> usize {
+        self.position
+    }
+
+    fn set_position(&mut self, position: usize) {
+        self.position = position;
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -23,6 +23,7 @@ pub mod decode;
 pub mod device;
 mod experts;
 pub mod kernels;
+pub mod kv;
 pub mod operands;
 pub mod production;
 pub mod reference;
@@ -34,9 +35,10 @@ mod tests;
 use super::{AttentionOp, ComponentOpPlan, LayerPlan, NormOp};
 use crate::error::VindexError;
 use backend::{
-    AttentionCall, BiasCall, GateCall, MatrixClass, NormCall, PlanBackend, ProjectCall, QkNormCall,
-    SinkCall, WeightFormat,
+    AttentionCall, AttentionStepCall, BiasCall, GateCall, MatrixClass, NormCall, PlanBackend,
+    ProjectCall, QkNormCall, SinkCall, WeightFormat,
 };
+use kv::KvState;
 use operands::OperandStore;
 use rayon::prelude::*;
 use reference::ReferenceBackend;
@@ -160,6 +162,74 @@ pub fn execute_plan_streaming<B: PlanBackend + ?Sized>(
     resume: Option<ResumePoint>,
     sink: &mut dyn FnMut(PlaneEvent) -> Result<(), VindexError>,
 ) -> Result<FinalOutput, VindexError> {
+    traverse(
+        plan,
+        store,
+        tokens,
+        backend,
+        resume,
+        sink,
+        None::<&mut dyn KvState>,
+    )
+}
+
+/// Batch prefill (VI3-INF-3): the batch traversal over `tokens`,
+/// populating the **caller's** continuation state — the same provider
+/// a [`decode::DecodeSession`] then resumes via
+/// [`with_kv_state`](decode::DecodeSession::with_kv_state). There is
+/// no batch-state → decode-state translation and the executor never
+/// manufactures a state implementation: continuation state belongs to
+/// the caller for its entire lifetime, and execution modes merely
+/// consume and update it.
+///
+/// The provider is `prepare`d with the plan's geometry, appended one
+/// conditioned K/V row pair per layer per position (all positions for
+/// layer 0, then layer 1 — the opposite interleaving to the decode
+/// step's), and its logical position advanced past `tokens`. A
+/// provider already holding state is *extended*: positions continue
+/// from `kv.position()`, so a long prompt can prefill in chunks.
+///
+/// Returns the last position's final-normed hidden state and logits,
+/// so generation can sample the first continuation token without an
+/// extra step.
+pub fn prefill_plan<B: PlanBackend + ?Sized>(
+    plan: &ComponentOpPlan,
+    store: &OperandStore,
+    tokens: &[u32],
+    backend: &B,
+    kv: &mut dyn KvState,
+) -> Result<FinalOutput, VindexError> {
+    kv.prepare(&kv::plan_kv_geometry(plan));
+    let base = kv.position();
+    let out = traverse(
+        plan,
+        store,
+        tokens,
+        backend,
+        None,
+        &mut |_| Ok(()),
+        Some(&mut *kv),
+    )?;
+    kv.set_position(base + tokens.len());
+    Ok(out)
+}
+
+/// The one traversal in this module (see [`execute_plan_streaming`]'s
+/// doc). `kv` switches the attention realisation: `None` runs the
+/// backend's batched attention; `Some` runs the decode step's
+/// per-position arithmetic into the provider — same numbers (the
+/// decode-vs-batch parity gates are the guarantee), plus the rows.
+/// `kv` and `resume` do not combine: a resumed run has already skipped
+/// layers whose rows a provider would need.
+fn traverse<B: PlanBackend + ?Sized, K: KvState + ?Sized>(
+    plan: &ComponentOpPlan,
+    store: &OperandStore,
+    tokens: &[u32],
+    backend: &B,
+    resume: Option<ResumePoint>,
+    sink: &mut dyn FnMut(PlaneEvent) -> Result<(), VindexError>,
+    mut kv: Option<&mut K>,
+) -> Result<FinalOutput, VindexError> {
     let embedding = plan.embedding.as_ref().ok_or_else(|| {
         VindexError::Parse(format!(
             "component `{}` has no embedding op — external hidden-state input is a later rung",
@@ -219,7 +289,8 @@ pub fn execute_plan_streaming<B: PlanBackend + ?Sized>(
     };
 
     for (index, layer) in plan.layers.iter().enumerate().skip(start_layer) {
-        let trace = execute_layer(layer, store, &mut h, hidden, backend)?;
+        let capture = kv.as_mut().map(|state| (&mut **state, index));
+        let trace = execute_layer(layer, store, &mut h, hidden, backend, capture)?;
         sink(PlaneEvent::Layer { index, trace })?;
     }
 
@@ -274,12 +345,13 @@ pub(super) fn scale_residual_delta(scale: Option<f32>, delta: &mut [f32]) {
 
 /// One decoder layer: norms and residuals exactly where the plan puts
 /// them — placement is data, not code structure.
-fn execute_layer<B: PlanBackend + ?Sized>(
+fn execute_layer<B: PlanBackend + ?Sized, K: KvState + ?Sized>(
     layer: &LayerPlan,
     store: &OperandStore,
     h: &mut [Vec<f32>],
     hidden: usize,
     backend: &B,
+    kv: Option<(&mut K, usize)>,
 ) -> Result<LayerTrace, VindexError> {
     // The attention input is normalised here, once, and handed to the
     // backend — the judged gate reads the same vector, so producing it
@@ -293,14 +365,26 @@ fn execute_layer<B: PlanBackend + ?Sized>(
         .par_iter()
         .map(|row| apply_norm_op(&layer.pre_attention_norm, store, row, backend))
         .collect::<Result<_, _>>()?;
-    let attn_out = attention(
-        &layer.attention,
-        &inputs,
-        layer.pre_attention_norm.eps,
-        store,
-        hidden,
-        backend,
-    )?;
+    let attn_out = match kv {
+        Some((kv, layer_index)) => attention_into_kv(
+            &layer.attention,
+            &inputs,
+            layer.pre_attention_norm.eps,
+            store,
+            hidden,
+            backend,
+            kv,
+            layer_index,
+        )?,
+        None => attention(
+            &layer.attention,
+            &inputs,
+            layer.pre_attention_norm.eps,
+            store,
+            hidden,
+            backend,
+        )?,
+    };
     h.par_iter_mut()
         .zip(attn_out.par_iter())
         .try_for_each(|(row, out)| {
@@ -493,6 +577,52 @@ impl AttentionOperands {
             sinks,
         }
     }
+}
+
+/// One layer's attention driven position-by-position into the caller's
+/// continuation state — the batch prefill's attention realisation.
+///
+/// The arithmetic per position is exactly the decode step's
+/// (`attention_step` against the rows appended so far), so the rows
+/// landing in the provider are the ones a later decode step reads,
+/// and bit-identity with the batched [`attention`] is what the
+/// decode-vs-batch parity gates already prove per backend — the
+/// prefill gates re-pin it end to end. Positions are absolute:
+/// appends continue from the provider's logical position, which the
+/// caller advances once the whole traversal completes.
+///
+/// Sequential by necessity (each position reads the previous ones'
+/// rows); the batch prefill is a semantic gate, not a fast path.
+#[allow(clippy::too_many_arguments)]
+fn attention_into_kv<B: PlanBackend + ?Sized, K: KvState + ?Sized>(
+    op: &AttentionOp,
+    inputs: &[Vec<f32>],
+    qk_norm_eps: f64,
+    store: &OperandStore,
+    hidden: usize,
+    backend: &B,
+    kv: &mut K,
+    layer_index: usize,
+) -> Result<Vec<Vec<f32>>, VindexError> {
+    let operands = AttentionOperands::load(
+        op,
+        store,
+        backend.weight_format(MatrixClass::AttentionProjection),
+    )?;
+    let base = kv.position();
+    let mut outputs = Vec::with_capacity(inputs.len());
+    for offset in 0..inputs.len() {
+        let call = operands.call(op, &inputs[offset..=offset], qk_norm_eps, hidden);
+        let out = backend.attention_step(AttentionStepCall {
+            op: call,
+            position: base + offset,
+            keys: kv.keys(layer_index),
+            values: kv.values(layer_index),
+        })?;
+        kv.append(layer_index, out.key, out.value);
+        outputs.push(out.output);
+    }
+    Ok(outputs)
 }
 
 /// Load the attention operands and hand the backend a fully resolved

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/decode.rs
@@ -25,7 +25,7 @@ use crate::format::vindex3::opplan::exec::production::ProductionBackend;
 use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
 use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
 
-fn fixture() -> (tempfile::TempDir, ComponentOpPlan, OperandStore) {
+pub(super) fn fixture() -> (tempfile::TempDir, ComponentOpPlan, OperandStore) {
     let dir = tempfile::tempdir().unwrap();
     miniature_glimmer(dir.path());
     let inventory = larql_models::inventory::build_inventory(dir.path()).unwrap();
@@ -41,7 +41,7 @@ fn fixture() -> (tempfile::TempDir, ComponentOpPlan, OperandStore) {
 
 /// Step every fixture token through a fresh session and return the last
 /// position's logits.
-fn decode_logits<B: PlanBackend>(
+pub(super) fn decode_logits<B: PlanBackend>(
     plan: &ComponentOpPlan,
     store: &OperandStore,
     backend: &B,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/golden.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/golden.rs
@@ -21,186 +21,19 @@
 
 use std::path::Path;
 
-use super::{lcg_values, norm_values, ShardBuilder};
+// The miniature writer and its geometry moved to the public
+// `format::vindex3::fixtures` module; the re-exports keep every test
+// file's `super::golden::*` imports stable.
+pub(super) use crate::format::vindex3::fixtures::{
+    miniature_glimmer, miniature_glimmer_with, MiniatureExtras, BIAS_SUFFIXES, G_FFN, G_HEAD_DIM,
+    G_HIDDEN, G_KV_HEADS, G_LAYERS, G_Q_HEADS, G_TOKENS, G_VOCAB, G_WINDOW, SINKS_SUFFIX,
+};
+
 use crate::format::vindex3::encode::encode_system;
 use crate::format::vindex3::inspect::inspect_container;
 use crate::format::vindex3::opplan::exec::operands::OperandStore;
 use crate::format::vindex3::opplan::exec::{execute_text, ExecutionTrace};
 use crate::format::vindex3::opplan::plan_component_ops;
-
-// ── The awkward fixture geometry, shared only as *numbers* ──
-pub(super) const G_HIDDEN: usize = 12;
-pub(super) const G_Q_HEADS: usize = 3;
-pub(super) const G_KV_HEADS: usize = 1;
-pub(super) const G_HEAD_DIM: usize = 4;
-pub(super) const G_FFN: usize = 20;
-pub(super) const G_VOCAB: usize = 29;
-pub(super) const G_LAYERS: usize = 2;
-pub(super) const G_WINDOW: usize = 3;
-pub(super) const G_TOKENS: [u32; 5] = [3, 17, 28, 0, 11];
-
-/// Optional attention operands the miniature can carry (A-9.1): Q/K/V/O
-/// projection biases (with `attention_bias: true` declared) and
-/// per-query-head sink logits. `perturb` names one of those tensors by
-/// suffix; the writer scales it by [`PERTURB_GAIN`], so a test can ask
-/// whether that single operand is load-bearing.
-#[derive(Default, Clone, Copy)]
-pub(super) struct MiniatureExtras {
-    pub attention_bias: bool,
-    pub sinks: bool,
-    pub perturb: Option<&'static str>,
-}
-
-/// Multiplier applied to a perturbed extra operand.
-pub(super) const PERTURB_GAIN: f32 = 3.0;
-
-/// The five extra attention operands, by layer-relative suffix.
-pub(super) const BIAS_SUFFIXES: [&str; 4] = [
-    "self_attn.q_proj.bias",
-    "self_attn.k_proj.bias",
-    "self_attn.v_proj.bias",
-    "self_attn.o_proj.bias",
-];
-pub(super) const SINKS_SUFFIX: &str = "self_attn.sinks";
-
-/// The two-layer miniature Glimmer checkpoint (F32, judged family).
-pub(super) fn miniature_glimmer(dir: &Path) {
-    miniature_glimmer_with(dir, MiniatureExtras::default());
-}
-
-/// The miniature with the A-9.1 extras.
-pub(super) fn miniature_glimmer_with(dir: &Path, extras: MiniatureExtras) {
-    let mut config = serde_json::json!({
-            "architectures": ["MuseGlimmerForConditionalGeneration"],
-            "torch_dtype": "float32",
-            "model_type": "muse_glimmer_text",
-            "hidden_size": G_HIDDEN,
-            "num_hidden_layers": G_LAYERS,
-            "intermediate_size": G_FFN,
-            "num_attention_heads": G_Q_HEADS,
-            "num_key_value_heads": G_KV_HEADS,
-            "head_dim": G_HEAD_DIM,
-            "vocab_size": G_VOCAB,
-            "sliding_window": G_WINDOW,
-            "rms_norm_eps": 1e-5,
-            "rope_parameters": { "rope_theta": 500000.0, "rope_type": "default" },
-            "layer_types": ["sliding_attention", "full_attention"],
-            "layer_rope_theta": [500000.0, 0.0],
-            "qk_scale_factor": 3.87,
-            "output_multiplier": 0.196,
-            "post_norm_eps": 1e-8,
-            "attn_logit_softcapping": 50.0,
-            "final_logit_softcapping": 20.0
-    });
-    if extras.attention_bias {
-        config["attention_bias"] = serde_json::json!(true);
-    }
-    std::fs::write(dir.join("config.json"), config.to_string()).unwrap();
-
-    let q_rows = G_Q_HEADS * G_HEAD_DIM;
-    let kv_rows = G_KV_HEADS * G_HEAD_DIM;
-    let mut shard = ShardBuilder::new();
-    shard.push(
-        "model.embed_tokens.weight",
-        &[G_VOCAB, G_HIDDEN],
-        &lcg_values(G_VOCAB * G_HIDDEN, 1),
-    );
-    shard.push("model.norm.weight", &[G_HIDDEN], &norm_values(G_HIDDEN, 2));
-    shard.push(
-        "lm_head.weight",
-        &[G_VOCAB, G_HIDDEN],
-        &lcg_values(G_VOCAB * G_HIDDEN, 3),
-    );
-    for layer in 0..G_LAYERS {
-        let seed = 900 + layer as u64 * 30;
-        let prefix = format!("model.layers.{layer}");
-        for (suffix, shape, values) in [
-            (
-                "self_attn.q_proj.weight",
-                vec![q_rows, G_HIDDEN],
-                lcg_values(q_rows * G_HIDDEN, seed),
-            ),
-            (
-                "self_attn.k_proj.weight",
-                vec![kv_rows, G_HIDDEN],
-                lcg_values(kv_rows * G_HIDDEN, seed + 1),
-            ),
-            (
-                "self_attn.v_proj.weight",
-                vec![kv_rows, G_HIDDEN],
-                lcg_values(kv_rows * G_HIDDEN, seed + 2),
-            ),
-            (
-                "self_attn.o_proj.weight",
-                vec![G_HIDDEN, q_rows],
-                lcg_values(G_HIDDEN * q_rows, seed + 3),
-            ),
-            (
-                "self_attn.gate_proj.weight",
-                vec![q_rows, G_HIDDEN],
-                lcg_values(q_rows * G_HIDDEN, seed + 4),
-            ),
-            (
-                "input_layernorm.weight",
-                vec![G_HIDDEN],
-                norm_values(G_HIDDEN, seed + 5),
-            ),
-            (
-                "post_attention_layernorm.weight",
-                vec![G_HIDDEN],
-                norm_values(G_HIDDEN, seed + 6),
-            ),
-            (
-                "pre_feedforward_layernorm.weight",
-                vec![G_HIDDEN],
-                norm_values(G_HIDDEN, seed + 7),
-            ),
-            (
-                "post_feedforward_layernorm.weight",
-                vec![G_HIDDEN],
-                norm_values(G_HIDDEN, seed + 8),
-            ),
-            (
-                "mlp.gate_proj.weight",
-                vec![G_FFN, G_HIDDEN],
-                lcg_values(G_FFN * G_HIDDEN, seed + 9),
-            ),
-            (
-                "mlp.up_proj.weight",
-                vec![G_FFN, G_HIDDEN],
-                lcg_values(G_FFN * G_HIDDEN, seed + 10),
-            ),
-            (
-                "mlp.down_proj.weight",
-                vec![G_HIDDEN, G_FFN],
-                lcg_values(G_HIDDEN * G_FFN, seed + 11),
-            ),
-        ] {
-            shard.push(&format!("{prefix}.{suffix}"), &shape, &values);
-        }
-        // Extras: values well away from zero so an unapplied bias or sink
-        // is a visible absence, not a rounding-level one.
-        let mut extra = |suffix: &str, len: usize, seed: u64| {
-            let mut values: Vec<f32> = lcg_values(len, seed).into_iter().map(|v| v * 4.0).collect();
-            if extras.perturb == Some(suffix) {
-                for v in &mut values {
-                    *v *= PERTURB_GAIN;
-                }
-            }
-            shard.push(&format!("{prefix}.{suffix}"), &[len], &values);
-        };
-        if extras.attention_bias {
-            extra(BIAS_SUFFIXES[0], q_rows, seed + 12);
-            extra(BIAS_SUFFIXES[1], kv_rows, seed + 13);
-            extra(BIAS_SUFFIXES[2], kv_rows, seed + 14);
-            extra(BIAS_SUFFIXES[3], G_HIDDEN, seed + 15);
-        }
-        if extras.sinks {
-            extra(SINKS_SUFFIX, G_Q_HEADS, seed + 16);
-        }
-    }
-    shard.write(dir);
-}
 
 // ── The oracle's own safetensors reader: header JSON + F32 bytes ──
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kv.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kv.rs
@@ -1,0 +1,292 @@
+//! VI3-INF-2 gates: continuation state behind the [`KvState`] seam.
+//!
+//! Three claims, each pinned separately:
+//!
+//! - the indirection changed nothing — a caller-provided [`RowKvState`]
+//!   produces logits bit-identical to the session-owned default (the
+//!   decode-vs-batch gates in `tests/decode.rs` already pin the default
+//!   against the batch traversal, so equality here chains all three);
+//! - the provider learns its geometry **from the plan** — KV row width
+//!   and sliding/full window arrive via `prepare`, not from any family
+//!   registry;
+//! - the state outlives the session — the caller still holds every row
+//!   after the session is dropped, which is what makes continuation
+//!   state a caller-side policy at all.
+
+use super::golden::{G_HEAD_DIM, G_KV_HEADS, G_LAYERS, G_TOKENS, G_WINDOW};
+use crate::format::vindex3::opplan::exec::backend::PlanBackend;
+use crate::format::vindex3::opplan::exec::decode::DecodeSession;
+use crate::format::vindex3::opplan::exec::kv::{
+    plan_kv_geometry, KvState, LayerKvGeometry, RowKvState,
+};
+use crate::format::vindex3::opplan::exec::production::ProductionBackend;
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use crate::format::vindex3::opplan::exec::{execute_plan, prefill_plan};
+
+/// A provider that records the calls the session makes, delegating
+/// storage to [`RowKvState`] so the run still completes.
+#[derive(Default)]
+struct RecordingKvState {
+    inner: RowKvState,
+    prepared: Vec<Vec<LayerKvGeometry>>,
+    append_order: Vec<usize>,
+    row_lens: Vec<usize>,
+}
+
+impl KvState for RecordingKvState {
+    fn prepare(&mut self, layers: &[LayerKvGeometry]) {
+        self.prepared.push(layers.to_vec());
+        self.inner.prepare(layers);
+    }
+
+    fn append(&mut self, layer: usize, key: Vec<f32>, value: Vec<f32>) {
+        self.append_order.push(layer);
+        self.row_lens.push(key.len());
+        assert_eq!(key.len(), value.len(), "K and V rows must share a width");
+        self.inner.append(layer, key, value);
+    }
+
+    fn keys(&self, layer: usize) -> &[Vec<f32>] {
+        self.inner.keys(layer)
+    }
+
+    fn values(&self, layer: usize) -> &[Vec<f32>] {
+        self.inner.values(layer)
+    }
+
+    fn position(&self) -> usize {
+        self.inner.position()
+    }
+
+    fn set_position(&mut self, position: usize) {
+        self.inner.set_position(position);
+    }
+}
+
+#[test]
+fn plan_geometry_names_row_width_and_window_per_layer() {
+    let (_c, plan, _store) = super::decode::fixture();
+    let geometry = plan_kv_geometry(&plan);
+    assert_eq!(
+        geometry,
+        vec![
+            LayerKvGeometry {
+                kv_dim: G_KV_HEADS * G_HEAD_DIM,
+                window: Some(G_WINDOW),
+            },
+            LayerKvGeometry {
+                kv_dim: G_KV_HEADS * G_HEAD_DIM,
+                window: None,
+            },
+        ],
+        "the miniature's sliding+full split must be explicit in the geometry"
+    );
+}
+
+#[test]
+fn a_caller_owned_provider_matches_the_session_owned_default_bit_for_bit() {
+    let (_c, plan, store) = super::decode::fixture();
+    let backend = ReferenceBackend::new();
+
+    let default_logits = super::decode::decode_logits(&plan, &store, &backend);
+
+    let mut kv = RowKvState::default();
+    let mut session = DecodeSession::with_kv_state(&plan, &store, &backend, &mut kv).unwrap();
+    let mut provided = None;
+    for &token in G_TOKENS.iter() {
+        provided = session.step(token).unwrap().logits;
+    }
+    assert_eq!(
+        provided.as_deref(),
+        Some(default_logits.as_slice()),
+        "caller-owned continuation state must not change the arithmetic"
+    );
+}
+
+// ── VI3-INF-3: batch prefill into the caller's provider ──
+//
+// Four arms, compared at the seam. A = the batch traversal
+// (`execute_plan`); B = batch prefill into a caller RowKvState, then
+// decode resumes the SAME provider; C = tokenwise prefill+decode over
+// its own RowKvState; D = the checkpoint-driven production forward,
+// already pinned ≡ A layer-by-layer by `tests/parity.rs` and the
+// golden oracle, so D chains through A without re-implementation here.
+//
+// The decisive control is B vs C **on the state itself**: if two
+// different traversals leave RowKvState bit-identical, continuation
+// state is a genuinely execution-independent representation — a
+// stronger claim than their next logits agreeing.
+
+fn assert_rows_equal(a: &RowKvState, b: &RowKvState, layers: usize) {
+    assert_eq!(a.position(), b.position(), "logical positions diverge");
+    for layer in 0..layers {
+        assert_eq!(
+            a.keys(layer),
+            b.keys(layer),
+            "K rows diverge at layer {layer}"
+        );
+        assert_eq!(
+            a.values(layer),
+            b.values(layer),
+            "V rows diverge at layer {layer}"
+        );
+    }
+}
+
+fn assert_prefill_matches_batch<B: PlanBackend>(backend: &B) {
+    let (_c, plan, store) = super::decode::fixture();
+    let batch = execute_plan(&plan, &store, &G_TOKENS, backend).unwrap();
+
+    let mut kv = RowKvState::default();
+    let prefilled = prefill_plan(&plan, &store, &G_TOKENS, backend, &mut kv).unwrap();
+
+    assert_eq!(prefilled.logits, batch.logits, "prefill logits diverge");
+    assert_eq!(
+        prefilled.final_hidden, batch.final_hidden,
+        "prefill final hidden diverges"
+    );
+    assert_eq!(kv.position(), G_TOKENS.len());
+}
+
+#[test]
+fn reference_batch_prefill_matches_the_batch_traversal_bit_for_bit() {
+    assert_prefill_matches_batch(&ReferenceBackend::new());
+}
+
+#[test]
+fn production_batch_prefill_matches_the_batch_traversal_bit_for_bit() {
+    assert_prefill_matches_batch(&ProductionBackend::new());
+}
+
+/// B vs C on the state: batch prefill and tokenwise prefill must leave
+/// the provider bit-identical — rows AND logical position.
+#[test]
+fn batch_and_tokenwise_prefill_leave_bit_identical_state() {
+    let (_c, plan, store) = super::decode::fixture();
+    let backend = ReferenceBackend::new();
+
+    let mut batch_kv = RowKvState::default();
+    let batch_out = prefill_plan(&plan, &store, &G_TOKENS, &backend, &mut batch_kv).unwrap();
+
+    let mut step_kv = RowKvState::default();
+    let mut step_logits = None;
+    {
+        let mut session =
+            DecodeSession::with_kv_state(&plan, &store, &backend, &mut step_kv).unwrap();
+        for &token in G_TOKENS.iter() {
+            step_logits = session.step(token).unwrap().logits;
+        }
+    }
+
+    assert_rows_equal(&batch_kv, &step_kv, G_LAYERS);
+    assert_eq!(
+        batch_out.logits, step_logits,
+        "prefill-final logits diverge"
+    );
+}
+
+/// The handoff: batch prefill populates the provider, a decode session
+/// resumes the SAME provider (its start position read from the state,
+/// not passed by anyone), and every continuation step's logits match a
+/// session that walked the whole sequence tokenwise itself.
+#[test]
+fn a_prefilled_provider_resumes_decode_bit_for_bit() {
+    const CONTINUATION_STEPS: usize = 8;
+    let (_c, plan, store) = super::decode::fixture();
+    let backend = ReferenceBackend::new();
+
+    // Oracle: one session walks prompt + continuation entirely tokenwise.
+    let mut oracle = DecodeSession::new(&plan, &store, &backend).unwrap();
+    let mut logits = None;
+    for &token in G_TOKENS.iter() {
+        logits = oracle.step(token).unwrap().logits;
+    }
+    let mut oracle_logits = vec![logits.unwrap()];
+    let mut oracle_ids = Vec::new();
+    for _ in 0..CONTINUATION_STEPS {
+        let next = argmax(oracle_logits.last().unwrap());
+        oracle_ids.push(next);
+        oracle_logits.push(oracle.step(next).unwrap().logits.unwrap());
+    }
+
+    // Arm B: batch prefill, then resume the same provider.
+    let mut kv = RowKvState::default();
+    let prefilled = prefill_plan(&plan, &store, &G_TOKENS, &backend, &mut kv).unwrap();
+    assert_eq!(
+        prefilled.logits.as_ref(),
+        Some(&oracle_logits[0]),
+        "prefill-final logits diverge from the tokenwise oracle"
+    );
+    let mut resumed = DecodeSession::with_kv_state(&plan, &store, &backend, &mut kv).unwrap();
+    assert_eq!(resumed.position(), G_TOKENS.len(), "resume position");
+    for (step, (&id, expected)) in oracle_ids.iter().zip(&oracle_logits[1..]).enumerate() {
+        let stepped = resumed.step(id).unwrap().logits.unwrap();
+        assert_eq!(&stepped, expected, "continuation step {step} diverges");
+    }
+    assert_eq!(resumed.position(), G_TOKENS.len() + CONTINUATION_STEPS);
+}
+
+/// Chunked prefill: extending a held state batch-style must equal one
+/// whole-prompt prefill — rows, position, and final logits.
+#[test]
+fn chunked_prefill_extends_the_state_bit_identically() {
+    let (_c, plan, store) = super::decode::fixture();
+    let backend = ReferenceBackend::new();
+
+    let mut whole = RowKvState::default();
+    let whole_out = prefill_plan(&plan, &store, &G_TOKENS, &backend, &mut whole).unwrap();
+
+    let (head, tail) = G_TOKENS.split_at(2);
+    let mut chunked = RowKvState::default();
+    prefill_plan(&plan, &store, head, &backend, &mut chunked).unwrap();
+    assert_eq!(chunked.position(), head.len());
+    let chunked_out = prefill_plan(&plan, &store, tail, &backend, &mut chunked).unwrap();
+
+    assert_rows_equal(&whole, &chunked, G_LAYERS);
+    assert_eq!(whole_out.logits, chunked_out.logits);
+}
+
+/// Ties keep the first index — the harness rule.
+fn argmax(logits: &[f32]) -> u32 {
+    logits
+        .iter()
+        .enumerate()
+        .fold((0usize, f32::NEG_INFINITY), |best, (index, &value)| {
+            if value > best.1 {
+                (index, value)
+            } else {
+                best
+            }
+        })
+        .0 as u32
+}
+
+#[test]
+fn the_provider_learns_geometry_from_the_plan_and_keeps_the_rows() {
+    let (_c, plan, store) = super::decode::fixture();
+    let backend = ReferenceBackend::new();
+    let mut kv = RecordingKvState::default();
+    {
+        let mut session = DecodeSession::with_kv_state(&plan, &store, &backend, &mut kv).unwrap();
+        for &token in G_TOKENS.iter() {
+            session.step(token).unwrap();
+        }
+    }
+
+    // prepare: exactly once, with the plan-derived geometry.
+    assert_eq!(kv.prepared, vec![plan_kv_geometry(&plan)]);
+
+    // appends: layers interleave within one position — 0..n per step.
+    let per_step: Vec<usize> = (0..G_LAYERS).collect();
+    let expected: Vec<usize> = G_TOKENS.iter().flat_map(|_| per_step.clone()).collect();
+    assert_eq!(kv.append_order, expected);
+
+    // every row has the plan's KV width.
+    assert!(kv.row_lens.iter().all(|&l| l == G_KV_HEADS * G_HEAD_DIM));
+
+    // the state survives the session: one row per consumed position.
+    for layer in 0..G_LAYERS {
+        assert_eq!(kv.keys(layer).len(), G_TOKENS.len());
+        assert_eq!(kv.values(layer).len(), G_TOKENS.len());
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -19,6 +19,7 @@ mod gemma4;
 mod gemma4_refusals;
 mod golden;
 mod kernels;
+mod kv;
 mod parity;
 mod routed;
 mod seam;
@@ -26,180 +27,13 @@ mod sinks_bias;
 mod smoke;
 mod streaming;
 
-use std::io::Write;
-use std::path::Path;
-
-/// Deterministic small weights: LCG over the flat index, scaled to
-/// ±0.05 so activations stay in a well-conditioned range.
-pub(super) fn lcg_values(n: usize, seed: u64) -> Vec<f32> {
-    let mut state = seed
-        .wrapping_mul(6364136223846793005)
-        .wrapping_add(1442695040888963407);
-    (0..n)
-        .map(|_| {
-            state = state
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            let unit = ((state >> 33) as f64) / ((1u64 << 31) as f64);
-            ((unit - 0.5) * 0.1) as f32
-        })
-        .collect()
-}
-
-/// Norm weights near 1.0 (never all-zero: that would mask norm bugs).
-pub(super) fn norm_values(n: usize, seed: u64) -> Vec<f32> {
-    lcg_values(n, seed).into_iter().map(|v| 1.0 + v).collect()
-}
-
-/// Write one F32 tensor into a safetensors header/payload pair.
-pub(super) struct ShardBuilder {
-    header: serde_json::Map<String, serde_json::Value>,
-    payload: Vec<u8>,
-}
-
-impl ShardBuilder {
-    pub(super) fn new() -> Self {
-        Self {
-            header: serde_json::Map::new(),
-            payload: Vec::new(),
-        }
-    }
-
-    pub(super) fn push(&mut self, name: &str, shape: &[usize], values: &[f32]) {
-        assert_eq!(shape.iter().product::<usize>(), values.len());
-        let start = self.payload.len();
-        for v in values {
-            self.payload.extend_from_slice(&v.to_le_bytes());
-        }
-        self.header.insert(
-            name.to_string(),
-            serde_json::json!({
-                "dtype": "F32",
-                "shape": shape,
-                "data_offsets": [start, self.payload.len()],
-            }),
-        );
-    }
-
-    /// Write one tensor of any dtype from raw little-endian bytes — for
-    /// packed MXFP4 (`U8`) expert banks.
-    pub(super) fn push_bytes(&mut self, name: &str, dtype: &str, shape: &[usize], bytes: &[u8]) {
-        let start = self.payload.len();
-        self.payload.extend_from_slice(bytes);
-        self.header.insert(
-            name.to_string(),
-            serde_json::json!({
-                "dtype": dtype,
-                "shape": shape,
-                "data_offsets": [start, self.payload.len()],
-            }),
-        );
-    }
-
-    pub(super) fn write(self, dir: &Path) {
-        let header_bytes = serde_json::to_vec(&serde_json::Value::Object(self.header)).unwrap();
-        let mut file = std::fs::File::create(dir.join("model.safetensors")).unwrap();
-        file.write_all(&(header_bytes.len() as u64).to_le_bytes())
-            .unwrap();
-        file.write_all(&header_bytes).unwrap();
-        file.write_all(&self.payload).unwrap();
-    }
-}
-
-/// Fixture geometry, shared by both sides of the parity gate.
-pub(super) const HIDDEN: usize = 64;
-pub(super) const INTERMEDIATE: usize = 256;
-pub(super) const VOCAB: usize = 128;
-pub(super) const Q_HEADS: usize = 8;
-pub(super) const KV_HEADS: usize = 2;
-pub(super) const HEAD_DIM: usize = 8;
-pub(super) const LAYERS: usize = 2;
-
-/// A dense Llama-shaped checkpoint with real F32 weights — loadable by
-/// the production path and encodable into a VINDEX3 container.
-pub(super) fn dense_f32_model(dir: &Path) {
-    std::fs::write(
-        dir.join("config.json"),
-        serde_json::json!({
-            "architectures": ["LlamaForCausalLM"],
-            "torch_dtype": "float32",
-            "model_type": "llama",
-            "hidden_size": HIDDEN,
-            "num_hidden_layers": LAYERS,
-            "intermediate_size": INTERMEDIATE,
-            "num_attention_heads": Q_HEADS,
-            "num_key_value_heads": KV_HEADS,
-            "head_dim": HEAD_DIM,
-            "vocab_size": VOCAB,
-            "rms_norm_eps": 1e-5,
-            "rope_theta": 10000.0
-        })
-        .to_string(),
-    )
-    .unwrap();
-
-    let q_rows = Q_HEADS * HEAD_DIM;
-    let kv_rows = KV_HEADS * HEAD_DIM;
-    let mut shard = ShardBuilder::new();
-    shard.push(
-        "model.embed_tokens.weight",
-        &[VOCAB, HIDDEN],
-        &lcg_values(VOCAB * HIDDEN, 1),
-    );
-    shard.push("model.norm.weight", &[HIDDEN], &norm_values(HIDDEN, 2));
-    shard.push(
-        "lm_head.weight",
-        &[VOCAB, HIDDEN],
-        &lcg_values(VOCAB * HIDDEN, 3),
-    );
-    for layer in 0..LAYERS {
-        let seed = 100 + layer as u64 * 10;
-        let prefix = format!("model.layers.{layer}");
-        shard.push(
-            &format!("{prefix}.self_attn.q_proj.weight"),
-            &[q_rows, HIDDEN],
-            &lcg_values(q_rows * HIDDEN, seed),
-        );
-        shard.push(
-            &format!("{prefix}.self_attn.k_proj.weight"),
-            &[kv_rows, HIDDEN],
-            &lcg_values(kv_rows * HIDDEN, seed + 1),
-        );
-        shard.push(
-            &format!("{prefix}.self_attn.v_proj.weight"),
-            &[kv_rows, HIDDEN],
-            &lcg_values(kv_rows * HIDDEN, seed + 2),
-        );
-        shard.push(
-            &format!("{prefix}.self_attn.o_proj.weight"),
-            &[HIDDEN, q_rows],
-            &lcg_values(HIDDEN * q_rows, seed + 3),
-        );
-        shard.push(
-            &format!("{prefix}.input_layernorm.weight"),
-            &[HIDDEN],
-            &norm_values(HIDDEN, seed + 4),
-        );
-        shard.push(
-            &format!("{prefix}.post_attention_layernorm.weight"),
-            &[HIDDEN],
-            &norm_values(HIDDEN, seed + 5),
-        );
-        shard.push(
-            &format!("{prefix}.mlp.gate_proj.weight"),
-            &[INTERMEDIATE, HIDDEN],
-            &lcg_values(INTERMEDIATE * HIDDEN, seed + 6),
-        );
-        shard.push(
-            &format!("{prefix}.mlp.up_proj.weight"),
-            &[INTERMEDIATE, HIDDEN],
-            &lcg_values(INTERMEDIATE * HIDDEN, seed + 7),
-        );
-        shard.push(
-            &format!("{prefix}.mlp.down_proj.weight"),
-            &[HIDDEN, INTERMEDIATE],
-            &lcg_values(HIDDEN * INTERMEDIATE, seed + 8),
-        );
-    }
-    shard.write(dir);
-}
+// The fixture writers and geometry moved to the public
+// `format::vindex3::fixtures` module (so sibling crates' integration
+// tests can encode the same containers these gates certify). The
+// re-exports keep every test file's `super::*` imports stable, with
+// the dense geometry under its historical short names.
+pub(super) use crate::format::vindex3::fixtures::{
+    dense_f32_model, lcg_values, norm_values, ShardBuilder, DENSE_HEAD_DIM as HEAD_DIM,
+    DENSE_HIDDEN as HIDDEN, DENSE_INTERMEDIATE as INTERMEDIATE, DENSE_LAYERS as LAYERS,
+    DENSE_Q_HEADS as Q_HEADS, DENSE_VOCAB as VOCAB,
+};


### PR DESCRIPTION
## What this is

VINDEX3 stops being merely executable inside `larql-vindex` and becomes a runtime. One arc, five parity-gated rungs:

```
VINDEX3 container
      -> ComponentOpPlan          (executable model definition)
      -> prefill / decode         (larql-vindex exec, one traversal)
      -> KvState / larql-kv       (caller-owned continuation state)
      -> LogitsSession            (larql-inference runtime seam)
      -> sampler / EOS / detok
      -> /v1/completions          (larql-server, SSE + buffered)
```

No `ModelWeights`, no `VectorIndex`, and no `ModelArchitecture` appear anywhere on the V3 path — including KV geometry (row width, sliding/full split), which the state providers learn from the executable plan itself.

## Rungs

**VI3-INF-0/1 — runtime seam.** `LogitsSession` (prefill/step/position), `Vindex3Session` over the canonical `DecodeSession`, `Vindex3Runtime` (refuses closure defects), `generate_session`/`continue_session` above the existing sampler/EOS machinery. Deliberately NOT folded into `open_inference_vindex`: the formats have different authority models and converge only above the session trait.

**VI3-INF-2 — caller-owned continuation state.** `DecodeSession` no longer owns K/V; it drives a `KvState` provider prepared with plan-derived `LayerKvGeometry`. State outlives the session.

**VI3-INF-3 — execution-independent state.** Batch prefill (`prefill_plan`, inside the single existing traversal) populates the SAME caller provider a decode session then resumes; the provider owns the logical continuation position (no separate start-position argument exists to disagree with it). The decisive gate: batch and tokenwise prefill leave `RowKvState` **bit-identical** — rows and position.

**VI3-KV-1 — canonical larql-kv state.** `CanonicalKvState` puts the ordinary `KvCache` behind the V3 contract with zero semantic change (matrices stay the storage authority; `next_position` is the logical position; windowed caches refused — windowing is KV-2 policy). Chain proven bit-for-bit:

```
V3 batch == V3 tokenwise == RowKvState == larql-kv canonical cache
```

(and the executor ≡ production-forward parity gates chain the production side on).

**VI3-SERVE-1 — over the wire.** The V2/V3 decision is made once, at binding (`bootstrap::load_artifact` on the container's generation marker; `AppState::served` resolution enum); `V3Model` holds `Vindex3Runtime` + tokenizer and is structurally unable to reach the old inference path. Wire shaping and stop/EOS semantics are shared with the V2 completions route by construction.

## Gates

- Prefill + per-step logits **bit-for-bit** vs the direct decode harness (Reference + Production), with a diverged-prompt control.
- Batch-vs-tokenwise prefill state bit-identity; prefill→resume ≡ full tokenwise; chunked ≡ whole-prompt prefill.
- KV-1: bit-identity vs `RowKvState` at every boundary + cache-matrix authority check + `from_cache`/`into_cache` round trip + explicit geometry-closure gate (larql-kv needs zero architecture inference for V3 continuation geometry).
- SERVE-1: HTTP stream matches the direct runtime arm token-for-token (order, count, first token, finish_reason); buffered ≡ concat; stop strings honoured both modes; **negative control** — the served container is refused by `load_vindex_config` and `load_single_vindex` while the V2 registry is empty and requests succeed; both arms of the binding dispatch tested.

## Test/coverage status

- larql-vindex 2599 lib + all integration green; larql-inference 1516; larql-kv 1243; larql-server 912 (all pre-existing V2 route tests untouched and green).
- clippy `-D warnings` clean on all four crates with their CI flag sets; fmt clean; workspace check clean.
- New/changed files all ≥90% line coverage; crate totals vs CI floors: vindex 94.3/71, kv 96.3/85, server 79.6/65.

## Known debts (recorded in module docs)

- `KvState` stays KV-shaped (`&[Vec<f32>]` rows mirror `AttentionStepCall`); a broader `ContinuationState` waits for KV-3 pressure.
- Serve path opens a fresh session per request (operand load per session) — session residency is SERVE-2 work.
- Chat route needs a V3 template story (`pick_template` reads `weights.arch`); completions is the served surface this rung.
- Fixture writers moved to public `larql_vindex::format::vindex3::fixtures` (follows the `test_support` precedent) so sibling crates encode the same containers the executor parity gates certify.
