### PR TITLE
feat(vindex3): V3 production reachable from the extraction surfaces (migration rung M2)

### DIFF
--- a/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
@@ -266,11 +266,81 @@ impl IndexBuildCallbacks for CliBuildCallbacks {
     }
 }
 
+/// The V3 arm: HF checkpoint artifacts → `encode_checkpoint` (plan gate
+/// with itemised blocking findings, segments, capability snapshot).
+///
+/// The V2 route's knobs shape a *transcoding* extraction; none of them
+/// applies to a verbatim encode, so any that was explicitly set refuses
+/// by name rather than being silently ignored.
+fn run_v3(args: &ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let refused: &[(&str, bool)] = &[
+        ("--from-vectors", args.from_vectors.is_some()),
+        ("--quant", args.quant != larql_vindex::QuantFormat::None),
+        (
+            "--expert-banks",
+            args.expert_banks != larql_vindex::ExtractionRequest::Legacy,
+        ),
+        ("--include-weights", args.include_weights),
+        ("--compact", args.compact),
+        ("--drop-gate-vectors", args.drop_gate_vectors),
+        ("--down-q4k", args.down_q4k),
+        ("--feature-major-down", args.feature_major_down),
+        (
+            "--summary-features-per-expert",
+            args.summary_features_per_expert != 0,
+        ),
+    ];
+    if let Some((flag, _)) = refused.iter().find(|(_, set)| *set) {
+        return Err(format!(
+            "{flag} shapes the V2 transcoding route and does not apply to a VINDEX3 \
+             encode; drop it or use --generation v2"
+        )
+        .into());
+    }
+
+    let model = args
+        .model
+        .as_deref()
+        .ok_or("a model path or HF id is required for --generation v3")?;
+    let model_path = larql_models::resolve_model_path(model)?;
+    if model_path.is_file() {
+        return Err(format!(
+            "{} is a GGUF file; the VINDEX3 encoder consumes HF checkpoint artifacts \
+             (config.json + safetensors) and a container may not transcode on the way \
+             in. Use --generation v2 for GGUF sources.",
+            model_path.display()
+        )
+        .into());
+    }
+
+    let encoded = larql_vindex::format::vindex3::encode::checkpoint::encode_checkpoint(
+        &model_path,
+        &args.output,
+    )?;
+    if encoded.capabilities.is_empty() {
+        eprintln!(
+            "note: no tokenizer.json beside the checkpoint — the container will bind \
+             with token-id capability only"
+        );
+    } else {
+        eprintln!("capabilities: {}", encoded.capabilities.join(", "));
+    }
+    eprintln!(
+        "encoded {} ({} representation(s), {:.2} GB payload) → {}",
+        encoded.artifact,
+        encoded.outcome.representations,
+        encoded.outcome.total_payload_bytes as f64 / 1e9,
+        encoded.outcome.container.display(),
+    );
+    Ok(())
+}
+
 pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
     // Resolve the container generation before any bytes move. Omitted =
     // Auto, decided by the one policy site in larql-vindex (the
-    // default-flip gate). An explicit `v3` refuses by name on this
-    // surface — it is never downgraded to a V2 extraction.
+    // default-flip gate). An admitted V3 takes the encode pipeline; a V3
+    // request this surface cannot honour refuses by name — it is never
+    // downgraded to a V2 extraction.
     {
         use larql_vindex::format::generation::{
             admit_extraction_generation, ContainerGeneration, GenerationRequest,
@@ -280,13 +350,7 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
             Some(generation) => GenerationRequest::Explicit(generation),
         };
         if admit_extraction_generation(request) == ContainerGeneration::V3 {
-            return Err(
-                "`larql extract` cannot write a VINDEX3 container yet: VINDEX3 \
-                 containers are produced by `larql vindex3 encode` from HF checkpoint \
-                 artifacts. `--generation v2` remains available and must be selected \
-                 explicitly rather than fallen back to."
-                    .into(),
-            );
+            return run_v3(&args);
         }
     }
 

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -324,6 +324,23 @@ fn run_encode(args: EncodeArgs) -> Result<(), Box<dyn std::error::Error>> {
         named.push((artifact_name(path), load_artifact(path)?));
     }
     let outcome = larql_vindex::format::vindex3::encode::encode_system(&named, &args.output)?;
