### PR TITLE
feat(vindex-cli): describe --peek — the numbers themselves

### DIFF
--- a/crates/vindex-cli/src/lib.rs
+++ b/crates/vindex-cli/src/lib.rs
@@ -91,8 +91,10 @@ pub fn representations_facts(root: &Path) -> Facts {
 }
 
 /// `vindex describe <address>` — one logical object, in full: identity,
-/// bindings, representations, and the head of its tensor table.
-pub fn describe_facts(root: &Path, address: &str, values: usize) -> Facts {
+/// bindings, representations, and the head of its tensor table. With
+/// `peek`, the first `values` decoded weights of one named tensor —
+/// the numbers themselves, read from the canonical bytes.
+pub fn describe_facts(root: &Path, address: &str, values: usize, peek: Option<&str>) -> Facts {
     let inspection = inspect_container(root, false).map_err(|e| format!("inspect: {e}"))?;
     let object = find_object(&inspection, address)?;
     let directory: Vec<Value> = inspection
@@ -121,10 +123,56 @@ pub fn describe_facts(root: &Path, address: &str, values: usize) -> Facts {
             })
         })
         .collect();
+    let peeked = match peek {
+        None => Value::Null,
+        Some(tensor) => {
+            let store = OperandStore::open(root, &inspection).map_err(|e| format!("open: {e}"))?;
+            let entry = inspection
+                .index
+                .representations
+                .values()
+                .find(|e| e.object == object.id)
+                .ok_or_else(|| format!("`{}` has no directory entry", object.id))?;
+            let (header, _) = read_segment_header(&root.join(&entry.segment))
+                .map_err(|e| format!("segment {}: {e}", entry.segment))?;
+            let t = header
+                .tensors
+                .iter()
+                .find(|t| t.name == tensor || t.name.ends_with(&format!(".{tensor}")))
+                .ok_or_else(|| {
+                    format!(
+                        "no tensor of `{}` matches `{tensor}` — tensors: {}",
+                        object.id,
+                        header
+                            .tensors
+                            .iter()
+                            .map(|t| t.name.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                })?;
+            let decoded = load_values(
+                &store,
+                &OperandRef {
+                    object: object.id.clone(),
+                    tensor: t.name.clone(),
+                    dtype: t.dtype.clone(),
+                    shape: t.shape.clone(),
+                },
+            )?;
+            json!({
+                "tensor": t.name,
+                "dtype": t.dtype,
+                "shape": t.shape,
+                "values": decoded.iter().take(values).collect::<Vec<_>>(),
+            })
+        }
+    };
     Ok(json!({
         "container": root.display().to_string(),
         "object": serde_json::to_value(object).map_err(|e| e.to_string())?,
         "directory": directory,
+        "peek": peeked,
     }))
 }
 

--- a/crates/vindex-cli/src/main.rs
+++ b/crates/vindex-cli/src/main.rs
@@ -38,6 +38,10 @@ enum Command {
         /// How many tensor-table rows to show per representation.
         #[arg(long, default_value_t = 8)]
         values: usize,
+        /// Decode and print the first values of this tensor (name or
+        /// suffix) — the numbers themselves, from the canonical bytes.
+        #[arg(long)]
+        peek: Option<String>,
     },
     /// The physical directory: what exists as bytes, with recorded fidelity.
     Representations { container: PathBuf },
@@ -138,6 +142,23 @@ fn render_representations(v: &Value) {
     }
 }
 
+fn render_peek(v: &Value) {
+    let Some(p) = v.get("peek").filter(|p| !p.is_null()) else {
+        return;
+    };
+    println!();
+    println!(
+        "{} {} {} — first values",
+        p["tensor"].as_str().unwrap_or("?"),
+        p["dtype"].as_str().unwrap_or("?"),
+        serde_json::to_string(&p["shape"]).unwrap_or_default()
+    );
+    for x in p["values"].as_array().into_iter().flatten() {
+        let x = x.as_f64().unwrap_or(0.0);
+        println!("  {}{:.6}", if x >= 0.0 { "+" } else { "" }, x);
+    }
+}
+
 fn render_describe(v: &Value) {
     let o = &v["object"];
     kv("object", o["id"].as_str().unwrap_or("?"));
@@ -153,6 +174,7 @@ fn render_describe(v: &Value) {
             ),
         );
     }
+    render_peek(v);
     for d in v["directory"].as_array().into_iter().flatten() {
         println!();
         kv(
@@ -342,7 +364,8 @@ fn main() -> ExitCode {
             container,
             address,
             values,
-        } => vindex_cli::describe_facts(container, address, *values),
+            peek,
+        } => vindex_cli::describe_facts(container, address, *values, peek.as_deref()),
         Command::Representations { container } => vindex_cli::representations_facts(container),
         Command::Diff {
             container,

--- a/crates/vindex-cli/tests/facts.rs
+++ b/crates/vindex-cli/tests/facts.rs
@@ -53,16 +53,34 @@ fn representations_list_the_physical_directory_with_fidelity() {
 #[test]
 fn describe_finds_an_object_by_suffix_and_shows_its_tensor_table() {
     let dir = container();
-    let v = describe_facts(dir.path(), "decoder_stack", 4).unwrap();
+    let v = describe_facts(dir.path(), "decoder_stack", 4, None).unwrap();
     assert_eq!(v["object"]["id"], "target.decoder_stack");
     let head = &v["directory"][0]["tensor_table_head"];
     assert!(!head.as_array().unwrap().is_empty(), "{v}");
 }
 
 #[test]
+fn describe_peek_decodes_the_actual_values_of_one_tensor() {
+    let dir = container();
+    let v = describe_facts(
+        dir.path(),
+        "decoder_stack",
+        4,
+        Some("input_layernorm.weight"),
+    )
+    .unwrap();
+    let vals = v["peek"]["values"].as_array().unwrap();
+    assert_eq!(vals.len(), 4, "{v}");
+    assert!(vals.iter().all(|x| x.as_f64().unwrap().is_finite()), "{v}");
+
+    let err = describe_facts(dir.path(), "decoder_stack", 4, Some("no.such.tensor")).unwrap_err();
+    assert!(err.contains("tensors:"), "{err}");
+}
+
+#[test]
 fn describe_refuses_an_unknown_address_by_naming_the_holdings() {
     let dir = container();
-    let err = describe_facts(dir.path(), "no.such.object", 4).unwrap_err();
+    let err = describe_facts(dir.path(), "no.such.object", 4, None).unwrap_err();
     assert!(err.contains("the graph holds"), "{err}");
 }
 


### PR DESCRIPTION
`vindex describe <container> <addr> --peek <tensor> --values N` decodes and prints the first N actual weights of one named tensor from the canonical bytes, through the same load path diff uses (packed encodings included). Boundary-suffix matching; unknown tensors refused by naming the holdings. Covers the last artifact-side shot in the quantization video that still needed a helper script.