### PR TITLE
feat(vindex3): add first production registry model

### DIFF
--- a/crates/larql-cli/src/commands/primary/pull_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/pull_cmd.rs
@@ -507,8 +507,8 @@ mod tests {
         abi: larql_vindex::registry::Vindex3Abi,
     ) -> larql_vindex::registry::RegistryManifest {
         use larql_vindex::registry::{
-            Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
-            REGISTRY_MANIFEST_SCHEMA_VERSION,
+            Attestation, Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel,
+            RegistryVariant, REGISTRY_MANIFEST_SCHEMA_VERSION,
         };
         let mut variants = std::collections::BTreeMap::new();
         variants.insert(
@@ -522,6 +522,7 @@ mod tests {
                 source: Provenance {
                     repo: "Qwen/Qwen3.8-27B".to_string(),
                     revision: "8c4fdeadbeef".to_string(),
+                    attestation: Attestation::Mechanical,
                 },
             },
         );

--- a/crates/larql-cli/src/commands/primary/serve_resolve.rs
+++ b/crates/larql-cli/src/commands/primary/serve_resolve.rs
@@ -79,7 +79,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use larql_vindex::registry::{
-        Provenance, RegistryArtifactRef, RegistryModel, RegistryVariant, Vindex3Abi,
+        Attestation, Provenance, RegistryArtifactRef, RegistryModel, RegistryVariant, Vindex3Abi,
         REGISTRY_MANIFEST_SCHEMA_VERSION,
     };
 
@@ -100,6 +100,7 @@ mod tests {
                 source: Provenance {
                     repo: "Qwen/Qwen3.8-27B".to_string(),
                     revision: "8c4fdeadbeef".to_string(),
+                    attestation: Attestation::Mechanical,
                 },
             },
         );

--- a/crates/larql-server/src/bootstrap/load.rs
+++ b/crates/larql-server/src/bootstrap/load.rs
@@ -551,8 +551,8 @@ mod resolve_artifact_path_tests {
     use std::collections::BTreeMap;
 
     use larql_vindex::registry::{
-        Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
-        Vindex3Abi, CURRENT_VINDEX3_ABI, REGISTRY_MANIFEST_SCHEMA_VERSION,
+        Attestation, Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel,
+        RegistryVariant, Vindex3Abi, CURRENT_VINDEX3_ABI, REGISTRY_MANIFEST_SCHEMA_VERSION,
     };
 
     use super::resolve_artifact_path_with;
@@ -570,6 +570,7 @@ mod resolve_artifact_path_tests {
                 source: Provenance {
                     repo: "Qwen/Qwen3.8-27B".to_string(),
                     revision: "8c4fdeadbeef".to_string(),
+                    attestation: Attestation::Mechanical,
                 },
             },
         );

--- a/crates/larql-vindex/src/format/huggingface/download/mod.rs
+++ b/crates/larql-vindex/src/format/huggingface/download/mod.rs
@@ -229,13 +229,47 @@ pub use hf_hub::api::Progress as DownloadProgress;
 ///
 /// Returns `None` on any failure (HEAD error, cache missing, etag
 /// absent, etc.); the caller falls back to `download_with_progress`.
+///
+/// # Why this only ever accepts the pinned revision's own snapshot dir
+///
+/// This used to also accept (a) any *other* revision's snapshot symlink
+/// for the same filename, and (b) the bare blob path with no snapshot
+/// symlink at all, on the reasoning that "the caller only needs a file
+/// it can open." That reasoning is wrong for this caller specifically:
+/// [`resolve_hf_vindex_with_progress`]'s V3 completeness loop discards
+/// the returned `PathBuf` entirely (`fetch(...).ok_or_else(...)?` —
+/// only the `Option`-ness is checked) and relies on every fetched file
+/// actually landing under `vindex_dir` (the pinned revision's own
+/// `snapshots/<revision>/` directory, established by `index.json`'s own
+/// fetch) — that is what the VINDEX3 container loader opens files
+/// relative to afterwards. A bare blob path, or a symlink living under
+/// some *other* revision's snapshot dir, satisfies neither: the loop
+/// reports success, but `vindex_dir` is left missing the file, and the
+/// failure only surfaces later, opaquely, when the container is opened.
+///
+/// Concretely: `target.embedding.bin`'s blob was already resident
+/// locally (deduped — identical BF16 embedding bytes from an earlier,
+/// unrelated pull of a sibling container), so this function used to
+/// report it "cached" via the removed fallback, the real
+/// `download_with_progress` call that would have created the pinned
+/// revision's own symlink never ran, and `larql serve` on the claimed
+/// registry name failed with a bare `IO error: No such file or
+/// directory` — nothing about that error named the missing symlink.
+///
+/// With no accepted fallback, an unpinned `revision: None` request
+/// always misses here (there is no single directory a "None" revision
+/// unambiguously names yet) and falls through to `download_with_progress`,
+/// which resolves "current HEAD" and places every file consistently —
+/// slightly less cache-optimized for the unpinned case, never silently
+/// wrong.
 fn cached_snapshot_file(
     kind: RepoKind,
     repo_id: &str,
     revision: Option<&str>,
     filename: &str,
 ) -> Option<(PathBuf, u64)> {
-    let (etag, size) = head_etag_and_size(kind, repo_id, revision, filename)?;
+    let revision = revision?;
+    let (etag, size) = head_etag_and_size(kind, repo_id, Some(revision), filename)?;
     let repo_dir = hf_cache_repo_dir(kind, repo_id)?;
     let blob_path = repo_dir.join("blobs").join(&etag);
     let meta = std::fs::metadata(&blob_path).ok()?;
@@ -248,27 +282,11 @@ fn cached_snapshot_file(
         return None;
     }
 
-    // Return the snapshot path (symlink → blob) if the repo has one,
-    // otherwise the blob path itself. Either works — the caller only
-    // needs a file it can open.
-    let snapshots = repo_dir.join("snapshots");
-    if let Ok(entries) = std::fs::read_dir(&snapshots) {
-        for entry in entries.flatten() {
-            let snap_file = entry.path().join(filename);
-            if snap_file.exists() {
-                return Some((snap_file, size));
-            }
-        }
+    let snap_file = repo_dir.join("snapshots").join(revision).join(filename);
+    if snap_file.exists() {
+        return Some((snap_file, size));
     }
-    // Fall back to the pinned revision (if any) even if the symlink is
-    // missing — the blob still has the bytes.
-    if let Some(rev) = revision {
-        let snap_file = snapshots.join(rev).join(filename);
-        if snap_file.exists() {
-            return Some((snap_file, size));
-        }
-    }
-    Some((blob_path, size))
+    None
 }
 
 /// Issue a HEAD against HF's file-resolve endpoint for this repo+file

--- a/crates/larql-vindex/src/format/huggingface/download/tests.rs
+++ b/crates/larql-vindex/src/format/huggingface/download/tests.rs
@@ -342,16 +342,25 @@ fn cached_snapshot_file_returns_snapshot_path_when_present() {
     );
 
     let (path, size) =
-        cached_snapshot_file(RepoKind::Dataset, "owner/repo", None, "file.bin").unwrap();
+        cached_snapshot_file(RepoKind::Dataset, "owner/repo", Some("main"), "file.bin").unwrap();
     assert_eq!(size, 5);
     assert!(path.ends_with("file.bin"));
 }
 
 #[test]
 #[serial]
