### PR TITLE
feat(vindex-cli): semantic addresses and the precision matrix

### DIFF
--- a/crates/vindex-cli/src/lib.rs
+++ b/crates/vindex-cli/src/lib.rs
@@ -18,7 +18,7 @@ use larql_vindex::format::vindex3::encode::segment::read_segment_header;
 use larql_vindex::format::vindex3::index::{ContainerAuthority, Vindex3Index};
 use larql_vindex::format::vindex3::inspect::{inspect_container, SystemInspection};
 use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
-use larql_vindex::format::vindex3::opplan::OperandRef;
+use larql_vindex::format::vindex3::opplan::{plan_component_ops, LayerFfn, OperandRef};
 use larql_vindex::format::vindex3::represent::nvfp4_pack::{split, PackLayout, DTYPE_NVFP4};
 use larql_vindex::format::vindex3::represent::{compile_representation, RepresentSpec};
 
@@ -96,6 +96,40 @@ pub fn representations_facts(root: &Path) -> Facts {
 /// the numbers themselves, read from the canonical bytes.
 pub fn describe_facts(root: &Path, address: &str, values: usize, peek: Option<&str>) -> Facts {
     let inspection = inspect_container(root, false).map_err(|e| format!("inspect: {e}"))?;
+    if let Some(resolved) = resolve_semantic(root, &inspection, address) {
+        let (role, op) = resolved?;
+        let mut representations: Vec<Value> = Vec::new();
+        for entry in inspection
+            .index
+            .representations
+            .values()
+            .filter(|e| e.object == op.object)
+        {
+            let (header, _) = read_segment_header(&root.join(&entry.segment))
+                .map_err(|e| format!("segment {}: {e}", entry.segment))?;
+            if let Some(t) = header.tensors.iter().find(|t| t.name == op.tensor) {
+                let weights: u128 = t.shape.iter().product::<usize>() as u128;
+                representations.push(json!({
+                    "encoding": entry.encoding,
+                    "dtype": t.dtype,
+                    "bits_per_weight": if weights > 0 { (t.len as u128 * 8) as f64 / weights as f64 } else { 0.0 },
+                    "bytes": t.len,
+                }));
+            }
+        }
+        let store = OperandStore::open(root, &inspection).map_err(|e| format!("open: {e}"))?;
+        let decoded = load_values(&store, &op)?;
+        return Ok(json!({
+            "container": root.display().to_string(),
+            "semantic": address,
+            "role": role,
+            "object": op.object,
+            "tensor": op.tensor,
+            "shape": op.shape,
+            "representations": representations,
+            "values": decoded.iter().take(values).collect::<Vec<_>>(),
+        }));
+    }
     let object = find_object(&inspection, address)?;
     let directory: Vec<Value> = inspection
         .index
@@ -212,6 +246,120 @@ pub fn precision_facts(root: &Path) -> Facts {
         "total_weight_slots": total_weights as u64,
         "stored_bits_per_weight_slot": if total_weights > 0 { (total_bits as f64) / (total_weights as f64) } else { 0.0 },
         "precision_map": index.precision_map,
+    }))
+}
+
+/// `vindex precision --matrix` — bits per weight, per layer and per
+/// semantic role, read from the representation each object would
+/// execute (the compiled pack when one exists, the canonical bytes
+/// otherwise). The rows are the precision map, seen: which cells of
+/// the model carry how many bits.
+pub fn precision_matrix_facts(root: &Path) -> Facts {
+    let inspection = inspect_container(root, false).map_err(|e| format!("inspect: {e}"))?;
+    let component = inspection
+        .graph
+        .components
+        .first()
+        .ok_or("the graph holds no components")?
+        .id
+        .clone();
+    let outcome =
+        plan_component_ops(&inspection, root, &component).map_err(|e| format!("plan: {e}"))?;
+    let plan = outcome
+        .plan
+        .ok_or_else(|| format!("component `{component}` has no plan"))?;
+
+    // Per object: the representation execution would bind — a compiled
+    // pack over the canonical bytes — and its tensor table of
+    // (byte length, weight count) per tensor name.
+    type TensorSizes = std::collections::BTreeMap<String, (u64, u128)>;
+    let mut tables: std::collections::BTreeMap<String, (String, TensorSizes)> =
+        std::collections::BTreeMap::new();
+    for object in &inspection.graph.objects {
+        let canonical = object.representations.first().map(|r| r.encoding.clone());
+        let mut chosen: Option<(
+            &String,
+            &larql_vindex::format::vindex3::index::RepresentationEntry,
+        )> = None;
+        for (id, e) in &inspection.index.representations {
+            if e.object != object.id {
+                continue;
+            }
+            let is_pack = Some(&e.encoding) != canonical.as_ref();
+            match &chosen {
+                None => chosen = Some((id, e)),
+                Some((_, cur)) => {
+                    let cur_is_pack = Some(&cur.encoding) != canonical.as_ref();
+                    if is_pack && !cur_is_pack {
+                        chosen = Some((id, e));
+                    }
+                }
+            }
+        }
+        if let Some((_, entry)) = chosen {
+            let (header, _) = read_segment_header(&root.join(&entry.segment))
+                .map_err(|e| format!("segment {}: {e}", entry.segment))?;
+            let table = header
+                .tensors
+                .into_iter()
+                .map(|t| {
+                    let weights: u128 = t.shape.iter().product::<usize>() as u128;
+                    (t.name, (t.len, weights))
+                })
+                .collect();
+            tables.insert(object.id.clone(), (entry.encoding.clone(), table));
+        }
+    }
+    let bits_of = |op: &OperandRef| -> Option<f64> {
+        let (_, table) = tables.get(&op.object)?;
+        let (len, weights) = table.get(&op.tensor)?;
+        if *weights == 0 {
+            return None;
+        }
+        Some((*len as u128 * 8) as f64 / *weights as f64)
+    };
+
+    const ROLES: [&str; 7] = ["gate", "up", "down", "q", "k", "v", "o"];
+    let mut rows: Vec<Value> = Vec::new();
+    for layer in &plan.layers {
+        let mut cells = serde_json::Map::new();
+        if let Some(ffn) = layer.ffn.dense() {
+            if let Some(g) = &ffn.gate {
+                if let Some(b) = bits_of(g) {
+                    cells.insert("gate".into(), json!(b));
+                }
+            }
+            if let Some(b) = bits_of(&ffn.up) {
+                cells.insert("up".into(), json!(b));
+            }
+            if let Some(b) = bits_of(&ffn.down) {
+                cells.insert("down".into(), json!(b));
+            }
+        }
+        if let Some(attn) = layer.attention.softmax() {
+            for (name, op) in [
+                ("q", &attn.q),
+                ("k", &attn.k),
+                ("v", &attn.v),
+                ("o", &attn.o),
+            ] {
+                if let Some(b) = bits_of(op) {
+                    cells.insert(name.into(), json!(b));
+                }
+            }
+        }
+        rows.push(json!({ "layer": layer.layer, "bits": Value::Object(cells) }));
+    }
+    let sources: Vec<Value> = tables
+        .iter()
+        .map(|(object, (encoding, _))| json!({ "object": object, "representation": encoding }))
+        .collect();
+    Ok(json!({
+        "container": root.display().to_string(),
+        "component": component,
+        "roles": ROLES,
+        "rows": rows,
+        "sources": sources,
     }))
 }
 