+    // Capability snapshot: tokenizer + HF metadata from the first
+    // artifact directory that carries them (the inventory records its
+    // source dir, so this covers both checkpoint-dir and saved-inventory
+    // inputs). A container without them binds with token-id capability
+    // only — which is why the granite smoke needed a manual copy before
+    // this existed.
+    for (_, inventory) in &named {
+        let copied =
+            larql_vindex::format::vindex3::encode::checkpoint::snapshot_checkpoint_capabilities(
+                std::path::Path::new(&inventory.path),
+                &args.output,
+            )?;
+        if !copied.is_empty() {
+            eprintln!("capabilities: {}", copied.join(", "));
+            break;
+        }
+    }
     eprintln!(
         "encoded {} representation(s), {:.2} GB payload → {}",
         outcome.representations,

--- a/crates/larql-lql/src/executor/lifecycle/extract.rs
+++ b/crates/larql-lql/src/executor/lifecycle/extract.rs
@@ -34,20 +34,7 @@ impl Session {
         };
         match admit_extraction_generation(request) {
             ContainerGeneration::V2 => {}
-            // This surface extracts from a live model's weights; the
-            // VINDEX3 producer (`larql vindex3 encode`) consumes HF
-            // checkpoint artifacts. Until EXTRACT is wired to the V3
-            // encoder, an explicit V3 request is refused by name — it is
-            // never downgraded to a V2 extraction.
-            ContainerGeneration::V3 => {
-                return Err(LqlError::Execution(
-                    "EXTRACT cannot write a VINDEX3 container from this surface yet: \
-                     VINDEX3 containers are produced by `larql vindex3 encode` from HF \
-                     checkpoint artifacts. FORMAT VINDEX2 remains available and must be \
-                     selected explicitly rather than fallen back to."
-                        .into(),
-                ));
-            }
+            ContainerGeneration::V3 => return self.exec_extract_v3(model, output),
         }
 
         let output_dir = PathBuf::from(output);
@@ -139,6 +126,61 @@ impl Session {
             memit_store,
         };
 
+        Ok(out)
+    }
+
+    /// The VINDEX3 arm: HF checkpoint artifacts → `encode_checkpoint`
+    /// (plan gate with itemised blocking findings, segments, capability
+    /// snapshot) → bind, through the same block `USE` binds with.
+    ///
+    /// The V2 arm above loads a model through `InferenceModel::load`,
+    /// which accepts GGUF as well as safetensors; the V3 encoder takes
+    /// only HF checkpoint artifacts, because a container may not
+    /// transcode on the way in. A source it cannot consume refuses by
+    /// name rather than falling back to a V2 extraction.
+    fn exec_extract_v3(&mut self, model: &str, output: &str) -> Result<Vec<String>, LqlError> {
+        let model_path = larql_models::resolve_model_path(model)
+            .map_err(|e| LqlError::exec("failed to resolve model path", e))?;
+        if model_path.is_file() {
+            return Err(LqlError::Execution(format!(
+                "{} is a GGUF file; the VINDEX3 encoder consumes HF checkpoint artifacts \
+                 (config.json + safetensors) and a container may not transcode on the way \
+                 in. Use FORMAT VINDEX2 for GGUF sources.",
+                model_path.display()
+            )));
+        }
+
+        let output_dir = PathBuf::from(output);
+        let mut out = vec![format!(
+            "Encoding checkpoint {} → {} (VINDEX3)...",
+            model_path.display(),
+            output_dir.display()
+        )];
+        let encoded = larql_vindex::format::vindex3::encode::checkpoint::encode_checkpoint(
+            &model_path,
+            &output_dir,
+        )
+        .map_err(|e| LqlError::exec("VINDEX3 encode failed", e))?;
+        out.push(format!(
+            "Encoded {} ({} representation(s), {} payload bytes).",
+            encoded.artifact,
+            encoded.outcome.representations,
+            format_number(encoded.outcome.total_payload_bytes as usize),
+        ));
+        if encoded.capabilities.is_empty() {
+            out.push(
+                "No tokenizer.json beside the checkpoint — binding with token-id \
+                 capability only."
+                    .into(),
+            );
+        } else {
+            out.push(format!(
+                "Capabilities: {}.",
+                encoded.capabilities.join(", ")
+            ));
+        }
+
+        out.extend(self.bind_v3_session(output_dir)?);
         Ok(out)
     }
 }

--- a/crates/larql-lql/src/executor/lifecycle/use_cmd.rs
+++ b/crates/larql-lql/src/executor/lifecycle/use_cmd.rs
@@ -37,52 +37,7 @@ impl Session {
                     larql_vindex::format::generation::detect_generation(&path),
                     Ok(larql_vindex::format::generation::ContainerGeneration::V3)
                 ) {
-                    let (runtime, tokenizer, knowledge) = crate::executor::vindex3::bind(&path)?;
-                    let plan_layers = runtime.plan().layers.len();
-                    let out = vec![
-                        format!(
-                            "Using: {} (VINDEX3, model: {}, component {}, {} layers, \
-                             execution closed)",
-                            path.display(),
-                            runtime.model_name(),
-                            crate::executor::vindex3::V3_COMPONENT,
-                            plan_layers,
-                        ),
-                        format!(
-                            "Supported: {}. Tokenizer: {}.",
-                            crate::executor::vindex3::SUPPORTED,
-                            if tokenizer.is_some() {
-                                "present"
-                            } else {
-                                "absent (token-id capability only)"
-                            },
-                        ),
-                    ];
-                    // A compiled container carries its L0 knowledge as
-                    // `knn_store.bin` (the same file V2 binds) — load it
-                    // into the overlay's store, exactly as the V2 arm
-                    // does below.
-                    let mut overlay =
-                        larql_vindex::format::vindex3::knowledge::KnowledgeOverlay::default();
-                    let knn_path = path.join(KNN_STORE_BIN);
-                    if knn_path.exists() {
-                        match larql_vindex::KnnStore::load(&knn_path) {
-                            Ok(store) => overlay.knn_store = store,
-                            Err(e) => {
-                                eprintln!("warning: failed to load knn_store.bin: {e}");
-                            }
-                        }
-                    }
-                    self.backend = Backend::Vindex3 {
-                        path,
-                        runtime,
-                        tokenizer,
-                        knowledge,
-                        overlay,
-                    };
-                    self.patch_recording = None;
-                    self.auto_patch = false;
-                    return Ok(out);
+                    return self.bind_v3_session(path);
                 }
 
                 let config = larql_vindex::load_vindex_config(&path)
