### PR TITLE
fix(vindex3): close drill findings F10/F13/F14; define the schema-6 delta once

### DIFF
--- a/crates/larql-vindex/docs/vindex3-format-spec.md
+++ b/crates/larql-vindex/docs/vindex3-format-spec.md
@@ -410,7 +410,7 @@ preserved — decided by these rules:
 | unknown `index.json` schema (`version` ∉ its supported set) | MUST refuse by name, stating the version found and the versions supported — before reading any byte |
 | unknown fields inside a supported `index.json` schema | MUST ignore for interpretation (additive evolution within a schema number) and MUST NOT drop them when rewriting the index |
 | unknown LYRW role / format / packing / layout tags | MUST preserve at read time; refusal belongs at capability-check time (§6.5, §11): a browse-only reader must not choke on a `down` region in a codec it never touches |
-| unknown files in the container directory | MUST ignore for interpretation; maintenance operations (COMPACT, §20) MUST NOT silently discard them |
+| unknown files in the container directory | MUST ignore for interpretation; maintenance operations (COMPACT, §20) MAY discard files nothing references — but only as named entries in their report, never silently. Registered capability files and every index-referenced segment are always carried |
 | a required operand absent for a requested operation | MUST refuse naming the operand, object, layer and segment — never best-effort execute (§11, §17) |
 | a cross-generation container (V2 directory to a V3 verb or vice versa) | MUST refuse naming both generations (§12.1) — no cross-loading, no silent conversion |
 
@@ -1067,6 +1067,43 @@ the component algebra holds as scoped, and the additive-evolution claim
 that carried residency out of these gates is real. The ontology
 question itself did not flinch.
 
+**The schema-6 delta, defined once.** Both lifts land in a single
+intentional semantic break — `GRAPH_SCHEMA` 5 → 6, one re-encode of the
+corpus — never as two migrations discovering each other halfway:
+
+```text
+operation-program-derived surfaces   completeness from the declared
+                                     program; object kinds imply nothing
+attention absent when absent         presence means semantic presence,
+                                     not successful serialization
+ContinuationState declaration        per-operation state schema
+KDA state precision                  declared, never chosen by the executor
+MLA latent-KV geometry               declared, never invented
+per-op norm-epsilon override         the MLA kv_a_layernorm fact (F6)
+explicit per-layer operator          no absent-means-softmax default (F7)
+fail-closed layer census             undeclared families block (F3)
+closure at encode                    encoding is the proof boundary (F4)
+```
+
+The schema-6 acceptance test is severe by design: an encoder may not
+emit a v6 graph unless declared operations ↔ required surfaces ↔
+complete semantic parameters ↔ required continuation-state schema ↔
+closed operand estate all reconcile. The Final invariant this buys:
+
+> **The encoded operation programme is the completeness authority, and
+> an encoder may not emit a programme whose required semantics or
+> operands do not close.**
+
+Validation witnesses (real checkpoints, in order):
+`state-spaces/mamba2-780m` — 48 Mamba2 layers, `attn_layer_idx: []`,
+zero attention: the pure case that must encode with no attention surface
+anywhere; `state-spaces/mamba2attn-2.7b` — six attention layers at
+declared indices among Mamba2 blocks: the A/B proving surfaces exist
+only where the declared program uses them, and that KV and SSM state
+coexist per-operation; then `tiiuae/Falcon3-Mamba-7B-Instruct` as the
+product-scale witness. Kimi-Linear remains the three-state hybrid
+witness for the ContinuationState half.
+
 ---
 
 ## 18. Operations, observation, and the independent reader
@@ -1154,8 +1191,9 @@ The guarantees that make transformations provable rather than asserted:
   is stamped `derived`, never `canonical`.
 - **COMPACT identity.** `COMPACT` reorganises physical storage and MUST
   preserve semantic identity — same graph, same effective values, same
-  answers; it MUST NOT discard container contents it does not understand
-  (§5.7).
+  answers. It carries byte-identically what it cannot decode, and it
+  discards unreferenced files only as named entries in its report —
+  silent discard is forbidden (§5.7).
 
 ---
 

--- a/crates/larql-vindex/src/format/vindex3/compile/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/compile/tests/mod.rs
@@ -142,3 +142,36 @@ fn bake_refuses_non_f32_edited_tensors() {
     assert!(err.to_string().contains("BF16"), "{err}");
     assert!(err.to_string().contains("representation-policy"), "{err}");
 }