@@ -348,6 +496,84 @@ fn open_side(
     Ok((store, tensors))
 }
 
+/// A semantic address, resolved through the container's own operation
+/// plan — the graph's judgement of what each tensor IS, never a
+/// filename convention. `layer.N.ffn.{gate|up|down}` (mlp accepted)
+/// and `layer.N.attention.{q|k|v|o}` (attn accepted). Returns the
+/// role label with the operand.
+fn resolve_semantic(
+    root: &Path,
+    inspection: &SystemInspection,
+    address: &str,
+) -> Option<Result<(String, OperandRef), String>> {
+    let parts: Vec<&str> = address.split('.').collect();
+    let [lit, layer, family, role] = parts.as_slice() else {
+        return None;
+    };
+    if *lit != "layer" {
+        return None;
+    }
+    let n: usize = layer.parse().ok()?;
+    let family = match *family {
+        "ffn" | "mlp" => "ffn",
+        "attention" | "attn" => "attention",
+        _ => return None,
+    };
+    let component = inspection.graph.components.first()?.id.clone();
+    let go = || -> Result<(String, OperandRef), String> {
+        let outcome =
+            plan_component_ops(inspection, root, &component).map_err(|e| format!("plan: {e}"))?;
+        let plan = outcome
+            .plan
+            .ok_or_else(|| format!("component `{component}` has no plan"))?;
+        let layer_plan = plan
+            .layers
+            .get(n)
+            .ok_or_else(|| format!("layer {n} — the plan holds layers 0..{}", plan.layers.len()))?;
+        match family {
+            "ffn" => {
+                let ffn = layer_plan.ffn.dense().ok_or_else(|| {
+                    let kind = match &layer_plan.ffn {
+                        LayerFfn::Routed(_) => "a routed (mixture-of-experts) FFN",
+                        LayerFfn::Hybrid(_) => "a hybrid FFN",
+                        LayerFfn::Dense(_) => unreachable!(),
+                    };
+                    format!(
+                        "layer {n} carries {kind} — per-expert addressing is not yet a CLI surface"
+                    )
+                })?;
+                let (label, op) = match *role {
+                    "gate" => (
+                        "FFN GATE PROJECTION",
+                        ffn.gate.as_ref().ok_or_else(|| {
+                            format!("layer {n}'s FFN is ungated — no gate operand")
+                        })?,
+                    ),
+                    "up" => ("FFN UP PROJECTION", &ffn.up),
+                    "down" => ("FFN DOWN PROJECTION", &ffn.down),
+                    other => return Err(format!("unknown ffn role `{other}` — gate, up, down")),
+                };
+                Ok((label.to_string(), op.clone()))
+            }
+            "attention" => {
+                let attn = layer_plan.attention.softmax().ok_or_else(|| {
+                    format!("layer {n} does not attend by softmax — its projections are the recurrence's, not q/k/v/o")
+                })?;
+                let (label, op) = match *role {
+                    "q" => ("ATTENTION QUERY PROJECTION", &attn.q),
+                    "k" => ("ATTENTION KEY PROJECTION", &attn.k),
+                    "v" => ("ATTENTION VALUE PROJECTION", &attn.v),
+                    "o" => ("ATTENTION OUTPUT PROJECTION", &attn.o),
+                    other => return Err(format!("unknown attention role `{other}` — q, k, v, o")),
+                };
+                Ok((label.to_string(), op.clone()))
+            }
+            _ => unreachable!(),
+        }
+    };
+    Some(go())
+}
+
 /// Decode one tensor to f32, whatever the container stored it as. The
 /// arithmetic for a packed encoding is the spec's — `tensor_scale ·
 /// e4m3(group scale) · e2m1(code)` — so what the diff compares is what
