### PR TITLE
fix(ci): return main to green — the yanked advisory and four merges' coverage debt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,9 +523,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/crates/larql-kv/src/vindex3/tests/mod.rs
+++ b/crates/larql-kv/src/vindex3/tests/mod.rs
@@ -268,3 +268,94 @@ fn a_misfit_row_width_is_refused() {
     }]);
     canonical.append(0, vec![0.0; 3], vec![0.0; 3]);
 }
+
+// ═══════════════════════════════════════════════════════════════
+// Adoption-boundary and refusal contracts
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn default_is_the_empty_provider() {
+    let mut provider = CanonicalKvState::default();
+    provider.prepare(&[LayerKvGeometry {
+        kv_dim: 4,
+        window: None,
+    }]);
+    assert_eq!(provider.geometry().len(), 1);
+    assert_eq!(provider.position(), 0);
+}
+
+#[test]
+fn an_adopted_cache_with_unwritten_layers_prepares_cleanly() {
+    // with_layers(2) holds two None layers: LayerRows must default (no
+    // rows to serve) and prepare's width check must skip what was never
+    // written rather than refuse it.
+    let mut adopted = CanonicalKvState::from_cache(KvCache::with_layers(2));
+    adopted.prepare(&[
+        LayerKvGeometry {
+            kv_dim: 4,
+            window: None,
+        },
+        LayerKvGeometry {
+            kv_dim: 4,
+            window: None,
+        },
+    ]);
+    assert!(adopted.keys(0).is_empty());
+    assert!(adopted.values(1).is_empty());
+}
+
+#[test]
+#[should_panic(expected = "adopted cache holds")]
+fn an_adopted_cache_for_a_different_layer_count_is_refused() {
+    let mut adopted = CanonicalKvState::from_cache(KvCache::with_layers(2));
+    adopted.prepare(&[LayerKvGeometry {
+        kv_dim: 4,
+        window: None,
+    }]);
+}
+
+#[test]
+#[should_panic(expected = "the plan says")]
+fn an_adopted_cache_with_misfit_rows_is_refused() {
+    let mut cache = KvCache::with_layers(1);
+    cache.set_layer(
+        0,
+        (
+            ndarray::Array2::zeros((1, 3)),
+            ndarray::Array2::zeros((1, 3)),
+        ),
+    );
+    let mut adopted = CanonicalKvState::from_cache(cache);
+    adopted.prepare(&[LayerKvGeometry {
+        kv_dim: 4,
+        window: None,
+    }]);
+}
+
+#[test]
+#[should_panic(expected = "V row at layer")]
+fn a_misfit_value_row_is_refused_even_when_the_key_fits() {
+    let mut canonical = CanonicalKvState::new();
+    canonical.prepare(&[LayerKvGeometry {
+        kv_dim: 4,
+        window: None,
+    }]);
+    canonical.append(0, vec![0.0; 4], vec![0.0; 3]);
+}
+
+#[test]
+fn recurrent_state_is_explicitly_unsupported_not_absent() {
+    use larql_vindex::format::vindex3::opplan::exec::kv::ContinuationError;
+    let mut provider = CanonicalKvState::new();
+    provider.prepare(&[LayerKvGeometry {
+        kv_dim: 4,
+        window: None,
+    }]);
+    match provider.recurrent_state(7) {
+        Err(ContinuationError::RecurrentUnsupported { provider, layer }) => {
+            assert_eq!(provider, "CanonicalKvState");
+            assert_eq!(layer, 7);
+        }
+        other => panic!("must refuse with the provider and layer named: {other:?}"),
+    }
+}

--- a/crates/larql-models/tests/test_architectures.rs
+++ b/crates/larql-models/tests/test_architectures.rs
@@ -1320,6 +1320,45 @@ fn qwen_qk_norm_keys() {
 }
 
 #[test]
