### PR TITLE
feat(vindex3): publish emits a deterministic registry candidate

### DIFF
--- a/crates/larql-cli/src/commands/primary/publish_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/publish_cmd/mod.rs
@@ -25,9 +25,14 @@
 //! - `upload`        — slice-preset resolution, the per-step upload plan,
 //!                      `UploadStep`/`StepOutcome`.
 //! - `progress`       — the indicatif progress-bar `PublishCallbacks` impl.
+//! - `registry_candidate` — `--emit-registry-candidate` (R3C): turns a
+//!                      successful publish's own pinned revision into a
+//!                      candidate `registry/models/<name>.json` body.
+//!                      Opt-in; plain `larql publish` is unaffected.
 
 mod collections;
 mod progress;
+mod registry_candidate;
 mod upload;
 
 use larql_vindex::format::filenames::*;
@@ -146,6 +151,59 @@ pub struct PublishArgs {
     /// existing visibility; this only affects repo *creation*.
     #[arg(long)]
     pub private: bool,
+
+    /// After a successful publish, emit a candidate VINDEX3 registry
+    /// record for `--repo`'s pinned artifact — R3C
+    /// (docs/vindex3-registry-design.md §13). Requires
+    /// `--registry-name`, `--registry-variant`, `--source-repo`,
+    /// `--source-revision`, and `--attested-by`; incompatible with
+    /// `--no-full` (a candidate names the full artifact's own
+    /// revision, which doesn't exist without publishing it). Never
+    /// writes into `registry/models/` or touches `registry/index.json`
+    /// — that's a separate promotion step (R3D), not this flag.
+    #[arg(long)]
+    pub emit_registry_candidate: bool,
+
+    /// Registry model name for the candidate (e.g. `granite-4.1-3b`).
+    /// Required with `--emit-registry-candidate`.
+    #[arg(long)]
+    pub registry_name: Option<String>,
+
+    /// Registry variant name for the candidate (e.g. `bf16`). Required
+    /// with `--emit-registry-candidate`.
+    #[arg(long)]
+    pub registry_variant: Option<String>,
+
+    /// Upstream checkpoint repo the published artifact was built from.
+    /// Required with `--emit-registry-candidate`. Never guessed from
+    /// `--repo`, a filename, or an HF cache path — candidate
+    /// generation must never invent information.
+    #[arg(long)]
+    pub source_repo: Option<String>,
+
+    /// Upstream checkpoint's pinned revision. Required with
+    /// `--emit-registry-candidate`, same reasoning as `--source-repo`.
+    #[arg(long)]
+    pub source_revision: Option<String>,
+
+    /// Who is vouching for `--source-repo`/`--source-revision`.
+    /// Required with `--emit-registry-candidate` — this rung's only
+    /// attestation path is hand-attested; no mechanical capture exists
+    /// yet (`encode` takes no source parameter at all).
+    #[arg(long)]
+    pub attested_by: Option<String>,
+
+    /// Override the VINDEX3 runtime ABI the candidate declares.
+    /// Defaults to the ABI this binary implements — not a guess, the
+    /// only value that could be correct without inventing a
+    /// compatibility range no second ABI value exists to justify yet.
+    #[arg(long)]
+    pub registry_abi: Option<u32>,
+
+    /// Write the registry candidate JSON here instead of printing it
+    /// to stdout.
+    #[arg(long)]
+    pub registry_candidate_out: Option<PathBuf>,
 }
 
 /// Whether `collections` is exactly [`DEFAULT_COLLECTIONS`] (case-insensitive,
