### PR TITLE
feat(vindex3): a reduced-depth draft is a physical plan, not a shard (ANE-4A0)

### DIFF
--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
@@ -31,10 +31,11 @@ use larql_vindex::error::VindexError;
 use larql_vindex::format::vindex3::inspect::inspect_container;
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
 use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
+use larql_vindex::format::vindex3::opplan::exec::prepared::ExecutionSlice;
 use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
 use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
 use larql_vindex::format::vindex3::opplan::exec::{
-    execute_plan, execute_plan_streaming, ExecutionTrace, PlaneEvent, ResumePoint,
+    execute_plan_streaming, execute_slice, ExecutionTrace, PlaneEvent, ResumePoint,
 };
 use larql_vindex::format::vindex3::opplan::plan_component_ops;
 use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
@@ -347,8 +348,17 @@ fn run_on<B: PlanBackend>(
             .collect::<Result<_, _>>()?;
         return super::bank::run_bank(backend, &engine, plan, store, &entries, &dump);
     }
+    // One flag, one meaning. A depth deeper than the model is refused by
+    // the slice itself rather than clamped: a run that silently served a
+    // different depth than it was asked for would poison a ladder.
+    let slice = match args.draft_depth {
+        Some(end) => ExecutionSlice::Draft { end },
+        None => ExecutionSlice::Full,
+    };
     if let Some(out) = &args.logit_dump {
-        return super::teacher_force::run_teacher_force(backend, &engine, tokens, plan, store, out);
+        return super::teacher_force::run_teacher_force(
+            backend, &engine, tokens, plan, store, out, slice,
+        );
     }
     match (&args.dump_layers, args.generate) {
         (Some(dir), _) => run_dump(dir, &engine, args, tokens, plan, store, backend),
@@ -356,7 +366,7 @@ fn run_on<B: PlanBackend>(
             super::generate::run_generate(backend, &engine, tokens, new_tokens, plan, store)
         }
         (None, None) => {
-            let trace = execute_plan(plan, store, tokens, backend)?;
+            let trace = execute_slice(plan, store, tokens, backend, slice)?;
             summarise(&engine, &trace);
             Ok(())
         }

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -203,6 +203,19 @@ pub struct ExecArgs {
     #[arg(long, conflicts_with_all = ["dump_layers", "resume", "generate"])]
     pub logit_dump: Option<PathBuf>,
 
+    /// Execute only the first N layers, then the component's own final
+    /// norm and output head — a reduced-depth *model*, not a shard.
+    ///
+    /// One semantic effect: `ExecutionSlice::Draft { end: N }`. Nothing
+    /// else about the run changes, which is the point — a draft measured
+    /// through a different code path than its target would confound
+    /// depth with harness.
+    ///
+    /// Omitted, or equal to the layer count, is the whole stack and is
+    /// bit-identical to leaving the flag off.
+    #[arg(long)]
+    pub draft_depth: Option<usize>,
+
     /// Lowered backends only: attribute each decode token's GPU time to
     /// its stage classes (stage-boundary timestamp counters) and print
     /// the ledger against the bytes each class reads. Sampling drains the

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/teacher_force.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/teacher_force.rs
@@ -25,7 +25,9 @@ use std::time::Instant;
 
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
 use larql_vindex::format::vindex3::opplan::exec::decode::DecodeSession;
+use larql_vindex::format::vindex3::opplan::exec::kv::RowKvState;
 use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
 use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
 
 /// Step `tokens` through the plan one position at a time, writing every
@@ -42,12 +44,23 @@ pub(super) fn run_teacher_force<B: PlanBackend>(
     plan: &ComponentOpPlan,
     store: &OperandStore,
     out: &Path,
+    slice: ExecutionSlice,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let loading = Instant::now();
-    let mut session = DecodeSession::new(plan, store, backend)?;
+    // Prepared explicitly rather than through `DecodeSession::new`, so
+    // the slice reaches the operand loader. A `Draft` prepares only its
+    // own layers — measured at 4 + ~13.4 reads per layer on the 27B
+    // container — which is what makes a shallow draft affordable at all.
+    let ops = PreparedOperands::load(plan, store, backend, slice.clone())?;
+    let mut kv = RowKvState::default();
+    let mut session = DecodeSession::over_prepared(plan, &ops, backend, &mut kv)?;
+    let prepare_s = loading.elapsed().as_secs_f64();
+    let executed = ops.executed_layers();
     eprintln!(
-        "weights resident in {:.1} s",
-        loading.elapsed().as_secs_f64()
+        "weights resident in {prepare_s:.1} s — layers {}..{} of {}",
+        executed.start,
+        executed.end,
+        plan.layers.len()
     );
 
     let started = Instant::now();
@@ -90,5 +103,33 @@ pub(super) fn run_teacher_force<B: PlanBackend>(
         started.elapsed().as_secs_f64() * 1000.0 / tokens.len() as f64,
     );
     println!("wrote [{}, {vocab}] f32 to {}", tokens.len(), out.display());
+
+    // A sidecar beside the plane, so a comparison can ASSERT the run's
+    // identity instead of trusting a filename. A depth result is only a
+    // depth result if the arms agree on backend, format policy and
+    // container; this project has manufactured a "depth effect" that was
+    // a backend effect before, and a bare .f32 carries no way to catch it.
+    let steps_s = started.elapsed().as_secs_f64();
+    let meta = format!(
+        "{{\n  \"engine\": \"{engine}\",\n  \"draft_depth\": {},\n  \
+         \"executed_layers\": [{}, {}],\n  \"model_layers\": {},\n  \
+         \"positions\": {},\n  \"vocab\": {vocab},\n  \
+         \"prepare_s\": {prepare_s:.3},\n  \"steps_s\": {steps_s:.3},\n  \
+         \"ms_per_position\": {:.1},\n  \
+         \"max_format_env\": \"{}\"\n}}\n",
+        match &slice {
+            ExecutionSlice::Draft { end } => end.to_string(),
+            _ => "null".to_string(),
+        },
+        executed.start,
+        executed.end,
+        plan.layers.len(),
+        tokens.len(),
+        steps_s * 1000.0 / tokens.len() as f64,
+        std::env::var("LARQL_CPU_MAX_FORMAT").unwrap_or_default(),
+    );
+    let meta_path = out.with_extension("meta.json");
+    std::fs::write(&meta_path, meta)?;
+    println!("wrote provenance to {}", meta_path.display());
     Ok(())
 }

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/generate.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/generate.rs
@@ -61,6 +61,7 @@ fn greedy_decode_runs_end_to_end_on_the_encoded_fixture() {
         logit_dump: None,
         bank: None,
         dump_dir: None,
+        draft_depth: None,
         profile: false,
     }))
     .expect("greedy decode over the fixture must complete");

