### PR TITLE
chore(vindex-cli): 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,7 +5178,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vindex-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "larql-models",

--- a/crates/vindex-cli/Cargo.toml
+++ b/crates/vindex-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vindex-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Version bump for the release carrying semantic addresses, `precision --matrix`, `describe --peek` and `vindex update`.