@@ -391,7 +617,15 @@ pub fn diff_facts(
     tensor_filter: Option<&str>,
 ) -> Facts {
     let inspection = inspect_container(root, false).map_err(|e| format!("inspect: {e}"))?;
-    let object = find_object(&inspection, address)?.id.clone();
+    let mut semantic_tensor: Option<String> = None;
+    let object = if let Some(resolved) = resolve_semantic(root, &inspection, address) {
+        let (_, op) = resolved?;
+        semantic_tensor = Some(op.tensor);
+        op.object
+    } else {
+        find_object(&inspection, address)?.id.clone()
+    };
+    let tensor_filter = semantic_tensor.as_deref().or(tensor_filter);
     let (encoding_a, encoding_b) = (encoding_a.to_uppercase(), encoding_b.to_uppercase());
     let (store_a, tensors_a) = open_side(root, &inspection, &object, &encoding_a)?;
     let (store_b, tensors_b) = open_side(root, &inspection, &object, &encoding_b)?;
@@ -400,6 +634,12 @@ pub fn diff_facts(
         .map(|(n, d, s)| (n.as_str(), (d.as_str(), s)))
         .collect();
 
+    // A semantic address names ONE tensor: the diff scopes to it, so
+    // the result is that tensor's answer rather than the object's.
+    let tensors_a: Vec<TensorEntry> = match &semantic_tensor {
+        Some(t) => tensors_a.into_iter().filter(|(n, _, _)| n == t).collect(),
+        None => tensors_a,
+    };
     let mut rows: Vec<Value> = Vec::new();
     let mut head: Option<Value> = None;
     let mut worst: f64 = -1.0;

--- a/crates/vindex-cli/src/main.rs
+++ b/crates/vindex-cli/src/main.rs
@@ -76,7 +76,13 @@ enum Command {
         encoding: String,
     },
     /// Bits per weight — derived from stored bytes over tensor elements, never asserted.
-    Precision { container: PathBuf },
+    Precision {
+        container: PathBuf,
+        /// The precision map, seen: bits per layer × semantic role, from the
+        /// representation each object would execute.
+        #[arg(long)]
+        matrix: bool,
+    },
     /// The container against its own recorded hashes, re-derived from the artifact alone.
     Verify { container: PathBuf },
     /// Install the latest release of this tool. Only ever runs when you ask:
@@ -169,6 +175,33 @@ fn render_peek(v: &Value) {
 }
 
 fn render_describe(v: &Value) {
+    if let Some(role) = v["role"].as_str() {
+        kv("role", role);
+        kv("object", v["object"].as_str().unwrap_or("?"));
+        kv("tensor", v["tensor"].as_str().unwrap_or("?"));
+        kv(
+            "shape",
+            serde_json::to_string(&v["shape"]).unwrap_or_default(),
+        );
+        for r in v["representations"].as_array().into_iter().flatten() {
+            kv(
+                "representation",
+                format!(
+                    "{} · {} · {:.4} bits/weight",
+                    r["encoding"].as_str().unwrap_or("?"),
+                    r["dtype"].as_str().unwrap_or("?"),
+                    r["bits_per_weight"].as_f64().unwrap_or(0.0)
+                ),
+            );
+        }
+        println!();
+        println!("VALUES");
+        for x in v["values"].as_array().into_iter().flatten() {
+            let x = x.as_f64().unwrap_or(0.0);
+            println!("  {}{:.6}", if x >= 0.0 { "+" } else { "" }, x);
+        }
+        return;
+    }
     let o = &v["object"];
     kv("object", o["id"].as_str().unwrap_or("?"));
     kv("kind", o["kind"].as_str().unwrap_or("?"));
@@ -203,6 +236,57 @@ fn render_describe(v: &Value) {
                 serde_json::to_string(&t["shape"]).unwrap_or_default()
             );
         }
+    }
+}
+
+fn render_precision_matrix(v: &Value) {
+    let roles: Vec<&str> = v["roles"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|r| r.as_str())
+        .collect();
+    let fmt_row = |bits: &Value| -> String {
+        roles
+            .iter()
+            .map(|r| match bits[r].as_f64() {
+                Some(b) => format!("{b:>7.2}"),
+                None => format!("{:>7}", "—"),
+            })
+            .collect::<String>()
+    };
+    println!(
+        "{:<10}{}",
+        "LAYER",
+        roles.iter().map(|r| format!("{r:>7}")).collect::<String>()
+    );
+    // Collapse runs of identical rows into ranges — a 64-layer model
+    // with a five-layer map should read as its regions, not 64 lines.
+    let rows: Vec<&Value> = v["rows"].as_array().into_iter().flatten().collect();
+    let mut i = 0;
+    while i < rows.len() {
+        let line = fmt_row(&rows[i]["bits"]);
+        let start = rows[i]["layer"].as_u64().unwrap_or(0);
+        let mut end = start;
+        while i + 1 < rows.len() && fmt_row(&rows[i + 1]["bits"]) == line {
+            i += 1;
+            end = rows[i]["layer"].as_u64().unwrap_or(end);
+        }
+        let label = if start == end {
+            format!("{start}")
+        } else {
+            format!("{start}–{end}")
+        };
+        println!("{label:<10}{line}");
+        i += 1;
+    }
+    println!();
+    for s in v["sources"].as_array().into_iter().flatten() {
+        println!(
+            "{:<34} {}",
+            s["object"].as_str().unwrap_or("?"),
+            s["representation"].as_str().unwrap_or("?")
+        );
     }
 }
 
