### PR TITLE
test(vindex-cli): DeltaNet refusal proven on an encoded hybrid

### DIFF
--- a/crates/vindex-cli/tests/facts.rs
+++ b/crates/vindex-cli/tests/facts.rs
@@ -7,7 +7,7 @@
 //! present. A corrupted byte must fail verify by name.
 
 use larql_vindex::format::vindex3::fixtures::{
-    dense_f32_model, encode_fixture_container, miniature_glimmer,
+    dense_f32_model, encode_fixture_container, hybrid_lllf_f32_model, miniature_glimmer,
 };
 use vindex_cli::{
     describe_facts, diff_facts, inspect_facts, precision_facts, precision_matrix_facts,
@@ -195,6 +195,25 @@ fn the_precision_matrix_reads_the_compiled_representation() {
         (down - 4.5).abs() < 0.1,
         "compiled down at {down} — expected ~4.5\n{v}"
     );
+}
+
+#[test]
+fn a_deltanet_layer_refuses_qkvo_and_a_full_attention_layer_answers() {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    encode_fixture_container(
+        hybrid_lllf_f32_model,
+        checkpoint.path(),
+        dir.path(),
+        "vindex-cli-hybrid",
+    );
+    // LLLF cadence: layers 0–2 are GatedDelta recurrences, layer 3 attends.
+    let err = describe_facts(dir.path(), "layer.0.attention.q", 2, None).unwrap_err();
+    assert!(err.contains("does not attend by softmax"), "{err}");
+
+    let v = describe_facts(dir.path(), "layer.3.attention.q", 2, None).unwrap();
+    assert_eq!(v["role"], "ATTENTION QUERY PROJECTION", "{v}");
+    assert_eq!(v["values"].as_array().unwrap().len(), 2, "{v}");
 }
 
 #[test]


### PR DESCRIPTION
The LLLF hybrid fixture, encoded through the real pipeline: DeltaNet layers refuse `attention.q` by naming what they are; the full-attention layer answers with role and values. Locks the film's refusal beat in CI.