### PR TITLE
The explorer ships: demo-container generator + fly deployment

### DIFF
--- a/crates/larql-server/src/bin/vindex3-demo.rs
+++ b/crates/larql-server/src/bin/vindex3-demo.rs
@@ -1,0 +1,45 @@
+//! vindex3-demo — write the public explorer's demo container.
+//!
+//! The public deployment (`deploy/fly-explorer/`) serves one immutable
+//! VINDEX3 container. This binary produces it at boot: the miniature
+//! Glimmer system — two layers with a mixed attention policy
+//! (Sliding(3)+RoPE, Full+NoPE), gated attention, synthetic weights —
+//! encoded through the real inventory → encode pipeline, plus the
+//! synthetic tokenizer, under the name `vindex3-demo`.
+//!
+//! Why generate instead of download: the container is kilobytes, the
+//! generator is the same fixture every LQL/serve gate runs against, and
+//! a boot-time regeneration means the public box holds no state worth
+//! keeping — wipe it and it rebuilds identically. What this is NOT: a
+//! production model. The weights are synthetic; the format, graph,
+//! provenance, and execution are real, which is exactly what the public
+//! explorer demonstrates.
+
+use larql_inference::test_utils::synthetic_tokenizer_json;
+use larql_vindex::format::vindex3::fixtures::{
+    encode_fixture_container, miniature_glimmer, G_VOCAB,
+};
+
+fn main() {
+    let Some(dest) = std::env::args().nth(1) else {
+        eprintln!("usage: vindex3-demo <output-dir>");
+        std::process::exit(2);
+    };
+    let dest = std::path::PathBuf::from(dest);
+    if dest.join("index.json").exists() {
+        println!("demo container already present at {}", dest.display());
+        return;
+    }
+    std::fs::create_dir_all(&dest).expect("create output dir");
+    let checkpoint =
+        std::env::temp_dir().join(format!("vindex3-demo-checkpoint-{}", std::process::id()));
+    std::fs::create_dir_all(&checkpoint).expect("create checkpoint dir");
+    encode_fixture_container(miniature_glimmer, &checkpoint, &dest, "vindex3-demo");
+    std::fs::write(
+        dest.join("tokenizer.json"),
+        synthetic_tokenizer_json(G_VOCAB),
+    )
+    .expect("write tokenizer");
+    let _ = std::fs::remove_dir_all(&checkpoint);
+    println!("demo container written to {}", dest.display());
+}

--- a/deploy/fly-explorer/Dockerfile
+++ b/deploy/fly-explorer/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+# The public explorer image: larql-server in PUBLIC_EXPLORER mode over
+# the generated demo container. See deploy/fly-explorer/README.md.
+FROM rust:1-slim AS builder
+WORKDIR /build
+
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates/ crates/
+
+RUN apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler cmake g++ libopenblas-dev && \
+    cargo build --release -p larql-server --bin larql-server --bin vindex3-demo && \
+    strip target/release/larql-server target/release/vindex3-demo
+
+FROM ubuntu:24.04
+RUN apt-get update && \
+    apt-get install -y ca-certificates libssl3 curl libopenblas0 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/larql-server /usr/local/bin/
+COPY --from=builder /build/target/release/vindex3-demo /usr/local/bin/
+COPY deploy/fly-explorer/start.sh /start.sh
+RUN chmod +x /start.sh
+
+EXPOSE 8080
+CMD ["/start.sh"]

