### PR TITLE
feat(vindex-cli): the token mixer becomes a first-class component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,7 +5178,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vindex-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "larql-models",

--- a/crates/vindex-cli/Cargo.toml
+++ b/crates/vindex-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vindex-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/vindex-cli/src/lib.rs
+++ b/crates/vindex-cli/src/lib.rs
@@ -18,7 +18,9 @@ use larql_vindex::format::vindex3::encode::segment::read_segment_header;
 use larql_vindex::format::vindex3::index::{ContainerAuthority, Vindex3Index};
 use larql_vindex::format::vindex3::inspect::{inspect_container, SystemInspection};
 use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
-use larql_vindex::format::vindex3::opplan::{plan_component_ops, LayerFfn, OperandRef};
+use larql_vindex::format::vindex3::opplan::{
+    plan_component_ops, ComponentOpPlan, LayerFfn, LayerPlan, OperandRef,
+};
 use larql_vindex::format::vindex3::represent::nvfp4_pack::{split, PackLayout, DTYPE_NVFP4};
 use larql_vindex::format::vindex3::represent::{compile_representation, RepresentSpec};
 
@@ -96,6 +98,33 @@ pub fn representations_facts(root: &Path) -> Facts {
 /// the numbers themselves, read from the canonical bytes.
 pub fn describe_facts(root: &Path, address: &str, values: usize, peek: Option<&str>) -> Facts {
     let inspection = inspect_container(root, false).map_err(|e| format!("inspect: {e}"))?;
+    // `layer.N.mixer` — the token mixer as a first-class semantic
+    // component: its programme, and every operand with the role the
+    // plan assigns it. Architecture-neutral by construction.
+    if let Some(n) = address
+        .strip_prefix("layer.")
+        .and_then(|r| r.strip_suffix(".mixer"))
+        .and_then(|n| n.parse::<usize>().ok())
+    {
+        let (_, plan) = primary_plan(root, &inspection)?;
+        let layer = plan
+            .layers
+            .get(n)
+            .ok_or_else(|| format!("layer {n} — the plan holds layers 0..{}", plan.layers.len()))?;
+        let operands: Vec<Value> = mixer_operands(layer)
+            .into_iter()
+            .map(|(role, op)| {
+                json!({ "role": role, "tensor": op.tensor, "shape": op.shape, "dtype": op.dtype })
+            })
+            .collect();
+        return Ok(json!({
+            "container": root.display().to_string(),
+            "semantic": address,
+            "mixer": mixer_label(layer),
+            "layer": n,
+            "operands": operands,
+        }));
+    }
     if let Some(resolved) = resolve_semantic(root, &inspection, address) {
         let (role, op) = resolved?;
         let mut representations: Vec<Value> = Vec::new();
@@ -249,25 +278,42 @@ pub fn precision_facts(root: &Path) -> Facts {
     }))
 }
 
+/// `vindex layers` — every layer's token-mixer programme, from the
+/// plan. Three seconds of terminal that says why a hybrid model is an
+/// interesting quantization subject.
+pub fn layers_facts(root: &Path) -> Facts {
+    let inspection = inspect_container(root, false).map_err(|e| format!("inspect: {e}"))?;
+    let (component, plan) = primary_plan(root, &inspection)?;
+    let rows: Vec<Value> = plan
+        .layers
+        .iter()
+        .map(|l| {
+            let ffn = match &l.ffn {
+                LayerFfn::Dense(_) => "dense",
+                LayerFfn::Routed(_) => "routed",
+                LayerFfn::Hybrid(_) => "hybrid",
+            };
+            json!({ "layer": l.layer, "mixer": mixer_label(l), "ffn": ffn })
+        })
+        .collect();
+    Ok(json!({
+        "container": root.display().to_string(),
+        "component": component,
+        "layers": rows,
+    }))
+}
+
 /// `vindex precision --matrix` — bits per weight, per layer and per
 /// semantic role, read from the representation each object would
 /// execute (the compiled pack when one exists, the canonical bytes