-fn cached_snapshot_file_returns_blob_when_no_snapshot_link() {
-    // Same blob present, but no snapshot directory linking to the
-    // filename. The function falls back to the raw blob path.
+fn cached_snapshot_file_misses_when_the_pinned_revisions_snapshot_has_no_link() {
+    // The blob's bytes are present (deduped from some other repo or
+    // revision), but the PINNED revision's own snapshot dir has no
+    // symlink for this filename yet. Must miss — not fall back to the
+    // raw blob path or to some other revision's copy — so the caller
+    // falls through to `download_with_progress`, which actually
+    // creates this exact revision's symlink. Regression coverage for
+    // the real bug this rewrite fixed: a `granite-4.1-3b` registry
+    // pull reported `target.embedding.bin` as "cached" via the
+    // now-removed blob-path fallback, no symlink was ever created
+    // under the pinned revision's snapshot dir, and `larql serve`
+    // failed opening the container with a bare, unhelpful IO error.
     let mut server = mockito::Server::new();
     let _g = HfTestEnv::new(&server.url());
     let _m = server
@@ -371,15 +380,25 @@ fn cached_snapshot_file_returns_blob_when_no_snapshot_link() {
         "owner/repo",
         "deadbeef",
         b"abcd",
-        None, // no snapshot dir
+        None, // no snapshot dir for any revision
         "f.bin",
     );
 
-    let (path, size) =
-        cached_snapshot_file(RepoKind::Dataset, "owner/repo", None, "f.bin").unwrap();
-    assert_eq!(size, 4);
-    // No snapshot link → returns the blob path directly.
-    assert!(path.ends_with("blobs/deadbeef"));
+    let result = cached_snapshot_file(RepoKind::Dataset, "owner/repo", Some("pinned"), "f.bin");
+    assert!(
+        result.is_none(),
+        "a bare blob with no symlink under the pinned revision must miss, not silently succeed"
+    );
+}
+
+#[test]
+fn cached_snapshot_file_misses_immediately_on_an_unpinned_revision() {
+    // `revision: None` can name no single snapshot directory
+    // unambiguously — always miss, unconditionally, before even
+    // issuing the HEAD request. No mock server is set up at all: a
+    // network call here would itself be the bug.
+    let result = cached_snapshot_file(RepoKind::Dataset, "owner/repo", None, "f.bin");
+    assert!(result.is_none());
 }
 
 #[test]
@@ -410,7 +429,7 @@ fn cached_snapshot_file_returns_none_on_size_mismatch() {
         "f.bin",
     );
 
-    let result = cached_snapshot_file(RepoKind::Dataset, "owner/repo", None, "f.bin");
+    let result = cached_snapshot_file(RepoKind::Dataset, "owner/repo", Some("main"), "f.bin");
     assert!(result.is_none(), "size mismatch must abort cache hit");
 }
 
@@ -428,7 +447,7 @@ fn cached_snapshot_file_returns_none_when_blob_missing() {
         .create();
 
     // No blob written — straight cache miss.
-    let result = cached_snapshot_file(RepoKind::Dataset, "owner/repo", None, "f.bin");
+    let result = cached_snapshot_file(RepoKind::Dataset, "owner/repo", Some("main"), "f.bin");
     assert!(result.is_none());
 }
 
@@ -461,17 +480,18 @@ fn cached_snapshot_file_works_for_model_prefix() {
     );
 
     let (path, size) =
-        cached_snapshot_file(RepoKind::Model, "owner/repo", None, "config.json").unwrap();
+        cached_snapshot_file(RepoKind::Model, "owner/repo", Some("main"), "config.json").unwrap();
     assert_eq!(size, 4);
     assert!(path.ends_with("config.json"));
 }
 
 #[test]
 #[serial]
-fn cached_snapshot_file_falls_back_through_revision_after_unrelated_snapshot_dir() {
-    // Build a cache where the entries-loop sees a snapshot dir
-    // that DOESN'T contain the filename, then the explicit
-    // `snapshots.join(rev)` fallback (lines ~258-261) succeeds.
+fn cached_snapshot_file_ignores_an_unrelated_revisions_snapshot_dir() {
+    // A DIFFERENT revision's snapshot dir has a file present (`noise`,
+    // for a different filename even) — the pinned-revision-only
+    // contract must not be satisfied by it. Only the pinned revision's
+    // own `snapshots/v7/target.bin` symlink counts.
     let mut server = mockito::Server::new();
     let _g = HfTestEnv::new(&server.url());
     let _m = server
@@ -489,12 +509,11 @@ fn cached_snapshot_file_falls_back_through_revision_after_unrelated_snapshot_dir
     let blobs = repo_dir.join("blobs");
     std::fs::create_dir_all(&blobs).unwrap();
     std::fs::write(blobs.join("rev-fallback"), b"abc").unwrap();
-    // Snapshot dir for `noise` (different filename) — entries loop
-    // visits this but the join misses.
+    // A different revision's snapshot dir, irrelevant to the request.
     let noise_snap = repo_dir.join("snapshots").join("noise");
     std::fs::create_dir_all(&noise_snap).unwrap();
     std::fs::write(noise_snap.join("other.bin"), b"abc").unwrap();
-    // Snapshot dir for the revision we'll request, with the file.
+    // The pinned revision's own snapshot dir, with the file.
     let pinned_snap = repo_dir.join("snapshots").join("v7");
     std::fs::create_dir_all(&pinned_snap).unwrap();
     std::fs::write(pinned_snap.join("target.bin"), b"abc").unwrap();
@@ -526,7 +545,7 @@ fn cached_snapshot_file_returns_none_when_blob_is_directory_not_file() {
     // Create the blob path as a DIRECTORY, not a regular file.
     std::fs::create_dir_all(blobs.join("dir-as-blob")).unwrap();
 
-    let result = cached_snapshot_file(RepoKind::Dataset, "owner/repo", None, "f.bin");
+    let result = cached_snapshot_file(RepoKind::Dataset, "owner/repo", Some("main"), "f.bin");
     assert!(result.is_none(), "blob-is-directory must miss");
 }
 
@@ -620,7 +639,11 @@ fn resolve_hf_vindex_with_progress_uses_cache_when_blob_present() {
     // disk, the function bypasses download_with_progress and goes
     // through the cache-hit branch (progress.init/update/finish
     // called with the [cached] tag). Build the cache + a matching
-    // HEAD response so the cache short-circuit fires.
+    // HEAD response so the cache short-circuit fires. The fast path
+    // only ever fires for a PINNED revision (see cached_snapshot_file's
+    // module docs) — an unpinned `hf://owner/repo` always misses it and
+    // goes through `download_with_progress` instead, so this request
+    // pins `@main` explicitly to exercise the cache-hit branch at all.
     let mut server = mockito::Server::new();
     let _g = HfTestEnv::new(&server.url());
     let body = br#"{"version":2}"#;
@@ -655,7 +678,7 @@ fn resolve_hf_vindex_with_progress_uses_cache_when_blob_present() {
         .with_status(404)
         .create();
 
-    let dir = resolve_hf_vindex_with_progress("hf://owner/repo", |_| NoOpProgress)
+    let dir = resolve_hf_vindex_with_progress("hf://owner/repo@main", |_| NoOpProgress)
         .expect("cache hit path must return Ok");
     assert!(dir.ends_with("main"), "expected snapshot dir under main");
 }

--- a/crates/larql-vindex/src/format/huggingface/publish/remote.rs
+++ b/crates/larql-vindex/src/format/huggingface/publish/remote.rs
@@ -117,11 +117,7 @@ pub(super) fn create_hf_repo(
     let resp = client
         .post(&url)
         .header("Authorization", format!("Bearer {token}"))
-        .json(&serde_json::json!({
-            "name": repo_id.split('/').next_back().unwrap_or(repo_id),
-            "type": repo_type,
-            "private": private,
-        }))
+        .json(&create_hf_repo_body(repo_id, repo_type, private))
         .send()
         .map_err(|e| VindexError::Parse(format!("HF API error: {e}")))?;
 
@@ -135,6 +131,33 @@ pub(super) fn create_hf_repo(
             "HF repo create failed ({status}): {body}"
         )))
     }
+}
+
+/// The `POST /api/repos/create` body. `repo_id`'s owner (everything before
+/// the last `/`) becomes `organization` — HF's create-repo API defaults an
+/// omitted `organization` to the *token's own* namespace, never the caller's
+/// intended one. Without this, `--repo larql/granite-4.1-3b` published from
+/// a `chrishayuk`-owned token silently landed under `chrishayuk/granite-4.1-3b`
+/// instead: the create call "succeeded" against the wrong namespace, and the
+/// very next preupload call (which does target the real `repo_id`) 404'd on
+/// a repo that was never actually created. A bare `repo_id` with no `/` (no
+/// owner named at all) omits the field, matching the pre-fix behaviour for
+/// that case — there is no intended namespace to override.
+pub(super) fn create_hf_repo_body(
+    repo_id: &str,
+    repo_type: &str,
+    private: bool,
+) -> serde_json::Value {
+    let name = repo_id.split('/').next_back().unwrap_or(repo_id);
+    let mut body = serde_json::json!({
+        "name": name,
+        "type": repo_type,
+        "private": private,
+    });
+    if let Some((owner, _)) = repo_id.rsplit_once('/') {
+        body["organization"] = serde_json::Value::String(owner.to_string());
+    }
+    body
 }
 
 /// Flip an already-created repo's visibility. Used at RELEASE