@@ -191,5 +146,58 @@ impl Session {
             }
             UseTarget::Remote(url) => self.exec_use_remote(url),
         }
+    }
+
+    /// Bind a VINDEX3 container as the session backend — the single V3
+    /// binding block, shared by `USE` and by `EXTRACT ... FORMAT VINDEX3`'s
+    /// auto-bind so the two can never drift.
+    pub(crate) fn bind_v3_session(
+        &mut self,
+        path: std::path::PathBuf,
+    ) -> Result<Vec<String>, LqlError> {
+        let (runtime, tokenizer, knowledge) = crate::executor::vindex3::bind(&path)?;
+        let plan_layers = runtime.plan().layers.len();
+        let out = vec![
+            format!(
+                "Using: {} (VINDEX3, model: {}, component {}, {} layers, \
+                 execution closed)",
+                path.display(),
+                runtime.model_name(),
+                crate::executor::vindex3::V3_COMPONENT,
+                plan_layers,
+            ),
+            format!(
+                "Supported: {}. Tokenizer: {}.",
+                crate::executor::vindex3::SUPPORTED,
+                if tokenizer.is_some() {
+                    "present"
+                } else {
+                    "absent (token-id capability only)"
+                },
+            ),
+        ];
+        // A compiled container carries its L0 knowledge as
+        // `knn_store.bin` (the same file V2 binds) — load it into the
+        // overlay's store, exactly as the V2 arm does.
+        let mut overlay = larql_vindex::format::vindex3::knowledge::KnowledgeOverlay::default();
+        let knn_path = path.join(KNN_STORE_BIN);
+        if knn_path.exists() {
+            match larql_vindex::KnnStore::load(&knn_path) {
+                Ok(store) => overlay.knn_store = store,
+                Err(e) => {
+                    eprintln!("warning: failed to load knn_store.bin: {e}");
+                }
+            }
+        }
+        self.backend = Backend::Vindex3 {
+            path,
+            runtime,
+            tokenizer,
+            knowledge,
+            overlay,
+        };
+        self.patch_recording = None;
+        self.auto_patch = false;
+        Ok(out)
     }
 }

--- a/crates/larql-lql/tests/cov_lifecycle_synthetic.rs
+++ b/crates/larql-lql/tests/cov_lifecycle_synthetic.rs
@@ -535,19 +535,27 @@ fn compile_path_into_vindex_from_other_vindex() {
     );
 }
 
-/// `EXTRACT ... FORMAT VINDEX3` refuses BY NAME before any model bytes
-/// move — this surface's V3 producer does not exist yet, and an explicit
-/// request must never silently downgrade to a V2 extraction. The refusal
-/// arriving (rather than a model-loading error for the bogus model id)
-/// proves the generation is resolved first.
+/// `EXTRACT ... FORMAT VINDEX3` routes to the V3 arm, not the V2 one.
+///
+/// The two arms fail differently on an unresolvable model — V3 resolves
+/// the checkpoint path for the encoder, V2 loads a model through
+/// `InferenceModel` — so the error names which arm ran. (The V3 arm's
+/// own behaviour — encode, capability snapshot, auto-bind, refusals — is
+/// gated end to end in `vindex3_extract.rs`.)
 #[test]
