### PR TITLE
feat(vindex-cli): diff and represent — the verb set is complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5181,6 +5181,7 @@ name = "vindex-cli"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "larql-models",
  "larql-vindex",
  "serde_json",
  "sha2",

--- a/crates/vindex-cli/Cargo.toml
+++ b/crates/vindex-cli/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/main.rs"
 
 [dependencies]
 larql-vindex = { path = "../larql-vindex" }
+larql-models = { path = "../larql-models" }
 clap = { version = "4.5", features = ["derive"] }
 serde_json.workspace = true
 sha2 = "0.10"

--- a/crates/vindex-cli/src/lib.rs
+++ b/crates/vindex-cli/src/lib.rs
@@ -16,7 +16,11 @@ use sha2::{Digest, Sha256};
 use larql_vindex::format::filenames::INDEX_JSON;
 use larql_vindex::format::vindex3::encode::segment::read_segment_header;
 use larql_vindex::format::vindex3::index::{ContainerAuthority, Vindex3Index};
-use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::inspect::{inspect_container, SystemInspection};
+use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
+use larql_vindex::format::vindex3::opplan::OperandRef;
+use larql_vindex::format::vindex3::represent::nvfp4_pack::{split, PackLayout, DTYPE_NVFP4};
+use larql_vindex::format::vindex3::represent::{compile_representation, RepresentSpec};
 
 pub type Facts = Result<Value, String>;
 
