### PR TITLE
fix(memit): accumulate FFN covariance in f64; escalate Cholesky ridge before failing

### DIFF
--- a/crates/larql-inference/src/forward/memit.rs
+++ b/crates/larql-inference/src/forward/memit.rs
@@ -427,8 +427,27 @@ fn memit_solve_layer(
         }
     }
 
-    let l = larql_compute::cpu::ops::linalg::cholesky(&cov_f64, ridge)
-        .map_err(|e| format!("MEMIT: Cholesky failed — {e}"))?;
+    // Adaptive ridge: if f64 accumulation still lands a negative pivot
+    // (rare — mostly defends against non-Gemma architectures we haven't
+    // profiled), escalate ridge up to 4 steps before giving up.
+    let mut current_ridge = ridge;
+    let l = loop {
+        match larql_compute::cpu::ops::linalg::cholesky(&cov_f64, current_ridge) {
+            Ok(l) => {
+                if current_ridge > ridge {
+                    eprintln!("MEMIT: Cholesky needed ridge escalation {ridge} → {current_ridge}");
+                }
+                break l;
+            }
+            Err(e) if current_ridge < ridge * 1000.0 => {
+                current_ridge *= 10.0;
+                eprintln!(
+                    "MEMIT: Cholesky pivot failed ({e}); retrying with ridge={current_ridge}"
+                );
+            }
+            Err(e) => return Err(format!("MEMIT: Cholesky failed after escalation — {e}")),
+        }
+    };
 
     // Q = K @ C⁻¹  [N × ffn_dim]
     // We compute this as: for each fact i, q_i = C⁻¹ @ k_i (column),

--- a/crates/larql-inference/src/forward/trace.rs
+++ b/crates/larql-inference/src/forward/trace.rs
@@ -298,9 +298,16 @@ pub fn estimate_ffn_covariance(
     let ffn_dim = first.shape()[1];
 
     // Accumulator — K^T K across all sampled token positions.
-    // Float64 would be safer but Array2<f32> suffices at our scales
-    // (we'll round to f32 when writing to disk anyway).
-    let mut ktk = Array2::<f32>::zeros((ffn_dim, ffn_dim));
+    //
+    // Accumulate in f64. With ffn_dim in the thousands and activation
+    // magnitudes ~1e3 (observed on Gemma 4 26B-A4B, ffn_dim = 2112), each
+    // entry grows to ~1e6 * N; f32 (24-bit mantissa) loses the low-order
+    // contributions and the accumulated Gram matrix stops being numerically
+    // PSD, so the downstream Cholesky in memit.rs hits a negative pivot.
+    // Converting to f64 *after* accumulation (memit.rs `cov_f64`) cannot
+    // recover precision that was already lost here. We downcast to f32 once,
+    // at the boundary, when returning.
+    let mut ktk = Array2::<f64>::zeros((ffn_dim, ffn_dim));
     let mut total_samples: usize = 0;
 
     // Re-process the first capture so we don't double-count it.
@@ -308,12 +315,12 @@ pub fn estimate_ffn_covariance(
     // with itself, summed across rows.
     for row in first.rows() {
         for i in 0..ffn_dim {
-            let vi = row[i];
+            let vi = row[i] as f64;
             if vi == 0.0 {
                 continue;
             }
             for j in 0..ffn_dim {
-                ktk[[i, j]] += vi * row[j];
+                ktk[[i, j]] += vi * (row[j] as f64);
             }
         }
         total_samples += 1;
@@ -331,12 +338,12 @@ pub fn estimate_ffn_covariance(
         };
         for row in k.rows() {
             for i in 0..ffn_dim {
-                let vi = row[i];
+                let vi = row[i] as f64;
                 if vi == 0.0 {
                     continue;
                 }
                 for j in 0..ffn_dim {
-                    ktk[[i, j]] += vi * row[j];
+                    ktk[[i, j]] += vi * (row[j] as f64);
                 }
             }
             total_samples += 1;
@@ -347,10 +354,11 @@ pub fn estimate_ffn_covariance(
         return None;
     }
 
-    // C = (K^T K) / N
-    let scale = 1.0 / total_samples as f32;
+    // C = (K^T K) / N, then downcast to f32 once at the boundary.
+    let scale = 1.0_f64 / total_samples as f64;
     ktk.mapv_inplace(|v| v * scale);
-    Some((ktk, total_samples))
+    let ktk_f32 = ktk.mapv(|v| v as f32);
+    Some((ktk_f32, total_samples))
 }
 
 /// Run a forward pass and capture both residuals and sparse activations.


### PR DESCRIPTION
## Problem

`estimate_ffn_covariance` (`crates/larql-inference/src/forward/trace.rs`) accumulates `KᵀK` in `f32`. The comment above it says *"Float64 would be safer but Array2<f32> suffices at our scales"* — that stops being true on larger models.

Observed on **Gemma 4 26B-A4B** (`ffn_dim = 2112`, activation magnitudes ~1e3) while running MEMIT locally: each accumulator entry grows to ~1e6 × N over thousands of sampled token positions; with a 24-bit mantissa the low-order contributions are dropped, and the accumulated Gram matrix is no longer numerically PSD. The Cholesky in `memit.rs` then hits a negative pivot and MEMIT fails with `Cholesky failed`.

`memit.rs` already converts the covariance to `f64` (`cov_f64`) before Cholesky, but that cannot recover precision lost during accumulation — the damage is upstream of that cast.

## Change

1. **`trace.rs`** — accumulate `KᵀK` in `f64`, scale in `f64`, downcast to `f32` once at the boundary when returning. Public signature unchanged (`Option<(Array2<f32>, usize)>`). Memory: one temporary `ffn_dim²` matrix at 8 bytes instead of 4 (≈36 MB vs 18 MB at 2112).
2. **`memit.rs`** — if Cholesky still fails on an architecture nobody has profiled, escalate `ridge` ×10 up to 1000× before returning the error, logging each escalation via `eprintln!`. Defensive only; (1) is the fix. Behaviour at the original ridge is unchanged when the first attempt succeeds.

Not included: the ridge *value*. My local fork hard-coded `ridge = 10.0` for Gemma 4 in April; `LARQL_MEMIT_RIDGE` (now in `compile/into_model.rs` / `into_vindex.rs`) is the right design, so nothing to add there.

## Verification

- `cargo build -p larql-inference -p larql-lql` on the pinned 1.98.0 toolchain: clean.
- `cargo clippy -p larql-inference -- -D warnings`: clean.
- `rustfmt --check` on both files: clean.
- `cargo test -p larql-inference`: exit 0 — but note the crate's tests are `#[ignore]` model-gated (0 ran, 4 ignored on Linux/CPU), so this is a compile/clippy-level check, not behavioural coverage of the change.
- I do not have a small, deterministic repro that fails in-tree without a Gemma-4-sized model; if you'd like one I can add a synthetic test that builds a `(N, ffn_dim)` matrix with ~1e3 magnitudes and asserts the f32 vs f64 Gram matrices differ beyond tolerance.

## Context

This was fixed in a local fork on 2026-04-21/22 and sat there; a repo cleanup surfaced it and a check of upstream `trace.rs:303` showed the `f32` accumulator still present, so here it is. First PR to this repo — happy to reshape it to whatever conventions you prefer.
