### PR TITLE
fix(ci): the bench regression verdict must not pass through make

### DIFF
--- a/.github/workflows/bench-regress.yml
+++ b/.github/workflows/bench-regress.yml
@@ -1,6 +1,6 @@
-# Bench regression detector — runs `make bench-check` on every PR
-# against a baseline saved on `main`. Fails the workflow if any cell
-# in the criterion bench suite regresses past Criterion's noise
+# Bench regression detector — runs `scripts/bench-regress.sh check` on
+# every PR against a baseline saved on `main`. Fails the workflow if any
+# cell in the criterion bench suite regresses past Criterion's noise
 # threshold.
 #
 # Surface covered (`make bench-save` / `make bench-check`):
@@ -74,11 +74,19 @@ jobs:
       - name: Check vs baseline (PRs + manual)
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         run: |
-          # Cold cache → bench-check prints "no baseline found" and
-          # exits 2. Treat as neutral: the first PR after CI is stood
-          # up shouldn't fail just because there's no baseline yet.
+          # Call the script DIRECTLY, never through `make`. GNU make exits
+          # 2 for any failed recipe (1 is reserved for `-q`), so going via
+          # `make bench-check` aliases the script's exit 1 (regression
+          # detected) onto its exit 2 (no baseline) — and the cold-start
+          # branch below then soft-passes a real regression as green. The
+          # 0 = clean / 1 = regression / 2 = no baseline contract only
+          # survives an unwrapped call.
+          #
+          # Cold cache → the script prints "no baseline found" and exits 2.
+          # Treat that as neutral: the first PR after CI is stood up
+          # shouldn't fail just because there's no baseline yet.
           set +e
-          make bench-check
+          bash scripts/bench-regress.sh check
           rc=$?
           set -e
           if [ "$rc" -eq 2 ]; then


### PR DESCRIPTION
Refs #287 — fixes the first of the two defects reported there. Deliberately does **not** close it; see "What this does not fix" below.

## The defect

`scripts/bench-regress.sh` documents a three-way contract (`bench-regress.sh:15`):

```
0 = clean, 1 = regression detected, 2 = no baseline
```

The workflow consumed it through `make bench-check` and soft-passed exit 2 as the cold-start case. But GNU make exits **2 for any failed recipe** — 1 is reserved for `-q` — so exit 1 and exit 2 arrive identically, and a detected regression takes the "no baseline" branch:

```
make: *** [bench-check] Error 1
[bench-regress] FAIL — regression detected vs baseline 'main'
##[warning]no criterion baseline cached; skipping regression check
```

→ job **success**. The check leg has never failed: of 429 completed `pull_request` runs, 428 succeeded, 1 was never executed, 0 failed.

Reproduced locally on GNU Make 3.81, the version on the `macos-14` runners:

```console
$ printf 'bench-check:\n\t@bash -c "exit 1"\n' > demo.mk
$ make -f demo.mk bench-check; echo $?
make: *** [bench-check] Error 1
2
```

## The fix

Call the script directly so the 0/1/2 contract survives. One line, plus a comment recording why the `make` hop cannot come back.

## Behaviour change — exactly one cell

| script exit | before (`make bench-check`) | after (direct) |
|---|---|---|
| 0 clean | GREEN | GREEN |
| **1 REGRESSION** | **GREEN — swallowed** | **RED — verdict lands** |
| 2 no baseline | GREEN | GREEN |

The cold-start soft-pass is intentional and preserved. A side effect of the same aliasing is also fixed: a build error or bench panic in the recipe was reported as a missing baseline and passed; it now fails.

## What this does not fix

This makes the gate *capable* of failing. It does not give it anything to check.

The baseline lives in `actions/cache`, and the pool sits at its eviction ceiling — **zero** `criterion-baseline` caches exist as of this PR, out of 13 total. PRs therefore still take the cold-start path and exit 2. The reporter's options are storing the baseline as an artifact, or keeping the cache and making a missed restore loud on non-cold-start PRs. That is a design call and is left to you, which is why #287 stays open.

**This PR cannot demonstrate its own fix.** With no baseline cached, its own `bench-regress` run will cold-start, exit 2, and go green — indistinguishable from the broken behaviour. Green here means "nothing broke", not "the gate works". The fix is evidenced by the exit-code table above and by the reporter's fork validation with a deliberate 300 µs slowdown injected into the `cholesky_factor` cells: unchanged workflow → FAIL swallowed, job green; with the one-liner → job fails correctly and the criterion report uploads.

## Testing

- `bench-regress.yml` parses as valid YAML; the `Check vs baseline` step body verified post-parse
- Exit-code table above reproduced end-to-end against a stub honouring the 0/1/2 contract, through both the old and new step logic
- No Rust changed, so fmt/clippy/test gates do not apply
