### PR TITLE
perf(vindex3): V3-SERVE-2 — batched prefill populates KV, no second traversal

### DIFF
--- a/crates/larql-server/CHANGELOG.md
+++ b/crates/larql-server/CHANGELOG.md
@@ -6,6 +6,53 @@ The format follows the conventions of [Keep a Changelog](https://keepachangelog.
 with dated entries (`YYYY-MM-DD`) instead of semantic versions during the
 pre-1.0 phase. Forward-looking work lives in [`ROADMAP.md`](ROADMAP.md).
 
+## [2026-08-23] — V3-SERVE-2: batched prefill populates KV; the next cost is now visible
+
+`PlanBackend::attention` returns `AttentionOut { outputs, keys, values }`.
+The batched realisation always computed the conditioned K/V rows — it
+must, to attend at all — and then discarded them, which is what forced a
+caller wanting a populated cache down the per-position path. "I want KV"
+no longer implies "run attention one position at a time".
+
+**Proven before the trait moved.** `exec/tests/attention_kv_parity.rs`
+showed the two realisations agree **bit-for-bit** on K, V and outputs —
+reference (the semantic anchor, sharing no arithmetic with
+`larql-compute`) and production, every layer, and all 40 layers of a
+real Granite container. With a control that fires on a perturbed input,
+because `max_abs = 0` everywhere looks the same as an inert harness.
+
+**Measured** (Granite 4.1 3B, battery, `prefill_into`):
+
+| prompt | post-2B | post-2C | gain |
+|---|---|---|---|
+| 5 | 0.448 s | 0.442 s | 1.01x |
+| 64 | 4.099 s | 3.428 s | 1.20x |
+| 325 | 34.587 s | 25.024 s | **1.38x** |
+
+Prefill rate 8.56 → **12.09 tok/s** (64 → 325). No change at n=5 with a
+gain that grows in n is the signature of fixing a per-position
+realisation; drift would have moved all three points.
+
+**What this exposed.** Same session, same power state, the CLI's
+batched path runs 19.50 tok/s over 64 → 256 where the server's prefill
+runs 11.37 — **1.72x** still outstanding. (The 21.4 tok/s CLI figure
+quoted earlier was taken on AC; re-measuring it on battery is what makes
+the comparison honest.) Both now run the same batched attention, so the
+remainder is what the server does *around* it — `kv.append` per position
+per layer and whatever `CanonicalKvState` costs to store a row. That was
+invisible while per-position attention dominated, and it is the next
+thing to measure.
+
+**Deliberately not done.** A *resumed* prefill still steps: a batched
+pass conditions position `p` as the `p`-th token of the sequence it is
+handed, so it cannot express a prefill starting part-way through one.
+The continuation-parity gate now straddles both branches — the
+whole-prompt arm takes the batched path, the split arm's second chunk
+takes the stepped one, and they must agree bit-for-bit.
+
+N1 post-2C: 20.75 s → 8.63 s (**2.40x**) on the frozen ledger, with the
+cached prefix still resuming (25 / 50 / 71 tokens).
+
 ## [2026-08-23] — N1 measured post-2B: 2.4x, and a claim of mine corrected
 
 Taken **before** 2C, because 2B has created an intermediate state that

--- a/crates/larql-server/ROADMAP.md
+++ b/crates/larql-server/ROADMAP.md
@@ -157,82 +157,56 @@ it. Confirmed on two real models — gpt-oss-20b 31.93 s → 0.75 s
 `session_with_kv` collapsing to 0.000 s on both. See
 [`CHANGELOG.md`](CHANGELOG.md).
 
-**V3-SERVE-2. Batched prefill that also populates KV, with no second
-replay.** The only remaining server-side performance problem, and now
-an isolated one: with operands resident, prefill is **99.6%** of a
-325-token request and time-to-first-token is entirely prefill-bound.
+**V3-SERVE-2. Batched prefill that also populates KV — DONE, and it
+exposed the next cost.** `PlanBackend::attention` now returns
+`AttentionOut { outputs, keys, values }`: the batched realisation always
+computed the conditioned rows and discarded them, which is what forced a
+caller wanting a populated cache down the per-position path. The two
+axes are now independent, and a fresh prefill takes the batched
+realisation and populates the provider from the one traversal it
+already performs.
 
-V3-SERVE-1 removed a constant and deliberately left this alone, which
-is what makes it independently measurable (Granite 4.1 3B, both arms in
-one process):
+Proven before the trait moved: the batched and per-position
+realisations agree **bit-for-bit** on K, V and outputs — reference and
+production backends, every layer, and all 40 layers of a real Granite
+container (`exec/tests/attention_kv_parity.rs`, with a control that
+fires on a perturbed input so the zeros are agreement rather than an
+inert harness).
 
-```text
-prefill rate      before    after       fixed prefill term
-  5 ->  64        19.61     16.16       3.897 s -> 0.139 s
- 64 -> 325         9.07      8.56
-```
-
-The slope did not move — residency does not touch per-token arithmetic —
-and it still halves with prompt length.
-
-**The defect is a coupling, not a slow kernel.** `traverse`'s `kv`
-argument silently *switches the attention realisation*: `None` runs
-batched attention (the `larql vindex3 exec` path, ~21 tok/s class),
-`Some` runs the decode step's per-position arithmetic — because that is
-the only realisation which happens to fill the provider. So "I want the
-KV populated" currently implies "run attention one position at a time",
-and that implication is the bug.
-
-The API should express two **independent** dimensions:
+Measured on Granite 4.1 3B, battery, prefill_into:
 
 ```text
-attention realization        KV behaviour
-  Batched                      None
-  DecodeStep                   Populate(&mut kv)
-                               Continue(&mut kv)
+prompt      post-2B    post-2C    gain
+     5      0.448 s    0.442 s    1.01x
+    64      4.099 s    3.428 s    1.20x
+   325     34.587 s   25.024 s    1.38x
+
+prefill rate    post-2B   post-2C
+  5 ->  64       16.16     19.76  tok/s
+ 64 -> 325        8.56     12.09  tok/s
 ```
 
-so a prefill reads as `{ realization: Batched, kv: Populate(..) }`
-rather than as today's accidental `kv.is_some() ⇒ per-position`. That
-separation is also what V3-DECOUPLE needs: an attention slice with an
-explicit KV contract is only expressible once the two axes are
-independent.
+No change at n=5 and a gain that grows with n is the signature of
+fixing a per-position realisation — a thermal or power drift would have
+moved all three points.
 
-Wanted — the KV rows as an **output of the same forward**, never a
-batched pass plus a replay to build the cache, which would be the
-double-work defect again in a new place:
+**The remaining gap is no longer attention.** Measured in the same
+session and power state, `larql vindex3 exec`'s batched path runs
+19.50 tok/s over 64 → 256 where the server's prefill runs 11.37 — still
+**1.72x**. (An earlier 21.4 tok/s figure for the CLI was taken on AC;
+re-measuring it on battery is what makes this comparison honest.) Both
+now run the same batched attention, so the difference is what the
+server does *around* it: populating the provider — `kv.append` per
+position per layer, and whatever `CanonicalKvState` does to store a
+row. That is the next thing to measure, and it was invisible while
+per-position attention dominated.
 
-```text
-prepared operands
-        ↓
-batched prefill
-        ├── hidden / output
-        └── KV population for positions [0..N)
-        ↓
-decode
-```
-
-Frozen gates:
-
-- exact logits / generated-token parity with the present KV-filling
-  prefill;
-- KV parity for continuation — the rows a resumed session reads must be
-  the rows it would have read;
-- N1 continuation still resumes, bit-identically;
-- **one traversal of the prompt, one attention realisation, KV
-  populated during that traversal** — no batched pass plus a replay to
-  build the cache, which would be the double-work defect again in a new
-  place. Assert it structurally, the way residency is asserted through
-  `OperandStore::load_count`, not with a stopwatch: a timing-only check
-  passes a batch-then-replay implementation that happens to be fast;
-- prompt-length slope improves materially toward the direct
-  `vindex3 exec` batched class;
-- V3-SERVE-1's fixed-cost win intact — re-run the phase profiler and
-  show `session_open` still 0.000 s and the fixed prefill term still
-  ~0.1 s.
-
-Do not touch 2B while doing it. The two wins are cleanly separated
-right now; combining them would forfeit the ability to attribute either.
+Not done, and deliberately: a **resumed** prefill still steps. A
+batched pass conditions position `p` as the `p`-th token of the
+sequence it is handed, so it cannot express a prefill that starts
+part-way through one. Giving `AttentionCall` an absolute-position base
+would lift that, and would matter for long-history N1 resumes; it is
+its own rung.
 
 **V3-SERVE-3. Backend injection.** The server hardcodes
 `ProductionBackend::new()`, so serving cannot use the Metal backend
@@ -299,14 +273,18 @@ the end, because each rung changes what the previous measurement meant:
 | pre-2B (gemma-2-2b) | 41.75 s | 41.14 s | 1.5% — inside noise |
 | post-2B (gpt-oss-20b) | 45.02 s | 18.77 s | **2.40x** |
 | post-2B (granite-4.1-3b) | 15.94 s | 7.69 s | **2.07x** |
-| post-2C | — | — | to measure |
+| post-2C (granite-4.1-3b) | 20.75 s | 8.63 s | **2.40x** |
 
 N1 was never broken; it was masked by ~7 s of per-request model
-materialisation. The post-2C row matters because 2C may *reduce* N1's
-absolute saving — if prefill gets 2–3x faster, skipping 100 cached
-tokens buys less wall time — while leaving it valuable for long
-histories and TTFT. Taking the middle row now is what keeps those two
-effects separable.
+materialisation. The post-2C row was expected to *shrink* N1's absolute
+saving — faster prefill means less to skip — and on the ratio it did
+not (2.07x → 2.40x). Read it cautiously: the cache-off arm's first turn
+was an outlier (6.63 s against ~2 s in every other run of it), which
+inflates that arm's total, and the runs are minutes apart on battery.
+What is solid is the shape, which is what the row was taken for: with
+the cache, turn time stays near new-turn cost; without it, it grows
+with history. N1 survives 2C as a structural win rather than a
+workaround for slow prefill.
 
 A longest-common-prefix resume is worth reconsidering after 2C, on the
 post-2C numbers, not before.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -202,6 +202,24 @@ pub struct BiasCall<'a> {
 /// interpreter — because the judged gate reads that same vector, and
 /// handing the backend one operand for both uses removes any chance of
 /// the two drifting apart.
+/// What a whole-sequence attention pass produces.
+///
+/// `outputs[p]` is position `p`'s attention output post
+/// output-projection; `keys[p]` / `values[p]` are the conditioned rows
+/// for that position — the rows a [`KvState`](super::kv::KvState)
+/// provider caches, in the same form [`PlanBackend::attention_step`]
+/// returns.
+///
+/// Positions are the sequence's own, starting at zero: a batched pass
+/// conditions position `p` as the `p`-th token, so it cannot express a
+/// prefill resuming part-way through a sequence. That is why the
+/// executor still steps when extending a populated provider.
+pub struct AttentionOut {
+    pub outputs: Vec<Vec<f32>>,
+    pub keys: Vec<Vec<f32>>,
+    pub values: Vec<Vec<f32>>,
+}
+
 pub struct AttentionCall<'a> {
     pub inputs: &'a [Vec<f32>],
     pub hidden: usize,
@@ -395,9 +413,20 @@ pub trait PlanBackend: Sync {
     /// rather than borrow another backend's arithmetic.
     fn project(&self, call: ProjectCall<'_>) -> Result<Vec<f32>, VindexError>;
 
-    /// Attention over the whole sequence, returning one output vector per
-    /// position (post output-projection).
-    fn attention(&self, call: AttentionCall<'_>) -> Result<Vec<Vec<f32>>, VindexError>;
+    /// Attention over the whole sequence.
+    ///
+    /// Returns the conditioned K/V rows alongside the outputs because
+    /// the realisation already computes them: it must, to attend at
+    /// all. Discarding them is what forced a caller that wanted a
+    /// populated K/V cache down [`Self::attention_step`] instead —
+    /// coupling "I want KV" to "run attention one position at a time"
+    /// (V3-SERVE-2).
+    ///
+    /// The rows must be the same rows [`Self::attention_step`] would
+    /// produce for the same position and input; both realisations of a
+    /// backend answer for one program, and the attention-parity gates
+    /// pin them together.
+    fn attention(&self, call: AttentionCall<'_>) -> Result<AttentionOut, VindexError>;
 
     /// One position's attention against cached K/V — the decode step.
     ///

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
@@ -47,9 +47,9 @@ use larql_compute::backend::MatMul;
 use larql_models::config::{Activation, GateActivation, GateCombine, GatePlacement, GateSource};
 
 use super::backend::{
-    AttentionCall, AttentionStepCall, AttentionStepOut, DispatchStats, FfnCall, GateCall,
-    MatrixClass, NormCall, PlanBackend, ProjectCall, ProjectedQkv, RoutedFfnCall, WeightFormat,
-    WeightFormats, WeightSlice,
+    AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, DispatchStats, FfnCall,
+    GateCall, MatrixClass, NormCall, PlanBackend, ProjectCall, ProjectedQkv, RoutedFfnCall,
+    WeightFormat, WeightFormats, WeightSlice,
 };
 use super::production::{
     add_expert_bias, add_output_bias, add_projection_biases, aggregate_heads,
@@ -367,7 +367,7 @@ impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
         self.gemv(call.weight, call.out_dim, call.in_dim, call.x)
     }
 
-    fn attention(&self, call: AttentionCall<'_>) -> Result<Vec<Vec<f32>>, VindexError> {
+    fn attention(&self, call: AttentionCall<'_>) -> Result<AttentionOut, VindexError> {
         // Same structure as the production backend's attention; the only
         // substitution is which arithmetic performs each projection.
         // Projections stay serial over positions here — the GPU queue is
@@ -424,7 +424,11 @@ impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
             add_output_bias(&call, &mut projected);
             out.push(projected);
         }
-        Ok(out)
+        Ok(AttentionOut {
+            outputs: out,
+            keys,
+            values,
+        })
     }
 
     fn attention_step(&self, step: AttentionStepCall<'_>) -> Result<AttentionStepOut, VindexError> {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -420,7 +420,30 @@ fn execute_layer<B: PlanBackend + ?Sized, K: KvState + ?Sized>(
         .par_iter()
         .map(|row| prepared.pre_attention.apply(backend, row))
         .collect();
+    // V3-SERVE-2: the attention realisation and the K/V behaviour are
+    // separate decisions. Wanting a populated provider does not mean
+    // wanting per-position arithmetic — the batched pass computes the
+    // same conditioned rows and now returns them, so it can populate the
+    // provider from the one traversal it already performs.
+    //
+    // The exception is not a preference but an expressibility limit: a
+    // batched pass conditions position `p` as the `p`-th token of the
+    // sequence it is given, so it cannot serve a prefill that resumes
+    // part-way through one. Extending a populated provider therefore
+    // still steps.
     let attn_out = match kv {
+        Some((kv, layer_index)) if kv.position() == 0 => {
+            let out = backend.attention(prepared.attention.call(
+                &layer.attention,
+                &inputs,
+                layer.pre_attention_norm.eps,
+                hidden,
+            ))?;
+            for (key, value) in out.keys.into_iter().zip(out.values) {
+                kv.append(layer_index, key, value);
+            }
+            out.outputs
+        }
         Some((kv, layer_index)) => attention_into_kv(
             &layer.attention,
             &prepared.attention,
@@ -431,12 +454,16 @@ fn execute_layer<B: PlanBackend + ?Sized, K: KvState + ?Sized>(
             kv,
             layer_index,
         )?,
-        None => backend.attention(prepared.attention.call(
-            &layer.attention,
-            &inputs,
-            layer.pre_attention_norm.eps,
-            hidden,
-        ))?,
+        None => {
+            backend
+                .attention(prepared.attention.call(
+                    &layer.attention,
+                    &inputs,
+                    layer.pre_attention_norm.eps,
+                    hidden,
+                ))?
+                .outputs
+        }
     };
     h.par_iter_mut()
         .zip(attn_out.par_iter())

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -35,8 +35,8 @@ use larql_compute::MoeGateRule;
 
 use super::super::super::graph::policy::AttentionSpan;
 use super::backend::{
-    AttentionCall, AttentionStepCall, AttentionStepOut, FfnCall, GateCall, NormCall, PlanBackend,
-    ProjectCall, ProjectedQkv, QkNormCall, RoutedFfnCall,
+    AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, FfnCall, GateCall, NormCall,
+    PlanBackend, ProjectCall, ProjectedQkv, QkNormCall, RoutedFfnCall,
 };
 use super::kernels::{rope_rotate, rope_rotate_scaled};
 use larql_compute::attention::rope::{
@@ -546,7 +546,7 @@ impl PlanBackend for ProductionBackend {
         ))
     }
 
-    fn attention(&self, call: AttentionCall<'_>) -> Result<Vec<Vec<f32>>, VindexError> {
+    fn attention(&self, call: AttentionCall<'_>) -> Result<AttentionOut, VindexError> {
         // Positions are independent, so projection runs in parallel with
         // each position's arithmetic untouched — bit-identical to the
         // serial order.
@@ -567,7 +567,7 @@ impl PlanBackend for ProductionBackend {
 
         // Each query position reads every position's K/V but writes only
         // its own output row — parallel over queries, arithmetic intact.
-        queries
+        let outputs: Vec<Vec<f32>> = queries
             .par_iter()
             .enumerate()
             .map(|(position, query)| {
@@ -580,7 +580,12 @@ impl PlanBackend for ProductionBackend {
                     &call.inputs[position],
                 )
             })
-            .collect()
+            .collect::<Result<_, VindexError>>()?;
+        Ok(AttentionOut {
+            outputs,
+            keys,
+            values,
+        })
     }
 
     fn attention_step(&self, step: AttentionStepCall<'_>) -> Result<AttentionStepOut, VindexError> {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
@@ -18,8 +18,8 @@ use larql_models::config::{
 
 use super::super::super::graph::policy::AttentionSpan;
 use super::backend::{
-    AttentionCall, AttentionStepCall, AttentionStepOut, FfnCall, GateCall, NormCall, PlanBackend,
-    ProjectCall, ProjectedQkv, QkNormCall, RoutedFfnCall,
+    AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, FfnCall, GateCall, NormCall,
+    PlanBackend, ProjectCall, ProjectedQkv, QkNormCall, RoutedFfnCall,
 };
 use super::kernels::{
     activate, matvec, norm, partial_rotary_frequencies, partial_rotary_slice, rope_rotate,
@@ -413,7 +413,7 @@ impl PlanBackend for ReferenceBackend {
         ))
     }
 
-    fn attention(&self, call: AttentionCall<'_>) -> Result<Vec<Vec<f32>>, VindexError> {
+    fn attention(&self, call: AttentionCall<'_>) -> Result<AttentionOut, VindexError> {
         // Projections per position, with QK normalisation, query scale
         // and position encoding applied in the judged order. Positions
         // are independent, so they run in parallel with each position's
@@ -435,7 +435,7 @@ impl PlanBackend for ReferenceBackend {
 
         // Each query position reads every position's K/V but writes only
         // its own output row — parallel over queries, arithmetic intact.
-        queries
+        let outputs: Vec<Vec<f32>> = queries
             .par_iter()
             .enumerate()
             .map(|(position, query)| {
@@ -448,7 +448,12 @@ impl PlanBackend for ReferenceBackend {
                     &call.inputs[position],
                 )
             })
-            .collect()
+            .collect::<Result<_, VindexError>>()?;
+        Ok(AttentionOut {
+            outputs,
+            keys,
+            values,
+        })
     }
 
     fn attention_step(&self, step: AttentionStepCall<'_>) -> Result<AttentionStepOut, VindexError> {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attention_kv_parity.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attention_kv_parity.rs
@@ -120,6 +120,14 @@ fn hidden_per_layer<B: PlanBackend>(
     per_layer
 }
 
+/// What one realisation produced: outputs, and the conditioned rows a
+/// provider would cache.
+struct Realisation {
+    outputs: Vec<Vec<f32>>,
+    keys: Vec<Vec<f32>>,
+    values: Vec<Vec<f32>>,
+}
+
 /// Run both realisations of one layer's attention over the same inputs.
 fn both_realisations<B: PlanBackend>(
     plan: &ComponentOpPlan,
@@ -127,7 +135,7 @@ fn both_realisations<B: PlanBackend>(
     backend: &B,
     layer_index: usize,
     hidden: &[Vec<f32>],
-) -> (Vec<Vec<f32>>, Vec<Vec<f32>>) {
+) -> (Realisation, Realisation) {
     let layer = &plan.layers[layer_index];
     let prepared = &ops.layers()[layer_index];
     let width = ops.hidden();
@@ -140,20 +148,29 @@ fn both_realisations<B: PlanBackend>(
         .collect();
 
     // Realisation A: one batched call over every position.
-    let batched = backend
+    let out = backend
         .attention(
             prepared
                 .attention
                 .call(&layer.attention, &inputs, eps, width),
         )
         .unwrap();
+    let batched = Realisation {
+        outputs: out.outputs,
+        keys: out.keys,
+        values: out.values,
+    };
 
     // Realisation B: position by position into a provider — the code
     // `attention_into_kv` runs, transcribed so the probe cannot drift
     // from it silently.
     let mut kv = RowKvState::default();
     kv.prepare(&super::super::kv::plan_kv_geometry(plan));
-    let mut stepped = Vec::with_capacity(inputs.len());
+    let mut stepped = Realisation {
+        outputs: Vec::with_capacity(inputs.len()),
+        keys: Vec::with_capacity(inputs.len()),
+        values: Vec::with_capacity(inputs.len()),
+    };
     for offset in 0..inputs.len() {
         let call = prepared
             .attention
@@ -166,8 +183,10 @@ fn both_realisations<B: PlanBackend>(
                 values: kv.values(layer_index),
             })
             .unwrap();
+        stepped.keys.push(out.key.clone());
+        stepped.values.push(out.value.clone());
         kv.append(layer_index, out.key, out.value);
-        stepped.push(out.output);
+        stepped.outputs.push(out.output);
     }
     (batched, stepped)
 }
@@ -180,19 +199,26 @@ fn probe<B: PlanBackend>(name: &str, backend: &B) {
 
     for (layer_index, rows) in hidden.iter().enumerate() {
         let (batched, stepped) = both_realisations(&plan, &ops, backend, layer_index, rows);
-        let d = diverge(&batched, &stepped);
-        println!(
-            "{name} layer {layer_index}: max_abs={:.3e} rel_rms={:.3e} bit_identical={}",
-            d.max_abs, d.rel_rms, d.bit_identical
-        );
-        assert!(
-            d.bit_identical,
-            "{name} layer {layer_index}: the batched and per-position attention \
-             realisations disagree (max_abs={:.3e}, rel_rms={:.3e}). The K/V rows the \
-             batched path computes are not the rows the provider accumulates, so \
-             V3-SERVE-2 cannot simply return them.",
-            d.max_abs, d.rel_rms
-        );
+        for (what, a, b) in [
+            ("K", &batched.keys, &stepped.keys),
+            ("V", &batched.values, &stepped.values),
+            ("output", &batched.outputs, &stepped.outputs),
+        ] {
+            let d = diverge(a, b);
+            println!(
+                "{name} layer {layer_index} {what}: max_abs={:.3e} rel_rms={:.3e} \
+                 bit_identical={}",
+                d.max_abs, d.rel_rms, d.bit_identical
+            );
+            assert!(
+                d.bit_identical,
+                "{name} layer {layer_index}: the batched and per-position realisations \
+                 disagree on {what} (max_abs={:.3e}, rel_rms={:.3e}). The rows the \
+                 batched pass returns are not the rows the provider would accumulate, \
+                 so populating from them changes what the model computes.",
+                d.max_abs, d.rel_rms
+            );
+        }
     }
 }
 
@@ -276,7 +302,7 @@ fn the_probe_reports_a_divergence_when_the_paths_are_fed_different_inputs() {
     skewed[2][0] += 1e-3;
     let (_, stepped_skewed) = both_realisations(&plan, &ops, &backend, 0, &skewed);
 
-    let d = diverge(&batched, &stepped_skewed);
+    let d = diverge(&batched.keys, &stepped_skewed.keys);
     assert!(
         !d.bit_identical && d.max_abs > 0.0,
         "the comparison did not notice a perturbed input — the parity result above \
@@ -319,20 +345,20 @@ fn real_container_batched_and_stepped_attention_agree_per_position() {
     let mut worst = 0.0f32;
     for (layer_index, rows) in hidden.iter().enumerate() {
         let (batched, stepped) = both_realisations(&plan, &ops, &backend, layer_index, rows);
-        let d = diverge(&batched, &stepped);
-        worst = worst.max(d.max_abs);
-        if !d.bit_identical {
-            println!(
-                "  layer {layer_index}: max_abs={:.3e} rel_rms={:.3e} NOT bit-identical",
+        for (what, a, b) in [
+            ("K", &batched.keys, &stepped.keys),
+            ("V", &batched.values, &stepped.values),
+            ("output", &batched.outputs, &stepped.outputs),
+        ] {
+            let d = diverge(a, b);
+            worst = worst.max(d.max_abs);
+            assert!(
+                d.bit_identical,
+                "layer {layer_index} of {path}: realisations disagree on {what} \
+                 (max_abs={:.3e}, rel_rms={:.3e})",
                 d.max_abs, d.rel_rms
             );
         }
-        assert!(
-            d.bit_identical,
-            "layer {layer_index} of {path}: realisations disagree \
-             (max_abs={:.3e}, rel_rms={:.3e})",
-            d.max_abs, d.rel_rms
-        );
     }
     println!(
         "{} layers, all bit-identical (worst max_abs {worst:.3e})",

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attention_kv_parity.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attention_kv_parity.rs
@@ -1,0 +1,341 @@
+//! Pre-2C probe: do the two attention realisations agree *at the
+//! attention boundary*, per layer and per position?
+//!
+//! V3-SERVE-2 wants `traverse`'s batched realisation to populate the KV
+//! provider, using the K/V rows it already computes and currently
+//! discards. The whole plan rests on those rows being the same rows the
+//! per-position path appends — so that is worth proving **before** the
+//! trait changes shape around them.
+//!
+//! # What this can and cannot observe today
+//!
+//! It cannot compare the K/V rows directly: `PlanBackend::attention`
+//! returns outputs only, and making it return the rows *is* the
+//! refactor. Adding a peephole for the probe would mean testing a code
+//! path the refactor then replaces.
+//!
+//! What it does instead is compare the two realisations where they are
+//! observable and where a K/V disagreement must surface — the attention
+//! outputs, per position, per layer, isolated from the rest of the
+//! stack. Position `p`'s batched output consumes the batched path's own
+//! K/V for positions `0..=p`; the stepped output consumes the rows the
+//! provider accumulated. If those rows disagreed anywhere, the outputs
+//! would have to disagree from that position on.
+//!
+//! This is strictly sharper than the existing decode-vs-batch gates,
+//! which compare **logits** at the end of the stack, where an attention
+//! difference has a whole FFN and residual chain in which to be masked.
+//!
+//! The direct row-equality gate belongs to the refactor commit, where
+//! the rows become returnable. This probe is what says the refactor is
+//! worth starting.
+
+use super::super::backend::{AttentionStepCall, PlanBackend};
+use super::super::kv::{KvState, RowKvState};
+use super::super::operands::OperandStore;
+use super::super::prepared::{ExecutionSlice, PreparedOperands};
+use super::super::production::ProductionBackend;
+use super::super::reference::ReferenceBackend;
+use super::super::{execute_prepared_streaming, PlaneEvent};
+use crate::format::vindex3::fixtures::{encode_fixture_container, miniature_glimmer};
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
+
+/// Enough positions that a K/V disagreement has somewhere to show.
+const TOKENS: [u32; 6] = [1, 2, 3, 4, 5, 6];
+
+fn fixture() -> (tempfile::TempDir, ComponentOpPlan, OperandStore) {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(
+        miniature_glimmer,
+        checkpoint.path(),
+        container.path(),
+        "attention-parity",
+    );
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let outcome = plan_component_ops(&inspection, container.path(), "target").unwrap();
+    assert!(outcome.closed(), "defects: {:?}", outcome.defects);
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    (container, outcome.plan.unwrap(), store)
+}
+
+/// Discrepancy between two row sets, in the two shapes that matter: the
+/// worst single element, and the error relative to the signal's own
+/// scale (so a large-magnitude row is not flattered by an absolute
+/// bound).
+struct Divergence {
+    max_abs: f32,
+    rel_rms: f32,
+    bit_identical: bool,
+}
+
+fn diverge(a: &[Vec<f32>], b: &[Vec<f32>]) -> Divergence {
+    assert_eq!(a.len(), b.len(), "row counts differ");
+    let mut max_abs = 0.0f32;
+    let mut sq_err = 0.0f64;
+    let mut sq_sig = 0.0f64;
+    let mut bit_identical = true;
+    for (ra, rb) in a.iter().zip(b) {
+        assert_eq!(ra.len(), rb.len(), "row widths differ");
+        for (x, y) in ra.iter().zip(rb) {
+            if x.to_bits() != y.to_bits() {
+                bit_identical = false;
+            }
+            let d = (x - y).abs();
+            max_abs = max_abs.max(d);
+            sq_err += f64::from(d) * f64::from(d);
+            sq_sig += f64::from(*x) * f64::from(*x);
+        }
+    }
+    Divergence {
+        max_abs,
+        rel_rms: if sq_sig > 0.0 {
+            (sq_err / sq_sig).sqrt() as f32
+        } else {
+            0.0
+        },
+        bit_identical,
+    }
+}
+
+/// The per-layer hidden states the batch traversal actually produces,
+/// so each layer's attention is probed on its real inputs rather than
+/// on synthetic rows.
+fn hidden_per_layer<B: PlanBackend>(
+    plan: &ComponentOpPlan,
+    ops: &PreparedOperands,
+    backend: &B,
+) -> Vec<Vec<Vec<f32>>> {
+    let mut per_layer = Vec::new();
+    execute_prepared_streaming(plan, ops, &TOKENS, backend, None, &mut |event| {
+        match event {
+            PlaneEvent::Embedded(rows) => per_layer.push(rows.to_vec()),
+            PlaneEvent::Layer { trace, .. } => per_layer.push(trace.post_layer.clone()),
+        }
+        Ok(())
+    })
+    .unwrap();
+    per_layer.pop(); // the last layer's output feeds no further attention
+    per_layer
+}
+
+/// Run both realisations of one layer's attention over the same inputs.
+fn both_realisations<B: PlanBackend>(
+    plan: &ComponentOpPlan,
+    ops: &PreparedOperands,
+    backend: &B,
+    layer_index: usize,
+    hidden: &[Vec<f32>],
+) -> (Vec<Vec<f32>>, Vec<Vec<f32>>) {
+    let layer = &plan.layers[layer_index];
+    let prepared = &ops.layers()[layer_index];
+    let width = ops.hidden();
+    let eps = layer.pre_attention_norm.eps;
+
+    // Exactly what `execute_layer` feeds attention.
+    let inputs: Vec<Vec<f32>> = hidden
+        .iter()
+        .map(|row| prepared.pre_attention.apply(backend, row))
+        .collect();
+
+    // Realisation A: one batched call over every position.
+    let batched = backend
+        .attention(
+            prepared
+                .attention
+                .call(&layer.attention, &inputs, eps, width),
+        )
+        .unwrap();
+
+    // Realisation B: position by position into a provider — the code
+    // `attention_into_kv` runs, transcribed so the probe cannot drift
+    // from it silently.
+    let mut kv = RowKvState::default();
+    kv.prepare(&super::super::kv::plan_kv_geometry(plan));
+    let mut stepped = Vec::with_capacity(inputs.len());
+    for offset in 0..inputs.len() {
+        let call = prepared
+            .attention
+            .call(&layer.attention, &inputs[offset..=offset], eps, width);
+        let out = backend
+            .attention_step(AttentionStepCall {
+                op: call,
+                position: offset,
+                keys: kv.keys(layer_index),
+                values: kv.values(layer_index),
+            })
+            .unwrap();
+        kv.append(layer_index, out.key, out.value);
+        stepped.push(out.output);
+    }
+    (batched, stepped)
+}
+
+fn probe<B: PlanBackend>(name: &str, backend: &B) {
+    let (_container, plan, store) = fixture();
+    let ops = PreparedOperands::load(&plan, &store, backend, ExecutionSlice::Full).unwrap();
+    let hidden = hidden_per_layer(&plan, &ops, backend);
+    assert_eq!(hidden.len(), plan.layers.len(), "one input set per layer");
+
+    for (layer_index, rows) in hidden.iter().enumerate() {
+        let (batched, stepped) = both_realisations(&plan, &ops, backend, layer_index, rows);
+        let d = diverge(&batched, &stepped);
+        println!(
+            "{name} layer {layer_index}: max_abs={:.3e} rel_rms={:.3e} bit_identical={}",
+            d.max_abs, d.rel_rms, d.bit_identical
+        );
+        assert!(
+            d.bit_identical,
+            "{name} layer {layer_index}: the batched and per-position attention \
+             realisations disagree (max_abs={:.3e}, rel_rms={:.3e}). The K/V rows the \
+             batched path computes are not the rows the provider accumulates, so \
+             V3-SERVE-2 cannot simply return them.",
+            d.max_abs, d.rel_rms
+        );
+    }
+}
+
+/// The semantic anchor: naive f32, sharing no arithmetic with
+/// `larql-compute`. If any backend is going to disagree with itself,
+/// this is the one where it matters most.
+#[test]
+fn reference_batched_and_stepped_attention_agree_per_position() {
+    probe("reference", &ReferenceBackend::new());
+}
+
+/// The backend the server actually runs.
+#[test]
+fn production_batched_and_stepped_attention_agree_per_position() {
+    probe("production", &ProductionBackend::new());
+}
+
+/// The rows must be a function of (operands, input, position) and
+/// nothing else — no hidden state carried between calls. If a second
+/// identical step produced different rows, returning them from a
+/// batched traversal would be unsound however well the parity above
+/// held.
+#[test]
+fn stepping_the_same_position_twice_yields_identical_rows() {
+    let backend = ProductionBackend::new();
+    let (_container, plan, store) = fixture();
+    let ops = PreparedOperands::load(&plan, &store, &backend, ExecutionSlice::Full).unwrap();
+    let hidden = hidden_per_layer(&plan, &ops, &backend);
+
+    let layer = &plan.layers[0];
+    let prepared = &ops.layers()[0];
+    let width = ops.hidden();
+    let inputs: Vec<Vec<f32>> = hidden[0]
+        .iter()
+        .map(|row| prepared.pre_attention.apply(&backend, row))
+        .collect();
+
+    let step = |position: usize| {
+        let call = prepared.attention.call(
+            &layer.attention,
+            &inputs[position..=position],
+            layer.pre_attention_norm.eps,
+            width,
+        );
+        backend
+            .attention_step(AttentionStepCall {
+                op: call,
+                position,
+                keys: &[],
+                values: &[],
+            })
+            .unwrap()
+    };
+
+    let first = step(0);
+    let second = step(0);
+    assert_eq!(first.key, second.key, "K row is not deterministic");
+    assert_eq!(first.value, second.value, "V row is not deterministic");
+    assert_eq!(first.output, second.output, "output is not deterministic");
+}
+
+/// Control: the probe must be able to *fail*.
+///
+/// A parity gate that reports `max_abs = 0` on everything looks the
+/// same whether the paths agree or the harness is inert. This feeds the
+/// two realisations deliberately different inputs — one position's row
+/// perturbed — and requires the comparison to notice. Without this, the
+/// green result above is not evidence.
+#[test]
+fn the_probe_reports_a_divergence_when_the_paths_are_fed_different_inputs() {
+    let backend = ProductionBackend::new();
+    let (_container, plan, store) = fixture();
+    let ops = PreparedOperands::load(&plan, &store, &backend, ExecutionSlice::Full).unwrap();
+    let hidden = hidden_per_layer(&plan, &ops, &backend);
+
+    let (batched, _) = both_realisations(&plan, &ops, &backend, 0, &hidden[0]);
+
+    // Perturb one element of one position's input and re-run the
+    // stepped side only.
+    let mut skewed = hidden[0].clone();
+    skewed[2][0] += 1e-3;
+    let (_, stepped_skewed) = both_realisations(&plan, &ops, &backend, 0, &skewed);
+
+    let d = diverge(&batched, &stepped_skewed);
+    assert!(
+        !d.bit_identical && d.max_abs > 0.0,
+        "the comparison did not notice a perturbed input — the parity result above \
+         would be meaningless (max_abs={:.3e}, rel_rms={:.3e})",
+        d.max_abs,
+        d.rel_rms
+    );
+    println!(
+        "control: perturbed input gives max_abs={:.3e} rel_rms={:.3e}",
+        d.max_abs, d.rel_rms
+    );
+}
+
+/// The same probe against a **real** container, so the result is not a
+/// statement about a two-layer miniature fixture.
+///
+/// Ignored by default because it needs a container on disk:
+///
+/// ```sh
+/// LARQL_V3_CONTAINER=~/chris-models/granite-4.1-3b.vindex3 \
+///   cargo test -p larql-vindex --lib attention_kv_parity -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "needs a real VINDEX3 container in LARQL_V3_CONTAINER"]
+fn real_container_batched_and_stepped_attention_agree_per_position() {
+    let Ok(path) = std::env::var("LARQL_V3_CONTAINER") else {
+        panic!("set LARQL_V3_CONTAINER to a container directory");
+    };
+    let root = std::path::Path::new(&path);
+    let inspection = inspect_container(root, false).unwrap();
+    let outcome = plan_component_ops(&inspection, root, "target").unwrap();
+    assert!(outcome.closed(), "defects: {:?}", outcome.defects);
+    let plan = outcome.plan.unwrap();
+    let store = OperandStore::open(root, &inspection).unwrap();
+
+    let backend = ProductionBackend::new();
+    let ops = PreparedOperands::load(&plan, &store, &backend, ExecutionSlice::Full).unwrap();
+    let hidden = hidden_per_layer(&plan, &ops, &backend);
+
+    let mut worst = 0.0f32;
+    for (layer_index, rows) in hidden.iter().enumerate() {
+        let (batched, stepped) = both_realisations(&plan, &ops, &backend, layer_index, rows);
+        let d = diverge(&batched, &stepped);
+        worst = worst.max(d.max_abs);
+        if !d.bit_identical {
+            println!(
+                "  layer {layer_index}: max_abs={:.3e} rel_rms={:.3e} NOT bit-identical",
+                d.max_abs, d.rel_rms
+            );
+        }
+        assert!(
+            d.bit_identical,
+            "layer {layer_index} of {path}: realisations disagree \
+             (max_abs={:.3e}, rel_rms={:.3e})",
+            d.max_abs, d.rel_rms
+        );
+    }
+    println!(
+        "{} layers, all bit-identical (worst max_abs {worst:.3e})",
+        hidden.len()
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_backend_decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_backend_decode.rs
@@ -13,8 +13,8 @@ use crate::error::VindexError;
 use crate::format::vindex3::encode::encode_system;
 use crate::format::vindex3::inspect::inspect_container;
 use crate::format::vindex3::opplan::exec::backend::{
-    AttentionCall, AttentionStepCall, AttentionStepOut, FfnCall, NormCall, PlanBackend,
-    ProjectCall, RoutedFfnCall, WeightSlice,
+    AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, FfnCall, NormCall,
+    PlanBackend, ProjectCall, RoutedFfnCall, WeightSlice,
 };
 use crate::format::vindex3::opplan::exec::decode::DecodeSession;
 use crate::format::vindex3::opplan::exec::execute_plan;
@@ -313,7 +313,7 @@ impl PlanBackend for RefusingBackend {
         self.inner.project(call)
     }
 
-    fn attention(&self, call: AttentionCall<'_>) -> Result<Vec<Vec<f32>>, VindexError> {
+    fn attention(&self, call: AttentionCall<'_>) -> Result<AttentionOut, VindexError> {
         self.inner.attention(call)
     }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/gemma4_refusals.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/gemma4_refusals.rs
@@ -110,10 +110,12 @@ fn partial_rotary_bases_execute_at_parity_and_are_distinct_rotations() {
         .map(|&policy| {
             let r = reference
                 .attention(call(&inputs, &w, policy))
-                .unwrap_or_else(|e| panic!("reference {policy:?}: {e}"));
+                .unwrap_or_else(|e| panic!("reference {policy:?}: {e}"))
+                .outputs;
             let p = production
                 .attention(call(&inputs, &w, policy))
-                .unwrap_or_else(|e| panic!("production {policy:?}: {e}"));
+                .unwrap_or_else(|e| panic!("production {policy:?}: {e}"))
+                .outputs;
             let diff = relative_diff(&r, &p);
             assert!(diff < PARITY, "{policy:?}: reference vs production {diff}");
             r

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -9,6 +9,7 @@
 //! about *semantics* — plan interpretation, operand binding, norm
 //! placement, RoPE convention, residual order — not shared arithmetic.
 
+mod attention_kv_parity;
 mod controls;
 mod coverage_backend_decode;
 mod coverage_device;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/residency.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/residency.rs
@@ -149,6 +149,14 @@ fn prepared_and_unprepared_paths_agree_bit_for_bit() {
 /// populated provider must land on the same logits as a session that
 /// prefilled the whole prompt itself. This is the property N1's
 /// bit-identical resumption rests on, now over shared operands.
+///
+/// Since V3-SERVE-2 this gate straddles both attention realisations,
+/// which is what makes it load-bearing: the whole-prompt arm starts at
+/// position 0 and takes the **batched** branch, while the split arm's
+/// second chunk extends a populated provider and takes the
+/// **per-position** branch. They must still agree bit-for-bit — a
+/// batched pass that populated K/V differently from the stepped one
+/// would show up here as a resumed continuation that diverges.
 #[test]
 fn resuming_over_a_prepared_image_matches_a_full_prefill() {
     let (_container, plan, store) = fixture();

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/seam.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/seam.rs
@@ -22,8 +22,8 @@ use crate::error::VindexError;
 use crate::format::vindex3::encode::encode_system;
 use crate::format::vindex3::inspect::inspect_container;
 use crate::format::vindex3::opplan::exec::backend::{
-    AttentionCall, AttentionStepCall, AttentionStepOut, FfnCall, NormCall, PlanBackend,
-    ProjectCall, RoutedFfnCall, WeightSlice,
+    AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, FfnCall, NormCall,
+    PlanBackend, ProjectCall, RoutedFfnCall, WeightSlice,
 };
 use crate::format::vindex3::opplan::exec::operands::OperandStore;
 use crate::format::vindex3::opplan::exec::production::ProductionBackend;
@@ -75,7 +75,7 @@ impl PlanBackend for RecordingBackend {
         self.inner.project(call)
     }
 
-    fn attention(&self, call: AttentionCall<'_>) -> Result<Vec<Vec<f32>>, VindexError> {
+    fn attention(&self, call: AttentionCall<'_>) -> Result<AttentionOut, VindexError> {
         self.record("attention");
         self.inner.attention(call)
     }
@@ -141,7 +141,7 @@ impl PlanBackend for PerturbedBackend {
         self.0.project(call)
     }
 
-    fn attention(&self, call: AttentionCall<'_>) -> Result<Vec<Vec<f32>>, VindexError> {
+    fn attention(&self, call: AttentionCall<'_>) -> Result<AttentionOut, VindexError> {
         self.0.attention(call)
     }
 


### PR DESCRIPTION
**V3-SERVE-2.** `PlanBackend::attention` now returns `AttentionOut { outputs, keys, values }`.

The batched realisation always computed the conditioned K/V rows — it must, to attend at all — and then discarded them. That discard is what forced any caller wanting a populated cache down the per-position path: *"I want KV populated"* silently meant *"run attention one position at a time"*. The two axes are now independent, and a fresh prefill takes the batched realisation and populates the provider from the single traversal it already performs. No batched pass plus a replay.

## Proven before the trait moved

`exec/tests/attention_kv_parity.rs` (first commit) showed the two realisations agree **bit-for-bit** on K, V and outputs:

- **reference** backend — the semantic anchor, sharing no arithmetic with `larql-compute` — every layer
- **production** backend, every layer
- all **40 layers of a real Granite container** (`#[ignore]`d, env-driven, so it re-runs against any container without a 13 GB fixture)

With a control that fires on a perturbed input (`max_abs=7.9e-4`), because `max_abs = 0` everywhere looks identical to an inert harness. Also gated: the rows are a function of `(operands, input, position)` and nothing else — stepping the same position twice yields identical K, V and output.

## Measured — Granite 4.1 3B, battery, `prefill_into`

| prompt | post-2B | post-2C | gain |
|---|---|---|---|
| 5 | 0.448 s | 0.442 s | 1.01× |
| 64 | 4.099 s | 3.428 s | 1.20× |
| 325 | 34.587 s | 25.024 s | **1.38×** |

Prefill rate **8.56 → 12.09 tok/s** (64 → 325). No change at n=5 with a gain that grows in n is the signature of fixing a per-position realisation — drift would have moved all three points.

## What it exposed

Same session, same power state, the CLI's batched path runs **19.50 tok/s** over 64 → 256 where the server's prefill runs **11.37** — **1.72× still outstanding**. (The 21.4 tok/s CLI figure quoted in earlier notes was taken on AC; re-measuring it on battery is what makes this comparison honest.)

Both now run the same batched attention, so the remainder is what the server does *around* it: `kv.append` per position per layer, and whatever `CanonicalKvState` costs to store a row. That was invisible while per-position attention dominated. It is the next thing to measure, and it is recorded as such rather than claimed as done.

## Deliberately not done

A **resumed** prefill still steps. A batched pass conditions position `p` as the `p`-th token of the sequence it is handed, so it cannot express a prefill starting part-way through one. Giving `AttentionCall` an absolute-position base would lift that and would matter for long-history N1 resumes; it is its own rung.

The continuation-parity gate now straddles both branches, which is what makes it load-bearing: the whole-prompt arm takes the batched path, the split arm's second chunk extends a populated provider and takes the stepped one, and they must still agree bit-for-bit.

## N1 after 2C

Frozen ledger, Granite: 20.75 s → 8.63 s (**2.40×**), cached prefix still resuming (25 / 50 / 71). Read the ratio cautiously — the cache-off arm's first turn was an outlier (6.63 s against ~2 s in every other run) — but the shape is what the row was taken for, and it holds: with the cache, turn time stays near new-turn cost; without it, it grows with history.

## Gates

vindex 2955 · inference 1788 · kv 1279 · server 1147 · lql 1093 · router 256 — all green. fmt and clippy `-D warnings` clean across all six crates.

**Pre-existing coverage red, not from this PR:** `larql-vindex` fails the policy on `format/generation.rs` (84.43%) and `quant/convert.rs` (81.54%). Verified by building `origin/main` in a separate worktree — it fails on *identical* files at *identical* percentages.