-fn extract_format_vindex3_refuses_by_name_before_loading() {
+fn extract_format_vindex3_takes_the_v3_arm() {
     let mut session = Session::new();
-    let err = try_run(
+    let v3 = try_run(
         &mut session,
         r#"EXTRACT MODEL "no-such-model" INTO "/nonexistent/out" FORMAT VINDEX3;"#,
     )
-    .expect_err("an explicit V3 request must refuse on this surface");
-    assert!(err.contains("vindex3 encode"), "{err}");
-    assert!(err.contains("FORMAT VINDEX2"), "{err}");
+    .expect_err("an unresolvable model must fail");
+    assert!(v3.contains("failed to resolve model path"), "{v3}");
+
+    let v2 = try_run(
+        &mut session,
+        r#"EXTRACT MODEL "no-such-model" INTO "/nonexistent/out" FORMAT VINDEX2;"#,
+    )
+    .expect_err("an unresolvable model must fail");
+    assert!(v2.contains("failed to load model"), "{v2}");
 }

--- a/crates/larql-lql/tests/vindex3_extract.rs
+++ b/crates/larql-lql/tests/vindex3_extract.rs
@@ -1,0 +1,183 @@
+//! Migration rung M2: `EXTRACT ... FORMAT VINDEX3` produces a container.
+//!
+//! The oracle is the same one the whole V3 arc has used — a round trip
+//! through the statement surface, compared against the path it must be
+//! equivalent to:
+//!
+//! ```text
+//! EXTRACT FORMAT VINDEX3  → container detects as V3
+//!                         → session is bound, no USE needed
+//!                         → INFER through the auto-bind
+//!                              == INFER through a fresh USE of the same
+//!                                 container, line for line
+//! ```
+//!
+//! The auto-bind equality is the point: `EXTRACT` must not grow a second
+//! binding path that drifts from `USE`'s.
+
+use std::path::Path;
+
+use larql_inference::test_utils::synthetic_tokenizer_json;
+use larql_lql::{parse, Session};
+use larql_vindex::format::generation::{detect_generation, ContainerGeneration};
+use larql_vindex::format::vindex3::fixtures::{miniature_glimmer, G_VOCAB};
+
+/// Windows temp paths contain backslashes, which the LQL lexer's escape
+/// pass would consume; doubling them leaves the path untouched on every
+/// platform.
+fn lql_path(path: impl AsRef<Path>) -> String {
+    path.as_ref().display().to_string().replace('\\', "\\\\")
+}
+
+fn run(session: &mut Session, stmt: &str) -> Vec<String> {
+    let parsed = parse(stmt).unwrap_or_else(|e| panic!("parse {stmt}: {e}"));
+    session
+        .execute(&parsed)
+        .unwrap_or_else(|e| panic!("execute {stmt}: {e}"))
+}
+
+fn try_run(session: &mut Session, stmt: &str) -> Result<Vec<String>, String> {
+    let parsed = parse(stmt).map_err(|e| format!("parse: {e}"))?;
+    session
+        .execute(&parsed)
+        .map_err(|e| format!("execute: {e}"))
+}
+
+/// An HF-checkpoint-shaped directory: config.json + safetensors, plus
+/// the tokenizer the capability snapshot must carry into the container.
+fn checkpoint_with_tokenizer() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_glimmer(dir.path());
+    std::fs::write(
+        dir.path().join("tokenizer.json"),
+        synthetic_tokenizer_json(G_VOCAB),
+    )
+    .unwrap();
+    dir
+}
+
+/// INFER's prediction rows, without the elapsed-time line: the claim
+/// under test is what the program predicts, not how long it took.
+fn predictions(lines: Vec<String>) -> Vec<String> {
+    lines.into_iter().filter(|l| l.contains("[id ")).collect()
+}
+
+fn extract_v3(session: &mut Session, checkpoint: &Path, out: &Path) -> Vec<String> {
+    run(
+        session,
+        &format!(
+            "EXTRACT MODEL \"{}\" INTO \"{}\" FORMAT VINDEX3;",
+            lql_path(checkpoint),
+            lql_path(out)
+        ),
+    )
+}
+
+/// THE gate: the statement produces a V3 container, carries the
+/// checkpoint's tokenizer into it, leaves the session bound, and that
+/// auto-bind behaves identically to a fresh `USE` of the same container.
+#[test]
+fn extract_format_vindex3_encodes_binds_and_matches_use() {
+    let checkpoint = checkpoint_with_tokenizer();
+    let out = tempfile::tempdir().unwrap();
+    let out_dir = out.path().join("container");
+
+    let mut session = Session::new();
+    let report = extract_v3(&mut session, checkpoint.path(), &out_dir).join("\n");
+
+    // The container is VINDEX3 by its own marker — not by filename.
+    assert_eq!(
+        detect_generation(&out_dir).unwrap(),
+        ContainerGeneration::V3,
+        "{report}"
+    );
+    // The capability snapshot ran: the tokenizer is beside the segments,
+    // so the container binds servable rather than token-id-only.
+    assert!(report.contains("Capabilities: tokenizer.json"), "{report}");
+    assert!(out_dir.join("tokenizer.json").exists());
+    assert!(report.contains("VINDEX3"), "{report}");
+
+    // The session is already bound — a statement runs with no USE.
+    let auto_bound = predictions(run(&mut session, r#"INFER "[3]" TOP 3;"#));
+
+    // …and that binding is the one USE produces, row for row.
+    let mut fresh = Session::new();
+    run(&mut fresh, &format!("USE \"{}\";", lql_path(&out_dir)));
+    let via_use = predictions(run(&mut fresh, r#"INFER "[3]" TOP 3;"#));
+    assert!(!auto_bound.is_empty(), "INFER must return prediction rows");
+    assert_eq!(
+        auto_bound, via_use,
+        "EXTRACT's auto-bind must be USE's binding, not a second path"
+    );
+}
+
+/// A checkpoint with no tokenizer still encodes — absence narrows
+/// capability, it is not an error — and the report says so rather than
+/// leaving the caller to discover it at INFER time.
+#[test]
+fn extract_format_vindex3_reports_a_tokenizerless_checkpoint() {
+    let checkpoint = tempfile::tempdir().unwrap();
+    miniature_glimmer(checkpoint.path());
+    let out = tempfile::tempdir().unwrap();
+    let out_dir = out.path().join("container");
+
+    let mut session = Session::new();
+    let report = extract_v3(&mut session, checkpoint.path(), &out_dir).join("\n");
+    assert_eq!(
+        detect_generation(&out_dir).unwrap(),
+        ContainerGeneration::V3
+    );
+    assert!(report.contains("token-id capability only"), "{report}");
+    assert!(!out_dir.join("tokenizer.json").exists());
+}
+
+/// A source the V3 encoder cannot consume refuses BY NAME, naming the
+/// escape hatch — never a silent downgrade to a V2 extraction.
+#[test]
+fn extract_format_vindex3_refuses_a_gguf_source_by_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let gguf = dir.path().join("model.gguf");
+    std::fs::write(&gguf, b"GGUF").unwrap();
+    let out = tempfile::tempdir().unwrap();
+
+    let mut session = Session::new();
+    let err = try_run(
+        &mut session,
+        &format!(
+            "EXTRACT MODEL \"{}\" INTO \"{}\" FORMAT VINDEX3;",
+            lql_path(&gguf),
+            lql_path(out.path().join("container"))
+        ),
+    )
+    .expect_err("GGUF is not an HF checkpoint");
+    assert!(err.contains("GGUF"), "{err}");
+    assert!(err.contains("FORMAT VINDEX2"), "{err}");
+}
+
+/// A directory that is not an HF checkpoint refuses through the
+/// statement surface, naming what the encoder consumes — the encode
+/// pipeline's refusals reach the caller rather than being flattened
+/// into "extraction failed".
+///
+/// (The plan gate's itemised blocking findings are gated where they are
+/// rendered, in larql-vindex's `encode::tests`; the drafter-shaped
+/// inventory fixture that produces an inadmissible plan is internal to
+/// that crate.)
+#[test]
+fn extract_format_vindex3_refuses_a_non_checkpoint_directory() {
+    let not_a_checkpoint = tempfile::tempdir().unwrap();
+    std::fs::write(not_a_checkpoint.path().join("readme.txt"), b"nothing").unwrap();
+    let out = tempfile::tempdir().unwrap();
+
+    let mut session = Session::new();
+    let err = try_run(
+        &mut session,
+        &format!(
+            "EXTRACT MODEL \"{}\" INTO \"{}\" FORMAT VINDEX3;",
+            lql_path(not_a_checkpoint.path()),
+            lql_path(out.path().join("container"))
+        ),
+    )
+    .expect_err("a directory with no config.json is not a checkpoint");
+    assert!(err.contains("config.json + safetensors"), "{err}");
+}

--- a/crates/larql-vindex/src/format/vindex3/encode/checkpoint.rs
+++ b/crates/larql-vindex/src/format/vindex3/encode/checkpoint.rs
@@ -1,0 +1,123 @@
+//! One-checkpoint encode: the pipeline both extraction surfaces share.
+//!
+//! Migration rung M2: `larql extract --generation v3` and LQL
+//! `EXTRACT ... FORMAT VINDEX3` must produce a container the same way
+//! `larql vindex3 encode` does — so the whole pipeline lives here, once:
+//!
+//! ```text
+//! checkpoint dir (config.json + *.safetensors)
+//!   → build_inventory          interpretation, once
+//!   → plan_system              admissibility, with the blocking
+//!                              findings RENDERED into the refusal
+//!                              (encode_system's own gate discards them)
+//!   → encode_system            segments + system_graph + index
+//!   → capability snapshot      tokenizer.json + the HF metadata set
+//! ```
+//!
+//! The capability snapshot exists because the encoder proper writes only
+//! what execution needs — segments, graph, index — while binding with
+//! full capability (INFER, chat templates) needs the checkpoint's
+//! tokenizer artifacts placed beside them. The V2 extractor has always
+//! done this; a V3 container produced by an extraction surface must not
+//! silently degrade to token-id-only capability.
+
+use std::path::Path;
+
+use larql_models::inventory::build_inventory;
+
+use super::{encode_system, EncodeOutcome};
+use crate::error::VindexError;
+use crate::format::filenames::TOKENIZER_JSON;
+use crate::format::vindex3::plan::plan_system;
+
+/// Checkpoint files that carry a container's *capabilities* rather than
+/// its executable bytes: the tokenizer itself plus the HF metadata set
+/// the V2 extractor snapshots (`snapshot_hf_metadata`). Copied verbatim
+/// when present; absence of any — including the tokenizer — is not an
+/// error, it just narrows what the bound container can do.
+pub const CHECKPOINT_CAPABILITY_FILES: [&str; 5] = [
+    TOKENIZER_JSON,
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "generation_config.json",
+    "chat_template.jinja",
+];
+
+/// What one checkpoint encode produced.
+#[derive(Debug)]
+pub struct CheckpointEncode {
+    pub outcome: EncodeOutcome,
+    /// The artifact name recorded in the container (the checkpoint
+    /// directory's stem — the same rule `larql vindex3 encode` uses).
+    pub artifact: String,
+    /// Capability files copied in from the checkpoint, in
+    /// [`CHECKPOINT_CAPABILITY_FILES`] order.
+    pub capabilities: Vec<String>,
+}
+
+/// Copy the checkpoint's capability files into an encoded container.
+///
+/// Present files copy verbatim (a failed copy of a present file is an
+/// error — never a silent degrade); absent files are skipped. Returns
+/// the names that were copied.
+pub fn snapshot_checkpoint_capabilities(
+    checkpoint: &Path,
+    container: &Path,
+) -> Result<Vec<String>, VindexError> {
+    let mut copied = Vec::new();
+    for name in CHECKPOINT_CAPABILITY_FILES {
+        let src = checkpoint.join(name);
+        if !src.exists() {
+            continue;
+        }
+        std::fs::copy(&src, container.join(name)).map_err(VindexError::Io)?;
+        copied.push(name.to_string());
+    }
+    Ok(copied)
+}
+
+/// Encode one HF checkpoint directory into a VINDEX3 container, with
+/// the capability snapshot.
+///
+/// Refusals name their cause: a directory `build_inventory` cannot read
+/// (no `config.json`) refuses as such, and an inadmissible plan refuses
+/// with every blocking finding itemised — the caller never has to
+/// re-run `larql vindex3 plan` to learn why.
+pub fn encode_checkpoint(checkpoint: &Path, out: &Path) -> Result<CheckpointEncode, VindexError> {
+    let inventory = build_inventory(checkpoint).map_err(|e| {
+        VindexError::Parse(format!(
+            "the VINDEX3 encoder consumes HF checkpoint artifacts (config.json + \
+             safetensors); {} is not one: {e}",
+            checkpoint.display()
+        ))
+    })?;
+    let artifact = checkpoint
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "artifact".to_string());
+    let named = [(artifact.clone(), inventory)];
+
+    let plan = plan_system(&named);
+    if !plan.admissible {
+        let blocking: Vec<String> = plan
+            .artifacts
+            .iter()
+            .flat_map(|a| &a.findings)
+            .filter(|f| f.blocks())
+            .map(|f| format!("{}: {}", f.subject, f.detail))
+            .collect();
+        return Err(VindexError::Parse(format!(
+            "refusing to encode an inadmissible plan ({} blocking finding(s)):\n  {}",
+            blocking.len(),
+            blocking.join("\n  ")
+        )));
+    }
+
+    let outcome = encode_system(&named, out)?;
+    let capabilities = snapshot_checkpoint_capabilities(checkpoint, out)?;
+    Ok(CheckpointEncode {
+        outcome,
+        artifact,
+        capabilities,
+    })
+}

--- a/crates/larql-vindex/src/format/vindex3/encode/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/encode/mod.rs
@@ -22,6 +22,7 @@
 //! └── segments/<object>.bin  self-describing framed segments
 //! ```
 
+pub mod checkpoint;
 pub mod segment;
 pub mod source;
 

--- a/crates/larql-vindex/src/format/vindex3/encode/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/encode/tests.rs
@@ -638,3 +638,105 @@ fn a_segment_claiming_a_different_representation_than_the_directory_is_a_defect(
         "{defects:?}"
     );
 }
+
+// ── checkpoint.rs: the shared one-checkpoint pipeline (rung M2) ──
+
+/// The full pipeline on the miniature checkpoint: encode succeeds, the
+/// container detects as V3, and the capability files present in the
+/// checkpoint (tokenizer.json here) are placed beside the segments.
+#[test]
+fn encode_checkpoint_produces_a_v3_container_with_capabilities() {
+    use crate::format::vindex3::encode::checkpoint::encode_checkpoint;
+    use crate::format::vindex3::fixtures::miniature_glimmer;
+
+    let checkpoint = tempfile::tempdir().unwrap();
+    miniature_glimmer(checkpoint.path());
+    std::fs::write(checkpoint.path().join("tokenizer.json"), "{}").unwrap();
+    std::fs::write(checkpoint.path().join("generation_config.json"), "{}").unwrap();
+
+    let out = tempfile::tempdir().unwrap();
+    let encoded = encode_checkpoint(checkpoint.path(), out.path()).unwrap();
+
+    assert!(encoded.outcome.representations > 0);
+    assert_eq!(
+        crate::format::generation::detect_generation(out.path()).unwrap(),
+        crate::format::generation::ContainerGeneration::V3,
+    );
+    assert_eq!(
+        encoded.capabilities,
+        vec![
+            "tokenizer.json".to_string(),
+            "generation_config.json".to_string()
+        ],
+        "present capability files copy, in declaration order"
+    );
+    assert!(out.path().join("tokenizer.json").exists());
+    assert!(out.path().join("generation_config.json").exists());
+    assert!(!out.path().join("chat_template.jinja").exists());
+}
+
+/// A tokenizer-less checkpoint still encodes — absence narrows
+/// capability, it is not an error.
+#[test]
+fn encode_checkpoint_tolerates_absent_capability_files() {
+    use crate::format::vindex3::encode::checkpoint::encode_checkpoint;
+    use crate::format::vindex3::fixtures::miniature_glimmer;
+
+    let checkpoint = tempfile::tempdir().unwrap();
+    miniature_glimmer(checkpoint.path());
+    let out = tempfile::tempdir().unwrap();
+    let encoded = encode_checkpoint(checkpoint.path(), out.path()).unwrap();
+    assert!(encoded.capabilities.is_empty());
+    assert!(!out.path().join("tokenizer.json").exists());
+}
+
+/// A directory that is not an HF checkpoint refuses by name — the
+/// message says what the encoder consumes.
+#[test]
+fn encode_checkpoint_refuses_a_non_checkpoint_dir() {
+    use crate::format::vindex3::encode::checkpoint::encode_checkpoint;
+
+    let not_a_checkpoint = tempfile::tempdir().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    let err = encode_checkpoint(not_a_checkpoint.path(), out.path()).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("config.json + safetensors"), "{msg}");
+}
+
+/// The artifact name is the checkpoint directory's stem — the same rule
+/// `larql vindex3 encode` applies.
+#[test]
+fn encode_checkpoint_names_the_artifact_by_directory_stem() {
+    use crate::format::vindex3::encode::checkpoint::encode_checkpoint;
+    use crate::format::vindex3::fixtures::miniature_glimmer;
+
+    let base = tempfile::tempdir().unwrap();
+    let checkpoint = base.path().join("mini-glimmer");
+    std::fs::create_dir(&checkpoint).unwrap();
+    miniature_glimmer(&checkpoint);
+    let out = tempfile::tempdir().unwrap();
+    let encoded = encode_checkpoint(&checkpoint, out.path()).unwrap();
+    assert_eq!(encoded.artifact, "mini-glimmer");
+}
+
+/// An inadmissible plan refuses with the blocking findings ITEMISED —
+/// `encode_system`'s own gate discards them and points at `vindex3
+/// plan`; the shared pipeline must not make two surfaces do that dance.
+#[test]
+fn encode_checkpoint_renders_blocking_findings_into_the_refusal() {
+    use crate::format::vindex3::encode::checkpoint::encode_checkpoint;
+
+    // A drafter checkpoint alone is inadmissible: its producer
+    // interface cannot resolve without the target artifact.
+    let checkpoint = tempfile::tempdir().unwrap();
+    drafter_shaped(checkpoint.path());
+
+    let out = tempfile::tempdir().unwrap();
+    let err = encode_checkpoint(checkpoint.path(), out.path()).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("blocking finding"), "{msg}");
+    assert!(
+        msg.lines().count() > 1,
+        "findings must be itemised, not counted: {msg}"
+    );
+}

