### PR TITLE
feat(vindex3): add production registry conformance checks

### DIFF
--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -133,6 +133,22 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo test -p larql-cli
 
+      # R3B: validates the checked-out PR's own registry/index.json +
+      # registry/models/*.json, through the exact assembly/validation
+      # code production_registry() uses (include_str! embeds whatever
+      # this checkout has at build time) — never a parallel checker
+      # that could drift from what the shipped binary actually accepts.
+      # Runs on all three OSes so a platform-specific path bug (the
+      # Windows-absolute-path class registry/reference.rs already hit
+      # once) shows up here too, not just in unit tests.
+      - name: Registry check (CPU only) on Linux/Windows
+        if: runner.os != 'macOS'
+        run: cargo run -p larql-cli --no-default-features -- registry check
+
+      - name: Registry check (default features) on macOS
+        if: runner.os == 'macOS'
+        run: cargo run -p larql-cli -- registry check
+
   coverage:
     name: coverage - ubuntu
     runs-on: ubuntu-latest

--- a/crates/larql-cli/src/commands/primary/mod.rs
+++ b/crates/larql-cli/src/commands/primary/mod.rs
@@ -19,6 +19,7 @@ pub mod model_cmd;
 pub mod publish_cmd;
 pub mod pull_cmd;
 pub mod recipe_cmd;
+pub mod registry_cmd;
 pub mod rm_cmd;
 pub mod run_cmd;
 pub mod run_cmd_image;

--- a/crates/larql-cli/src/commands/primary/registry_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/registry_cmd.rs
@@ -1,0 +1,156 @@
+//! `larql registry <subcommand>` — validate the VINDEX3 production
+//! registry (R3B).
+//!
+//! `check` is the only verb today. It reuses the exact assembly/
+//! validation code `production_registry()` panics behind
+//! (`larql_vindex::registry::{load_production_registry, load_registry_from_dir}`)
+//! rather than a second, parallel checker — CI's definition of "valid
+//! registry" can never drift from the runtime's own definition, which a
+//! Python JSON schema check run alongside it could.
+//!
+//! A future `larql registry promote` (R3D) is the reason this is a
+//! subcommand group already, not a bare top-level `larql registry-check`
+//! — the promotion workflow ends with exactly this same check:
+//! `write model JSON -> larql registry check -> git diff -> PR`.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Subcommand)]
+pub enum RegistryCommand {
+    /// Validate `index.json` + `models/*.json` — schema, pinned
+    /// revisions, a valid attestation, every referenced model file
+    /// present and parseable, `default_variant` resolvable, ABI
+    /// supported.
+    Check(CheckArgs),
+}
+
+#[derive(Args)]
+pub struct CheckArgs {
+    /// Registry directory to validate (`index.json` + `models/*.json`).
+    /// Omit to validate the registry embedded in this binary — for a
+    /// CI build, that's exactly the checked-out PR's own `registry/`
+    /// files, since `include_str!` embeds whatever was present at
+    /// compile time.
+    pub path: Option<PathBuf>,
+}
+
+pub fn run(cmd: RegistryCommand) -> Result<(), Box<dyn std::error::Error>> {
+    match cmd {
+        RegistryCommand::Check(args) => check(args),
+    }
+}
+
+fn check(args: CheckArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let manifest = match &args.path {
+        Some(path) => larql_vindex::registry::load_registry_from_dir(path)?,
+        None => larql_vindex::registry::load_production_registry()?,
+    };
+
+    let source = args
+        .path
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "(embedded in this binary)".to_string());
+
+    println!("Registry OK: {source}");
+    println!(
+        "  schema_version {}, {} model(s)",
+        manifest.schema_version,
+        manifest.models.len()
+    );
+    for (name, model) in &manifest.models {
+        println!(
+            "  {name} — default `{}`, {} variant(s)",
+            model.default_variant,
+            model.variants.len()
+        );
+        for (variant_name, variant) in &model.variants {
+            println!(
+                "    {variant_name}: {}@{} (ABI {})",
+                variant.artifact.repo, variant.artifact.revision, variant.abi
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_MODEL_JSON: &str = r#"{
+        "default_variant": "bf16",
+        "variants": {
+            "bf16": {
+                "artifact": {"repo": "larql/example", "revision": "abc123"},
+                "abi": 1,
+                "source": {
+                    "repo": "example/example",
+                    "revision": "def456",
+                    "attestation": {"kind": "mechanical"}
+                }
+            }
+        }
+    }"#;
+
+    fn write(dir: &std::path::Path, rel: &str, contents: &str) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    // The no-path (embedded) form is exercised at the larql-vindex layer
+    // (`registry::embedded_tests`, `registry::check_tests`) against the
+    // real checked-in registry/ — duplicating that here would just be
+    // the same assertion against the same data through an extra layer.
+    // These tests cover what's actually specific to the CLI wrapper: the
+    // explicit-path dispatch, and that a validation failure propagates
+    // as an `Err` (the caller's `Error: {e}` + exit 1 convention) rather
+    // than a panic or a silently-swallowed exit 0.
+
+    #[test]
+    fn check_with_an_explicit_path_to_a_valid_registry_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "index.json",
+            r#"{"schema_version": 1, "models": ["example"]}"#,
+        );
+        write(dir.path(), "models/example.json", VALID_MODEL_JSON);
+
+        check(CheckArgs {
+            path: Some(dir.path().to_path_buf()),
+        })
+        .expect("a well-formed registry directory must validate");
+    }
+
+    #[test]
+    fn check_with_an_explicit_path_to_an_invalid_registry_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "index.json",
+            r#"{"schema_version": 1, "models": ["example"]}"#,
+        );
+        let floating = VALID_MODEL_JSON.replace("\"abc123\"", "\"main\"");
+        write(dir.path(), "models/example.json", &floating);
+
+        let err = check(CheckArgs {
+            path: Some(dir.path().to_path_buf()),
+        })
+        .expect_err("a floating revision must refuse, not print success");
+        assert!(err.to_string().contains("main"));
+    }
+
+    #[test]
+    fn check_with_a_missing_path_errors_naming_the_directory() {
+        let missing = std::path::PathBuf::from("/does/not/exist/at/all");
+        let err = check(CheckArgs {
+            path: Some(missing),
+        })
+        .expect_err("a nonexistent registry directory must error, not panic");
+        assert!(err.to_string().contains("index.json"));
+    }
+}

