### PR TITLE
feat(vindex): consumer readiness — support or refuse, never invisibility (migration rung M3)

### DIFF
--- a/crates/larql-cli/src/commands/primary/slice_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/slice_cmd.rs
@@ -373,6 +373,19 @@ pub fn run(args: SliceArgs) -> Result<(), Box<dyn std::error::Error>> {
     // 1. Resolve source through the cache shorthand.
     let src = cache::resolve_model(&args.source)?;
 
+    // Slicing selects files by VINDEX2 filename patterns. A VINDEX3
+    // container's payload lives in `segments/`, so those patterns match
+    // nothing and the copy would look like a success while producing a
+    // container missing its weights. Refuse, naming the generation.
+    if let Ok(found) = larql_vindex::format::generation::detect_generation(&src) {
+        if found != larql_vindex::format::generation::ContainerGeneration::V2 {
+            return Err(larql_vindex::format::generation::unsupported_generation(
+                "slice", &src, found,
+            )
+            .into());
+        }
+    }
+
     // 2. Build requested part set (parts ∪ preset expansion).
     let mut wanted: BTreeSet<Part> = BTreeSet::new();
     if let Some(ref p) = args.preset {

--- a/crates/larql-lql/src/executor/introspection.rs
+++ b/crates/larql-lql/src/executor/introspection.rs
@@ -451,34 +451,66 @@ impl Session {
         Ok(out)
     }
 
+    /// `SHOW MODELS` — every container in the working directory, of
+    /// **either** generation.
+    ///
+    /// This listed only containers whose `index.json` parsed as a V2
+    /// config, so a VINDEX3 container in the directory silently
+    /// vanished: the user saw an empty listing beside a model they had
+    /// just extracted. Consumer readiness
+    /// (`docs/vindex-generation-policy.md`) forbids that — a container
+    /// is either understood or explicitly accounted for, never hidden —
+    /// so the listing reads the generation-neutral summary and names
+    /// the generation in its own column. A directory holding an
+    /// `index.json` this binary cannot identify is listed too, with the
+    /// reason in place of its facts.
     pub(crate) fn exec_show_models(&self) -> Result<Vec<String>, LqlError> {
+        let cwd = std::env::current_dir().unwrap_or_default();
+        Self::show_models_in(&cwd)
+    }
+
+    /// The listing itself, over an explicit directory — `SHOW MODELS`
+    /// passes the working directory. Split out so the
+    /// both-generations claim is testable without changing a
+    /// process-global cwd.
+    pub fn show_models_in(dir: &std::path::Path) -> Result<Vec<String>, LqlError> {
         let mut out = Vec::new();
         out.push(format!(
-            "{:<35} {:>10} {:>8} {:>12}",
-            "Model", "Size", "Layers", "Status"
+            "{:<35} {:>10} {:>5} {:>8} {:>12}",
+            "Model", "Size", "Gen", "Layers", "Status"
         ));
-        out.push("-".repeat(70));
+        out.push("-".repeat(75));
 
-        let cwd = std::env::current_dir().unwrap_or_default();
-        if let Ok(entries) = std::fs::read_dir(&cwd) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            let mut rows: Vec<String> = Vec::new();
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.is_dir() {
-                    let index_json = path.join(INDEX_JSON);
-                    if index_json.exists() {
-                        if let Ok(config) = larql_vindex::load_vindex_config(&path) {
-                            let size = dir_size(&path);
-                            out.push(format!(
-                                "{:<35} {:>10} {:>8} {:>12}",
-                                path.file_name().unwrap_or_default().to_string_lossy(),
-                                format_bytes(size),
-                                config.num_layers,
-                                "ready",
-                            ));
-                        }
-                    }
+                if !path.is_dir() || !path.join(INDEX_JSON).exists() {
+                    continue;
                 }
+                let name = path.file_name().unwrap_or_default().to_string_lossy();
+                let size = format_bytes(dir_size(&path));
+                rows.push(
+                    match larql_vindex::format::generation::summarize_container(&path) {
+                        Ok(summary) => format!(
+                            "{:<35} {:>10} {:>5} {:>8} {:>12}",
+                            name,
+                            size,
+                            summary.generation.schema_label(),
+                            summary.num_layers,
+                            "ready",
+                        ),
+                        // Unidentifiable, but present: say so rather than
+                        // drop the row.
+                        Err(_) => format!(
+                            "{:<35} {:>10} {:>5} {:>8} {:>12}",
+                            name, size, "?", "-", "unreadable",
+                        ),
+                    },
+                );
             }
+            rows.sort();
+            out.extend(rows);
         }
 
         if out.len() == 2 {

--- a/crates/larql-lql/src/executor/vindex3.rs
+++ b/crates/larql-lql/src/executor/vindex3.rs
@@ -21,9 +21,14 @@ use crate::executor::{Backend, Session};
 
 /// The statements a VINDEX3 binding serves today. Everything else gets
 /// [`unsupported`] — a capability refusal, not a format apology.
+/// The capability string is part of the contract, not decoration: a
+/// statement that executes on a V3 binding must appear here, or the
+/// binding is understating what it serves. EXTRACT does execute (the
+/// dispatch does not gate on the backend) and now says so.
 pub(crate) const SUPPORTED: &str = "SELECT, DESCRIBE, WALK, EXPLAIN WALK, \
-     SHOW RELATIONS/LAYERS/FEATURES/ENTITIES/PATCHES, INFER [TOP n] [GENERATE n], \
-     EXPLAIN INFER, TRACE, STATS, USE, INSERT [MODE KNN|COMPOSE], DELETE, UPDATE, MERGE, \
+     SHOW RELATIONS/LAYERS/FEATURES/ENTITIES/PATCHES/MODELS, INFER [TOP n] [GENERATE n], \
+     EXPLAIN INFER, TRACE, STATS, USE, EXTRACT [FORMAT VINDEX2|VINDEX3], \
+     INSERT [MODE KNN|COMPOSE], DELETE, UPDATE, MERGE, \
      BEGIN/SAVE/APPLY/REMOVE PATCH, COMPILE [CURRENT] INTO VINDEX, DIFF [PHYSICAL], COMPACT INTO VINDEX";
 
 /// Component id a container's text stack is bound under.

--- a/crates/larql-lql/tests/vindex3_extract.rs
+++ b/crates/larql-lql/tests/vindex3_extract.rs
@@ -181,3 +181,59 @@ fn extract_format_vindex3_refuses_a_non_checkpoint_directory() {
     .expect_err("a directory with no config.json is not a checkpoint");
     assert!(err.contains("config.json + safetensors"), "{err}");
 }
+
+// ── M3 consumer readiness: no V3 artifact silently disappears ──
+
+/// `SHOW MODELS` lists containers of BOTH generations.
+///
+/// It previously listed only directories whose `index.json` parsed as a
+/// VINDEX2 config, so a V3 container in the working directory vanished
+/// from the listing entirely — the user saw nothing beside a model they
+/// had just extracted. Invisibility is not an allowed consumer state:
+/// a container is understood, or explicitly accounted for.
+#[test]
+fn show_models_lists_both_generations_and_never_hides_one() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // A real V3 container, produced the way M2 produces them.
+    let checkpoint = checkpoint_with_tokenizer();
+    let mut session = Session::new();
+    extract_v3(
+        &mut session,
+        checkpoint.path(),
+        &dir.path().join("v3-model"),
+    );
+
+    // A V2 container beside it (index.json is the listing's whole input).
+    std::fs::create_dir(dir.path().join("v2-model")).unwrap();
+    std::fs::write(
+        dir.path().join("v2-model").join("index.json"),
+        r#"{"version":2,"model":"legacy","num_layers":34}"#,
+    )
+    .unwrap();
+
+    // And a directory holding an index.json this binary cannot identify.
+    std::fs::create_dir(dir.path().join("mystery")).unwrap();
+    std::fs::write(dir.path().join("mystery").join("index.json"), "{}").unwrap();
+
+    let listing = larql_lql::Session::show_models_in(dir.path())
+        .expect("listing")
+        .join("\n");
+
+    assert!(
+        listing.contains("v3-model"),
+        "V3 must be listed:\n{listing}"
+    );
+    assert!(
+        listing.contains("v2-model"),
+        "V2 must be listed:\n{listing}"
+    );
+    assert!(
+        listing.contains("mystery"),
+        "an unidentifiable container is accounted for, not dropped:\n{listing}"
+    );
+    // The generation is named, so V2 is not the implicit normal case.
+    assert!(listing.contains("v3"), "{listing}");
+    assert!(listing.contains("v2"), "{listing}");
+    assert!(listing.contains("unreadable"), "{listing}");
+}

--- a/crates/larql-server/src/routes/models.rs
+++ b/crates/larql-server/src/routes/models.rs
@@ -37,7 +37,9 @@ const MODEL_OBJECT: &str = "model";
 const LIST_OBJECT: &str = "list";
 const OWNED_BY: &str = "larql";
 /// larql-specific `generation` marker for VINDEX3 containers.
-const V3_GENERATION: u32 = 3;
+/// Reported as `generation` on a V3 entry. Sourced from the format
+/// crate so the API and the container's own marker cannot drift.
+const V3_GENERATION: u32 = larql_vindex::format::generation::ContainerGeneration::V3.number();
 
 /// Returns the boot-time of this server in unix seconds. Used as the
 /// `created` field for every loaded model — close enough to the
@@ -80,8 +82,14 @@ pub async fn handle_models(State(state): State<Arc<AppState>>) -> Json<serde_jso
 }
 
 /// One list/retrieve entry for a V2 model. Extras beyond the OpenAI
-/// contract (`path`, `features`, `loaded`) are larql-specific and
-/// ignored by compatible clients.
+/// contract (`path`, `generation`, `features`, `loaded`) are
+/// larql-specific and ignored by compatible clients.
+///
+/// `generation` is reported for **both** classes. Emitting it only for
+/// V3 made V2 the implicit normal case and V3 the special one, so a
+/// client could not tell "generation 2" from "this server predates the
+/// field" without knowing larql's release history. Discovery states the
+/// generation of everything it lists.
 fn v2_entry(m: &LoadedModel, created: u64, multi: bool) -> serde_json::Value {
     let total_features: usize = m.config.layers.iter().map(|l| l.num_features).sum();
     serde_json::json!({
@@ -90,6 +98,7 @@ fn v2_entry(m: &LoadedModel, created: u64, multi: bool) -> serde_json::Value {
         "created": created,
         "owned_by": OWNED_BY,
         "path": model_path(&m.id, multi),
+        "generation": larql_vindex::format::generation::ContainerGeneration::V2.number(),
         "features": total_features,
         "loaded": true,
     })

--- a/crates/larql-vindex/src/format/generation.rs
+++ b/crates/larql-vindex/src/format/generation.rs
@@ -122,6 +122,22 @@ impl ContainerGeneration {
         }
     }
 
+    /// Short label for tables and API fields — "v2" / "v3".
+    pub const fn schema_label(self) -> &'static str {
+        match self {
+            Self::V2 => "v2",
+            Self::V3 => "v3",
+        }
+    }
+
+    /// The generation number, for APIs that report it numerically.
+    pub const fn number(self) -> u32 {
+        match self {
+            Self::V2 => 2,
+            Self::V3 => 3,
+        }
+    }
+
     /// Human-readable name used in diagnostics — "VINDEX2" / "VINDEX3".
     pub const fn name(self) -> &'static str {
         match self {
@@ -266,6 +282,71 @@ pub fn detect_generation(dir: &Path) -> Result<ContainerGeneration, VindexError>
             ),
         }),
     }