@@ -90,23 +94,7 @@ pub fn representations_facts(root: &Path) -> Facts {
 /// bindings, representations, and the head of its tensor table.
 pub fn describe_facts(root: &Path, address: &str, values: usize) -> Facts {
     let inspection = inspect_container(root, false).map_err(|e| format!("inspect: {e}"))?;
-    let object = inspection
-        .graph
-        .objects
-        .iter()
-        .find(|o| o.id == address || o.id.ends_with(address))
-        .ok_or_else(|| {
-            let known: Vec<&str> = inspection
-                .graph
-                .objects
-                .iter()
-                .map(|o| o.id.as_str())
-                .collect();
-            format!(
-                "no logical object matches `{address}` — the graph holds: {}",
-                known.join(", ")
-            )
-        })?;
+    let object = find_object(&inspection, address)?;
     let directory: Vec<Value> = inspection
         .index
         .representations
@@ -221,5 +209,299 @@ pub fn verify_facts(root: &Path) -> Facts {
         "failures": failures,
         "verified": failures == 0,
         "scope": "self — recorded hashes re-derived from the artifact alone; source faithfulness is the reference implementation's G4",
+    }))
+}
+
+fn find_object<'a>(
+    inspection: &'a SystemInspection,
+    address: &str,
+) -> Result<&'a larql_vindex::format::vindex3::graph::object::LogicalObject, String> {
+    inspection
+        .graph
+        .objects
+        .iter()
+        .find(|o| o.id == address || o.id.ends_with(address))
+        .ok_or_else(|| {
+            let known: Vec<&str> = inspection
+                .graph
+                .objects
+                .iter()
+                .map(|o| o.id.as_str())
+                .collect();
+            format!(
+                "no logical object matches `{address}` — the graph holds: {}",
+                known.join(", ")
+            )
+        })
+}
+
+/// A tensor as one side's header declares it: name, dtype, shape.
+type TensorEntry = (String, String, Vec<usize>);
+
+/// One side of a diff: the store bound to `encoding`, plus that
+/// encoding's tensor table for the object. Refuses an encoding the
+/// container does not hold, naming what it does.
+fn open_side(
+    root: &Path,
+    inspection: &SystemInspection,
+    object: &str,
+    encoding: &str,
+) -> Result<(OperandStore, Vec<TensorEntry>), String> {
+    let canonical = inspection
+        .graph
+        .objects
+        .iter()
+        .find(|o| o.id == object)
+        .and_then(|o| o.representations.first())
+        .map(|r| r.encoding.clone())
+        .ok_or_else(|| format!("object `{object}` declares no representations"))?;
+    let store = if encoding.eq_ignore_ascii_case(&canonical) {
+        OperandStore::open(root, inspection).map_err(|e| format!("open {encoding}: {e}"))?
+    } else {
+        OperandStore::open_for(
+            root,
+            inspection,
+            Some(encoding),
+            RepresentationSource::Stored,
+        )
+        .map_err(|e| format!("open {encoding}: {e}"))?
+    };
+    let bound = store
+        .selection()
+        .get(object)
+        .map(|s| s.encoding.clone())
+        .unwrap_or_default();
+    if !bound.eq_ignore_ascii_case(encoding) {
+        let held: Vec<String> = inspection
+            .index
+            .representations
+            .values()
+            .filter(|e| e.object == object)
+            .map(|e| e.encoding.clone())
+            .collect();
+        return Err(format!(
+            "`{object}` has no {encoding} representation — the container holds: {}",
+            held.join(", ")
+        ));
+    }
+    let entry = inspection
+        .index
+        .representations
+        .values()
+        .find(|e| e.object == object && e.encoding.eq_ignore_ascii_case(encoding))
+        .ok_or_else(|| format!("no directory entry for {object}@{encoding}"))?;
+    let (header, _) = read_segment_header(&root.join(&entry.segment))
+        .map_err(|e| format!("segment {}: {e}", entry.segment))?;
+    let tensors = header
+        .tensors
+        .into_iter()
+        .map(|t| (t.name, t.dtype, t.shape))
+        .collect();
+    Ok((store, tensors))
+}
+
+/// Decode one tensor to f32, whatever the container stored it as. The
+/// arithmetic for a packed encoding is the spec's — `tensor_scale ·
+/// e4m3(group scale) · e2m1(code)` — so what the diff compares is what
+/// a matmul against those bytes would effectively use.
+fn load_values(store: &OperandStore, operand: &OperandRef) -> Result<Vec<f32>, String> {
+    if operand.dtype != DTYPE_NVFP4 {
+        return store
+            .load(operand)
+            .map_err(|e| format!("load {}: {e}", operand.tensor));
+    }
+    let raw = store
+        .load_raw(operand)
+        .map_err(|e| format!("read {}: {e}", operand.tensor))?;
+    let layout = PackLayout::derive(&operand.shape, &operand.tensor)
+        .map_err(|e| format!("{}: {e}", operand.tensor))?;
+    let (packed, scales, tensor_scale) = split(&raw.bytes, &layout, &operand.tensor)
+        .map_err(|e| format!("{}: {e}", operand.tensor))?;
+    let matrix = larql_models::quant::nvfp4::Nvfp4Matrix {
+        packed: packed.to_vec(),
+        scales: scales.to_vec(),
+        tensor_scale,
+    };
+    let (rows, k) = (operand.shape[0], operand.shape[1]);
+    let mut out = vec![0.0f32; rows * k];
+    larql_models::quant::nvfp4::dequantize_into(&matrix, rows, k, &mut out)
+        .map_err(|e| format!("decode {}: {e:?}", operand.tensor))?;
+    Ok(out)
+}
+
+/// `vindex diff <a> <b> <address>` — one object decoded under two of
+/// the container's own representations, compared value by value. The
+/// error is derived, never asserted: both sides decode through the
+/// same load path execution uses, and the numbers are whatever the
+/// bytes disagree by.
+pub fn diff_facts(
+    root: &Path,
+    encoding_a: &str,
+    encoding_b: &str,
+    address: &str,
+    values: usize,
+    tensor_filter: Option<&str>,
+) -> Facts {
+    let inspection = inspect_container(root, false).map_err(|e| format!("inspect: {e}"))?;
+    let object = find_object(&inspection, address)?.id.clone();
+    let (encoding_a, encoding_b) = (encoding_a.to_uppercase(), encoding_b.to_uppercase());
+    let (store_a, tensors_a) = open_side(root, &inspection, &object, &encoding_a)?;
+    let (store_b, tensors_b) = open_side(root, &inspection, &object, &encoding_b)?;
+    let dtypes_b: std::collections::BTreeMap<&str, (&str, &Vec<usize>)> = tensors_b
+        .iter()
+        .map(|(n, d, s)| (n.as_str(), (d.as_str(), s)))
+        .collect();
+
+    let mut rows: Vec<Value> = Vec::new();
+    let mut head: Option<Value> = None;
+    let mut worst: f64 = -1.0;
+    let mut sum_sq = 0.0f64;
+    let mut max_error = 0.0f64;
+    let mut total_weights = 0u64;
+    let mut changed_values = 0u64;
+    for (name, dtype_a, shape) in &tensors_a {
+        let Some((dtype_b, shape_b)) = dtypes_b.get(name.as_str()) else {
+            rows.push(json!({ "tensor": name, "note": format!("only in {encoding_a}") }));
+            continue;
+        };
+        if shape != *shape_b {
+            rows.push(json!({
+                "tensor": name,
+                "note": format!("shape differs: {shape:?} vs {shape_b:?}"),
+            }));
+            continue;
+        }
+        let make_ref = |dtype: &str| OperandRef {
+            object: object.clone(),
+            tensor: name.clone(),
+            dtype: dtype.to_string(),
+            shape: shape.clone(),
+        };
+        let va = load_values(&store_a, &make_ref(dtype_a))
+            .map_err(|e| format!("as {encoding_a}: {e}"))?;
+        let vb = load_values(&store_b, &make_ref(dtype_b))
+            .map_err(|e| format!("as {encoding_b}: {e}"))?;
+        let n = va.len().min(vb.len());
+        let mut t_sum_sq = 0.0f64;
+        let mut t_max = 0.0f64;
+        let mut t_changed = 0u64;
+        for i in 0..n {
+            let d = (va[i] as f64) - (vb[i] as f64);
+            t_sum_sq += d * d;
+            if d.abs() > t_max {
+                t_max = d.abs();
+            }
+            if d != 0.0 {
+                t_changed += 1;
+            }
+        }
+        let rms = if n > 0 {
+            (t_sum_sq / n as f64).sqrt()
+        } else {
+            0.0
+        };
+        sum_sq += t_sum_sq;
+        total_weights += n as u64;
+        changed_values += t_changed;
+        if t_max > max_error {
+            max_error = t_max;
+        }
+        rows.push(json!({
+            "tensor": name,
+            "dtype_a": dtype_a,
+            "dtype_b": dtype_b,
+            "weights": n as u64,
+            "changed": t_changed,
+            "rms_error": rms,
+            "max_error": t_max,
+        }));
+        let wanted = match tensor_filter {
+            Some(f) => name == f || name.ends_with(f),
+            None => rms > worst,
+        };
+        if wanted && (tensor_filter.is_some() || rms > worst) {
+            worst = rms;
+            head = Some(json!({
+                "tensor": name,
+                "rows": (0..n.min(values)).map(|i| json!({
+                    "a": va[i],
+                    "b": vb[i],
+                    "error": vb[i] - va[i],
+                })).collect::<Vec<Value>>(),
+            }));
+        }
+    }
+    if let Some(f) = tensor_filter {
+        if head.is_none() {
+            return Err(format!(
+                "no tensor of `{object}` matches `{f}` — tensors: {}",
+                tensors_a
+                    .iter()
+                    .map(|(n, _, _)| n.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
+    Ok(json!({
+        "container": root.display().to_string(),
+        "object": object,
+        "a": encoding_a,
+        "b": encoding_b,
+        "tensors": rows,
+        "values": head,
+        "total_weights": total_weights,
+        "changed_values": changed_values,
+        "rms_error": if total_weights > 0 { (sum_sq / total_weights as f64).sqrt() } else { 0.0 },
+        "max_error": max_error,
+        "identical": changed_values == 0,
+    }))
+}
+
+/// `vindex represent <src> <out>` — compile a representation the spec
+/// defines, through the reference compiler. The output container
+/// carries every original segment plus the compiled packs; nothing is
+/// destroyed, and `vindex verify` holds on the result.
+pub fn represent_facts(src: &Path, out: &Path, encoding: &str) -> Facts {
+    let mut spec = RepresentSpec::nvfp4();
+    spec.encoding = encoding.to_uppercase();
+    let report = compile_representation(src, out, &spec).map_err(|e| format!("represent: {e}"))?;
+    let compiled: Vec<Value> = report
+        .compiled_objects
+        .iter()
+        .map(|c| {
+            json!({
+                "object": c.object,
+                "representation": c.representation_id,
+                "compiled_tensors": c.compiled_tensors,
+                "carried_tensors": c.carried_tensors,
+                "source_bytes": c.source_bytes,
+                "compiled_bytes": c.compiled_bytes,
+                "compression": c.compression(),
+                "preserved_roles": c.preserved.iter()
+                    .map(|(role, n)| json!({ "role": format!("{role:?}"), "tensors": n }))
+                    .collect::<Vec<Value>>(),
+            })
+        })
+        .collect();
+    let preserved: Vec<Value> = report
+        .preserved_objects
+        .iter()
+        .map(|p| {
+            json!({
+                "object": p.object,
+                "encoding": p.encoding,
+                "bytes": p.bytes,
+            })
+        })
+        .collect();
+    Ok(json!({
+        "source": src.display().to_string(),
+        "out": out.display().to_string(),
+        "encoding": spec.encoding,
+        "map": spec.map_name(),
+        "compiled": compiled,
+        "preserved": preserved,
+        "linked_segments": report.linked_segments,
     }))
 }

--- a/crates/vindex-cli/src/main.rs
+++ b/crates/vindex-cli/src/main.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 #[derive(Parser)]
 #[command(
     name = "vindex",
-    about = "The format-native VINDEX3 tool: inspect, describe, representations, precision, verify.",
+    about = "The format-native VINDEX3 tool: inspect, describe, representations, diff, represent, precision, verify.",
     version
 )]
 struct Cli {
@@ -41,6 +41,34 @@ enum Command {
     },
     /// The physical directory: what exists as bytes, with recorded fidelity.
     Representations { container: PathBuf },
+    /// One object under two of the container's representations, decoded and
+    /// compared value by value — the error derived, never asserted.
+    Diff {
+        container: PathBuf,
+        /// First encoding (e.g. F32, BF16).
+        a: String,
+        /// Second encoding (e.g. NVFP4).
+        b: String,
+        /// A logical object id, or an unambiguous suffix of one.
+        address: String,
+        /// How many per-value rows to show.
+        #[arg(long, default_value_t = 8)]
+        values: usize,
+        /// Show values from this tensor (name or suffix) instead of the
+        /// tensor with the largest error.
+        #[arg(long)]
+        tensor: Option<String>,
+    },
+    /// Compile a representation through the reference compiler into a new
+    /// container beside the original. Nothing is destroyed.
+    Represent {
+        container: PathBuf,
+        /// Where to write the new container.
+        out: PathBuf,
+        /// Target encoding.
+        #[arg(long, default_value = "NVFP4")]
+        encoding: String,
+    },
     /// Bits per weight — derived from stored bytes over tensor elements, never asserted.
     Precision { container: PathBuf },
     /// The container against its own recorded hashes, re-derived from the artifact alone.
@@ -179,6 +207,108 @@ fn render_precision(v: &Value) {
     }
 }
 
+fn render_diff(v: &Value) {
+    kv("object", v["object"].as_str().unwrap_or("?"));
+    kv(
+        "comparing",
+        format!(
+            "{} against {}",
+            v["a"].as_str().unwrap_or("?"),
+            v["b"].as_str().unwrap_or("?")
+        ),
+    );
+    println!();
+    println!(
+        "{:<38} {:>10} {:>10} {:>13} {:>13}",
+        "TENSOR", "WEIGHTS", "CHANGED", "RMS", "MAX"
+    );
+    for t in v["tensors"].as_array().into_iter().flatten() {
+        if let Some(note) = t["note"].as_str() {
+            println!("{:<38} {note}", t["tensor"].as_str().unwrap_or("?"));
+            continue;
+        }
+        println!(
+            "{:<38} {:>10} {:>10} {:>13.6} {:>13.6}",
+            t["tensor"].as_str().unwrap_or("?"),
+            t["weights"].as_u64().unwrap_or(0),
+            t["changed"].as_u64().unwrap_or(0),
+            t["rms_error"].as_f64().unwrap_or(0.0),
+            t["max_error"].as_f64().unwrap_or(0.0)
+        );
+    }
+    if let Some(head) = v["values"].as_object() {
+        println!();
+        println!("{} — first values", head["tensor"].as_str().unwrap_or("?"));
+        println!("{:>13} {:>13} {:>13}", "A", "B", "ERROR");
+        for r in head["rows"].as_array().into_iter().flatten() {
+            println!(
+                "{:>13.6} {:>13.6} {:>13.6}",
+                r["a"].as_f64().unwrap_or(0.0),
+                r["b"].as_f64().unwrap_or(0.0),
+                r["error"].as_f64().unwrap_or(0.0)
+            );
+        }
+    }
+    println!();
+    if v["identical"].as_bool().unwrap_or(false) {
+        kv("result", "identical — every decoded value agrees");
+    } else {
+        kv(
+            "result",
+            format!(
+                "{} of {} values differ · rms {:.6} · max {:.6}",
+                v["changed_values"],
+                v["total_weights"],
+                v["rms_error"].as_f64().unwrap_or(0.0),
+                v["max_error"].as_f64().unwrap_or(0.0)
+            ),
+        );
+    }
+}
+
+fn render_represent(v: &Value) {
+    kv("encoding", v["encoding"].as_str().unwrap_or("?"));
+    kv("map", v["map"].as_str().unwrap_or("?"));
+    kv("out", v["out"].as_str().unwrap_or("?"));
+    for c in v["compiled"].as_array().into_iter().flatten() {
+        println!();
+        kv("compiled", c["object"].as_str().unwrap_or("?"));
+        kv(
+            "tensors",
+            format!(
+                "{} re-encoded · {} carried verbatim",
+                c["compiled_tensors"], c["carried_tensors"]
+            ),
+        );
+        kv(
+            "bytes",
+            format!(
+                "{} → {} ({:.2}× smaller)",
+                c["source_bytes"],
+                c["compiled_bytes"],
+                c["compression"].as_f64().unwrap_or(0.0)
+            ),
+        );
+    }
+    for p in v["preserved"].as_array().into_iter().flatten() {
+        println!();
+        kv(
+            "preserved",
+            format!(
+                "{} — wholly at {} ({} bytes)",
+                p["object"].as_str().unwrap_or("?"),
+                p["encoding"].as_str().unwrap_or("?"),
+                p["bytes"]
+            ),
+        );
+    }
+    println!();
+    kv(
+        "linked",
+        format!("{} segment(s) untouched", v["linked_segments"]),
+    );
+}
+
 fn render_verify(v: &Value) {
     for e in v["entries"].as_array().into_iter().flatten() {
         let ok = e["segment_ok"].as_bool().unwrap_or(false)
@@ -211,6 +341,19 @@ fn main() -> ExitCode {
             values,
         } => vindex_cli::describe_facts(container, address, *values),
         Command::Representations { container } => vindex_cli::representations_facts(container),
+        Command::Diff {
+            container,
+            a,
+            b,
+            address,
+            values,
+            tensor,
+        } => vindex_cli::diff_facts(container, a, b, address, *values, tensor.as_deref()),
+        Command::Represent {
+            container,
+            out,
+            encoding,
+        } => vindex_cli::represent_facts(container, out, encoding),
         Command::Precision { container } => vindex_cli::precision_facts(container),
         Command::Verify { container } => vindex_cli::verify_facts(container),
     };
@@ -223,6 +366,8 @@ fn main() -> ExitCode {
                     Command::Inspect { .. } => render_inspect(&v),
                     Command::Describe { .. } => render_describe(&v),
                     Command::Representations { .. } => render_representations(&v),
+                    Command::Diff { .. } => render_diff(&v),
+                    Command::Represent { .. } => render_represent(&v),
                     Command::Precision { .. } => render_precision(&v),
                     Command::Verify { .. } => render_verify(&v),
                 }

--- a/crates/vindex-cli/tests/facts.rs
+++ b/crates/vindex-cli/tests/facts.rs
@@ -6,9 +6,12 @@
 //! self-verification from its bytes, with no source checkpoint
 //! present. A corrupted byte must fail verify by name.
 
-use larql_vindex::format::vindex3::fixtures::{encode_fixture_container, miniature_glimmer};
+use larql_vindex::format::vindex3::fixtures::{
+    dense_f32_model, encode_fixture_container, miniature_glimmer,
+};
 use vindex_cli::{
-    describe_facts, inspect_facts, precision_facts, representations_facts, verify_facts,
+    describe_facts, diff_facts, inspect_facts, precision_facts, represent_facts,
+    representations_facts, verify_facts,
 };
 
 fn container() -> tempfile::TempDir {
@@ -73,6 +76,68 @@ fn precision_is_derived_from_bytes_over_elements_never_asserted() {
         (eff - 32.0).abs() < 0.5,
         "effective {eff} — expected ~32 for the F32 fixture"
     );
+}
+
+/// The dense (16-aligned) fixture, encoded and then compiled to NVFP4
+/// through `represent_facts` — the two-representation container the
+/// diff tests interrogate.
+fn compiled_container() -> (tempfile::TempDir, serde_json::Value) {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let src = tempfile::tempdir().unwrap();
+    encode_fixture_container(
+        dense_f32_model,
+        checkpoint.path(),
+        src.path(),
+        "vindex-cli-dense",
+    );
+    let out = tempfile::tempdir().unwrap();
+    let report = represent_facts(src.path(), out.path(), "nvfp4").unwrap();
+    (out, report)
+}
+
+#[test]
+fn represent_compiles_a_pack_and_the_result_still_verifies() {
+    let (out, report) = compiled_container();
+    let compiled = report["compiled"].as_array().unwrap();
+    assert!(!compiled.is_empty(), "{report}");
+    assert!(
+        compiled[0]["compression"].as_f64().unwrap() > 1.0,
+        "{report}"
+    );
+    let v = verify_facts(out.path()).unwrap();
+    assert!(v["verified"].as_bool().unwrap(), "{v}");
+}
+
+#[test]
+fn diff_of_a_representation_against_itself_is_identical() {
+    let (out, report) = compiled_container();
+    let object = report["compiled"][0]["object"].as_str().unwrap();
+    let v = diff_facts(out.path(), "F32", "F32", object, 4, None).unwrap();
+    assert!(v["identical"].as_bool().unwrap(), "{v}");
+    assert_eq!(v["rms_error"], 0.0, "{v}");
+}
+
+#[test]
+fn diff_derives_a_nonzero_error_between_source_and_compiled_bytes() {
+    let (out, report) = compiled_container();
+    let object = report["compiled"][0]["object"].as_str().unwrap();
+    let v = diff_facts(out.path(), "F32", "NVFP4", object, 4, None).unwrap();
+    assert!(!v["identical"].as_bool().unwrap(), "{v}");
+    assert!(v["rms_error"].as_f64().unwrap() > 0.0, "{v}");
+    assert!(
+        v["max_error"].as_f64().unwrap() >= v["rms_error"].as_f64().unwrap(),
+        "{v}"
+    );
+    let rows = v["values"]["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 4, "{v}");
+}
+
+#[test]
+fn diff_refuses_an_encoding_the_container_does_not_hold() {
+    let (out, report) = compiled_container();
+    let object = report["compiled"][0]["object"].as_str().unwrap();
+    let err = diff_facts(out.path(), "F32", "INT8", object, 4, None).unwrap_err();
+    assert!(err.contains("the container holds"), "{err}");
 }
 
 #[test]


### PR DESCRIPTION
The two missing format-native verbs. `diff` decodes one object under two of the container's representations — the packed side by the spec's arithmetic — and derives per-tensor rms/max plus a per-value head; unheld encodings are refused by naming what the container holds. `represent` wraps the reference compiler and reports re-encoded vs carried tensors, bytes, preserved objects, linked segments; the output still passes `vindex verify`. Ten tests gate it on the dense fixture, including exact-zero self-diff and refusal cases.