### PR TITLE
fix(deploy): explorer image carries registry/

### DIFF
--- a/deploy/fly-explorer/Dockerfile
+++ b/deploy/fly-explorer/Dockerfile
@@ -6,6 +6,9 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
+# larql-vindex embeds registry model records via include_str! at compile
+# time — the build context must carry them.
+COPY registry/ registry/
 
 RUN apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler cmake g++ libopenblas-dev && \
     cargo build --release -p larql-server --bin larql-server --bin vindex3-demo && \


### PR DESCRIPTION
The remote build failed in the builder stage: larql-vindex embeds registry/models/*.json via include_str!, and the build context held only crates/. One COPY line.