+
+/// Drill finding F13: a field this build does not understand must
+/// survive the bake (candidate spec §5.7 — a rewriter MUST NOT drop
+/// what it cannot interpret). COMPACT preserves by carrying the file
+/// byte-identically; the bake rewrites the index, so preservation must
+/// be structural.
+#[test]
+fn bake_preserves_unknown_index_fields() {
+    use crate::format::filenames::INDEX_JSON;
+
+    let (container, plan, _store) = fixture();
+    let (overrides, _gate) = gate_edit(&plan);
+
+    // A future 3.x writer added vocabulary this build has never seen.
+    let index_path = container.path().join(INDEX_JSON);
+    let mut raw: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&index_path).unwrap()).unwrap();
+    raw["residency_contract"] = serde_json::json!({ "access_class": "demand_driven" });
+    std::fs::write(&index_path, serde_json::to_string_pretty(&raw).unwrap()).unwrap();
+
+    let out = tempfile::tempdir().unwrap();
+    bake_container(container.path(), &overrides, out.path()).unwrap();
+
+    let baked: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.path().join(INDEX_JSON)).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        baked["residency_contract"]["access_class"],
+        serde_json::json!("demand_driven"),
+        "an unknown index field must survive the bake, not be dropped by the struct round-trip"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/encode/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/encode/mod.rs
@@ -34,7 +34,7 @@ use std::path::{Path, PathBuf};
 
 use larql_models::inventory::ArchitectureInventory;
 
-use super::graph::{most_specific_owner, ComponentRole, LogicalObject, SystemGraph};
+use super::graph::{most_specific_owner, LogicalObject, SystemGraph};
 use super::index::{RepresentationEntry, Vindex3Index};
 use super::plan::plan_system;
 use crate::error::VindexError;