+fn qwen_classic_norm_weights_are_not_offsets() {
+    // Only qwen3_5/qwen3_next store norm weights as offsets from one;
+    // the rest of the family stores them plain.
+    let arch = qwen_arch();
+    assert_eq!(arch.norm_weight_offset(), 0.0);
+    assert_eq!(arch.qk_norm_weight_offset(), 0.0);
+}
+
+#[test]
+fn qwen35_declared_output_gate_resolves_to_the_hf_sigmoid_spec() {
+    use larql_models::config::{GateActivation, GateCombine, GatePlacement, GateSource};
+    let arch = detect_from_json(&serde_json::json!({
+        "model_type": "qwen3_5",
+        "hidden_size": 2048, "num_hidden_layers": 4, "intermediate_size": 5504,
+        "num_attention_heads": 16, "num_key_value_heads": 2,
+        "attn_output_gate": true
+    }));
+    let spec = arch.attention_output_gate().expect("gate declared true");
+    assert_eq!(spec.source, GateSource::FusedQueryProjection);
+    // Sigmoid, NOT the silu the config's `output_gate_type: "swish"`
+    // spelling suggests — HF computes `x · sigmoid(g)`.
+    assert_eq!(spec.activation, GateActivation::Sigmoid);
+    assert_eq!(spec.combine, GateCombine::ElementwiseMultiply);
+    assert_eq!(
+        spec.placement,
+        GatePlacement::AfterAggregationBeforeOutputProjection
+    );
+
+    // Declared false (or absent) is no gate, not a disabled gate.
+    let ungated = detect_from_json(&serde_json::json!({
+        "model_type": "qwen3_5",
+        "hidden_size": 2048, "num_hidden_layers": 4, "intermediate_size": 5504,
+        "num_attention_heads": 16, "num_key_value_heads": 2,
+        "attn_output_gate": false
+    }));
+    assert!(ungated.attention_output_gate().is_none());
+}
+
+#[test]
 fn qwen_dense_returns_none_for_moe_keys() {
     let arch = qwen_arch();
     assert!(arch.moe_router_key(0).is_none());

--- a/crates/larql-models/tests/test_position_policy.rs
+++ b/crates/larql-models/tests/test_position_policy.rs
@@ -1,0 +1,158 @@
+//! The position-policy surface the QW-3.5/3.8 work added: the M-RoPE
+//! axis table, the `MRope` accessor arms, and the linear-attention
+//! topology facts. These are consumed heavily from larql-vindex, but a
+//! consumer in another crate is not coverage here — the contract each
+//! function states is asserted in the crate that owns it.
+
+use larql_models::config::position::{mrope_axis_table, PositionPolicy, RotaryFrequencyBasis};
+use larql_models::inventory::report::{LinearAttentionTopology, RecurrentStateDtype};
+
+// ═══════════════════════════════════════════════════════════════
+// mrope_axis_table — transcribed from HF `apply_interleaved_mrope`
+// ═══════════════════════════════════════════════════════════════
+
+/// Qwen3.8's real geometry: section [11, 11, 10] over 32 frequencies.
+/// HF starts from all-T and overwrites `slice(1, section[1]*3, 3)` with
+/// H and `slice(2, section[2]*3, 3)` with W — so the table must read
+/// `T H W T H W …` with H stopping after 11 slots and W after 10.
+#[test]
+fn interleaved_axis_table_matches_hf_slice_semantics() {
+    let axes = mrope_axis_table([11, 11, 10], true, 32);
+    assert_eq!(axes.len(), 32);
+    for (slot, axis) in axes.iter().enumerate() {
+        let expected = match slot % 3 {
+            1 if slot < 33 => 1, // H: slots 1,4,…,31 — all under 11·3
+            2 if slot < 30 => 2, // W: slots 2,5,…,29 — under 10·3
+            _ => 0,
+        };
+        assert_eq!(*axis, expected, "slot {slot}");
+    }
+    assert_eq!(axes.iter().filter(|a| **a == 1).count(), 11);
+    assert_eq!(axes.iter().filter(|a| **a == 2).count(), 10);
+}
+
+/// Slots past `n_freqs` must not be written: a table narrower than the
+/// section's own span truncates rather than panics.
+#[test]
+fn interleaved_axis_table_truncates_at_n_freqs() {
+    let axes = mrope_axis_table([2, 2, 2], true, 4);
+    // T at 0 and 3; H at 1 (next H slot 4 >= n_freqs); W at 2.
+    assert_eq!(axes, vec![0, 1, 2, 0]);
+}
+
+/// The non-interleaved layout is contiguous blocks: `T… H… W…`.
+#[test]
+fn sectioned_axis_table_is_contiguous_blocks() {
+    let axes = mrope_axis_table([2, 3, 1], false, 6);
+    assert_eq!(axes, vec![0, 0, 1, 1, 1, 2]);
+}
+
+/// A section that over-declares past `n_freqs` stops at the table's
+/// edge on whichever axis it runs out.
+#[test]
+fn sectioned_axis_table_truncates_mid_axis() {
+    let axes = mrope_axis_table([2, 3, 3], false, 6);
+    assert_eq!(axes, vec![0, 0, 1, 1, 1, 2]);
+    // And a T block wider than the whole table leaves everything T.
+    assert_eq!(mrope_axis_table([8, 1, 1], false, 4), vec![0, 0, 0, 0]);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// PositionPolicy — the MRope accessor arms
+// ═══════════════════════════════════════════════════════════════
+
+fn qwen38_mrope(basis: RotaryFrequencyBasis) -> PositionPolicy {
+    PositionPolicy::MRope {
+        theta: 5_000_000.0,
+        rotary_fraction: 0.25,
+        basis,
+        section: [11, 11, 10],
+        interleaved: true,
+    }
+}
+
+#[test]
+fn mrope_accessors_answer_the_declared_facts() {
+    let policy = qwen38_mrope(RotaryFrequencyBasis::RotaryWidth);
+    assert_eq!(policy.mrope(), Some(([11, 11, 10], true)));
+    assert_eq!(policy.rotary_fraction(), Some(0.25));
+    // Qwen3.8 declares `rope_type: "default"` — the multi-axis facts
+    // live in `mrope_section`, so the default basis answers no
+    // `rope_type` spelling at all.
+    assert_eq!(policy.declared_rope_type(), None);
+}
+
+#[test]
+fn mrope_head_width_basis_spells_proportional() {
+    let policy = qwen38_mrope(RotaryFrequencyBasis::HeadWidth);
+    assert_eq!(policy.declared_rope_type(), Some("proportional"));
+}
+
+#[test]
+fn non_mrope_policies_declare_no_axis_split() {
+    assert_eq!(PositionPolicy::Rope { theta: 10_000.0 }.mrope(), None);
+    assert_eq!(PositionPolicy::None.mrope(), None);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// RecurrentStateDtype — only the declared-and-executed value exists
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn recurrent_state_dtype_reads_both_spellings_and_refuses_the_rest() {
+    assert_eq!(
+        RecurrentStateDtype::from_declared("float32"),
+        Some(RecurrentStateDtype::Float32)
+    );
+    assert_eq!(
+        RecurrentStateDtype::from_declared("f32"),
+        Some(RecurrentStateDtype::Float32)
+    );
+    // An undeclared spelling is None — refused, never defaulted.
+    assert_eq!(RecurrentStateDtype::from_declared("bfloat16"), None);
+    assert_eq!(RecurrentStateDtype::Float32.declared_name(), "float32");
+}
+
+// ═══════════════════════════════════════════════════════════════
+// LinearAttentionTopology — Qwen3.8's declared geometry closes
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn qwen38_geometry_closes_on_the_observed_projection_widths() {
+    let topo = LinearAttentionTopology {
+        key_heads: 16,
+        key_head_dim: 128,
+        value_heads: 48,
+        value_head_dim: 128,
+        conv_kernel: 4,
+        state_dtype: Some(RecurrentStateDtype::Float32),
+    };
+    // 2·16·128 + 48·128 — the observed in_proj_qkv row count.
+    assert_eq!(topo.qkv_channels(), 10_240);
+    assert_eq!(topo.value_width(), 6_144);
+}
+
+#[test]
+fn from_config_requires_every_dimension() {
+    let full = larql_models::detect_from_json(&serde_json::json!({
+        "model_type": "qwen3_next",
+        "hidden_size": 2048, "num_hidden_layers": 4, "intermediate_size": 5504,
+        "num_attention_heads": 16, "num_key_value_heads": 2,
+        "linear_num_key_heads": 16, "linear_key_head_dim": 128,
+        "linear_num_value_heads": 48, "linear_value_head_dim": 128,
+        "linear_conv_kernel_dim": 4, "mamba_ssm_dtype": "float32"
+    }));
+    let topo =
+        LinearAttentionTopology::from_config(full.config()).expect("every dimension declared");
+    assert_eq!(topo.qkv_channels(), 10_240);
+    assert_eq!(topo.state_dtype, Some(RecurrentStateDtype::Float32));
+
+    // A partially declared recurrence is refused, not completed.
+    let partial = larql_models::detect_from_json(&serde_json::json!({
+        "model_type": "qwen3_next",
+        "hidden_size": 2048, "num_hidden_layers": 4, "intermediate_size": 5504,
+        "num_attention_heads": 16, "num_key_value_heads": 2,
+        "linear_num_key_heads": 16
+    }));
+    assert_eq!(LinearAttentionTopology::from_config(partial.config()), None);
+}

--- a/crates/larql-server/tests/test_public_explorer.rs
+++ b/crates/larql-server/tests/test_public_explorer.rs
@@ -248,3 +248,56 @@ async fn the_rest_read_routes_are_mounted() {
         assert_eq!(response.status(), StatusCode::OK, "{uri}");
     }
 }
+
+// ═══════════════════════════════════════════════════════════════
+// The bridge's failure surface
+// ═══════════════════════════════════════════════════════════════
+
+/// A container that does not bind fails the boot, not the first
+/// request: `spawn` returns the bind error and no bridge exists.
+#[test]
+fn a_container_that_does_not_bind_fails_spawn() {
+    let result = larql_server::lql_bridge::spawn(
+        std::path::Path::new("/nonexistent/container.vindex3"),
+        std::time::Duration::from_secs(1),
+    );
+    let Err(err) = result else {
+        panic!("binding a missing container must fail the boot");
+    };
+    assert!(!err.to_string().is_empty());
+}
+
+/// A statement that parses and is permitted but fails at execution is
+/// 422 — the profile refused nothing, the session tried and failed.
+#[tokio::test]
+async fn an_execution_failure_is_422_not_500() {
+    let container = v3_container();
+    let app = public_app(container.path());
+    // A layer the fixture does not have: the statement parses, passes
+    // the profile, and fails inside the executor.
+    let (status, body) = query(&app, "SHOW FEATURES 99;").await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{body}");
+    assert!(
+        body["error"].as_str().unwrap().contains("no features"),
+        "{body}"
+    );
+}
+
+/// An already-elapsed deadline reports the timeout, with the budget
+/// named. The statement must be genuinely slow: a trivial one can win
+/// the race against the first poll of the zero-duration timeout (the
+/// session thread runs in parallel), so the job is a full generation.
+#[tokio::test]
+async fn an_exhausted_deadline_is_a_bridge_timeout() {
+    let container = v3_container();
+    let bridge =
+        larql_server::lql_bridge::spawn(container.path(), std::time::Duration::ZERO).unwrap();
+    // A full 32-token generation cannot finish inside the synchronous
+    // gap between enqueueing the job and polling the elapsed deadline.
+    match bridge.query("INFER \"[3]\" GENERATE 32;".into()).await {
+        Err(larql_server::lql_bridge::QueryFailure::Bridge(msg)) => {
+            assert!(msg.contains("timed out"), "{msg}");
+        }
+        other => panic!("a zero deadline must time out, got {other:?}"),
+    }
+}

--- a/crates/larql-server/tests/test_vindex3_demo_bin.rs
+++ b/crates/larql-server/tests/test_vindex3_demo_bin.rs
@@ -1,0 +1,37 @@
+//! The `vindex3-demo` binary — the public explorer's boot-time
+//! container generator. The encoding logic is the same fixture every
+//! LQL/serve gate runs; what THIS binary owns is the argv contract and
+//! the idempotence check, so those are what these tests run — as the
+//! real subprocess, not a re-implementation.
+
+use std::process::Command;
+
+fn demo_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_vindex3-demo"))
+}
+
+#[test]
+fn no_output_dir_is_usage_error_2() {
+    let out = demo_bin().output().expect("binary runs");
+    assert_eq!(out.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("usage"));
+}
+
+#[test]
+fn writes_a_container_once_and_is_idempotent_after() {
+    let dest = tempfile::tempdir().unwrap();
+    let out = demo_bin().arg(dest.path()).output().expect("binary runs");
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(dest.path().join("index.json").exists());
+    assert!(dest.path().join("tokenizer.json").exists());
+    assert!(String::from_utf8_lossy(&out.stdout).contains("written to"));
+
+    // Boot-time regeneration: a present container is left alone.
+    let again = demo_bin().arg(dest.path()).output().expect("binary runs");
+    assert!(again.status.success());
+    assert!(String::from_utf8_lossy(&again.stdout).contains("already present"));
+}


### PR DESCRIPTION
Main has been red since well before today's merge train, from two independent causes; this returns every workflow to green without loosening any floor.

## The advisory

Upstream yanked `chacha20 0.10.1` (pulled via quinn/h3), so `cargo-deny · advisories` fails on every branch. Moved to 0.10.2 — verified locally: `advisories ok`.

## The coverage debt

Three crates sat under their 90% per-file floors, each traced to the merge that introduced it (larql-kv broke at #308, larql-server at #321, larql-models earlier). Every fix is tests against the exact uncovered lines — no floor was lowered and no file was excluded:

| File | Was | Fix |
|---|---|---|
| `larql-kv/vindex3/mod.rs` | 80.83% | adoption-boundary + fail-closed `recurrent_state` refusal tests |
| `larql-models/inventory/report.rs` | 47.73% | `RecurrentStateDtype` + `LinearAttentionTopology` contracts, closing on Qwen3.8's observed widths |
| `larql-models/config/position.rs` | 84.44% | M-RoPE axis tables vs HF slice semantics, `MRope` accessor arms |
| `larql-models/architectures/qwen.rs` | 88.64% | classic-qwen norm offset; declared output gate → HF sigmoid spec |
| `larql-server/bin/vindex3-demo.rs` | 0.00% | the real subprocess: usage exit 2, write-then-idempotent |
| `larql-server/lql_bridge.rs` | 77.27% | bind failure, execution→422, exhausted-deadline timeout |

The timeout test earns a note: a trivial statement can win the race against an already-elapsed deadline (the session thread runs in parallel), which is the same shape as the `chat_nanosecond_timeout_returns_504` flake — so the timed job is a full 32-token generation, measured 40/40 stable.

All three coverage policies verified locally with the CI-identical commands: kv 96.30%, models 91.07% (included 96.11%), server included 93.43% — every file at or above its floor.