--- a/crates/larql-vindex/src/format/huggingface/publish/remote_tests.rs
+++ b/crates/larql-vindex/src/format/huggingface/publish/remote_tests.rs
@@ -612,6 +612,34 @@ fn create_hf_repo_uses_last_path_segment_as_name() {
 }
 
 #[test]
+fn create_hf_repo_body_omits_organization_for_a_bare_name() {
+    // A repo_id with no `/` names no owner at all — `organization`
+    // must be entirely absent so HF defaults the create to the
+    // token's own namespace, which is exactly what "no owner
+    // requested" should mean.
+    let body = create_hf_repo_body("loose-repo", "model", false);
+    assert_eq!(body["name"], "loose-repo");
+    assert!(
+        body.get("organization").is_none(),
+        "unexpected organization field: {body}"
+    );
+}
+
+#[test]
+fn create_hf_repo_body_sends_organization_for_a_namespaced_repo() {
+    // The real fix: omitting `organization` makes HF default repo
+    // creation to the *token's own* namespace, not the caller's
+    // intended one — `--repo larql/granite-4.1-3b` from a
+    // `chrishayuk`-owned token used to silently create
+    // `chrishayuk/granite-4.1-3b` instead, and the next call (which
+    // does address the real repo_id) 404'd on a repo that was never
+    // created. `organization` must carry the owner verbatim.
+    let body = create_hf_repo_body("larql/granite-4.1-3b", "model", false);
+    assert_eq!(body["name"], "granite-4.1-3b");
+    assert_eq!(body["organization"], "larql");
+}
+
+#[test]
 #[serial]
 fn create_hf_repo_send_failure_propagates() {
     let _guard = EnvBaseGuard::new(UNREACHABLE_ENDPOINT);

--- a/crates/larql-vindex/src/registry/embedded.rs
+++ b/crates/larql-vindex/src/registry/embedded.rs
@@ -1,0 +1,120 @@
+//! The production VINDEX3 registry's actual data — `registry/index.json` +
+//! `registry/models/*.json` at the repo root, baked into the binary at
+//! compile time.
+//!
+//! # Why compile-time embed, not a runtime file read
+//!
+//! `docs/vindex3-registry-design.md` §7 left this open ("embedded? a
+//! file? fetched?"). A runtime read relative to the process's working
+//! directory or executable path only works from a source checkout —
+//! release binaries (ADR-0026) ship standalone, with no repo nearby. A
+//! remote fetch would make every `larql pull <registry-name>` depend on
+//! a second service beyond HF, which §7 already ruled out ("no website,
+//! no remote registry service"). `include_str!` matches the precedent
+//! [`super::fixtures`] already set — "static, in-process, no network" —
+//! while still sourcing from real, git-reviewed JSON files rather than a
+//! Rust literal, so a registry change is an ordinary reviewable diff.
+//!
+//! The real consequence, accepted deliberately: a new or updated entry
+//! reaches users only via a new binary release, not instantly on merge.
+//! That is not a regression — "official status conferred by PR merge"
+//! (the promotion design, `docs/vindex3-registry-publishing-design.md`)
+//! was already going to require a release to actually ship the entry;
+//! this just means the release, not the merge, is the activation point.
+//!
+//! # Why one embed per model, not a glob
+//!
+//! `include_str!` needs a compile-time literal path — it cannot walk
+//! `registry/models/` at build time without a build script. R3A is
+//! deliberately one entry (`docs/vindex3-registry-design.md`'s own
+//! scoping note: prove the representation works before generalising
+//! it). [`embedded_model_json`] is the one place a second entry's
+//! `include_str!` line joins this match — a small, explicit list, not
+//! speculative glob machinery for a count that has been one.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use super::error::RegistryError;
+use super::manifest::{RegistryManifest, RegistryModel};
+
+/// `registry/index.json` — the table of contents: which models exist,
+/// under which manifest schema.
+const INDEX_JSON: &str = include_str!("../../../../registry/index.json");
+
+/// `registry/models/granite-4.1-3b.json` — see [`embedded_model_json`].
+const GRANITE_4_1_3B_JSON: &str = include_str!("../../../../registry/models/granite-4.1-3b.json");
+
+/// `registry/index.json`'s own shape: schema version plus the list of
+/// model names this registry claims. Not [`RegistryManifest`] itself —
+/// that type's `models` map holds full bodies; the index only names
+/// them, mirroring the two-file split on disk.
+#[derive(Debug, Deserialize)]
+struct RegistryIndex {
+    schema_version: u32,
+    models: Vec<String>,
+}
+
+/// The embedded JSON text for one `registry/models/<name>.json`, or
+/// `None` if `name` isn't one this binary was built with. Distinct from
+/// "not a registered model" (that's [`RegistryError::UnknownModel`],
+/// raised once resolution runs) — this is "index.json names a model
+/// file this binary has no `include_str!` for", a build-time skew
+/// between the two files that a real registry entry should never reach
+/// (R3B's CI conformance gate is the intended place to catch it before
+/// merge); [`assemble_registry`] still refuses it cleanly rather than
+/// panicking here, since a corrupted or hand-edited index is exactly
+/// the case this should fail loudly, not silently, on.
+fn embedded_model_json(name: &str) -> Option<&'static str> {
+    match name {
+        "granite-4.1-3b" => Some(GRANITE_4_1_3B_JSON),
+        _ => None,
+    }
+}
+
+/// Parse, assemble, and validate the checked-in `registry/` files into a
+/// [`RegistryManifest`]. The one function [`super::production::production_registry`]
+/// trusts to have already done all of this by the time a caller sees a
+/// plain, infallible `RegistryManifest`.
+pub(super) fn load_production_registry() -> Result<RegistryManifest, RegistryError> {
+    assemble_registry(INDEX_JSON, embedded_model_json)
+}
+
+/// Testable core of [`load_production_registry`]. `lookup` is injected
+/// (same convention as [`super::production::resolve_claimed_with`]) so
+/// every branch — malformed index, an index/embed name mismatch,
+/// malformed per-model JSON, a manifest that parses but fails
+/// `validate()` — is provable without depending on the real,
+/// compile-time-fixed `registry/` contents.
+pub(super) fn assemble_registry<'a>(
+    index_json: &str,
+    lookup: impl Fn(&str) -> Option<&'a str>,
+) -> Result<RegistryManifest, RegistryError> {
+    let index: RegistryIndex =
+        serde_json::from_str(index_json).map_err(|e| RegistryError::MalformedManifest {
+            reason: format!("registry/index.json: {e}"),
+        })?;
+
+    let mut models = BTreeMap::new();
+    for name in index.models {
+        let json = lookup(&name).ok_or_else(|| RegistryError::MalformedManifest {
+            reason: format!(
+                "registry/index.json names model '{name}', which has no matching \
+                 registry/models/{name}.json embedded in this binary"
+            ),
+        })?;
+        let model: RegistryModel =
+            serde_json::from_str(json).map_err(|e| RegistryError::MalformedManifest {
+                reason: format!("registry/models/{name}.json: {e}"),
+            })?;
+        models.insert(name, model);
+    }
+
+    let manifest = RegistryManifest {
+        schema_version: index.schema_version,
+        models,
+    };
+    manifest.validate()?;
+    Ok(manifest)
+}

