### PR TITLE
fix(ci): shannon-verify must trigger on the crate its math lives in

### DIFF
--- a/.github/workflows/shannon-verify.yml
+++ b/.github/workflows/shannon-verify.yml
@@ -24,6 +24,7 @@ on:
     branches: [main]
     paths:
       - 'crates/larql-cli/**'
+      - 'crates/larql-compute/**'
       - 'crates/larql-inference/**'
       - 'crates/larql-models/**'
       - 'scripts/shannon_score_*.py'
@@ -36,6 +37,7 @@ on:
     branches: [main]
     paths:
       - 'crates/larql-cli/**'
+      - 'crates/larql-compute/**'
       - 'crates/larql-inference/**'
       - 'crates/larql-models/**'
       - 'scripts/shannon_score_*.py'


### PR DESCRIPTION
Two-line fix for #320: `crates/larql-compute/**` joins both `paths` lists in `shannon-verify.yml`.

The gate was created 2026-05-16 to net the three config-loading divergences; the rms_norm/rope math it guards moved to `crates/larql-compute` on 2026-05-18 (82a333a7), leaving the filter matching only re-export shims. The reporter verified on a fork that a compute-only edit does not launch the gate today, does with this fix, and that the gate genuinely catches a planted bug-2-style fault in `residual.rs` (75.851% disagreement vs the 0.5% threshold) when it runs.

Their design question — whether the filter should instead track the verify binary's whole dependency closure — is left open deliberately; this restores the promise the workflow header already makes.

Closes #320.