### PR TITLE
feat(server): typed container facts — the protocol's read nouns

### DIFF
--- a/crates/larql-server/src/routes/container_facts.rs
+++ b/crates/larql-server/src/routes/container_facts.rs
@@ -1,0 +1,125 @@
+//! Typed container facts — the query protocol's read nouns.
+//!
+//! `GET /v1/components`, `/v1/representations`, `/v1/provenance`,
+//! `/v1/authority`: the same declarations the LQL directory statements
+//! print, returned as structured JSON so a client can *render* them
+//! rather than re-parse prose. This is the protocol taking shape: any
+//! independent VINDEX3 reader could serve these from `index.json` and
+//! the system graph alone, which is exactly the litmus test for what
+//! belongs on the surface. Read-only; the container is the authority;
+//! nothing here is reconstructed from names.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::Json;
+
+use crate::error::ServerError;
+use crate::state::{AppState, ServedModel};
+use larql_vindex::format::filenames::INDEX_JSON;
+use larql_vindex::format::vindex3::index::{ContainerAuthority, Vindex3Index};
+use larql_vindex::format::vindex3::inspect::inspect_container;
+
+fn v3_path(state: &AppState) -> Result<std::path::PathBuf, ServerError> {
+    match state.served_or_err(None)? {
+        ServedModel::V3(model) => Ok(model.path.clone()),
+        ServedModel::V2(_) => Err(ServerError::NotFound(
+            "container facts require a VINDEX3 binding".into(),
+        )),
+    }
+}
+
+fn read_index(root: &std::path::Path) -> Result<Vindex3Index, ServerError> {
+    let text = std::fs::read_to_string(root.join(INDEX_JSON))
+        .map_err(|e| ServerError::Internal(format!("read {INDEX_JSON}: {e}")))?;
+    serde_json::from_str(&text)
+        .map_err(|e| ServerError::Internal(format!("parse {INDEX_JSON}: {e}")))
+}
+
+/// `GET /v1/components` — the system graph's census, structured.
+pub async fn handle_components(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    state.bump_requests();
+    let path = v3_path(&state)?;
+    let inspection = inspect_container(&path, false)
+        .map_err(|e| ServerError::Internal(format!("inspect container: {e}")))?;
+    Ok(Json(serde_json::json!({
+        "components": inspection.components,
+        "objects": inspection.graph.objects.len(),
+        "edges": inspection.graph.edges.len(),
+        "coherent": inspection.is_coherent(),
+    })))
+}
+
+/// `GET /v1/representations` — the physical directory.
+pub async fn handle_representations(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    state.bump_requests();
+    let index = read_index(&v3_path(&state)?)?;
+    let entries: Vec<serde_json::Value> = index
+        .representations
+        .iter()
+        .map(|(id, e)| {
+            serde_json::json!({
+                "id": id,
+                "object": e.object,
+                "encoding": e.encoding,
+                "tensor_count": e.tensor_count,
+                "payload_bytes": e.payload_bytes,
+                "compiled_from": e.compiled_from,
+            })
+        })
+        .collect();
+    Ok(Json(serde_json::json!({ "entries": entries })))
+}
+
+/// `GET /v1/provenance` — whole hashes and lineage. Digests are never
+/// abbreviated: provenance abbreviated is provenance lost.
+pub async fn handle_provenance(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    state.bump_requests();
+    let index = read_index(&v3_path(&state)?)?;
+    let entries: Vec<serde_json::Value> = index
+        .representations
+        .iter()
+        .map(|(id, e)| {
+            serde_json::json!({
+                "id": id,
+                "object": e.object,
+                "segment": e.segment,
+                "payload_sha256": e.payload_sha256,
+                "segment_sha256": e.segment_sha256,
+                "compiled_from": e.compiled_from,
+                "source_representation_digest": e.source_representation_digest,
+            })
+        })
+        .collect();
+    Ok(Json(serde_json::json!({
+        "authority": match index.authority {
+            ContainerAuthority::Canonical => "canonical",
+            ContainerAuthority::Derived => "derived",
+        },
+        "derived_from_model": index.derived_from_model,
+        "entries": entries,
+    })))
+}
+
+/// `GET /v1/authority` — the container's own declaration.
+pub async fn handle_authority(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    state.bump_requests();
+    let index = read_index(&v3_path(&state)?)?;
+    let profiles: Vec<&str> = index.profiles.iter().map(|p| p.name.as_str()).collect();
+    Ok(Json(serde_json::json!({
+        "authority": match index.authority {
+            ContainerAuthority::Canonical => "canonical",
+            ContainerAuthority::Derived => "derived",
+        },
+        "derived_from_model": index.derived_from_model,
+        "profiles": profiles,
+    })))
+}