--- a/crates/larql-vindex/src/registry/embedded_tests.rs
+++ b/crates/larql-vindex/src/registry/embedded_tests.rs
@@ -1,0 +1,137 @@
+//! Colocated tests for [`super::embedded`].
+//!
+//! Two layers, deliberately separate: [`assemble_registry`]'s own
+//! branches (malformed index, index/embed name skew, malformed
+//! per-model JSON, a manifest that parses but fails `validate()`) are
+//! proved with a synthetic index and an injected lookup — the same
+//! `resolve_claimed`/`resolve_claimed_with` convention this crate
+//! already uses for testing real-data wrappers. The real,
+//! compile-time-embedded `registry/` files are proved separately, once,
+//! against R3A's own acceptance gate
+//! (`docs/vindex3-registry-design.md`):
+//!
+//! ```text
+//! production_registry()
+//!     -> reads canonical repo registry
+//!     -> granite-4.1-3b exists
+//!     -> resolves to pinned VINDEX3 artifact
+//! ```
+
+use super::embedded::{assemble_registry, load_production_registry};
+use super::error::RegistryError;
+use super::production::production_registry;
+use super::resolver::{resolve, ArtifactRef, Vindex3Resolution};
+
+const VALID_MODEL_JSON: &str = r#"{
+    "default_variant": "nvfp4",
+    "variants": {
+        "nvfp4": {
+            "artifact": {"repo": "larql/example", "revision": "abc123"},
+            "abi": 1,
+            "source": {
+                "repo": "example/example",
+                "revision": "def456",
+                "attestation": {"kind": "mechanical"}
+            }
+        }
+    }
+}"#;
+
+fn only_lookup<'a>(name: &'a str, json: &'a str) -> impl Fn(&str) -> Option<&'a str> + 'a {
+    move |candidate| (candidate == name).then_some(json)
+}
+
+// ── assemble_registry: synthetic data, every branch ─────────────────────
+
+#[test]
+fn assemble_registry_succeeds_on_a_well_formed_index_and_model() {
+    let index = r#"{"schema_version": 1, "models": ["example"]}"#;
+    let manifest = assemble_registry(index, only_lookup("example", VALID_MODEL_JSON)).unwrap();
+    assert!(manifest.models.contains_key("example"));
+}
+
+#[test]
+fn assemble_registry_rejects_malformed_index_json() {
+    let err = assemble_registry("not json", |_| None).unwrap_err();
+    assert!(matches!(err, RegistryError::MalformedManifest { .. }));
+}
+
+#[test]
+fn assemble_registry_rejects_a_name_the_index_claims_but_lookup_does_not_have() {
+    // The index/embed skew case: `registry/index.json` names a model
+    // with no matching `include_str!` arm — R3B's CI conformance gate
+    // is meant to catch this before merge, but the loader itself must
+    // still refuse cleanly, never panic.
+    let index = r#"{"schema_version": 1, "models": ["not-embedded"]}"#;
+    let err = assemble_registry(index, |_| None).unwrap_err();
+    let RegistryError::MalformedManifest { reason } = err else {
+        panic!("expected MalformedManifest, got {err:?}");
+    };
+    assert!(reason.contains("not-embedded"), "{reason}");
+}
+
+#[test]
+fn assemble_registry_rejects_malformed_model_json() {
+    let index = r#"{"schema_version": 1, "models": ["example"]}"#;
+    let err = assemble_registry(index, only_lookup("example", "not json")).unwrap_err();
+    let RegistryError::MalformedManifest { reason } = err else {
+        panic!("expected MalformedManifest, got {err:?}");
+    };
+    assert!(reason.contains("example.json"), "{reason}");
+}
+
+#[test]
+fn assemble_registry_propagates_a_manifest_that_parses_but_fails_validation() {
+    // An unpinned artifact revision — parses fine as a `RegistryModel`,
+    // but `RegistryManifest::validate()` must still refuse it. Proves
+    // `assemble_registry` actually calls `validate()`, not just `parse`.
+    let floating_model = VALID_MODEL_JSON.replace("\"abc123\"", "\"main\"");
+    let index = r#"{"schema_version": 1, "models": ["example"]}"#;
+    let err = assemble_registry(index, only_lookup("example", &floating_model)).unwrap_err();
+    assert!(matches!(err, RegistryError::UnpinnedRevision { .. }));
+}
+
+// ── The real embedded registry/ files ────────────────────────────────────
+
+#[test]
+fn the_embedded_registry_loads_and_validates() {
+    load_production_registry().unwrap();
+}
+
+#[test]
+fn granite_4_1_3b_is_claimed_by_the_production_registry() {
+    let registry = production_registry();
+    assert!(
+        registry.models.contains_key("granite-4.1-3b"),
+        "registry/index.json must list granite-4.1-3b, and \
+         registry/models/granite-4.1-3b.json must embed successfully"
+    );
+}
+
+#[test]
+fn granite_4_1_3b_resolves_to_a_pinned_huggingface_artifact() {
+    let registry = production_registry();
+    let resolution = resolve("granite-4.1-3b", &registry).unwrap();
+    let Vindex3Resolution::Registry(resolved) = resolution else {
+        panic!("a claimed registry name must resolve to Vindex3Resolution::Registry");
+    };
+    assert_eq!(resolved.name.as_str(), "granite-4.1-3b");
+    match resolved.artifact {
+        ArtifactRef::HuggingFace { repo, revision } => {
+            assert_eq!(repo, "larql/granite-4.1-3b");
+            assert!(
+                !revision.is_empty() && revision != "main",
+                "the pinned revision must be a real, immutable commit sha, not a floating ref: {revision}"
+            );
+        }
+        other => panic!("expected an HF artifact reference, got {other:?}"),
+    }
+}
+
+#[test]
+fn production_registry_matches_load_production_registry() {
+    // `production_registry()` is the infallible façade `load_production_registry()`
+    // panics behind (module docs) — proving they agree is proving the façade
+    // adds no drift, not just that each works in isolation.
+    assert_eq!(production_registry(), load_production_registry().unwrap());
+}

