### PR TITLE
fix(vindex-cli): findings from the granite runthrough

### DIFF
--- a/crates/vindex-cli/src/lib.rs
+++ b/crates/vindex-cli/src/lib.rs
@@ -161,8 +161,8 @@ pub fn precision_facts(root: &Path) -> Facts {
     Ok(json!({
         "container": root.display().to_string(),
         "entries": per_entry,
-        "total_weights": total_weights as u64,
-        "effective_bits_per_weight": if total_weights > 0 { (total_bits as f64) / (total_weights as f64) } else { 0.0 },
+        "total_weight_slots": total_weights as u64,
+        "stored_bits_per_weight_slot": if total_weights > 0 { (total_bits as f64) / (total_weights as f64) } else { 0.0 },
         "precision_map": index.precision_map,
     }))
 }
@@ -415,11 +415,13 @@ pub fn diff_facts(
             "rms_error": rms,
             "max_error": t_max,
         }));
+        // A suffix only matches at a path boundary: `0.mlp.down` must not
+        // match `30.mlp.down`. The first matching tensor wins.
         let wanted = match tensor_filter {
-            Some(f) => name == f || name.ends_with(f),
+            Some(f) => head.is_none() && (name == f || name.ends_with(&format!(".{f}"))),
             None => rms > worst,
         };
-        if wanted && (tensor_filter.is_some() || rms > worst) {
+        if wanted {
             worst = rms;
             head = Some(json!({
                 "tensor": name,

--- a/crates/vindex-cli/src/main.rs
+++ b/crates/vindex-cli/src/main.rs
@@ -101,8 +101,8 @@ fn render_inspect(v: &Value) {
             "{:<22} {:<16} {:>7} {:>8}",
             c["id"].as_str().unwrap_or("?"),
             c["role"].as_str().unwrap_or("?"),
-            c["num_layers"],
-            c["hidden_size"]
+            c["num_layers"].as_u64().unwrap_or(0),
+            c["hidden_size"].as_u64().unwrap_or(0)
         );
     }
     println!();
@@ -132,8 +132,8 @@ fn render_representations(v: &Value) {
             e["id"].as_str().unwrap_or("?"),
             e["encoding"].as_str().unwrap_or("?"),
             e["fidelity"].as_str().unwrap_or("—"),
-            e["tensor_count"],
-            e["payload_bytes"]
+            e["tensor_count"].as_u64().unwrap_or(0),
+            e["payload_bytes"].as_u64().unwrap_or(0)
         );
     }
 }
@@ -185,18 +185,21 @@ fn render_precision(v: &Value) {
             "{:<34} {:<10} {:>16} {:>14} {:>10.4}",
             e["id"].as_str().unwrap_or("?"),
             e["encoding"].as_str().unwrap_or("?"),
-            e["weights"],
-            e["payload_bytes"],
+            e["weights"].as_u64().unwrap_or(0),
+            e["payload_bytes"].as_u64().unwrap_or(0),
             e["bits_per_weight"].as_f64().unwrap_or(0.0)
         );
     }
     println!();
-    kv("weights", &v["total_weights"]);
     kv(
-        "effective",
+        "weight slots",
+        v["total_weight_slots"].as_u64().unwrap_or(0),
+    );
+    kv(
+        "stored",
         format!(
-            "{:.4} bits / weight",
-            v["effective_bits_per_weight"].as_f64().unwrap_or(0.0)
+            "{:.4} bits / weight slot, across every representation carried — an archival container counts each representation of an object; the execution-relevant figure is the BITS/W of the representation a profile selects",
+            v["stored_bits_per_weight_slot"].as_f64().unwrap_or(0.0)
         ),
     );
     if !v["precision_map"].is_null() {

--- a/crates/vindex-cli/tests/facts.rs
+++ b/crates/vindex-cli/tests/facts.rs
@@ -70,7 +70,7 @@ fn describe_refuses_an_unknown_address_by_naming_the_holdings() {
 fn precision_is_derived_from_bytes_over_elements_never_asserted() {
     let dir = container();
     let v = precision_facts(dir.path()).unwrap();
-    let eff = v["effective_bits_per_weight"].as_f64().unwrap();
+    let eff = v["stored_bits_per_weight_slot"].as_f64().unwrap();
     // The miniature encodes F32 source tensors: 32 bits per weight.
     assert!(
         (eff - 32.0).abs() < 0.5,


### PR DESCRIPTION
Running every verb against the real 3B container surfaced three fixes: `diff --tensor` suffixes now match only at path boundaries (`0.mlp.down` no longer selects `30.mlp.down`) and the first match wins; precision's aggregate is renamed `stored_bits_per_weight_slot` because summing across every carried representation is a storage fact, not effective precision — the per-representation BITS/W column is the execution-relevant figure; and numeric columns now format through `as_u64` since `serde_json::Value`'s Display ignores width specifiers.