@@ -324,12 +324,16 @@ fn system_index(
     representations: BTreeMap<String, RepresentationEntry>,
     segments: BTreeMap<String, u32>,
 ) -> Result<Vindex3Index, VindexError> {
-    let primary = graph
-        .components
-        .iter()
-        .find(|c| c.role == ComponentRole::PrimaryText)
-        .or_else(|| graph.components.first())
-        .ok_or_else(|| VindexError::Parse("graph has no components".into()))?;
+    let primary = match graph.primary_text_component() {
+        Ok(component) => component,
+        // A graph with no primary_text (a lone drafter, say) falls back to
+        // its only component; ambiguity never falls back (drill F10).
+        Err(crate::format::vindex3::graph::PrimaryTextLookup::Absent) => graph
+            .components
+            .first()
+            .ok_or_else(|| VindexError::Parse("graph has no components".into()))?,
+        Err(ambiguous) => return Err(VindexError::Parse(ambiguous.to_string())),
+    };
     let family = named
         .iter()
         .find(|(name, _)| *name == primary.source_artifact)

--- a/crates/larql-vindex/src/format/vindex3/graph/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/mod.rs
@@ -121,7 +121,54 @@ pub enum GraphDefect {
     ObjectUnbound(String),
 }
 
+/// Why [`SystemGraph::primary_text_component`] could not answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrimaryTextLookup {
+    /// No component carries the role.
+    Absent,
+    /// More than one does. First-match selection is exactly how two
+    /// text-shaped components go quietly wrong (ontology drill F10), so
+    /// ambiguity names the candidates and refuses — it is never resolved
+    /// by position.
+    Ambiguous(Vec<String>),
+}
+
+impl std::fmt::Display for PrimaryTextLookup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Absent => write!(f, "graph has no primary_text component"),
+            Self::Ambiguous(ids) => write!(
+                f,
+                "expected exactly one primary_text component; found {}: {} — refusing to pick the first",
+                ids.len(),
+                ids.join(", ")
+            ),
+        }
+    }
+}
+
 impl SystemGraph {
+    /// The unique primary-text component.
+    ///
+    /// The only sanctioned way to answer "the text model": callers that
+    /// used `find(role == PrimaryText)` got first-match semantics, which
+    /// is quiet wrongness the day a second text-shaped component exists.
+    pub fn primary_text_component(&self) -> Result<&Component, PrimaryTextLookup> {
+        let mut primaries = self
+            .components
+            .iter()
+            .filter(|c| c.role == crate::format::vindex3::graph::component::ComponentRole::PrimaryText);
+        match (primaries.next(), primaries.next()) {
+            (Some(only), None) => Ok(only),
+            (None, _) => Err(PrimaryTextLookup::Absent),
+            (Some(first), Some(second)) => {
+                let mut ids = vec![first.id.clone(), second.id.clone()];
+                ids.extend(primaries.map(|c| c.id.clone()));
+                Err(PrimaryTextLookup::Ambiguous(ids))
+            }
+        }
+    }
+
     /// Structural validation: ids unique, every reference resolvable,
     /// every object physically bound.
     pub fn validate(&self) -> Vec<GraphDefect> {

--- a/crates/larql-vindex/src/format/vindex3/graph/tests/validate.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/tests/validate.rs
@@ -156,3 +156,52 @@ fn graph_round_trips_through_json_with_nope_policies() {
     );
     assert_eq!(back.edges, graph.edges);
 }
+
+/// Drill finding F10: "the text model" is answered by uniqueness, never
+/// by first match — ambiguity names the candidates and refuses.
+#[test]
+fn primary_text_resolution_is_unique_or_refused() {
+    use crate::format::vindex3::graph::PrimaryTextLookup;
+
+    // Exactly one primary: resolved.
+    let graph = valid_graph();
+    assert_eq!(
+        graph.primary_text_component().unwrap().id,
+        "target",
+        "a unique primary_text component resolves"
+    );
+
+    // None: absent, distinctly from ambiguous (encode's drafter-only
+    // fallback depends on the distinction).
+    let none = SystemGraph {
+        schema: GRAPH_SCHEMA,
+        components: vec![component("draft", ComponentRole::Drafter, 2)],
+        objects: vec![],
+        edges: vec![],
+    };
+    assert_eq!(
+        none.primary_text_component().unwrap_err(),
+        PrimaryTextLookup::Absent
+    );
+
+    // Two: refused, naming both candidates — never first-wins.
+    let two = SystemGraph {
+        schema: GRAPH_SCHEMA,
+        components: vec![
+            component("target", ComponentRole::PrimaryText, 8),
+            component("second_text", ComponentRole::PrimaryText, 4),
+        ],
+        objects: vec![],
+        edges: vec![],
+    };
+    let err = two.primary_text_component().unwrap_err();
+    assert_eq!(
+        err,
+        PrimaryTextLookup::Ambiguous(vec!["target".to_string(), "second_text".to_string()])
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains("exactly one") && message.contains("target") && message.contains("second_text"),
+        "the refusal names the candidates: {message}"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/index.rs
+++ b/crates/larql-vindex/src/format/vindex3/index.rs
@@ -182,6 +182,17 @@ pub struct Vindex3Index {
     /// is what an operator needs to find the authority again.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub derived_from_model: Option<String>,
+    /// Fields this build does not understand, carried verbatim.
+    ///
+    /// The compatibility rules (candidate spec §5.7) bind the writer, not
+    /// just the reader: additive 3.x vocabulary must survive a rewrite.
+    /// Ontology-drill finding F13 was exactly this loss — COMPILE
+    /// round-tripped the index through this struct and dropped newer
+    /// fields, while COMPACT (which carries the file byte-identically)
+    /// preserved them. The flatten map closes that asymmetry for every
+    /// struct round-trip at once.
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
 }
 
 fn is_canonical(a: &ContainerAuthority) -> bool {
@@ -213,6 +224,7 @@ impl Vindex3Index {
             authority: ContainerAuthority::Canonical,
             precision_map: None,
             derived_from_model: None,
+            extra: BTreeMap::new(),
         }
     }
 

--- a/crates/larql-vindex/src/format/vindex3/plan/capability.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/capability.rs
@@ -277,12 +277,13 @@ fn outside_closure(capability: Capability, finding: &Finding, graph: &SystemGrap
     }
 }
 
-/// The primary text component, when the graph has one.
+/// The primary text component, when the graph has exactly one.
+///
+/// Ambiguity resolves to `None`, never to the first match (drill F10):
+/// grading capabilities against an arbitrarily chosen text component
+/// would be quiet wrongness; absence downgrades visibly instead.
 fn text_component(graph: &SystemGraph) -> Option<&Component> {
-    graph
-        .components
-        .iter()
-        .find(|c| c.role == ComponentRole::PrimaryText)
+    graph.primary_text_component().ok()
 }
 
 /// Admissibility of one capability: does anything it depends on block?

--- a/crates/larql-vindex/src/format/vindex3/plan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/mod.rs
@@ -416,14 +416,11 @@ fn component_for_key<'a>(built: &'a BuiltGraph, component_name: &str) -> Option<
         .iter()
         .find(|c| c.id == component_name)
         .or_else(|| {
+            // The aliases resolve only when the primary is unique —
+            // ambiguity yields no component rather than the first one
+            // (drill F10).
             (component_name == ROOT || component_name == TEXT)
-                .then(|| {
-                    built
-                        .graph
-                        .components
-                        .iter()
-                        .find(|c| c.role == ComponentRole::PrimaryText)
-                })
+                .then(|| built.graph.primary_text_component().ok())
                 .flatten()
         })
 }

--- a/docs/vindex3-ontology-drill.md
+++ b/docs/vindex3-ontology-drill.md
@@ -289,11 +289,11 @@ amend §5.7 to "discard only with report".
 | F7 | `AttentionLayerPolicy.operator` `serde(default)` = Softmax — absence silently reinterprets | **schema gap** (silent default) | explicit operator at schema 6 |
 | F8 | `plan_kv_geometry` panics on recurrent layers; two production callers (LQL STATS, EXPLAIN) | defect | migrate callers to `plan_continuation_geometry` |
 | F9 | KDA/MLA execution is a family-shaped, test-only loader bypassing plan/roles; plan path refuses honestly | implementation gap | plan-driven KDA/MLA executor; not a freeze blocker |