--- a/crates/larql-vindex/src/registry/error.rs
+++ b/crates/larql-vindex/src/registry/error.rs
@@ -74,6 +74,12 @@ pub enum RegistryError {
     #[error("explicit local reference '{path}' does not exist or is not a directory")]
     LocalPathNotFound { path: String },
 
+    #[error(
+        "registry entry for '{name}' variant '{variant}' marks its source hand-attested but \
+         names no one ('by' is empty) — a hand-attestation must say who to ask"
+    )]
+    EmptyAttestationBy { name: String, variant: String },
+
     #[error(transparent)]
     Underlying(#[from] VindexError),
 }

--- a/crates/larql-vindex/src/registry/fixtures.rs
+++ b/crates/larql-vindex/src/registry/fixtures.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeMap;
 
 use super::abi::CURRENT_VINDEX3_ABI;
 use super::manifest::{
-    Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
+    Attestation, Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
     REGISTRY_MANIFEST_SCHEMA_VERSION,
 };
 
@@ -35,6 +35,7 @@ pub fn tiny_static_registry() -> RegistryManifest {
             source: Provenance {
                 repo: "Qwen/Qwen3.8-27B".to_string(),
                 revision: "8c4fdeadbeef".to_string(),
+                attestation: Attestation::Mechanical,
             },
         },
     );
@@ -49,6 +50,7 @@ pub fn tiny_static_registry() -> RegistryManifest {
             source: Provenance {
                 repo: "Qwen/Qwen3.8-27B".to_string(),
                 revision: "8c4fdeadbeef".to_string(),
+                attestation: Attestation::Mechanical,
             },
         },
     );

--- a/crates/larql-vindex/src/registry/manifest.rs
+++ b/crates/larql-vindex/src/registry/manifest.rs
@@ -49,6 +49,31 @@ pub struct RegistryArtifactRef {
     pub revision: String,
 }
 
+/// How a [`Provenance`]'s `{repo, revision}` was determined.
+///
+/// `encode` takes no source parameter at all (design doc §4/publishing
+/// grounding, Q4) — nothing in the pipeline mechanically guarantees a
+/// registry entry's source is correct. This is the marker the design's
+/// open question 4 asked for: an entry must say which case it is, never
+/// let a hand-checked value silently read as pipeline-verified.
+/// `#[serde(tag = "kind")]` so the JSON itself always names one — no
+/// field can be omitted and default to the safer-looking case.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Attestation {
+    /// The pipeline itself produced and checked `{repo, revision}` —
+    /// no case exists yet (the encode-time gap above), but the variant
+    /// is here so one can be wired in later without reshaping every
+    /// existing entry.
+    Mechanical,
+    /// A person read `{repo, revision}` off the checkpoint/cache by hand
+    /// and is vouching for it. `by` names who, so the audit trail
+    /// (design doc's "git history, not a field" rule for revisions)
+    /// has the same answer for *this* claim: who to ask, not just that
+    /// someone did.
+    HandAttested { by: String },
+}
+
 /// Where a registry variant's VINDEX3 container was built *from* — the
 /// upstream checkpoint, carried out-of-band from the container itself.
 /// `Vindex3Index` carries no provenance fields (design doc §4); this is
@@ -58,6 +83,7 @@ pub struct RegistryArtifactRef {
 pub struct Provenance {
     pub repo: String,
     pub revision: String,
+    pub attestation: Attestation,
 }
 
 /// One selectable build of a registry model.
@@ -123,6 +149,7 @@ impl RegistryManifest {
             for (variant_name, variant) in &model.variants {
                 check_pinned(name, variant_name, &variant.artifact.revision)?;
                 check_pinned(name, variant_name, &variant.source.revision)?;
+                check_attested(name, variant_name, &variant.source.attestation)?;
             }
         }
         Ok(())
@@ -136,6 +163,25 @@ fn check_pinned(name: &str, variant: &str, revision: &str) -> Result<(), Registr
             variant: variant.to_string(),
             revision: revision.to_string(),
         });
+    }
+    Ok(())
+}
+
+/// A `HandAttested { by: "" }` would satisfy the enum's shape while
+/// saying nothing an audit trail could act on — the same "structurally
+/// present but empty" gap [`check_pinned`] closes for revisions.
+fn check_attested(
+    name: &str,
+    variant: &str,
+    attestation: &Attestation,
+) -> Result<(), RegistryError> {
+    if let Attestation::HandAttested { by } = attestation {
+        if by.trim().is_empty() {
+            return Err(RegistryError::EmptyAttestationBy {
+                name: name.to_string(),
+                variant: variant.to_string(),
+            });
+        }
     }
     Ok(())
 }

--- a/crates/larql-vindex/src/registry/manifest_tests.rs
+++ b/crates/larql-vindex/src/registry/manifest_tests.rs
@@ -8,7 +8,7 @@ use super::abi::CURRENT_VINDEX3_ABI;
 use super::error::RegistryError;
 use super::fixtures::{tiny_static_registry, tiny_static_registry_json};
 use super::manifest::{
-    Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
+    Attestation, Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
     REGISTRY_MANIFEST_SCHEMA_VERSION,
 };
 
@@ -40,6 +40,22 @@ fn variant(artifact_revision: &str, source_revision: &str) -> RegistryVariant {
         source: Provenance {
             repo: "Qwen/Qwen3.8-27B".to_string(),
             revision: source_revision.to_string(),
+            attestation: Attestation::Mechanical,
+        },
+    }
+}
+
+fn hand_attested_variant(by: &str) -> RegistryVariant {
+    RegistryVariant {
+        artifact: RegistryArtifactRef {
+            repo: "larql/qwen3.8-27b-nvfp4".to_string(),
+            revision: "abc123f0".to_string(),
+        },
+        abi: CURRENT_VINDEX3_ABI,
+        source: Provenance {
+            repo: "Qwen/Qwen3.8-27B".to_string(),
+            revision: "8c4fdead".to_string(),
+            attestation: Attestation::HandAttested { by: by.to_string() },
         },
     }
 }
