### PR TITLE
feat(vindex): extraction-generation policy seam + default-flip gate (migration rung M1)

### DIFF
--- a/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
@@ -121,6 +121,25 @@ pub struct ExtractIndexArgs {
     /// Skip stages that already have output files (resume interrupted builds).
     #[arg(long)]
     resume: bool,
+
+    /// Container generation to write: `v2` or `v3`, explicitly. Omitted =
+    /// no preference — the vindex crate's extraction-generation policy
+    /// decides (the default-flip gate), never a CLI default. `v3` refuses
+    /// on this surface rather than downgrading: VINDEX3 containers are
+    /// produced by `larql vindex3 encode` from HF checkpoint artifacts.
+    #[arg(long, value_parser = parse_generation)]
+    generation: Option<larql_vindex::format::generation::ContainerGeneration>,
+}
+
+fn parse_generation(
+    s: &str,
+) -> Result<larql_vindex::format::generation::ContainerGeneration, String> {
+    use larql_vindex::format::generation::ContainerGeneration;
+    match s.to_lowercase().as_str() {
+        "v2" | "vindex2" => Ok(ContainerGeneration::V2),
+        "v3" | "vindex3" => Ok(ContainerGeneration::V3),
+        other => Err(format!("unknown container generation '{other}' (v2 | v3)")),
+    }
 }
 
 fn parse_quant(s: &str) -> Result<larql_vindex::QuantFormat, String> {
@@ -248,6 +267,29 @@ impl IndexBuildCallbacks for CliBuildCallbacks {
 }
 
 pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
+    // Resolve the container generation before any bytes move. Omitted =
+    // Auto, decided by the one policy site in larql-vindex (the
+    // default-flip gate). An explicit `v3` refuses by name on this
+    // surface — it is never downgraded to a V2 extraction.
+    {
+        use larql_vindex::format::generation::{
+            admit_extraction_generation, ContainerGeneration, GenerationRequest,
+        };
+        let request = match args.generation {
+            None => GenerationRequest::Auto,
+            Some(generation) => GenerationRequest::Explicit(generation),
+        };
+        if admit_extraction_generation(request) == ContainerGeneration::V3 {
+            return Err(
+                "`larql extract` cannot write a VINDEX3 container yet: VINDEX3 \
+                 containers are produced by `larql vindex3 encode` from HF checkpoint \
+                 artifacts. `--generation v2` remains available and must be selected \
+                 explicitly rather than fallen back to."
+                    .into(),
+            );
+        }
+    }
+
     let mut callbacks = CliBuildCallbacks::new();
     let build_start = Instant::now();
 

--- a/crates/larql-factory/src/build/stages/extract.rs
+++ b/crates/larql-factory/src/build/stages/extract.rs
@@ -1,10 +1,11 @@
 //! EXTRACT — `larql extract` against the FETCH-scoped HF cache.
 //!
-//! Maps the recipe's free-form `extractor.options` to the two flags
+//! Maps the recipe's free-form `extractor.options` to the flags
 //! that currently exist on `larql extract`: `down_q4k` (bool) implies
 //! `--quant q4k --down-q4k` — `--down-q4k` is a modifier of `--quant
-//! q4k`, invalid on its own — and `drop_gate_vectors` (bool) maps
-//! directly. Any other option key (e.g. the sample recipe's
+//! q4k`, invalid on its own — `drop_gate_vectors` (bool) maps
+//! directly, and `generation` (`"v2"`/`"v3"`) pins the container
+//! generation via `--generation`. Any other option key (e.g. the sample recipe's
 //! `preserve_mtp_head`) has no CLI flag yet and is silently ignored —
 //! `options` is deliberately open-ended per docs/vindex-factory.md §4,
 //! and a future extractor version may recognise more of them.
@@ -20,6 +21,11 @@ use crate::Recipe;
 const HF_HUB_CACHE_ENV: &str = "HF_HUB_CACHE";
 const DOWN_Q4K_OPTION_KEY: &str = "down_q4k";
 const DROP_GATE_VECTORS_OPTION_KEY: &str = "drop_gate_vectors";
+/// `extractor.options.generation` — an explicit container-generation pin
+/// (`"v2"` | `"v3"`), forwarded as `--generation`. Absent = no preference:
+/// the tool's own policy site decides, and the recipe's `build_id` already
+/// reflects the pin when one is set (options participate in `build_id`).
+const GENERATION_OPTION_KEY: &str = "generation";
 
 fn option_bool(recipe: &Recipe, key: &str) -> bool {
     recipe
@@ -61,6 +67,16 @@ pub fn invocation(recipe: &Recipe, full_dir: &Path, hf_cache_dir: &Path) -> Invo
     }
     if option_bool(recipe, DROP_GATE_VECTORS_OPTION_KEY) {
         args.push("--drop-gate-vectors".to_string());
+    }
+    if let Some(generation) = recipe
+        .spec
+        .extractor
+        .options
+        .get(GENERATION_OPTION_KEY)
+        .and_then(|v| v.as_str())
+    {
+        args.push("--generation".to_string());
+        args.push(generation.to_string());
     }
     // Safe unconditionally: a no-op on a fresh build, resumes a
     // partially-completed one on retry (§7's "each stage independently
@@ -144,6 +160,34 @@ mod tests {
         let inv = invocation(&recipe, &full, &cache);
         assert!(!inv.args.contains(&"--quant".to_string()));
         assert!(!inv.args.contains(&"--down-q4k".to_string()));
+    }
+
+    #[test]
+    fn generation_option_pins_the_container_generation() {
+        let mut recipe = sample_recipe();
+        recipe.spec.extractor.options.insert(
+            GENERATION_OPTION_KEY.into(),
+            serde_json::Value::String("v2".into()),
+        );
+        let (full, cache) = dirs();
+        let inv = invocation(&recipe, &full, &cache);
+        let at = inv
+            .args
+            .iter()
+            .position(|a| a == "--generation")
+            .expect("--generation forwarded");
+        assert_eq!(inv.args[at + 1], "v2");
+    }
+
+    #[test]
+    fn absent_generation_option_expresses_no_preference() {
+        let recipe = sample_recipe();
+        let (full, cache) = dirs();
+        let inv = invocation(&recipe, &full, &cache);
+        assert!(
+            !inv.args.contains(&"--generation".to_string()),
+            "the recipe must not smuggle a surface-local default"
+        );
     }
 
     #[test]

--- a/crates/larql-lql/src/ast.rs
+++ b/crates/larql-lql/src/ast.rs
@@ -12,6 +12,11 @@ pub enum Statement {
         components: Option<Vec<Component>>,
         layers: Option<Range>,
         extract_level: ExtractLevel,
+        /// `FORMAT VINDEX2 | VINDEX3` — which container generation to
+        /// write. `None` = no preference; the executor resolves it
+        /// through the vindex crate's single extraction-generation
+        /// policy, never a parser- or surface-local default.
+        format: Option<ExtractFormat>,
     },
     Compile {
         vindex: VindexRef,
@@ -271,6 +276,15 @@ pub enum ExtractLevel {
     Inference,
     /// + up, norms, lm_head (~10 GB f16), enables COMPILE
     All,
+}
+
+/// `EXTRACT ... FORMAT <generation>` — an explicit container-generation
+/// request. Absence means "no preference", which is NOT the same value:
+/// the default lives in one policy site in the vindex crate, not here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtractFormat {
+    Vindex2,
+    Vindex3,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/larql-lql/src/executor/lifecycle/extract.rs
+++ b/crates/larql-lql/src/executor/lifecycle/extract.rs
@@ -2,13 +2,16 @@
 
 use std::path::PathBuf;
 
-use crate::ast::{Component, ExtractLevel, Range};
+use crate::ast::{Component, ExtractFormat, ExtractLevel, Range};
 use crate::error::LqlError;
 use crate::executor::helpers::format_number;
 use crate::executor::memit_persist::load_memit_store;
 use crate::executor::{Backend, Session};
 use crate::relations::RelationClassifier;
 use larql_vindex::format::filenames::KNN_STORE_BIN;
+use larql_vindex::format::generation::{
+    admit_extraction_generation, ContainerGeneration, GenerationRequest,
+};
 
 impl Session {
     pub(crate) fn exec_extract(
@@ -18,7 +21,35 @@ impl Session {
         _components: Option<&[Component]>,
         _layers: Option<&Range>,
         _extract_level: ExtractLevel,
+        format: Option<ExtractFormat>,
     ) -> Result<Vec<String>, LqlError> {
+        // Resolve the generation FIRST — the request must be admitted or
+        // refused before any model bytes move. `None` is "no preference",
+        // resolved by the vindex crate's single policy site (the
+        // default-flip gate), never by a default here.
+        let request = match format {
+            None => GenerationRequest::Auto,
+            Some(ExtractFormat::Vindex2) => GenerationRequest::Explicit(ContainerGeneration::V2),
+            Some(ExtractFormat::Vindex3) => GenerationRequest::Explicit(ContainerGeneration::V3),
+        };
+        match admit_extraction_generation(request) {
+            ContainerGeneration::V2 => {}
+            // This surface extracts from a live model's weights; the
+            // VINDEX3 producer (`larql vindex3 encode`) consumes HF
+            // checkpoint artifacts. Until EXTRACT is wired to the V3
+            // encoder, an explicit V3 request is refused by name — it is
+            // never downgraded to a V2 extraction.
+            ContainerGeneration::V3 => {
+                return Err(LqlError::Execution(
+                    "EXTRACT cannot write a VINDEX3 container from this surface yet: \
+                     VINDEX3 containers are produced by `larql vindex3 encode` from HF \
+                     checkpoint artifacts. FORMAT VINDEX2 remains available and must be \
+                     selected explicitly rather than fallen back to."
+                        .into(),
+                ));
+            }
+        }
+
         let output_dir = PathBuf::from(output);
 
         let mut out = Vec::new();

--- a/crates/larql-lql/src/executor/mod.rs
+++ b/crates/larql-lql/src/executor/mod.rs
@@ -194,12 +194,14 @@ impl Session {
                 components,
                 layers,
                 extract_level,
+                format,
             } => self.exec_extract(
                 model,
                 output,
                 components.as_deref(),
                 layers.as_ref(),
                 *extract_level,
+                *format,
             ),
             Statement::Compile {
                 vindex,

--- a/crates/larql-lql/src/parser/lifecycle.rs
+++ b/crates/larql-lql/src/parser/lifecycle.rs
@@ -15,6 +15,7 @@ impl Parser {
         let mut components = None;
         let mut layers = None;
         let mut extract_level = ExtractLevel::Browse;
+        let mut format = None;
 
         loop {
             match self.peek() {
@@ -25,6 +26,26 @@ impl Parser {
                 crate::lexer::Token::Keyword(Keyword::Layers) => {
                     self.advance();
                     layers = Some(self.parse_range()?);
+                }
+                crate::lexer::Token::Keyword(Keyword::Format) => {
+                    self.advance();
+                    // VINDEX2 / VINDEX3 are bare identifiers, as with
+                    // COMPILE INTO VINDEX.
+                    format = Some(match self.peek() {
+                        crate::lexer::Token::Ident(ref s) if s.eq_ignore_ascii_case("vindex2") => {
+                            self.advance();
+                            ExtractFormat::Vindex2
+                        }
+                        crate::lexer::Token::Ident(ref s) if s.eq_ignore_ascii_case("vindex3") => {
+                            self.advance();
+                            ExtractFormat::Vindex3
+                        }
+                        other => {
+                            return Err(ParseError(format!(
+                                "EXTRACT FORMAT expects VINDEX2 or VINDEX3, found {other:?}"
+                            )))
+                        }
+                    });
                 }
                 crate::lexer::Token::Keyword(Keyword::With) => {
                     self.advance();
@@ -52,6 +73,7 @@ impl Parser {
             components,
             layers,
             extract_level,
+            format,
         })
     }
 

--- a/crates/larql-lql/src/parser/tests.rs
+++ b/crates/larql-lql/src/parser/tests.rs
@@ -17,12 +17,14 @@ fn parse_extract_minimal() {
             components,
             layers,
             extract_level,
+            format,
         } => {
             assert_eq!(model, "google/gemma-3-4b-it");
             assert_eq!(output, "gemma3-4b.vindex");
             assert!(components.is_none());
             assert!(layers.is_none());
             assert_eq!(extract_level, ExtractLevel::Browse);
+            assert_eq!(format, None, "no FORMAT clause = no preference");
         }
         _ => panic!("expected Extract"),
     }

--- a/crates/larql-lql/tests/cov_lifecycle_synthetic.rs
+++ b/crates/larql-lql/tests/cov_lifecycle_synthetic.rs
@@ -534,3 +534,20 @@ fn compile_path_into_vindex_from_other_vindex() {
         ),
     );
 }
+
+/// `EXTRACT ... FORMAT VINDEX3` refuses BY NAME before any model bytes
+/// move — this surface's V3 producer does not exist yet, and an explicit
+/// request must never silently downgrade to a V2 extraction. The refusal
+/// arriving (rather than a model-loading error for the bogus model id)
+/// proves the generation is resolved first.
+#[test]
+fn extract_format_vindex3_refuses_by_name_before_loading() {
+    let mut session = Session::new();
+    let err = try_run(
+        &mut session,
+        r#"EXTRACT MODEL "no-such-model" INTO "/nonexistent/out" FORMAT VINDEX3;"#,
+    )
+    .expect_err("an explicit V3 request must refuse on this surface");
+    assert!(err.contains("vindex3 encode"), "{err}");
+    assert!(err.contains("FORMAT VINDEX2"), "{err}");
+}

--- a/crates/larql-lql/tests/cov_parser_lexer.rs
+++ b/crates/larql-lql/tests/cov_parser_lexer.rs
@@ -790,6 +790,36 @@ fn extract_with_unknown_keyword_is_error() {
 }
 
 #[test]
+fn extract_format_names_a_generation_or_stays_absent() {
+    use larql_lql::ast::ExtractFormat;
+    // Explicit requests parse, case-insensitively (bare identifiers, as
+    // with COMPILE INTO VINDEX).
+    match ok(r#"EXTRACT MODEL "m" INTO "o.vindex" FORMAT VINDEX2;"#) {
+        Statement::Extract { format, .. } => assert_eq!(format, Some(ExtractFormat::Vindex2)),
+        other => panic!("got {other:?}"),
+    }
+    match ok(r#"EXTRACT MODEL "m" INTO "o.vindex" FORMAT vindex3 WITH INFERENCE;"#) {
+        Statement::Extract {
+            format,
+            extract_level,
+            ..
+        } => {
+            assert_eq!(format, Some(ExtractFormat::Vindex3));
+            assert_eq!(extract_level, larql_lql::ast::ExtractLevel::Inference);
+        }
+        other => panic!("got {other:?}"),
+    }
+    // Absence is "no preference" — a distinct value from either request,
+    // resolved by the vindex crate's policy site, not the parser.
+    match ok(r#"EXTRACT MODEL "m" INTO "o.vindex";"#) {
+        Statement::Extract { format, .. } => assert_eq!(format, None),
+        other => panic!("got {other:?}"),
+    }
+    // FORMAT followed by anything else is a parse error.
+    err(r#"EXTRACT MODEL "m" INTO "o.vindex" FORMAT GGUF;"#);
+}
+
+#[test]
 fn diff_with_all_optional_clauses() {
     let stmt = ok(r#"DIFF "a.vindex" "b.vindex" LAYER 5 RELATION "capital-of" LIMIT 10;"#);
     match stmt {

--- a/crates/larql-vindex/src/format/generation.rs
+++ b/crates/larql-vindex/src/format/generation.rs
@@ -158,6 +158,50 @@ impl ContainerGeneration {
 pub const ALL_GENERATIONS: [ContainerGeneration; 2] =
     [ContainerGeneration::V2, ContainerGeneration::V3];
 
+/// Which container generation a caller **asked** a fresh extraction to
+/// write.
+///
+/// Deliberately a different type from [`ContainerGeneration`] (what the
+/// policy *decided*), for the same reason `ExtractionRequest` is not
+/// `ExtractionTarget`: "V3 was requested and refused" and "V3 was never
+/// requested" must never collapse into the same value. Every extraction
+/// surface (LQL `EXTRACT`, `larql extract`, factory recipes) resolves its
+/// caller's intent to this type and passes it through
+/// [`admit_extraction_generation`] — none of them carries its own default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GenerationRequest {
+    /// No preference; [`DEFAULT_EXTRACTION_GENERATION`] applies.
+    Auto,
+    /// The named generation, explicitly. Refuses if the surface cannot
+    /// produce it — never downgrades.
+    Explicit(ContainerGeneration),
+}
+
+/// **The default-flip gate.** The generation `Auto` resolves to — i.e.
+/// what a fresh extraction writes when the caller expressed no preference.
+///
+/// Flipping this constant to `V3` IS the "VINDEX3 becomes the primary
+/// generation" decision. It is made here, once, together with the pinned
+/// test in `generation_tests.rs` that names the decision — never as a
+/// side effect of a CLI default, a recipe template, or a surface-local
+/// fallback. Until the flip: V3 stays the explicitly-requested
+/// generation, V2 the default; after it: V2 becomes the explicitly-
+/// requested compatibility generation.
+pub const DEFAULT_EXTRACTION_GENERATION: ContainerGeneration = ContainerGeneration::V2;
+
+/// Resolve a caller's extraction-generation request to a decision.
+///
+/// This is deliberately the only place `Auto` gains a meaning. It cannot
+/// refuse — whether the *surface* can actually produce the decided
+/// generation is that surface's own admission step, and its refusal must
+/// name the request rather than fall back.
+pub fn admit_extraction_generation(request: GenerationRequest) -> ContainerGeneration {
+    match request {
+        GenerationRequest::Auto => DEFAULT_EXTRACTION_GENERATION,
+        GenerationRequest::Explicit(generation) => generation,
+    }
+}
+
 /// Map a schema revision to its owning container generation.
 ///
 /// `index.json.version` remains the **sole** dispatch input — no filename

--- a/crates/larql-vindex/src/format/generation_tests.rs
+++ b/crates/larql-vindex/src/format/generation_tests.rs
@@ -6,8 +6,9 @@
 //! `version == generation` fails loudly.
 
 use super::generation::{
-    detect_generation, generation_for_schema, schema_range_label, supported_schema_summary,
-    ContainerGeneration, IndexSchemaVersion, ALL_GENERATIONS, V2_CURRENT_SCHEMA, V2_MIN_SCHEMA,
+    admit_extraction_generation, detect_generation, generation_for_schema, schema_range_label,
+    supported_schema_summary, ContainerGeneration, GenerationRequest, IndexSchemaVersion,
+    ALL_GENERATIONS, DEFAULT_EXTRACTION_GENERATION, V2_CURRENT_SCHEMA, V2_MIN_SCHEMA,
     V3_CURRENT_SCHEMA,
 };
 use crate::format::filenames::INDEX_JSON;
@@ -274,4 +275,35 @@ fn malformed_json_is_a_parse_error() {
 fn a_schema_version_displays_as_its_number() {
     assert_eq!(schema(3).to_string(), "3");
     assert_eq!(schema(3).get(), 3);
+}
+
+/// **The default-flip gate's pinned test.** A fresh extraction with no
+/// expressed preference writes VINDEX2 today. Flipping the programme to
+/// "VINDEX3 is the primary generation" means changing
+/// `DEFAULT_EXTRACTION_GENERATION` AND this test together — that pair is
+/// the explicit decision. If this test fails because the constant moved,
+/// the flip was made deliberately; update the assertion in the same
+/// commit that states the new policy.
+#[test]
+fn auto_extraction_resolves_to_v2_until_the_default_flip_is_decided() {
+    assert_eq!(
+        admit_extraction_generation(GenerationRequest::Auto),
+        ContainerGeneration::V2,
+    );
+    assert_eq!(DEFAULT_EXTRACTION_GENERATION, ContainerGeneration::V2);
+}
+
+/// Explicit requests pass through admission untouched, in both
+/// directions — the escape hatch works the same before and after the
+/// flip.
+#[test]
+fn explicit_generation_requests_are_never_overridden() {
+    assert_eq!(
+        admit_extraction_generation(GenerationRequest::Explicit(ContainerGeneration::V2)),
+        ContainerGeneration::V2,
+    );
+    assert_eq!(
+        admit_extraction_generation(GenerationRequest::Explicit(ContainerGeneration::V3)),
+        ContainerGeneration::V3,
+    );
 }

--- a/docs/vindex-generation-policy.md
+++ b/docs/vindex-generation-policy.md
@@ -1,0 +1,79 @@
+# Container-generation policy: the VINDEX2 → VINDEX3 transition
+
+Status: **contract adopted; default not yet flipped.**
+The semantic catch-up phase closed 2026-08-22: VINDEX3 reached full LQL
+parity with VINDEX2 (execution, inference, browse, mutation, patching,
+compose + parity, COMPILE, logical DIFF, COMPACT), gated cross-platform,
+with a real-model compose smoke green on granite-4.1-3b. VINDEX3 is the
+**candidate primary generation**; VINDEX2 is the **compatibility
+generation**.
+
+## The migration contract
+
+```text
+New extraction        → VINDEX3 by default            (after the flip)
+Existing VINDEX2      → continues to open and run
+Generation detection  → bind once at load
+Higher layers         → never care which generation was bound
+New semantic features → V3 only, unless compatibility requires V2
+V2                    → compatibility generation, no architectural expansion
+Escape hatch          → explicit V2 extraction/binding during the transition
+```
+
+## The default-flip gate
+
+The flip is a **named decision, made in exactly one place** — never a
+side effect of a CLI default, a recipe template, or a surface-local
+fallback:
+
+- `crates/larql-vindex/src/format/generation.rs` —
+  `DEFAULT_EXTRACTION_GENERATION` is the generation an extraction with no
+  expressed preference writes. It is `V2` today.
+- `crates/larql-vindex/src/format/generation_tests.rs` —
+  `auto_extraction_resolves_to_v2_until_the_default_flip_is_decided` pins
+  it. Flipping means changing the constant **and** this test in the same
+  commit; that pair is the decision.
+
+Every extraction surface resolves caller intent to a `GenerationRequest`
+(`Auto` | `Explicit(generation)`) and passes it through
+`admit_extraction_generation`. `Auto` gains its meaning only there.
+"V3 was requested and refused" and "V3 was never requested" are distinct
+by construction, and an explicit request is **never downgraded** — a
+surface that cannot produce the requested generation refuses by name.
+
+## Surfaces
+
+| Surface | Request spelling | Today (`Auto` → V2) |
+|---|---|---|
+| LQL | `EXTRACT MODEL "m" INTO "o" [FORMAT VINDEX2\|VINDEX3]` | `FORMAT VINDEX3` refuses by name (producer not wired); `FORMAT VINDEX2` explicit; absent = policy |
+| CLI | `larql extract --generation {v2\|v3}` | `--generation v3` refuses by name; omitted = policy |
+| Factory | `extractor.options.generation: "v2"\|"v3"` → forwarded as `--generation` | absent = tool policy; a pin participates in `build_id` |
+| V3 producer | `larql vindex3 encode <hf-artifacts>` | the only VINDEX3 producer today |
+
+Binding needs no policy: `detect_generation` (`index.json` schema
+version, the sole discriminator — no filename or shape sniffing) already
+dispatches `USE`, the server bootstrap, and `DIFF` operands, and fails
+closed on unknown schemas.
+
+## Rungs to the flip
+
+- **M1 (this document + the seam)** — policy type, pinned default,
+  explicit request spellings on every surface, refusals instead of
+  downgrades. No behaviour change.
+- **M2 — V3 production reachable from the extraction surfaces.** Wire
+  `FORMAT VINDEX3` / `--generation v3` to the V3 encoder for admissible
+  sources; the V3 path must reach parity on the extraction side channels
+  (tokenizer.json, HF metadata snapshot) so a default-produced container
+  binds with full capability; post-extract auto-bind takes the V3 arm.
+- **M3 — consumer readiness.** V2-only consumers either route by
+  detection or refuse by name: `SHOW MODELS` must list V3 containers,
+  `run`/`walk`/`describe`/`stats`, Vindexfile `FROM`, slice/publish/link,
+  quant converters; `/v1/models` reports `generation` for both.
+- **M4 — the flip.** `DEFAULT_EXTRACTION_GENERATION = V3` + the pinned
+  test, in one commit. V2 becomes the explicitly-requested compatibility
+  generation. Evidence rows required by then: the real-model compose
+  smoke (done — granite-4.1-3b) and whatever Metal-path/scale rows the
+  release checklist names.
+
+After the flip, V2 receives no architectural expansion — compatibility
+fixes only.


### PR DESCRIPTION
Rung M1 of the VINDEX2→VINDEX3 migration ladder: the explicit default-flip gate, with no behaviour change.

## What
- `GenerationRequest {Auto, Explicit(gen)}` + `DEFAULT_EXTRACTION_GENERATION = V2` + `admit_extraction_generation` in `larql-vindex/format/generation.rs` — the only place `Auto` gains a meaning. The pinned test `auto_extraction_resolves_to_v2_until_the_default_flip_is_decided` makes the future flip a deliberate two-line decision (constant + test, one commit) rather than a side effect of any surface default.
- Escape-hatch spellings on every extraction surface:
  - LQL: `EXTRACT MODEL "m" INTO "o" FORMAT VINDEX2|VINDEX3`
  - CLI: `larql extract --generation {v2|v3}`
  - Factory: `extractor.options.generation` → forwarded as `--generation` (participates in `build_id`; absence = no preference, never a recipe-local default)
- Refusal, never downgrade: an explicit V3 request refuses by name (today's only V3 producer is `larql vindex3 encode` over HF checkpoint artifacts), resolved before any model bytes move — gated by test.
- `docs/vindex-generation-policy.md`: the migration contract (new extraction → V3 after the flip; V2 keeps opening; bind-once detection; higher layers generation-blind; V2 = compatibility generation, no architectural expansion) and the rungs M1→M4.

## Why a seam and not a flip
The survey showed the flip is not a one-line default change: `larql extract` and `vindex3 encode` are different machines with different inputs, V3 encode writes no tokenizer.json yet, and several consumers are V2-only (`SHOW MODELS` hides V3 containers; run/Vindexfile/slice/publish assume V2). Those are rungs M2–M3; M4 is the flip itself.

## Gates
clippy -D warnings on all four touched crates, fmt, full larql-lql / larql-factory / larql-cli / generation test suites green. `Auto` still resolves to V2 — behaviour identical.