### PR TITLE
fix(lql): V3 prompts prepend the container's declared BOS

### DIFF
--- a/crates/larql-inference/src/lib.rs
+++ b/crates/larql-inference/src/lib.rs
@@ -272,7 +272,9 @@ pub use layer_graph::{
     WalkLayerGraph,
 };
 pub use model::{load_model_dir, resolve_model_path, DequantScratch, ModelWeights, WeightsView};
-pub use tokenizer::{decode_token, decode_token_raw, encode_prompt, load_tokenizer};
+pub use tokenizer::{
+    decode_token, decode_token_raw, encode_prompt, load_tokenizer, maybe_prepend_bos,
+};
 pub use trace::{
     trace as trace_decomposed, trace_residuals, AnswerWaypoint, BoundaryStore, BoundaryWriter,
     ContextStore, ContextTier, ContextWriter, LayerSummary, ResidualTrace, TraceNode,

--- a/crates/larql-inference/src/tokenizer.rs
+++ b/crates/larql-inference/src/tokenizer.rs
@@ -106,7 +106,7 @@ pub fn encode_prompt(
 /// that already have token ids (e.g. from a cached encoding) can reuse
 /// the logic, and so the prepend contract can be unit-tested without
 /// standing up a real tokenizer.
-pub(crate) fn maybe_prepend_bos(mut ids: Vec<u32>, bos: Option<u32>) -> Vec<u32> {
+pub fn maybe_prepend_bos(mut ids: Vec<u32>, bos: Option<u32>) -> Vec<u32> {
     if let Some(bos) = bos {
         if ids.first().copied() != Some(bos) {
             ids.insert(0, bos);

--- a/crates/larql-lql/src/executor/backend.rs
+++ b/crates/larql-lql/src/executor/backend.rs
@@ -69,6 +69,12 @@ pub(crate) enum Backend {
         /// Always present — mutation capability is not gated on the
         /// tokenizer.
         overlay: larql_vindex::format::vindex3::knowledge::KnowledgeOverlay,
+        /// The BOS token id the container **declares**, resolved once at
+        /// bind. Every prompt this session encodes prepends it when the
+        /// tokenizer's own post-processor did not — the V2 surface gets
+        /// the same fact from its architecture, and the two must agree
+        /// (`v2_and_v3_prompt_encoders_agree_on_a_bos_requiring_model`).
+        bos_token: Option<u32>,
     },
     /// Remote server backend — queries forwarded via HTTP.
     /// Local patches can be applied for client-side overlay.

--- a/crates/larql-lql/src/executor/lifecycle/use_cmd.rs
+++ b/crates/larql-lql/src/executor/lifecycle/use_cmd.rs
@@ -189,12 +189,14 @@ impl Session {
                 }
             }
         }
+        let bos_token = crate::executor::vindex3::declared_bos_token(&path);
         self.backend = Backend::Vindex3 {
             path,
             runtime,
             tokenizer,
             knowledge,
             overlay,
+            bos_token,
         };
         self.patch_recording = None;
         self.auto_patch = false;

--- a/crates/larql-lql/src/executor/mutation/insert/compose_v3/balance.rs
+++ b/crates/larql-lql/src/executor/mutation/insert/compose_v3/balance.rs
@@ -79,6 +79,7 @@ impl Session {
         let mut best_down: Option<Vec<f32>> = None;
         let mut stale_iters = 0usize;
 
+        let bos = self.v3_bos_token();
         for _iter in 0..BALANCE_ITERS {
             let target_prob = {
                 let Backend::Vindex3 {
@@ -91,7 +92,7 @@ impl Session {
                     unreachable!("caller matched the backend");
                 };
                 let tokenizer = tokenizer.as_ref().expect("compose install had a tokenizer");
-                let prompt_ids = encode_v3_prompt(tokenizer, prompt.as_str())?;
+                let prompt_ids = encode_v3_prompt(tokenizer, prompt.as_str(), bos)?;
                 probe_target_prob(runtime, tokenizer, overlay, &prompt_ids, target)?
             };
 
@@ -135,6 +136,7 @@ impl Session {
         layer: usize,
         feature: usize,
     ) -> Result<(), LqlError> {
+        let bos = self.v3_bos_token();
         if self.installed_edges.is_empty() {
             return Ok(());
         }
@@ -159,7 +161,8 @@ impl Session {
                     .collect();
                 let mut regressed = false;
                 for fact in priors {
-                    let fact_ids = encode_v3_prompt(tokenizer, fact.canonical_prompt.as_str())?;
+                    let fact_ids =
+                        encode_v3_prompt(tokenizer, fact.canonical_prompt.as_str(), bos)?;
                     let p =
                         probe_target_prob(runtime, tokenizer, overlay, &fact_ids, &fact.target)?;
                     if p < PRIOR_FLOOR {

--- a/crates/larql-lql/src/executor/mutation/insert/compose_v3/capture.rs
+++ b/crates/larql-lql/src/executor/mutation/insert/compose_v3/capture.rs
@@ -71,8 +71,14 @@ pub(super) fn capture_layer_decoys(
         // Base program, same tap as the canonical capture — decoy
         // residuals must match the baseline the gates will be judged
         // against.
-        let residual =
-            capture_layer_residual(runtime, tokenizer, decoy_prompt.as_str(), layer, None)?;
+        let residual = capture_layer_residual(
+            runtime,
+            tokenizer,
+            decoy_prompt.as_str(),
+            layer,
+            None,
+            session.v3_bos_token(),
+        )?;
         captured.push(larql_vindex::ndarray::Array1::from_vec(residual));
     }
     Ok(Some(captured))

--- a/crates/larql-lql/src/executor/mutation/insert/compose_v3/mod.rs
+++ b/crates/larql-lql/src/executor/mutation/insert/compose_v3/mod.rs
@@ -114,6 +114,7 @@ impl Session {
         confidence: Option<f32>,
         alpha_override: Option<f32>,
     ) -> Result<Vec<String>, LqlError> {
+        let bos = self.v3_bos_token();
         let alpha_mul = alpha_override.unwrap_or(DEFAULT_INSERT_ALPHA_MUL);
         let c_score = confidence.unwrap_or(DEFAULT_INSERT_CONFIDENCE);
 
@@ -176,6 +177,7 @@ impl Session {
                 prompt.as_str(),
                 layer,
                 None,
+                bos,
             )?;
             pending_decoys = capture::capture_layer_decoys(
                 self,

--- a/crates/larql-lql/src/executor/mutation/insert/knn_v3.rs
+++ b/crates/larql-lql/src/executor/mutation/insert/knn_v3.rs
@@ -29,6 +29,7 @@ impl Session {
         layer_hint: Option<u32>,
         confidence: Option<f32>,
     ) -> Result<Vec<String>, LqlError> {
+        let bos = self.v3_bos_token();
         let (install_layer, key, target_id);
         {
             let Backend::Vindex3 {
@@ -76,6 +77,7 @@ impl Session {
                 prompt.as_str(),
                 install_layer,
                 overrides.as_ref(),
+                bos,
             )?;
         }
 

--- a/crates/larql-lql/src/executor/mutation/rebalance.rs
+++ b/crates/larql-lql/src/executor/mutation/rebalance.rs
@@ -169,6 +169,7 @@ impl Session {
         floor: f64,
         ceiling: f64,
     ) -> Result<Vec<String>, LqlError> {
+        let bos = self.v3_bos_token();
         use crate::executor::mutation::insert::probe_target_prob;
         use crate::executor::vindex3::encode_v3_prompt;
         use crate::executor::Backend;
@@ -194,7 +195,7 @@ impl Session {
                         unreachable!("dispatch matched the backend");
                     };
                     let tokenizer = tokenizer.as_ref().expect("compose install had a tokenizer");
-                    let ids = encode_v3_prompt(tokenizer, fact.canonical_prompt.as_str())?;
+                    let ids = encode_v3_prompt(tokenizer, fact.canonical_prompt.as_str(), bos)?;
                     probe_target_prob(runtime, tokenizer, overlay, &ids, &fact.target)?
                 };
                 final_probs[i] = prob;

--- a/crates/larql-lql/src/executor/query/mod.rs
+++ b/crates/larql-lql/src/executor/query/mod.rs
@@ -91,9 +91,8 @@ mod tests {
         .expect("tokenizer")
     }
 
-    #[test]
-    fn encode_vindex_prompt_prepends_gemma4_bos() {
-        let config = larql_vindex::VindexConfig {
+    fn gemma4_config() -> larql_vindex::VindexConfig {
+        larql_vindex::VindexConfig {
             family: "gemma4".into(),
             num_layers: 2,
             hidden_size: 8,
@@ -108,12 +107,54 @@ mod tests {
                 ..Default::default()
             }),
             ..Default::default()
-        };
+        }
+    }
+
+    #[test]
+    fn encode_vindex_prompt_prepends_gemma4_bos() {
         let tokenizer = tokenizer_without_bos_postprocessor();
 
-        let ids = encode_vindex_prompt(&config, &tokenizer, "hello").expect("encode");
+        let ids = encode_vindex_prompt(&gemma4_config(), &tokenizer, "hello").expect("encode");
 
         assert_eq!(ids, vec![2, 3]);
+    }
+
+    /// **The BOS blind spot.** `encode_vindex_prompt` (V2) consults the
+    /// architecture and prepends BOS where the tokenizer's
+    /// post-processor does not; `encode_v3_prompt` does a bare encode.
+    /// On a BOS-requiring model whose tokenizer.json carries no BOS
+    /// post-processor — Gemma 4 is exactly that — the two surfaces feed
+    /// the model DIFFERENT token sequences for the same user prompt.
+    ///
+    /// The compose/parity fixtures cannot see this: their synthetic
+    /// tokenizers and non-BOS architectures make both arms agree by
+    /// accident. This pins the difference directly.
+    #[test]
+    fn v2_and_v3_prompt_encoders_agree_on_a_bos_requiring_model() {
+        let tokenizer = tokenizer_without_bos_postprocessor();
+        let config = gemma4_config();
+
+        // The V3 side reads the fact the container CARRIES — the
+        // checkpoint's own generation_config.json, placed beside the
+        // segments by the M2 capability snapshot. A real Gemma 4
+        // checkpoint declares bos_token_id 2 there, which is the same
+        // id gemma4.rs's architecture hardcodes for the V2 side.
+        let container = tempfile::tempdir().unwrap();
+        std::fs::write(
+            container.path().join("generation_config.json"),
+            serde_json::json!({"bos_token_id": 2}).to_string(),
+        )
+        .unwrap();
+
+        let v2 = encode_vindex_prompt(&config, &tokenizer, "hello").expect("v2 encode");
+        let bos = crate::executor::vindex3::declared_bos_token(container.path());
+        let v3 = crate::executor::vindex3::encode_v3_prompt(&tokenizer, "hello", bos)
+            .expect("v3 encode");
+
+        assert_eq!(
+            v2, v3,
+            "the same prompt must reach both generations as the same tokens"
+        );
     }
 
     #[test]

--- a/crates/larql-lql/src/executor/vindex3.rs
+++ b/crates/larql-lql/src/executor/vindex3.rs
@@ -40,6 +40,16 @@ pub(crate) fn unsupported(what: &str) -> LqlError {
 }
 
 impl Session {
+    /// The BOS token id the bound V3 container declares, resolved once
+    /// at bind. `None` on any other backend — callers are already in a
+    /// V3 arm when they ask.
+    pub(crate) fn v3_bos_token(&self) -> Option<u32> {
+        match &self.backend {
+            Backend::Vindex3 { bos_token, .. } => *bos_token,
+            _ => None,
+        }
+    }
+
     /// `INFER` on a V3 binding. Without `GENERATE`: classic single-step
     /// top-k next-token prediction, priced from the batch-prefill
     /// logits. With `GENERATE n`: greedy autoregressive continuation
@@ -54,6 +64,7 @@ impl Session {
             runtime,
             tokenizer,
             overlay,
+            bos_token,
             ..
         } = &self.backend
         else {
@@ -66,7 +77,7 @@ impl Session {
                     .into(),
             )
         })?;
-        let prompt_ids = encode_v3_prompt(tokenizer, prompt)?;
+        let prompt_ids = encode_v3_prompt(tokenizer, prompt, *bos_token)?;
 
         let start = std::time::Instant::now();
 
@@ -424,6 +435,7 @@ impl Session {
             runtime,
             tokenizer,
             overlay,
+            bos_token,
             ..
         } = &self.backend
         else {
@@ -432,7 +444,7 @@ impl Session {
         let tokenizer = tokenizer.as_ref().ok_or_else(|| {
             LqlError::Execution("TRACE needs a tokenizer — this container carries none".into())
         })?;
-        let prompt_ids = encode_v3_prompt(tokenizer, prompt)?;
+        let prompt_ids = encode_v3_prompt(tokenizer, prompt, *bos_token)?;
 
         // TRACE observes the same effective program INFER runs — a
         // compose edit must not fork the two.
@@ -524,8 +536,9 @@ pub(crate) fn capture_layer_residual(
     prompt: &str,
     layer: usize,
     overrides: Option<&larql_inference::vindex3::OperandOverrides>,
+    bos: Option<u32>,
 ) -> Result<Vec<f32>, LqlError> {
-    let prompt_ids = encode_v3_prompt(tokenizer, prompt)?;
+    let prompt_ids = encode_v3_prompt(tokenizer, prompt, bos)?;
     let mut captured: Option<Vec<f32>> = None;
     let mut sink = |event: larql_inference::vindex3::PlaneEvent| {
         if let larql_inference::vindex3::PlaneEvent::Layer { index, trace } = event {
@@ -545,7 +558,49 @@ pub(crate) fn capture_layer_residual(
     captured.ok_or_else(|| LqlError::Execution(format!("no residual captured at layer {layer}")))
 }
 
-pub(crate) fn encode_v3_prompt(tokenizer: &Tokenizer, prompt: &str) -> Result<Vec<u32>, LqlError> {
+/// HF configs a container carries that declare the BOS token id, most
+/// authoritative first. Both arrive with the M2 capability snapshot.
+const BOS_DECLARING_FILES: [&str; 2] = ["generation_config.json", "tokenizer_config.json"];
+
+/// The BOS token id this container **declares**, or `None` when it
+/// declares none.
+///
+/// The V2 surface gets this fact from a reconstructed
+/// `ModelArchitecture` (`arch.bos_token_id()`); V3 must not rediscover
+/// architecture, so it reads the checkpoint's own declaration, carried
+/// into the container by the capability snapshot. For Gemma 4 — the
+/// architecture that needs BOS *and* omits it from the tokenizer's
+/// `TemplateProcessing.single` template — both sources say 2, which is
+/// what `v2_and_v3_prompt_encoders_agree_on_a_bos_requiring_model`
+/// pins.
+///
+/// A container predating the capability snapshot carries neither file
+/// and declares nothing; it encodes exactly as it did before.
+pub(crate) fn declared_bos_token(container: &std::path::Path) -> Option<u32> {
+    for name in BOS_DECLARING_FILES {
+        let Ok(text) = std::fs::read_to_string(container.join(name)) else {
+            continue;
+        };
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+            continue;
+        };
+        if let Some(id) = json.get("bos_token_id").and_then(|v| v.as_u64()) {
+            return u32::try_from(id).ok();
+        }
+    }
+    None
+}
+
+/// Encode a prompt for the V3 program, prepending the container's
+/// declared BOS when the tokenizer's own post-processor did not.
+///
+/// Shares `maybe_prepend_bos` with the V2 path (`encode_prompt`), so
+/// the "prepend only if missing" contract has one implementation.
+pub(crate) fn encode_v3_prompt(
+    tokenizer: &Tokenizer,
+    prompt: &str,
+    bos: Option<u32>,
+) -> Result<Vec<u32>, LqlError> {
     let encoding = tokenizer
         .encode(prompt, true)
         .map_err(|e| LqlError::Execution(format!("tokenize: {e}")))?;
@@ -553,7 +608,7 @@ pub(crate) fn encode_v3_prompt(tokenizer: &Tokenizer, prompt: &str) -> Result<Ve
     if ids.is_empty() {
         return Err(LqlError::Execution("prompt tokenises to empty".into()));
     }
-    Ok(ids)
+    Ok(larql_inference::maybe_prepend_bos(ids, bos))
 }
 
 /// Softmax over the logits, then the top-k `(token_id, probability)`
@@ -570,4 +625,65 @@ pub(crate) fn top_k_probs(logits: &[f32], k: usize) -> Vec<(u32, f32)> {
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(k);
     scored
+}
+
+#[cfg(test)]
+mod tests {
+    use super::declared_bos_token;
+
+    fn container_with(name: &str, body: serde_json::Value) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(name), body.to_string()).unwrap();
+        dir
+    }
+
+    /// The primary declaration: HF's `generation_config.json`.
+    #[test]
+    fn generation_config_declares_the_bos_token() {
+        let dir = container_with(
+            "generation_config.json",
+            serde_json::json!({"bos_token_id": 2}),
+        );
+        assert_eq!(declared_bos_token(dir.path()), Some(2));
+    }
+
+    /// `tokenizer_config.json` answers when the generation config does
+    /// not — both arrive with the capability snapshot, and older
+    /// checkpoints carry only the latter.
+    #[test]
+    fn tokenizer_config_answers_when_generation_config_is_silent() {
+        let dir = container_with(
+            "tokenizer_config.json",
+            serde_json::json!({"bos_token_id": 7, "tokenizer_class": "GPT2Tokenizer"}),
+        );
+        assert_eq!(declared_bos_token(dir.path()), Some(7));
+
+        // …and the generation config wins when both speak.
+        std::fs::write(
+            dir.path().join("generation_config.json"),
+            serde_json::json!({"bos_token_id": 2}).to_string(),
+        )
+        .unwrap();
+        assert_eq!(declared_bos_token(dir.path()), Some(2));
+    }
+
+    /// A container that declares nothing — including one predating the
+    /// capability snapshot — encodes exactly as it did before.
+    #[test]
+    fn a_container_declaring_nothing_yields_no_bos() {
+        let empty = tempfile::tempdir().unwrap();
+        assert_eq!(declared_bos_token(empty.path()), None);
+
+        let silent = container_with("generation_config.json", serde_json::json!({"top_k": 64}));
+        assert_eq!(declared_bos_token(silent.path()), None);
+    }
+
+    /// Malformed carried config is not a hard failure: the fact is
+    /// absent, the container still binds.
+    #[test]
+    fn malformed_config_is_treated_as_no_declaration() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("generation_config.json"), "{not json").unwrap();
+        assert_eq!(declared_bos_token(dir.path()), None);
+    }
 }

--- a/docs/vindex-generation-policy.md
+++ b/docs/vindex-generation-policy.md
@@ -85,6 +85,35 @@ version, the sole discriminator — no filename or shape sniffing) already
 dispatches `USE`, the server bootstrap, and `DIFF` operands, and fails
 closed on unknown schemas.
 
+## Cross-generation contract: prompt encoding
+
+A user prompt must reach both generations as the **same token sequence**.
+
+The two surfaces learn the BOS fact from different places, and that is
+deliberate:
+
+| | Source of the BOS fact |
+|---|---|
+| V2 | the reconstructed `ModelArchitecture` — `arch.bos_token_id()` |
+| V3 | the container's own carried `generation_config.json` → `tokenizer_config.json` |
+
+V3 must not reconstruct architecture, so it reads the checkpoint's own
+declaration, carried into the container by the M2 capability snapshot.
+Both then prepend through one shared contract
+(`larql_inference::maybe_prepend_bos`: prepend only when the tokenizer's
+post-processor did not already).
+
+This matters for exactly the models where the tokenizer's
+`TemplateProcessing.single` template omits BOS while the model requires
+it — Gemma 4 is the live case: architecture and `generation_config.json`
+both say id 2. Gated by
+`v2_and_v3_prompt_encoders_agree_on_a_bos_requiring_model`, whose control
+(passing no declared BOS) reproduces the pre-fix divergence `[2,3]` vs
+`[3]`.
+
+A container that declares nothing — including any predating the
+capability snapshot — encodes exactly as before.
+
 ## Rungs to the flip
 
 - **M1 — the seam. DONE** (PR #290): policy type, pinned default,


### PR DESCRIPTION
Closes the BOS blind spot between the generations before M3.

## The divergence

PR #282 routed the V2 mutation and query paths through `encode_vindex_prompt`, which prepends BOS where the architecture needs it and the tokenizer's post-processor does not. The V3 path kept a bare `tokenizer.encode`. The two merged without textual conflict and **every existing gate stayed green** — the compose/parity fixtures use synthetic tokenizers and non-BOS architectures, so both arms agreed by accident.

On a real BOS-requiring model they do not. The new gate's control reproduces it exactly:

```
same prompt →  V2: [2, 3]      V3: [3]
```

The model sees a broken prefix on one surface only. Gemma 4 is the live case: its tokenizer omits BOS from `TemplateProcessing.single` while the model requires id 2.

## The fix respects the authority split

| | Source of the BOS fact |
|---|---|
| V2 | reconstructed `ModelArchitecture` — `arch.bos_token_id()` |
| V3 | the container's carried `generation_config.json` → `tokenizer_config.json` |

V3 must not reconstruct architecture, so it reads the checkpoint's **own declaration**, carried into the container by the M2 capability snapshot. Resolved once at bind, stored on the binding, consumed by every prompt the session encodes. Both surfaces prepend through one shared contract (`maybe_prepend_bos`, now public): prepend only when the encoding does not already start with it.

A container that declares nothing — including any predating the capability snapshot — encodes exactly as before.

## Gates

The cross-generation agreement gate, **with its control verified to fail pre-fix**, plus four on the fact reader: primary source, fallback, precedence, silence, malformed config. clippy `-D warnings`, fmt, and the full larql-lql / larql-inference suites green. Contract documented in `docs/vindex-generation-policy.md`.