@@ -138,4 +154,59 @@ fn from_json_rejects_a_manifest_that_parses_but_fails_validation() {
 fn from_json_rejects_malformed_json_text() {
     let err = RegistryManifest::from_json("not json").unwrap_err();
     assert!(matches!(err, RegistryError::MalformedManifest { .. }));
+}
+
+// ── Attestation ──────────────────────────────────────────────────────────
+
+#[test]
+fn a_hand_attestation_naming_someone_validates() {
+    let mut variants = BTreeMap::new();
+    variants.insert("27b-nvfp4".to_string(), hand_attested_variant("chrishayuk"));
+    let m = one_model("27b-nvfp4", variants);
+    m.validate().unwrap();
+}
+
+#[test]
+fn a_hand_attestation_naming_no_one_refuses() {
+    let mut variants = BTreeMap::new();
+    variants.insert("27b-nvfp4".to_string(), hand_attested_variant(""));
+    let m = one_model("27b-nvfp4", variants);
+    let err = m.validate().unwrap_err();
+    assert!(matches!(err, RegistryError::EmptyAttestationBy { .. }));
+}
+
+#[test]
+fn a_hand_attestation_naming_only_whitespace_refuses() {
+    let mut variants = BTreeMap::new();
+    variants.insert("27b-nvfp4".to_string(), hand_attested_variant("   "));
+    let m = one_model("27b-nvfp4", variants);
+    let err = m.validate().unwrap_err();
+    assert!(matches!(err, RegistryError::EmptyAttestationBy { .. }));
+}
+
+#[test]
+fn attestation_round_trips_through_json_tagged_by_kind() {
+    // `#[serde(tag = "kind")]` is the load-bearing choice: the wire
+    // format always names which case an entry is, so a manifest text
+    // can never omit the field and silently read as the
+    // safer-looking `Mechanical` case.
+    let mechanical = serde_json::to_value(Attestation::Mechanical).unwrap();
+    assert_eq!(mechanical, serde_json::json!({"kind": "mechanical"}));
+
+    let hand_attested = serde_json::to_value(Attestation::HandAttested {
+        by: "chrishayuk".to_string(),
+    })
+    .unwrap();
+    assert_eq!(
+        hand_attested,
+        serde_json::json!({"kind": "hand_attested", "by": "chrishayuk"})
+    );
+
+    let parsed: Attestation = serde_json::from_value(hand_attested).unwrap();
+    assert_eq!(
+        parsed,
+        Attestation::HandAttested {
+            by: "chrishayuk".to_string()
+        }
+    );
 }

--- a/crates/larql-vindex/src/registry/mod.rs
+++ b/crates/larql-vindex/src/registry/mod.rs
@@ -21,12 +21,15 @@
 //! this resolver, and a tiny static test registry ([`fixtures`]).
 //! Rung 2 ("resolver convergence", §10) added [`production`] — the
 //! shared claimed/unclaimed dispatch `larql-cli` and `larql-server` both
-//! call, and the (still empty) production registry. Not a generic model
+//! call. Rung 3A (§11) gave the production registry its first real
+//! data — [`embedded`] embeds `registry/index.json` +
+//! `registry/models/*.json` at compile time. Not a generic model
 //! registry, and VINDEX2 has no representation in this schema at all —
 //! see [`manifest`] and [`resolver`] for where that is enforced
 //! structurally rather than by convention.
 
 mod abi;
+mod embedded;
 mod error;
 pub mod fixtures;
 mod manifest;
@@ -36,6 +39,8 @@ mod resolver;
 
 #[cfg(test)]
 mod abi_tests;
+#[cfg(test)]
+mod embedded_tests;
 #[cfg(test)]
 mod manifest_tests;
 #[cfg(test)]
@@ -48,7 +53,7 @@ mod resolver_tests;
 pub use abi::{Vindex3Abi, CURRENT_VINDEX3_ABI};
 pub use error::RegistryError;
 pub use manifest::{
-    Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
+    Attestation, Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
     REGISTRY_MANIFEST_SCHEMA_VERSION,
 };
 pub use production::{

--- a/crates/larql-vindex/src/registry/production.rs
+++ b/crates/larql-vindex/src/registry/production.rs
@@ -15,32 +15,31 @@
 //! identity everywhere), so the dispatch moved here, into the one crate
 //! every caller already depends on.
 //!
-//! # The production registry is empty
+//! # Where the production registry's data comes from
 //!
-//! No official VINDEX3 model has been published yet, and where real
-//! registry data will actually come from (embedded? a file? fetched?)
-//! remains a separate, undecided question — out of scope for the
-//! resolver-convergence rung. Returning an empty manifest here means
-//! zero behaviour change for any caller today; the claimed/unclaimed
-//! split (see [`resolve_claimed`]) activates itself correctly the
-//! moment a real entry is added, with no second migration required.
+//! `registry/index.json` + `registry/models/*.json` at the repo root,
+//! embedded into this binary at compile time — see [`super::embedded`]
+//! for the full reasoning (R3A, `docs/vindex3-registry-design.md` §7).
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use super::embedded::load_production_registry;
 use super::error::RegistryError;
-use super::manifest::{RegistryManifest, REGISTRY_MANIFEST_SCHEMA_VERSION};
+use super::manifest::RegistryManifest;
 use super::reference::ModelReference;
 use super::resolver::lookup_claimed_variant;
 use crate::VindexError;
 
-/// The production VINDEX3 registry. Empty until an official model is
-/// published — see the module docs.
+/// The production VINDEX3 registry.
+///
+/// Panics only if the checked-in `registry/` files this binary was
+/// built with are malformed — a state R3B's CI conformance gate exists
+/// to catch before merge, the same "fixture serialises" contract
+/// [`super::fixtures::tiny_static_registry_json`] already relies on for
+/// its own embedded data.
 pub fn production_registry() -> RegistryManifest {
-    RegistryManifest {
-        schema_version: REGISTRY_MANIFEST_SCHEMA_VERSION,
-        models: BTreeMap::new(),
-    }
+    load_production_registry()
+        .expect("registry/index.json + registry/models/*.json are checked-in, CI-validated data")
 }
 
 /// The claimed half of [`resolve_claimed`]/[`resolve_claimed_with`],

--- a/crates/larql-vindex/src/registry/production_tests.rs
+++ b/crates/larql-vindex/src/registry/production_tests.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use super::abi::{Vindex3Abi, CURRENT_VINDEX3_ABI};
 use super::error::RegistryError;
 use super::manifest::{
-    Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
+    Attestation, Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
     REGISTRY_MANIFEST_SCHEMA_VERSION,
 };
 use super::production::{production_registry, resolve_claimed, resolve_claimed_with};
@@ -28,6 +28,7 @@ fn registry_claiming_qwen38(abi: Vindex3Abi) -> RegistryManifest {
             source: Provenance {
                 repo: "Qwen/Qwen3.8-27B".to_string(),
                 revision: "8c4fdeadbeef".to_string(),
+                attestation: Attestation::Mechanical,
             },
         },
     );
@@ -46,8 +47,13 @@ fn registry_claiming_qwen38(abi: Vindex3Abi) -> RegistryManifest {
 }
 
 #[test]
-fn production_registry_is_empty_today() {
-    assert!(production_registry().models.is_empty());
+fn production_registry_is_no_longer_empty_since_r3a() {
+    // Was `production_registry_is_empty_today` through rung 2 — R3A
+    // (`registry/index.json` + `registry/models/*.json`, embedded at
+    // compile time via `super::embedded`) is the point this stops
+    // being true. See `embedded_tests` for what the real entries are
+    // and R3A's own acceptance gate.
+    assert!(!production_registry().models.is_empty());
 }
 
 #[test]
@@ -133,6 +139,7 @@ fn a_claimed_name_with_an_explicit_variant_fetches_and_validates_that_variant() 
             source: Provenance {
                 repo: "Qwen/Qwen3.8-27B".to_string(),
                 revision: "8c4fdeadbeef".to_string(),
+                attestation: Attestation::Mechanical,
             },
         },
     );