@@ -401,7 +485,13 @@ fn main() -> ExitCode {
             out,
             encoding,
         } => vindex_cli::represent_facts(container, out, encoding),
-        Command::Precision { container } => vindex_cli::precision_facts(container),
+        Command::Precision { container, matrix } => {
+            if *matrix {
+                vindex_cli::precision_matrix_facts(container)
+            } else {
+                vindex_cli::precision_facts(container)
+            }
+        }
         Command::Verify { container } => vindex_cli::verify_facts(container),
         Command::Update { .. } => unreachable!("handled above"),
     };
@@ -416,7 +506,13 @@ fn main() -> ExitCode {
                     Command::Representations { .. } => render_representations(&v),
                     Command::Diff { .. } => render_diff(&v),
                     Command::Represent { .. } => render_represent(&v),
-                    Command::Precision { .. } => render_precision(&v),
+                    Command::Precision { matrix, .. } => {
+                        if *matrix {
+                            render_precision_matrix(&v)
+                        } else {
+                            render_precision(&v)
+                        }
+                    }
                     Command::Verify { .. } => render_verify(&v),
                     Command::Update { .. } => unreachable!("handled above"),
                 }

--- a/crates/vindex-cli/tests/facts.rs
+++ b/crates/vindex-cli/tests/facts.rs
@@ -10,8 +10,8 @@ use larql_vindex::format::vindex3::fixtures::{
     dense_f32_model, encode_fixture_container, miniature_glimmer,
 };
 use vindex_cli::{
-    describe_facts, diff_facts, inspect_facts, precision_facts, represent_facts,
-    representations_facts, verify_facts,
+    describe_facts, diff_facts, inspect_facts, precision_facts, precision_matrix_facts,
+    represent_facts, representations_facts, verify_facts,
 };
 
 fn container() -> tempfile::TempDir {
@@ -156,6 +156,45 @@ fn diff_refuses_an_encoding_the_container_does_not_hold() {
     let object = report["compiled"][0]["object"].as_str().unwrap();
     let err = diff_facts(out.path(), "F32", "INT8", object, 4, None).unwrap_err();
     assert!(err.contains("the container holds"), "{err}");
+}
+
+#[test]
+fn semantic_addresses_resolve_through_the_plan_not_filenames() {
+    let (out, _) = compiled_container();
+    let v = describe_facts(out.path(), "layer.0.ffn.down", 4, None).unwrap();
+    assert_eq!(v["role"], "FFN DOWN PROJECTION", "{v}");
+    assert_eq!(v["values"].as_array().unwrap().len(), 4, "{v}");
+    let encs: Vec<&str> = v["representations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|r| r["encoding"].as_str())
+        .collect();
+    assert!(encs.contains(&"NVFP4"), "{v}");
+
+    let err = describe_facts(out.path(), "layer.99.ffn.down", 4, None).unwrap_err();
+    assert!(err.contains("the plan holds layers"), "{err}");
+}
+
+#[test]
+fn a_semantic_diff_scopes_to_its_one_tensor() {
+    let (out, _) = compiled_container();
+    let v = diff_facts(out.path(), "F32", "NVFP4", "layer.0.ffn.down", 4, None).unwrap();
+    assert_eq!(v["tensors"].as_array().unwrap().len(), 1, "{v}");
+    assert!(v["rms_error"].as_f64().unwrap() > 0.0, "{v}");
+}
+
+#[test]
+fn the_precision_matrix_reads_the_compiled_representation() {
+    let (out, _) = compiled_container();
+    let v = precision_matrix_facts(out.path()).unwrap();
+    let rows = v["rows"].as_array().unwrap();
+    assert!(!rows.is_empty(), "{v}");
+    let down = rows[0]["bits"]["down"].as_f64().unwrap();
+    assert!(
+        (down - 4.5).abs() < 0.1,
+        "compiled down at {down} — expected ~4.5\n{v}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
`describe`/`diff` accept `layer.N.ffn.{gate|up|down}` and `layer.N.attention.{q|k|v|o}`, resolved through the operation plan (roles, not filenames; honest refusals for routed/DeltaNet layers and out-of-range indices). `precision --matrix` renders bits per layer × role from the representation execution would bind, collapsing identical layer runs into ranges — the precision map, seen. Fourteen tests.