+}
+
+/// The refusal a consumer owes a container generation it does not
+/// implement.
+///
+/// Consumer readiness has three allowed states — supports, explicitly
+/// refuses, or is not reached — and "silently does nothing" is not one
+/// of them. A V2-only verb that meets a V3 container must say which
+/// verb, which container, and which generation, so the user can act;
+/// "not found" and an empty listing are both failures of this contract.
+///
+/// Prefer this over hand-rolled strings: one wording means one thing to
+/// grep for when the flip lands and these refusals start turning into
+/// implementations.
+pub fn unsupported_generation(op: &str, dir: &Path, found: ContainerGeneration) -> VindexError {
+    VindexError::Parse(format!(
+        "{op} does not support {} containers yet; {} is generation {}",
+        found.name(),
+        dir.display(),
+        found.schema_label(),
+    ))
+}
+
+/// A container's identity, readable without knowing its generation.
+///
+/// The consumer-readiness rule (`docs/vindex-generation-policy.md`) is
+/// that no VINDEX3 artifact may enter the system and then silently
+/// disappear from a listing. Listing surfaces therefore need one fact
+/// source that answers for both generations — otherwise each surface
+/// grows its own `match generation` and V3 falls out of whichever one
+/// nobody updated.
+#[derive(Debug, Clone)]
+pub struct ContainerSummary {
+    pub generation: ContainerGeneration,
+    /// The model identity the container names itself by.
+    pub model: String,
+    pub num_layers: usize,
+}
+
+/// Read one container's identity, whichever generation it holds.
+///
+/// Both generations record model and layer count in `index.json`, so
+/// this stays a single small read — cheap enough for a directory scan,
+/// and it never opens segments or builds a plan.
+pub fn summarize_container(dir: &Path) -> Result<ContainerSummary, VindexError> {
+    let generation = detect_generation(dir)?;
+    let text = std::fs::read_to_string(dir.join(INDEX_JSON))?;
+    let probe: IdentityProbe =
+        serde_json::from_str(&text).map_err(|e| VindexError::Parse(e.to_string()))?;
+    Ok(ContainerSummary {
+        generation,
+        model: probe.model.unwrap_or_default(),
+        num_layers: probe.num_layers.unwrap_or(0),
+    })
+}
+
+/// The identity fields both generations spell the same way in
+/// `index.json`. Optional throughout: a container missing one is
+/// listed with the field blank, never hidden.
+#[derive(serde::Deserialize)]
+struct IdentityProbe {
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    num_layers: Option<usize>,
 }
 
 /// Minimal view over `index.json` — the version field and nothing else.