--- a/crates/larql-vindex/src/registry/resolver_tests.rs
+++ b/crates/larql-vindex/src/registry/resolver_tests.rs
@@ -9,7 +9,7 @@ use super::abi::{Vindex3Abi, CURRENT_VINDEX3_ABI};
 use super::error::RegistryError;
 use super::fixtures::tiny_static_registry;
 use super::manifest::{
-    Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
+    Attestation, Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
     REGISTRY_MANIFEST_SCHEMA_VERSION,
 };
 use super::resolver::{resolve, ArtifactRef, Vindex3Resolution};
@@ -50,6 +50,7 @@ fn bare_name_resolves_to_the_declared_default_variant() {
         Provenance {
             repo: "Qwen/Qwen3.8-27B".to_string(),
             revision: "8c4fdeadbeef".to_string(),
+            attestation: Attestation::Mechanical,
         }
     );
     assert_eq!(resolved.abi, CURRENT_VINDEX3_ABI);
@@ -129,6 +130,7 @@ fn registry_with_abi(abi: Vindex3Abi) -> RegistryManifest {
             source: Provenance {
                 repo: "Qwen/Qwen3.8-27B".to_string(),
                 revision: "8c4fdeadbeef".to_string(),
+                attestation: Attestation::Mechanical,
             },
         },
     );

--- a/docs/vindex3-registry-design.md
+++ b/docs/vindex3-registry-design.md
@@ -701,3 +701,95 @@ these untouched — no VINDEX3 execution path exists for them yet, per
 the rung-1 inventory); widening explicit `hf://`/local-path forms into
 the new resolver's stricter arms; `--profile` CLI wiring once a real
 registry entry exists to select a variant of.
