### PR TITLE
perf(vindex3): Qwen3.8 CPU decode 0.053 -> 0.904 tok/s, 17.2x, trajectory unchanged (CPU-1A2)

### DIFF
--- a/crates/larql-kv/src/vindex3/mod.rs
+++ b/crates/larql-kv/src/vindex3/mod.rs
@@ -231,4 +231,30 @@ impl KvState for CanonicalKvState {
     fn set_position(&mut self, position: usize) {
         self.cache.next_position = position;
     }
+
+    /// **Explicitly unsupported, not absent.**
+    ///
+    /// The canonical cache holds per-position K/V rows and nothing else,
+    /// so a hybrid stack reaching the serving path fails closed here and
+    /// names which side is missing. Returning `None` would make this
+    /// indistinguishable from "this layer needs no state" and let a
+    /// 48-recurrent-layer model serve from zeroed buffers — a different
+    /// model, reported as this one.
+    ///
+    /// SERVE-HYBRID replaces this with real buffers and re-establishes
+    /// serving parity; until then the refusal is the correct answer.
+    fn recurrent_state(
+        &mut self,
+        layer: usize,
+    ) -> Result<
+        &mut larql_vindex::format::vindex3::opplan::exec::continuation::RecurrentState,
+        larql_vindex::format::vindex3::opplan::exec::kv::ContinuationError,
+    > {
+        Err(
+            larql_vindex::format::vindex3::opplan::exec::kv::ContinuationError::RecurrentUnsupported {
+                provider: "CanonicalKvState",
+                layer,
+            },
+        )
+    }
 }

--- a/crates/larql-models/src/architectures/qwen.rs
+++ b/crates/larql-models/src/architectures/qwen.rs
@@ -11,6 +11,31 @@ use crate::config::{
 };
 use crate::tensor_keys::{attn_bias, moe_experts, qk_norm};
 
+/// Model types whose RMSNorm stores the weight as an OFFSET FROM ONE.
+///
+/// `Qwen3_5RMSNorm` initialises its weight to **zeros** and applies
+/// `x_normed * (1.0 + weight)`. `Qwen3RMSNorm` initialises to **ones** and
+/// applies `weight * x_normed`. Same family name, opposite conventions,
+/// and the saved tensors are not interchangeable.
+///
+/// Qwen3.8 is the evidence: its `input_layernorm` weight has norm 3.83,
+/// and HF's normed output has norm 75.5 — only reachable through
+/// `(1 + w)`, since `w * x_normed` would land near 3.83. Applying the
+/// weight directly made every decoder norm wrong and put the model's
+/// first diverging plane at layer 0.
+///
+/// Read from the upstream classes rather than inferred: `qwen3`,
+/// `qwen3_moe` and `qwen3_vl` are ones-initialised and stay at offset 0.
+/// `qwen3_next` shares Qwen3.5's convention.
+const PLUS_ONE_NORM_FAMILIES: &[&str] = &["qwen3_5", "qwen3_next"];
+
+/// Whether this model type's saved norm weights are offsets from one.
+fn stores_norm_weight_as_offset(model_type: &str) -> bool {
+    PLUS_ONE_NORM_FAMILIES
+        .iter()
+        .any(|family| model_type.starts_with(family))
+}
+
 pub struct QwenArch {
     config: ModelConfig,
 }
@@ -60,6 +85,24 @@ impl ModelArchitecture for QwenArch {
                 combine: GateCombine::ElementwiseMultiply,
                 placement: GatePlacement::AfterAggregationBeforeOutputProjection,
             })
+    }
+
+    /// See [`PLUS_ONE_NORM_FAMILIES`]. Covers the decoder norms and the
+    /// final norm, which are the same class upstream.
+    fn norm_weight_offset(&self) -> f32 {
+        if stores_norm_weight_as_offset(&self.config.model_type) {
+            1.0
+        } else {
+            0.0
+        }
+    }
+
+    /// The per-head Q/K norms are that same class too — `Qwen3_5Attention`
+    /// builds them as `Qwen3_5RMSNorm(head_dim)` — so they share the
+    /// convention. Declared separately because the two offsets are
+    /// independent facts and a family could differ.
+    fn qk_norm_weight_offset(&self) -> f32 {
+        self.norm_weight_offset()
     }
 
     // ── MoE (Qwen3-MoE, Qwen2-MoE) ──

--- a/crates/larql-vindex/src/format/vindex3/fixtures.rs
+++ b/crates/larql-vindex/src/format/vindex3/fixtures.rs
@@ -607,3 +607,163 @@ pub fn shrink_q_proj_to_ungated_width(dir: &Path) {
     }
     shard.write(dir);
 }
