### PR TITLE
fix(models): judged non-finite config boundary — witness finding zero closed

### DIFF
--- a/crates/larql-models/src/config/mod.rs
+++ b/crates/larql-models/src/config/mod.rs
@@ -30,6 +30,7 @@ pub mod linear_attn;
 pub mod mla;
 pub mod model_config;
 pub mod moe_router;
+pub mod nonfinite_json;
 pub mod norm;
 pub mod position;
 pub mod rope;

--- a/crates/larql-models/src/config/nonfinite_json.rs
+++ b/crates/larql-models/src/config/nonfinite_json.rs
@@ -1,0 +1,130 @@
+//! The judged non-finite boundary for `config.json`.
+//!
+//! Python's `json.dumps` writes non-finite floats as the bare literals
+//! `Infinity`, `-Infinity` and `NaN` (`allow_nan` defaults on), and the
+//! HF ecosystem ships them — `transformers` wrote
+//! `"time_step_limit": [0.0, Infinity]` into `mamba2-780m-hf`'s config,
+//! which RFC 8259 has no spelling for and a strict parser rightly
+//! refuses (ontology drill, "the first live witness", finding zero).
+//!
+//! The judgment, made here and nowhere else (the `PositionPolicy`
+//! zero-theta discipline): a non-finite literal is preserved as the
+//! **string it spells** — `Infinity` becomes `"Infinity"` — never
+//! impersonated by a large float, because a fabricated value wearing a
+//! number is exactly the class of quiet lie the format refuses. A
+//! consumer that judges such a key handles the string deliberately; an
+//! unconsumed key carries it to the registry as the declaration it was.
+//!
+//! The strict parse runs first: a conforming config never pays for the
+//! scan, and the rewrite is attempted only after strict refusal.
+
+/// Parse a checkpoint `config.json`, tolerating Python's bare
+/// non-finite literals by quoting them (see module doc).
+pub fn parse_config_json(text: &str) -> serde_json::Result<serde_json::Value> {
+    match serde_json::from_str(text) {
+        Ok(value) => Ok(value),
+        Err(strict_error) => match quote_nonfinite_literals(text) {
+            Some(rewritten) => serde_json::from_str(&rewritten),
+            None => Err(strict_error),
+        },
+    }
+}
+
+/// Quote bare `Infinity` / `-Infinity` / `NaN` outside strings.
+///
+/// Returns `None` when the text contains none (so the caller keeps the
+/// strict parser's own error for genuinely malformed JSON).
+fn quote_nonfinite_literals(text: &str) -> Option<String> {
+    const TOKENS: &[&str] = &["-Infinity", "Infinity", "NaN"];
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len() + 16);
+    let mut i = 0;
+    let mut in_string = false;
+    let mut changed = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if in_string {
+            out.push(b as char);
+            if b == b'\\' && i + 1 < bytes.len() {
+                out.push(bytes[i + 1] as char);
+                i += 2;
+                continue;
+            }
+            if b == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if b == b'"' {
+            in_string = true;
+            out.push('"');
+            i += 1;
+            continue;
+        }
+        let matched = TOKENS.iter().find(|token| {
+            let end = i + token.len();
+            bytes[i..].starts_with(token.as_bytes())
+                && bytes
+                    .get(end)
+                    .is_none_or(|next| !next.is_ascii_alphanumeric() && *next != b'_')
+        });
+        if let Some(token) = matched {
+            out.push('"');
+            out.push_str(token);
+            out.push('"');
+            i += token.len();
+            changed = true;
+            continue;
+        }
+        out.push(b as char);
+        i += 1;
+    }
+    changed.then_some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_config_json;
+
+    #[test]
+    fn strict_json_passes_through_untouched() {
+        let value = parse_config_json(r#"{"a": 1.5, "b": "Infinity in a string"}"#).unwrap();
+        assert_eq!(value["a"], serde_json::json!(1.5));
+        assert_eq!(value["b"], serde_json::json!("Infinity in a string"));
+    }
+
+    #[test]
+    fn the_mamba2_shape_parses_with_the_literal_preserved_as_a_string() {
+        // The live witness's exact shape: transformers' allow_nan output.
+        let value =
+            parse_config_json(r#"{"time_step_limit": [0.0, Infinity], "model_type": "mamba2"}"#)
+                .unwrap();
+        assert_eq!(
+            value["time_step_limit"],
+            serde_json::json!([0.0, "Infinity"]),
+            "the declaration is preserved as the string it spells, never a fabricated float"
+        );
+        assert_eq!(value["model_type"], serde_json::json!("mamba2"));
+    }
+
+    #[test]
+    fn negative_infinity_and_nan_quote_as_whole_tokens() {
+        let value = parse_config_json(r#"{"lo": -Infinity, "x": NaN}"#).unwrap();
+        assert_eq!(value["lo"], serde_json::json!("-Infinity"));
+        assert_eq!(value["x"], serde_json::json!("NaN"));
+    }
+
+    #[test]
+    fn genuinely_malformed_json_keeps_the_strict_error() {
+        // No non-finite literal to rescue: the strict parser's own error
+        // must survive, not a second confusing one from a no-op rewrite.
+        assert!(parse_config_json(r#"{"a": }"#).is_err());
+    }
+
+    #[test]
+    fn identifier_prefixes_do_not_match() {
+        // `NaNite` is not `NaN`; a key-adjacent word must not be quoted.
+        assert!(parse_config_json(r#"{"a": NaNite}"#).is_err());
+    }
+}

--- a/crates/larql-models/src/detect/config_io.rs
+++ b/crates/larql-models/src/detect/config_io.rs
@@ -81,7 +81,9 @@ pub(super) fn read_config_json(config_path: &Path) -> Result<serde_json::Value, 
         return Err(ModelError::ConfigMissing(config_path.to_path_buf()));
     }
     let text = std::fs::read_to_string(config_path)?;
-    Ok(serde_json::from_str::<serde_json::Value>(&text)?)
+    // The judged non-finite boundary (config::nonfinite_json): bare
+    // Python `Infinity`/`NaN` literals parse as the strings they spell.
+    Ok(crate::config::nonfinite_json::parse_config_json(&text)?)
 }
 
 /// Fail loudly when a parsed config is missing any field whose silent

--- a/crates/larql-models/src/inventory/mod.rs
+++ b/crates/larql-models/src/inventory/mod.rs
@@ -57,7 +57,10 @@ pub fn build_inventory(model_dir: &Path) -> Result<ArchitectureInventory, ModelE
         return Err(ModelError::ConfigMissing(config_path));
     }
     let text = std::fs::read_to_string(&config_path)?;
-    let config: serde_json::Value = serde_json::from_str(&text)?;
+    // The judged non-finite boundary: HF configs carry Python's bare
+    // `Infinity`/`NaN` literals; they parse here as the strings they
+    // spell, and nowhere else (config::nonfinite_json).
+    let config: serde_json::Value = crate::config::nonfinite_json::parse_config_json(&text)?;
 
     let identity = resolved::read_identity(&config);
     let (detection, topology) = resolved::resolve(&config, &identity);

--- a/docs/vindex3-ontology-drill.md
+++ b/docs/vindex3-ontology-drill.md
@@ -374,6 +374,16 @@ conversion of `state-spaces/mamba2-780m`; the original repos ship
 
 ## Closure log
 
+- **2026-08-30, finding zero closed:** the judged non-finite boundary
+  (`larql-models/src/config/nonfinite_json.rs`) — both config-parse
+  sites now route through one function that quotes Python's bare
+  `Infinity`/`-Infinity`/`NaN` literals as the strings they spell,
+  never impersonating them with a fabricated float; strict JSON pays
+  nothing, genuinely malformed JSON keeps the strict error. The raw
+  witness stub parses and produces the identical 19-blocking verdict,
+  with `time_step_limit` declared as `[0.0, "Infinity"]` in the
+  findings.
+
 - **2026-08-30, same day:** F13 closed (flattened preservation map on
   `Vindex3Index`, gated by `bake_preserves_unknown_index_fields`); F14
   closed (§5.7 amended to reported-discard); F10 closed


### PR DESCRIPTION
Closes finding zero from the first live witness: HF configs carrying Python's bare `Infinity`/`-Infinity`/`NaN` literals now parse at exactly one judged boundary (`config::nonfinite_json`), preserving each literal as the string it spells — never impersonated by a fabricated float. Strict JSON pays nothing; malformed JSON keeps the strict error; identifier prefixes don't match.

Proof: the raw (unpatched) `mamba2-780m-hf` stub parses and refuses with the identical 19-blocking verdict, `time_step_limit` declared as `[0.0, "Infinity"]`. Drill closure log updated.

Gates: larql-models 728+ tests green, clippy clean, larql-cli builds.