--- a/crates/larql-vindex/examples/ane4a0b_operand_substrate.rs
+++ b/crates/larql-vindex/examples/ane4a0b_operand_substrate.rs
@@ -1,0 +1,160 @@
+//! ANE-4A0b — does a reduced physical plan cost what the PLAN costs, or
+//! what the CONTAINER costs?
+//!
+//! The invariant under test:
+//!
+//! > The cost of executing a reduced physical plan scales with the plan,
+//! > not with the size of the authoritative container.
+//!
+//! That is what makes `ExecutionSlice` a physical *view* over VINDEX3
+//! rather than a filter applied after the fact. A four-layer draft that
+//! reads sixty-four layers of weights is not a view; it is a full model
+//! that throws most of its work away, and it would make every
+//! reduced-depth measurement meaningless as an economics claim.
+//!
+//! Reading the code says the invariant holds — `OperandStore` seeks to
+//! one tensor per operand, and `PreparedOperands::load` slices the layer
+//! range before loading anything. This measures it instead, because the
+//! nastier failure mode is exactly the one reading misses: execution
+//! skipping layers while preparation still reads their weights.
+//!
+//! Two instruments, and they answer different questions:
+//!
+//! ```text
+//! load_count   how many operands were READ from the container
+//!              -> the view claim
+//! peak RSS     how much was MATERIALISED as f32 at once
+//!              -> the affordability claim
+//! ```
+//!
+//! `load_count` is the one that can prove the invariant; RSS can be
+//! confounded by allocator behaviour and page cache, so it is reported
+//! rather than asserted on. Take RSS from the outside:
+//!
+//! ```text
+//! /usr/bin/time -l cargo run --release -p larql-vindex \
+//!     --example ane4a0b_operand_substrate -- <container> 1,2,4
+//! ```
+//!
+//! Deliberately does NOT run `Full` on a 27B container: that is ~93 GB of
+//! f32 on a machine whose disk cannot grow swap. The depths here are
+//! chosen to stay bounded, and the point is the SHAPE of the curve.
+
+use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::opplan::exec::execute_slice;
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::prepared::ExecutionSlice;
+use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use larql_vindex::format::vindex3::opplan::plan_component_ops;
+use std::time::Instant;
+
+/// Any valid ids: this rung measures the operand substrate, not the
+/// model's answer. Real tokenisation matters at the depth ladder, not
+/// here.
+const TOKENS: &[u32] = &[1, 2, 3];
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let container = args.next().unwrap_or_else(|| {
+        eprintln!("usage: ane4a0b_operand_substrate <container> [depths, default 1,2,4]");
+        std::process::exit(2);
+    });
+    let depths: Vec<usize> = args
+        .next()
+        .unwrap_or_else(|| "1,2,4".to_string())
+        .split(',')
+        .map(|d| d.trim().parse().expect("depth"))
+        .collect();
+
+    let root = std::path::Path::new(&container);
+    let inspection = inspect_container(root, false).expect("inspect");
+    let plan = plan_component_ops(&inspection, root, "target")
+        .expect("plan")
+        .plan
+        .expect("the container carries a target plan");
+    let depth = plan.layers.len();
+    println!("container: {container}");
+    println!("component `{}` has {depth} layers\n", plan.component);
+
+    println!(
+        "{:>7}{:>10}{:>14}{:>16}{:>12}",
+        "depth", "layers", "operand reads", "reads/layer", "wall s"
+    );
+
+    let mut rows: Vec<(usize, u64)> = Vec::new();
+    for &end in &depths {
+        if end > depth {
+            eprintln!("skipping depth {end}: deeper than the model");
+            continue;
+        }
+        // A fresh store per arm, so `load_count` is this arm's reads and
+        // not a running total across arms.
+        let store = OperandStore::open(root, &inspection).expect("store");
+        let before = store.load_count();
+        let t = Instant::now();
+        let trace = execute_slice(
+            &plan,
+            &store,
+            TOKENS,
+            &ReferenceBackend,
+            ExecutionSlice::Draft { end },
+        )
+        .expect("draft traversal");
+        let secs = t.elapsed().as_secs_f64();
+        let reads = store.load_count() - before;
+
+        // The guard: execution must have run exactly the requested
+        // prefix. Without this, a low read count could mean the slice
+        // worked or that the traversal quietly did less than it claimed.
+        assert_eq!(
+            trace.executed_layers,
+            (0..end).collect::<Vec<_>>(),
+            "draft of depth {end} executed {:?}",
+            trace.executed_layers
+        );
+        assert!(
+            trace.logits.as_ref().is_some_and(|l| !l.is_empty()),
+            "a draft owns the head, so it must produce logits"
+        );
+
+        println!(
+            "{:>7}{:>10}{:>14}{:>16.1}{:>12.2}",
+            end,
+            trace.executed_layers.len(),
+            reads,
+            reads as f64 / end as f64,
+            secs
+        );
+        rows.push((end, reads));
+    }
+
+    // The invariant, stated as arithmetic rather than left to the eye.
+    //
+    // Reads should be affine in depth: a fixed cost for the ends
+    // (embedding table, final norm, output head) plus a constant per
+    // layer. If reads were instead flat in depth, preparation is reading
+    // the whole container regardless of the slice, and the "view" claim
+    // is false.
+    if rows.len() >= 2 {
+        let (d0, r0) = rows[0];
+        let (d1, r1) = rows[rows.len() - 1];
+        let per_layer = (r1 as f64 - r0 as f64) / (d1 as f64 - d0 as f64);
+        let ends = r0 as f64 - per_layer * d0 as f64;
+        println!("\nreads ~ {ends:.0} + {per_layer:.1} per layer");
+        println!(
+            "extrapolated to the full {depth}-layer model: {:.0} reads",
+            ends + per_layer * depth as f64
+        );
+        if per_layer <= 0.0 {
+            println!(
+                "\nINVARIANT VIOLATED: reads do not grow with depth — preparation is \
+                 not honouring the slice"
+            );
+            std::process::exit(1);
+        }
+        println!(
+            "\nINVARIANT HOLDS: operand reads scale with the plan ({per_layer:.1} per \
+             layer), not with the container"
+        );
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -83,6 +83,13 @@ pub struct ExecutionTrace {
     /// layer 0.
     pub embedded: Vec<Vec<f32>>,
     pub layers: Vec<LayerTrace>,
+    /// Plan indices of the layers that actually ran, in order.
+    ///
+    /// A reduced-depth run has to be able to prove it executed the
+    /// prefix it asked for rather than silently falling back to the
+    /// whole stack — and a full run has to be able to prove the reverse.
+    /// `layers` alone cannot say that: a count is not an identity.
+    pub executed_layers: Vec<usize>,
     /// Final-normed hidden state of the last position.
     pub final_hidden: Vec<f32>,
     /// Logits of the last position, when the plan carries an output op.
@@ -147,19 +154,39 @@ pub fn execute_plan<'s, B: PlanBackend + ?Sized>(
     tokens: &[u32],
     backend: &B,
 ) -> Result<ExecutionTrace, VindexError> {
+    execute_slice(plan, store, tokens, backend, ExecutionSlice::Full)
+}
+
+/// [`execute_plan`] over a chosen [`ExecutionSlice`].
+///
+/// `execute_plan` is this with [`ExecutionSlice::Full`], so the two can
+/// never disagree about what a whole model means.
+pub fn execute_slice<'s, B: PlanBackend + ?Sized>(
+    plan: &ComponentOpPlan,
+    store: impl Into<OperandSource<'s>>,
+    tokens: &[u32],
+    backend: &B,
+    slice: ExecutionSlice,
+) -> Result<ExecutionTrace, VindexError> {
     let store = store.into();
     let mut embedded = Vec::new();
     let mut layers = Vec::with_capacity(plan.layers.len());
-    let out = execute_plan_streaming(plan, store, tokens, backend, None, &mut |event| {
+    let mut executed_layers = Vec::with_capacity(plan.layers.len());
+    let ops = PreparedOperands::load(plan, store, backend, slice)?;
+    let out = execute_prepared_streaming(plan, &ops, tokens, backend, None, &mut |event| {
         match event {
             PlaneEvent::Embedded(rows) => embedded = rows.to_vec(),
-            PlaneEvent::Layer { trace, .. } => layers.push(trace),
+            PlaneEvent::Layer { index, trace } => {
+                layers.push(trace);
+                executed_layers.push(index);
+            }
         }
         Ok(())
     })?;
     Ok(ExecutionTrace {
         embedded,
         layers,
+        executed_layers,
         final_hidden: out.final_hidden,
         logits: out.logits,
     })
@@ -316,7 +343,16 @@ fn traverse<B: PlanBackend + ?Sized, K: KvState + ?Sized>(
     // QW-1 put this refusal up front for exactly that reason; the
     // question it asks has changed (from "can this run at all" to "can
     // this provider hold the state"), its position must not.
+    //
+    // Scoped to the layers this slice will actually execute. For `Full`
+    // that is every layer and the check is unchanged; a reduced-depth
+    // draft must not be refused — or charged state — for a recurrence in
+    // a layer it never runs.
+    let executed = ops.first_layer()..ops.first_layer() + ops.layers().len();
     for (offset, layer) in plan.layers.iter().enumerate() {
+        if !executed.contains(&offset) {
+            continue;
+        }
         if layer.attention.softmax().is_some() {
             continue;
         }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -69,6 +69,27 @@ pub enum ExecutionSlice {
     /// embedding, no final norm, no head. Hidden states in, hidden
     /// states out — the shape a layer-range shard executes.
     LayerRange { start: usize, end: usize },
+    /// Embedding, layers `[0, end)`, then the component's **own** final
+    /// norm and output head — a reduced-depth model that still speaks
+    /// the target's token vocabulary.
+    ///
+    /// Not a [`Self::LayerRange`] with the ends bolted on. A shard is a
+    /// hidden-state transform and composes with other shards; this is a
+    /// complete model that happens to be shallower, and it owns both
+    /// ends precisely so its logits are comparable to the target's. The
+    /// distinction is the whole point: a drafter is a different semantic
+    /// object, not a slice with options.
+    ///
+    /// `Draft { end: plan.layers.len() }` must be observationally
+    /// identical to [`Self::Full`] — that equivalence is the gate the
+    /// variant has to pass before any reduced depth is believed.
+    ///
+    /// Prefix-only by construction. Selecting a *scattered* subset of a
+    /// hybrid stack is not merely a coarser approximation: omitted
+    /// recurrent layers own state transitions that later layers consume,
+    /// so `{0, 8, 16, ...}` is not yet a defined program. That is a
+    /// separate rung, and this variant deliberately cannot express it.
+    Draft { end: usize },
 }
 
 impl ExecutionSlice {
@@ -77,13 +98,14 @@ impl ExecutionSlice {
         match self {
             Self::Full => 0..plan.layers.len(),
             Self::LayerRange { start, end } => *start..*end,
+            Self::Draft { end } => 0..*end,
         }
     }
 
     /// Whether the slice carries the stack's ends — embedding on the
     /// way in, final norm and output head on the way out.
     pub fn is_whole_stack(&self) -> bool {
-        matches!(self, Self::Full)
+        matches!(self, Self::Full | Self::Draft { .. })
     }
 
     /// Refuse a slice the plan cannot satisfy. A shard asked for layers
@@ -91,6 +113,23 @@ impl ExecutionSlice {
     /// "as much as exists" would serve a silently wrong submodel — the
     /// same failure the V3 load options used to have.
     fn validate(&self, plan: &ComponentOpPlan) -> Result<(), VindexError> {
+        if let Self::Draft { end } = self {
+            if *end == 0 {
+                return Err(VindexError::Parse(
+                    "a draft slice must execute at least one layer — `Draft { end: 0 }` is the \
+                     embedding and head with nothing between them"
+                        .to_string(),
+                ));
+            }
+            if *end > plan.layers.len() {
+                return Err(VindexError::Parse(format!(
+                    "draft slice of depth {end} is deeper than component `{}`, which has {} layers",
+                    plan.component,
+                    plan.layers.len()
+                )));
+            }
+            return Ok(());
+        }
         let Self::LayerRange { start, end } = self else {
             return Ok(());
         };
@@ -614,6 +653,17 @@ impl PreparedOperands {
 
     pub(super) fn first_layer(&self) -> usize {
         self.first_layer
+    }
+
+    /// The plan-layer indices this prepared set will execute, as a
+    /// half-open range.
+    ///
+    /// Public because the identity of the work is part of a run's
+    /// provenance: a caller banking logits has to be able to record —
+    /// and a comparison to assert — which layers actually ran, and
+    /// neither can be inferred from a layer count.
+    pub fn executed_layers(&self) -> std::ops::Range<usize> {
+        self.first_layer..self.first_layer + self.layers.len()
     }
 
     pub(super) fn layers(&self) -> &[PreparedLayer] {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/draft_slice.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/draft_slice.rs
@@ -1,0 +1,285 @@
+//! ANE-4A0: the draft slice, and the gate it has to pass before any
+//! reduced depth is believed.
+//!
+//! [`ExecutionSlice::Draft`] is a reduced-depth model that still owns
+//! both ends of the stack — embedding in, the component's own final norm
+//! and output head out — so its logits are comparable to the target's.
+//! That is what makes it a drafter rather than a shard.
+//!
+//! **The gate is observational equivalence at full depth.** A new
+//! traversal seam that changes the model's logits when it selects every
+//! layer is not an acceptance experiment; it is an inference bug, and
+//! every reduced-depth number measured through it would inherit the bug
+//! rather than the model. So `Draft { end: L }` must reproduce `Full`
+//! exactly — bit-identical logits, and the same layers executed in the
+//! same order.
+//!
+//! Bit-identical is the right bar here, not a tolerance: both arms run
+//! the same operands through the same backend in the same order, so any
+//! difference at all would be the seam's doing.
+//!
+//! The reduced control is deliberately `L - 1`, not 4 or 8. It asks the
+//! narrow structural question — does truncation work cleanly through the
+//! hybrid state machinery and the final head — before the interesting
+//! one. A drafter that is merely one layer short should still produce
+//! well-formed logits that differ from the target's; if it does not
+//! differ, the slice was ignored, and if it is malformed, the depth
+//! ladder would have been measuring a broken program.
+//!
+//! Env-gated on the real 51 GB container, and skips LOUDLY rather than
+//! reporting success over a missing subject:
+//!
+//! ```text
+//! QW38_CONTAINER=~/chris-models/Qwen3.8-27B.vindex3 \
+//!   cargo test draft_slice -- --nocapture --ignored
+//! ```
+
+use crate::format::vindex3::encode::encode_system;
+use crate::format::vindex3::fixtures::hybrid_lllf_f32_model;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::execute_slice;
+use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::exec::prepared::ExecutionSlice;
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
+
+/// The same LLLF hybrid fixture QW-3.6b/3.7 traverse: three recurrent
+/// layers then a softmax one, so the draft slice meets durable
+/// continuation state rather than a pure residual stack.
+fn hybrid() -> (tempfile::TempDir, ComponentOpPlan, OperandStore) {
+    let src = tempfile::tempdir().unwrap();
+    hybrid_lllf_f32_model(src.path());
+    let inventory = larql_models::inventory::build_inventory(src.path()).unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_system(&[("hybrid".to_string(), inventory)], container.path())
+        .expect("the hybrid fixture is admissible");
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let outcome = plan_component_ops(&inspection, container.path(), "target").unwrap();
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    (container, outcome.plan.unwrap(), store)
+}
+
+/// **The gate, on a fixture.** Cheap enough to run every time, and it
+/// asks exactly what the real-container version asks: selecting every
+/// layer through the new seam must be the old traversal, bit for bit.
+#[test]
+fn a_full_depth_draft_is_the_whole_stack_on_the_hybrid_fixture() {
+    let (_dir, plan, store) = hybrid();
+    let depth = plan.layers.len();
+    let tokens = &[1u32, 0, 2];
+
+    let full = execute_slice(
+        &plan,
+        &store,
+        tokens,
+        &ReferenceBackend,
+        ExecutionSlice::Full,
+    )
+    .expect("full traversal");
+    let draft = execute_slice(
+        &plan,
+        &store,
+        tokens,
+        &ReferenceBackend,
+        ExecutionSlice::Draft { end: depth },
+    )
+    .expect("full-depth draft traversal");
+
+    assert_eq!(draft.executed_layers, (0..depth).collect::<Vec<_>>());
+    assert_eq!(draft.executed_layers, full.executed_layers);
+    assert_eq!(
+        draft.logits, full.logits,
+        "a full-depth draft must be the target bit for bit"
+    );
+    assert_eq!(draft.final_hidden, full.final_hidden);
+}
+
+/// Truncation must reach the head, stay finite, and actually change the
+/// answer — through a stack whose earlier layers keep recurrent state.
+#[test]
+fn a_shorter_draft_executes_its_prefix_and_changes_the_answer() {
+    let (_dir, plan, store) = hybrid();
+    let depth = plan.layers.len();
+    assert!(depth >= 2, "the fixture needs a layer to drop");
+    let tokens = &[1u32, 0, 2];
+
+    let full = execute_slice(
+        &plan,
+        &store,
+        tokens,
+        &ReferenceBackend,
+        ExecutionSlice::Full,
+    )
+    .expect("full traversal");
+    let short = execute_slice(
+        &plan,
+        &store,
+        tokens,
+        &ReferenceBackend,
+        ExecutionSlice::Draft { end: depth - 1 },
+    )
+    .expect("shortened draft traversal");
+
+    assert_eq!(short.executed_layers, (0..depth - 1).collect::<Vec<_>>());
+    let logits = short.logits.as_ref().expect("the draft carries a head");
+    assert_eq!(logits.len(), full.logits.as_ref().unwrap().len());
+    assert!(logits.iter().all(|v| v.is_finite()));
+    assert_ne!(
+        short.logits, full.logits,
+        "dropping a layer changed nothing — the slice was ignored"
+    );
+}
+
+/// A draft is a model, so it must refuse the degenerate depths rather
+/// than serve a silently wrong submodel.
+#[test]
+fn a_draft_refuses_zero_depth_and_overdeep_requests() {
+    let (_dir, plan, store) = hybrid();
+    let depth = plan.layers.len();
+    let tokens = &[1u32];
+    for (end, expect) in [(0usize, "at least one layer"), (depth + 1, "deeper than")] {
+        let err = execute_slice(
+            &plan,
+            &store,
+            tokens,
+            &ReferenceBackend,
+            ExecutionSlice::Draft { end },
+        )
+        .expect_err("a draft of depth {end} must be refused");
+        assert!(
+            err.to_string().contains(expect),
+            "depth {end} refused with the wrong reason: {err}"
+        );
+    }
+}
+
+/// "The capital of France is" — the QW-3.7 trajectory's prompt, so a
+/// divergence here can be read against a banked result rather than
+/// against nothing.
+const PROMPT_TOKENS: &[u32] = &[976, 6722, 315, 9822, 374];
+
+#[test]
+#[ignore = "needs the real 51 GB Qwen3.8-27B container; set QW38_CONTAINER"]
+fn a_full_depth_draft_is_the_target_exactly() {
+    let Ok(container) = std::env::var("QW38_CONTAINER") else {
+        eprintln!("SKIP draft_slice: set QW38_CONTAINER");
+        return;
+    };
+    let root = std::path::Path::new(&container);
+    let inspection = inspect_container(root, false).unwrap();
+    let plan = plan_component_ops(&inspection, root, "target")
+        .unwrap()
+        .plan
+        .expect("the container carries a target plan");
+    let store = OperandStore::open(root, &inspection).unwrap();
+    let backend = ReferenceBackend::new();
+    let depth = plan.layers.len();
+    eprintln!("draft_slice: {depth} layers, prompt {PROMPT_TOKENS:?}");
+
+    let full = execute_slice(&plan, &store, PROMPT_TOKENS, &backend, ExecutionSlice::Full)
+        .expect("full traversal");
+    let draft = execute_slice(
+        &plan,
+        &store,
+        PROMPT_TOKENS,
+        &backend,
+        ExecutionSlice::Draft { end: depth },
+    )
+    .expect("full-depth draft traversal");
+
+    // Which layers ran, not merely how many. A count cannot tell a
+    // prefix from a planner falling back to the whole stack.
+    assert_eq!(
+        draft.executed_layers, full.executed_layers,
+        "a full-depth draft must execute exactly the layers the target does"
+    );
+    assert_eq!(
+        draft.executed_layers,
+        (0..depth).collect::<Vec<_>>(),
+        "and those layers must be the whole stack in order"
+    );
+
+    let (Some(fl), Some(dl)) = (full.logits.as_ref(), draft.logits.as_ref()) else {
+        panic!("both arms must carry an output head");
+    };
+    assert_eq!(fl.len(), dl.len(), "logit width must match");
+    let differing = fl.iter().zip(dl).filter(|(a, b)| a != b).count();
+    assert_eq!(
+        differing,
+        0,
+        "full-depth draft diverged from the target in {differing} of {} logits — the seam \
+         changes the model, so no reduced-depth measurement through it would mean anything",
+        fl.len()
+    );
+    eprintln!("draft_slice: {} logits bit-identical", fl.len());
+}
+
+#[test]
+#[ignore = "needs the real 51 GB Qwen3.8-27B container; set QW38_CONTAINER"]
+fn one_layer_short_executes_the_prefix_and_changes_the_answer() {
+    let Ok(container) = std::env::var("QW38_CONTAINER") else {
+        eprintln!("SKIP draft_slice: set QW38_CONTAINER");
+        return;
+    };
+    let root = std::path::Path::new(&container);
+    let inspection = inspect_container(root, false).unwrap();
+    let plan = plan_component_ops(&inspection, root, "target")
+        .unwrap()
+        .plan
+        .expect("the container carries a target plan");
+    let store = OperandStore::open(root, &inspection).unwrap();
+    let backend = ReferenceBackend::new();
+    let depth = plan.layers.len();
+
+    let full = execute_slice(&plan, &store, PROMPT_TOKENS, &backend, ExecutionSlice::Full)
+        .expect("full traversal");
+    let short = execute_slice(
+        &plan,
+        &store,
+        PROMPT_TOKENS,
+        &backend,
+        ExecutionSlice::Draft { end: depth - 1 },
+    )
+    .expect("L-1 draft traversal");
+
+    assert_eq!(
+        short.executed_layers,
+        (0..depth - 1).collect::<Vec<_>>(),
+        "the L-1 draft must execute exactly the first {} layers",
+        depth - 1
+    );
+
+    let logits = short.logits.as_ref().expect("the draft carries a head");
+    assert_eq!(
+        logits.len(),
+        full.logits.as_ref().unwrap().len(),
+        "a draft speaks the target's vocabulary — same logit width"
+    );
+    assert!(
+        logits.iter().all(|v| v.is_finite()),
+        "the L-1 draft produced non-finite logits — truncation is not clean through the \
+         hybrid state machinery or the final head"
+    );
+    // Dropping a layer must change the answer. If it does not, the slice
+    // was ignored and the "reduced" arm is the target wearing a label.
+    assert!(
+        logits
+            .iter()
+            .zip(full.logits.as_ref().unwrap())
+            .any(|(a, b)| a != b),
+        "the L-1 draft is bit-identical to the full target — the slice had no effect"
+    );
+
+    let argmax = |v: &[f32]| {
+        v.iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map(|(i, _)| i)
+            .unwrap()
+    };
+    eprintln!(
+        "draft_slice: L-1 argmax {} vs target argmax {}",
+        argmax(logits),
+        argmax(full.logits.as_ref().unwrap())
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -20,6 +20,7 @@ mod coverage_device;
 mod coverage_experts_production;
 mod decode;
 mod device;
+mod draft_slice;
 mod gated_delta_parity;
 mod gated_delta_tiny;
 mod hybrid_traversal;

--- a/docs/ane4a-draft-plan.md
+++ b/docs/ane4a-draft-plan.md
@@ -1,0 +1,146 @@
+# ANE-4A0 / 0b — the draft slice, and the operand substrate under it
+
+Branch `worktree-ane4a-qwen-drafter`, from QW-3.7 (`78f71e6b`). Banked
+2026-08-26.
+
+The thesis this rung serves: **speculative decoding by changing the
+physical plan of one model, rather than loading a second model.** Before
+any of that can be measured, two things have to be true — the reduced
+plan must be a real program, and executing it must cost what the *plan*
+costs rather than what the *container* costs.
+
+---
+
+## ANE-4A0 — `ExecutionSlice::Draft { end }`
+
+```
+embedding -> layers [0, end) -> the component's own final norm -> head -> logits
+```
+
+A distinct variant, not an option on `LayerRange`. `LayerRange` is a
+hidden-state shard that composes with other shards; a draft is a complete
+model that happens to be shallower, and it owns both ends precisely so
+its logits are comparable to the target's. `is_whole_stack()` is now
+`Full | Draft`.
+
+**Prefix-only by construction.** The variant cannot express `{0, 8, 16,
+…}`, and that is deliberate: in a hybrid stack, omitted recurrent layers
+own state transitions later layers consume, so a scattered subset is not
+yet a defined program. Distributed selection is a separate rung, and the
+type refuses to let it be smuggled in as a parameter.
+
+### The gate: observational equivalence at full depth
+
+A new traversal seam that changes the model's logits when it selects
+every layer is not an experiment, it is an inference bug — and every
+reduced-depth number measured through it would inherit the bug rather
+than the model. So the bar is bit-identical, not a tolerance: both arms
+run the same operands through the same backend in the same order, so any
+difference at all is the seam's doing.
+
+```
+hybrid LLLF fixture      Draft{L} == Full   logits, final_hidden, executed_layers
+                         Draft{L-1}         executes 0..L-1, finite, differs
+                         Draft{0}, Draft{L+1}   refused, with the right reason
+
+Granite 4.1 3B, 40 layers, real 6.3 GB container
+                         Draft{40} == Full  100,352 logits BIT-IDENTICAL
+                         Draft{39}          executes 0..39, finite, differs
+```
+
+The fixture arm runs in CI. The real-container arm is `#[ignore]`d behind
+`QW38_CONTAINER` and skips loudly rather than reporting success over a
+missing subject.
+
+### Two supporting changes the gate required
+
+- **`ExecutionTrace::executed_layers`** — the plan indices that actually
+  ran. A count cannot distinguish a prefix from a planner falling back to
+  the whole stack, so every assertion here is on identity, not length.
+- **The recurrent-state precheck is scoped to the executed range.** It
+  refuses before any output if a recurrence has nowhere to keep its
+  durable buffers; unscoped, a draft was being refused — or charged
+  state — for layers it never runs. `Full` is unchanged.
+
+---
+
+## ANE-4A0b — the operand substrate
+
+Reading the code suggested the invariant already held. It was measured
+instead, because the failure mode reading misses is exactly the
+interesting one: **execution skipping layers while preparation still
+reads their weights.**
+
+Measured on the real 51 GB Qwen3.8-27B container:
+
+```
+depth  layers  operand reads  reads/layer  wall s
+1      1        17            17.0          4.47
+2      2        31            15.5          5.37
+4      4        57            14.2          7.06
+8      8       111            13.9         10.47
+
+reads ~ 4 + 13.4 per layer      extrapolates to 863 for the full 64
+peak RSS across all four arms: 26.5 GB
+```
+
+Affine in depth, with a small fixed term. **The invariant holds:**
+
+> The cost of executing a reduced physical plan scales with the plan, not
+> with the size of the authoritative container.
+
+`ExecutionSlice` is therefore already a physical *view* over VINDEX3, not
+a filter applied after the fact. **No loader change is needed.**
+
+Why it works, for the record: `OperandStore::open` reads only segment
+headers, `load_raw` seeks to one tensor and reads just its bytes, and
+`PreparedOperands::load` slices the layer range *before* loading
+anything. The 4-operand fixed term is the ends — embedding table, final
+norm, output head.
+
+### The economics finding this exposed
+
+The ends do not scale with depth, and on this model they are not small:
+
+```
+embedding table   248320 x 5120  =  5.09 GB as f32
+output head       248320 x 5120  =  5.09 GB as f32
+```
+
+So a drafter pays **~10 GB of resident vocabulary and ~3.6 s of the
+wall time regardless of how shallow it is** — at depth 8 the ends are
+still about a third of the run. A shallow drafter is cheap in layers and
+expensive in vocabulary, which is a real constraint on the
+accepted-tokens-per-millisecond metric and was not visible from any
+projection microbenchmark.
+
+### What is still deferred, and why
+
+`Full` on Qwen3.8-27B extrapolates to **~93 GB of f32 resident** —
+against ~80 GB effectively available, a 2 GB swap file, and a data volume
+that is 100% full so swap cannot grow. That is a probable hard hang, not
+an error message. The full-depth Qwen parity gate therefore stays unrun;
+Granite proved the seam against real weights at a fifth of the depth and
+a tenth of the footprint.
+
+**Drafts, however, are cheap** — depth 8 on Qwen is well inside budget —
+and drafts are what ANE-4A actually needs. The depth ladder can proceed
+on the real target without ever materialising the full model.
+
+---
+
+## Next
+
+- Real tokenisation from the container's `tokenizer.json`; `TOKENS` in
+  the probe and `PROMPT_TOKENS` in the env-gated test are placeholders,
+  valid but arbitrary, which is fine for a substrate measurement and not
+  fine for a depth ladder.
+- The depth ladder itself: KL against the target, top-1 agreement,
+  target-token rank, then acceptance — on the ordinary backend, before
+  the ANE enters the question at all.
+- An incidental data point worth remembering when that ladder runs: on
+  Granite, `Draft{39}` changed the logits but **not** the argmax
+  (264 either way). One prompt, one depth, no weight at all — but it is
+  the first hint that top-1 agreement may survive truncation further than
+  logit-level agreement does, which is precisely the asymmetry
+  speculative decoding lives on.


### PR DESCRIPTION
A reduced-depth model over the same VINDEX3 container, as a physical plan rather than a second model — the substrate ANE-4A needs before it can ask whether a shallow Qwen3.8 predicts the full one well enough to draft for it.

## What this adds

`ExecutionSlice::Draft { end }` — embedding, layers `[0, end)`, then the component's **own** final norm and output head, so its logits are comparable to the target's.

It is deliberately **not** an option on `LayerRange`. A shard is a hidden-state transform that composes with other shards; a draft is a complete model that happens to be shallower and owns both ends. And it is **prefix-only by construction**: the variant cannot express `{0, 8, 16, …}`, because in a hybrid stack omitted recurrent layers own state transitions later layers consume, so a scattered subset is not yet a defined program. That is a separate rung, and the type refuses to let it be smuggled in as a parameter.

## The gate

A seam that changes the model's logits when it selects *every* layer is not an experiment, it is an inference bug — and every reduced-depth number measured through it would inherit the bug rather than the model. So the bar is bit-identical, not a tolerance:

| arm | result |
|---|---|
| hybrid LLLF fixture, `Draft{L}` vs `Full` | identical logits, `final_hidden`, `executed_layers` |
| hybrid fixture, `Draft{L-1}` | executes `0..L-1`, finite, differs |
| `Draft{0}` / `Draft{L+1}` | refused, with the right reason |
| **Granite 4.1 3B, real container, 40 layers** | **100,352 logits BIT-IDENTICAL** |
| **CLI, `--draft-depth 40` vs no flag, production backend** | **BYTE-IDENTICAL** |

The fixture arms run in CI. The real-container arms are env-gated on `QW38_CONTAINER` and skip loudly rather than reporting success over a missing subject.

## The substrate invariant, measured

> The cost of executing a reduced physical plan scales with the plan, not with the size of the authoritative container.

Reading the code suggested this already held. It was measured instead, because the failure mode reading misses is exactly the interesting one — execution skipping layers while preparation still reads their weights. On the real 51 GB Qwen3.8-27B container:

```
depth  layers  operand reads  reads/layer  wall s
1      1        17            17.0          4.47
2      2        31            15.5          5.37
4      4        57            14.2          7.06
8      8       111            13.9         10.47

reads ~ 4 + 13.4 per layer      26.5 GB peak RSS across all arms
```

Affine in depth, so `ExecutionSlice` is already a physical *view* over VINDEX3 and **no loader change is warranted**. `OperandStore::open` reads only segment headers, `load_raw` seeks to one tensor, and `PreparedOperands::load` slices the layer range before loading anything.

## What that exposed

The stack's ends do not scale with depth, and on this model they are not small: the embedding table and output head are each 248320 × 5120 — 5.09 GB as f32 — so a draft pays ~10 GB resident and ~3.6 s whatever its depth. Two Granite timing points put the same floor at ~11.6 ms/position against ~2.96 ms per layer: 9% of a full-depth run, but a third of a depth-8 one.

**A shallow drafter is cheap in layers and expensive in vocabulary.** That is a real constraint on any accepted-tokens-per-millisecond argument, and no projection microbenchmark showed it.

## Supporting changes

- `ExecutionTrace::executed_layers` and `PreparedOperands::executed_layers()` — the plan indices that actually ran. A count cannot distinguish a prefix from a planner falling back to the whole stack, so the assertions are on identity.
- The recurrent-state precheck is scoped to the executed range. Unscoped, a draft was refused — or charged state — for layers it never runs. `Full` is unchanged.
- `execute_slice(...)`, with `execute_plan` as its `Full` case, so the two can never disagree about what a whole model means.

## CLI

`larql vindex3 exec --draft-depth N`, one semantic effect, reusing the existing `--logit-dump` writer so draft planes are directly comparable to a target bank produced by the same command. A depth deeper than the model is refused by the slice rather than clamped.

Each dump now writes a provenance sidecar — backend, draft depth, executed layers, positions, vocab, prepare/step timing, `LARQL_CPU_MAX_FORMAT` — so a comparison can **assert** the arms match rather than trust a filename. This project has manufactured a "depth effect" that was a backend effect before.

## Not in this PR

The depth-vs-agreement ladder itself. That needs a scorer (KL, top-1 agreement, target-token rank, top-k containment) against the banked full-depth target logits, which is the next piece of work.

3495 tests pass, fmt clean, clippy clean.