--- a/crates/larql-cli/src/main.rs
+++ b/crates/larql-cli/src/main.rs
@@ -87,6 +87,11 @@ enum Commands {
     /// Publish a vindex to HuggingFace — full vindex plus slice siblings.
     Publish(publish_cmd::PublishArgs),
 
+    /// Validate the VINDEX3 production registry (registry/index.json +
+    /// registry/models/*.json).
+    #[command(subcommand)]
+    Registry(registry_cmd::RegistryCommand),
+
     /// Remove a cached vindex.
     Rm(rm_cmd::RmArgs),
 
@@ -615,6 +620,7 @@ fn real_main() -> i32 {
         Commands::Show(args) => show_cmd::run(args),
         Commands::Slice(args) => slice_cmd::run(args),
         Commands::Publish(args) => publish_cmd::run(args),
+        Commands::Registry(cmd) => registry_cmd::run(cmd),
         Commands::Rm(args) => rm_cmd::run(args),
 
         // ── Build / extract ──

--- a/crates/larql-vindex/src/registry/check.rs
+++ b/crates/larql-vindex/src/registry/check.rs
@@ -1,0 +1,75 @@
+//! Validate a `registry/` directory on disk — the filesystem-reading
+//! counterpart to [`super::embedded`]'s compile-time `include_str!` path.
+//!
+//! # Why this exists (R3B)
+//!
+//! `larql registry check <PATH>` needs to validate a checked-out PR's
+//! `registry/index.json` + `registry/models/*.json` — real files on disk,
+//! not yet baked into any binary. The load-bearing choice: it reuses
+//! [`assemble_registry`], the exact core `production_registry()` panics
+//! behind for the embedded case, rather than a second parallel checker.
+//! A CI gate whose definition of "valid registry" could drift from the
+//! runtime's own definition is worse than no gate — it can pass while
+//! the real resolver would refuse, or refuse while the real resolver
+//! would accept.
+//!
+//! # No path argument
+//!
+//! `larql registry check` with no path validates the *embedded*
+//! registry instead — see [`super::embedded::load_production_registry`].
+//! For a CI build, that's equivalent to checking the same files this
+//! module reads, since `include_str!` embeds whatever was checked out
+//! at compile time; the two entry points exist because R3D's future
+//! promotion workflow needs to check a *candidate* directory that may
+//! not be `registry/` itself yet, before it's moved into place.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use super::embedded::{assemble_registry, parse_index};
+use super::error::RegistryError;
+use super::manifest::RegistryManifest;
+
+/// Filename of the table-of-contents file within a registry directory.
+const INDEX_FILE: &str = "index.json";
+/// Subdirectory holding one JSON file per model.
+const MODELS_DIR: &str = "models";
+
+/// Read and validate a registry directory laid out as
+/// `<dir>/index.json` + `<dir>/models/<name>.json`.
+///
+/// The model filename is derived from the index-listed name
+/// (`models/<name>.json`), never read from a separate field inside the
+/// model's own JSON — there is no independent "manifest's own name" to
+/// drift out of sync with the index, the same single-source-of-truth
+/// choice the schema already makes for every other fact ([`super::manifest`]).
+/// A name the index lists with no matching file is therefore reported
+/// as exactly that: a missing file at the path this function expected,
+/// not a generic IO error.
+pub fn load_registry_from_dir(dir: &Path) -> Result<RegistryManifest, RegistryError> {
+    let index_path = dir.join(INDEX_FILE);
+    let index_json =
+        std::fs::read_to_string(&index_path).map_err(|e| RegistryError::MalformedManifest {
+            reason: format!("reading {}: {e}", index_path.display()),
+        })?;
+    let index = parse_index(&index_json)?;
+
+    // Every model file is read eagerly into an owned map before
+    // `assemble_registry` runs: its `lookup` closure hands back a
+    // borrow, and a closure can't return a borrow of bytes it would
+    // otherwise have to allocate fresh on each call.
+    let mut files = BTreeMap::new();
+    for name in &index.models {
+        let model_path = dir.join(MODELS_DIR).join(format!("{name}.json"));
+        let text =
+            std::fs::read_to_string(&model_path).map_err(|e| RegistryError::MalformedManifest {
+                reason: format!(
+                    "registry/index.json names model '{name}', expected at {}: {e}",
+                    model_path.display()
+                ),
+            })?;
+        files.insert(name.clone(), text);
+    }
+
+    assemble_registry(&index_json, |name| files.get(name).map(String::as_str))
+}

--- a/crates/larql-vindex/src/registry/check_tests.rs
+++ b/crates/larql-vindex/src/registry/check_tests.rs
@@ -1,0 +1,149 @@
+//! Colocated tests for [`super::check`] — the filesystem-reading
+//! registry validator `larql registry check <PATH>` (R3B) and CI both
+//! call. Deliberately independent of the real embedded `registry/`
+//! contents (see `embedded_tests` for those): a temp directory is
+//! written fresh per test, proving the function against synthetic data
+//! the same way `embedded::assemble_registry`'s own tests do.
+
+use super::check::load_registry_from_dir;
+use super::error::RegistryError;
+
+const VALID_MODEL_JSON: &str = r#"{
+    "default_variant": "bf16",
+    "variants": {
+        "bf16": {
+            "artifact": {"repo": "larql/example", "revision": "abc123"},
+            "abi": 1,
+            "source": {
+                "repo": "example/example",
+                "revision": "def456",
+                "attestation": {"kind": "mechanical"}
+            }
+        }
+    }
+}"#;
+
+fn write(dir: &std::path::Path, rel: &str, contents: &str) {
+    let path = dir.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, contents).unwrap();
+}
+
+#[test]
+fn a_well_formed_registry_directory_loads_and_validates() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "index.json",
+        r#"{"schema_version": 1, "models": ["example"]}"#,
+    );
+    write(dir.path(), "models/example.json", VALID_MODEL_JSON);
+
+    let manifest = load_registry_from_dir(dir.path()).unwrap();
+    assert!(manifest.models.contains_key("example"));
+}
+
+#[test]
+fn a_missing_index_file_reports_which_path_it_looked_at() {
+    let dir = tempfile::tempdir().unwrap();
+    let err = load_registry_from_dir(dir.path()).unwrap_err();
+    let RegistryError::MalformedManifest { reason } = err else {
+        panic!("expected MalformedManifest, got {err:?}");
+    };
+    assert!(reason.contains("index.json"), "{reason}");
+}
+
+#[test]
+fn malformed_index_json_refuses() {
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "index.json", "not json");
+
+    let err = load_registry_from_dir(dir.path()).unwrap_err();
+    assert!(matches!(err, RegistryError::MalformedManifest { .. }));
+}
+
+#[test]
+fn a_model_the_index_names_with_no_file_reports_the_expected_path() {
+    // The filename is derived from the index-listed name — never read
+    // from a separate field inside the model's own JSON — so a missing
+    // file names exactly the path this function expected, not a bare
+    // "file not found."
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "index.json",
+        r#"{"schema_version": 1, "models": ["ghost"]}"#,
+    );
+
+    let err = load_registry_from_dir(dir.path()).unwrap_err();
+    let RegistryError::MalformedManifest { reason } = err else {
+        panic!("expected MalformedManifest, got {err:?}");
+    };
+    assert!(reason.contains("ghost"), "{reason}");
+    assert!(reason.contains("models"), "{reason}");
+}
+
+#[test]
+fn malformed_model_json_refuses_naming_the_file() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "index.json",
+        r#"{"schema_version": 1, "models": ["example"]}"#,
+    );
+    write(dir.path(), "models/example.json", "not json");
+
+    let err = load_registry_from_dir(dir.path()).unwrap_err();
+    let RegistryError::MalformedManifest { reason } = err else {
+        panic!("expected MalformedManifest, got {err:?}");
+    };
+    assert!(reason.contains("example.json"), "{reason}");
+}
+
+#[test]
+fn a_manifest_that_parses_but_fails_validation_refuses() {
+    // An unpinned artifact revision — parses fine, but validate() must
+    // still catch it. Proves this path actually validates, not just
+    // parses.
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "index.json",
+        r#"{"schema_version": 1, "models": ["example"]}"#,
+    );
+    let floating = VALID_MODEL_JSON.replace("\"abc123\"", "\"main\"");
+    write(dir.path(), "models/example.json", &floating);
+
+    let err = load_registry_from_dir(dir.path()).unwrap_err();
+    assert!(matches!(err, RegistryError::UnpinnedRevision { .. }));
+}
+
+#[test]
+fn a_registry_with_multiple_models_loads_them_all() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "index.json",
+        r#"{"schema_version": 1, "models": ["alpha", "beta"]}"#,
+    );
+    write(dir.path(), "models/alpha.json", VALID_MODEL_JSON);
+    write(dir.path(), "models/beta.json", VALID_MODEL_JSON);
+
+    let manifest = load_registry_from_dir(dir.path()).unwrap();
+    assert_eq!(manifest.models.len(), 2);
+    assert!(manifest.models.contains_key("alpha"));
+    assert!(manifest.models.contains_key("beta"));
+}
+
+#[test]
+fn the_real_checked_in_registry_directory_also_loads_through_this_path() {
+    // The same real registry/ files embedded_tests proves against
+    // production_registry(), read from disk instead — the two entry
+    // points must agree on the one registry that actually exists.
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../registry")
+        .canonicalize()
+        .expect("crates/larql-vindex/../../registry must resolve to the repo-root registry/ dir");
+    let manifest = load_registry_from_dir(&repo_root).unwrap();
+    assert!(manifest.models.contains_key("granite-4.1-3b"));
+}