-| F10 | Six `find(PrimaryText)` first-match sites — quiet wrongness when two text components exist | defect | uniqueness assertions now; role algebra post-3.0 |
+| F10 | `find(PrimaryText)` first-match sites — quiet wrongness when two text components exist (three of the six reported sites were already plural-safe `filter`s) | defect — **closed** | `SystemGraph::primary_text_component`: unique or refused naming the candidates; encode errors on ambiguity, capability/alias resolution yields none rather than first |
 | F11 | One edge species; producer must be PrimaryText; consumer hard-coded FeatureProjector; two producers refuses | scope decision | declare the 3.0 component algebra; typed edge kinds post-3.0 |
 | F12 | Closed graph enums + exact-schema refusal: every vocabulary addition is wire-breaking + re-encode | posture decision | spec must state the graph's strict-versioning posture explicitly |
-| F13 | COMPILE drops unknown `index.json` fields (struct round-trip); COMPACT preserves them | defect vs §5.7 | preserve-on-rewrite in COMPILE |
-| F14 | COMPACT collects unregistered sidecar files (reported, not silent) | defect vs §5.7 wording | reconcile: extend preservation or amend §5.7 |
+| F13 | COMPILE drops unknown `index.json` fields (struct round-trip); COMPACT preserves them | defect vs §5.7 — **closed** | flattened preservation map on `Vindex3Index`; every struct round-trip now carries unknown fields; gated by `bake_preserves_unknown_index_fields` |
+| F14 | COMPACT collects unregistered sidecar files (reported, not silent) | defect vs §5.7 wording — **closed** | §5.7 amended: reported discard of unreferenced files is sanctioned; silent discard forbidden |
 | F15 | Per-expert permutation has no serialisable home; `ProjectionAddressing` deliberately runtime-only | additive-safe (missing vocab) | optional permutation field, 3.x |
 | F16 | `OperandRole` append-only, exact-suffix, fail-closed; codec fallthroughs all named refusals; COMPACT byte-blind | held | the healthy core the freeze protects |
 
@@ -329,3 +329,22 @@ enumerated**. The freeze checklist after this drill:
 
 Nothing on that list is a discovery about *what VINDEX3 is*. That
 question did not flinch.
+
+For the 3.0 release history, the drill's one-sentence result:
+
+> **The ontology drill found defects in how VINDEX3 expressed two
+> already-known abstractions; it found no missing abstraction required
+> to describe the four hostile architectures.**
+
+## Closure log
+
+- **2026-08-30, same day:** F13 closed (flattened preservation map on
+  `Vindex3Index`, gated by `bake_preserves_unknown_index_fields`); F14
+  closed (§5.7 amended to reported-discard); F10 closed
+  (`SystemGraph::primary_text_component` — unique or refused naming the
+  candidates; three of the six reported sites were already plural-safe
+  `filter`s). The schema-6 delta was defined once, in §17.4 of the
+  candidate, with the severe acceptance rule and real validation
+  witnesses: `mamba2-780m` (pure SSM), `mamba2attn-2.7b` (the
+  surfaces-follow-program A/B), `Falcon3-Mamba-7B-Instruct`
+  (product-scale), Kimi-Linear (three-state hybrid).


### PR DESCRIPTION
Closes the three immediately-closable ontology-drill findings and pins the complete schema-6 semantic delta in one place, per the freeze discipline: one intentional break, one re-encode, both lifts together.

- **F13 (preservation on rewrite):** `Vindex3Index` gains a `#[serde(flatten)]` preservation map — unknown 3.x fields survive the bake and every other struct round-trip. Test: `bake_preserves_unknown_index_fields`.
- **F14 (§5.7 ↔ COMPACT):** spec reconciled to reported-discard semantics; silent discard forbidden.
- **F10 (first-match text component):** `SystemGraph::primary_text_component` — unique, or refused naming the candidates (`expected exactly one primary_text component; found 2: …`). Encode errors on ambiguity; capability grading and the root/text aliases resolve to none rather than first. Three of the six reported sites were already plural-safe filters.
- **Schema-6 delta (§17.4):** operation-program-derived surfaces, attention-absent-when-absent, ContinuationState declarations (KDA precision, MLA latent-KV, the F6 epsilon), explicit per-layer operator, fail-closed census, closure at encode — with the severe acceptance rule and named validation witnesses (mamba2-780m, mamba2attn-2.7b, Falcon3-Mamba-7B-Instruct, Kimi-Linear).

Gates: `cargo test -p larql-vindex --lib` 3354 passed · dependents check · clippy clean.