--- a/crates/larql-server/src/routes/mod.rs
+++ b/crates/larql-server/src/routes/mod.rs
@@ -1,5 +1,6 @@
 //! Router setup — maps URL paths to handlers.
 
+pub mod container_facts;
 pub mod describe;
 pub mod embed;
 pub mod expert;
@@ -74,6 +75,10 @@ const TOKEN_DECODE: &str = "/v1/token/decode";
 // freshly-assigned spare server can mirror the shard locally.
 const SHARD: &str = "/v1/shard/{model_id}/{range}";
 const QUERY: &str = "/v1/query";
+const COMPONENTS: &str = "/v1/components";
+const REPRESENTATIONS: &str = "/v1/representations";
+const PROVENANCE: &str = "/v1/provenance";
+const AUTHORITY: &str = "/v1/authority";
 
 const OPENAI_EMBEDDINGS: &str = "/v1/embeddings";
 const OPENAI_COMPLETIONS: &str = "/v1/completions";
@@ -116,6 +121,13 @@ pub fn public_explorer_router(
         .route(WALK, get(walk::handle_walk))
         .route(RELATIONS, get(relations::handle_relations))
         .route(STATS, get(stats::handle_stats))
+        .route(COMPONENTS, get(container_facts::handle_components))
+        .route(
+            REPRESENTATIONS,
+            get(container_facts::handle_representations),
+        )
+        .route(PROVENANCE, get(container_facts::handle_provenance))
+        .route(AUTHORITY, get(container_facts::handle_authority))
         .with_state(state)
         .merge(
             Router::new()

--- a/crates/larql-server/tests/test_public_explorer.rs
+++ b/crates/larql-server/tests/test_public_explorer.rs
@@ -194,6 +194,47 @@ async fn mutating_routes_are_not_mounted() {
     }
 }
 
+/// The typed container facts — the protocol's read nouns — answer
+/// with structure a client can render, from the container alone.
+#[tokio::test]
+async fn container_facts_answer_typed() {
+    let container = v3_container();
+    let app = public_app(container.path());
+
+    let get = |uri: &'static str| {
+        let app = app.clone();
+        async move {
+            let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+            let response = app.oneshot(req).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{uri}");
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            serde_json::from_slice::<serde_json::Value>(&bytes).unwrap()
+        }
+    };
+
+    let components = get("/v1/components").await;
+    assert_eq!(components["components"][0]["id"], "target", "{components}");
+    assert!(components["coherent"].as_bool().unwrap(), "{components}");
+
+    let reps = get("/v1/representations").await;
+    assert!(!reps["entries"].as_array().unwrap().is_empty(), "{reps}");
+
+    let prov = get("/v1/provenance").await;
+    let first = &prov["entries"][0];
+    assert!(
+        first["payload_sha256"].as_str().unwrap().len() >= 32,
+        "{prov}"
+    );
+
+    let auth = get("/v1/authority").await;
+    assert!(
+        auth["authority"] == "canonical" || auth["authority"] == "derived",
+        "{auth}"
+    );
+}
+
 /// The read-only REST routes stay available beside /v1/query — the
 /// protocol has two dialects (REST nouns and LQL statements) over one
 /// state.


### PR DESCRIPTION
GET /v1/components, /v1/representations, /v1/provenance, /v1/authority on the public explorer router — structured JSON of the container's own declarations (inspect_container for the census, index.json for the rest, digests whole). The read half of the query protocol the site documents; gated in test_public_explorer.