--- a/deploy/fly-explorer/README.md
+++ b/deploy/fly-explorer/README.md
@@ -1,0 +1,49 @@
+# vindex3-explorer — the public explorer on fly.io
+
+The hardened public endpoint behind vindex3.org's **ENTER A MODEL**
+terminal: `larql-server --public-explorer` over one immutable demo
+container.
+
+## What it serves
+
+- `POST /v1/query` — one LQL statement per request, executed under
+  `CapabilityProfile::PublicExplorer` (read surface + `INFER` with
+  `GENERATE ≤ 32`; everything else refuses with 403 after parsing,
+  before execution — see `crates/larql-lql/docs/spec.md` §4.5).
+- `GET /v1/health`, `/v1/models`, `/v1/describe`, `/v1/walk`,
+  `/v1/relations`, `/v1/stats` — the read-only REST nouns.
+- Nothing else. Mutating routes are not mounted.
+
+## The container
+
+`vindex3-demo`, regenerated at every boot by the `vindex3-demo` binary
+(`crates/larql-server/src/bin/vindex3-demo.rs`): the miniature Glimmer
+system — two layers, mixed attention policy (Sliding(3)+RoPE,
+Full+NoPE), gated attention — encoded through the real inventory →
+encode pipeline, ~40 KB on disk. Synthetic weights, real format: the
+graph, directory, provenance, authority, and execution the terminal
+walks are all genuine. No volume, no HF download, no state worth
+keeping: wipe the machine and it rebuilds identically.
+
+## Deploy
+
+```bash
+fly apps create vindex3-explorer
+fly deploy --app vindex3-explorer --config deploy/fly-explorer/fly.toml --remote-only
+```
+
+Hardening is layered: fly's connection limits → per-IP rate limit
+(`RATE_LIMIT`, default 120/min, trusting `X-Forwarded-For` from fly's
+proxy) → server concurrency limit (`MAX_CONCURRENT`) → the capability
+profile inside the LQL session. The machine auto-stops when idle and
+cold-starts in a few seconds (the container regeneration is
+milliseconds).
+
+## Custom domain
+
+```bash
+fly certs add public.vindex3.org --app vindex3-explorer
+```
+
+then add the CNAME (`public` → `vindex3-explorer.fly.dev`) at the DNS
+host.

--- a/deploy/fly-explorer/fly.toml
+++ b/deploy/fly-explorer/fly.toml
@@ -1,0 +1,27 @@
+app = "vindex3-explorer"
+primary_region = "lhr"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+  DEMO_DIR = "/data/vindex3-demo"
+  RATE_LIMIT = "120/min"
+  MAX_CONCURRENT = "4"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 50
+    soft_limit = 40
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/deploy/fly-explorer/start.sh
+++ b/deploy/fly-explorer/start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# The public box holds no state worth keeping: the demo container is
+# regenerated at every boot (kilobytes, deterministic), so a wiped
+# machine rebuilds identically and there is no volume to manage.
+DEMO_DIR="${DEMO_DIR:-/data/vindex3-demo}"
+vindex3-demo "$DEMO_DIR"
+
+# Working directory = the published catalogue: SHOW MODELS lists the
+# process cwd, so the public listing is exactly what lives here.
+cd "$(dirname "$DEMO_DIR")"
+
+exec larql-server "$DEMO_DIR" \
+  --public-explorer \
+  --cors \
+  --no-docs \
+  --rate-limit "${RATE_LIMIT:-120/min}" \
+  --max-concurrent "${MAX_CONCURRENT:-4}" \
+  --trust-forwarded-for \
+  --port "${PORT:-8080}" \
+  --host 0.0.0.0


### PR DESCRIPTION
Follow-up to #321 — makes the public explorer deployable.

- **`vindex3-demo` bin**: boot-time generator for the ~40 KB miniature-Glimmer demo container (real inventory → encode pipeline, synthetic weights, idempotent). No HF download, no volume, no state worth keeping.
- **`deploy/fly-explorer/`**: Dockerfile + start.sh + fly.toml for `vindex3-explorer` (shared-cpu-1x, auto-stop, per-IP rate limit trusting fly's proxy, `--public-explorer --cors --no-docs`).

Verified locally: `SHOW COMPONENTS` answers with the graph census over HTTP, `DROP` → 400 at parse, `DELETE` → 403 naming PUBLIC_EXPLORER.