--- a/crates/larql-vindex/src/format/generation_tests.rs
+++ b/crates/larql-vindex/src/format/generation_tests.rs
@@ -307,3 +307,46 @@ fn explicit_generation_requests_are_never_overridden() {
         ContainerGeneration::V3,
     );
 }
+
+/// The listing fact source answers for BOTH generations — the enabler
+/// for "no V3 artifact silently disappears from a consumer surface".
+#[test]
+fn summarize_container_reads_either_generation() {
+    use super::generation::summarize_container;
+
+    let v2 = temp_dir("summary-v2");
+    std::fs::write(
+        v2.join(INDEX_JSON),
+        r#"{"version":2,"model":"gemma-3-4b","num_layers":34}"#,
+    )
+    .unwrap();
+    let s = summarize_container(&v2).unwrap();
+    assert_eq!(s.generation, ContainerGeneration::V2);
+    assert_eq!(s.model, "gemma-3-4b");
+    assert_eq!(s.num_layers, 34);
+
+    let v3 = temp_dir("summary-v3");
+    std::fs::write(
+        v3.join(INDEX_JSON),
+        r#"{"version":4,"model":"granite-4.1-3b","num_layers":40}"#,
+    )
+    .unwrap();
+    let s = summarize_container(&v3).unwrap();
+    assert_eq!(s.generation, ContainerGeneration::V3);
+    assert_eq!(s.model, "granite-4.1-3b");
+    assert_eq!(s.num_layers, 40);
+}
+
+/// A container missing identity fields is listed with them blank —
+/// never hidden, and never a hard failure.
+#[test]
+fn summarize_container_tolerates_missing_identity_fields() {
+    use super::generation::summarize_container;
+
+    let dir = temp_dir("summary-sparse");
+    std::fs::write(dir.join(INDEX_JSON), r#"{"version":4}"#).unwrap();
+    let s = summarize_container(&dir).unwrap();
+    assert_eq!(s.generation, ContainerGeneration::V3);
+    assert!(s.model.is_empty());
+    assert_eq!(s.num_layers, 0);
+}

--- a/crates/larql-vindex/src/quant/convert.rs
+++ b/crates/larql-vindex/src/quant/convert.rs
@@ -242,6 +242,21 @@ pub fn vindex_to_fp4(
     std::fs::create_dir_all(&dst_tmp)
         .map_err(|e| VindexError::Parse(format!("create staging dir: {e}")))?;
 
+    // The converter transcodes VINDEX2 tensors named by the V2 layout.
+    // A V3 container's payload lives in framed segments, so parsing its
+    // index.json as a V2 config fails deep inside serde with a message
+    // about a missing field rather than about the generation. Refuse up
+    // front, naming it.
+    if let Ok(found) = crate::format::generation::detect_generation(src) {
+        if found != crate::format::generation::ContainerGeneration::V2 {
+            return Err(crate::format::generation::unsupported_generation(
+                "quantisation conversion",
+                src,
+                found,
+            ));
+        }
+    }
+
     // Parse source config.
     let mut src_config: VindexConfig = serde_json::from_str(
         &std::fs::read_to_string(src.join(INDEX_JSON))

--- a/docs/vindex-generation-policy.md
+++ b/docs/vindex-generation-policy.md
@@ -114,6 +114,49 @@ both say id 2. Gated by
 A container that declares nothing — including any predating the
 capability snapshot — encodes exactly as before.
 
+## Consumer matrix (M3)
+
+**Acceptance criterion: no VINDEX3 artifact can enter the system and
+then silently disappear from a consumer surface.** Every consumer is in
+one of two states — *supports*, or *refuses explicitly, naming the
+generation*. "Hidden", "not found", and an empty listing are failures of
+this contract, not neutral outcomes.
+
+| Consumer | V3 state | How |
+|---|---|---|
+| `USE` / binding | supports | `detect_generation`, bind-once |
+| `INFER` / `TRACE` / browse / mutation / lifecycle | supports | the V3 statement arms |
+| `EXTRACT ... FORMAT VINDEX3` | supports | M2's shared encode pipeline |
+| `SHOW MODELS` | supports | `summarize_container`, generation column |
+| `/v1/models` | supports | `generation` reported for **both** classes |
+| `larql vindex3 *` | supports | V3-native verbs |
+| `link` | supports | aliasing is generation-agnostic |
+| `run` | explicit refuse | `load_vindex_config` names the generation |
+| Vindexfile `FROM` | explicit refuse | `load_vindex_config` names the generation |
+| `publish` | explicit refuse | `load_vindex_config` names the generation |
+| `slice` | explicit refuse | `unsupported_generation("slice", …)` |
+| quantisation conversion | explicit refuse | `unsupported_generation(…)` |
+
+Two of these were genuine defects rather than gaps:
+
+- **`SHOW MODELS` hid V3 containers.** It listed only directories whose
+  `index.json` parsed as a V2 config, so a container the user had just
+  extracted did not appear at all. It now reads the generation-neutral
+  `summarize_container`, names the generation in its own column, and
+  lists a container it cannot identify as `unreadable` rather than
+  dropping the row.
+- **`slice` and quantisation conversion would have produced wrong
+  output**, not an error: both select or parse by V2 layout, so a V3
+  container yields a copy missing its weights, or a serde error about a
+  missing field rather than about the generation. Both now refuse up
+  front through `unsupported_generation`, one wording to grep for when
+  these refusals start becoming implementations.
+
+Capability strings are part of this contract. The V3 `SUPPORTED` string
+lists `EXTRACT` and `SHOW MODELS`, which execute on a V3 binding and
+previously went unadvertised — a binding that understates what it serves
+is the same class of problem as a listing that hides what exists.
+
 ## Rungs to the flip
 
 - **M1 — the seam. DONE** (PR #290): policy type, pinned default,
@@ -124,10 +167,8 @@ capability snapshot — encodes exactly as before.
   `--generation v3`, capability snapshot closing the tokenizer/HF
   metadata gap on all three producers, post-extract auto-bind through
   `USE`'s own binding block.
-- **M3 — consumer readiness.** V2-only consumers either route by
-  detection or refuse by name: `SHOW MODELS` must list V3 containers,
-  `run`/`walk`/`describe`/`stats`, Vindexfile `FROM`, slice/publish/link,
-  quant converters; `/v1/models` reports `generation` for both.
+- **M3 — consumer readiness. DONE**: every consumer supports V3 or
+  refuses naming the generation; see the consumer matrix above.
 - **M4 — the flip.** `DEFAULT_EXTRACTION_GENERATION = V3` + the pinned
   test, in one commit. V2 becomes the explicitly-requested compatibility
   generation. Evidence rows required by then: the real-model compose


### PR DESCRIPTION
Rung M3 of the VINDEX2→VINDEX3 migration ladder. Every consumer of a container is now in one of two declared states: **supports VINDEX3**, or **refuses it explicitly and names the generation**. "Hidden", "not found", and an empty listing stop being outcomes.

## Acceptance criterion

> No VINDEX3 artifact can enter the system and then silently disappear from a consumer surface.

| Consumer | V3 state | How |
|---|---|---|
| `USE` / binding | supports | `detect_generation`, bind-once |
| `INFER`/`TRACE`/browse/mutation/lifecycle | supports | the V3 statement arms |
| `EXTRACT ... FORMAT VINDEX3` | supports | M2's shared encode pipeline |
| `SHOW MODELS` | **supports (was hidden)** | `summarize_container`, generation column |
| `/v1/models` | supports | `generation` reported for **both** classes |
| `larql vindex3 *` | supports | V3-native verbs |
| `link` | supports | aliasing is generation-agnostic |
| `run` | explicit refuse | `load_vindex_config` names the generation |
| Vindexfile `FROM` | explicit refuse | `load_vindex_config` names the generation |
| `publish` | explicit refuse | `load_vindex_config` names the generation |
| `slice` | **explicit refuse (was wrong output)** | `unsupported_generation` |
| quantisation conversion | **explicit refuse (was wrong error)** | `unsupported_generation` |

## Two of these were defects, not gaps

**`SHOW MODELS` hid V3 containers.** It listed only directories whose `index.json` parsed as a VINDEX2 config, so a container the user had just extracted did not appear at all — an empty listing beside a model that plainly existed. It now reads a generation-neutral summary, names the generation in its own column, and lists a container it cannot identify as `unreadable` rather than dropping the row. The listing moved to `Session::show_models_in(dir)` because the old function read a process-global cwd and no test could reach it.

**`slice` and quantisation conversion would have produced wrong output, not an error.** slice matches V2 filename patterns, so a V3 container yields a copy missing its weights *while reporting success*; the quant converter parses a V3 `index.json` as a V2 config and fails deep in serde about a missing field rather than about the generation.

## Shared pieces

In `format::generation`, so no consumer needs V2/V3 internals: `summarize_container` reads model and layer count from either generation's `index.json` (both spell the fields identically, so it stays one small read), and `unsupported_generation` gives every refusal one wording — one thing to grep for when these refusals start becoming implementations.

`/v1/models` previously emitted `generation` only for V3, making V2 the implicit normal case: a client could not tell "generation 2" from "this server predates the field". The V3 constant now comes from `ContainerGeneration::V3.number()` so the API and the container's own marker cannot drift.

The V3 `SUPPORTED` string lists `EXTRACT` and `SHOW MODELS` — both execute on a V3 binding and neither was advertised. A binding that understates what it serves is the same class of problem as a listing that hides what exists.

## Gates

Both-generations listing including the unidentifiable row; the summary reader across V2, V3, and a container missing its identity fields. clippy `-D warnings`, fmt, and the full larql-vindex / larql-lql / larql-server / larql-cli suites green, re-verified after rebase onto `29d65cba`.

Matrix documented in `docs/vindex-generation-policy.md`. The default is still unmoved — `Auto` resolves to V2; that is **M4**.