--- a/crates/larql-vindex/src/registry/embedded.rs
+++ b/crates/larql-vindex/src/registry/embedded.rs
@@ -51,9 +51,19 @@ const GRANITE_4_1_3B_JSON: &str = include_str!("../../../../registry/models/gran
 /// that type's `models` map holds full bodies; the index only names
 /// them, mirroring the two-file split on disk.
 #[derive(Debug, Deserialize)]
-struct RegistryIndex {
-    schema_version: u32,
-    models: Vec<String>,
+pub(super) struct RegistryIndex {
+    pub(super) schema_version: u32,
+    pub(super) models: Vec<String>,
+}
+
+/// Parse `registry/index.json`'s text alone — shared by [`assemble_registry`]
+/// and [`super::check::load_registry_from_dir`], which both need the
+/// model-name list before they can even know what to read next
+/// (the embedded per-model consts, or `models/<name>.json` on disk).
+pub(super) fn parse_index(index_json: &str) -> Result<RegistryIndex, RegistryError> {
+    serde_json::from_str(index_json).map_err(|e| RegistryError::MalformedManifest {
+        reason: format!("registry/index.json: {e}"),
+    })
 }
 
 /// The embedded JSON text for one `registry/models/<name>.json`, or
@@ -77,7 +87,14 @@ fn embedded_model_json(name: &str) -> Option<&'static str> {
 /// [`RegistryManifest`]. The one function [`super::production::production_registry`]
 /// trusts to have already done all of this by the time a caller sees a
 /// plain, infallible `RegistryManifest`.
-pub(super) fn load_production_registry() -> Result<RegistryManifest, RegistryError> {
+///
+/// Also the non-panicking half of `larql registry check` (R3B) with no
+/// path argument: validates exactly what THIS binary was built with —
+/// for a CI build, that's the PR's own `registry/` files, since
+/// `include_str!` embeds whatever was checked out at compile time. No
+/// separate "is the registry valid" definition to drift from
+/// [`super::production::production_registry`]'s own.
+pub fn load_production_registry() -> Result<RegistryManifest, RegistryError> {
     assemble_registry(INDEX_JSON, embedded_model_json)
 }
 
@@ -91,10 +108,7 @@ pub(super) fn assemble_registry<'a>(
     index_json: &str,
     lookup: impl Fn(&str) -> Option<&'a str>,
 ) -> Result<RegistryManifest, RegistryError> {
-    let index: RegistryIndex =
-        serde_json::from_str(index_json).map_err(|e| RegistryError::MalformedManifest {
-            reason: format!("registry/index.json: {e}"),
-        })?;
+    let index = parse_index(index_json)?;
 
     let mut models = BTreeMap::new();
     for name in index.models {

--- a/crates/larql-vindex/src/registry/mod.rs
+++ b/crates/larql-vindex/src/registry/mod.rs
@@ -23,12 +23,16 @@
 //! shared claimed/unclaimed dispatch `larql-cli` and `larql-server` both
 //! call. Rung 3A (§11) gave the production registry its first real
 //! data — [`embedded`] embeds `registry/index.json` +
-//! `registry/models/*.json` at compile time. Not a generic model
-//! registry, and VINDEX2 has no representation in this schema at all —
-//! see [`manifest`] and [`resolver`] for where that is enforced
-//! structurally rather than by convention.
+//! `registry/models/*.json` at compile time. Rung 3B added [`check`] —
+//! the filesystem-reading counterpart CI and `larql registry check`
+//! validate a checked-out `registry/` directory with, reusing the same
+//! assembly/validation core rather than a second definition of "valid."
+//! Not a generic model registry, and VINDEX2 has no representation in
+//! this schema at all — see [`manifest`] and [`resolver`] for where
+//! that is enforced structurally rather than by convention.
 
 mod abi;
+mod check;
 mod embedded;
 mod error;
 pub mod fixtures;
@@ -39,6 +43,8 @@ mod resolver;
 
 #[cfg(test)]
 mod abi_tests;
+#[cfg(test)]
+mod check_tests;
 #[cfg(test)]
 mod embedded_tests;
 #[cfg(test)]
@@ -51,6 +57,8 @@ mod reference_tests;
 mod resolver_tests;
 
 pub use abi::{Vindex3Abi, CURRENT_VINDEX3_ABI};
+pub use check::load_registry_from_dir;
+pub use embedded::load_production_registry;
 pub use error::RegistryError;
 pub use manifest::{
     Attestation, Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,

--- a/docs/vindex3-registry-design.md
+++ b/docs/vindex3-registry-design.md
@@ -792,4 +792,54 @@ pinned revision → miss) and the now-narrower unpinned-revision case.
 and downloaded a complete container; `larql serve granite-4.1-3b`
 loaded it and served a real `/v1/chat/completions` request end to end
 ("The capital of France is" → "Paris."). No fixture registry, no manual
-local path, no floating HF revision, anywhere in that chain.
+local path, no floating HF revision, anywhere in that chain. R3A
+shipped as its own PR (#305), separate from and frozen ahead of R3B.
+
+## 12. Rung 3B — registry CI/conformance (2026-08-24)
+
+Pure conformance, no new model, no promotion command — proving a
+checked-in `registry/` cannot become invalid unnoticed, using the exact
+same Rust code `production_registry()` already trusts, not a parallel
+Python JSON checker that could drift from the runtime's own definition
+of "valid."
+
+**`load_registry_from_dir`** (new `registry/check.rs`) is the
+filesystem-reading counterpart to [`embedded`]'s compile-time
+`include_str!` path — same `assemble_registry` core, same
+`RegistryManifest::validate()`, same error types. `embedded.rs`'s index
+parsing was factored out into a shared `parse_index` so both entry
+points read `index.json`'s shape identically rather than each parsing
+it their own way. A model name the index lists with no matching
+`models/<name>.json` file is reported naming the exact path expected —
+the filename is derived from the index-listed name by construction,
+never read from a separate field inside the model's own JSON, so there
+is no independent "manifest's own name" that could disagree with the
+index (the same single-source-of-truth choice the schema already makes
+for everything else).
+
+**`larql registry check [PATH]`** (new `registry_cmd.rs`, a subcommand
+group deliberately — R3D's future `larql registry promote` joins it
+later, not a bare top-level verb): no `PATH` validates the registry
+*embedded in this binary* — `load_production_registry()`'s own data,
+which for a CI build is exactly the checked-out PR's `registry/` files,
+since `include_str!` embeds whatever was present at compile time. A
+`PATH` reads and validates that directory from disk instead, for R3D's
+promotion workflow (`write model JSON -> larql registry check ->
+git diff -> PR`) to check a *candidate* directory before it's moved
+into place.
+
+**CI wiring**: `.github/workflows/larql-cli.yml`'s existing cross-platform
+`test` job (ubuntu/windows/macos-14) gained a `registry check` step
+right after its existing test step — no new job, since the binary is
+already being built there. Runs on all three OSes deliberately, so a
+platform-specific path bug (the Windows-absolute-path class
+`registry/reference.rs` already hit once, rung 1) would surface here
+too, not just in unit tests.
+
+Gates: larql-vindex 2828 lib tests + all integration binaries (+8 from
+R3A's 2820: `check.rs`'s own tests); larql-cli 775 (+3); clippy
+`-D warnings` and `cargo fmt --check` clean workspace-wide. Coverage
+verified against the real `check_coverage_policy.py` gate: unchanged
+94.30% total, 43 debt baselines (none newly added), `check.rs` 100%
+line coverage, `embedded.rs` 94.12% (both new/changed files clear the
+90% floor).


### PR DESCRIPTION
R3B — proves a checked-in `registry/` cannot become invalid unnoticed, using the exact Rust assembly/validation code `production_registry()` already trusts, not a parallel Python JSON checker that could drift from the runtime's own definition of "valid."

## `load_registry_from_dir`

New `registry/check.rs` — the filesystem-reading counterpart to `embedded`'s compile-time `include_str!` path. Same `assemble_registry` core, same `RegistryManifest::validate()`, same error types. `embedded.rs`'s index parsing was factored out into a shared `parse_index` so both entry points read `index.json`'s shape identically. A model name the index lists with no matching `models/<name>.json` file is reported naming the exact path expected — the filename is derived from the index-listed name by construction, never read from a separate field inside the model's own JSON, so there's no independent "manifest's own name" that could drift out of sync with the index.

## `larql registry check [PATH]`

New `registry_cmd.rs` — a subcommand group deliberately, not a bare top-level verb, since R3D's future `larql registry promote` joins it later. No `PATH` validates the registry embedded in this binary (`load_production_registry()`'s own data, which for a CI build is exactly the checked-out PR's `registry/` files, since `include_str!` embeds whatever was present at compile time). A `PATH` reads and validates that directory from disk instead, for R3D's promotion workflow to check a candidate before it's moved into place.

## CI wiring

`.github/workflows/larql-cli.yml`'s existing cross-platform `test` job (ubuntu/windows/macos-14) gained a `registry check` step right after its existing test step — no new job, the binary is already being built there. Runs on all three OSes deliberately, so a platform-specific path bug (the Windows-absolute-path class `registry/reference.rs` already hit once, rung 1) would surface here too, not just in unit tests.

## Gates

- larql-vindex: 2828 lib tests + all integration binaries (+8 from R3A's 2820: `check.rs`'s own tests, both synthetic and against the real checked-in `registry/`)
- larql-cli: 775 (+3)
- clippy `-D warnings` and `cargo fmt --check` clean workspace-wide
- Coverage verified against the real `check_coverage_policy.py` gate: unchanged 94.30% total, 43 debt baselines (none newly added), `check.rs` 100% line coverage, `embedded.rs` 94.12% (both new/changed files clear the 90% floor)

See `docs/vindex3-registry-design.md` §12 for the full account.