--- a/docs/lql-guide.md
+++ b/docs/lql-guide.md
@@ -29,9 +29,19 @@ EXTRACT MODEL "google/gemma-3-4b-it" INTO "gemma3-4b.vindex" WITH INFERENCE;
 
 -- Full (~10 GB f16 / ~18 GB f32, enables COMPILE for recompilation)
 EXTRACT MODEL "google/gemma-3-4b-it" INTO "gemma3-4b.vindex" WITH ALL;
+
+-- Pick the container generation explicitly. Omitted = no preference,
+-- resolved by the extraction-generation policy (docs/vindex-generation-policy.md).
+EXTRACT MODEL "google/gemma-3-4b-it" INTO "gemma3-4b.vindex" FORMAT VINDEX3;
 ```
 
+A `FORMAT VINDEX3` extraction encodes the checkpoint's own bytes into a
+VINDEX3 container (HF checkpoint artifacts only — GGUF sources refuse by
+name rather than transcoding on the way in), carries the tokenizer and
+HF metadata in beside it, and leaves the session bound: no `USE` needed.
+
 CLI equivalent: `larql extract-index google/gemma-3-4b-it -o gemma3-4b.vindex --level inference --f16`
+(add `--generation v3` for a VINDEX3 container).
 
 ### 2. Connect
 

--- a/docs/vindex-generation-policy.md
+++ b/docs/vindex-generation-policy.md
@@ -45,10 +45,40 @@ surface that cannot produce the requested generation refuses by name.
 
 | Surface | Request spelling | Today (`Auto` → V2) |
 |---|---|---|
-| LQL | `EXTRACT MODEL "m" INTO "o" [FORMAT VINDEX2\|VINDEX3]` | `FORMAT VINDEX3` refuses by name (producer not wired); `FORMAT VINDEX2` explicit; absent = policy |
-| CLI | `larql extract --generation {v2\|v3}` | `--generation v3` refuses by name; omitted = policy |
+| LQL | `EXTRACT MODEL "m" INTO "o" [FORMAT VINDEX2\|VINDEX3]` | `FORMAT VINDEX3` encodes + auto-binds; `FORMAT VINDEX2` explicit; absent = policy |
+| CLI | `larql extract --generation {v2\|v3}` | `--generation v3` encodes; omitted = policy |
 | Factory | `extractor.options.generation: "v2"\|"v3"` → forwarded as `--generation` | absent = tool policy; a pin participates in `build_id` |
-| V3 producer | `larql vindex3 encode <hf-artifacts>` | the only VINDEX3 producer today |
+| V3 producer | `larql vindex3 encode <hf-artifacts>` | the multi-artifact system encoder |
+
+### What a V3 request produces
+
+Both extraction surfaces run one shared pipeline —
+`larql_vindex::format::vindex3::encode::checkpoint::encode_checkpoint`:
+
+```text
+checkpoint dir (config.json + *.safetensors)
+  → build_inventory     interpretation, once
+  → plan_system         admissibility, blocking findings ITEMISED in the refusal
+  → encode_system       segments + system_graph + index
+  → capability snapshot tokenizer.json + tokenizer_config/special_tokens_map/
+                        generation_config/chat_template
+```
+
+The capability snapshot is what keeps a V3-produced container servable:
+the encoder proper writes only what execution needs, so without it a
+fresh container binds with token-id capability only and refuses `INFER`.
+`larql vindex3 encode` places the same files, so all three producers
+agree.
+
+Sources the encoder cannot consume refuse **by name**, never by
+downgrade: GGUF (a container may not transcode on the way in — use
+`FORMAT VINDEX2`), non-checkpoint directories, and V2-only transcoding
+flags (`--quant`, `--expert-banks`, `--compact`, …) passed alongside
+`--generation v3`.
+
+After a V3 extraction the LQL session is **already bound**, through the
+same `bind_v3_session` block `USE` uses — gated by an equality test, so
+`EXTRACT` cannot grow a second binding path that drifts.
 
 Binding needs no policy: `detect_generation` (`index.json` schema
 version, the sole discriminator — no filename or shape sniffing) already
@@ -57,14 +87,14 @@ closed on unknown schemas.
 
 ## Rungs to the flip
 
-- **M1 (this document + the seam)** — policy type, pinned default,
+- **M1 — the seam. DONE** (PR #290): policy type, pinned default,
   explicit request spellings on every surface, refusals instead of
   downgrades. No behaviour change.
-- **M2 — V3 production reachable from the extraction surfaces.** Wire
-  `FORMAT VINDEX3` / `--generation v3` to the V3 encoder for admissible
-  sources; the V3 path must reach parity on the extraction side channels
-  (tokenizer.json, HF metadata snapshot) so a default-produced container
-  binds with full capability; post-extract auto-bind takes the V3 arm.
+- **M2 — V3 production reachable from the extraction surfaces. DONE**:
+  one shared `encode_checkpoint` pipeline behind `FORMAT VINDEX3` /
+  `--generation v3`, capability snapshot closing the tokenizer/HF
+  metadata gap on all three producers, post-extract auto-bind through
+  `USE`'s own binding block.
 - **M3 — consumer readiness.** V2-only consumers either route by
   detection or refuse by name: `SHOW MODELS` must list V3 containers,
   `run`/`walk`/`describe`/`stats`, Vindexfile `FROM`, slice/publish/link,


### PR DESCRIPTION
Rung M2 of the VINDEX2→VINDEX3 migration ladder: a `FORMAT VINDEX3` / `--generation v3` request now actually produces a container. The default is unmoved — `Auto` still resolves to V2.

## One shared pipeline

`larql_vindex::format::vindex3::encode::checkpoint::encode_checkpoint` backs every producer:

```text
checkpoint dir (config.json + safetensors)
  → build_inventory     interpretation, once
  → plan_system         admissibility, blocking findings ITEMISED
  → encode_system       segments + system_graph + index
  → capability snapshot tokenizer + HF metadata
