### PR TITLE
ci: mutation testing must not be able to cancel the quality check

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,132 @@
+# Mutation testing on the PR diff — a SIGNAL, never a gate.
+#
+# Split out of `quality.yml` on 2026-08-27, and the reason is the whole
+# point of the file. The job is declared `continue-on-error: true`
+# because a mutation run is advisory. But `continue-on-error` only
+# covers a job that FAILS: a job killed by `timeout-minutes` is
+# CANCELLED, and one cancelled job makes the entire workflow run
+# conclude `cancelled` regardless. So while this lived in `quality.yml`,
+# a mutation run that ran out of clock turned the whole quality check
+# red even though MSRV, cargo-deny, cargo-audit, buf lint and doc-links
+# had all passed.
+#
+# That was not hypothetical and not rare. It fired on the PRs with the
+# largest diffs — the ones mutation testing takes longest on, and the
+# ones most worth gating: three runs cancelled at exactly 45m across
+# #313 and #316, while a 61m run on a smaller diff passed. The quality
+# signal was least trustworthy exactly where it mattered most.
+#
+# Alone in its own workflow, a timeout here reports as a timeout here
+# and poisons nothing. Read a timed-out run as INCOMPLETE, never as
+# clean — see the notes on the step below.
+
+name: mutants
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  mutants:
+    name: cargo-mutants${{ matrix.label }} (informational)
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    # PR-only: --in-diff needs a base to diff against, and a full-workspace
+    # mutation run is many hours of compute.
+    if: github.event_name == 'pull_request'
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      # Same shape as `msrv` above, and for the same underlying reason:
+      # larql-compute-metal "compiles to an empty crate on non-macOS
+      # hosts" (its own doc comment) — every line inside its
+      # `#[cfg(target_os = "macos")]` modules is structurally invisible to
+      # a ubuntu runner, for every PR, forever. The macos-14 leg, scoped
+      # to `-p larql-compute-metal`, is the only way this workspace's
+      # mutation testing ever sees that code at all.
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: ""
+            package_args: ""
+            diff_paths: "."
+            openblas: true
+          - os: macos-14
+            label: " · larql-compute-metal"
+            package_args: "-p larql-compute-metal"
+            diff_paths: "crates/larql-compute-metal"
+            openblas: false
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Computed before any install so an empty diff (e.g. a PR that
+      # never touches crates/larql-compute-metal, on the macOS leg) skips
+      # the toolchain/cargo-mutants install entirely — macOS runner
+      # minutes cost roughly 10x a Linux minute, and most PRs will not
+      # touch this specific crate.
+      - name: Compute PR diff
+        id: diff
+        run: |
+          git diff "origin/${{ github.base_ref }}...HEAD" -- ${{ matrix.diff_paths }} > /tmp/pr.diff
+          lines=$(wc -l < /tmp/pr.diff)
+          echo "diff is $lines lines"
+          echo "has_changes=$([ "$lines" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Install stable Rust
+        if: steps.diff.outputs.has_changes == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-mutants
+        if: steps.diff.outputs.has_changes == 'true'
+        uses: taiki-e/install-action@cargo-mutants
+
+      - name: Install OpenBLAS
+        if: steps.diff.outputs.has_changes == 'true' && matrix.openblas
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      # This job is a signal, not a gate, and it is capped twice over:
+      # `--in-diff` restricts mutants to lines the PR touched, and
+      # `timeout-minutes: 45` bounds the job.
+      #
+      # Read a *timed-out* run as "incomplete", never as "clean". If the job
+      # hits the wall clock the runner kills this step and the summary below
+      # never prints — the only evidence is the job's own timeout status.
+      # `--no-shuffle` at least makes the mutants it did get through a
+      # deterministic prefix rather than a random sample, and the report
+      # upload runs `if: always()` so partial results survive.
+      #
+      # Exit-status interpretation lives in scripts/check_mutants_exit_status.sh
+      # — shared by both matrix legs so they can't drift out of sync. See
+      # that script for why exit 4 gets its own, louder treatment: this
+      # exact job hit it (841, then 1317 candidate mutants, zero ever run)
+      # across two pushes while moe_zero_copy.rs broke the ubuntu build
+      # (chrishayuk/larql#244), and still showed a plain green
+      # "cargo-mutants (informational) success" in the PR checks tab.
+      - name: Mutation-test the diff
+        if: steps.diff.outputs.has_changes == 'true'
+        run: |
+          set +e
+          cargo mutants ${{ matrix.package_args }} --in-diff /tmp/pr.diff --timeout 120 --no-shuffle
+          status=$?
+          echo "cargo-mutants exit status: $status"
+          bash scripts/check_mutants_exit_status.sh "$status"
+          exit 0
+
+      - name: No changes in scope
+        if: steps.diff.outputs.has_changes == 'false'
+        run: echo "No changes under '${{ matrix.diff_paths }}' — skipping mutation testing for this leg."
+
+      - name: Upload mutants report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutants-report-${{ matrix.os }}
+          path: mutants.out/
+          if-no-files-found: ignore

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,7 +11,11 @@
 #   msrv        — the declared rust-version really compiles      (blocking)
 #   proto-lint  — buf lint over the four gRPC schemas            (blocking)
 #   doc-links   — every relative Markdown link resolves          (blocking)
-#   mutants     — mutation testing on the PR diff             (informational)
+#
+# Mutation testing lives in `mutants.yml`, not here: it is informational,
+# and a job cancelled by `timeout-minutes` concludes the whole run as
+# `cancelled` no matter how it is declared — which turned this check red
+# on the largest PRs while every gate in it had passed.
 #
 # NOTE ON `schedule`: this workflow deliberately has no `paths:` filter and
 # runs weekly. Advisories are published against code that has not changed —
@@ -196,104 +200,3 @@ jobs:
       # duplicate field numbers, unresolvable types).
       - name: Build descriptor set
         run: buf build --output /dev/null
-
-  mutants:
-    name: cargo-mutants${{ matrix.label }} (informational)
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
-    # PR-only: --in-diff needs a base to diff against, and a full-workspace
-    # mutation run is many hours of compute.
-    if: github.event_name == 'pull_request'
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-      # Same shape as `msrv` above, and for the same underlying reason:
-      # larql-compute-metal "compiles to an empty crate on non-macOS
-      # hosts" (its own doc comment) — every line inside its
-      # `#[cfg(target_os = "macos")]` modules is structurally invisible to
-      # a ubuntu runner, for every PR, forever. The macos-14 leg, scoped
-      # to `-p larql-compute-metal`, is the only way this workspace's
-      # mutation testing ever sees that code at all.
-      matrix:
-        include:
-          - os: ubuntu-latest
-            label: ""
-            package_args: ""
-            diff_paths: "."
-            openblas: true
-          - os: macos-14
-            label: " · larql-compute-metal"
-            package_args: "-p larql-compute-metal"
-            diff_paths: "crates/larql-compute-metal"
-            openblas: false
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      # Computed before any install so an empty diff (e.g. a PR that
-      # never touches crates/larql-compute-metal, on the macOS leg) skips
-      # the toolchain/cargo-mutants install entirely — macOS runner
-      # minutes cost roughly 10x a Linux minute, and most PRs will not
-      # touch this specific crate.
-      - name: Compute PR diff
-        id: diff
-        run: |
-          git diff "origin/${{ github.base_ref }}...HEAD" -- ${{ matrix.diff_paths }} > /tmp/pr.diff
-          lines=$(wc -l < /tmp/pr.diff)
-          echo "diff is $lines lines"
-          echo "has_changes=$([ "$lines" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-
-      - name: Install stable Rust
-        if: steps.diff.outputs.has_changes == 'true'
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-mutants
-        if: steps.diff.outputs.has_changes == 'true'
-        uses: taiki-e/install-action@cargo-mutants
-
-      - name: Install OpenBLAS
-        if: steps.diff.outputs.has_changes == 'true' && matrix.openblas
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libopenblas-dev pkg-config
-
-      # This job is a signal, not a gate, and it is capped twice over:
-      # `--in-diff` restricts mutants to lines the PR touched, and
-      # `timeout-minutes: 45` bounds the job.
-      #
-      # Read a *timed-out* run as "incomplete", never as "clean". If the job
-      # hits the wall clock the runner kills this step and the summary below
-      # never prints — the only evidence is the job's own timeout status.
-      # `--no-shuffle` at least makes the mutants it did get through a
-      # deterministic prefix rather than a random sample, and the report
-      # upload runs `if: always()` so partial results survive.
-      #
-      # Exit-status interpretation lives in scripts/check_mutants_exit_status.sh
-      # — shared by both matrix legs so they can't drift out of sync. See
-      # that script for why exit 4 gets its own, louder treatment: this
-      # exact job hit it (841, then 1317 candidate mutants, zero ever run)
-      # across two pushes while moe_zero_copy.rs broke the ubuntu build
-      # (chrishayuk/larql#244), and still showed a plain green
-      # "cargo-mutants (informational) success" in the PR checks tab.
-      - name: Mutation-test the diff
-        if: steps.diff.outputs.has_changes == 'true'
-        run: |
-          set +e
-          cargo mutants ${{ matrix.package_args }} --in-diff /tmp/pr.diff --timeout 120 --no-shuffle
-          status=$?
-          echo "cargo-mutants exit status: $status"
-          bash scripts/check_mutants_exit_status.sh "$status"
-          exit 0
-
-      - name: No changes in scope
-        if: steps.diff.outputs.has_changes == 'false'
-        run: echo "No changes under '${{ matrix.diff_paths }}' — skipping mutation testing for this leg."
-
-      - name: Upload mutants report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: mutants-report-${{ matrix.os }}
-          path: mutants.out/
-          if-no-files-found: ignore


### PR DESCRIPTION
`cargo-mutants` could turn the `quality` check red while every gate inside it passed. This moves it to its own workflow.

## The mechanism

The job is declared `continue-on-error: true` because it is a signal, not a gate. But **`continue-on-error` only covers a job that FAILS.** A job killed by `timeout-minutes` is *cancelled*, and a single cancelled job concludes the whole workflow run as `cancelled` regardless of how the job is declared. GitHub then renders that as a failed check.

So a mutation run that ran out of clock reported `quality` as not-green even though MSRV (both platforms), all four `cargo-deny` checks, `cargo-audit`, `buf lint` and `doc links` had every one passed.

## It is not rare, and it hits the wrong PRs

Every cancelled `quality` run in recent history sits at **exactly 45m** — the mutants cap — and they cluster on the largest diffs, which are both the slowest to mutation-test and the most worth gating:

```
cancelled  45m  cpu7-parallel-execution   (#316)
cancelled  45m  cpu7-parallel-execution   (#316, earlier)
cancelled  45m  worktree-encoder-r4       (#313)
success    61m  worktree-ane4a-qwen-...   (smaller diff, finished)
```

The 61m success is the control: the workflow itself is not capped, only that one job is. So the quality signal was least trustworthy exactly where it mattered most — and it is why #313 was merged showing a red `cargo-mutants (informational)`.

## Why split rather than raise the cap

We raised the `larql-compute-metal` timeout in #318 because that job's limit sat *below its own median runtime* — a bounded, measurable mistake. This is different. The workflow's own comment says a full-workspace mutation run is "many hours of compute", and the job is capped deliberately, twice over (`--in-diff` plus the clock). Any finite cap can still be hit, so raising it would only move the defect to a larger diff.

Alone in its own workflow, a timeout reports as a timeout and poisons nothing.

## What changed

- `mutants.yml` — new; holds the job verbatim. Both matrix legs (`ubuntu-latest`, and the `macos-14` leg scoped to `-p larql-compute-metal` that is the only way this workspace's mutation testing sees Metal code at all), all 8 steps, the `--in-diff` scoping, `check_mutants_exit_status.sh` handling and the `if: always()` report upload are unchanged.
- `quality.yml` — job removed; header updated to point at the new file and record why, so it does not get folded back in.

No change to what mutation testing does, only to what its clock can take down with it. The existing guidance still stands and is carried over: **read a timed-out run as incomplete, never as clean.**