+
+/// A four-layer **hybrid** stack on an `LLLF` cadence: three Gated
+/// DeltaNet layers and one softmax layer.
+///
+/// The fixture the QW-3.6b traversal gates run on. Small, but not too
+/// small to discriminate:
+///
+/// * **three** recurrent layers before the softmax one, so a dispatch
+///   that ran the first operator for every layer is caught by position,
+///   not just by count;
+/// * the softmax layer is **last**, so a traversal that refuses lazily
+///   has already emitted three layers before it gets there;
+/// * `conv_kernel` 4 against sequences longer than 4, so the convolution
+///   history spans a batch boundary.
+pub fn hybrid_lllf_f32_model(dir: &Path) {
+    // Linear-attention geometry: 2*Hk*Dk + Hv*Dv channels.
+    const KEY_HEADS: usize = 2;
+    const VALUE_HEADS: usize = 4;
+    const LIN_DIM: usize = 8;
+    const CONV_KERNEL: usize = 4;
+    let qkv = 2 * KEY_HEADS * LIN_DIM + VALUE_HEADS * LIN_DIM;
+    let value_width = VALUE_HEADS * LIN_DIM;
+    let layers = 4;
+
+    std::fs::write(
+        dir.join("config.json"),
+        serde_json::json!({
+            "architectures": ["Qwen3_5ForCausalLM"],
+            "torch_dtype": "float32",
+            "model_type": "qwen3_5",
+            "hidden_size": DENSE_HIDDEN,
+            "num_hidden_layers": layers,
+            "intermediate_size": DENSE_INTERMEDIATE,
+            "num_attention_heads": DENSE_Q_HEADS,
+            "num_key_value_heads": DENSE_KV_HEADS,
+            "head_dim": DENSE_HEAD_DIM,
+            "vocab_size": DENSE_VOCAB,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "layer_types": ["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+            "full_attention_interval": 4,
+            "linear_num_key_heads": KEY_HEADS,
+            "linear_num_value_heads": VALUE_HEADS,
+            "linear_key_head_dim": LIN_DIM,
+            "linear_value_head_dim": LIN_DIM,
+            "linear_conv_kernel_dim": CONV_KERNEL,
+            "mamba_ssm_dtype": "float32"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let q_rows = DENSE_Q_HEADS * DENSE_HEAD_DIM;
+    let kv_rows = DENSE_KV_HEADS * DENSE_HEAD_DIM;
+    let mut shard = ShardBuilder::new();
+    shard.push(
+        "model.embed_tokens.weight",
+        &[DENSE_VOCAB, DENSE_HIDDEN],
+        &lcg_values(DENSE_VOCAB * DENSE_HIDDEN, 1),
+    );
+    shard.push(
+        "model.norm.weight",
+        &[DENSE_HIDDEN],
+        &norm_values(DENSE_HIDDEN, 2),
+    );
+    shard.push(
+        "lm_head.weight",
+        &[DENSE_VOCAB, DENSE_HIDDEN],
+        &lcg_values(DENSE_VOCAB * DENSE_HIDDEN, 3),
+    );
+    for layer in 0..layers {
+        let seed = 100 + layer as u64 * 20;
+        let prefix = format!("model.layers.{layer}");
+        if layer % 4 == 3 {
+            // The softmax layer.
+            for (name, rows, s) in [
+                ("q_proj", q_rows, seed),
+                ("k_proj", kv_rows, seed + 1),
+                ("v_proj", kv_rows, seed + 2),
+            ] {
+                shard.push(
+                    &format!("{prefix}.self_attn.{name}.weight"),
+                    &[rows, DENSE_HIDDEN],
+                    &lcg_values(rows * DENSE_HIDDEN, s),
+                );
+            }
+            shard.push(
+                &format!("{prefix}.self_attn.o_proj.weight"),
+                &[DENSE_HIDDEN, q_rows],
+                &lcg_values(DENSE_HIDDEN * q_rows, seed + 3),
+            );
+        } else {
+            // A recurrence: nine operands, no q/k/v/o.
+            shard.push(
+                &format!("{prefix}.linear_attn.in_proj_qkv.weight"),
+                &[qkv, DENSE_HIDDEN],
+                &lcg_values(qkv * DENSE_HIDDEN, seed),
+            );
+            for (name, s) in [("in_proj_a", seed + 1), ("in_proj_b", seed + 2)] {
+                shard.push(
+                    &format!("{prefix}.linear_attn.{name}.weight"),
+                    &[VALUE_HEADS, DENSE_HIDDEN],
+                    &lcg_values(VALUE_HEADS * DENSE_HIDDEN, s),
+                );
+            }
+            shard.push(
+                &format!("{prefix}.linear_attn.in_proj_z.weight"),
+                &[value_width, DENSE_HIDDEN],
+                &lcg_values(value_width * DENSE_HIDDEN, seed + 3),
+            );
+            shard.push(
+                &format!("{prefix}.linear_attn.conv1d.weight"),
+                &[qkv, 1, CONV_KERNEL],
+                &lcg_values(qkv * CONV_KERNEL, seed + 4),
+            );
+            shard.push(
+                &format!("{prefix}.linear_attn.A_log"),
+                &[VALUE_HEADS],
+                &lcg_values(VALUE_HEADS, seed + 5),
+            );
+            shard.push(
+                &format!("{prefix}.linear_attn.dt_bias"),
+                &[VALUE_HEADS],
+                &lcg_values(VALUE_HEADS, seed + 6),
+            );
+            shard.push(
+                &format!("{prefix}.linear_attn.norm.weight"),
+                &[LIN_DIM],
+                &norm_values(LIN_DIM, seed + 7),
+            );
+            shard.push(
+                &format!("{prefix}.linear_attn.out_proj.weight"),
+                &[DENSE_HIDDEN, value_width],
+                &lcg_values(DENSE_HIDDEN * value_width, seed + 8),
+            );
+        }
+        for (name, s) in [
+            ("input_layernorm", seed + 10),
+            ("post_attention_layernorm", seed + 11),
+        ] {
+            shard.push(
+                &format!("{prefix}.{name}.weight"),
+                &[DENSE_HIDDEN],
+                &norm_values(DENSE_HIDDEN, s),
+            );
+        }
+        for (name, rows, cols, s) in [
+            ("gate_proj", DENSE_INTERMEDIATE, DENSE_HIDDEN, seed + 12),
+            ("up_proj", DENSE_INTERMEDIATE, DENSE_HIDDEN, seed + 13),
+            ("down_proj", DENSE_HIDDEN, DENSE_INTERMEDIATE, seed + 14),
+        ] {
+            shard.push(
+                &format!("{prefix}.mlp.{name}.weight"),
+                &[rows, cols],
+                &lcg_values(rows * cols, s),
+            );
+        }
+    }
+    shard.write(dir);
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -395,6 +395,17 @@ pub trait PlanBackend: Sync {
         WeightFormat::F32
     }
 
+    /// How this backend performs a Gated DeltaNet layer's dense
+    /// projections.
+    ///
+    /// Defaults to the literal scalar transcription, so a backend that
+    /// says nothing gets the reference arithmetic rather than inheriting
+    /// somebody else's. The recurrence itself is not selectable — only
+    /// the five matrix products around it.
+    fn dense_projector(&self) -> &dyn super::gated_delta::DenseProjector {
+        &super::gated_delta::ScalarProjections
+    }
+
     /// Residency hint before a decode run: every matrix operand the
     /// session will read, already loaded. Computes nothing and must
     /// change no number — a backend may warm caches or wire device

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -238,7 +238,12 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
             // Attention input is normalised once and handed over; the
             // judged gate reads the same vector (same as the batch path).
             let inputs = [state.pre_attention.apply(self.backend, &h)];
-            let call = state.attention.call(
+            // The decode step is still softmax-only: it appends a KV row
+            // per position, which a recurrence has none of. QW-3.6b wires
+            // the BATCH traversal; the single-position path follows once
+            // the batch one is parity-proven, and until then it refuses
+            // by name rather than running 16 of 64 layers.
+            let call = state.attention.softmax()?.call(
                 super::softmax_or_refuse(layer)?,
                 &inputs,
                 layer.pre_attention_norm.eps,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -24,7 +24,7 @@
 //! [`attention_step`]: super::backend::PlanBackend::attention_step
 
 use super::backend::{AttentionStepCall, NormCall, PlanBackend};
-use super::kv::{plan_kv_geometry, KvState, RowKvState};
+use super::kv::{KvState, RowKvState};
 use super::observe::{NoopObserver, StepEvent, StepObserver};
 use super::operands::OperandSource;
 use super::prepared::{ExecutionSlice, PreparedOperands};
@@ -164,7 +164,12 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
         backend: &'a B,
         mut kv: KvSlot<'a>,
     ) -> Result<Self, VindexError> {
-        kv.state_mut().prepare(&plan_kv_geometry(plan));
+        // The FULL continuation geometry, KV and recurrent alike.
+        // `plan_kv_geometry` is the KV-only adapter and refuses a hybrid
+        // plan; a session over one needs both forms announced.
+        kv.state_mut().prepare_continuation(
+            &super::continuation::plan_continuation_geometry(plan).map_err(VindexError::Parse)?,
+        )?;
         Ok(Self {
             plan,
             backend,
@@ -238,27 +243,47 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
             // Attention input is normalised once and handed over; the
             // judged gate reads the same vector (same as the batch path).
             let inputs = [state.pre_attention.apply(self.backend, &h)];
-            // The decode step is still softmax-only: it appends a KV row
-            // per position, which a recurrence has none of. QW-3.6b wires
-            // the BATCH traversal; the single-position path follows once
-            // the batch one is parity-proven, and until then it refuses
-            // by name rather than running 16 of 64 layers.
-            let call = state.attention.softmax()?.call(
-                super::softmax_or_refuse(layer)?,
-                &inputs,
-                layer.pre_attention_norm.eps,
-                hidden,
-            );
-            let out = self.backend.attention_step(AttentionStepCall {
-                op: call,
-                position,
-                keys: self.kv.state().keys(index),
-                values: self.kv.state().values(index),
-            })?;
-            self.kv.state_mut().append(index, out.key, out.value);
+            // One position, either operator. A recurrence appends no KV
+            // row — it rewrites its own buffers in place, which is only
+            // correct because those buffers are DURABLE: the convolution
+            // history spans the step boundary, and a single-position call
+            // that reconstructed it from the batch would see a window of
+            // one. That is the whole point of QW-3.6a.
+            let raw_attn = match &state.attention {
+                super::prepared::PreparedAttention::GatedDelta(delta) => {
+                    let recurrent = self.kv.state_mut().recurrent_state(index)?;
+                    let mut planes = super::gated_delta::layer_forward(
+                        &delta.op,
+                        &delta.weights(),
+                        &inputs,
+                        recurrent,
+                        super::gated_delta::Mutation::None,
+                    );
+                    planes.output.remove(0)
+                }
+                super::prepared::PreparedAttention::Softmax(sops) => {
+                    let call = sops.call(
+                        layer
+                            .attention
+                            .softmax()
+                            .expect("prepared softmax operands imply a softmax op"),
+                        &inputs,
+                        layer.pre_attention_norm.eps,
+                        hidden,
+                    );
+                    let out = self.backend.attention_step(AttentionStepCall {
+                        op: call,
+                        position,
+                        keys: self.kv.state().keys(index),
+                        values: self.kv.state().values(index),
+                    })?;
+                    self.kv.state_mut().append(index, out.key, out.value);
+                    out.output
+                }
+            };
             let mut attn_out = match &state.post_attention {
-                Some(norm) => norm.apply(self.backend, &out.output),
-                None => out.output,
+                Some(norm) => norm.apply(self.backend, &raw_attn),
+                None => raw_attn,
             };
             super::scale_residual_delta(layer.residual_scale, &mut attn_out);
             self.backend.residual_add(&mut h, &attn_out);

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -252,12 +252,14 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
             let raw_attn = match &state.attention {
                 super::prepared::PreparedAttention::GatedDelta(delta) => {
                     let recurrent = self.kv.state_mut().recurrent_state(index)?;
-                    let mut planes = super::gated_delta::layer_forward(
+                    let projector = self.backend.dense_projector();
+                    let mut planes = super::gated_delta::layer_forward_with(
                         &delta.op,
                         &delta.weights(),
                         &inputs,
                         recurrent,
                         super::gated_delta::Mutation::None,
+                        projector,
                     );
                     planes.output.remove(0)
                 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/gated_delta.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/gated_delta.rs
@@ -294,6 +294,35 @@ pub struct LayerPlanes {
     pub output: Vec<Vec<f32>>,
 }
 
+/// How a Gated DeltaNet layer performs its DENSE projections.
+///
+/// The seam exists so a backend can accelerate the five matrix products
+/// around the recurrence **without touching the recurrence**. Everything
+/// QW-2/QW-2E proved stage-by-stage against HF — the convolution, the
+/// head expansion, the gates, the delta rule, the gated norm — is below
+/// this trait and identical for every implementation.
+///
+/// `ReferenceBackend` keeps [`ScalarProjections`], which is the literal
+/// transcription and shares no arithmetic with `larql-compute`. That
+/// independence is what makes it an oracle, so it is never routed
+/// through BLAS however much faster BLAS is.
+pub trait DenseProjector: Sync {
+    /// `y = W x`, with `W` row-major `[out_dim, x.len()]`.
+    fn project(&self, weight: &[f32], x: &[f32], out_dim: usize) -> Vec<f32>;
+}
+
+/// The literal projection: one scalar dot per row.
+///
+/// Measured at a flat 5.6 GB/s across every Qwen3.8 projection shape —
+/// which is why it is the oracle and not the execution strategy.
+pub struct ScalarProjections;
+
+impl DenseProjector for ScalarProjections {
+    fn project(&self, weight: &[f32], x: &[f32], out_dim: usize) -> Vec<f32> {
+        matvec(weight, x, out_dim)
+    }
+}
+
 fn matvec(w: &[f32], x: &[f32], out_dim: usize) -> Vec<f32> {
     let in_dim = x.len();
     (0..out_dim)
@@ -331,6 +360,20 @@ pub fn layer_forward(
     state: &mut RecurrentState,
     mutation: Mutation,
 ) -> LayerPlanes {
+    layer_forward_with(op, w, hidden, state, mutation, &ScalarProjections)
+}
+
+/// [`layer_forward`] with a chosen projection strategy. The public entry
+/// point above always passes [`ScalarProjections`], so the reference
+/// path is unchanged and the oracle stays independent.
+pub fn layer_forward_with(
+    op: &GatedDeltaOp,
+    w: &GatedDeltaWeights<'_>,
+    hidden: &[Vec<f32>],
+    state: &mut RecurrentState,
+    mutation: Mutation,
+    proj: &dyn DenseProjector,
+) -> LayerPlanes {
     let (hk, hv) = (op.num_key_heads, op.num_value_heads);
     let (dk, dv) = (op.key_head_dim, op.value_head_dim);
     let (key_dim, value_dim) = (hk * dk, hv * dv);
@@ -342,7 +385,7 @@ pub fn layer_forward(
     // Stage 1: the fused projection, per position.
     let mixed: Vec<Vec<f32>> = hidden
         .iter()
-        .map(|h| matvec(w.in_proj_qkv, h, conv_dim))
+        .map(|h| proj.project(w.in_proj_qkv, h, conv_dim))
         .collect();
 
     // Stage 2: depthwise causal convolution, then SiLU.
@@ -425,9 +468,9 @@ pub fn layer_forward(
         let value = conv[t][key_dim * 2..key_dim * 2 + value_dim].to_vec();
 
         // Stage 5: the gates.
-        let a = matvec(w.in_proj_a, &hidden[t], hv);
-        let b = matvec(w.in_proj_b, &hidden[t], hv);
-        let z = matvec(w.in_proj_z, &hidden[t], value_dim);
+        let a = proj.project(w.in_proj_a, &hidden[t], hv);
+        let b = proj.project(w.in_proj_b, &hidden[t], hv);
+        let z = proj.project(w.in_proj_z, &hidden[t], value_dim);
         let beta: Vec<f32> = b.iter().map(|x| 1.0 / (1.0 + (-x).exp())).collect();
         let g: Vec<f32> = (0..hv)
             .map(|h| -w.a_log[h].exp() * softplus(a[h] + w.dt_bias[h]))
@@ -462,7 +505,7 @@ pub fn layer_forward(
         // Stage 8: back into the residual stream.
         planes
             .output
-            .push(matvec(w.out_proj, &normed, hidden[t].len()));
+            .push(proj.project(w.out_proj, &normed, hidden[t].len()));
         planes.query.push(q);
         planes.key.push(k);
         planes.value.push(value);

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/kv.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/kv.rs
@@ -30,6 +30,7 @@
 //!   a later rung tied to that backend contract.
 
 use super::super::ComponentOpPlan;
+use super::continuation::{LayerContinuationGeometry, RecurrentState};
 
 /// One layer's continuation-state geometry, read from the plan.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,7 +91,7 @@ pub fn try_plan_kv_geometry(plan: &ComponentOpPlan) -> Result<Vec<LayerKvGeometr
 /// The decode step appends layer 0..n for position p, then again for
 /// p+1; the batch prefill appends all positions for layer 0, then all
 /// for layer 1 — a provider must not assume one interleaving.
-pub trait KvState {
+pub trait ContinuationProvider {
     /// Announce the traversal's geometry before any append. An
     /// announcement, **not** a reset: a provider already holding rows
     /// (a prefilled state being resumed) keeps them.
@@ -119,7 +120,97 @@ pub trait KvState {
     /// once per consumed position on the decode path, once at the end
     /// of a batch prefill.
     fn set_position(&mut self, position: usize);
+
+    /// Announce the FULL continuation geometry, KV and recurrent alike.
+    ///
+    /// Separate from [`prepare`](Self::prepare) so a provider that holds
+    /// only KV needs no change: the default projects to the KV subset and
+    /// delegates. A provider that holds recurrent buffers overrides this
+    /// and allocates them here.
+    fn prepare_continuation(
+        &mut self,
+        layers: &[LayerContinuationGeometry],
+    ) -> Result<(), ContinuationError> {
+        let kv: Vec<LayerKvGeometry> = layers.iter().filter_map(|g| g.kv().cloned()).collect();
+        // Providers are indexed by ABSOLUTE layer index. Filtering to the
+        // KV subset preserves that only when every layer keeps rows —
+        // true for the KV-only providers this default exists for, and
+        // false the moment a stack is hybrid, which is why a hybrid plan
+        // must have been refused by `recurrent_state` before reaching a
+        // provider that took this default.
+        if kv.len() != layers.len() {
+            return Err(ContinuationError::RecurrentUnsupported {
+                provider: "a KV-only provider",
+                layer: layers.iter().position(|g| g.kv().is_none()).unwrap_or(0),
+            });
+        }
+        self.prepare(&kv);
+        Ok(())
+    }
+
+    /// This layer's durable recurrent buffers.
+    ///
+    /// **Required, and returns a Result rather than an Option.** A
+    /// provider that cannot hold recurrent state must say so — an
+    /// `Option` here would make "I have no buffers" and "this operator
+    /// needs none" the same answer, which is precisely the ambiguity
+    /// [`LayerContinuationGeometry::Stateless`] exists to prevent one
+    /// level down. Every implementor states its position explicitly;
+    /// nothing inherits an answer by omission.
+    fn recurrent_state(&mut self, layer: usize) -> Result<&mut RecurrentState, ContinuationError>;
 }
+
+/// Why a continuation provider could not answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContinuationError {
+    /// This provider holds no recurrent buffers at all. Not a defect in
+    /// the plan — a statement about the provider, which is why it names
+    /// itself: a hybrid model reaching a KV-only serving cache must fail
+    /// closed and say which side is missing.
+    RecurrentUnsupported {
+        provider: &'static str,
+        layer: usize,
+    },
+    /// The provider holds recurrent buffers, but not for this layer —
+    /// a softmax layer was asked for a recurrence, or the reverse.
+    NotRecurrent {
+        provider: &'static str,
+        layer: usize,
+    },
+}
+
+impl std::fmt::Display for ContinuationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RecurrentUnsupported { provider, layer } => write!(
+                f,
+                "continuation provider `{provider}` holds no recurrent state, which layer \
+                 {layer} requires; refusing rather than running the layer stateless"
+            ),
+            Self::NotRecurrent { provider, layer } => write!(
+                f,
+                "layer {layer} is not a recurrent layer in `{provider}`'s geometry; asking \
+                 it for recurrent state is a dispatch bug"
+            ),
+        }
+    }
+}
+
+impl From<ContinuationError> for crate::error::VindexError {
+    fn from(value: ContinuationError) -> Self {
+        Self::Parse(value.to_string())
+    }
+}
+
+/// The seam's previous name.
+///
+/// `KvState` described the runtime model when every layer kept rows. It no
+/// longer does: Qwen3.8 keeps a delta matrix and a convolution history on
+/// 48 of its 64 layers and no rows at all. The alias exists so the serving
+/// stack and its KV-1 bit-identity gate keep compiling through QW-3.6b;
+/// it goes away at STATE-CONSOLIDATE, when `ContinuationState` becomes the
+/// authoritative seam and KV becomes its projection.
+pub use ContinuationProvider as KvState;
 
 /// The default provider: plain per-layer row vectors — exactly the
 /// state [`DecodeSession`](super::decode::DecodeSession) used to own
@@ -128,6 +219,13 @@ pub trait KvState {
 #[derive(Default)]
 pub struct RowKvState {
     layers: Vec<LayerRows>,
+    /// Durable recurrent buffers, one slot per layer, `None` on layers
+    /// that keep rows instead. Allocated by
+    /// [`prepare_continuation`](ContinuationProvider::prepare_continuation)
+    /// from the plan's geometry — never lazily on first use, because a
+    /// buffer conjured mid-traversal would start from zeros in the middle
+    /// of a sequence and look like a working continuation.
+    recurrent: Vec<Option<RecurrentState>>,
     position: usize,
 }
 
@@ -171,6 +269,56 @@ impl KvState for RowKvState {
 
     fn position(&self) -> usize {
         self.position
+    }
+
+    fn prepare_continuation(
+        &mut self,
+        layers: &[LayerContinuationGeometry],
+    ) -> Result<(), ContinuationError> {
+        // KV rows keep their own announcement contract (an announcement,
+        // not a reset), so the recurrent side follows the same rule: a
+        // resumed state keeps its buffers and only their SHAPE is
+        // re-checked.
+        // Sized by the FULL layer count, not the KV subset: this
+        // provider is indexed by absolute layer index, and a stack whose
+        // layer 3 is the only softmax one would otherwise write its rows
+        // at slot 0.
+        if self.layers.is_empty() {
+            self.layers = layers.iter().map(|_| LayerRows::default()).collect();
+        } else {
+            assert_eq!(
+                self.layers.len(),
+                layers.len(),
+                "resumed KV state holds {} layers but the plan declares {}",
+                self.layers.len(),
+                layers.len()
+            );
+        }
+        if self.recurrent.is_empty() {
+            self.recurrent = layers
+                .iter()
+                .map(|g| g.recurrent().map(RecurrentState::zeros))
+                .collect();
+        } else {
+            assert_eq!(
+                self.recurrent.len(),
+                layers.len(),
+                "resumed continuation state holds {} layers but the plan declares {}",
+                self.recurrent.len(),
+                layers.len()
+            );
+        }
+        Ok(())
+    }
+
+    fn recurrent_state(&mut self, layer: usize) -> Result<&mut RecurrentState, ContinuationError> {
+        self.recurrent
+            .get_mut(layer)
+            .and_then(Option::as_mut)
+            .ok_or(ContinuationError::NotRecurrent {
+                provider: "RowKvState",
+                layer,
+            })
     }
 
     fn set_position(&mut self, position: usize) {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -44,7 +44,7 @@ use backend::{
 };
 use kv::KvState;
 use operands::OperandSource;
-use prepared::{ExecutionSlice, PreparedLayer, PreparedOperands};
+use prepared::{ExecutionSlice, PreparedAttention, PreparedLayer, PreparedOperands};
 use rayon::prelude::*;
 use reference::ReferenceBackend;
 use weights::{load_weight, LoadedWeight};
@@ -189,15 +189,31 @@ pub fn execute_prepared_streaming<B: PlanBackend + ?Sized>(
     resume: Option<ResumePoint>,
     sink: &mut dyn FnMut(PlaneEvent) -> Result<(), VindexError>,
 ) -> Result<FinalOutput, VindexError> {
-    traverse(
-        plan,
-        ops,
-        tokens,
-        backend,
-        resume,
-        sink,
-        None::<&mut dyn KvState>,
-    )
+    // A one-shot forward owns whatever continuation state the plan needs.
+    //
+    // For a wholly-softmax stack that is nothing: `None` keeps the
+    // existing behaviour exactly, including not materialising KV rows a
+    // caller never asked for. A stack with a recurrence has no such
+    // choice — its layers cannot run without durable buffers — so this
+    // allocates them for the duration of the call. The provider starts at
+    // position 0, which keeps every softmax layer on the batched
+    // attention path it already took.
+    if plan.layers.iter().all(|l| l.attention.softmax().is_some()) {
+        return traverse(
+            plan,
+            ops,
+            tokens,
+            backend,
+            resume,
+            sink,
+            None::<&mut dyn KvState>,
+        );
+    }
+    let mut owned = kv::RowKvState::default();
+    owned.prepare_continuation(
+        &continuation::plan_continuation_geometry(plan).map_err(VindexError::Parse)?,
+    )?;
+    traverse(plan, ops, tokens, backend, resume, sink, Some(&mut owned))
 }
 
 /// Batch prefill (VI3-INF-3): the batch traversal over `tokens`,
@@ -243,7 +259,12 @@ pub fn prefill_prepared<B: PlanBackend + ?Sized>(
     backend: &B,
     kv: &mut dyn KvState,
 ) -> Result<FinalOutput, VindexError> {
-    kv.prepare(&kv::plan_kv_geometry(plan));
+    // The FULL geometry, KV and recurrent alike. `plan_kv_geometry` is
+    // the KV-only adapter and refuses a hybrid plan outright, which was
+    // the right answer while nothing could execute one.
+    kv.prepare_continuation(
+        &continuation::plan_continuation_geometry(plan).map_err(VindexError::Parse)?,
+    )?;
     let base = kv.position();
     let out = traverse(
         plan,
@@ -281,6 +302,34 @@ fn traverse<B: PlanBackend + ?Sized, K: KvState + ?Sized>(
         ))
     })?;
     let hidden = embedding.table.shape[1];
+
+    // **Refuse before any output.** A recurrence needs durable buffers,
+    // and discovering at layer 63 that nobody can hold them would mean
+    // every earlier layer had already been emitted — a caller left
+    // holding 16 of 64 layers cannot tell that from a finished model.
+    // QW-1 put this refusal up front for exactly that reason; the
+    // question it asks has changed (from "can this run at all" to "can
+    // this provider hold the state"), its position must not.
+    for (offset, layer) in plan.layers.iter().enumerate() {
+        if layer.attention.softmax().is_some() {
+            continue;
+        }
+        let Some(provider) = kv.as_mut() else {
+            return Err(VindexError::Parse(format!(
+                "layer {} carries `{}`, which keeps durable continuation state, and this \
+                 traversal was given no provider to hold it",
+                layer.layer,
+                layer.attention.declared_name(),
+            )));
+        };
+        provider.recurrent_state(offset).map_err(|e| {
+            VindexError::Parse(format!(
+                "layer {} carries `{}`: {e}",
+                layer.layer,
+                layer.attention.declared_name(),
+            ))
+        })?;
+    }
 
     let (start_layer, mut h) = match resume {
         Some(point) => {
@@ -433,39 +482,73 @@ fn execute_layer<B: PlanBackend + ?Sized, K: KvState + ?Sized>(
     // sequence it is given, so it cannot serve a prefill that resumes
     // part-way through one. Extending a populated provider therefore
     // still steps.
-    let attention_op = softmax_or_refuse(layer)?;
-    let attn_out = match kv {
-        Some((kv, layer_index)) if kv.position() == 0 => {
-            let out = backend.attention(prepared.attention.call(
-                attention_op,
+    // Dispatch on the OPERATOR the prepared layer holds. There is no
+    // `softmax_or_refuse` here any more: a recurrence is something this
+    // traversal runs, not something it declines. Both arms produce the
+    // attention block's output for every position, and the residual and
+    // FFN below are shared — the operator changes what attention IS, not
+    // what a decoder layer does around it.
+    let attn_out = match &prepared.attention {
+        PreparedAttention::GatedDelta(ops) => {
+            let Some((provider, layer_index)) = kv else {
+                return Err(VindexError::Parse(format!(
+                    "layer {} runs a recurrence, which needs durable continuation state, \
+                     and this traversal was given no provider to hold it",
+                    layer.layer
+                )));
+            };
+            // Resolved BEFORE any arithmetic. A provider that cannot hold
+            // these buffers must not see a half-updated layer — the same
+            // refuse-before-commit contract QW-1 established for the plan.
+            let state = provider.recurrent_state(layer_index)?;
+            gated_delta::layer_forward(
+                &ops.op,
+                &ops.weights(),
                 &inputs,
-                layer.pre_attention_norm.eps,
-                hidden,
-            ))?;
-            for (key, value) in out.keys.into_iter().zip(out.values) {
-                kv.append(layer_index, key, value);
-            }
-            out.outputs
+                state,
+                gated_delta::Mutation::None,
+            )
+            .output
         }
-        Some((kv, layer_index)) => attention_into_kv(
-            attention_op,
-            &prepared.attention,
-            &inputs,
-            layer.pre_attention_norm.eps,
-            hidden,
-            backend,
-            kv,
-            layer_index,
-        )?,
-        None => {
-            backend
-                .attention(prepared.attention.call(
+        PreparedAttention::Softmax(ops) => {
+            let attention_op = layer
+                .attention
+                .softmax()
+                .expect("prepared softmax operands imply a softmax op");
+            match kv {
+                Some((kv, layer_index)) if kv.position() == 0 => {
+                    let out = backend.attention(ops.call(
+                        attention_op,
+                        &inputs,
+                        layer.pre_attention_norm.eps,
+                        hidden,
+                    ))?;
+                    for (key, value) in out.keys.into_iter().zip(out.values) {
+                        kv.append(layer_index, key, value);
+                    }
+                    out.outputs
+                }
+                Some((kv, layer_index)) => attention_into_kv(
                     attention_op,
+                    ops,
                     &inputs,
                     layer.pre_attention_norm.eps,
                     hidden,
-                ))?
-                .outputs
+                    backend,
+                    kv,
+                    layer_index,
+                )?,
+                None => {
+                    backend
+                        .attention(ops.call(
+                            attention_op,
+                            &inputs,
+                            layer.pre_attention_norm.eps,
+                            hidden,
+                        ))?
+                        .outputs
+                }
+            }
         }
     };
     h.par_iter_mut()

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -819,24 +819,3 @@ fn project<B: PlanBackend + ?Sized>(
         x,
     })
 }
-
-/// This layer's softmax attention op, or a refusal naming what it carries
-/// instead.
-///
-/// Support or refuse, never invisibility (rung M3). A Gated DeltaNet layer
-/// has no per-position keys or values to hand a softmax backend and keeps
-/// no KV row, so there is nothing here to execute *as attention* — and on
-/// a hybrid checkpoint that is not an edge case: Qwen3.8-27B declares 48
-/// of its 64 layers that way. Running the plan anyway would execute a
-/// different model and report a number for it, which is the one outcome
-/// this engine refuses.
-pub(crate) fn softmax_or_refuse(layer: &LayerPlan) -> Result<&AttentionOp, VindexError> {
-    layer.attention.softmax().ok_or_else(|| {
-        VindexError::Parse(format!(
-            "layer {} carries `{}`, which this executor cannot run: it has \
-             no softmax attention and keeps no KV row",
-            layer.layer,
-            layer.attention.declared_name(),
-        ))
-    })
-}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -501,12 +501,13 @@ fn execute_layer<B: PlanBackend + ?Sized, K: KvState + ?Sized>(
             // these buffers must not see a half-updated layer — the same
             // refuse-before-commit contract QW-1 established for the plan.
             let state = provider.recurrent_state(layer_index)?;
-            gated_delta::layer_forward(
+            gated_delta::layer_forward_with(
                 &ops.op,
                 &ops.weights(),
                 &inputs,
                 state,
                 gated_delta::Mutation::None,
+                backend.dense_projector(),
             )
             .output
         }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -52,7 +52,7 @@ use super::weights::{load_weight, LoadedWeight};
 use super::AttentionOperands;
 use crate::error::VindexError;
 
-use super::super::{ComponentOpPlan, NormOp, OutputOp};
+use super::super::{ComponentOpPlan, GatedDeltaOp, LayerAttention, NormOp, OperandRef, OutputOp};
 
 /// Which part of a component's program to prepare.
 ///
@@ -136,13 +136,114 @@ impl PreparedNorm {
 /// One layer's operands, lowered into the backend's execution form.
 pub(super) struct PreparedLayer {
     pub(super) pre_attention: PreparedNorm,
-    pub(super) attention: AttentionOperands,
+    pub(super) attention: PreparedAttention,
     pub(super) post_attention: Option<PreparedNorm>,
     pub(super) pre_ffn: PreparedNorm,
     pub(super) ffn: FfnOperands,
     pub(super) post_ffn: Option<PreparedNorm>,
     /// The layer's output scalar, when the plan carries one.
     pub(super) layer_scale: Option<f32>,
+}
+
+/// Which attention-class operator a prepared layer holds operands for.
+///
+/// An enum, not `Option<AttentionOperands>` and not "softmax unless
+/// proven otherwise": a layer runs exactly one operator, and the
+/// alternative spellings both make "I could not tell" indistinguishable
+/// from "it is softmax". Qwen3.8 is 48 layers where that difference is
+/// the whole model.
+///
+/// Chosen from the op plan's `LayerAttention`, which the op builder
+/// derived from operand EVIDENCE — so the operands loaded here and the
+/// operator dispatched later cannot disagree.
+pub(super) enum PreparedAttention {
+    Softmax(Box<AttentionOperands>),
+    GatedDelta(Box<GatedDeltaOperands>),
+}
+
+impl PreparedAttention {
+    /// Matrix operands for device placement.
+    ///
+    /// A recurrence contributes none: its nine operands are elementwise
+    /// glue and a depthwise convolution, not the matrix traffic a device
+    /// backend holds resident — and no device backend runs this operator
+    /// yet, so placing them would reserve memory nothing reads.
+    fn weight_slices(&self) -> Vec<WeightSlice<'_>> {
+        match self {
+            Self::Softmax(ops) => ops.weight_slices(),
+            Self::GatedDelta(_) => Vec::new(),
+        }
+    }
+
+    /// The softmax operands, or a refusal naming what this layer holds.
+    ///
+    /// The KV-shaped paths still call this; it is the one place they
+    /// learn that a layer is not theirs.
+    pub(super) fn softmax(&self) -> Result<&AttentionOperands, VindexError> {
+        match self {
+            Self::Softmax(ops) => Ok(ops),
+            Self::GatedDelta(_) => Err(VindexError::Parse(
+                "this layer runs a Gated DeltaNet recurrence; it has no softmax operands"
+                    .to_string(),
+            )),
+        }
+    }
+}
+
+/// The nine operands a Gated DeltaNet layer reads, loaded once.
+pub(super) struct GatedDeltaOperands {
+    pub(super) op: GatedDeltaOp,
+    pub(super) in_proj_qkv: Vec<f32>,
+    pub(super) in_proj_a: Vec<f32>,
+    pub(super) in_proj_b: Vec<f32>,
+    pub(super) in_proj_z: Vec<f32>,
+    pub(super) conv1d: Vec<f32>,
+    pub(super) a_log: Vec<f32>,
+    pub(super) dt_bias: Vec<f32>,
+    pub(super) norm: Vec<f32>,
+    pub(super) out_proj: Vec<f32>,
+    pub(super) norm_eps: f32,
+}
+
+impl GatedDeltaOperands {
+    fn load(
+        op: &GatedDeltaOp,
+        store: OperandSource<'_>,
+        norm_eps: f32,
+    ) -> Result<Self, VindexError> {
+        // f32 throughout: the recurrence is elementwise glue and a
+        // convolution, not the matrix traffic a backend picks a format
+        // for. The reference path is the only consumer today.
+        let load = |r: &OperandRef| store.load(r);
+        Ok(Self {
+            op: op.clone(),
+            in_proj_qkv: load(&op.in_proj_qkv)?,
+            in_proj_a: load(&op.in_proj_a)?,
+            in_proj_b: load(&op.in_proj_b)?,
+            in_proj_z: load(&op.in_proj_z)?,
+            conv1d: load(&op.conv1d)?,
+            a_log: load(&op.a_log)?,
+            dt_bias: load(&op.dt_bias)?,
+            norm: load(&op.norm)?,
+            out_proj: load(&op.out_proj)?,
+            norm_eps,
+        })
+    }
+
+    pub(super) fn weights(&self) -> super::gated_delta::GatedDeltaWeights<'_> {
+        super::gated_delta::GatedDeltaWeights {
+            in_proj_qkv: &self.in_proj_qkv,
+            in_proj_a: &self.in_proj_a,
+            in_proj_b: &self.in_proj_b,
+            in_proj_z: &self.in_proj_z,
+            conv1d: &self.conv1d,
+            a_log: &self.a_log,
+            dt_bias: &self.dt_bias,
+            norm: &self.norm,
+            out_proj: &self.out_proj,
+            norm_eps: self.norm_eps,
+        }
+    }
 }
 
 /// A component's operands, lowered once for a given slice and backend.
@@ -200,11 +301,21 @@ impl PreparedOperands {
         for layer in &plan.layers[range] {
             layers.push(PreparedLayer {
                 pre_attention: PreparedNorm::load(&layer.pre_attention_norm, store)?,
-                attention: AttentionOperands::load(
-                    super::softmax_or_refuse(layer)?,
-                    store,
-                    backend.weight_format(MatrixClass::AttentionProjection),
-                )?,
+                // The operator is decided here, from the plan, and the
+                // operands follow it. No layer is prepared as softmax by
+                // default.
+                attention: match &layer.attention {
+                    LayerAttention::Softmax(op) => {
+                        PreparedAttention::Softmax(Box::new(AttentionOperands::load(
+                            op,
+                            store,
+                            backend.weight_format(MatrixClass::AttentionProjection),
+                        )?))
+                    }
+                    LayerAttention::GatedDelta(op) => PreparedAttention::GatedDelta(Box::new(
+                        GatedDeltaOperands::load(op, store, layer.pre_attention_norm.eps as f32)?,
+                    )),
+                },
                 post_attention: layer
                     .post_attention_norm
                     .as_ref()

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -174,20 +174,6 @@ impl PreparedAttention {
             Self::GatedDelta(_) => Vec::new(),
         }
     }
-
-    /// The softmax operands, or a refusal naming what this layer holds.
-    ///
-    /// The KV-shaped paths still call this; it is the one place they
-    /// learn that a layer is not theirs.
-    pub(super) fn softmax(&self) -> Result<&AttentionOperands, VindexError> {
-        match self {
-            Self::Softmax(ops) => Ok(ops),
-            Self::GatedDelta(_) => Err(VindexError::Parse(
-                "this layer runs a Gated DeltaNet recurrence; it has no softmax operands"
-                    .to_string(),
-            )),
-        }
-    }
 }
 
 /// The nine operands a Gated DeltaNet layer reads, loaded once.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -39,6 +39,26 @@ use super::backend::{
     AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, FfnCall, GateCall, NormCall,
     PlanBackend, ProjectCall, ProjectedQkv, QkNormCall, RoutedFfnCall,
 };
+/// Gated DeltaNet's dense projections through `larql-compute`, which
+/// dispatches to BLAS `sgemv` (Accelerate on macOS, OpenBLAS on
+/// Linux/FreeBSD, scalar on Windows by deliberate choice).
+///
+/// Measured against the scalar transcription on Qwen3.8's real shapes:
+/// 18.5x at 10240x5120, 19.2x at 6144x5120, 20.8x at 5120x6144, and
+/// 46.9x at the tiny 48x5120 — BLAS call overhead never lost, so all
+/// five projections route here rather than only the large ones.
+///
+/// NOT bit-identical: sgemv reassociates the sum, measured at rel_rms
+/// ~1.3e-6 against the scalar path. The existing parity gates are what
+/// judge that, and the reference implementation stays independent.
+struct BlasProjections;
+
+impl super::gated_delta::DenseProjector for BlasProjections {
+    fn project(&self, weight: &[f32], x: &[f32], out_dim: usize) -> Vec<f32> {
+        matmul_vec(x, weight, out_dim, x.len())
+    }
+}
+
 use super::kernels::{
     gather_fused_half, mrope_rotate_scaled, rope_rotate, rope_rotate_scaled, FusedHalf,
 };
@@ -568,6 +588,10 @@ impl ProductionBackend {
 }
 
 impl PlanBackend for ProductionBackend {
+    fn dense_projector(&self) -> &dyn super::gated_delta::DenseProjector {
+        &BlasProjections
+    }
+
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attention_kv_parity.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attention_kv_parity.rs
@@ -147,14 +147,17 @@ fn both_realisations<B: PlanBackend>(
         .map(|row| prepared.pre_attention.apply(backend, row))
         .collect();
 
+    // This probe is about the KV realisations of SOFTMAX attention, so
+    // it takes the softmax operands directly and would not compile for a
+    // recurrence — which is the honest shape: a recurrence keeps no rows
+    // and has no batched-vs-stepped KV question to answer.
+    let super::super::prepared::PreparedAttention::Softmax(attn_ops) = &prepared.attention else {
+        panic!("this probe is for softmax layers");
+    };
+
     // Realisation A: one batched call over every position.
     let out = backend
-        .attention(prepared.attention.softmax().unwrap().call(
-            layer.attention.softmax().unwrap(),
-            &inputs,
-            eps,
-            width,
-        ))
+        .attention(attn_ops.call(layer.attention.softmax().unwrap(), &inputs, eps, width))
         .unwrap();
     let batched = Realisation {
         outputs: out.outputs,
@@ -173,7 +176,7 @@ fn both_realisations<B: PlanBackend>(
         values: Vec::with_capacity(inputs.len()),
     };
     for offset in 0..inputs.len() {
-        let call = prepared.attention.softmax().unwrap().call(
+        let call = attn_ops.call(
             layer.attention.softmax().unwrap(),
             &inputs[offset..=offset],
             eps,
@@ -260,8 +263,11 @@ fn stepping_the_same_position_twice_yields_identical_rows() {
         .map(|row| prepared.pre_attention.apply(&backend, row))
         .collect();
 
+    let super::super::prepared::PreparedAttention::Softmax(attn_ops) = &prepared.attention else {
+        panic!("this probe is for softmax layers");
+    };
     let step = |position: usize| {
-        let call = prepared.attention.softmax().unwrap().call(
+        let call = attn_ops.call(
             layer.attention.softmax().unwrap(),
             &inputs[position..=position],
             layer.pre_attention_norm.eps,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attention_kv_parity.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attention_kv_parity.rs
@@ -149,11 +149,12 @@ fn both_realisations<B: PlanBackend>(
 
     // Realisation A: one batched call over every position.
     let out = backend
-        .attention(
-            prepared
-                .attention
-                .call(layer.attention.softmax().unwrap(), &inputs, eps, width),
-        )
+        .attention(prepared.attention.softmax().unwrap().call(
+            layer.attention.softmax().unwrap(),
+            &inputs,
+            eps,
+            width,
+        ))
         .unwrap();
     let batched = Realisation {
         outputs: out.outputs,
@@ -172,7 +173,7 @@ fn both_realisations<B: PlanBackend>(
         values: Vec::with_capacity(inputs.len()),
     };
     for offset in 0..inputs.len() {
-        let call = prepared.attention.call(
+        let call = prepared.attention.softmax().unwrap().call(
             layer.attention.softmax().unwrap(),
             &inputs[offset..=offset],
             eps,
@@ -260,7 +261,7 @@ fn stepping_the_same_position_twice_yields_identical_rows() {
         .collect();
 
     let step = |position: usize| {
-        let call = prepared.attention.call(
+        let call = prepared.attention.softmax().unwrap().call(
             layer.attention.softmax().unwrap(),
             &inputs[position..=position],
             layer.pre_attention_norm.eps,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/gated_delta_refusal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/gated_delta_refusal.rs
@@ -113,15 +113,25 @@ fn a_hybrid_plan_is_refused_before_any_layer_output() {
             Ok(())
         });
 
-    let err = result.expect_err("a plan carrying a recurrence must not execute");
+    let err = result.expect_err("a plan naming operands the container lacks must not execute");
+    // The claim this test has always made, unchanged: nothing is emitted
+    // before the refusal. The recurrence is in the LAST layer, so a lazy
+    // refusal would have committed three layers first.
     assert!(
         events.is_empty(),
         "refused only AFTER committing output: {events:?}"
     );
+    // What CHANGED at QW-3.6b: a recurrence is no longer refused for
+    // being a recurrence — the traversal runs them. This fixture injects
+    // a `GatedDelta` op into a plan whose container holds no
+    // `linear_attn.*` tensors, so what is now wrong with it is the
+    // disagreement between plan and operands, and the refusal names that.
+    // The recurrence-execution claims moved to
+    // `tests::hybrid_traversal`, which runs a real encoded hybrid stack.
     let message = err.to_string();
     assert!(
-        message.contains("linear_attention"),
-        "the refusal must name the unsupported semantic, not a downstream \
+        message.contains("in_proj_qkv"),
+        "the refusal must name the operand it could not find, not a downstream \
          symptom; got: {message}"
     );
 }
@@ -132,8 +142,8 @@ fn a_hybrid_plan_is_refused_before_any_layer_output() {
 fn the_one_shot_entry_point_refuses_too() {
     let (_container, plan, store) = hybrid_plan();
     let err = execute_plan(&plan, &store, &[1u32, 2, 3], &ReferenceBackend)
-        .expect_err("a plan carrying a recurrence must not execute");
-    assert!(err.to_string().contains("linear_attention"), "{err}");
+        .expect_err("a plan naming operands the container lacks must not execute");
+    assert!(err.to_string().contains("in_proj_qkv"), "{err}");
 }
 
 /// The regression half: an unmodified softmax plan still runs. Without

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/hybrid_traversal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/hybrid_traversal.rs
@@ -240,3 +240,65 @@ fn a_persisted_split_prefix_matches_one_batch() {
         "global position drifted"
     );
 }
+
+/// **QW-3.7 — decode equals batch on a hybrid stack.**
+///
+/// The single-position path and the batched one must agree token for
+/// token. This is the gate that makes autoregressive generation
+/// meaningful: a decode step that reconstructed its convolution window
+/// from the current batch would see a window of ONE and still produce
+/// plausible numbers, and only a comparison against the batched
+/// realisation catches it.
+///
+/// Both arms teacher-force the same tokens, so a per-position difference
+/// is attributable to the realisation rather than to the two arms having
+/// generated different text.
+#[test]
+fn stepping_a_hybrid_stack_matches_the_batched_traversal() {
+    use crate::format::vindex3::opplan::exec::decode::DecodeSession;
+
+    let (_c, plan, store) = hybrid();
+    let tokens = [1u32, 2, 3, 4, 5, 6, 7];
+
+    // Batched: the realisation QW-3.6b proved against HF.
+    let mut batched = RowKvState::default();
+    let batch_logits = run(&plan, &store, &tokens, &mut batched).unwrap();
+
+    // Stepped: one position at a time, state carried in place.
+    let mut session = DecodeSession::new(&plan, &store, &ReferenceBackend).unwrap();
+    let mut last = Vec::new();
+    for &token in &tokens {
+        last = session
+            .step(token)
+            .unwrap()
+            .logits
+            .expect("the fixture carries an output head");
+    }
+
+    assert_eq!(last.len(), batch_logits.len());
+    let num: f32 = last
+        .iter()
+        .zip(&batch_logits)
+        .map(|(a, b)| (a - b) * (a - b))
+        .sum();
+    let den: f32 = batch_logits.iter().map(|b| b * b).sum();
+    let rel = (num / den.max(f32::MIN_POSITIVE)).sqrt();
+    assert!(
+        rel < 1e-5,
+        "stepped decode disagrees with the batched traversal on a hybrid stack: \
+         rel_rms {rel:e} — the recurrent buffers are not carrying across steps"
+    );
+
+    // The recurrent buffers must have MOVED, or the comparison above
+    // would also be satisfied by two runs that both did nothing.
+    for (index, layer) in plan.layers.iter().enumerate() {
+        if matches!(layer.attention, LayerAttention::GatedDelta(_)) {
+            let state = batched.recurrent_state(index).unwrap();
+            assert!(
+                state.buffer(0).cells().iter().any(|c| *c != 0.0)
+                    && state.buffer(1).cells().iter().any(|c| *c != 0.0),
+                "layer {index} finished with untouched state"
+            );
+        }
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/hybrid_traversal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/hybrid_traversal.rs
@@ -1,0 +1,242 @@
+//! QW-3.6b: the traversal runs a hybrid stack.
+//!
+//! Four gates, frozen before the refactor:
+//!
+//! 1. **Dispatch** — an `LLLF` stack calls three recurrent paths and one
+//!    softmax path, checked by POSITION rather than by count.
+//! 2. **Wrong state kind** — a provider that cannot hold recurrent
+//!    buffers refuses, and refuses before committing any output.
+//! 3. **State update** — a recurrent layer mutates both its buffers and
+//!    appends no KV row; a softmax layer appends one KV position and
+//!    touches no recurrent buffer.
+//! 4. **Prefix equivalence** — `0..n` in one batch equals `0..k` then
+//!    `k..n` with the state persisted. The first test that proves the
+//!    whole continuation substrate composes rather than merely typechecks.
+
+use crate::format::vindex3::encode::encode_system;
+use crate::format::vindex3::fixtures::hybrid_lllf_f32_model;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::kv::{
+    ContinuationError, ContinuationProvider, RowKvState,
+};
+use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan, LayerAttention};
+
+/// The encoded hybrid fixture, planned and ready to execute.
+fn hybrid() -> (tempfile::TempDir, ComponentOpPlan, OperandStore) {
+    let src = tempfile::tempdir().unwrap();
+    hybrid_lllf_f32_model(src.path());
+    let inventory = larql_models::inventory::build_inventory(src.path()).unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_system(&[("hybrid".to_string(), inventory)], container.path())
+        .expect("the hybrid fixture is admissible");
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let outcome = plan_component_ops(&inspection, container.path(), "target").unwrap();
+    assert!(outcome.closed(), "defects: {:#?}", outcome.defects);
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    (container, outcome.plan.unwrap(), store)
+}
+
+fn run(
+    plan: &ComponentOpPlan,
+    store: &OperandStore,
+    tokens: &[u32],
+    provider: &mut dyn ContinuationProvider,
+) -> Result<Vec<f32>, crate::error::VindexError> {
+    let base = provider.position();
+    let out = crate::format::vindex3::opplan::exec::prefill_plan(
+        plan,
+        store,
+        tokens,
+        &ReferenceBackend,
+        provider,
+    )?;
+    assert_eq!(provider.position(), base + tokens.len());
+    Ok(out.logits.expect("the fixture carries an output head"))
+}
+
+/// **Gate 1 — dispatch.** Three recurrences then one softmax, by position.
+#[test]
+fn an_lllf_stack_dispatches_three_recurrences_then_one_softmax() {
+    let (_c, plan, _store) = hybrid();
+    let kinds: Vec<&str> = plan
+        .layers
+        .iter()
+        .map(|l| match &l.attention {
+            LayerAttention::GatedDelta(_) => "L",
+            LayerAttention::Softmax(_) => "F",
+        })
+        .collect();
+    assert_eq!(
+        kinds,
+        vec!["L", "L", "L", "F"],
+        "the plan itself must carry the cadence, by position"
+    );
+}
+
+/// **Gate 2 — wrong state kind, refused before any output.**
+///
+/// A KV-only provider meets a stack whose first three layers keep no
+/// rows. It must refuse, name the semantic, and emit nothing — the
+/// softmax layer is LAST precisely so a lazy refusal cannot pass.
+#[test]
+fn a_kv_only_provider_refuses_a_recurrence_before_committing_output() {
+    /// Holds rows and says plainly that it holds nothing else.
+    #[derive(Default)]
+    struct KvOnly(RowKvState);
+    impl ContinuationProvider for KvOnly {
+        fn prepare(
+            &mut self,
+            layers: &[crate::format::vindex3::opplan::exec::kv::LayerKvGeometry],
+        ) {
+            self.0.prepare(layers)
+        }
+        fn append(&mut self, layer: usize, key: Vec<f32>, value: Vec<f32>) {
+            self.0.append(layer, key, value)
+        }
+        fn keys(&self, layer: usize) -> &[Vec<f32>] {
+            self.0.keys(layer)
+        }
+        fn values(&self, layer: usize) -> &[Vec<f32>] {
+            self.0.values(layer)
+        }
+        fn position(&self) -> usize {
+            self.0.position()
+        }
+        fn set_position(&mut self, position: usize) {
+            self.0.set_position(position)
+        }
+        fn recurrent_state(
+            &mut self,
+            layer: usize,
+        ) -> Result<
+            &mut crate::format::vindex3::opplan::exec::continuation::RecurrentState,
+            ContinuationError,
+        > {
+            Err(ContinuationError::RecurrentUnsupported {
+                provider: "KvOnly",
+                layer,
+            })
+        }
+    }
+
+    let (_c, plan, store) = hybrid();
+    let mut provider = KvOnly::default();
+    let geometry =
+        crate::format::vindex3::opplan::exec::continuation::plan_continuation_geometry(&plan)
+            .unwrap();
+    // Refused at ANNOUNCEMENT — earlier still than the first layer. The
+    // provider is told the geometry before a single token is embedded,
+    // so a provider that cannot hold it says so there.
+    let announced = provider
+        .prepare_continuation(&geometry)
+        .expect_err("a KV-only provider cannot hold this stack's state");
+    assert!(
+        matches!(announced, ContinuationError::RecurrentUnsupported { .. }),
+        "the refusal must say the provider lacks recurrent state, not something \
+         downstream: {announced:?}"
+    );
+
+    // ...and the same refusal on a traversal that USES the provider,
+    // before any output is committed. The softmax layer is LAST, so a
+    // lazy refusal would have emitted three layers first.
+    let mut provider = KvOnly::default();
+    let err = crate::format::vindex3::opplan::exec::prefill_plan(
+        &plan,
+        &store,
+        &[1u32, 2, 3, 4, 5],
+        &ReferenceBackend,
+        &mut provider,
+    )
+    .expect_err("a KV-only provider cannot prefill this stack");
+    assert!(
+        err.to_string().contains("recurrent"),
+        "the refusal must name the missing side: {err}"
+    );
+    // Nothing was committed — not even allocated. The provider never
+    // reached a layer, so its logical position never advanced.
+    assert_eq!(
+        provider.position(),
+        0,
+        "refused only AFTER advancing the continuation position"
+    );
+}
+
+/// **Gate 3 — state update.** Each layer touches its own kind of state
+/// and only its own.
+#[test]
+fn each_layer_updates_its_own_kind_of_state_and_no_other() {
+    let (_c, plan, store) = hybrid();
+    let mut provider = RowKvState::default();
+    run(&plan, &store, &[1u32, 2, 3, 4, 5], &mut provider).unwrap();
+
+    for (index, layer) in plan.layers.iter().enumerate() {
+        match &layer.attention {
+            LayerAttention::GatedDelta(_) => {
+                let state = provider.recurrent_state(index).expect("a recurrent layer");
+                let matrix = state.buffer(0).cells().to_vec();
+                let conv = state.buffer(1).cells().to_vec();
+                assert!(
+                    matrix.iter().any(|c| *c != 0.0),
+                    "layer {index}: the delta matrix never moved"
+                );
+                assert!(
+                    conv.iter().any(|c| *c != 0.0),
+                    "layer {index}: the convolution history never moved"
+                );
+                assert!(
+                    provider.keys(index).is_empty() && provider.values(index).is_empty(),
+                    "layer {index} kept KV rows it has no keys or values for"
+                );
+            }
+            LayerAttention::Softmax(_) => {
+                assert_eq!(
+                    provider.keys(index).len(),
+                    5,
+                    "layer {index}: one KV row per position"
+                );
+                assert_eq!(provider.values(index).len(), 5);
+                assert!(
+                    provider.recurrent_state(index).is_err(),
+                    "layer {index} allocated recurrent buffers for a softmax layer"
+                );
+            }
+        }
+    }
+}
+
+/// **Gate 4 — prefix equivalence.** One batch equals a persisted split.
+///
+/// The integration proof: it exercises the convolution history, the delta
+/// matrix, the KV rows, the global position and the hybrid dispatch at
+/// once. Any one of them failing to carry shows up here.
+#[test]
+fn a_persisted_split_prefix_matches_one_batch() {
+    let (_c, plan, store) = hybrid();
+    let tokens = [1u32, 2, 3, 4, 5];
+
+    let mut whole = RowKvState::default();
+    let one = run(&plan, &store, &tokens, &mut whole).unwrap();
+
+    let mut split = RowKvState::default();
+    run(&plan, &store, &tokens[..3], &mut split).unwrap();
+    let two = run(&plan, &store, &tokens[3..], &mut split).unwrap();
+
+    // Compare the LAST position, which both arms produced.
+    let (a, b) = (&one, &two);
+    assert_eq!(a.len(), b.len());
+    let num: f32 = a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum();
+    let den: f32 = a.iter().map(|x| x * x).sum();
+    let rel = (num / den.max(f32::MIN_POSITIVE)).sqrt();
+    assert!(
+        rel < 1e-5,
+        "a persisted split must reproduce the single batch: rel_rms {rel:e} — one of \
+         {{conv history, delta matrix, KV rows, position}} is not carrying"
+    );
+    assert_eq!(
+        whole.position(),
+        split.position(),
+        "global position drifted"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kv.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kv.rs
@@ -61,6 +61,18 @@ impl KvState for RecordingKvState {
     fn set_position(&mut self, position: usize) {
         self.inner.set_position(position);
     }
+
+    /// A KV-only recorder: it records rows, so it says so.
+    fn recurrent_state(
+        &mut self,
+        layer: usize,
+    ) -> Result<&mut super::super::continuation::RecurrentState, super::super::kv::ContinuationError>
+    {
+        Err(super::super::kv::ContinuationError::RecurrentUnsupported {
+            provider: "RecordingKvState",
+            layer,
+        })
+    }
 }
 
 #[test]

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -23,6 +23,7 @@ mod hybrid_traversal;
 mod mrope_parity;
 mod output_gate_fused;
 mod plan_fixtures;
+mod qw36c_layer0;
 #[rustfmt::skip]
 mod qw2_tiny_fixture;
 mod gated_delta_refusal;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -23,6 +23,7 @@ mod hybrid_traversal;
 mod mrope_parity;
 mod output_gate_fused;
 mod plan_fixtures;
+mod projection_bench;
 mod qw36c_layer0;
 #[rustfmt::skip]
 mod qw2_tiny_fixture;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -19,6 +19,7 @@ mod decode;
 mod device;
 mod gated_delta_parity;
 mod gated_delta_tiny;
+mod hybrid_traversal;
 mod mrope_parity;
 mod output_gate_fused;
 mod plan_fixtures;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/projection_bench.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/projection_bench.rs
@@ -1,0 +1,88 @@
+//! CPU-1A2: what the dense projections around Gated DeltaNet cost, and
+//! whether the BLAS-backed path is faster at each shape.
+//!
+//! Measurement, not a pass/fail gate — env-gated so it never runs in CI:
+//!
+//! ```text
+//! QW_PROJ_BENCH=1 cargo test --release projection_bench -- --nocapture
+//! ```
+//!
+//! The two tiny projections (`in_proj_a`/`in_proj_b`, 48 x 5120) are here
+//! precisely because BLAS call overhead may LOSE on them. A strategy that
+//! routed all five through BLAS for conceptual tidiness would be choosing
+//! consistency over measurement.
+
+use std::time::Instant;
+
+use crate::format::vindex3::fixtures::lcg_values;
+use crate::format::vindex3::opplan::exec::kernels::matvec;
+
+/// Qwen3.8's real projection shapes, `(name, out_dim, in_dim)`.
+const SHAPES: &[(&str, usize, usize)] = &[
+    ("delta in_proj_qkv", 10240, 5120),
+    ("delta in_proj_z", 6144, 5120),
+    ("delta out_proj", 5120, 6144),
+    ("delta in_proj_a", 48, 5120),
+    ("ffn gate/up (control)", 17408, 5120),
+];
+
+fn bench(label: &str, out_dim: usize, in_dim: usize) {
+    let w = lcg_values(out_dim * in_dim, 11);
+    let x = lcg_values(in_dim, 22);
+    let macs = (out_dim * in_dim) as f64;
+    let bytes = (out_dim * in_dim * 4) as f64;
+
+    // Iterations scaled so every shape gets a comparable amount of work;
+    // one pass over a 210 MB weight is already long, a 48-row one is not.
+    let iters = (2_000_000_000.0 / macs).clamp(3.0, 400.0) as usize;
+
+    let mut sink = 0.0f32;
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        let y = matvec(&w, out_dim, in_dim, &x);
+        sink += y[0];
+    }
+    let scalar = t0.elapsed().as_secs_f64() / iters as f64;
+
+    let t1 = Instant::now();
+    for _ in 0..iters {
+        let y = larql_compute::cpu::ops::moe::math::matmul_vec(&x, &w, out_dim, in_dim);
+        sink += y[0];
+    }
+    let blas = t1.elapsed().as_secs_f64() / iters as f64;
+
+    // Same inputs, so a disagreement is the arithmetic, not the data.
+    let a = matvec(&w, out_dim, in_dim, &x);
+    let b = larql_compute::cpu::ops::moe::math::matmul_vec(&x, &w, out_dim, in_dim);
+    let (mut num, mut den) = (0.0f64, 0.0f64);
+    for (p, q) in a.iter().zip(&b) {
+        num += (*p as f64 - *q as f64).powi(2);
+        den += (*q as f64).powi(2);
+    }
+    let rel = (num / den.max(f64::MIN_POSITIVE)).sqrt();
+
+    println!(
+        "  {label:22} {out_dim:>6}x{in_dim:<5}  scalar {:8.2} ms {:6.2} GB/s  |  \
+         blas {:8.2} ms {:7.2} GB/s  |  {:6.1}x  rel {:.2e}",
+        scalar * 1e3,
+        bytes / scalar / 1e9,
+        blas * 1e3,
+        bytes / blas / 1e9,
+        scalar / blas,
+        rel
+    );
+    std::hint::black_box(sink);
+}
+
+#[test]
+fn projection_bench() {
+    if std::env::var("QW_PROJ_BENCH").is_err() {
+        eprintln!("SKIP projection_bench: set QW_PROJ_BENCH=1");
+        return;
+    }
+    println!("\n  Qwen3.8 dense projections — scalar vs larql-compute BLAS\n");
+    for (label, out_dim, in_dim) in SHAPES {
+        bench(label, *out_dim, *in_dim);
+    }
+    println!();
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/qw36c_layer0.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/qw36c_layer0.rs
@@ -1,0 +1,318 @@
+//! QW-3.6c: isolate the first diverging layer of the real Qwen3.8-27B.
+//!
+//! The per-layer census over the real container put the divergence at the
+//! very first plane after the embedding:
+//!
+//! ```text
+//! layer_000 (embedding)   rel_rms 0.0000e0   cos 1.0000000   EXACT
+//! layer_001 (leaves L0)   rel_rms 1.2798e0   cos 0.8694140   <-- first
+//! ```
+//!
+//! Layer 0 is a Gated DeltaNet layer, so this runs THAT operator alone,
+//! on the real container's operands and HF's own normalised input, and
+//! compares against HF's `linear_attn` output. It separates the operator
+//! from the traversal: QW-2E proved the operator against HF using
+//! captured weights, and what is new here is the container's operands and
+//! this executor's plumbing around them.
+//!
+//! Env-gated — needs the 51 GB container and an HF capture — and skips
+//! LOUDLY rather than reporting success over a missing subject:
+//!
+//! ```text
+//! QW36C_CONTAINER=~/chris-models/Qwen3.8-27B.vindex3 \
+//! QW36C_CAPS=/path/to/l0_caps.json cargo test qw36c -- --nocapture
+//! ```
+
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::continuation::RecurrentState;
+use crate::format::vindex3::opplan::exec::gated_delta::{layer_forward, state_geometry, Mutation};
+use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::{plan_component_ops, LayerAttention};
+
+/// Accumulated in **f64**. The subject is f32, but a 248,320-term dot
+/// summed in f32 loses more precision than the difference being measured:
+/// the same comparison reads cos 0.9998944 in f32 and 0.9999807 in f64.
+/// An f32 instrument reports a divergence that is its own rounding — the
+/// measurement has to be more precise than the thing measured.
+fn metrics(mine: &[f32], theirs: &[f32]) -> (f32, f32, f32) {
+    let (mut num, mut den, mut dot, mut na, mut nb) = (0.0f64, 0.0f64, 0.0f64, 0.0f64, 0.0f64);
+    for (x, y) in mine.iter().zip(theirs) {
+        let (x, y) = (*x as f64, *y as f64);
+        num += (x - y) * (x - y);
+        den += y * y;
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    let mx = mine
+        .iter()
+        .zip(theirs)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    (
+        (num / den.max(f64::MIN_POSITIVE)).sqrt() as f32,
+        (dot / (na.sqrt() * nb.sqrt()).max(f64::MIN_POSITIVE)) as f32,
+        mx,
+    )
+}
+
+#[test]
+fn the_first_recurrent_layer_matches_hf_on_the_real_container() {
+    let (Ok(container), Ok(caps)) = (
+        std::env::var("QW36C_CONTAINER"),
+        std::env::var("QW36C_CAPS"),
+    ) else {
+        eprintln!("SKIP qw36c: set QW36C_CONTAINER and QW36C_CAPS");
+        return;
+    };
+    let root = std::path::Path::new(&container);
+    let inspection = inspect_container(root, false).unwrap();
+    let plan = plan_component_ops(&inspection, root, "target")
+        .unwrap()
+        .plan
+        .unwrap();
+    let store = OperandStore::open(root, &inspection).unwrap();
+
+    let LayerAttention::GatedDelta(op) = &plan.layers[0].attention else {
+        panic!("layer 0 of this container is not a recurrence");
+    };
+    let caps: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(caps).unwrap()).unwrap();
+    let grab = |k: &str| -> Vec<Vec<f32>> {
+        caps[k]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|row| {
+                row.as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|v| v.as_f64().unwrap() as f32)
+                    .collect()
+            })
+            .collect()
+    };
+    // HF's OWN normalised input, so the norm is not on trial here.
+    let ln_in = grab("ln_in");
+    let hf_attn = grab("attn");
+
+    let load = |r: &crate::format::vindex3::opplan::OperandRef| store.load(r).unwrap();
+    let (qkv, a, b, z, conv, alog, dt, nrm, outp) = (
+        load(&op.in_proj_qkv),
+        load(&op.in_proj_a),
+        load(&op.in_proj_b),
+        load(&op.in_proj_z),
+        load(&op.conv1d),
+        load(&op.a_log),
+        load(&op.dt_bias),
+        load(&op.norm),
+        load(&op.out_proj),
+    );
+    let weights = crate::format::vindex3::opplan::exec::gated_delta::GatedDeltaWeights {
+        in_proj_qkv: &qkv,
+        in_proj_a: &a,
+        in_proj_b: &b,
+        in_proj_z: &z,
+        conv1d: &conv,
+        a_log: &alog,
+        dt_bias: &dt,
+        norm: &nrm,
+        out_proj: &outp,
+        norm_eps: plan.layers[0].pre_attention_norm.eps as f32,
+    };
+    let mut state = RecurrentState::zeros(&state_geometry(op).unwrap());
+    let planes = layer_forward(op, &weights, &ln_in, &mut state, Mutation::None);
+
+    println!("\n  pos   rel_rms      cosine      max_abs     |mine|     |hf|");
+    println!("  ------------------------------------------------------------");
+    let mut worst = 0.0f32;
+    for (t, (mine, theirs)) in planes.output.iter().zip(&hf_attn).enumerate() {
+        let (rel, cos, mx) = metrics(mine, theirs);
+        let nm: f32 = mine.iter().map(|v| v * v).sum::<f32>().sqrt();
+        let nt: f32 = theirs.iter().map(|v| v * v).sum::<f32>().sqrt();
+        println!("  {t}   {rel:.4e}  {cos:.7}  {mx:.4e}  {nm:9.4}  {nt:9.4}");
+        worst = worst.max(rel);
+    }
+    // Bound set FROM the measured range (4.8e-4 … 2.7e-3 across the five
+    // positions), not chosen to pass. The floor is not f32 arithmetic
+    // order — a 5120-term f32 dot disagrees by ~4e-6 — so something at
+    // the 1e-3 scale remains unexplained between a BF16 container and an
+    // fp32-from-BF16 HF load. It is recorded as an open question rather
+    // than absorbed into a comfortable tolerance: see the commit for
+    // QW-3.6c.
+    assert!(
+        worst < 5e-3,
+        "the recurrence disagrees with HF on the real container: worst rel_rms {worst:e}"
+    );
+}
+
+/// Every OTHER stage of layer 0, isolated the same way.
+///
+/// The recurrence matches; the assembled layer does not. So the defect is
+/// in what the traversal does around the operator, and each stage is
+/// checked against HF's own capture of it rather than inferred from the
+/// layer's final residual.
+#[test]
+fn every_stage_of_the_first_layer_matches_hf() {
+    let (Ok(container), Ok(caps)) = (
+        std::env::var("QW36C_CONTAINER"),
+        std::env::var("QW36C_CAPS"),
+    ) else {
+        eprintln!("SKIP qw36c stages: set QW36C_CONTAINER and QW36C_CAPS");
+        return;
+    };
+    let root = std::path::Path::new(&container);
+    let inspection = inspect_container(root, false).unwrap();
+    let plan = plan_component_ops(&inspection, root, "target")
+        .unwrap()
+        .plan
+        .unwrap();
+    let store = OperandStore::open(root, &inspection).unwrap();
+    let layer = &plan.layers[0];
+
+    let caps: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(caps).unwrap()).unwrap();
+    let grab = |k: &str| -> Vec<Vec<f32>> {
+        caps[k]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|row| {
+                row.as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|v| v.as_f64().unwrap() as f32)
+                    .collect()
+            })
+            .collect()
+    };
+    let ln_in = grab("ln_in");
+    let ln_post = grab("ln_post");
+    let hf_mlp = grab("mlp");
+
+    // The residual entering layer 0 — the plane the census showed is
+    // bit-exact, so any disagreement below is this layer's own.
+    let plane0: Vec<Vec<f32>> = {
+        let raw = std::fs::read(
+            std::path::Path::new(&std::env::var("QW36C_PLANES").unwrap_or_default())
+                .join("layer_000.f32"),
+        )
+        .expect("set QW36C_PLANES to the --dump-layers directory");
+        let hidden = ln_in[0].len();
+        raw.chunks_exact(4)
+            .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+            .collect::<Vec<f32>>()
+            .chunks_exact(hidden)
+            .map(<[f32]>::to_vec)
+            .collect()
+    };
+
+    let rms = |x: &[f32], w: &[f32], offset: f32, eps: f64| -> Vec<f32> {
+        let mean: f64 = x.iter().map(|v| (*v as f64) * (*v as f64)).sum::<f64>() / x.len() as f64;
+        let inv = 1.0 / (mean + eps).sqrt();
+        x.iter()
+            .zip(w)
+            .map(|(v, wv)| ((*v as f64 * inv) as f32) * (wv + offset))
+            .collect()
+    };
+    let report = |name: &str, mine: &[f32], theirs: &[f32]| {
+        let (rel, cos, mx) = metrics(mine, theirs);
+        let nm: f32 = mine.iter().map(|v| v * v).sum::<f32>().sqrt();
+        let nt: f32 = theirs.iter().map(|v| v * v).sum::<f32>().sqrt();
+        println!(
+            "  {name:22} rel {rel:.4e}  cos {cos:.7}  max {mx:.4e}  |mine| {nm:8.4}  |hf| {nt:8.4}"
+        );
+        rel
+    };
+
+    println!();
+    let w_pre = store.load(&layer.pre_attention_norm.weight).unwrap();
+    let mine_ln_in = rms(
+        plane0.last().unwrap(),
+        &w_pre,
+        layer.pre_attention_norm.weight_offset,
+        layer.pre_attention_norm.eps,
+    );
+    let a = report("pre_attention norm", &mine_ln_in, ln_in.last().unwrap());
+
+    let w_ffn = store.load(&layer.pre_ffn_norm.weight).unwrap();
+    // HF's residual after attention, so the norm is on trial and not the
+    // recurrence that feeds it.
+    let hf_attn = grab("attn");
+    let resid: Vec<f32> = plane0
+        .last()
+        .unwrap()
+        .iter()
+        .zip(hf_attn.last().unwrap())
+        .map(|(p, a)| p + a)
+        .collect();
+    let mine_ln_post = rms(
+        &resid,
+        &w_ffn,
+        layer.pre_ffn_norm.weight_offset,
+        layer.pre_ffn_norm.eps,
+    );
+    let b = report("pre_ffn norm", &mine_ln_post, ln_post.last().unwrap());
+
+    println!(
+        "
+  pre_attention weight |w| {:.4}   pre_ffn weight |w| {:.4}",
+        w_pre.iter().map(|v| v * v).sum::<f32>().sqrt(),
+        w_ffn.iter().map(|v| v * v).sum::<f32>().sqrt()
+    );
+    let _ = hf_mlp;
+    // Measured 1.3e-3 and 2.6e-3. Same open question as above.
+    assert!(
+        a < 5e-3 && b < 5e-3,
+        "a norm stage disagrees with HF: pre_attn {a:e} pre_ffn {b:e}"
+    );
+}
+
+/// **The acceptance gate.** All 248,320 logits, and the same next token.
+///
+/// The closure measurement, not the debugging instrument — the per-layer
+/// census above is what finds a defect; this is what says there is not
+/// one. Reads the planes a `--dump-layers` run wrote, so it scores the
+/// shipped executable path rather than a re-derivation.
+#[test]
+fn the_real_checkpoint_reproduces_hf_logits_and_next_token() {
+    let (Ok(planes), Ok(oracle)) = (std::env::var("QW36C_PLANES"), std::env::var("QW36C_ORACLE"))
+    else {
+        eprintln!("SKIP qw36c logits: set QW36C_PLANES and QW36C_ORACLE");
+        return;
+    };
+    let hf: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(oracle).unwrap()).unwrap();
+    let theirs: Vec<f32> = hf["logits"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_f64().unwrap() as f32)
+        .collect();
+    let raw = std::fs::read(std::path::Path::new(&planes).join("logits.f32")).unwrap();
+    let all: Vec<f32> = raw
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect();
+    let mine = &all[all.len() - theirs.len()..];
+
+    let (rel, cos, mx) = metrics(mine, &theirs);
+    let arg = |v: &[f32]| {
+        v.iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .unwrap()
+            .0
+    };
+    let (mine_arg, hf_arg) = (arg(mine), arg(&theirs));
+    println!(
+        "
+  logits {}   rel_rms {rel:.4e}  cos {cos:.7}  max_abs {mx:.4e}",
+        theirs.len()
+    );
+    println!("  argmax  LARQL {mine_arg}   HF {hf_arg}");
+
+    assert_eq!(mine_arg, hf_arg, "different next token");
+    assert!(cos > 0.9999, "logit direction diverged: cos {cos:.7}");
+    assert!(rel < 2e-2, "logit magnitude diverged: rel_rms {rel:e}");
+}

--- a/scripts/qw38_hf_greedy_oracle.py
+++ b/scripts/qw38_hf_greedy_oracle.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""HF greedy token trajectory — the QW-3.7 acceptance oracle.
+
+Greedy so the comparison is deterministic on both sides: any sampling
+would make a trajectory mismatch uninterpretable. Records the argmax id
+AND its logit at every step, so a divergence can be read as "different
+token" or "same token, drifting margin".
+
+Usage:
+  python3 scripts/qw38_hf_greedy_oracle.py <ckpt> --tokens 760,... --new 12 --out traj.json
+"""
+import argparse, json, sys
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("checkpoint")
+    ap.add_argument("--tokens", required=True)
+    ap.add_argument("--new", type=int, default=12)
+    ap.add_argument("--dtype", default="float32", choices=["float32", "bfloat16"])
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+
+    ids = [int(t) for t in a.tokens.split(",")]
+    tok = AutoTokenizer.from_pretrained(a.checkpoint)
+    model = AutoModelForCausalLM.from_pretrained(
+        a.checkpoint, dtype=getattr(torch, a.dtype), low_cpu_mem_usage=True, device_map="cpu"
+    ).eval()
+
+    steps = []
+    cur = list(ids)
+    with torch.no_grad():
+        for i in range(a.new):
+            out = model(torch.tensor([cur]))
+            logits = out.logits[0, -1].float()
+            nxt = int(logits.argmax())
+            steps.append({
+                "step": i,
+                "id": nxt,
+                "logit": float(logits[nxt]),
+                "runner_up": float(torch.topk(logits, 2).values[1]),
+                "token": tok.decode([nxt]),
+            })
+            cur.append(nxt)
+            print(f"  {i}: {nxt} {tok.decode([nxt])!r}", file=sys.stderr)
+
+    json.dump({
+        "checkpoint": a.checkpoint, "dtype": a.dtype, "prompt_ids": ids,
+        "steps": steps, "text": tok.decode(cur),
+    }, open(a.out, "w"), indent=1)
+    print(f"\n  {tok.decode(cur)!r}", file=sys.stderr)
+
+main()

--- a/scripts/qw38_hf_layer_oracle.py
+++ b/scripts/qw38_hf_layer_oracle.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""HF per-layer residual planes for the QW-3.6c divergence census.
+
+The DEBUGGING instrument, not the acceptance gate: it captures the
+residual stream leaving every layer so the FIRST diverging layer can be
+identified, rather than hypothesising backwards from a wrong final token.
+
+Qwen3.8's cadence is LLLF, so the answer is diagnostic by position:
+
+    embedding differs        -> embedding / token pipeline
+    L0 differs               -> recurrent layer integration
+    L0..L2 agree, L3 differs -> softmax integration (M-RoPE, gate, KV)
+    many agree, one differs  -> position- or layer-specific semantics
+
+Only the LAST position is kept per plane — 5120 floats x 65 planes is
+tiny beside the model, and it is the position the logits come from.
+
+Usage:
+  python3 scripts/qw38_hf_layer_oracle.py <ckpt> --tokens 760,6511,... --out planes.json
+"""
+import argparse, json, sys
+import torch
+from transformers import AutoModelForCausalLM
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("checkpoint")
+    ap.add_argument("--tokens", required=True, help="comma-separated ids")
+    ap.add_argument("--dtype", default="float32", choices=["float32", "bfloat16"])
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+
+    ids = torch.tensor([[int(t) for t in a.tokens.split(",")]], dtype=torch.long)
+    model = AutoModelForCausalLM.from_pretrained(
+        a.checkpoint, dtype=getattr(torch, a.dtype), low_cpu_mem_usage=True, device_map="cpu"
+    ).eval()
+
+    with torch.no_grad():
+        out = model(ids, output_hidden_states=True)
+
+    # `hidden_states[0]` is the embedding output; [i+1] leaves layer i.
+    planes = [h[0, -1].float().tolist() for h in out.hidden_states]
+    logits = out.logits[0, -1].float()
+    json.dump({
+        "checkpoint": a.checkpoint,
+        "dtype": a.dtype,
+        "input_ids": ids[0].tolist(),
+        "position": ids.shape[1] - 1,
+        "hidden": len(planes[0]),
+        "planes": planes,            # [num_layers+1][hidden], last position
+        "argmax_id": int(logits.argmax()),
+        "logits": logits.tolist(),
+    }, open(a.out, "w"))
+    print(f"{len(planes)} planes (embedding + {len(planes)-1} layers), "
+          f"hidden {len(planes[0])}, argmax {int(logits.argmax())}", file=sys.stderr)
+
+main()


### PR DESCRIPTION
> **Stacked on #303** (which stacks on #301). Based on `worktree-qw36b-hybrid-traversal`, so this PR shows only CPU-1A2. Retarget as the lower PRs land.

```text
Qwen3.8-27B decode

  reference scalar          18,979 ms/token    0.053 tok/s
  production BLAS            4,670 ms/token    0.214 tok/s     4.06x
  + DeltaNet projections     1,106 ms/token    0.904 tok/s     4.22x

  total 17.2x        prompt 126.7 s -> 35.1 s
  12/12 HF tokens unchanged at every step
```

No new dependency. No change to the reference arithmetic.

---

## Profile first, and it was free

`/usr/bin/sample` on the live process gave line-level attribution with no instrumentation — release carries `debug = "line-tables-only"` and the decode step inlines into four attributable lines:

```text
FFN            63.3%   1.43 GMAC/s
DeltaNet       20.7%   1.41 GMAC/s
softmax attn    9.7%   0.91 GMAC/s
lm_head         6.3%   1.06 GMAC/s
```

**Every class at ~1.4 GMAC/s.** That uniformity was the finding: not a bad kernel somewhere, one scalar dot-product loop everywhere, single-threaded — no Rayon worker appeared at all, because the batch path parallelises over *positions* and decode has one.

## The first 4x needed no code

`larql-compute::matmul_vec` already dispatches to BLAS `sgemv`, and `blas-src` is already wired **cross-platform**: Accelerate on macOS, OpenBLAS on Linux/FreeBSD, deliberately absent on Windows for a documented memory-pool race. The *production* backend uses it; the reference backend that was profiled does not.

Switching backends alone: **4.07×**, identical ids. A VINDEX3-specific Accelerate backend would have been a worse architecture than the portable seam that already existed.

## Which left DeltaNet as 84% of decode

`gated_delta::layer_forward` had a private scalar `matvec` and was called identically for every backend. Measured on Qwen3.8's real shapes:

```text
shape                   scalar             blas              speedup
in_proj_qkv 10240x5120  37.59 ms   5.58    2.03 ms  103.41    18.5x
in_proj_z    6144x5120  22.45 ms   5.61    1.17 ms  107.60    19.2x
out_proj     5120x6144  22.56 ms   5.58    1.09 ms  115.92    20.8x
in_proj_a      48x5120   0.18 ms   5.60    0.00 ms  262.31    46.9x
ffn control 17408x5120  63.82 ms   5.59    3.51 ms  101.48    18.2x
                                   GB/s             GB/s
```

Scalar is a **flat 5.6 GB/s at every shape** — one loop, one ceiling.

The two tiny `48 x 5120` projections were expected to *lose* to BLAS call overhead. They won hardest — 46.9×, at 262 GB/s, because a 1 MB weight sits in cache. All five projections route through BLAS **on measurement, not on consistency**; a strategy that had assumed the tiny ones should stay scalar would have been wrong.

## The seam keeps the oracle independent

```rust
trait DenseProjector { fn project(&self, w, x, out_dim) -> Vec<f32>; }

ReferenceBackend  -> ScalarProjections   literal, unchanged
ProductionBackend -> BlasProjections     larql-compute
```

`layer_forward` still means the literal transcription — it delegates to `layer_forward_with(..., &ScalarProjections)`. Only the five matrix products are selectable. The convolution, head expansion, gates, delta rule and gated norm that QW-2/QW-2E proved stage-by-stage against HF sit **below** the seam and are identical for every backend.

The reference path is deliberately *not* routed through BLAS however much faster it is: sharing no arithmetic with `larql-compute` is what makes it an oracle. `PlanBackend::dense_projector` defaults to the scalar one, so a backend that says nothing gets reference arithmetic rather than inheriting somebody else's.

`sgemv` reassociates the sum, so this is **not bit-identical** — measured at rel_rms ~1.3e-6 against scalar. The existing parity gates judge that, and the 12-token HF trajectory is unchanged.

## Where the remaining 1106 ms goes

```text
matvec        ~947 ms  (~86%)     206 delta + 741 other
non-matvec    ~159 ms             recurrence, conv, norms, allocs
bandwidth     97.3 GB/s = 24% of ~400 nominal
```

The Amdahl prediction was 947 ms; reality is 1106 ms — **~15% optimistic**. Banked as a prediction rather than a pass criterion, and the machine corrected it.

Decode now runs at 97.3 GB/s against the microbench's 100–116 GB/s, so it is genuinely executing at BLAS speed rather than being dragged by something hidden.

## Next ceiling, and an empirical roofline

Weights are held as F32: **107.6 GB streamed per token against 53.8 GB stored.** CPU-1B is real `WeightFormat::BF16` — not aliased to F16, since the exponent ranges differ materially.

CPU-1A2's more useful by-product is an *empirical* CPU roofline rather than the marketing bandwidth number. If GEMV stays near ~110 GB/s, a BF16 traffic floor is roughly `53.8 / 110 ≈ 489 ms/token ≈ 2.0 tok/s`, plus non-matvec work.

Chasing the 159 ms residue first would be the wrong order: eliminating it *entirely* only reaches ~947 ms.

## Verification

5892 tests pass, `cargo fmt --check` clean, `cargo clippy --tests -- -D warnings` clean across `larql-vindex` / `larql-kv` / `larql-models` / `larql-cli`.

`projection_bench` is env-gated (`QW_PROJ_BENCH=1`) and never runs in CI. Real-model timings are from `~/chris-models/Qwen3.8-27B.vindex3` on an M3 Max.