```

**The capability snapshot closes a real gap.** The encoder proper writes only what execution needs, so a freshly encoded container was tokenizer-less *by construction* and bound with token-id capability only — that is why the granite real-model smoke needed a manual tokenizer copy. `tokenizer.json` plus the V2 extractor's own snapshot set (`tokenizer_config.json`, `special_tokens_map.json`, `generation_config.json`, `chat_template.jinja`) now travel with the container from all three producers: `larql vindex3 encode`, `larql extract --generation v3`, and LQL `EXTRACT ... FORMAT VINDEX3`. Present files copy verbatim; absence narrows capability and is reported rather than erroring.

**Itemised refusals.** `encode_system`'s own gate discards the plan's blocking findings and tells the caller to re-run the plan verb — no answer when the encode was a side effect of an `EXTRACT` statement. The shared pipeline renders them.

## Binding

LQL auto-binds the fresh container through `bind_v3_session`, the `USE` arm's own binding block factored out. An equality gate pins EXTRACT's auto-bind `INFER` to `USE`'s, so the two cannot drift into separate binding paths.

## Refusals, never downgrades

GGUF sources (a container may not transcode on the way in), non-checkpoint directories, and V2-transcoding flags (`--quant`, `--expert-banks`, `--compact`, …) passed alongside `--generation v3` all refuse by name and point at the escape hatch.

## Gates

5 new in `larql-vindex` `encode::tests` (pipeline, absent capabilities, non-checkpoint refusal, artifact naming, itemised findings) and 4 new end-to-end in `larql-lql/tests/vindex3_extract.rs`. New file reads 98.2% lines. clippy `-D warnings`, fmt, and the full larql-vindex / larql-lql / larql-cli suites green.

Remaining before the flip: **M3** consumer readiness (`SHOW MODELS` currently hides V3 containers; `run`/Vindexfile/slice/publish/link are V2-only; `/v1/models` reports `generation` asymmetrically), then **M4**, the flip itself.