-/// otherwise). The rows are the precision map, seen: which cells of
-/// the model carry how many bits.
+/// otherwise). Programme-aware: layers are grouped by their token
+/// mixer, each group carrying the columns its programme actually has,
+/// and the model's other surfaces (embedding, head, towers) are
+/// listed with their own derived bits. No architecture is forced into
+/// another's schema.
 pub fn precision_matrix_facts(root: &Path) -> Facts {
     let inspection = inspect_container(root, false).map_err(|e| format!("inspect: {e}"))?;
-    let component = inspection
-        .graph
-        .components
-        .first()
-        .ok_or("the graph holds no components")?
-        .id
-        .clone();
-    let outcome =
-        plan_component_ops(&inspection, root, &component).map_err(|e| format!("plan: {e}"))?;
-    let plan = outcome
-        .plan
-        .ok_or_else(|| format!("component `{component}` has no plan"))?;
+    let (component, plan) = primary_plan(root, &inspection)?;
 
     // Per object: the representation execution would bind — a compiled
     // pack over the canonical bytes — and its tensor table of
@@ -319,10 +365,29 @@ pub fn precision_matrix_facts(root: &Path) -> Facts {
         Some((*len as u128 * 8) as f64 / *weights as f64)
     };
 
-    const ROLES: [&str; 7] = ["gate", "up", "down", "q", "k", "v", "o"];
-    let mut rows: Vec<Value> = Vec::new();
+    // Group layers by programme; each group's columns are what its
+    // programme actually computes with.
+    let short = |role: &str| -> &'static str {
+        match role {
+            "query" => "q",
+            "key" => "k",
+            "value" => "v",
+            "output" => "o",
+            "output gate" => "zgate",
+            "fused recurrent q|k|v" => "qkv",
+            "decay projection" => "decay",
+            "write-strength projection" => "write",
+            "output-gate projection" => "zgate",
+            "causal conv over q|k|v" => "conv",
+            "output projection" => "out",
+            _ => "",
+        }
+    };
+    let mut programmes: Vec<(String, Vec<String>, Vec<Value>)> = Vec::new();
     for layer in &plan.layers {
+        let label = mixer_label(layer).to_string();
         let mut cells = serde_json::Map::new();
+        let mut roles: Vec<String> = vec!["gate".into(), "up".into(), "down".into()];
         if let Some(ffn) = layer.ffn.dense() {
             if let Some(g) = &ffn.gate {
                 if let Some(b) = bits_of(g) {
@@ -336,30 +401,66 @@ pub fn precision_matrix_facts(root: &Path) -> Facts {
                 cells.insert("down".into(), json!(b));
             }
         }
-        if let Some(attn) = layer.attention.softmax() {
-            for (name, op) in [
-                ("q", &attn.q),
-                ("k", &attn.k),
-                ("v", &attn.v),
-                ("o", &attn.o),
-            ] {
-                if let Some(b) = bits_of(op) {
-                    cells.insert(name.into(), json!(b));
-                }
+        for (role, op) in mixer_operands(layer) {
+            let col = short(role);
+            if col.is_empty() {
+                continue;
+            }
+            roles.push(col.to_string());
+            if let Some(b) = bits_of(&op) {
+                cells.insert(col.to_string(), json!(b));
             }
         }
-        rows.push(json!({ "layer": layer.layer, "bits": Value::Object(cells) }));
+        let row = json!({ "layer": layer.layer, "bits": Value::Object(cells) });
+        match programmes.iter_mut().find(|(l, _, _)| *l == label) {
+            Some((_, _, rows)) => rows.push(row),
+            None => programmes.push((label, roles, vec![row])),
+        }
     }
-    let sources: Vec<Value> = tables
+    // The model's other surfaces: every object outside the layer plan,
+    // at the bits its bound representation derives to.
+    let planned: std::collections::BTreeSet<String> = plan
+        .layers
         .iter()
-        .map(|(object, (encoding, _))| json!({ "object": object, "representation": encoding }))
+        .flat_map(|l| {
+            let mut ops: Vec<String> = mixer_operands(l)
+                .into_iter()
+                .map(|(_, o)| o.object)
+                .collect();
+            if let Some(ffn) = l.ffn.dense() {
+                if let Some(g) = &ffn.gate {
+                    ops.push(g.object.clone());
+                }
+                ops.push(ffn.up.object.clone());
+                ops.push(ffn.down.object.clone());
+            }
+            ops
+        })
+        .collect();
+    let surfaces: Vec<Value> = tables
+        .iter()
+        .filter(|(object, _)| !planned.contains(*object))
+        .map(|(object, (encoding, table))| {
+            let (bits, weights) = table.values().fold((0u128, 0u128), |(b, w), (len, n)| {
+                (b + *len as u128 * 8, w + n)
+            });
+            json!({
+                "object": object,
+                "representation": encoding,
+                "bits_per_weight": if weights > 0 { bits as f64 / weights as f64 } else { 0.0 },
+            })
+        })
         .collect();
     Ok(json!({
         "container": root.display().to_string(),
         "component": component,
-        "roles": ROLES,
-        "rows": rows,
-        "sources": sources,
+        "programmes": programmes.into_iter().map(|(label, roles, rows)| json!({
+            "label": label,
+            "layers": rows.len(),
+            "roles": roles,
+            "rows": rows,
+        })).collect::<Vec<Value>>(),
+        "surfaces": surfaces,
     }))
 }
 
@@ -496,6 +597,74 @@ fn open_side(
     Ok((store, tensors))
 }
 
+fn primary_plan(
+    root: &Path,
+    inspection: &SystemInspection,
+) -> Result<(String, ComponentOpPlan), String> {
+    let component = inspection
+        .graph
+        .components
+        .first()
+        .ok_or("the graph holds no components")?
+        .id
+        .clone();
+    let outcome =
+        plan_component_ops(inspection, root, &component).map_err(|e| format!("plan: {e}"))?;
+    let plan = outcome
+        .plan
+        .ok_or_else(|| format!("component `{component}` has no plan"))?;
+    Ok((component, plan))
+}
+
+/// The token mixer's programme label, from the plan — never inferred
+/// from a name.
+fn mixer_label(layer: &LayerPlan) -> &'static str {
+    match layer.attention.softmax() {
+        Some(attn) => {
+            if attn.output_gate.is_some() {
+                "GATED ATTENTION"
+            } else {
+                "SOFTMAX ATTENTION"
+            }
+        }
+        None => "GATED DELTANET",
+    }
+}
+
+/// The mixer's operands, each with the semantic role the plan assigns.
+fn mixer_operands(layer: &LayerPlan) -> Vec<(&'static str, OperandRef)> {
+    match layer.attention.softmax() {
+        Some(attn) => {
+            let mut ops = vec![
+                ("query", attn.q.clone()),
+                ("key", attn.k.clone()),
+                ("value", attn.v.clone()),
+                ("output", attn.o.clone()),
+            ];
+            if let Some(g) = &attn.output_gate {
+                ops.push(("output gate", g.projection.clone()));
+            }
+            ops
+        }
+        None => {
+            let Some(gd) = layer.attention.gated_delta() else {
+                return Vec::new();
+            };
+            vec![
+                ("fused recurrent q|k|v", gd.in_proj_qkv.clone()),
+                ("decay projection", gd.in_proj_a.clone()),
+                ("write-strength projection", gd.in_proj_b.clone()),
+                ("output-gate projection", gd.in_proj_z.clone()),
+                ("causal conv over q|k|v", gd.conv1d.clone()),
+                ("log decay", gd.a_log.clone()),
+                ("timestep bias", gd.dt_bias.clone()),
+                ("gated norm", gd.norm.clone()),
+                ("output projection", gd.out_proj.clone()),
+            ]
+        }
+    }
+}
+
 /// A semantic address, resolved through the container's own operation
 /// plan — the graph's judgement of what each tensor IS, never a
 /// filename convention. `layer.N.ffn.{gate|up|down}` (mlp accepted)
@@ -557,7 +726,7 @@ fn resolve_semantic(
             }
             "attention" => {
                 let attn = layer_plan.attention.softmax().ok_or_else(|| {
-                    format!("layer {n} does not attend by softmax — its projections are the recurrence's, not q/k/v/o")
+                    format!("layer {n} has no softmax-attention component — its token mixer is GATED DELTANET; try `describe layer.{n}.mixer`")
                 })?;
                 let (label, op) = match *role {
                     "q" => ("ATTENTION QUERY PROJECTION", &attn.q),

--- a/crates/vindex-cli/src/main.rs
+++ b/crates/vindex-cli/src/main.rs
@@ -47,6 +47,8 @@ enum Command {
     },
     /// The physical directory: what exists as bytes, with recorded fidelity.
     Representations { container: PathBuf },
+    /// Every layer's token-mixer programme, from the operation plan.
+    Layers { container: PathBuf },
     /// One object under two of the container's representations, decoded and
     /// compared value by value — the error derived, never asserted.
     Diff {
@@ -174,7 +176,50 @@ fn render_peek(v: &Value) {
     }
 }
 
+fn render_layers(v: &Value) {
+    let rows: Vec<&Value> = v["layers"].as_array().into_iter().flatten().collect();
+    let line = |r: &Value| {
+        format!(
+            "{:<18} ffn {}",
+            r["mixer"].as_str().unwrap_or("?"),
+            r["ffn"].as_str().unwrap_or("?")
+        )
+    };
+    let mut i = 0;
+    while i < rows.len() {
+        let l = line(rows[i]);
+        let start = rows[i]["layer"].as_u64().unwrap_or(0);
+        let mut end = start;
+        while i + 1 < rows.len() && line(rows[i + 1]) == l {
+            i += 1;
+            end = rows[i]["layer"].as_u64().unwrap_or(end);
+        }
+        let label = if start == end {
+            format!("{start}")
+        } else {
+            format!("{start}–{end}")
+        };
+        println!("{label:<10}{l}");
+        i += 1;
+    }
+}
+
 fn render_describe(v: &Value) {
+    if let Some(mixer) = v["mixer"].as_str() {
+        kv("layer", v["layer"].as_u64().unwrap_or(0));
+        kv("token mixer", mixer);
+        println!();
+        println!("{:<28} {:<38} SHAPE", "SEMANTICS", "TENSOR");
+        for op in v["operands"].as_array().into_iter().flatten() {
+            println!(
+                "{:<28} {:<38} {}",
+                op["role"].as_str().unwrap_or("?"),
+                op["tensor"].as_str().unwrap_or("?"),
+                serde_json::to_string(&op["shape"]).unwrap_or_default()
+            );
+        }
+        return;
+    }
     if let Some(role) = v["role"].as_str() {
         kv("role", role);
         kv("object", v["object"].as_str().unwrap_or("?"));
@@ -240,52 +285,61 @@ fn render_describe(v: &Value) {
 }
 
 fn render_precision_matrix(v: &Value) {
-    let roles: Vec<&str> = v["roles"]
-        .as_array()
-        .into_iter()
-        .flatten()
-        .filter_map(|r| r.as_str())
-        .collect();
-    let fmt_row = |bits: &Value| -> String {
-        roles
-            .iter()
-            .map(|r| match bits[r].as_f64() {
-                Some(b) => format!("{b:>7.2}"),
-                None => format!("{:>7}", "—"),
-            })
-            .collect::<String>()
-    };
-    println!(
-        "{:<10}{}",
-        "LAYER",
-        roles.iter().map(|r| format!("{r:>7}")).collect::<String>()
-    );
-    // Collapse runs of identical rows into ranges — a 64-layer model
-    // with a five-layer map should read as its regions, not 64 lines.
-    let rows: Vec<&Value> = v["rows"].as_array().into_iter().flatten().collect();
-    let mut i = 0;
-    while i < rows.len() {
-        let line = fmt_row(&rows[i]["bits"]);
-        let start = rows[i]["layer"].as_u64().unwrap_or(0);
-        let mut end = start;
-        while i + 1 < rows.len() && fmt_row(&rows[i + 1]["bits"]) == line {
-            i += 1;
-            end = rows[i]["layer"].as_u64().unwrap_or(end);
-        }
-        let label = if start == end {
-            format!("{start}")
-        } else {
-            format!("{start}–{end}")
-        };
-        println!("{label:<10}{line}");
-        i += 1;
-    }
-    println!();
-    for s in v["sources"].as_array().into_iter().flatten() {
+    for prog in v["programmes"].as_array().into_iter().flatten() {
+        let roles: Vec<&str> = prog["roles"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|r| r.as_str())
+            .collect();
         println!(
-            "{:<34} {}",
+            "{} · {} layer(s)",
+            prog["label"].as_str().unwrap_or("?"),
+            prog["layers"].as_u64().unwrap_or(0)
+        );
+        let fmt_row = |bits: &Value| -> String {
+            roles
+                .iter()
+                .map(|r| match bits[r].as_f64() {
+                    Some(b) => format!("{b:>7.2}"),
+                    None => format!("{:>7}", "—"),
+                })
+                .collect::<String>()
+        };
+        println!(
+            "{:<10}{}",
+            "LAYER",
+            roles.iter().map(|r| format!("{r:>7}")).collect::<String>()
+        );
+        // Collapse runs of identical rows into ranges — a 64-layer
+        // model with a five-layer map should read as its regions.
+        let rows: Vec<&Value> = prog["rows"].as_array().into_iter().flatten().collect();
+        let mut i = 0;
+        while i < rows.len() {
+            let line = fmt_row(&rows[i]["bits"]);
+            let start = rows[i]["layer"].as_u64().unwrap_or(0);
+            let mut end = start;
+            while i + 1 < rows.len() && fmt_row(&rows[i + 1]["bits"]) == line {
+                i += 1;
+                end = rows[i]["layer"].as_u64().unwrap_or(end);
+            }
+            let label = if start == end {
+                format!("{start}")
+            } else {
+                format!("{start}–{end}")
+            };
+            println!("{label:<10}{line}");
+            i += 1;
+        }
+        println!();
+    }
+    println!("MODEL SURFACES");
+    for s in v["surfaces"].as_array().into_iter().flatten() {
+        println!(
+            "{:<34} {:<8} {:>8.4} bits/weight",
             s["object"].as_str().unwrap_or("?"),
-            s["representation"].as_str().unwrap_or("?")
+            s["representation"].as_str().unwrap_or("?"),
+            s["bits_per_weight"].as_f64().unwrap_or(0.0)
         );
     }
 }
@@ -472,6 +526,7 @@ fn main() -> ExitCode {
             peek,
         } => vindex_cli::describe_facts(container, address, *values, peek.as_deref()),
         Command::Representations { container } => vindex_cli::representations_facts(container),
+        Command::Layers { container } => vindex_cli::layers_facts(container),
         Command::Diff {
             container,
             a,
@@ -504,6 +559,7 @@ fn main() -> ExitCode {
                     Command::Inspect { .. } => render_inspect(&v),
                     Command::Describe { .. } => render_describe(&v),
                     Command::Representations { .. } => render_representations(&v),
+                    Command::Layers { .. } => render_layers(&v),
                     Command::Diff { .. } => render_diff(&v),
                     Command::Represent { .. } => render_represent(&v),
                     Command::Precision { matrix, .. } => {

--- a/crates/vindex-cli/tests/facts.rs
+++ b/crates/vindex-cli/tests/facts.rs
@@ -10,8 +10,8 @@ use larql_vindex::format::vindex3::fixtures::{
     dense_f32_model, encode_fixture_container, hybrid_lllf_f32_model, miniature_glimmer,
 };
 use vindex_cli::{
-    describe_facts, diff_facts, inspect_facts, precision_facts, precision_matrix_facts,
-    represent_facts, representations_facts, verify_facts,
+    describe_facts, diff_facts, inspect_facts, layers_facts, precision_facts,
+    precision_matrix_facts, represent_facts, representations_facts, verify_facts,
 };
 
 fn container() -> tempfile::TempDir {
@@ -185,15 +185,20 @@ fn a_semantic_diff_scopes_to_its_one_tensor() {
 }
 
 #[test]
-fn the_precision_matrix_reads_the_compiled_representation() {
+fn the_precision_matrix_reads_the_compiled_representation_by_programme() {
     let (out, _) = compiled_container();
     let v = precision_matrix_facts(out.path()).unwrap();
-    let rows = v["rows"].as_array().unwrap();
-    assert!(!rows.is_empty(), "{v}");
+    let programmes = v["programmes"].as_array().unwrap();
+    assert!(!programmes.is_empty(), "{v}");
+    let rows = programmes[0]["rows"].as_array().unwrap();
     let down = rows[0]["bits"]["down"].as_f64().unwrap();
     assert!(
         (down - 4.5).abs() < 0.1,
         "compiled down at {down} — expected ~4.5\n{v}"
+    );
+    assert!(
+        !v["surfaces"].as_array().unwrap().is_empty(),
+        "embedding/head surfaces expected: {v}"
     );
 }
 
@@ -209,11 +214,51 @@ fn a_deltanet_layer_refuses_qkvo_and_a_full_attention_layer_answers() {
     );
     // LLLF cadence: layers 0–2 are GatedDelta recurrences, layer 3 attends.
     let err = describe_facts(dir.path(), "layer.0.attention.q", 2, None).unwrap_err();
-    assert!(err.contains("does not attend by softmax"), "{err}");
+    assert!(err.contains("token mixer is GATED DELTANET"), "{err}");
+    assert!(err.contains("layer.0.mixer"), "{err}");
 
     let v = describe_facts(dir.path(), "layer.3.attention.q", 2, None).unwrap();
     assert_eq!(v["role"], "ATTENTION QUERY PROJECTION", "{v}");
     assert_eq!(v["values"].as_array().unwrap().len(), 2, "{v}");
+}
+
+#[test]
+fn the_mixer_is_a_first_class_semantic_component() {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    encode_fixture_container(
+        hybrid_lllf_f32_model,
+        checkpoint.path(),
+        dir.path(),
+        "vindex-cli-hybrid",
+    );
+    let v = describe_facts(dir.path(), "layer.0.mixer", 2, None).unwrap();
+    assert_eq!(v["mixer"], "GATED DELTANET", "{v}");
+    let roles: Vec<&str> = v["operands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|o| o["role"].as_str())
+        .collect();
+    assert!(roles.contains(&"fused recurrent q|k|v"), "{roles:?}");
+    assert!(roles.contains(&"decay projection"), "{roles:?}");
+
+    let v = describe_facts(dir.path(), "layer.3.mixer", 2, None).unwrap();
+    assert!(
+        v["mixer"] == "SOFTMAX ATTENTION" || v["mixer"] == "GATED ATTENTION",
+        "{v}"
+    );
+
+    let l = layers_facts(dir.path()).unwrap();
+    let mixers: Vec<&str> = l["layers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|r| r["mixer"].as_str())
+        .collect();
+    assert_eq!(mixers.len(), 4, "{l}");
+    assert_eq!(mixers[0], "GATED DELTANET", "{l}");
+    assert_ne!(mixers[3], "GATED DELTANET", "{l}");
 }
 
 #[test]


### PR DESCRIPTION
`describe layer.N.mixer` (programme + every operand with its plan-assigned role), `vindex layers` (mixer programme per layer, ranges collapsed), programme-aware `precision --matrix` (groups by mixer with each programme's own columns + MODEL SURFACES), and the corrected refusal — DeltaNet layers have recurrent q/k/v, so the message now says what the mixer is and where to look. v0.5.0. Sixteen tests incl. the encoded LLLF hybrid.