+
+## 11. Rung 3A — the production registry's data source (2026-08-24)
+
+Deliberately narrow, per the user's own scoping: canonical
+`registry/index.json` + `registry/models/*.json` at the repo root,
+parsed by the *existing* production Rust schema, containing one real
+entry (`granite-4.1-3b`) — no promotion command in this rung. The
+point of keeping R3A alone is proving production registry data can
+exist, be validated, and be consumed by the resolver **without fixture
+machinery**, before any promotion tooling exists that could mask a
+problem in the representation itself.
+
+**The data-source question §7 left open** ("embedded? a file?
+fetched?") is answered: **compile-time embed**, via `include_str!`
+(`crates/larql-vindex/src/registry/embedded.rs`), matching
+[`fixtures`]'s existing "static, in-process, no network" precedent. A
+runtime file read relative to the process only works from a source
+checkout — release binaries (ADR-0026) ship standalone with no repo
+nearby; a remote fetch would add a second service dependency beyond HF
+for every `pull`/`serve`, which this rung's own non-goals already
+ruled out. Accepted consequence: a new or updated entry reaches users
+on the next binary *release*, not instantly on merge — no regression,
+since "official status conferred by PR merge" (§8 of the publishing
+doc) was already going to need a release to actually ship the entry.
+
+**File split, and why two files, not one**: `registry/index.json`
+names which models exist under which manifest schema version;
+`registry/models/<name>.json` holds one model's full body
+(`RegistryModel`: default variant + variants). `embedded.rs` parses
+the index, then for each named model looks up a **small, explicit**
+`include_str!` list (`embedded_model_json`) rather than a glob —
+`include_str!` needs a compile-time literal path, and R3A is
+deliberately one entry; a generalised N-model embed mechanism ahead of
+a second real entry existing would be exactly the premature machinery
+this initiative has avoided elsewhere. A second entry adds one
+`include_str!` line and one match arm, reviewed in the same PR as its
+`registry/models/*.json` file.
+
+**Testability**: `embedded.rs`'s core (`assemble_registry`) takes an
+injected `lookup` closure — the same convention `production.rs`
+already used for `resolve_claimed`/`resolve_claimed_with` — so every
+failure branch (malformed index, an index name with no matching embed,
+malformed per-model JSON, a manifest that parses but fails
+`validate()`) is provable against synthetic data, independent of the
+real embedded files. `production_registry()` stays the plain,
+infallible `RegistryManifest` every existing caller already expects;
+it panics only if the checked-in `registry/` files themselves are
+malformed, which R3B's CI conformance gate exists to catch before
+merge — the same "fixture serialises" contract
+`fixtures::tiny_static_registry_json` already relies on.
+
+**R3A's acceptance gate**:
+
+```text
+production_registry()
+    -> reads canonical repo registry
+    -> granite-4.1-3b exists
+    -> resolves to pinned VINDEX3 artifact
+```
+
+See `docs/vindex3-registry-publishing-design.md` §8 for the
+`granite-4.1-3b` publish itself, including a real `create_hf_repo`
+namespace bug found and fixed along the way.
+
+**A second real bug, found by actually running the acceptance gate, not
+just wiring it**: `larql pull granite-4.1-3b` + `larql serve
+granite-4.1-3b` initially failed — `open VINDEX3 container: IO error:
+No such file or directory` — even though `pull` itself reported
+success. Root cause in `cached_snapshot_file`
+(`format/huggingface/download/mod.rs`): its "already cached" fast path
+accepted a blob whose bytes existed locally (deduped — this session had
+already pulled a byte-identical `target.embedding.bin` from an
+unrelated repo) but for which the *pinned revision's own* snapshot
+symlink didn't exist, falling back to returning the bare blob path. The
+V3 completeness loop that calls it discards the returned path entirely
+(`fetch(...).ok_or_else(...)?` — only checks `Option`-ness), so it
+reported success while the pinned revision's `snapshots/<rev>/` never
+actually got the symlink the container loader needs. Fixed by making
+the fast path only ever accept the pinned revision's own snapshot
+symlink — an unpinned `revision: None` now always misses immediately
+and falls through to `download_with_progress`, which creates the
+correct symlink without re-transferring already-local bytes. Regression
+tests pin the exact failure shape (blob present, symlink absent for the
+pinned revision → miss) and the now-narrower unpinned-revision case.
+
+**R3A acceptance gate: PASSED for real**, both bugs above fixed first —
+`larql pull granite-4.1-3b` resolved through the production registry to
+`hf://larql/granite-4.1-3b@1048a8eb2fec5812a698e76d7e603527d0475c17`
+and downloaded a complete container; `larql serve granite-4.1-3b`
+loaded it and served a real `/v1/chat/completions` request end to end
+("The capital of France is" → "Paris."). No fixture registry, no manual
+local path, no floating HF revision, anywhere in that chain.

--- a/docs/vindex3-registry-publishing-design.md
+++ b/docs/vindex3-registry-publishing-design.md
@@ -312,7 +312,19 @@ inline below.
    marker, or simply accepting the field as-is with a comment/CI note
    until the mechanized path lands. Avoid a silent, indistinguishable
    "looks the same as a verified fact" field.
-   **Deferred to the registry schema's own design pass — not yet built.**
+   **Decided and built (R3A, 2026-08-24): a structural enum, not an
+   optional field.** `Provenance.attestation: Attestation` where
+   `Attestation` is `Mechanical | HandAttested { by: String }`
+   (`#[serde(tag = "kind")]`, `crates/larql-vindex/src/registry/manifest.rs`).
+   Rejected the `Option<String>` shape from the original framing:
+   `None` reads as "not attested" *or* "mechanically verified"
+   depending on which the reader assumes, exactly the silent
+   ambiguity this question warned against. The enum forces every
+   entry's JSON to name `"kind"` explicitly — nothing can omit the
+   field and default to the safer-looking case. `validate()` also
+   refuses a `HandAttested` naming no one (`by` empty or
+   whitespace-only) — a structurally-present but empty attestation
+   would be the same gap one field down.
 
 ## 8. Proposed first milestone target
 
@@ -333,3 +345,45 @@ Success shape, unchanged from the instruction: `larql pull
 real `registry/models/*.json` entry, the artifact lives on HF with a
 pinned revision, the downloaded container validates, `/v1/runtime`
 reports it — no test fixture anywhere in that loop.
+
+**R3A execution (2026-08-24)**: published `larql/granite-4.1-3b`
+(`granite-4.1-3b-deploy.vindex3`, the NVFP4 build — three local
+candidates existed, `-deploy` chosen as newest/deploy-ready) via
+`larql publish` — no slices, no collections, VINDEX3-safe defaults
+downgrade both automatically. Publish target went through two
+redirects before landing: `larql/*` was the original intent, but the
+HF token's account had no orgs at publish time, so the fallback was
+`chrishayuk/granite-4.1-3b`; the `larql` org was created mid-session
+and publishing switched back to it before any data landed under the
+personal namespace (the abandoned `chrishayuk/granite-4.1-3b` shell
+was deleted, never held real bytes).
+
+**A real bug found and fixed during this**: `create_hf_repo`
+(`crates/larql-vindex/src/format/huggingface/publish/remote.rs`)
+stripped the owner off `repo_id` for the repo *name* but never sent an
+`organization` field in the `POST /api/repos/create` body — HF then
+silently defaults repo creation to the *token's own* namespace,
+regardless of what `--repo` named. This "worked" for every prior
+`chrishayuk/*` publish purely because `chrishayuk` is the token
+owner; it broke the very first `larql/*` publish attempt (repo
+created under `chrishayuk`, the next preupload call against
+`larql/granite-4.1-3b` 404'd on a repo that was never actually
+created there). Fixed by deriving `organization` from `repo_id`'s
+owner and always sending it when present; 2 new tests pin the fix
+directly against the pure body-building function
+(`create_hf_repo_body`, made `pub(super)` for the sibling test file
+per this crate's established plain-file-testing convention).
+
+Upstream source provenance for this entry:
+`ibm-granite/granite-4.1-3b`, revision
+`c0650403e44e78ec0262dab1c90914c65b196c4e` — recovered from the local
+HF hub cache's `refs/main` for that repo, and cross-checked against
+the container's own (out-of-schema, pre-dating this initiative)
+`index.json.model`/`derived_from_model` fields, which matched
+character-for-character. Marked `Attestation::HandAttested { by:
+"chrishayuk" }` per §7 item 4 above: this correlation is a real,
+verified fact, but nothing in the `encode` pipeline's own documented
+contract guarantees it (the encode-time gap `Provenance` exists to
+name) — the honest marker is hand-attested, not mechanical, matching
+this section's own "milestone 1 may hand-attest, if visibly marked"
+decision.

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "models": [
+    "granite-4.1-3b"
+  ]
+}

--- a/registry/models/granite-4.1-3b.json
+++ b/registry/models/granite-4.1-3b.json
@@ -1,0 +1,20 @@
+{
+  "default_variant": "bf16",
+  "variants": {
+    "bf16": {
+      "artifact": {
+        "repo": "larql/granite-4.1-3b",
+        "revision": "1048a8eb2fec5812a698e76d7e603527d0475c17"
+      },
+      "abi": 1,
+      "source": {
+        "repo": "ibm-granite/granite-4.1-3b",
+        "revision": "c0650403e44e78ec0262dab1c90914c65b196c4e",
+        "attestation": {
+          "kind": "hand_attested",
+          "by": "chrishayuk"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
> `larql pull granite-4.1-3b` -> `larql serve granite-4.1-3b` -> a real `/v1/chat/completions` request ("The capital of France is" -> " Paris."), entirely through the production registry. No fixture registry, no manual local path, no floating HF revision.

## R3A — the first real production registry entry

`registry/index.json` + `registry/models/granite-4.1-3b.json`, embedded at compile time and consumed by `production_registry()` through the same resolver every caller (`serve`, `pull`, `/v1/runtime/model`) already shares. Deliberately narrow — no promotion tooling in this rung. The point is proving production registry data can exist, be validated, and be consumed without fixture machinery, before any promotion tooling exists that could mask a problem in the representation itself.

### Schema: `Attestation`

`Provenance` gains `attestation: Attestation` (`Mechanical | HandAttested{by}`), closing the marker gap the publishing design's open question 4 had deferred. An `Option<String>` was considered and rejected: `None` would read as either "not attested" or "mechanically verified" depending on the reader — exactly the silent ambiguity that question warned against. `validate()` also refuses a `HandAttested` naming no one.

### Data source: compile-time embed

`registry/index.json` + `registry/models/*.json` embedded via `include_str!` (new `registry/embedded.rs`) — matches `fixtures`'s existing "static, in-process, no network" precedent, since release binaries have no repo nearby at runtime. One explicit `include_str!` + match arm per model, not a glob — R3A is deliberately one entry. `assemble_registry` takes an injected `lookup` closure (same convention as `production.rs`'s `resolve_claimed_with`) so every failure branch is tested against synthetic data.

`granite-4.1-3b.json`'s variant is `bf16`, not the originally-planned `nvfp4` — the NVFP4 build hit a genuine, general VINDEX3 serving gap (tracked separately, out of scope here). Source provenance was recovered from the local HF cache and cross-checked byte-for-byte against the container's own metadata, but honestly marked hand-attested rather than mechanical: nothing in `encode`'s documented contract guarantees it.

### Two real bugs found and fixed

Both required to make the acceptance loop actually true rather than nominal — found by running the gate, not by inspection:

1. **`create_hf_repo` never sent `organization`** to HF's repo-create API, so every publish silently landed in the token owner's own namespace regardless of `--repo`. Every prior publish "worked" purely because the token owner happened to match; the first `--repo` targeting a different namespace created the repo in the wrong place and the next call 404'd.
2. **`cached_snapshot_file`'s stale-cache fallback** reported a file "cached" via a fallback to its bare blob path whenever the bytes existed locally (e.g. deduped from an unrelated pull) but the pinned revision's own snapshot symlink didn't exist. The V3 completeness loop that calls it discards the returned path and only checks presence, so `pull` reported success while `serve` later failed with a bare, unhelpful IO error.

### Gates

- larql-vindex: 2820 lib tests + all integration binaries (was 2804 pre-#302; net +16)
- larql-cli: 772
- larql-server: 575
- clippy `-D warnings` and `cargo fmt --check` clean workspace-wide
- Coverage verified against the real `check_coverage_policy.py` gate: larql-vindex 94.30% total (43 debt baselines, none newly added; both new registry files clear the 90% floor; `download/mod.rs` ratcheted 64.0%→74.10%); larql-server 83.60% total (12 debt baselines; `bootstrap/load.rs` ratcheted 66.0%→77.14%)

See `docs/vindex3-registry-design.md` §11 and `docs/vindex3-registry-publishing-design.md` §8 for the full account.