@@ -164,6 +222,13 @@ pub(super) fn collections_match_default(collections: &[String]) -> bool {
 }
 
 pub fn run(args: PublishArgs) -> Result<(), Box<dyn std::error::Error>> {
+    // 0. Registry-candidate flags, checked before any network call —
+    // a caller with a missing companion flag finds out immediately,
+    // not after paying for a real publish. `None` when
+    // `--emit-registry-candidate` wasn't passed: plain `larql publish`
+    // takes no new code path at all.
+    let candidate_request = registry_candidate::parse_candidate_request(&args)?;
+
     // 1. Resolve source.
     let src = cache::resolve_model(&args.source)?;
     if !src.is_dir() {
@@ -338,6 +403,14 @@ pub fn run(args: PublishArgs) -> Result<(), Box<dyn std::error::Error>> {
     for r in &results {
         println!("  larql pull hf://{}@{}", r.repo, r.revision);
     }
+
+    // 7. Registry candidate — opt-in, and strictly last: only a
+    // successful publish (every prior step already returned Ok) has a
+    // pinned revision worth building a candidate from.
+    if let Some(request) = candidate_request {
+        registry_candidate::emit(request, &results)?;
+    }
+
     Ok(())
 }
 
@@ -396,6 +469,14 @@ mod tests {
             repo_type: "model".to_string(),
             private: false,
             no_prune: false,
+            emit_registry_candidate: false,
+            registry_name: None,
+            registry_variant: None,
+            source_repo: None,
+            source_revision: None,
+            attested_by: None,
+            registry_abi: None,
+            registry_candidate_out: None,
         }
     }
 

--- a/crates/larql-cli/src/commands/primary/publish_cmd/registry_candidate.rs
+++ b/crates/larql-cli/src/commands/primary/publish_cmd/registry_candidate.rs
@@ -1,0 +1,232 @@
+//! Registry candidate emission (R3C) — the `--emit-registry-candidate`
+//! flag family on `larql publish`.
+//!
+//! Plain `larql publish` (the flag omitted) is untouched by this
+//! module: [`parse_candidate_request`] returns `Ok(None)` immediately,
+//! and [`super::run`] never calls [`emit`] at all in that case.
+
+use std::path::PathBuf;
+
+use larql_vindex::registry::{build_candidate, CandidateInputs, Vindex3Abi};
+
+use super::upload::StepOutcome;
+use super::PublishArgs;
+
+/// Every argument `--emit-registry-candidate` needs, checked up front
+/// — before any upload runs — so a caller with a missing companion
+/// flag finds out immediately, not after paying for a real publish.
+#[derive(Debug)]
+pub(super) struct CandidateRequest {
+    name: String,
+    variant: String,
+    source_repo: String,
+    source_revision: String,
+    attested_by: String,
+    abi: Option<Vindex3Abi>,
+    out: Option<PathBuf>,
+}
+
+/// Parse and validate `args`' registry-candidate flags.
+///
+/// `Ok(None)` — `--emit-registry-candidate` wasn't passed, nothing to
+/// do. `Ok(Some(_))` — every required companion flag is present.
+/// `Err` — the flag combination is invalid (a required flag missing,
+/// or paired with `--no-full`), named clearly enough to fix without
+/// re-reading `--help`.
+pub(super) fn parse_candidate_request(
+    args: &PublishArgs,
+) -> Result<Option<CandidateRequest>, Box<dyn std::error::Error>> {
+    if !args.emit_registry_candidate {
+        return Ok(None);
+    }
+    if args.no_full {
+        return Err(
+            "--emit-registry-candidate requires publishing the full artifact \
+             (--no-full names no full artifact to build a candidate for)"
+                .into(),
+        );
+    }
+    Ok(Some(CandidateRequest {
+        name: require(&args.registry_name, "--registry-name")?,
+        variant: require(&args.registry_variant, "--registry-variant")?,
+        source_repo: require(&args.source_repo, "--source-repo")?,
+        source_revision: require(&args.source_revision, "--source-revision")?,
+        attested_by: require(&args.attested_by, "--attested-by")?,
+        abi: args.registry_abi.map(Vindex3Abi),
+        out: args.registry_candidate_out.clone(),
+    }))
+}
+
+fn require(value: &Option<String>, flag: &str) -> Result<String, Box<dyn std::error::Error>> {
+    value
+        .clone()
+        .ok_or_else(|| format!("--emit-registry-candidate requires {flag}").into())
+}
+
+/// Build the candidate from the just-completed publish's own `results`
+/// — the `full` step's real, pinned `{repo, revision}`, never
+/// re-derived or guessed here — validate it through the real registry
+/// schema, then print or write it. A candidate that fails to build is
+/// a real error: a successful artifact publish with a broken candidate
+/// request is reported, never silently dropped.
+pub(super) fn emit(
+    request: CandidateRequest,
+    results: &[StepOutcome],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let full = results.iter().find(|r| r.label == "full").ok_or(
+        "--emit-registry-candidate found no `full` publish step to build a candidate from",
+    )?;
+
+    let model = build_candidate(CandidateInputs {
+        name: request.name.clone(),
+        variant: request.variant,
+        artifact_repo: full.repo.clone(),
+        artifact_revision: full.revision.clone(),
+        abi: request.abi,
+        source_repo: request.source_repo,
+        source_revision: request.source_revision,
+        attested_by: request.attested_by,
+    })?;
+
+    let json = serde_json::to_string_pretty(&model)?;
+    match request.out {
+        Some(path) => {
+            std::fs::write(&path, format!("{json}\n"))?;
+            println!("\nRegistry candidate:\n  {}", path.display());
+        }
+        None => {
+            println!("\nRegistry candidate ({}):", request.name);
+            println!("{json}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_args() -> PublishArgs {
+        PublishArgs {
+            source: "src".to_string(),
+            repo: "larql/example".to_string(),
+            full: true,
+            no_full: false,
+            slices: Vec::new(),
+            slice_repo_template: "{repo}-{preset}".to_string(),
+            tmp_dir: None,
+            dry_run: false,
+            collections: Vec::new(),
+            model_title: None,
+            family: None,
+            library_title: "LARQL Vindex Library".to_string(),
+            force_upload: false,
+            no_prune: false,
+            repo_type: "model".to_string(),
+            private: false,
+            emit_registry_candidate: false,
+            registry_name: None,
+            registry_variant: None,
+            source_repo: None,
+            source_revision: None,
+            attested_by: None,
+            registry_abi: None,
+            registry_candidate_out: None,
+        }
+    }
+
+    #[test]
+    fn the_flag_omitted_returns_none_and_requires_nothing() {
+        let args = base_args();
+        assert!(parse_candidate_request(&args).unwrap().is_none());
+    }
+
+    #[test]
+    fn the_flag_alone_with_no_companions_errors_naming_the_first_missing_one() {
+        let mut args = base_args();
+        args.emit_registry_candidate = true;
+        let err = parse_candidate_request(&args).unwrap_err();
+        assert!(err.to_string().contains("--registry-name"));
+    }
+
+    #[test]
+    fn every_companion_flag_present_parses() {
+        let mut args = base_args();
+        args.emit_registry_candidate = true;
+        args.registry_name = Some("granite-4.1-3b".to_string());
+        args.registry_variant = Some("bf16".to_string());
+        args.source_repo = Some("ibm-granite/granite-4.1-3b".to_string());
+        args.source_revision = Some("c0650403".to_string());
+        args.attested_by = Some("chrishayuk".to_string());
+
+        let request = parse_candidate_request(&args).unwrap().unwrap();
+        assert_eq!(request.name, "granite-4.1-3b");
+        assert_eq!(request.variant, "bf16");
+    }
+
+    #[test]
+    fn combined_with_no_full_refuses() {
+        let mut args = base_args();
+        args.emit_registry_candidate = true;
+        args.no_full = true;
+        let err = parse_candidate_request(&args).unwrap_err();
+        assert!(err.to_string().contains("--no-full"));
+    }
+
+    fn valid_request() -> CandidateRequest {
+        CandidateRequest {
+            name: "granite-4.1-3b".to_string(),
+            variant: "bf16".to_string(),
+            source_repo: "ibm-granite/granite-4.1-3b".to_string(),
+            source_revision: "c0650403e44e78ec0262dab1c90914c65b196c4e".to_string(),
+            attested_by: "chrishayuk".to_string(),
+            abi: None,
+            out: None,
+        }
+    }
+
+    fn full_step_outcome() -> StepOutcome {
+        StepOutcome {
+            label: "full".to_string(),
+            repo: "larql/granite-4.1-3b".to_string(),
+            url: "https://huggingface.co/larql/granite-4.1-3b".to_string(),
+            revision: "1048a8eb2fec5812a698e76d7e603527d0475c17".to_string(),
+        }
+    }
+
+    #[test]
+    fn emit_with_no_full_step_in_results_errors() {
+        let err = emit(valid_request(), &[]).unwrap_err();
+        assert!(err.to_string().contains("full"));
+    }
+
+    #[test]
+    fn emit_writes_the_pinned_artifact_revision_from_the_real_publish_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("candidate.json");
+        let mut request = valid_request();
+        request.out = Some(out.clone());
+
+        emit(request, std::slice::from_ref(&full_step_outcome())).unwrap();
+
+        let text = std::fs::read_to_string(&out).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            json["variants"]["bf16"]["artifact"]["revision"],
+            "1048a8eb2fec5812a698e76d7e603527d0475c17"
+        );
+        assert_eq!(
+            json["variants"]["bf16"]["artifact"]["repo"],
+            "larql/granite-4.1-3b"
+        );
+        assert!(json.get("name").is_none());
+    }
+
+    #[test]
+    fn emit_propagates_a_candidate_that_fails_real_schema_validation() {
+        let mut request = valid_request();
+        request.source_revision = "main".to_string();
+        let err = emit(request, &[full_step_outcome()]).unwrap_err();
+        assert!(err.to_string().contains("immutable pin"));
+    }
+}

--- a/crates/larql-vindex/src/format/huggingface/publish/tests.rs
+++ b/crates/larql-vindex/src/format/huggingface/publish/tests.rs
@@ -439,6 +439,114 @@ fn publish_vindex_with_opts_happy_path_invokes_callbacks() {
 
 #[test]
 #[serial]
+fn publish_then_candidate_end_to_end_against_a_mocked_hf_endpoint() {
+    // R3C's own acceptance gate, run for real rather than asserted
+    // piecewise: publish against a mocked HF endpoint, let it return a
+    // pinned commit, build a registry candidate from THAT exact
+    // publish result (never a hand-typed stand-in revision), and prove
+    // the candidate carries the real values and validates through the
+    // real registry schema — the same `RegistryManifest::validate()`
+    // `production_registry()` trusts, called inside `build_candidate`
+    // itself.
+    let mut server = mockito::Server::new();
+    let _base = EnvGuard::set(protocol::TEST_BASE_ENV, &server.url());
+    let _tok = EnvGuard::set("HF_TOKEN", "tok");
+
+    let _create = server
+        .mock("POST", "/api/repos/create")
+        .with_status(200)
+        .with_body("{}")
+        .expect_at_least(1)
+        .create();
+    let _preupload = server
+        .mock("POST", "/api/models/larql/granite-4.1-3b/preupload/main")
+        .with_status(200)
+        .with_body(r#"{"files":[{"path":"index.json","uploadMode":"regular"}]}"#)
+        .expect_at_least(1)
+        .create();
+    let _commit = server
+        .mock("POST", "/api/models/larql/granite-4.1-3b/commit/main")
+        .with_status(200)
+        .with_body("{}")
+        .expect_at_least(1)
+        .create();
+    let _head = mock_repo_head_sha(
+        &mut server,
+        "larql/granite-4.1-3b",
+        "1048a8eb2fec5812a698e76d7e603527d0475c17",
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    make_minimal_vindex(tmp.path());
+
+    let published = publish_vindex_with_opts(
+        tmp.path(),
+        "larql/granite-4.1-3b",
+        &PublishOptions::default(),
+        &mut SilentPublishCallbacks,
+    )
+    .expect("mocked publish must succeed");
+    assert_eq!(
+        published.revision,
+        "1048a8eb2fec5812a698e76d7e603527d0475c17"
+    );
+
+    let model = crate::registry::build_candidate(crate::registry::CandidateInputs {
+        name: "granite-4.1-3b".to_string(),
+        variant: "bf16".to_string(),
+        // The published artifact's own repo/revision — "larql/granite-4.1-3b"
+        // is the same string this test passed to `publish_vindex_with_opts`
+        // above, `published.revision` is what the MOCKED HF endpoint
+        // actually returned, not re-typed.
+        artifact_repo: "larql/granite-4.1-3b".to_string(),
+        artifact_revision: published.revision.clone(),
+        abi: None,
+        source_repo: "ibm-granite/granite-4.1-3b".to_string(),
+        source_revision: "c0650403e44e78ec0262dab1c90914c65b196c4e".to_string(),
+        attested_by: "chrishayuk".to_string(),
+    })
+    .expect("a candidate built from real inputs must pass real registry validation");
+
+    let variant = model.variants.get("bf16").expect("bf16 variant present");
+    assert_eq!(variant.artifact.repo, "larql/granite-4.1-3b");
+    assert_eq!(
+        variant.artifact.revision, "1048a8eb2fec5812a698e76d7e603527d0475c17",
+        "the candidate's artifact.revision must be the pinned commit the \
+         MOCKED HF endpoint actually returned, not a guessed or hand-typed value"
+    );
+    assert_eq!(variant.source.repo, "ibm-granite/granite-4.1-3b");
+    assert_eq!(
+        variant.source.revision,
+        "c0650403e44e78ec0262dab1c90914c65b196c4e"
+    );
+    assert_eq!(
+        variant.source.attestation,
+        crate::registry::Attestation::HandAttested {
+            by: "chrishayuk".to_string()
+        }
+    );
+
+    // Missing provenance inputs fail rather than being guessed —
+    // R3C's own invariant, proven against the same real publish result
+    // rather than synthetic data.
+    let refused = crate::registry::build_candidate(crate::registry::CandidateInputs {
+        name: "granite-4.1-3b".to_string(),
+        variant: "bf16".to_string(),
+        artifact_repo: "larql/granite-4.1-3b".to_string(),
+        artifact_revision: published.revision,
+        abi: None,
+        source_repo: "ibm-granite/granite-4.1-3b".to_string(),
+        source_revision: "c0650403e44e78ec0262dab1c90914c65b196c4e".to_string(),
+        attested_by: String::new(),
+    });
+    assert!(
+        refused.is_err(),
+        "an empty attestation must refuse, never silently build a candidate"
+    );
+}
+
+#[test]
+#[serial]
 fn publish_fails_when_the_pinned_revision_cannot_be_fetched() {
     // Every file uploaded successfully, but the final "what's main's
     // HEAD now" call fails — this must fail the whole publish, not

--- a/crates/larql-vindex/src/registry/candidate.rs
+++ b/crates/larql-vindex/src/registry/candidate.rs
@@ -1,0 +1,133 @@
+//! Turn a successful `larql publish` into a deterministic candidate
+//! registry record (R3C).
+//!
+//! # Scope, deliberately narrow
+//!
+//! This is `publish` (artifact exists) emitting a *proposal* for what
+//! `registry/models/<name>.json` could say — it never writes into
+//! `registry/models/`, never touches `registry/index.json`, and never
+//! commits anything. That split (publish vs. promote) is the design's
+//! own R3D boundary (`docs/vindex3-registry-design.md` §6): promotion —
+//! re-fetching the pinned artifact, re-validating it, running whatever
+//! gates exist, and actually writing the registry entry — is separate,
+//! later work.
+//!
+//! # The one invariant that matters here
+//!
+//! **Candidate generation must never invent information.** Every field
+//! is either mechanically known from the publish that just happened
+//! (`artifact.repo`/`artifact.revision`, straight from
+//! [`super::manifest::RegistryArtifactRef`]'s source of truth — the real
+//! `PublishResult` a caller already has, not re-derived here), an
+//! explicit policy default this binary can state about itself (the ABI
+//! it implements), or an explicit value the caller supplied
+//! (`source.repo`, `source.revision`, who's attesting to them). Nothing
+//! here guesses a source checkpoint from a filename, an HF cache path,
+//! or the published repo's own name — a caller with no source
+//! information gets a refusal, not a plausible-looking fabrication.
+//!
+//! # Why this reuses `RegistryManifest::validate()`, not a lighter check
+//!
+//! [`build_candidate`] wraps its one model into a one-entry
+//! [`RegistryManifest`] and calls `.validate()` on it before returning
+//! anything — the exact code `production_registry()` trusts and
+//! `registry check` (R3B) calls out to. A candidate that would fail
+//! real registry validation (a floating revision, an empty attestation)
+//! is refused here, at generation time, not discovered later by
+//! whatever eventually runs `registry check` on it.
+
+use std::collections::BTreeMap;
+
+use super::abi::Vindex3Abi;
+use super::error::RegistryError;
+use super::manifest::{
+    Attestation, Provenance, RegistryArtifactRef, RegistryManifest, RegistryModel, RegistryVariant,
+    REGISTRY_MANIFEST_SCHEMA_VERSION,
+};
+
+/// Every fact a candidate needs, named by where it came from — see the
+/// module docs' invariant. No field here has a silent default except
+/// [`CandidateInputs::abi`], which explicitly documents what its
+/// default means.
+pub struct CandidateInputs {
+    /// The registry model name this candidate is *for* — not embedded
+    /// in the returned [`RegistryModel`] itself (that type has no name
+    /// field, by the same single-source-of-truth choice `check.rs`
+    /// already makes: a model's name lives in `registry/index.json` and
+    /// its filename, never duplicated inside the model's own JSON), but
+    /// callers need it to know what to name the file/print in a
+    /// summary.
+    pub name: String,
+    /// The variant name this candidate selects as its (only, so far)
+    /// default variant.
+    pub variant: String,
+    /// The published VINDEX3 container's own HF repo — mechanically
+    /// known from the publish that just happened.
+    pub artifact_repo: String,
+    /// The published container's pinned HF revision — mechanically
+    /// known (`PublishResult::revision`, `fetch_repo_head_sha`).
+    pub artifact_revision: String,
+    /// The VINDEX3 runtime ABI this candidate declares. Defaults to
+    /// [`super::abi::CURRENT_VINDEX3_ABI`] when `None` — not a guess:
+    /// it's the one ABI this binary actually implements, the only
+    /// value that could be correct without inventing a compatibility
+    /// range no second ABI value exists to justify yet (see
+    /// `abi.rs`'s own module docs).
+    pub abi: Option<Vindex3Abi>,
+    /// Upstream checkpoint repo the published artifact was built from.
+    /// Explicit input only — R3C never derives this from the published
+    /// repo's name, a filename, or an HF cache path.
+    pub source_repo: String,
+    /// Upstream checkpoint's pinned revision. Explicit input only, same
+    /// reasoning as `source_repo`.
+    pub source_revision: String,
+    /// Who is vouching for `source_repo`/`source_revision`. This rung's
+    /// only attestation path is [`Attestation::HandAttested`] — no
+    /// mechanical capture exists yet (`encode` takes no source
+    /// parameter at all, the same gap `docs/vindex3-registry-design.md`
+    /// §4 and the publishing design's Q2/Q3 already named).
+    pub attested_by: String,
+}
+
+/// Build and validate a one-model, one-variant registry candidate.
+///
+/// Returns the [`RegistryModel`] body exactly as it would appear at
+/// `registry/models/<name>.json` — a caller serialises it directly,
+/// with `inputs.name` (not embedded in the return value) driving the
+/// filename or a printed summary.
+pub fn build_candidate(inputs: CandidateInputs) -> Result<RegistryModel, RegistryError> {
+    let variant = RegistryVariant {
+        artifact: RegistryArtifactRef {
+            repo: inputs.artifact_repo,
+            revision: inputs.artifact_revision,
+        },
+        abi: inputs.abi.unwrap_or(super::abi::CURRENT_VINDEX3_ABI),
+        source: Provenance {
+            repo: inputs.source_repo,
+            revision: inputs.source_revision,
+            attestation: Attestation::HandAttested {
+                by: inputs.attested_by,
+            },
+        },
+    };
+
+    let mut variants = BTreeMap::new();
+    variants.insert(inputs.variant.clone(), variant);
+    let model = RegistryModel {
+        default_variant: inputs.variant,
+        variants,
+    };
+
+    // Validate through the real schema, wrapped as the one-entry
+    // manifest it would join — never a lighter, candidate-only check
+    // that could accept something `registry check` would later refuse.
+    let mut models = BTreeMap::new();
+    models.insert(inputs.name, model.clone());
+    let manifest = RegistryManifest {
+        schema_version: REGISTRY_MANIFEST_SCHEMA_VERSION,
+        models,
+    };
+    manifest.validate()?;
+
+    Ok(model)
+}

--- a/crates/larql-vindex/src/registry/candidate_tests.rs
+++ b/crates/larql-vindex/src/registry/candidate_tests.rs
@@ -1,0 +1,103 @@
+//! Colocated tests for [`super::candidate`] — R3C's core invariant
+//! ("candidate generation must never invent information") and its
+//! reuse of the real registry schema for validation.
+
+use super::abi::{Vindex3Abi, CURRENT_VINDEX3_ABI};
+use super::candidate::{build_candidate, CandidateInputs};
+use super::error::RegistryError;
+use super::manifest::Attestation;
+
+fn valid_inputs() -> CandidateInputs {
+    CandidateInputs {
+        name: "granite-4.1-3b".to_string(),
+        variant: "bf16".to_string(),
+        artifact_repo: "larql/granite-4.1-3b".to_string(),
+        artifact_revision: "1048a8eb2fec5812a698e76d7e603527d0475c17".to_string(),
+        abi: None,
+        source_repo: "ibm-granite/granite-4.1-3b".to_string(),
+        source_revision: "c0650403e44e78ec0262dab1c90914c65b196c4e".to_string(),
+        attested_by: "chrishayuk".to_string(),
+    }
+}
+
+#[test]
+fn a_well_formed_candidate_builds_and_validates() {
+    let model = build_candidate(valid_inputs()).unwrap();
+    assert_eq!(model.default_variant, "bf16");
+    let variant = model.variants.get("bf16").unwrap();
+    assert_eq!(variant.artifact.repo, "larql/granite-4.1-3b");
+    assert_eq!(
+        variant.artifact.revision,
+        "1048a8eb2fec5812a698e76d7e603527d0475c17"
+    );
+    assert_eq!(variant.source.repo, "ibm-granite/granite-4.1-3b");
+    assert_eq!(
+        variant.source.revision,
+        "c0650403e44e78ec0262dab1c90914c65b196c4e"
+    );
+    assert_eq!(
+        variant.source.attestation,
+        Attestation::HandAttested {
+            by: "chrishayuk".to_string()
+        }
+    );
+}
+
+#[test]
+fn abi_defaults_to_the_current_abi_when_not_overridden() {
+    let model = build_candidate(valid_inputs()).unwrap();
+    let variant = model.variants.get("bf16").unwrap();
+    assert_eq!(variant.abi, CURRENT_VINDEX3_ABI);
+}
+
+#[test]
+fn an_explicit_abi_override_is_used_verbatim() {
+    let mut inputs = valid_inputs();
+    inputs.abi = Some(Vindex3Abi(7));
+    let model = build_candidate(inputs).unwrap();
+    assert_eq!(model.variants.get("bf16").unwrap().abi, Vindex3Abi(7));
+}
+
+#[test]
+fn a_floating_artifact_revision_refuses_through_the_real_schema() {
+    // Proves build_candidate actually validates, not just assembles —
+    // a floating artifact.revision must be refused the same way a
+    // hand-written registry/models/*.json would be.
+    let mut inputs = valid_inputs();
+    inputs.artifact_revision = "main".to_string();
+    let err = build_candidate(inputs).unwrap_err();
+    assert!(matches!(err, RegistryError::UnpinnedRevision { .. }));
+}
+
+#[test]
+fn a_floating_source_revision_refuses() {
+    let mut inputs = valid_inputs();
+    inputs.source_revision = "latest".to_string();
+    let err = build_candidate(inputs).unwrap_err();
+    assert!(matches!(err, RegistryError::UnpinnedRevision { .. }));
+}
+
+#[test]
+fn an_empty_attested_by_refuses() {
+    // The only attestation path R3C offers is HandAttested — an empty
+    // `by` must refuse exactly the way a hand-written registry entry
+    // would, not silently accept a hand-attestation naming no one.
+    let mut inputs = valid_inputs();
+    inputs.attested_by = String::new();
+    let err = build_candidate(inputs).unwrap_err();
+    assert!(matches!(err, RegistryError::EmptyAttestationBy { .. }));
+}
+
+#[test]
+fn the_candidate_never_carries_its_own_name_field() {
+    // The model body is exactly what would live at
+    // registry/models/<name>.json — the name lives in the index and
+    // the filename, never duplicated inside the model's own JSON
+    // (same choice check.rs's own docs make).
+    let model = build_candidate(valid_inputs()).unwrap();
+    let json = serde_json::to_value(&model).unwrap();
+    assert!(
+        json.get("name").is_none(),
+        "RegistryModel must not serialise a name field: {json}"
+    );
+}

--- a/crates/larql-vindex/src/registry/mod.rs
+++ b/crates/larql-vindex/src/registry/mod.rs
@@ -27,11 +27,15 @@
 //! the filesystem-reading counterpart CI and `larql registry check`
 //! validate a checked-out `registry/` directory with, reusing the same
 //! assembly/validation core rather than a second definition of "valid."
+//! Rung 3C added [`candidate`] — turning a successful `larql publish`
+//! into a deterministic, schema-validated candidate registry record,
+//! without ever writing into `registry/models/` itself (that's R3D).
 //! Not a generic model registry, and VINDEX2 has no representation in
 //! this schema at all — see [`manifest`] and [`resolver`] for where
 //! that is enforced structurally rather than by convention.
 
 mod abi;
+mod candidate;
 mod check;
 mod embedded;
 mod error;
@@ -43,6 +47,8 @@ mod resolver;
 
 #[cfg(test)]
 mod abi_tests;
+#[cfg(test)]
+mod candidate_tests;
 #[cfg(test)]
 mod check_tests;
 #[cfg(test)]
@@ -57,6 +63,7 @@ mod reference_tests;
 mod resolver_tests;
 
 pub use abi::{Vindex3Abi, CURRENT_VINDEX3_ABI};
+pub use candidate::{build_candidate, CandidateInputs};
 pub use check::load_registry_from_dir;
 pub use embedded::load_production_registry;
 pub use error::RegistryError;

--- a/docs/vindex3-registry-design.md
+++ b/docs/vindex3-registry-design.md
@@ -843,3 +843,77 @@ verified against the real `check_coverage_policy.py` gate: unchanged
 94.30% total, 43 debt baselines (none newly added), `check.rs` 100%
 line coverage, `embedded.rs` 94.12% (both new/changed files clear the
 90% floor).
+
+## 13. Rung 3C — publish emits a candidate, never writes the registry (2026-08-24)
+
+One thing, narrowly: **turn a successful `larql publish` into a
+deterministic candidate registry record.** Not `registry/models/`
+itself (R3D), not a promotion command, not the NVFP4 runtime gap
+([[project_vindex3_nvfp4_attention_widening_gap]] in memory) — that's
+a separate programme.
+
+**The one invariant, enforced structurally**: candidate generation must
+never invent information. `CandidateInputs` (new `registry/candidate.rs`)
+names each field by where it came from — `artifact.repo`/
+`artifact.revision` are mechanically known (the *real* publish result's
+own `{repo, revision}`, never re-derived or guessed), `abi` is an
+explicit policy default (`CURRENT_VINDEX3_ABI` — the one value this
+binary actually implements, not invented), and `source.repo`/
+`source.revision`/`attested_by` are explicit caller input only — never
+derived from `--repo`, a filename, or an HF cache path. Missing any
+required input is a refusal before any candidate is built, never a
+guess.
+
+`build_candidate` validates through the **real** schema: it wraps its
+one model into a one-entry `RegistryManifest` and calls
+`.validate()` — the exact code `production_registry()` trusts and
+`registry check` (R3B) calls — before returning anything. A candidate
+that would fail real registry validation (floating revision, empty
+attestation) is refused at generation time, not discovered later by
+whoever eventually runs `registry check` on it.
+
+**`larql publish --emit-registry-candidate`** (new
+`publish_cmd/registry_candidate.rs`) is opt-in and additive only —
+plain `larql publish` takes no new code path at all
+(`parse_candidate_request` returns `Ok(None)` immediately when the
+flag is absent). When passed, it requires `--registry-name`,
+`--registry-variant`, `--source-repo`, `--source-revision`, and
+`--attested-by` — checked up front, before any network call, so a
+missing companion flag is reported immediately rather than after
+paying for a real publish. Incompatible with `--no-full` (a candidate
+names the full artifact's own revision, which doesn't exist without
+publishing it). `--registry-candidate-out PATH` writes the JSON there;
+omitted, it prints to stdout. The candidate body is exactly what would
+live at `registry/models/<name>.json` — no `name` field inside it (the
+name lives in the index and the filename, the same single-source-of-
+truth choice `check.rs` already makes) — a caller feeds it straight
+into `larql registry check` once R3D exists to consume it.
+
+**Acceptance gate, run for real, not asserted piecewise**: a new test
+(`format::huggingface::publish::tests::publish_then_candidate_end_to_end_against_a_mocked_hf_endpoint`)
+publishes against a mocked HF endpoint, lets it return a pinned commit,
+builds a candidate from *that exact* publish result, and asserts the
+candidate's `artifact.revision` is the mocked endpoint's own returned
+value (never a hand-typed stand-in) plus exact `source.repo`/
+`source.revision`/`attestation` — then separately proves an empty
+attestation refuses rather than silently building. Plain `larql
+publish` behaviour is unchanged (all 36 pre-existing `publish_cmd`
+tests pass unmodified; the flag-omitted path returns `Ok(None)`
+before any of the new logic runs).
+
+Gates: larql-vindex 2908 lib tests + all integration binaries (+80 net
+over R3B's 2828 — includes unrelated work merged to `main` between R3B
+and R3C, plus `candidate.rs`'s own 7 tests and the new end-to-end
+acceptance test); larql-cli 787 (+7 from R3B's 775 net of the same
+merged-in delta, plus `registry_candidate.rs`'s own tests); clippy
+`-D warnings` and `cargo fmt --check` clean workspace-wide. Coverage
+verified against the real `check_coverage_policy.py` gate: 94.30%
+total, 43 debt baselines unchanged; `registry/candidate.rs` 100% line
+coverage; `format/huggingface/publish/mod.rs` (a pre-existing 74.0%
+debt baseline) now measures 90.29%, ratcheted further above its floor.
+
+**Per explicit instruction, stopped here**: does not write into
+`registry/models/`, does not touch `registry/index.json`, not
+committed, no PR opened. R3D (promotion — re-fetch the pinned artifact,
+re-validate, run whatever gates exist, write the registry entry) is
+next, deliberately not bundled in.


### PR DESCRIPTION
R3C — turns a successful `larql publish` into a deterministic candidate registry record. Never writes into `registry/models/` or touches `registry/index.json` — that's promotion (R3D), separate, later work.

## The one invariant that matters

**Candidate generation must never invent information.** `CandidateInputs` (`registry/candidate.rs`) names every field by where it came from — `artifact.repo`/`artifact.revision` are mechanically known (the real publish result's own `{repo, revision}`, never re-derived or guessed here), `abi` is an explicit policy default (`CURRENT_VINDEX3_ABI` — the one value this binary actually implements, overridable but never invented), and `source.repo`/`source.revision`/`attested_by` are explicit caller input only — never derived from `--repo`, a filename, or an HF cache path. A caller missing any required input gets a refusal, not a plausible-looking fabrication.

`build_candidate` validates through the **real** schema: it wraps its one model into a one-entry `RegistryManifest` and calls `.validate()` — the exact code `production_registry()` trusts and `registry check` (R3B) calls out to — before returning anything. Returns the bare `RegistryModel` body with no `name` field inside it — the name lives in the index and the filename, the same single-source-of-truth choice `check.rs` already made.

## `larql publish --emit-registry-candidate`

Opt-in and strictly additive: plain `larql publish` takes no new code path at all (`parse_candidate_request` returns `Ok(None)` immediately when the flag is absent, proven by all 36 pre-existing `publish_cmd` tests passing unmodified). Requires `--registry-name`, `--registry-variant`, `--source-repo`, `--source-revision`, and `--attested-by`, checked before any network call. Refuses combined with `--no-full`. `--registry-candidate-out PATH` writes the JSON there; omitted, it prints to stdout.

## Acceptance gate, run for real

A new test publishes against a **mocked HF endpoint**, the mock returns a pinned commit, the candidate is built from that exact `PublishResult`, and the test asserts exact `artifact.revision`/`source.repo`/`source.revision`/`attestation` values — then separately proves an empty `attested_by` refuses rather than silently building.

## Gates

- larql-vindex: 3020 lib tests + all integration binaries
- larql-cli: 794
- clippy `-D warnings` and `cargo fmt --check` clean workspace-wide
- Coverage verified against the real `check_coverage_policy.py` gate: 94.30% total, 43 debt baselines unchanged; `candidate.rs` 100% line coverage; `publish/mod.rs` (a pre-existing 74.0% debt baseline) now 90.29%

See `docs/vindex3-registry-design.md` §13 for the full account.
