### PR TITLE
REPRESENT: composed-map precision search — first earned composed topology (Kimi L24-26 @ Q8_0)

### DIFF
--- a/crates/larql-compute-metal/src/kernels/quant.rs
+++ b/crates/larql-compute-metal/src/kernels/quant.rs
@@ -68,6 +68,9 @@ pub struct QuantKernels {
     pub q6k_grouped_experts_pipeline: KernelHandle,
     /// Q4_K sibling — what the engine's MoE down projection needs.
     pub q4k_grouped_experts_pipeline: KernelHandle,
+    /// Q8_0 sibling — the precision ladder's middle rung (8.5 bpw),
+    /// canonical ggml 34-byte blocks. Same grouped ABI as the other two.
+    pub q8_0_grouped_experts_pipeline: KernelHandle,
 
     /// K2 layout/decode tournament: four MXFP4 grouped-expert arms that read
     /// the same weights through different scale layouts and decode strategies.
@@ -209,6 +212,8 @@ impl QuantKernels {
             h::<shaders::q6k_grouped_experts::Kernel>(device, library);
         let q4k_grouped_experts_pipeline =
             h::<shaders::q4k_grouped_experts::Kernel>(device, library);
+        let q8_0_grouped_experts_pipeline =
+            h::<shaders::q8_0_grouped_experts::Kernel>(device, library);
 
         let mxfp4g_split_lut16_pipeline =
             h::<shaders::mxfp4_grouped_experts::KernelSplitLut16>(device, library);
@@ -285,6 +290,7 @@ impl QuantKernels {
             nvfp4_matvec_x2m_pipeline,
             q6k_grouped_experts_pipeline,
             q4k_grouped_experts_pipeline,
+            q8_0_grouped_experts_pipeline,
             mxfp4g_split_lut16_pipeline,
             mxfp4g_split_lut16_vec_pipeline,
             mxfp4g_inter_lut16_pipeline,

--- a/crates/larql-compute-metal/src/shaders/mod.rs
+++ b/crates/larql-compute-metal/src/shaders/mod.rs
@@ -67,6 +67,7 @@ pub mod q6k_geglu_gelu_tanh_down_cached;
 pub mod q6k_grouped_experts;
 pub mod q6k_matvec;
 pub mod q6k_matvec_8sg;
+pub mod q8_0_grouped_experts;
 pub mod q8_attn_proj;
 pub mod q8_matvec;
 pub mod qk_norm;
@@ -133,6 +134,7 @@ pub fn all_shaders() -> String {
     src.push_str(&mxfp4_grouped_experts::shader());
     src.push_str(q6k_grouped_experts::SHADER);
     src.push_str(q4k_grouped_experts::SHADER);
+    src.push_str(q8_0_grouped_experts::SHADER);
     src.push_str(q4k_matvec::SHADER);
     src.push_str(q4k_matvec_8sg::SHADER);
     src.push_str(q4k_matvec_stride32::SHADER);

--- a/crates/larql-compute-metal/src/shaders/q8_0_grouped_experts.rs
+++ b/crates/larql-compute-metal/src/shaders/q8_0_grouped_experts.rs
@@ -1,0 +1,83 @@
+//! Q8_0 grouped-expert matvec — all selected experts in ONE dispatch.
+//!
+//! The precision ladder's middle rung: canonical ggml Q8_0 (34 bytes per
+//! 32-element block — little-endian f16 scale + 32 signed int8), 8.5 bpw
+//! against BF16's 16 and Q6_K's 6.5625. It exists because the depth sweep
+//! placed the strict whole-layer Q6_K boundary at the FINAL MoE layer
+//! only; the open question is how much of the stack an ~8-bit
+//! representation admits under the same frozen contract, and that
+//! question cannot be asked until the grouped path can execute one.
+//!
+//! Same ABI as `q6k_grouped_experts` — bank + byte-offset table + shared
+//! or per-slot X — so `grouped_handle_for` selects it as a handle swap,
+//! never a different lowering. Grid, tiling and output layout are
+//! identical: `(row_tiles, n_selected)`, one simdgroup per output row,
+//! `out[slot * N + row]`.
+//!
+//! Unlike Q4/Q6 there is no nibble unpacking: each weight is one byte,
+//! decoded as `d * q`. Lanes stride the row's blocks; each lane decodes
+//! its block's scale once and accumulates the 32-element sub-dot in f32.
+
+/// Output rows per threadgroup — one simdgroup each, matching the other
+/// grouped kernels so occupancy comparisons stay like-for-like.
+pub const ROWS_PER_TG: u64 = 4;
+pub const THREADS_PER_TG: u64 = 128;
+
+pub const SHADER: &str = r#"
+constant uint Q80G_ROWS_PER_TG = 4;
+// Canonical ggml Q8_0: f16 scale (2 bytes) + 32 int8 quants.
+constant uint Q80G_BLOCK_BYTES = 34;
+
+kernel void q8_0_grouped_experts(
+    device const uchar*  W8      [[buffer(0)]],  // all expert payloads
+    device const uint*   offsets [[buffer(1)]],  // [n_sel] byte offset per slot
+    device const float*  X       [[buffer(2)]],  // shared [K], or [n_sel, K]
+    device float*        out     [[buffer(3)]],  // [n_sel, N] per-expert outputs
+    constant uint&       N       [[buffer(4)]],
+    constant uint&       K       [[buffer(5)]],
+    // 0 = every slot reads the same X (gate/up: one hidden state for all
+    // experts). K = each slot reads its own X (down: each expert consumes
+    // its OWN intermediate activation). Explicit for the same reason as
+    // the Q6_K sibling: getting it wrong silently computes the wrong
+    // expert's product.
+    constant uint&       XSTRIDE [[buffer(6)]],
+    uint2 tg_id    [[threadgroup_position_in_grid]],
+    uint  lane     [[thread_index_in_simdgroup]],
+    uint  sg_id    [[simdgroup_index_in_threadgroup]])
+{
+    // tg_id.y selects the expert slot; tg_id.x the row tile within it.
+    const uint slot    = tg_id.y;
+    const uint row_idx = tg_id.x * Q80G_ROWS_PER_TG + sg_id;
+    if (row_idx >= N) { return; }
+
+    const uint blocks        = K / 32u;
+    const uint bytes_per_row = blocks * Q80G_BLOCK_BYTES;
+    device const uchar* row = W8 + offsets[slot] + row_idx * bytes_per_row;
+    device const float* Xs  = X + (ulong)slot * XSTRIDE;
+
+    float acc = 0.0f;
+    for (uint b = lane; b < blocks; b += 32u) {
+        device const uchar* blk = row + b * Q80G_BLOCK_BYTES;
+        ushort d_bits = ushort(blk[0]) | (ushort(blk[1]) << 8u);
+        float  d = decode_f16_metal(d_bits);
+        device const char* q = (device const char*)(blk + 2u);
+        const uint xb = b * 32u;
+        float sum = 0.0f;
+        for (uint j = 0u; j < 32u; ++j) {
+            sum += float(q[j]) * Xs[xb + j];
+        }
+        acc += d * sum;
+    }
+
+    acc = simd_sum(acc);
+    if (lane == 0u) { out[slot * N + row_idx] = acc; }
+}
+"#;
+
+/// Marker for the kernel-handle binding. See `metal::kernel::TiledKernel`.
+pub struct Kernel;
+impl crate::kernels::TiledKernel for Kernel {
+    const KERNEL_NAME: &'static str = "q8_0_grouped_experts";
+    const ROWS_PER_TG: u64 = ROWS_PER_TG;
+    const THREADS_PER_TG: u64 = THREADS_PER_TG;
+}

--- a/crates/larql-compute-metal/src/trait_impl/kda/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kda/mod.rs
@@ -37,11 +37,10 @@ use metal::{Buffer, ComputeCommandEncoderRef, MTLSize};
 
 use super::bf16_grouped::{encode_grouped, GroupedBinding, GroupedShape};
 use super::grouped_experts::{ExpertOffset, GroupedError, InputLayout};
+use super::kimi_layer::ExpertEncoding;
 use crate::shaders::kda as kda_shader;
 use crate::MetalBackend;
 
-/// Bytes per bf16 code.
-const BF16_BYTES: usize = 2;
 /// `o_proj` is one slot at offset zero. A `static` so its address is
 /// stable and the device table can be cached rather than rebuilt.
 static O_PROJ_SINGLE_SLOT: [ExpertOffset; 1] = [ExpertOffset(0)];
@@ -80,8 +79,17 @@ pub struct KdaDeviceWeights<'a> {
     /// offset. One buffer because the grouped kernel binds one.
     pub qkv_bank: &'a [u8],
     pub qkv_offsets: &'a [ExpertOffset; CONV_STREAMS],
-    /// `[hidden, width]` bf16.
+    /// `[hidden, width]`, in the same encoding as `qkv_bank`.
     pub o_proj: &'a [u8],
+    /// Physical representation of `qkv_bank` and `o_proj` — the two
+    /// wide projections and NOTHING else. The convolutions, the low-rank
+    /// decay/output gates, `b_proj`, `A_log`, `dt_bias` and `o_norm`
+    /// stay f32 whatever this says: they are a few MB against ~75 MB a
+    /// layer, and they feed the numerically delicate recurrence, which
+    /// this rung deliberately does not touch. Dispatch selects the
+    /// grouped kernel by this value, so bytes can never pair with
+    /// another encoding's kernel.
+    pub projection_encoding: ExpertEncoding,
     /// `[width, conv_kernel]` each.
     pub q_conv1d: &'a [f32],
     pub k_conv1d: &'a [f32],
@@ -372,7 +380,13 @@ impl MetalBackend {
                 found: state.shape.width(),
             });
         }
-        let per_slot = width * hidden * BF16_BYTES;
+        // Bounds at the ENCODING's own stride — a bf16 validator run
+        // over a smaller quantised bank would over-demand and refuse
+        // valid banks; the reverse would under-demand and read past.
+        let per_slot = w
+            .projection_encoding
+            .matrix_bytes(width, hidden)
+            .ok_or(GroupedError::KNotSuperblockAligned { k: hidden })?;
         for (slot, off) in w.qkv_offsets.iter().enumerate() {
             if off.0 as usize + per_slot > w.qkv_bank.len() {
                 return Err(GroupedError::OffsetOutOfRange {
@@ -382,6 +396,20 @@ impl MetalBackend {
                     have: w.qkv_bank.len(),
                 });
             }
+        }
+        // o_proj transposes the reduction axis, so its stride is its
+        // own: `[hidden, width]` at k = width.
+        let o_bytes = w
+            .projection_encoding
+            .matrix_bytes(hidden, width)
+            .ok_or(GroupedError::KNotSuperblockAligned { k: width })?;
+        if w.o_proj.len() < o_bytes {
+            return Err(GroupedError::OffsetOutOfRange {
+                slot: 0,
+                offset: 0,
+                need: o_bytes,
+                have: w.o_proj.len(),
+            });
         }
 
         Ok(())
@@ -433,10 +461,13 @@ impl MetalBackend {
         let o_offsets = self.stable_offset_table(&O_PROJ_SINGLE_SLOT);
 
         // q|k|v — one grouped dispatch of three slots, all reading `x`.
+        // The handle follows the weights' encoding, same contract as
+        // `grouped_experts_encoded`: bytes can never pair with another
+        // encoding's kernel.
         let (qkv_w, qkv_w_off) = self.bufs().weights(w.qkv_bank);
         encode_grouped(
             enc,
-            self.default_grouped_handle(),
+            self.grouped_handle_for(w.projection_encoding),
             GroupedBinding {
                 w: &qkv_w,
                 w_offset: qkv_w_off,
@@ -522,7 +553,7 @@ impl MetalBackend {
         let (o_w, o_w_off) = self.bufs().weights(w.o_proj);
         encode_grouped(
             enc,
-            self.default_grouped_handle(),
+            self.grouped_handle_for(w.projection_encoding),
             GroupedBinding {
                 w: &o_w,
                 w_offset: o_w_off,

--- a/crates/larql-compute-metal/src/trait_impl/kda/tests.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kda/tests.rs
@@ -138,6 +138,7 @@ impl Weights {
             qkv_bank: &self.qkv_bank,
             qkv_offsets: &self.qkv_offsets,
             o_proj: &self.o_bytes,
+            projection_encoding: ExpertEncoding::Bf16,
             q_conv1d: &self.conv[0],
             k_conv1d: &self.conv[1],
             v_conv1d: &self.conv[2],
@@ -413,4 +414,217 @@ fn the_state_starts_at_zero_and_the_shape_derives_its_widths() {
         assert_eq!(c.len(), WIDTH * (KERNEL - 1));
         assert!(c.iter().all(|v| *v == 0.0), "conv window must start zero");
     }
+}
+
+// ── Q8_0 projections ────────────────────────────────────────────────
+//
+// Its own geometry because Q8_0 blocks are 32 codes wide: the file's
+// HIDDEN = 6 cannot legally encode at all (that impossibility is itself
+// asserted below). WIDTH = 32 keeps o_proj's reduction axis aligned
+// too, so both dispatches run the real quantised kernel.
+
+const Q8_HEADS: usize = 2;
+const Q8_DIM: usize = 16;
+const Q8_HIDDEN: usize = 64;
+const Q8_WIDTH: usize = Q8_HEADS * Q8_DIM;
+
+fn q8_shape() -> KdaShape {
+    KdaShape {
+        hidden: Q8_HIDDEN,
+        num_heads: Q8_HEADS,
+        head_dim: Q8_DIM,
+        conv_kernel: KERNEL,
+    }
+}
+
+/// Both arms' banks from ONE set of values: the bf16 arm binds the
+/// narrowed codes, the Q8_0 arm binds `quantize_q8_0` of the exact
+/// widened values of those same codes. The only difference between the
+/// arms is therefore the Q8_0 roundtrip itself — not a second RNG draw.
+struct DualBanks {
+    bf16_qkv: Vec<u8>,
+    bf16_offsets: [ExpertOffset; 3],
+    bf16_o: Vec<u8>,
+    q8_qkv: Vec<u8>,
+    q8_offsets: [ExpertOffset; 3],
+    q8_o: Vec<u8>,
+    f32s: Weights,
+}
+
+fn dual_banks() -> DualBanks {
+    let per = Q8_WIDTH * Q8_HIDDEN;
+    let (qb, qe) = bf16_matrix(Q8_WIDTH, Q8_HIDDEN, 0.1);
+    let (kb, ke) = bf16_matrix(Q8_WIDTH, Q8_HIDDEN, 1.3);
+    let (vb, ve) = bf16_matrix(Q8_WIDTH, Q8_HIDDEN, 2.7);
+    let (ob, oe) = bf16_matrix(Q8_HIDDEN, Q8_WIDTH, 3.9);
+    let mut bf16_qkv = Vec::with_capacity(3 * per * 2);
+    for b in [&qb, &kb, &vb] {
+        bf16_qkv.extend_from_slice(b);
+    }
+    let q8: Vec<Vec<u8>> = [&qe, &ke, &ve]
+        .iter()
+        .map(|e| larql_compute::cpu::ops::q4_common::quantize_q8_0(e))
+        .collect();
+    let q8_per = q8[0].len();
+    let mut q8_qkv = Vec::with_capacity(3 * q8_per);
+    for b in &q8 {
+        assert_eq!(b.len(), q8_per);
+        q8_qkv.extend_from_slice(b);
+    }
+    DualBanks {
+        bf16_qkv,
+        bf16_offsets: [
+            ExpertOffset(0),
+            ExpertOffset((per * 2) as u32),
+            ExpertOffset((2 * per * 2) as u32),
+        ],
+        bf16_o: ob,
+        q8_qkv,
+        q8_offsets: [
+            ExpertOffset(0),
+            ExpertOffset(q8_per as u32),
+            ExpertOffset((2 * q8_per) as u32),
+        ],
+        q8_o: larql_compute::cpu::ops::q4_common::quantize_q8_0(&oe),
+        f32s: Weights {
+            qkv_bank: Vec::new(),
+            qkv_offsets: [ExpertOffset(0); 3],
+            qkv_exact: [qe, ke, ve],
+            o_bytes: Vec::new(),
+            o_exact: oe,
+            conv: [
+                synth(Q8_WIDTH * KERNEL, 0.5),
+                synth(Q8_WIDTH * KERNEL, 1.5),
+                synth(Q8_WIDTH * KERNEL, 2.5),
+            ],
+            fa: synth(Q8_DIM * Q8_HIDDEN, 4.1),
+            fb: synth(Q8_WIDTH * Q8_DIM, 5.2),
+            ga: synth(Q8_DIM * Q8_HIDDEN, 6.3),
+            gb: synth(Q8_WIDTH * Q8_DIM, 7.4),
+            bp: synth(Q8_HEADS * Q8_HIDDEN, 8.5),
+            a_log: synth(Q8_HEADS, 9.6),
+            dt: synth(Q8_WIDTH, 10.7),
+            o_norm: synth(Q8_DIM, 11.8).iter().map(|v| v + 1.0).collect(),
+            eps: 1e-5,
+        },
+    }
+}
+
+impl DualBanks {
+    fn device(&self, encoding: ExpertEncoding) -> KdaDeviceWeights<'_> {
+        let f = &self.f32s;
+        let (bank, offsets, o): (&[u8], _, &[u8]) = match encoding {
+            ExpertEncoding::Bf16 => (&self.bf16_qkv, &self.bf16_offsets, &self.bf16_o),
+            _ => (&self.q8_qkv, &self.q8_offsets, &self.q8_o),
+        };
+        KdaDeviceWeights {
+            qkv_bank: bank,
+            qkv_offsets: offsets,
+            o_proj: o,
+            projection_encoding: encoding,
+            q_conv1d: &f.conv[0],
+            k_conv1d: &f.conv[1],
+            v_conv1d: &f.conv[2],
+            f_a_proj: &f.fa,
+            f_b_proj: &f.fb,
+            g_a_proj: &f.ga,
+            g_b_proj: &f.gb,
+            b_proj: &f.bp,
+            a_log: &f.a_log,
+            dt_bias: &f.dt,
+            o_norm: &f.o_norm,
+            norm_eps: f.eps,
+        }
+    }
+}
+
+/// Q8_0 projections through the real quantised grouped kernel track the
+/// bf16 step across a multi-token run, and the delta is NOT vacuous —
+/// the roundtrip genuinely changed the weights, so an exactly-equal
+/// output would mean the Q8_0 arm silently ran the bf16 kernel.
+///
+/// Multi-token matters here for the same reason it did for the delta
+/// rule: the recurrence carries the perturbation forward, so a token-0
+/// agreement alone would not show the state stays coherent under a
+/// quantised projection feeding it.
+#[test]
+fn q8_projections_track_the_bf16_step_across_tokens() {
+    let m = backend();
+    let banks = dual_banks();
+    let shape = q8_shape();
+    let s_bf16 = KdaDeviceState::zeros(&m, shape);
+    let s_q8 = KdaDeviceState::zeros(&m, shape);
+    let mut max_rel = 0.0f32;
+    for t in 0..4 {
+        let x = synth(Q8_HIDDEN, 0.3 + t as f32);
+        let (out_b, _) = m
+            .kda_attention_step(banks.device(ExpertEncoding::Bf16), shape, &s_bf16, &x)
+            .expect("bf16 arm runs");
+        let (out_q, _) = m
+            .kda_attention_step(banks.device(ExpertEncoding::Q80), shape, &s_q8, &x)
+            .expect("q8 arm runs");
+        let rms: f32 = (out_b.iter().map(|v| v * v).sum::<f32>() / out_b.len() as f32).sqrt();
+        let d_rms: f32 = (out_b
+            .iter()
+            .zip(&out_q)
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum::<f32>()
+            / out_b.len() as f32)
+            .sqrt();
+        let rel = d_rms / rms.max(f32::EPSILON);
+        max_rel = max_rel.max(rel);
+        assert!(
+            rel < 5e-2,
+            "token {t}: Q8_0 projections displaced the output by rel {rel} — that is \
+             quantisation of two projections, not a decode fault, and it should be \
+             orders under this bound"
+        );
+    }
+    assert!(
+        max_rel > 1e-6,
+        "the arms never separated: the Q8_0 dispatch is not actually reading \
+         quantised bytes"
+    );
+}
+
+/// Bounds are enforced at the ENCODING's own stride: a Q8_0 bank one
+/// byte short of three slots is refused by name, where the bf16
+/// validator's larger stride would have mis-blamed a healthy bank.
+#[test]
+fn q8_bank_bounds_are_checked_at_the_q8_stride() {
+    let m = backend();
+    let banks = dual_banks();
+    let shape = q8_shape();
+    let state = KdaDeviceState::zeros(&m, shape);
+    let mut w = banks.device(ExpertEncoding::Q80);
+    let truncated = &banks.q8_qkv[..banks.q8_qkv.len() - 1];
+    w.qkv_bank = truncated;
+    assert!(
+        matches!(
+            m.kda_attention_step(w, shape, &state, &synth(Q8_HIDDEN, 0.0)),
+            Err(GroupedError::OffsetOutOfRange { .. })
+        ),
+        "a truncated Q8_0 bank must be refused before the encoder opens"
+    );
+}
+
+/// A reduction axis that is not a whole number of Q8_0 blocks cannot be
+/// encoded, and the step says so rather than reading garbage: the
+/// file's own HIDDEN = 6 geometry is exactly such a shape.
+#[test]
+fn a_misaligned_reduction_axis_refuses_q8_by_name() {
+    let m = backend();
+    let w = weights();
+    let state = KdaDeviceState::zeros(&m, shape());
+    let device = KdaDeviceWeights {
+        projection_encoding: ExpertEncoding::Q80,
+        ..w.device()
+    };
+    assert!(
+        matches!(
+            m.kda_attention_step(device, shape(), &state, &synth(HIDDEN, 0.0)),
+            Err(GroupedError::KNotSuperblockAligned { k: HIDDEN })
+        ),
+        "k = {HIDDEN} is not a whole number of 32-wide blocks"
+    );
 }

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/ffn.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/ffn.rs
@@ -310,6 +310,86 @@ impl MetalBackend {
         bank.0
     }
 
+    /// One grouped dispatch under a NAMED encoding, end to end.
+    ///
+    /// The encoding-aware sibling of `bf16_grouped_experts`: bounds are
+    /// checked against the encoding's OWN per-expert stride (a Q8_0 bank
+    /// is smaller than the BF16 arithmetic it stands in for, so the BF16
+    /// validator would demand bytes that rightly do not exist), and the
+    /// handle comes from `grouped_handle_for`, so this cannot pair bytes
+    /// with another encoding's kernel. This is the direct gate for a
+    /// grouped kernel's decode: quantise a bank, dispatch, compare with
+    /// the CPU dequantised reference.
+    pub fn grouped_experts_encoded(
+        &self,
+        encoding: super::ExpertEncoding,
+        weights: &[u8],
+        offsets: &[ExpertOffset],
+        x: &[f32],
+        shape: GroupedShape,
+    ) -> Result<Vec<f32>, GroupedError> {
+        if offsets.is_empty() {
+            return Err(GroupedError::NoExpertsSelected);
+        }
+        let per_expert = encoding
+            .matrix_bytes(shape.n, shape.k)
+            .ok_or(GroupedError::KNotSuperblockAligned { k: shape.k })?;
+        for (slot, off) in offsets.iter().enumerate() {
+            let need = off.0 as usize + per_expert;
+            if need > weights.len() {
+                return Err(GroupedError::OffsetOutOfRange {
+                    slot,
+                    offset: off.0,
+                    need,
+                    have: weights.len(),
+                });
+            }
+        }
+        let x_needed = match shape.layout {
+            InputLayout::Shared => shape.k,
+            InputLayout::PerSlot => shape.k * offsets.len(),
+        };
+        if x.len() < x_needed {
+            return Err(GroupedError::OffsetOutOfRange {
+                slot: 0,
+                offset: 0,
+                need: x_needed,
+                have: x.len(),
+            });
+        }
+
+        let (buf_w, w_offset) = self.bufs().weights(weights);
+        let buf_o = self.offset_table(offsets);
+        let buf_x = self.bufs().transient_from_f32(&x[..x_needed]);
+        let buf_out = self.bufs().output((offsets.len() * shape.n * 4) as u64);
+
+        let cmd = self.queue().new_command_buffer();
+        let enc = cmd.new_compute_command_encoder();
+        encode_grouped(
+            enc,
+            self.grouped_handle_for(encoding),
+            GroupedBinding {
+                w: &buf_w,
+                w_offset,
+                offsets: &buf_o,
+                x: &buf_x,
+                out: &buf_out,
+            },
+            offsets.len(),
+            shape,
+        );
+        enc.end_encoding();
+        cmd.commit();
+        let _ = crate::cb_status::wait_checked(
+            cmd,
+            "crates/larql-compute-metal/src/trait_impl/kimi_layer/ffn.rs:encoded",
+        );
+        Ok(crate::buffers::read_buffer_f32(
+            &buf_out,
+            offsets.len() * shape.n,
+        ))
+    }
+
     /// The grouped kernel that reads this encoding.
     ///
     /// All three share one binding ABI, so this is a handle swap and
@@ -317,6 +397,7 @@ impl MetalBackend {
     fn grouped_handle_for(&self, encoding: super::ExpertEncoding) -> &crate::kernels::KernelHandle {
         match encoding {
             super::ExpertEncoding::Bf16 => self.default_grouped_handle(),
+            super::ExpertEncoding::Q80 => &self.quant.q8_0_grouped_experts_pipeline,
             super::ExpertEncoding::Q6K => &self.quant.q6k_grouped_experts_pipeline,
             super::ExpertEncoding::Q4K => &self.quant.q4k_grouped_experts_pipeline,
         }

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/ffn.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/ffn.rs
@@ -394,7 +394,10 @@ impl MetalBackend {
     ///
     /// All three share one binding ABI, so this is a handle swap and
     /// never a different lowering.
-    fn grouped_handle_for(&self, encoding: super::ExpertEncoding) -> &crate::kernels::KernelHandle {
+    pub(crate) fn grouped_handle_for(
+        &self,
+        encoding: super::ExpertEncoding,
+    ) -> &crate::kernels::KernelHandle {
         match encoding {
             super::ExpertEncoding::Bf16 => self.default_grouped_handle(),
             super::ExpertEncoding::Q80 => &self.quant.q8_0_grouped_experts_pipeline,

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/mod.rs
@@ -121,6 +121,9 @@ pub struct ProjectionBank<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExpertEncoding {
     Bf16,
+    /// Canonical ggml Q8_0: 34-byte blocks of 32 (f16 scale + 32 int8),
+    /// 8.5 bpw — the precision ladder's rung between BF16 and Q6_K.
+    Q80,
     Q6K,
     Q4K,
 }
@@ -129,6 +132,7 @@ impl ExpertEncoding {
     pub fn name(self) -> &'static str {
         match self {
             ExpertEncoding::Bf16 => "BF16",
+            ExpertEncoding::Q80 => "Q8_0",
             ExpertEncoding::Q6K => "Q6_K",
             ExpertEncoding::Q4K => "Q4_K",
         }
@@ -139,6 +143,7 @@ impl ExpertEncoding {
     pub fn matrix_bytes(self, n: usize, k: usize) -> Option<usize> {
         match self {
             ExpertEncoding::Bf16 => Some(n * k * 2),
+            ExpertEncoding::Q80 => k.is_multiple_of(32).then(|| n * k / 32 * 34),
             ExpertEncoding::Q6K | ExpertEncoding::Q4K => k.is_multiple_of(256).then(|| {
                 let per = if self == ExpertEncoding::Q6K {
                     210

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/encoding.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/encoding.rs
@@ -1,0 +1,218 @@
+//! The Q8_0 grouped kernel's decode, against the codec's own reference.
+//!
+//! The claim under test is narrow: the kernel reads canonical ggml
+//! Q8_0 blocks (f16 scale + 32 int8) and computes the same matvec the
+//! CPU computes from `dequantize_q8_0` of the same bytes. Quantisation
+//! error is deliberately OUT of scope — both arms read the same
+//! quantised values, so a disagreement is a decode or addressing fault,
+//! never "Q8_0 is lossy".
+//!
+//! Shapes are chosen to exercise the kernel's actual strides: K = 1088
+//! gives 34 blocks per row, one more than the 32 simd lanes, so the
+//! block loop's second iteration runs on lanes 0-1; N = 8 spans two row
+//! tiles of `ROWS_PER_TG = 4`.
+
+use larql_compute::cpu::ops::q4_common::{dequantize_q8_0, quantize_q8_0};
+
+use crate::trait_impl::bf16_grouped::GroupedShape;
+use crate::trait_impl::grouped_experts::{ExpertOffset, GroupedError, InputLayout};
+use crate::trait_impl::kimi_layer::ExpertEncoding;
+use crate::MetalBackend;
+
+const SLOTS: usize = 3;
+const N: usize = 8;
+const K: usize = 1088;
+/// Decode parity, not quantisation quality: both arms read identical
+/// quantised values, so only f32 summation order separates them.
+const TOLERANCE: f32 = 1e-3;
+
+fn backend() -> MetalBackend {
+    MetalBackend::new().expect("Metal device available on test host")
+}
+
+fn synth(n: usize, seed: f32) -> Vec<f32> {
+    (0..n)
+        .map(|i| ((i as f32) * 0.37 + seed).sin() * 0.4)
+        .collect()
+}
+
+/// `SLOTS` distinct `[N, K]` expert matrices quantised to Q8_0, banked
+/// back to back, plus each slot's byte offset and the dequantised f32
+/// form of each expert for the CPU arm.
+fn q8_bank() -> (Vec<u8>, Vec<ExpertOffset>, Vec<Vec<f32>>) {
+    let per_expert = ExpertEncoding::Q80
+        .matrix_bytes(N, K)
+        .expect("K is a whole number of blocks");
+    let mut bank = Vec::with_capacity(SLOTS * per_expert);
+    let mut dequantised = Vec::with_capacity(SLOTS);
+    let mut offsets = Vec::with_capacity(SLOTS);
+    for slot in 0..SLOTS {
+        let q = quantize_q8_0(&synth(N * K, 1.0 + slot as f32));
+        assert_eq!(q.len(), per_expert, "codec and layout must agree on bytes");
+        offsets.push(ExpertOffset((slot * per_expert) as u32));
+        dequantised.push(dequantize_q8_0(&q, N * K).expect("wellformed blocks"));
+        bank.extend_from_slice(&q);
+    }
+    (bank, offsets, dequantised)
+}
+
+fn matvec(w: &[f32], x: &[f32]) -> Vec<f32> {
+    (0..N)
+        .map(|r| {
+            w[r * K..(r + 1) * K]
+                .iter()
+                .zip(x)
+                .map(|(a, b)| a * b)
+                .sum()
+        })
+        .collect()
+}
+
+fn max_abs(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len());
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0f32, f32::max)
+}
+
+/// The kernel decodes exactly what the codec's own dequantiser reads —
+/// with a control proving the comparison could fail: the UNQUANTISED
+/// weights give a visibly different answer, so agreement with the
+/// dequantised arm is not agreement-with-anything.
+#[test]
+fn q8_0_grouped_matches_the_cpu_dequantised_reference() {
+    let m = backend();
+    let (bank, offsets, deq) = q8_bank();
+    let x = synth(K, 0.31);
+
+    let got = m
+        .grouped_experts_encoded(
+            ExpertEncoding::Q80,
+            &bank,
+            &offsets,
+            &x,
+            GroupedShape {
+                n: N,
+                k: K,
+                layout: InputLayout::Shared,
+            },
+        )
+        .expect("q8_0 grouped dispatch");
+    assert_eq!(got.len(), SLOTS * N);
+
+    let mut quantisation_moved_something = false;
+    for slot in 0..SLOTS {
+        let want = matvec(&deq[slot], &x);
+        let err = max_abs(&got[slot * N..(slot + 1) * N], &want);
+        assert!(
+            err < TOLERANCE,
+            "slot {slot}: decode parity broke — max |Δ| {err:e} against the \
+             dequantised reference"
+        );
+        let unquantised = matvec(&synth(N * K, 1.0 + slot as f32), &x);
+        if max_abs(&want, &unquantised) > TOLERANCE {
+            quantisation_moved_something = true;
+        }
+    }
+    assert!(
+        quantisation_moved_something,
+        "quantisation changed nothing measurable, so decode parity was proven \
+         against a reference indistinguishable from the raw weights"
+    );
+}
+
+/// Identity travels in the offset table, not in a slot's position.
+#[test]
+fn the_offset_table_decides_which_expert_a_slot_computes() {
+    let m = backend();
+    let (bank, offsets, _) = q8_bank();
+    let x = synth(K, 0.77);
+    let shape = GroupedShape {
+        n: N,
+        k: K,
+        layout: InputLayout::Shared,
+    };
+
+    let forward = m
+        .grouped_experts_encoded(ExpertEncoding::Q80, &bank, &offsets, &x, shape)
+        .expect("forward order");
+    let reversed_table: Vec<ExpertOffset> = offsets.iter().rev().copied().collect();
+    let reversed = m
+        .grouped_experts_encoded(ExpertEncoding::Q80, &bank, &reversed_table, &x, shape)
+        .expect("reversed order");
+
+    for slot in 0..SLOTS {
+        assert_eq!(
+            forward[slot * N..(slot + 1) * N],
+            reversed[(SLOTS - 1 - slot) * N..(SLOTS - slot) * N],
+            "slot {slot}: reversing the table must reverse the output blocks exactly"
+        );
+    }
+}
+
+/// `XSTRIDE = K`: each slot consumes its OWN input vector — the down
+/// projection's regime, where getting the stride wrong computes a real
+/// number from the wrong expert's activation.
+#[test]
+fn per_slot_inputs_reach_their_own_slots() {
+    let m = backend();
+    let (bank, offsets, deq) = q8_bank();
+    let xs: Vec<f32> = (0..SLOTS).flat_map(|s| synth(K, 5.0 + s as f32)).collect();
+
+    let got = m
+        .grouped_experts_encoded(
+            ExpertEncoding::Q80,
+            &bank,
+            &offsets,
+            &xs,
+            GroupedShape {
+                n: N,
+                k: K,
+                layout: InputLayout::PerSlot,
+            },
+        )
+        .expect("per-slot dispatch");
+
+    for slot in 0..SLOTS {
+        let want = matvec(&deq[slot], &xs[slot * K..(slot + 1) * K]);
+        let err = max_abs(&got[slot * N..(slot + 1) * N], &want);
+        assert!(
+            err < TOLERANCE,
+            "slot {slot}: per-slot input regime broke — max |Δ| {err:e}"
+        );
+    }
+}
+
+/// Bounds come from Q8_0's OWN stride: a bank sized for Q8_0 is smaller
+/// than the BF16 arithmetic it stands in for and must still bind; a
+/// truncated bank and an unencodable K are refused by name.
+#[test]
+fn q8_0_bounds_are_checked_at_the_q8_0_stride() {
+    let m = backend();
+    let (bank, offsets, _) = q8_bank();
+    let x = synth(K, 0.11);
+    let shape = GroupedShape {
+        n: N,
+        k: K,
+        layout: InputLayout::Shared,
+    };
+
+    let short = &bank[..bank.len() - 1];
+    match m.grouped_experts_encoded(ExpertEncoding::Q80, short, &offsets, &x, shape) {
+        Err(GroupedError::OffsetOutOfRange { slot, .. }) => {
+            assert_eq!(slot, SLOTS - 1, "the last slot is the one that ran out")
+        }
+        other => panic!("a truncated bank must refuse by range, got {other:?}"),
+    }
+
+    let bad_k = GroupedShape {
+        n: N,
+        k: K + 1,
+        layout: InputLayout::Shared,
+    };
+    match m.grouped_experts_encoded(ExpertEncoding::Q80, &bank, &offsets, &x, bad_k) {
+        Err(GroupedError::KNotSuperblockAligned { k }) => assert_eq!(k, K + 1),
+        other => panic!("an unencodable K must refuse by alignment, got {other:?}"),
+    }
+}

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/mod.rs
@@ -171,6 +171,7 @@ impl Fixture {
             qkv_bank: &self.qkv_bank,
             qkv_offsets: &self.qkv_offsets,
             o_proj: &self.o_proj,
+            projection_encoding: ExpertEncoding::Bf16,
             q_conv1d: &f[0],
             k_conv1d: &f[1],
             v_conv1d: &f[2],

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/mod.rs
@@ -709,6 +709,7 @@ fn a_kda_layer_and_an_mla_layer_share_one_command_buffer() {
 
 mod addressing;
 mod dense;
+mod encoding;
 mod head;
 mod shared;
 

--- a/crates/larql-compute/src/cpu/ops/q4_common/mod.rs
+++ b/crates/larql-compute/src/cpu/ops/q4_common/mod.rs
@@ -45,3 +45,8 @@ pub use matvec_f32::q4k_matvec_into;
 pub use quantize::{
     q4k_to_q4kf, quantize_q4_0, quantize_q4_k, quantize_q4_kf, quantize_q6_k, quantize_to_q8,
 };
+// Canonical ggml Q8_0 codec (34-byte blocks). Re-exported rather than
+// re-implemented: larql-models owns the checkpoint-side block formats,
+// and a second encoder here could drift from the one GGUF ingestion
+// already trusts.
+pub use larql_models::quant::ggml::{dequantize_q8_0, quantize_q8_0};

--- a/crates/larql-models/src/quant/ggml/legacy.rs
+++ b/crates/larql-models/src/quant/ggml/legacy.rs
@@ -2,8 +2,10 @@
 //! 32 elements per super-block; one f16 (or two for Q4_1/Q5_1) scale
 //! per block. K-quants (Q4_K, Q6_K) live in their own modules.
 //!
-//! `dequantize_q4_1` and `dequantize_q8_0` stay `pub(super)` because
-//! they're only reached through `super::dequantize` dispatch.
+//! `dequantize_q4_1` stays `pub(super)` because it's only reached
+//! through `super::dequantize` dispatch. `dequantize_q8_0` is public:
+//! the vindex REPRESENT pipeline and the Metal grouped-kernel tests
+//! use it directly as the decode reference for Q8_0 expert banks.
 
 use crate::ModelError;
 
@@ -63,7 +65,7 @@ pub(super) fn dequantize_q4_1(data: &[u8], n_elements: usize) -> Result<Vec<f32>
 }
 
 /// Q8_0: block = f16 scale (2B) + 32 signed int8 quants.
-pub(super) fn dequantize_q8_0(data: &[u8], n_elements: usize) -> Result<Vec<f32>, ModelError> {
+pub fn dequantize_q8_0(data: &[u8], n_elements: usize) -> Result<Vec<f32>, ModelError> {
     let block_size = 34;
     let n_blocks = check_block_input("Q8_0", data, n_elements, 32, block_size)?;
     let mut out = Vec::with_capacity(n_elements);

--- a/crates/larql-models/src/quant/ggml/mod.rs
+++ b/crates/larql-models/src/quant/ggml/mod.rs
@@ -32,7 +32,7 @@ pub mod q6_k;
 pub mod quantize;
 pub mod tq;
 
-pub use legacy::{dequantize_q4_0, dequantize_q5_0, dequantize_q5_1};
+pub use legacy::{dequantize_q4_0, dequantize_q5_0, dequantize_q5_1, dequantize_q8_0};
 pub use q3_k::dequantize_q3_k;
 pub use q4_k::{dequantize_q4_k, q4k_row_dot, q4k_row_scaled_add};
 pub use q5_k::dequantize_q5_k;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/kimi_source.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/kimi_source.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use larql_compute::backend::ComputeBackend;
 use larql_compute_metal::trait_impl::grouped_experts::ExpertOffset;
 use larql_compute_metal::trait_impl::kda::{KdaDeviceState, KdaShape};
+use larql_compute_metal::trait_impl::kimi_layer::ExpertEncoding as MetalEncoding;
 use larql_compute_metal::trait_impl::mla::{MlaDeviceState, MlaShape};
 use larql_compute_metal::MetalBackend;
 
@@ -363,6 +364,10 @@ impl KimiSourceModel {
                     ExpertOffset((2 * per) as u32),
                 ],
                 o_proj: self.decoder.bytes(&t("o_proj.weight"))?,
+                // The loader binds the container's own bf16 bytes; a
+                // compiled KDA-projection candidate is a later rung's
+                // overlay arm, not a silent default.
+                encoding: MetalEncoding::Bf16,
                 f32s,
             },
             DeviceState::Kda(KdaDeviceState::zeros(metal, g.kda)),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/kimi_source.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/kimi_source.rs
@@ -34,7 +34,7 @@ use larql_compute_metal::MetalBackend;
 use super::stack_metal::{DeviceAttn, DeviceLayer, DeviceState, HybridHead};
 use crate::error::VindexError;
 use crate::format::vindex3::encode::segment::read_segment_header;
-use crate::format::vindex3::represent::compile::LayerBankLayout;
+use crate::format::vindex3::represent::compile::CandidatePlacement;
 use crate::format::vindex3::represent::compiler::{
     bank_base, read_source_identity, CandidateIndex,
 };
@@ -42,7 +42,7 @@ use crate::format::vindex3::represent::physical::{
     EncodedRegion, ExpertBankBinding, ExpertEncoding, ExtentPolicy, PhysicalStore,
     ProjectionAddressing, RoutedProjection, SharedExpertBinding, WeightRegion,
 };
-use crate::format::vindex3::represent::policy::{layer_of, projection_of};
+use crate::format::vindex3::represent::policy::{layer_of, projection_of, Role};
 use crate::format::vindex3::represent::source_bank::source_expert_bank;
 
 /// `kv_a_layernorm`'s epsilon is the reference class's DEFAULT, not the
@@ -556,11 +556,14 @@ pub struct CandidateOverlay {
     /// projection-scoped candidate, and the rest stay source-backed.
     /// Derived from the SEALS, for the same reason as `layers`.
     projections: Vec<String>,
-    encoding: ExpertEncoding,
-    /// The geometry the completeness proof ran against — reused to
-    /// place the read views exactly where the compiler wrote.
-    hidden: usize,
-    inter: usize,
+    /// Physical representation per compiled LAYER — a composed map's
+    /// layers need not share one (Q8_0 band beside a Q6_K layer).
+    encodings: std::collections::BTreeMap<u32, ExpertEncoding>,
+    /// Where each layer's bank sits in the segment — the same
+    /// definition the compiler wrote and `verify_complete` proved.
+    /// Geometry lives in the placement's layouts; the overlay keeps
+    /// only the expert count, which the layouts do not carry.
+    placement: CandidatePlacement,
     experts: u32,
 }
 
@@ -582,16 +585,26 @@ impl CandidateOverlay {
         let index: CandidateIndex = serde_json::from_slice(&std::fs::read(dir.join("index.json"))?)
             .map_err(|e| VindexError::Parse(format!("candidate index: {e}")))?;
         index.source.verify(&read_source_identity(source_dir)?)?;
-        let (layers, projections) = verify_complete(&index, geometry)?;
-        let encoding = ExpertEncoding::parse(&index.map.encoding).ok_or_else(|| {
-            VindexError::Parse(format!(
-                "candidate encodes `{}`, which no grouped kernel reads",
-                index.map.encoding
-            ))
-        })?;
+        let (layers, projections, placement) = verify_complete(&index, geometry)?;
+        // Per LAYER, from the placement the completeness proof ran on —
+        // a composed map's layers need not share one encoding.
+        let mut encodings = std::collections::BTreeMap::new();
+        for &layer in &layers {
+            let name = &placement.layout(layer)?.encoding;
+            let enc = ExpertEncoding::parse(name).ok_or_else(|| {
+                VindexError::Parse(format!(
+                    "candidate encodes layer {layer} as `{name}`, which no grouped \
+                     kernel reads"
+                ))
+            })?;
+            encodings.insert(layer, enc);
+        }
         let segment = dir.join("segments").join(format!("{}.bin", index.object));
         let store = Arc::new(PhysicalStore::map_compiled(
-            "kimi-q6-candidate",
+            // Encoding-agnostic on purpose: the id lands in evidence
+            // attributions, and a Q8_0 candidate labelled "q6" would
+            // misstate the representation under test.
+            "kimi-candidate-bank",
             &segment,
             &index.ledger,
         )?);
@@ -600,9 +613,8 @@ impl CandidateOverlay {
             store,
             layers,
             projections,
-            encoding,
-            hidden: geometry.hidden,
-            inter: geometry.moe_intermediate,
+            encodings,
+            placement,
             experts: geometry.experts,
         })
     }
@@ -613,6 +625,14 @@ impl CandidateOverlay {
 
     /// Which projections this candidate compiled. Fewer than three
     /// means the rest execute from the source.
+    /// The physical representation this LAYER's sealed operands carry —
+    /// from the map the compiler executed, verified parseable at open.
+    pub fn encoding_of(&self, layer: u32) -> Result<ExpertEncoding, VindexError> {
+        self.encodings.get(&layer).copied().ok_or_else(|| {
+            VindexError::Parse(format!("layer {layer} is not compiled in this candidate"))
+        })
+    }
+
     pub fn compiled_projections(&self) -> &[String] {
         &self.projections
     }
@@ -627,7 +647,14 @@ impl CandidateOverlay {
             } else {
                 self.projections.join("+")
             },
-            self.index.map.encoding
+            self.layers
+                .iter()
+                .map(|l| {
+                    let enc = self.encodings.get(l).map(|e| e.name()).unwrap_or("?");
+                    format!("L{l}:{enc}")
+                })
+                .collect::<Vec<_>>()
+                .join(" ")
         )
     }
 
@@ -738,15 +765,10 @@ impl CandidateOverlay {
     }
 
     fn binding_inner(&self, layer: u32, projection: &str) -> Result<RoutedProjection, VindexError> {
-        // The SAME layout derivation `verify_complete` proved every seal
+        // The SAME placement `verify_complete` proved every seal
         // against — one definition of where an expert's bytes are.
-        let layout = LayerBankLayout::new(
-            layer,
-            &self.index.map.encoding,
-            self.experts,
-            self.hidden,
-            self.inter,
-        )?;
+        let layout = self.placement.layout(layer)?.clone();
+        let layer_base = self.placement.layer_base(layer)?;
         if layout.gate_up_stride != layout.down_stride {
             return Err(VindexError::Parse(format!(
                 "layer {layer}: gate/up stride {} != down stride {} — identity addressing \
@@ -758,15 +780,16 @@ impl CandidateOverlay {
             VindexError::Parse("a compiled expert stride does not fit 32 bits".to_string())
         })?;
         let bank_bytes = layout.bank_bytes("w1")?;
+        let encoding = self.encoding_of(layer)?;
         let region = |proj: &str| -> Result<EncodedRegion, VindexError> {
-            let base = bank_base(&layout, proj)?;
+            let base = layer_base + bank_base(&layout, proj)?;
             Ok(EncodedRegion {
                 region: self.store.span(base, bank_bytes).ok_or_else(|| {
                     VindexError::Parse(format!(
                         "candidate segment is too short for the {proj} bank at {base}"
                     ))
                 })?,
-                encoding: self.encoding,
+                encoding,
             })
         };
         // Every compiled projection is a full execution-shaped bank:
@@ -800,7 +823,7 @@ impl CandidateOverlay {
 pub fn verify_complete(
     index: &CandidateIndex,
     geometry: &KimiGeometry,
-) -> Result<(Vec<u32>, Vec<String>), VindexError> {
+) -> Result<(Vec<u32>, Vec<String>, CandidatePlacement), VindexError> {
     let overlaps = index.ledger.overlaps();
     if !overlaps.is_empty() {
         return Err(VindexError::Parse(format!(
@@ -848,14 +871,21 @@ pub fn verify_complete(
             )));
         }
     }
+    // ONE placement, the same definition the compiler wrote under: each
+    // layer's base is the sum of the preceding compiled layers' extents,
+    // each at its OWN encoding — which is what lets a composed map hold
+    // a Q8_0 band beside a Q6_K layer in one candidate.
+    let placement = CandidatePlacement::resolve(
+        &index.map,
+        Role::ExpertWeight,
+        &layers,
+        geometry.experts,
+        geometry.hidden,
+        geometry.moe_intermediate,
+    )?;
     for &layer in &layers {
-        let layout = LayerBankLayout::new(
-            layer,
-            &index.map.encoding,
-            geometry.experts,
-            geometry.hidden,
-            geometry.moe_intermediate,
-        )?;
+        let layout = placement.layout(layer)?;
+        let layer_base = placement.layer_base(layer)?;
         for expert in 0..geometry.experts {
             for proj in projections.iter().map(String::as_str) {
                 let tensor = format!("{layer}.block_sparse_moe.experts.{expert}.{proj}.weight");
@@ -867,7 +897,7 @@ pub fn verify_complete(
                     ))
                 })?;
                 let slot = layout.slot(proj, expert)?;
-                let want_offset = bank_base(&layout, proj)? + slot.offset;
+                let want_offset = layer_base + bank_base(layout, proj)? + slot.offset;
                 if seal.target_offset != want_offset || seal.target_len != slot.len {
                     return Err(VindexError::Parse(format!(
                         "`{tensor}` is sealed at {}+{} but the layout places it at \
@@ -875,14 +905,15 @@ pub fn verify_complete(
                         seal.target_offset, seal.target_len, slot.len
                     )));
                 }
-                if seal.encoding != index.map.encoding {
+                if seal.encoding != layout.encoding {
                     return Err(VindexError::Parse(format!(
-                        "`{tensor}` is sealed as {} but the map says {}",
-                        seal.encoding, index.map.encoding
+                        "`{tensor}` is sealed as {} but the map resolves layer {layer} \
+                         to {}",
+                        seal.encoding, layout.encoding
                     )));
                 }
             }
         }
     }
-    Ok((layers, projections))
+    Ok((layers, projections, placement))
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/stack_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/stack_metal.rs
@@ -312,6 +312,7 @@ fn device_region(r: &EncodedRegion) -> DeviceRegion<'_> {
         bytes: r.region.bytes(),
         encoding: match r.encoding {
             PhysEncoding::Bf16 => ExpertEncoding::Bf16,
+            PhysEncoding::Q80 => ExpertEncoding::Q80,
             PhysEncoding::Q6K => ExpertEncoding::Q6K,
             PhysEncoding::Q4K => ExpertEncoding::Q4K,
         },

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/stack_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/stack_metal.rs
@@ -58,6 +58,11 @@ pub enum DeviceAttn {
         qkv_bank: Vec<u8>,
         qkv_offsets: [ExpertOffset; 3],
         o_proj: Vec<u8>,
+        /// Physical representation of `qkv_bank` and `o_proj` — carried
+        /// beside the bytes so the dispatch can never pair them with
+        /// another encoding's kernel. The f32 operands below are always
+        /// exactly what they say.
+        encoding: ExpertEncoding,
         /// conv1d x3, f_a, f_b, g_a, g_b, b_proj, a_log, dt_bias, o_norm
         /// — `KdaDeviceWeights`'s own field order.
         f32s: Vec<Vec<f32>>,
@@ -164,6 +169,7 @@ impl DeviceLayer {
                     qkv_bank,
                     qkv_offsets,
                     o_proj,
+                    encoding,
                     f32s: f,
                 },
                 DeviceState::Kda(state),
@@ -172,6 +178,7 @@ impl DeviceLayer {
                     qkv_bank,
                     qkv_offsets,
                     o_proj,
+                    projection_encoding: *encoding,
                     q_conv1d: &f[0],
                     k_conv1d: &f[1],
                     v_conv1d: &f[2],

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/generate_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/generate_metal.rs
@@ -43,7 +43,7 @@ use larql_compute::backend::ComputeBackend;
 use larql_compute_metal::shaders::kimi_layer::NOT_RESIDENT;
 use larql_compute_metal::trait_impl::grouped_experts::ExpertOffset;
 use larql_compute_metal::trait_impl::kda::{KdaDeviceState, KdaShape};
-use larql_compute_metal::trait_impl::kimi_layer::KimiHead;
+use larql_compute_metal::trait_impl::kimi_layer::{ExpertEncoding as MetalEncoding, KimiHead};
 use larql_compute_metal::MetalBackend;
 use larql_models::config::{KdaGeometry, MlaGeometry, NormType};
 use serde_json::Value;
@@ -260,6 +260,7 @@ fn attention_for(
                     ExpertOffset((2 * per) as u32),
                 ],
                 o_proj: read_bf16_bytes(dir, &format!("layer{i}_kda_o_proj")),
+                encoding: MetalEncoding::Bf16,
                 f32s: f32_order
                     .iter()
                     .map(|f| read_f32(dir, &format!("layer{i}_kda_{f}")))

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_metal.rs
@@ -36,6 +36,7 @@ use std::time::Instant;
 
 use larql_compute_metal::trait_impl::grouped_experts::ExpertOffset;
 use larql_compute_metal::trait_impl::kda::{KdaDeviceState, KdaDeviceWeights, KdaShape};
+use larql_compute_metal::trait_impl::kimi_layer::ExpertEncoding;
 use larql_compute_metal::MetalBackend;
 use larql_models::config::{KdaGeometry, NormType};
 use serde_json::Value;
@@ -502,6 +503,7 @@ impl DeviceWeights {
             qkv_bank: &self.qkv_bank,
             qkv_offsets: &self.qkv_offsets,
             o_proj: &self.o_proj,
+            projection_encoding: ExpertEncoding::Bf16,
             q_conv1d: &fx.qc,
             k_conv1d: &fx.kc,
             v_conv1d: &fx.vc,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
@@ -1,0 +1,291 @@
+//! **KDA-1B rung 1b — one real KDA layer's projections at Q8_0, judged
+//! by the same teacher-forced consequence metrics as the expert cells.**
+//!
+//! The question is scientific before it is economic: does quantising a
+//! projection that FEEDS A RECURRENCE behave like quantising an expert
+//! matrix (error absorbed or cascaded through later routers), or does
+//! recurrent carry amplify representation error into a different
+//! failure class? The expert cell at the same depth is the yardstick —
+//! L25 routed experts at Q8_0 measured kl p99 2.3e-4 on this bank.
+//!
+//! The candidate arm is a TRANSIENT requant: the container's own bf16
+//! bytes for the target layer's `q|k|v` bank and `o_proj` are widened
+//! and re-encoded as Q8_0 at load, then dispatched through the real
+//! quantised grouped kernel. No compile machinery, no overlay — that
+//! machinery is earned only if this lever proves behaviourally cheap.
+//! Everything else in both arms is pointer-identical by construction:
+//! the ONLY difference is the two projections' physical representation.
+//!
+//! ```text
+//! LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.aligned.vindex3 \
+//! LARQL_KIMI_QUALITY_BANK=~/chris-models/qbanks/kimi-quality-bank-256x32 \
+//! LARQL_KDA_Q8_LAYER=25 LARQL_Q2A_SEQUENCES=8 \
+//!   cargo test -p larql-vindex --features gpu --release --lib kda_q8_real -- --nocapture
+//! ```
+
+use std::time::Instant;
+
+use larql_compute::backend::ComputeBackend;
+use larql_compute::cpu::ops::q4_common::quantize_q8_0;
+use larql_compute_metal::trait_impl::grouped_experts::ExpertOffset;
+use larql_compute_metal::trait_impl::kimi_layer::ExpertEncoding as MetalEncoding;
+use larql_compute_metal::MetalBackend;
+use serde_json::Value;
+
+use super::q2a_teacher_forced::{
+    env_dir, observation, run_sequence, sequence_embeddings, BANK_ENV, SOURCE_ENV,
+};
+use crate::format::vindex3::opplan::exec::kimi_source::KimiSourceModel;
+use crate::format::vindex3::opplan::exec::stack_metal::{DeviceAttn, DeviceLayer, HybridStack};
+use crate::format::vindex3::represent::bank::BankBuilder;
+use crate::format::vindex3::represent::quality::{kimi_logit_v3, Criterion, QualityEvidence};
+
+/// Which KDA layer's projections the candidate arm re-encodes.
+/// Default 25: the depth with the richest expert-side evidence, so the
+/// recurrence-vs-router comparison is at matched depth.
+const LAYER_ENV: &str = "LARQL_KDA_Q8_LAYER";
+const LAYER_DEFAULT: usize = 25;
+/// Diagnostic slice, same default as the expert probes.
+const SEQUENCES_ENV: &str = "LARQL_Q2A_SEQUENCES";
+const SEQUENCES_DEFAULT: usize = 8;
+
+fn env_count(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Exact KL(baseline ‖ candidate) over the FULL vocabulary, one
+/// position. The bank's own KL is authority; this exists for the
+/// TOKEN-DISTANCE curve — each sequence starts from clean recurrent
+/// state, so position index IS distance from the perturbation's onset,
+/// and the curve answers the question this probe was built for: does
+/// recurrent carry make projection error decay, hold, or accumulate?
+fn full_kl(baseline: &[f32], candidate: &[f32]) -> f64 {
+    let lse = |v: &[f32]| {
+        let m = v.iter().copied().fold(f32::NEG_INFINITY, f32::max) as f64;
+        m + v.iter().map(|x| (*x as f64 - m).exp()).sum::<f64>().ln()
+    };
+    let (zb, zc) = (lse(baseline), lse(candidate));
+    baseline
+        .iter()
+        .zip(candidate)
+        .map(|(b, c)| {
+            let pb = (*b as f64 - zb).exp();
+            pb * ((*b as f64 - zb) - (*c as f64 - zc))
+        })
+        .sum()
+}
+
+fn widen_bf16(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(2)
+        .map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16))
+        .collect()
+}
+
+/// Re-encode the layer's two wide projections in place. Returns the
+/// (bf16, q8) byte counts so the caller can assert the swap really
+/// happened — an arm that silently kept bf16 would measure nothing.
+fn requant_kda_projections(layer: &mut DeviceLayer) -> (usize, usize) {
+    let shape = layer.kda_shape;
+    let (width, hidden) = (shape.num_heads * shape.head_dim, shape.hidden);
+    let DeviceAttn::Kda {
+        qkv_bank,
+        qkv_offsets,
+        o_proj,
+        encoding,
+        ..
+    } = &mut layer.attn
+    else {
+        panic!("the target layer must be KDA — pick one from the interleave");
+    };
+    let per = width * hidden * 2;
+    let before = qkv_bank.len() + o_proj.len();
+    let mut q8 = Vec::new();
+    let mut offsets = [ExpertOffset(0); 3];
+    for (slot, off) in qkv_offsets.iter().enumerate() {
+        let start = off.0 as usize;
+        offsets[slot] = ExpertOffset(q8.len() as u32);
+        q8.extend(quantize_q8_0(&widen_bf16(&qkv_bank[start..start + per])));
+    }
+    *qkv_bank = q8;
+    *qkv_offsets = offsets;
+    *o_proj = quantize_q8_0(&widen_bf16(o_proj));
+    *encoding = MetalEncoding::Q80;
+    (before, layer_bytes(layer))
+}
+
+fn layer_bytes(layer: &DeviceLayer) -> usize {
+    match &layer.attn {
+        DeviceAttn::Kda {
+            qkv_bank, o_proj, ..
+        } => qkv_bank.len() + o_proj.len(),
+        _ => unreachable!("asserted KDA above"),
+    }
+}
+
+/// `build_stack`, with one hook: the target layer's projections are
+/// re-encoded BEFORE its attention banks are registered — a mutation
+/// after registration would leave the residency declaration pointing at
+/// freed bf16 bytes.
+fn build_stack_with<'a>(
+    metal: &MetalBackend,
+    model: &KimiSourceModel,
+    mutate: Option<usize>,
+) -> (HybridStack<'a>, Option<(usize, usize)>) {
+    let n = model.geometry.num_layers;
+    let mut swapped = None;
+    let mut device: Vec<Option<DeviceLayer>> = Vec::with_capacity(n);
+    for i in 0..n {
+        let mut d = model
+            .device_layer(metal, i, None)
+            .unwrap_or_else(|e| panic!("layer {i} must load: {e}"));
+        if mutate == Some(i) {
+            swapped = Some(requant_kda_projections(&mut d));
+        }
+        device.push(Some(d));
+    }
+    for d in device.iter().flatten() {
+        for bank in d.attention_banks() {
+            metal.register_weight_region(bank);
+        }
+    }
+    let host = (0..n).map(|_| None).collect();
+    let mut stack = HybridStack::new(device, host);
+    assert!(stack.attach_head(model.head().expect("the head must load")));
+    (stack, swapped)
+}
+
+#[test]
+fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
+    let (Some(source_dir), Some(bank_dir)) = (env_dir(SOURCE_ENV), env_dir(BANK_ENV)) else {
+        eprintln!("skipped: set {SOURCE_ENV} and {BANK_ENV}");
+        return;
+    };
+    if std::env::var("LARQL_RESIDENCY_SET").is_ok() {
+        panic!("unset LARQL_RESIDENCY_SET: this run must use implicit residency");
+    }
+    let Some(metal) = MetalBackend::new() else {
+        #[cfg(target_os = "macos")]
+        panic!("MetalBackend::new() returned None on macOS — the shader library failed");
+        #[cfg(not(target_os = "macos"))]
+        return;
+    };
+    let layer = env_count(LAYER_ENV, LAYER_DEFAULT);
+    let sequences = env_count(SEQUENCES_ENV, SEQUENCES_DEFAULT);
+
+    let manifest: Value =
+        serde_json::from_slice(&std::fs::read(bank_dir.join("manifest.json")).expect("manifest"))
+            .expect("bank manifest parses");
+    let positions = manifest["positions"].as_u64().unwrap() as usize;
+
+    let t0 = Instant::now();
+    let model = KimiSourceModel::open(&source_dir).expect("source container opens");
+    let g = model.geometry.clone();
+    let moe_layers: Vec<u32> = (g.dense_prefix_layers..g.num_layers)
+        .map(|l| l as u32)
+        .collect();
+    model
+        .register_stores(&metal, &moe_layers)
+        .expect("stores register");
+    let (mut baseline, none) = build_stack_with(&metal, &model, None);
+    let (mut candidate, swapped) = build_stack_with(&metal, &model, Some(layer));
+    metal.seal_weight_regions();
+    assert!(none.is_none());
+    let (bf16_bytes, q8_bytes) = swapped.expect("the target layer was re-encoded");
+    assert!(
+        q8_bytes < bf16_bytes,
+        "Q8_0 must be smaller than bf16 — the swap did not happen"
+    );
+    eprintln!(
+        "[kda-q8] arms loaded in {:.1}s; layer {layer} projections {bf16_bytes} -> \
+         {q8_bytes} bytes ({:.1}% of bf16); everything else identical by construction",
+        t0.elapsed().as_secs_f64(),
+        100.0 * q8_bytes as f64 / bf16_bytes as f64,
+    );
+
+    let t1 = Instant::now();
+    let mut builder = BankBuilder::new();
+    // KL by position index, across sequences — the token-distance curve.
+    let mut kl_by_pos: Vec<Vec<f64>> = vec![Vec::new(); positions];
+    for seq in 0..sequences {
+        let rows = sequence_embeddings(&bank_dir, seq, positions, g.hidden);
+        let base = run_sequence(&metal, &mut baseline, &rows, g.hidden);
+        let cand = run_sequence(&metal, &mut candidate, &rows, g.hidden);
+        for (pos, ((lb, tb), (lc, tc))) in base.into_iter().zip(cand).enumerate() {
+            kl_by_pos[pos].push(full_kl(&lb, &lc));
+            builder.observe(&observation(seq, pos, &lb, &tb, &lc, &tc));
+        }
+    }
+    let min_covered = builder.min_covered_mass();
+    let bank = builder.finish();
+    let curve: Vec<serde_json::Value> = kl_by_pos
+        .iter()
+        .map(|v| {
+            let mut s = v.clone();
+            s.sort_by(|a, b| a.partial_cmp(b).expect("KL is finite"));
+            let mean = s.iter().sum::<f64>() / s.len() as f64;
+            serde_json::json!({"mean": mean, "max": s[s.len() - 1]})
+        })
+        .collect();
+    // Quartile means of the curve, so decay/hold/accumulate reads off
+    // one line without a plot.
+    let q = positions / 4;
+    let qmean = |r: std::ops::Range<usize>| {
+        let vals: Vec<f64> = r.flat_map(|p| kl_by_pos[p].iter().copied()).collect();
+        vals.iter().sum::<f64>() / vals.len() as f64
+    };
+    eprintln!(
+        "[kda-q8] token-distance KL means by quartile of position 0..{positions}: \
+         {:.3e} | {:.3e} | {:.3e} | {:.3e}",
+        qmean(0..q),
+        qmean(q..2 * q),
+        qmean(2 * q..3 * q),
+        qmean(3 * q..positions),
+    );
+
+    let evidence = QualityEvidence {
+        gate: kimi_logit_v3(),
+        bank: bank.clone(),
+    };
+    let verdict = evidence.verdict();
+    let bank_manifest_sha256 = {
+        use sha2::{Digest, Sha256};
+        let bytes = std::fs::read(bank_dir.join("manifest.json")).expect("bank manifest reads");
+        format!("{:x}", Sha256::digest(&bytes))
+    };
+    let report = serde_json::json!({
+        "run": format!("kda-q8-l{layer}"),
+        "scope": "KDA projections (qkv bank + o_proj) of ONE layer, transient requant — no compiled candidate",
+        "gate": evidence.gate,
+        "authority_report": evidence.report(),
+        "verdict_passed": verdict.passed(),
+        "verdict_failures": verdict.failures.iter()
+            .map(|(c, d)| format!("{}: {d}", c.name())).collect::<Vec<_>>(),
+        "bank_manifest_sha256": bank_manifest_sha256,
+        "bank": bank,
+        "positions": bank.positions,
+        "min_covered_mass": min_covered,
+        "bytes": {"bf16": bf16_bytes, "q8_0": q8_bytes},
+        "kl_by_position": curve,
+        "wall_seconds": t1.elapsed().as_secs_f64(),
+    });
+    let path = format!("/tmp/kimi_kda-q8-l{layer}_report.json");
+    std::fs::write(
+        &path,
+        serde_json::to_vec_pretty(&report).expect("serialises"),
+    )
+    .expect("report writes");
+    eprintln!("{}", evidence.report());
+    eprintln!("[kda-q8] verdict: {verdict:?} — report at {path}");
+
+    if bank.positions < 4096 {
+        assert!(!verdict.passed(), "sub-4096 positions can never pass v3");
+        assert!(verdict
+            .failures
+            .iter()
+            .any(|(c, d)| *c == Criterion::Positions && d.contains("< 4096")));
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_layer_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_layer_metal.rs
@@ -29,7 +29,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use larql_compute::cpu::ops::q4_common::quantize_q6_k;
+use larql_compute::cpu::ops::q4_common::{quantize_q6_k, quantize_q8_0};
 use larql_compute_metal::shaders::kimi_layer::NOT_RESIDENT;
 use larql_compute_metal::trait_impl::bf16_moe_block::{ExpertBankRef, MoeBlockCall, MoeFfnBanks};
 use larql_compute_metal::trait_impl::grouped_experts::ExpertOffset;
@@ -1139,5 +1139,105 @@ fn a_projection_declaring_the_wrong_encoding_is_refused_before_execution() {
     assert!(
         matches!(err, GroupedError::OffsetOutOfRange { slot: 0, .. }),
         "expected the gate projection to be named, got {err:?}"
+    );
+}
+
+/// Re-encode each block of a bf16 bank to Q8_0, block by block — the
+/// Q8_0 sibling of `to_q6k_blocks`, at the 34-bytes-per-32 stride.
+fn to_q8_0_blocks(src: &[u8], per: usize, n: usize, k: usize) -> (Vec<u8>, usize) {
+    assert!(k.is_multiple_of(32), "k={k} cannot be Q8_0");
+    let q_per = n * k / 32 * 34;
+    let mut out = Vec::with_capacity(src.len() / per * q_per);
+    for block in src.chunks_exact(per) {
+        let q = quantize_q8_0(&widen(block));
+        assert_eq!(q.len(), q_per);
+        out.extend_from_slice(&q);
+    }
+    (out, q_per)
+}
+
+/// **Q8_0 sits strictly ABOVE Q6_K on the fidelity axis at a real
+/// layer.** Both quantisations of all three projections move the layer
+/// output — they are real representations, not pass-throughs — and
+/// Q8_0's displacement is strictly smaller than Q6_K's on the same
+/// weights and input.
+///
+/// This is the smoke gate the precision ladder stands on: if an ~8-bit
+/// bank did NOT beat Q6_K here, running teacher-forced quality banks
+/// against it would measure a defect, not a representation.
+#[test]
+fn q8_0_displaces_the_layer_output_less_than_q6_k() {
+    let Some((b, f)) = setup() else {
+        return;
+    };
+    let per = f.inter * f.hidden * 2;
+    let per_down = f.hidden * f.inter * 2;
+
+    let state_ref = KdaDeviceState::zeros(&b, f.shape());
+    let (want, _) = b
+        .kimi_decoder_layer(f.layer(&state_ref), &f.x)
+        .expect("reference layer runs");
+
+    // One closure per encoding, differing ONLY in the re-encoder, so
+    // the two arms cannot drift in table construction or bank layout.
+    type Requant<'a> = &'a dyn Fn(&[u8], usize, usize, usize) -> (Vec<u8>, usize);
+    let run = |requant_gate_up: Requant, requant_down: Requant, enc: ExpertEncoding| -> Vec<f32> {
+        let (g, q_per) = requant_gate_up(&f.bank_gate, per, f.inter, f.hidden);
+        let (u, _) = requant_gate_up(&f.bank_up, per, f.inter, f.hidden);
+        let (d, q_per_down) = requant_down(&f.bank_down, per_down, f.hidden, f.inter);
+        let (sg, _) = requant_gate_up(&f.shared_gate, per, f.inter, f.hidden);
+        let (su, _) = requant_gate_up(&f.shared_up, per, f.inter, f.hidden);
+        let (sd, _) = requant_down(&f.shared_down, per_down, f.hidden, f.inter);
+        let identity: Vec<usize> = (0..f.bank_gate.len() / per).collect();
+        let t = table(&f.residency, per, q_per, &identity);
+        let td = table(&f.residency, per_down, q_per_down, &identity);
+        let state = KdaDeviceState::zeros(&b, f.shape());
+        let mut w = f.layer(&state);
+        if let FfnSpec::Moe(m) = &mut w.ffn {
+            fn bank<'a>(
+                bytes: &'a [u8],
+                tbl: &'a [u32],
+                shared: &'a [u8],
+                enc: ExpertEncoding,
+            ) -> ProjectionBank<'a> {
+                ProjectionBank {
+                    routed: EncodedRegion {
+                        bytes,
+                        encoding: enc,
+                    },
+                    addressing: ExpertAddressing::Table(tbl),
+                    shared: Some(EncodedRegion {
+                        bytes: shared,
+                        encoding: enc,
+                    }),
+                }
+            }
+            m.gate = bank(&g, &t, &sg, enc);
+            m.up = bank(&u, &t, &su, enc);
+            m.down = bank(&d, &td, &sd, enc);
+            let (out, _) = b.kimi_decoder_layer(w, &f.x).expect("quantised layer runs");
+            return out;
+        }
+        unreachable!("the fixture layer is routed");
+    };
+
+    let q8 = run(&to_q8_0_blocks, &to_q8_0_blocks, ExpertEncoding::Q80);
+    let q6 = run(&to_q6k_blocks, &to_q6k_blocks, ExpertEncoding::Q6K);
+
+    let rel = |a: &[f32], c: &[f32]| {
+        let se: f64 = a.iter().zip(c).map(|(x, y)| ((x - y) as f64).powi(2)).sum();
+        let ss: f64 = c.iter().map(|y| (*y as f64).powi(2)).sum();
+        (se / ss).sqrt()
+    };
+    let (e8, e6) = (rel(&q8, &want), rel(&q6, &want));
+    eprintln!("[q8] all-projection displacement vs BF16: Q8_0 {e8:.3e}, Q6_K {e6:.3e}");
+    assert!(
+        e8 > 0.0,
+        "Q8_0 must move the answer, or this proves nothing about its decode"
+    );
+    assert!(
+        e8 < e6,
+        "Q8_0 ({e8:.3e}) must displace the output LESS than Q6_K ({e6:.3e}) on the same \
+         weights, or the ladder's middle rung is below its bottom one"
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_layer_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_layer_metal.rs
@@ -192,6 +192,7 @@ impl Fixture {
             qkv_bank: &self.qkv_bank,
             qkv_offsets: &self.qkv_offsets,
             o_proj: &self.o_proj,
+            projection_encoding: ExpertEncoding::Bf16,
             q_conv1d: &f.qc,
             k_conv1d: &f.kc,
             v_conv1d: &f.vc,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_two_layer.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_two_layer.rs
@@ -173,6 +173,7 @@ impl Layer {
                     qkv_bank,
                     qkv_offsets,
                     o_proj,
+                    projection_encoding: ExpertEncoding::Bf16,
                     q_conv1d: &f[0],
                     k_conv1d: &f[1],
                     v_conv1d: &f[2],

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -48,6 +48,7 @@ mod output_gate_fused;
 mod plan_fixtures;
 mod projection_bench;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
+mod q2a_decode_bench;
 mod q2a_teacher_forced;
 mod qw36c_layer0;
 mod stack_dispatch_refusal;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -27,6 +27,8 @@ mod hybrid_traversal;
 mod kda_metal;
 mod kda_parity;
 mod kda_parity_real;
+#[cfg(all(feature = "gpu", target_os = "macos"))]
+mod kda_q8_real;
 mod kda_refusal;
 mod kimi_kda_layer_real;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
@@ -47,8 +49,12 @@ mod mrope_parity;
 mod output_gate_fused;
 mod plan_fixtures;
 mod projection_bench;
+// Each module carries its OWN cfg: inserting a bare `mod` line above a
+// gated one hands the attribute to the newcomer and silently un-gates
+// the original — that exact capture broke six CI jobs on PR #346.
 #[cfg(all(feature = "gpu", target_os = "macos"))]
 mod q2a_decode_bench;
+#[cfg(all(feature = "gpu", target_os = "macos"))]
 mod q2a_teacher_forced;
 mod qw36c_layer0;
 mod stack_dispatch_refusal;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_decode_bench.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_decode_bench.rs
@@ -1,0 +1,193 @@
+//! **The decode-rate benchmark for a composed REPRESENT candidate.**
+//!
+//! The same two arms `q2a_teacher_forced` judges for QUALITY — the
+//! source container's BF16 stack beside the candidate overlay's
+//! compiled banks — timed instead of judged. Quality authority belongs
+//! to the frozen contract at 8192 positions; this file answers the
+//! other half of the economics: what the admitted map buys in decode
+//! rate, on this machine, in this session.
+//!
+//! Protocol, per the repo's measured bench discipline:
+//!
+//! * **Both arms in one process, interleaved in blocks**, the order
+//!   alternating block to block — the BF16 figure is re-earned beside
+//!   the candidate, never compared against a number from another
+//!   session or day (machine state shifts move e2e timings by ±6%).
+//! * **Warm-up precedes measurement** (pipeline caches, page cache),
+//!   and the per-arm result is the MINIMUM block time — the floor the
+//!   machine demonstrated — with every block printed, not averaged
+//!   away.
+//! * Timing wraps ONLY [`HybridStack::forward`]: the same
+//!   one-command-buffer-per-token step serving takes, logits readback
+//!   included, instrumentation off (`forward`, not `forward_traced`).
+//!
+//! ```text
+//! LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.aligned.vindex3 \
+//! LARQL_KIMI_Q6_CANDIDATE=/tmp/kimi-map-l24-26q80.vindex3 \
+//! LARQL_KIMI_QUALITY_BANK=~/chris-models/qbanks/kimi-quality-bank-256x32 \
+//!   cargo test -p larql-vindex --features gpu --release --lib \
+//!   q2a_decode_bench -- --nocapture
+//! ```
+
+use std::time::Instant;
+
+use larql_compute::backend::ComputeBackend;
+use larql_compute_metal::MetalBackend;
+use serde_json::Value;
+
+use super::q2a_teacher_forced::{
+    build_stack, env_dir, sequence_embeddings, BANK_ENV, CANDIDATE_ENV, SOURCE_ENV,
+};
+use crate::format::vindex3::opplan::exec::kimi_source::{CandidateOverlay, KimiSourceModel};
+use crate::format::vindex3::opplan::exec::stack_metal::HybridStack;
+
+/// Tokens per measured block. At the BF16 stack's known ~27 ms/token a
+/// 128-token block is ~3.5 s — long enough to average submission
+/// jitter, short enough that all blocks of both arms interleave inside
+/// one machine state.
+const TOKENS_ENV: &str = "LARQL_BENCH_TOKENS";
+const TOKENS_DEFAULT: usize = 128;
+/// Measured blocks per arm. Every block is printed; the summary takes
+/// the minimum.
+const BLOCKS_ENV: &str = "LARQL_BENCH_BLOCKS";
+const BLOCKS_DEFAULT: usize = 4;
+/// Unmeasured warm-up tokens per arm before any block.
+const WARMUP_TOKENS: usize = 64;
+
+fn env_count(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .map(|v| {
+            v.parse()
+                .unwrap_or_else(|_| panic!("{var}={v} is not a count"))
+        })
+        .unwrap_or(default)
+}
+
+/// Feed `tokens` bank rows through one arm, resetting recurrent state
+/// at each sequence boundary exactly as the quality runner does, and
+/// return (wall seconds, device-reported GPU milliseconds).
+fn run_tokens(
+    metal: &MetalBackend,
+    stack: &mut HybridStack<'_>,
+    rows: &[Vec<Vec<f32>>],
+    hidden: usize,
+    tokens: usize,
+) -> (f64, f64) {
+    let positions = rows[0].len();
+    let mut gpu_ms = 0.0;
+    let t0 = Instant::now();
+    for t in 0..tokens {
+        let (seq, pos) = (t / positions % rows.len(), t % positions);
+        if pos == 0 {
+            stack.reset_states().expect("stack resets");
+        }
+        let (logits, _traces, timing) = stack
+            .forward(metal, &rows[seq][pos], hidden)
+            .expect("a decode step must not refuse");
+        assert!(!logits.is_empty() && logits[0].is_finite());
+        gpu_ms += timing.device_gpu_ms;
+    }
+    (t0.elapsed().as_secs_f64(), gpu_ms)
+}
+
+#[test]
+fn decode_rate_of_the_candidate_map_beside_its_own_bf16_baseline() {
+    let (Some(source_dir), Some(candidate_dir), Some(bank_dir)) = (
+        env_dir(SOURCE_ENV),
+        env_dir(CANDIDATE_ENV),
+        env_dir(BANK_ENV),
+    ) else {
+        eprintln!("skipped: set {SOURCE_ENV}, {CANDIDATE_ENV} and {BANK_ENV}");
+        return;
+    };
+    // Same refusal as the quality runner: the residency SET would wire
+    // the ~94 GB expert bank past the wired-collector wall.
+    if std::env::var("LARQL_RESIDENCY_SET").is_ok() {
+        panic!("unset LARQL_RESIDENCY_SET: the bench must use implicit residency");
+    }
+    let Some(metal) = MetalBackend::new() else {
+        #[cfg(target_os = "macos")]
+        panic!("MetalBackend::new() returned None on macOS — the shader library failed");
+        #[cfg(not(target_os = "macos"))]
+        return;
+    };
+    let tokens = env_count(TOKENS_ENV, TOKENS_DEFAULT);
+    let blocks = env_count(BLOCKS_ENV, BLOCKS_DEFAULT);
+
+    let manifest: Value =
+        serde_json::from_slice(&std::fs::read(bank_dir.join("manifest.json")).expect("manifest"))
+            .expect("bank manifest parses");
+    let positions = manifest["positions"].as_u64().unwrap() as usize;
+    let hidden = manifest["hidden"].as_u64().unwrap() as usize;
+
+    let t0 = Instant::now();
+    let model = KimiSourceModel::open(&source_dir).expect("source container opens");
+    let g = model.geometry.clone();
+    assert_eq!(g.hidden, hidden, "the bank was exported for this model");
+    let overlay =
+        CandidateOverlay::open(&candidate_dir, &source_dir, &g).expect("candidate overlay opens");
+    let moe_layers: Vec<u32> = (g.dense_prefix_layers..g.num_layers)
+        .map(|l| l as u32)
+        .collect();
+    model
+        .register_stores(&metal, &moe_layers)
+        .expect("stores register");
+    overlay.register_store(&metal);
+    let mut baseline = build_stack(&metal, &model, None);
+    let mut candidate = build_stack(&metal, &model, Some(&overlay));
+    metal.seal_weight_regions();
+    eprintln!(
+        "[bench] both arms loaded in {:.1}s; candidate scope {}",
+        t0.elapsed().as_secs_f64(),
+        overlay.scope()
+    );
+
+    // Enough distinct rows that a block never re-times one hot row, cycled
+    // deterministically.
+    let seqs_needed = (tokens.max(WARMUP_TOKENS)).div_ceil(positions).max(1);
+    let rows: Vec<Vec<Vec<f32>>> = (0..seqs_needed)
+        .map(|s| sequence_embeddings(&bank_dir, s, positions, hidden))
+        .collect();
+
+    for (name, stack) in [("baseline", &mut baseline), ("candidate", &mut candidate)] {
+        let (wall, _gpu) = run_tokens(&metal, stack, &rows, hidden, WARMUP_TOKENS);
+        eprintln!("[bench] warm-up {name}: {WARMUP_TOKENS} tokens in {wall:.2}s (unmeasured)");
+    }
+
+    // Interleaved blocks, order alternating so a monotone machine-state
+    // drift cannot systematically favour one arm.
+    let mut wall_ms: [Vec<f64>; 2] = [Vec::new(), Vec::new()];
+    let mut gpu_ms: [Vec<f64>; 2] = [Vec::new(), Vec::new()];
+    for block in 0..blocks {
+        let order: [usize; 2] = if block % 2 == 0 { [0, 1] } else { [1, 0] };
+        for arm in order {
+            let (name, stack) = match arm {
+                0 => ("baseline", &mut baseline),
+                _ => ("candidate", &mut candidate),
+            };
+            let (wall, gpu) = run_tokens(&metal, stack, &rows, hidden, tokens);
+            let per_tok = wall * 1000.0 / tokens as f64;
+            wall_ms[arm].push(per_tok);
+            gpu_ms[arm].push(gpu / tokens as f64);
+            eprintln!(
+                "[bench] block {block} {name}: {per_tok:.2} ms/token = {:.2} tok/s \
+                 (gpu {:.2} ms/token)",
+                1000.0 / per_tok,
+                gpu / tokens as f64,
+            );
+        }
+    }
+
+    let floor = |v: &[f64]| v.iter().copied().fold(f64::INFINITY, f64::min);
+    let (b_ms, c_ms) = (floor(&wall_ms[0]), floor(&wall_ms[1]));
+    let (b_gpu, c_gpu) = (floor(&gpu_ms[0]), floor(&gpu_ms[1]));
+    eprintln!(
+        "[bench] FLOOR baseline {:.2} tok/s ({b_ms:.2} ms wall, {b_gpu:.2} ms gpu) | \
+         candidate {:.2} tok/s ({c_ms:.2} ms wall, {c_gpu:.2} ms gpu) | speedup {:.3}x \
+         over {blocks} blocks x {tokens} tokens/arm",
+        1000.0 / b_ms,
+        1000.0 / c_ms,
+        b_ms / c_ms,
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_teacher_forced.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_teacher_forced.rs
@@ -130,7 +130,7 @@ fn top_k_ids(logits: &[f32], k: usize) -> Vec<usize> {
 /// One position's paired measurement, from both arms' full logit
 /// vectors, traced routes, and the router's own scores.
 #[allow(clippy::too_many_arguments)]
-fn observation(
+pub(super) fn observation(
     seq: usize,
     pos: usize,
     baseline: &[f32],
@@ -335,7 +335,7 @@ pub(super) fn build_stack<'a>(
 
 /// Run `positions` teacher-forced steps of one sequence through one
 /// arm, returning each position's full logits and its execution trace.
-fn run_sequence(
+pub(super) fn run_sequence(
     metal: &MetalBackend,
     stack: &mut HybridStack<'_>,
     rows: &[Vec<f32>],

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_teacher_forced.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_teacher_forced.rs
@@ -1,29 +1,32 @@
-//! **Q2a — the teacher-forced quality runner, 1024 positions.**
-//!
-//! Two arms through the real mixed Metal stack, loaded from the source
-//! VINDEX3 container itself:
+//! **The teacher-forced quality runner** — two arms through the real
+//! mixed Metal stack, loaded from the source VINDEX3 container itself:
 //!
 //! ```text
-//! baseline    every routed layer  -> source expert_bank   (BF16, Table)
-//! candidate   layer 1 routed      -> compiled Q6_K bank   (Identity)
-//!             everything else     -> the SAME source stores
+//! baseline    every routed layer   -> source expert_bank   (BF16, Table)
+//! candidate   the overlay's layers -> compiled banks       (Identity,
+//!             each at its map's encoding — Q8_0, Q6_K, or a composed
+//!             map holding several layers at different encodings)
+//!             everything else      -> the SAME source stores
 //! ```
 //!
-//! The single changed variable is layer 1's routed ExpertWeight
-//! representation: BF16 source bytes vs the exact persistent Q6_K bytes
-//! the compiler sealed. Router, norms, attention, shared experts, state
-//! initialisation and the teacher-forced token prefix are identical by
-//! construction — and asserted, not assumed.
+//! The changed variable is exactly the candidate's compiled scope:
+//! source BF16 bytes vs the persistent bytes the compiler sealed.
+//! Router, norms, attention, shared experts, state initialisation and
+//! the teacher-forced token prefix are identical by construction — and
+//! asserted, not assumed, per compiled layer.
 //!
-//! **This run is NON-PROMOTABLE by design**: 1024 positions is under
-//! `kimi-logit-v1`'s `positions_min` of 4096, so the gate must refuse
-//! however flattering the metrics are. Its product is the machinery and
-//! the closure report, not a verdict; Q2b runs the full 8192.
+//! **The verdict semantics follow scale.** Below `positions_min` (4096)
+//! this is a DIAGNOSTIC: the gate must refuse on positions however
+//! flattering the numbers, and the harness asserts that refusal. At
+//! 8192 (`LARQL_Q2A_SEQUENCES=256`) the verdict IS the product — frozen
+//! `kimi-logit-v3` decides, the report is written BEFORE any verdict
+//! assertion, and a FAIL is a result, not a harness failure.
 //!
 //! ```text
-//! LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.vindex3 \
-//! LARQL_KIMI_Q6_CANDIDATE=/tmp/kimi-q6-candidate.vindex3 \
+//! LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.aligned.vindex3 \
+//! LARQL_KIMI_Q6_CANDIDATE=/tmp/kimi-q80-l25.vindex3 \
 //! LARQL_KIMI_QUALITY_BANK=/tmp/kimi_quality_bank \
+//! LARQL_Q2A_SEQUENCES=8 LARQL_Q2A_LABEL=q80-l25 \
 //!   cargo test -p larql-vindex --features gpu --release --lib q2a_teacher_forced -- --nocapture
 //! ```
 
@@ -48,9 +51,9 @@ use crate::format::vindex3::represent::quality::{
     kimi_logit_v1, kimi_logit_v2, kimi_logit_v3, Criterion, QualityEvidence,
 };
 
-const SOURCE_ENV: &str = "LARQL_KIMI_VINDEX3";
-const CANDIDATE_ENV: &str = "LARQL_KIMI_Q6_CANDIDATE";
-const BANK_ENV: &str = "LARQL_KIMI_QUALITY_BANK";
+pub(super) const SOURCE_ENV: &str = "LARQL_KIMI_VINDEX3";
+pub(super) const CANDIDATE_ENV: &str = "LARQL_KIMI_Q6_CANDIDATE";
+pub(super) const BANK_ENV: &str = "LARQL_KIMI_QUALITY_BANK";
 
 /// Q2a's slice of the exported bank: 32 of the 256 sequences.
 ///
@@ -95,7 +98,7 @@ fn report_path(label: &str) -> String {
     format!("/tmp/kimi_{label}_report.json")
 }
 
-fn env_dir(var: &str) -> Option<PathBuf> {
+pub(super) fn env_dir(var: &str) -> Option<PathBuf> {
     std::env::var_os(var).map(PathBuf::from)
 }
 
@@ -277,7 +280,12 @@ fn weigh_top_1(baseline: &[f32], candidate: &[f32]) -> Option<Top1Change> {
 }
 
 /// Per-sequence embedding rows from the exported bank.
-fn sequence_embeddings(dir: &Path, seq: usize, positions: usize, hidden: usize) -> Vec<Vec<f32>> {
+pub(super) fn sequence_embeddings(
+    dir: &Path,
+    seq: usize,
+    positions: usize,
+    hidden: usize,
+) -> Vec<Vec<f32>> {
     let bytes = std::fs::read(dir.join(format!("seq_{seq}.f32")))
         .unwrap_or_else(|e| panic!("seq_{seq}.f32: {e}"));
     assert_eq!(
@@ -297,7 +305,7 @@ fn sequence_embeddings(dir: &Path, seq: usize, positions: usize, hidden: usize) 
 
 /// Build one arm: every layer on device, the head riding the last
 /// epoch. `overlay` present = the candidate arm.
-fn build_stack<'a>(
+pub(super) fn build_stack<'a>(
     metal: &MetalBackend,
     model: &KimiSourceModel,
     overlay: Option<&CandidateOverlay>,
@@ -397,7 +405,17 @@ fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
         t0.elapsed().as_secs_f64(),
         overlay.compiled_layers()
     );
+    // The EARLIEST compiled layer (verify_complete sorts): the one
+    // layer whose router input is untouched in BOTH arms, so its own
+    // routing must be identical — the cascade/local discriminator. A
+    // composed map's later compiled layers see moved hidden states and
+    // may legitimately route differently.
     let overlay_layer = overlay.compiled_layers()[0] as usize;
+    let compiled_set: Vec<usize> = overlay
+        .compiled_layers()
+        .iter()
+        .map(|&l| l as usize)
+        .collect();
 
     // ── Load both arms; the loader refuses on any missing operand. ──
     let t1 = Instant::now();
@@ -417,13 +435,15 @@ fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
         t1.elapsed().as_secs_f64()
     );
 
-    // ── Physical attribution: the intended stores are the bound ones. ──
-    {
+    // ── Physical attribution: the intended stores are the bound ones,
+    //    at EVERY compiled layer — a composed map earns the check per
+    //    layer, at that layer's own encoding. ──
+    for &probe_layer in &compiled_set {
         let probe_b = model
-            .device_layer(&metal, overlay_layer, None)
+            .device_layer(&metal, probe_layer, None)
             .expect("baseline probe layer");
         let probe_c = model
-            .device_layer(&metal, overlay_layer, Some(&overlay))
+            .device_layer(&metal, probe_layer, Some(&overlay))
             .expect("candidate probe layer");
         // The BASELINE arm is entirely source-backed, whatever the
         // candidate's scope.
@@ -455,7 +475,12 @@ fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
         ] {
             let want_candidate = compiled.contains(&spelling);
             let (store, enc) = if want_candidate {
-                ("kimi-q6-candidate", ExpertEncoding::Q6K)
+                (
+                    "kimi-candidate-bank",
+                    overlay
+                        .encoding_of(probe_layer as u32)
+                        .expect("the probed layer is compiled"),
+                )
             } else {
                 ("kimi-source-expert-bank", ExpertEncoding::Bf16)
             };
@@ -487,7 +512,7 @@ fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
             // table-addressed over the source, and that asymmetry
             // inside one layer is the thing this binding exists to
             // express.
-            let is_candidate = proj.store_id() == "kimi-q6-candidate";
+            let is_candidate = proj.store_id() == "kimi-candidate-bank";
             match (&proj.addressing, is_candidate) {
                 (ProjectionAddressing::Identity { experts, .. }, true) => assert_eq!(
                     *experts, g.experts,
@@ -507,21 +532,12 @@ fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
         assert_eq!(shared.gate.encoding, ExpertEncoding::Bf16);
         // A layer the overlay does NOT compile is the same physical
         // bytes in both arms — pointer-identical, not merely same-named.
-        // A layer the overlay does NOT compile. The one after,
-        // normally — but the deepest layer has none after it, and the
-        // probe's claim is about a source-precision NEIGHBOUR, not
-        // about direction.
-        let neighbour = if overlay_layer + 1 < g.num_layers {
-            overlay_layer + 1
-        } else {
-            overlay_layer - 1
-        };
-        assert!(
-            neighbour < g.num_layers
-                && neighbour >= g.dense_prefix_layers
-                && !overlay.compiled_layers().contains(&(neighbour as u32)),
-            "the neighbour probe needs a routed source-precision layer"
-        );
+        // A layer the overlay does NOT compile — the first routed one
+        // outside the compiled set. A composed map may compile a whole
+        // band, so "the one after" is not necessarily source-backed.
+        let neighbour = (g.dense_prefix_layers..g.num_layers)
+            .find(|l| !compiled_set.contains(l))
+            .expect("the neighbour probe needs a routed source-precision layer");
         let nb = model.device_layer(&metal, neighbour, None).expect("nb");
         let nc = model
             .device_layer(&metal, neighbour, Some(&overlay))
@@ -533,15 +549,19 @@ fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
             "layer {neighbour} must be the SAME mapped bytes in both arms"
         );
         let checked = overlay
-            .verify_reads_match_seals(overlay_layer as u32, 16)
+            .verify_reads_match_seals(probe_layer as u32, 16)
             .expect("the bytes the loader reads must be the bytes the compiler sealed");
         eprintln!(
-            "[q2a] attribution: {} — compiled projections {:?} from q6-candidate/Q6_K, the \
-             rest source/BF16 and pointer-identical to the baseline; shared from decoder \
+            "[q2a] attribution: {} — compiled projections {:?} from kimi-candidate-bank/{}, \
+             the rest source/BF16 and pointer-identical to the baseline; shared from decoder \
              stack in both; layer {neighbour} pointer-identical; {checked} compiled operands \
              hash-match their seals",
             overlay.scope(),
             compiled,
+            overlay
+                .encoding_of(probe_layer as u32)
+                .expect("the probed layer is compiled")
+                .name(),
         );
     }
 
@@ -650,7 +670,13 @@ fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
         "min_covered_mass": min_covered,
         "stores": {
             "baseline_layer1_routed": "kimi-source-expert-bank (BF16, Table)",
-            "candidate_layer1_routed": "kimi-q6-candidate (Q6_K, Identity)",
+            "candidate_layer1_routed": format!(
+                "kimi-candidate-bank ({}, Identity)",
+                overlay
+                    .encoding_of(overlay_layer as u32)
+                    .expect("the probed layer is compiled")
+                    .name()
+            ),
             "shared_experts": "kimi-source-decoder-stack (BF16, both arms)",
         },
         "layer1_routed_experts": {

--- a/crates/larql-vindex/src/format/vindex3/represent/arena.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/arena.rs
@@ -171,7 +171,7 @@ impl RepresentationArena {
 /// claims Q6_K would make the whole evidence chain a lie, and the
 /// failure would look like "quantisation is free".
 fn encode(encoding: &str, values: &[f32], name: &str) -> Result<Vec<u8>, VindexError> {
-    use larql_compute::cpu::ops::q4_common::{quantize_q4_k, quantize_q6_k};
+    use larql_compute::cpu::ops::q4_common::{quantize_q4_k, quantize_q6_k, quantize_q8_0};
     match encoding {
         "Q6_K" | "Q4_K" => {
             if !values.len().is_multiple_of(256) {
@@ -186,6 +186,16 @@ fn encode(encoding: &str, values: &[f32], name: &str) -> Result<Vec<u8>, VindexE
             } else {
                 quantize_q4_k(values)
             })
+        }
+        "Q8_0" => {
+            if !values.len().is_multiple_of(32) {
+                return Err(VindexError::Parse(format!(
+                    "tensor `{name}`: {} values is not a whole number of 32-element \
+                     blocks, so Q8_0 rows would share a scale",
+                    values.len()
+                )));
+            }
+            Ok(quantize_q8_0(values))
         }
         "BF16" => Ok(values
             .iter()

--- a/crates/larql-vindex/src/format/vindex3/represent/arena_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/arena_tests.rs
@@ -261,6 +261,79 @@ fn a_shape_that_would_straddle_superblocks_is_refused() {
     assert!(format!("{err}").contains("superblock"), "{err}");
 }
 
+/// Q8_0 is encoded through the canonical ggml codec — byte-identical to
+/// `quantize_q8_0` over the same widened values, and the round trip is
+/// bounded by the format's own quantisation step. This is the arm the
+/// precision ladder's middle rung compiles candidates with, so the
+/// bytes must be exactly what the grouped kernel's decode gate proved.
+#[test]
+fn q8_0_is_encoded_canonically_and_round_trips_within_its_scale() {
+    use larql_compute::cpu::ops::q4_common::{dequantize_q8_0, quantize_q8_0};
+
+    let c = FakeContainer::new().with("3.mlp.experts.7.down_proj.weight", 0.3);
+    let arena = RepresentationArena::new(PrecisionMap {
+        encoding: "Q8_0".into(),
+        ..scoped_map(None)
+    });
+    let op = operand("3.mlp.experts.7.down_proj.weight");
+    let got = arena
+        .resolve(&c, Role::ExpertWeight, &op)
+        .expect("resolves");
+    assert_eq!(got.encoding, "Q8_0");
+    // 34 bytes per 32-element block.
+    assert_eq!(got.bytes.len(), K / 32 * 34);
+
+    // The values the arena encoded are the widened stored bytes, so the
+    // canonical codec over the same values must agree byte for byte.
+    let stored = c.load_stored(&op).expect("stored");
+    let widened: Vec<f32> = stored
+        .bytes
+        .chunks_exact(2)
+        .map(|p| f32::from_bits((u16::from_le_bytes([p[0], p[1]]) as u32) << 16))
+        .collect();
+    assert_eq!(*got.bytes, quantize_q8_0(&widened));
+
+    // Round trip bounded per block: half a step (amax/254) plus the f16
+    // scale's own rounding (2^-11 relative).
+    let decoded = dequantize_q8_0(&got.bytes, K).expect("decodes");
+    for (b, (vals, deqs)) in widened.chunks(32).zip(decoded.chunks(32)).enumerate() {
+        let amax = vals.iter().map(|v| v.abs()).fold(0.0f32, f32::max);
+        let bound = amax * (1.0 / 254.0 + 1.0 / 1024.0);
+        for (v, d) in vals.iter().zip(deqs) {
+            assert!(
+                (v - d).abs() <= bound,
+                "block {b}: |{v} - {d}| exceeds the format's own step {bound}"
+            );
+        }
+    }
+}
+
+/// Q8_0's block is 32 elements: a tensor that is not a whole number of
+/// them is refused, for the same shared-scale reason as the K-quants.
+#[test]
+fn q8_0_refuses_a_shape_that_straddles_its_blocks() {
+    let mut c = FakeContainer::new();
+    c.tensors.insert(
+        (
+            "target.expert_bank".into(),
+            "3.mlp.experts.7.down_proj.weight".into(),
+        ),
+        vec![0.5f32; K + 16],
+    );
+    let arena = RepresentationArena::new(PrecisionMap {
+        encoding: "Q8_0".into(),
+        ..scoped_map(None)
+    });
+    let err = arena
+        .resolve(
+            &c,
+            Role::ExpertWeight,
+            &operand("3.mlp.experts.7.down_proj.weight"),
+        )
+        .expect_err("must refuse");
+    assert!(format!("{err}").contains("32-element"), "{err}");
+}
+
 /// The arena reports the map it executes and how many operands it has
 /// materialised — the per-ARM accounting two arms are compared by.
 #[test]

--- a/crates/larql-vindex/src/format/vindex3/represent/compile.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/compile.rs
@@ -92,6 +92,15 @@ impl LayerBankLayout {
                 let per_sb = if encoding == "Q6_K" { 210 } else { 144 };
                 Ok((elems / 256) as u64 * per_sb)
             }
+            "Q8_0" => {
+                if !k.is_multiple_of(32) {
+                    return Err(VindexError::Parse(format!(
+                        "k={k} is not a whole number of 32-element blocks, so rows \
+                         would share a scale in Q8_0"
+                    )));
+                }
+                Ok((elems / 32) as u64 * 34)
+            }
             other => Err(VindexError::Parse(format!(
                 "no compiled layout for encoding `{other}`"
             ))),
@@ -152,6 +161,125 @@ impl LayerBankLayout {
     pub fn bank_bytes(&self, projection: &str) -> Result<u64, VindexError> {
         let last = self.slot(projection, self.experts - 1)?;
         Ok(last.offset + last.len)
+    }
+
+    /// Total bytes of this layer's THREE projection banks — the
+    /// layer's whole extent in a candidate segment.
+    pub fn layer_bytes(&self) -> Result<u64, VindexError> {
+        Ok(2 * self.bank_bytes("w1")? + self.bank_bytes("w2")?)
+    }
+}
+
+/// Where each compiled layer's bank begins in a candidate segment that
+/// holds SEVERAL layers — the composed-map extension of `bank_base`.
+///
+/// Layers are placed ascending by index; each layer's extent is its
+/// OWN encoding's three projection banks, so one candidate can hold
+/// L20..=25 at Q8_0 beside L26 at Q6_K. A single-layer placement puts
+/// its layer at base 0, byte-identical to the layout every existing
+/// candidate was compiled with — this is an extension, never a
+/// migration.
+///
+/// ONE definition, used by the compiler, the completeness verifier and
+/// the loader, for the same reason `bank_base` is `pub(crate)` in one
+/// place: two derivations of the same offset WILL drift.
+#[derive(Debug, Clone)]
+pub struct CandidatePlacement {
+    /// `(layout, base)` per layer, ascending by layer index.
+    placed: Vec<(LayerBankLayout, u64)>,
+}
+
+impl CandidatePlacement {
+    /// Resolve placement for `layers` under `map`.
+    ///
+    /// Each layer's encoding is the map's OWN answer for that layer's
+    /// operands (`PrecisionMap::resolve` over the three projections).
+    /// A layer whose compiled projections resolve to DIFFERENT
+    /// encodings is refused by name — per-projection precision within
+    /// one layer's identity-addressed bank is not placeable, because
+    /// identity addressing carries one stride. A layer the map does
+    /// not compile at all is refused too: placing it would reserve
+    /// bytes no seal will ever cover.
+    pub fn resolve(
+        map: &super::map::PrecisionMap,
+        role: super::policy::Role,
+        layers: &[u32],
+        experts: u32,
+        hidden: usize,
+        inter: usize,
+    ) -> Result<Self, VindexError> {
+        let mut sorted: Vec<u32> = layers.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        if sorted.is_empty() {
+            return Err(VindexError::Parse(
+                "a candidate placement over no layers places nothing".into(),
+            ));
+        }
+        let mut placed = Vec::with_capacity(sorted.len());
+        let mut base = 0u64;
+        for layer in sorted {
+            let mut encodings: Vec<(&str, String)> = Vec::new();
+            for proj in ["w1", "w3", "w2"] {
+                let tensor = format!("{layer}.block_sparse_moe.experts.0.{proj}.weight");
+                if let super::map::Precision::Compiled(enc) = map.resolve(role, &tensor) {
+                    encodings.push((proj, enc.to_string()));
+                }
+            }
+            let Some((_, encoding)) = encodings.first() else {
+                return Err(VindexError::Parse(format!(
+                    "layer {layer} is in the placement but the map `{}` compiles none of \
+                     its projections",
+                    map.name
+                )));
+            };
+            if let Some((proj, other)) = encodings.iter().find(|(_, e)| e != encoding) {
+                return Err(VindexError::Parse(format!(
+                    "layer {layer}: `{}` resolves to {encoding} but `{proj}` to {other} — \
+                     an identity-addressed layer bank carries ONE encoding; per-projection \
+                     precision within a layer is not placeable",
+                    encodings[0].0
+                )));
+            }
+            let layout = LayerBankLayout::new(layer, encoding, experts, hidden, inter)?;
+            let extent = layout.layer_bytes()?;
+            placed.push((layout, base));
+            base = base
+                .checked_add(extent)
+                .ok_or_else(|| VindexError::Parse("candidate placement overflows u64".into()))?;
+        }
+        Ok(Self { placed })
+    }
+
+    /// The layers this placement covers, ascending.
+    pub fn layers(&self) -> impl Iterator<Item = u32> + '_ {
+        self.placed.iter().map(|(l, _)| l.layer)
+    }
+
+    /// This layer's layout, or a refusal naming the layer.
+    pub fn layout(&self, layer: u32) -> Result<&LayerBankLayout, VindexError> {
+        self.placed
+            .iter()
+            .find(|(l, _)| l.layer == layer)
+            .map(|(l, _)| l)
+            .ok_or_else(|| {
+                VindexError::Parse(format!(
+                    "layer {layer} is not in this candidate's placement"
+                ))
+            })
+    }
+
+    /// Where this layer's bank begins in the segment.
+    pub fn layer_base(&self, layer: u32) -> Result<u64, VindexError> {
+        self.placed
+            .iter()
+            .find(|(l, _)| l.layer == layer)
+            .map(|(_, b)| *b)
+            .ok_or_else(|| {
+                VindexError::Parse(format!(
+                    "layer {layer} is not in this candidate's placement"
+                ))
+            })
     }
 }
 

--- a/crates/larql-vindex/src/format/vindex3/represent/compile_real_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/compile_real_tests.rs
@@ -38,12 +38,124 @@ const LAYER_ENV: &str = "LARQL_Q6_LAYER";
 /// Which projection, in the checkpoint's own spelling (`w1` gate, `w3`
 /// up, `w2` down). Unset compiles all three.
 const PROJECTION_ENV: &str = "LARQL_Q6_PROJECTION";
+/// Which encoding to compile the scoped operands into. Unset is Q6_K —
+/// the driver's historical default. The precision ladder sets `Q8_0`:
+/// the depth sweep answered "how deep can Q6_K go" (only layer 26), so
+/// the live question is what an ~8-bit representation admits, and that
+/// is a different candidate under the SAME driver, not a new one.
+const ENCODING_ENV: &str = "LARQL_Q6_ENCODING";
 
 fn scope_layer() -> u32 {
     std::env::var(LAYER_ENV)
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(1)
+}
+
+/// Refuses an encoding no grouped kernel reads, loudly, before any
+/// bytes are written — a candidate that compiles but cannot execute
+/// would burn a bank run to discover a typo.
+fn scope_encoding() -> String {
+    let enc = std::env::var(ENCODING_ENV)
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "Q6_K".into());
+    assert!(
+        super::physical::ExpertEncoding::parse(&enc).is_some(),
+        "{ENCODING_ENV}={enc} names no encoding a grouped kernel reads"
+    );
+    enc
+}
+
+/// A COMPOSED map: `"20-25:Q8_0,26:Q6_K"` — inclusive layer bands, each
+/// at its own encoding, one candidate. When set it overrides the
+/// single-layer/encoding envs, because a composed map IS the scope.
+const MAP_ENV: &str = "LARQL_Q6_MAP";
+
+fn scope_composed() -> Option<Vec<((u32, u32), String)>> {
+    let spec = std::env::var(MAP_ENV).ok().filter(|v| !v.is_empty())?;
+    let bands = spec
+        .split(',')
+        .map(|band| {
+            let (range, enc) = band
+                .split_once(':')
+                .unwrap_or_else(|| panic!("{MAP_ENV}: `{band}` is not `LAYERS:ENCODING`"));
+            let (lo, hi) = match range.split_once('-') {
+                Some((a, b)) => (
+                    a.trim().parse().expect("band start"),
+                    b.trim().parse().expect("band end"),
+                ),
+                None => {
+                    let l = range.trim().parse().expect("band layer");
+                    (l, l)
+                }
+            };
+            assert!(lo <= hi, "{MAP_ENV}: band `{band}` is inverted");
+            assert!(
+                super::physical::ExpertEncoding::parse(enc.trim()).is_some(),
+                "{MAP_ENV}: `{enc}` names no encoding a grouped kernel reads"
+            );
+            ((lo, hi), enc.trim().to_string())
+        })
+        .collect::<Vec<_>>();
+    // Bands must not overlap — one layer, one encoding.
+    for (i, ((lo_a, hi_a), _)) in bands.iter().enumerate() {
+        for ((lo_b, hi_b), _) in bands.iter().skip(i + 1) {
+            assert!(
+                hi_a < lo_b || hi_b < lo_a,
+                "{MAP_ENV}: bands overlap at layers {}..={} vs {}..={}",
+                lo_a,
+                hi_a,
+                lo_b,
+                hi_b
+            );
+        }
+    }
+    Some(bands)
+}
+
+/// Every layer a composed spec names, ascending.
+fn composed_layers(bands: &[((u32, u32), String)]) -> Vec<u32> {
+    let mut layers: Vec<u32> = bands.iter().flat_map(|((lo, hi), _)| *lo..=*hi).collect();
+    layers.sort_unstable();
+    layers
+}
+
+/// The composed precision map: one exception per band, catch-all source.
+fn composed_map(bands: &[((u32, u32), String)]) -> PrecisionMap {
+    let name = format!(
+        "kimi-map-{}",
+        bands
+            .iter()
+            .map(|((lo, hi), enc)| {
+                let tag = enc.to_lowercase().replace('_', "");
+                if lo == hi {
+                    format!("l{lo}{tag}")
+                } else {
+                    format!("l{lo}-{hi}{tag}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("-")
+    );
+    PrecisionMap {
+        name,
+        encoding: bands[0].1.clone(),
+        roles: vec!["expert-weight".into()],
+        exceptions: bands
+            .iter()
+            .map(|((lo, hi), enc)| Exception {
+                projection: None,
+                layers: Some((*lo, *hi)),
+                encoding: Some(enc.clone()),
+            })
+            .chain([Exception {
+                projection: None,
+                layers: None,
+                encoding: None,
+            }])
+            .collect(),
+    }
 }
 
 /// One or more projections, comma-separated. Empty compiles all three.
@@ -69,7 +181,7 @@ struct SegmentSource {
 impl SegmentSource {
     fn open(
         container: &std::path::Path,
-        layer: u32,
+        layers: &[u32],
     ) -> Result<(Self, Vec<SourceTensor>), VindexError> {
         let path = container.join("segments").join(format!("{OBJECT}.bin"));
         let (header, payload_start) =
@@ -77,7 +189,9 @@ impl SegmentSource {
         let mut offsets = std::collections::BTreeMap::new();
         let mut tensors = Vec::new();
         for t in header.tensors {
-            if crate::format::vindex3::represent::policy::layer_of(&t.name) == Some(layer) {
+            if crate::format::vindex3::represent::policy::layer_of(&t.name)
+                .is_some_and(|l| layers.contains(&l))
+            {
                 tensors.push(SourceTensor {
                     name: t.name.clone(),
                     shape: t.shape.to_vec(),
@@ -122,12 +236,15 @@ impl SourceOperands for SegmentSource {
 /// "which part of this layer's FFN is the sensitive one": gate and up
 /// feed the nonlinear activation, down writes back to the residual
 /// stream, and they need not be equally safe to quantise.
-fn layer_q6(layer: u32, projections: &[String]) -> PrecisionMap {
+fn layer_q6(layer: u32, projections: &[String], encoding: &str) -> PrecisionMap {
+    // "Q6_K" -> "q6k", "Q8_0" -> "q80": the map's name carries its
+    // encoding, so two candidates for one layer never collide.
+    let tag = encoding.to_lowercase().replace('_', "");
     let name = if projections.is_empty() {
-        format!("kimi-expertweight-layer{layer}-q6k")
+        format!("kimi-expertweight-layer{layer}-{tag}")
     } else {
         format!(
-            "kimi-expertweight-layer{layer}-{}-q6k",
+            "kimi-expertweight-layer{layer}-{}-{tag}",
             projections.join("+")
         )
     };
@@ -136,7 +253,7 @@ fn layer_q6(layer: u32, projections: &[String]) -> PrecisionMap {
         vec![Exception {
             projection: None,
             layers: Some((layer, layer)),
-            encoding: Some("Q6_K".into()),
+            encoding: Some(encoding.into()),
         }]
     } else {
         projections
@@ -144,13 +261,13 @@ fn layer_q6(layer: u32, projections: &[String]) -> PrecisionMap {
             .map(|p| Exception {
                 projection: Some(p.clone()),
                 layers: Some((layer, layer)),
-                encoding: Some("Q6_K".into()),
+                encoding: Some(encoding.into()),
             })
             .collect()
     };
     PrecisionMap {
         name,
-        encoding: "Q6_K".into(),
+        encoding: encoding.into(),
         roles: vec!["expert-weight".into()],
         exceptions: scoped
             .into_iter()
@@ -182,16 +299,32 @@ fn compile_the_layer_one_q6_candidate() {
         eprintln!("skipped: set {CONTAINER_ENV} to the source .vindex3");
         return;
     };
-    let (layer, projections) = (scope_layer(), scope_projections());
+    let projections = scope_projections();
+    // A composed spec is one candidate over several layer bands; the
+    // single-layer envs are the degenerate one-band form of the same
+    // thing. The map NAME differs (layer_q6's spelling is what existing
+    // candidates resume under), so composition is opt-in via the env,
+    // never a silent rename.
+    let composed = scope_composed();
+    let bands = composed
+        .clone()
+        .unwrap_or_else(|| vec![((scope_layer(), scope_layer()), scope_encoding())]);
+    let layers = composed_layers(&bands);
+    if composed.is_some() {
+        assert!(
+            projections.is_empty(),
+            "a composed map compiles whole layers; {PROJECTION_ENV} does not apply"
+        );
+    }
     let out_dir = std::env::var_os(OUT_ENV)
         .map(PathBuf::from)
         .unwrap_or_else(|| std::env::temp_dir().join("kimi-q6-candidate.vindex3"));
     std::fs::create_dir_all(out_dir.join("segments")).expect("out dir");
     let bank = out_dir.join("segments").join(format!("{OBJECT}.bin"));
 
-    let (source, tensors) = SegmentSource::open(&container, layer).expect("source segment");
+    let (source, tensors) = SegmentSource::open(&container, &layers).expect("source segment");
     eprintln!(
-        "[compile] layer {layer}{}: {} source tensors from {}",
+        "[compile] layers {layers:?}{}: {} source tensors from {}",
         if projections.is_empty() {
             String::new()
         } else {
@@ -202,12 +335,16 @@ fn compile_the_layer_one_q6_candidate() {
     );
     assert_eq!(
         tensors.len(),
-        (EXPERTS * 3) as usize,
-        "layer {layer} must hold 3 projections for each of {EXPERTS} experts"
+        layers.len() * (EXPERTS * 3) as usize,
+        "each of layers {layers:?} must hold 3 projections for each of {EXPERTS} experts"
     );
 
     let index_path = out_dir.join("index.json");
-    let map = layer_q6(layer, &projections);
+    let map = match &composed {
+        Some(bands) => composed_map(bands),
+        None => layer_q6(layers[0], &projections, &bands[0].1),
+    };
+    let map_name = map.name.clone();
     let mut index = std::fs::read(&index_path)
         .ok()
         .and_then(|b| serde_json::from_slice::<CandidateIndex>(&b).ok())
@@ -253,8 +390,9 @@ fn compile_the_layer_one_q6_candidate() {
 
     let on_disk = std::fs::metadata(&bank).expect("stat").len();
     eprintln!(
-        "[compile] layer {layer} Q6_K: {} sealed, {} resumed, {} left at source; \
+        "[compile] {}: {} sealed, {} resumed, {} left at source; \
          {:.2} GB in {secs:.1}s ({:.0} MB/s); bank file {:.2} GB",
+        map_name,
         outcome.sealed,
         outcome.resumed,
         outcome.source_precision,
@@ -290,19 +428,20 @@ fn compile_the_layer_one_q6_candidate() {
     // Every operand the scope covers is sealed; the rest were left at
     // source and never written. A projection-scoped map compiles a
     // THIRD of the layer, which is the point of scoping it.
-    let in_scope = if projections.is_empty() {
+    let per_layer_in_scope = if projections.is_empty() {
         (EXPERTS * 3) as usize
     } else {
         EXPERTS as usize * projections.len()
     };
+    let in_scope = per_layer_in_scope * layers.len();
     assert_eq!(
         outcome.sealed + outcome.resumed,
         in_scope,
-        "every in-scope layer-{layer} operand must be sealed or already sealed"
+        "every in-scope operand of layers {layers:?} must be sealed or already sealed"
     );
     assert_eq!(
         outcome.source_precision,
-        (EXPERTS * 3) as usize - in_scope,
+        layers.len() * (EXPERTS * 3) as usize - in_scope,
         "everything outside the scope stays at source precision, unwritten"
     );
     assert!(index.ledger.overlaps().is_empty(), "banks must not collide");
@@ -310,21 +449,33 @@ fn compile_the_layer_one_q6_candidate() {
         !index.is_authoritative(),
         "no quality bank has run, so these bytes must NOT be selected"
     );
-    // The compiled population, against the format's own geometry.
-    // 256 experts x [1024, 2304] at Q6_K is 210 bytes per 256-element
-    // superblock — ~0.50 GB a projection, ~1.49 GB for all three.
+    // The compiled population, against the format's own geometry: every
+    // projection of this layer is 1024 x 2304 elements (gate/up
+    // [inter, hidden], down [hidden, inter] — same product), so the
+    // ledger's byte count is EXACTLY the encoding's per-matrix size
+    // times the in-scope operand count. Derived from the same
+    // `matrix_bytes` the layout uses, so a drift here is a compiler
+    // fault, never a stale constant.
     let expected = index.ledger.compiled_bytes();
-    let per_projection = 0.496e9;
-    let want = per_projection * in_scope as f64 / EXPERTS as f64;
-    assert!(
-        (expected as f64 - want).abs() < 0.1e9,
-        "layer {layer}{} at Q6_K should be ~{:.2} GB, got {:.2} GB",
+    let want: u64 = bands
+        .iter()
+        .map(|((lo, hi), enc)| {
+            let per_matrix = super::compile::LayerBankLayout::matrix_bytes(enc, 1024, 2304)
+                .expect("the driver's geometry is encodable");
+            per_matrix * per_layer_in_scope as u64 * u64::from(hi - lo + 1)
+        })
+        .sum();
+    assert_eq!(
+        expected,
+        want,
+        "`{}`{} should be exactly {:.3} GB, got {:.3} GB",
+        map_name,
         if projections.is_empty() {
             String::new()
         } else {
             format!(" / {}", projections.join("+"))
         },
-        want / 1e9,
+        want as f64 / 1e9,
         expected as f64 / 1e9
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/compiler.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/compiler.rs
@@ -28,7 +28,9 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use super::arena::{RepresentationArena, SourceOperands};
-use super::compile::{hash_bytes, CompilationLedger, LayerBankLayout, OperandSeal, Pending};
+use super::compile::{
+    hash_bytes, CandidatePlacement, CompilationLedger, LayerBankLayout, OperandSeal, Pending,
+};
 use super::map::{Precision, PrecisionMap};
 use super::policy::{layer_of, projection_of, Role};
 use super::selection::Promotion;
@@ -203,14 +205,24 @@ impl CandidateIndex {
         object: impl Into<String>,
         map: PrecisionMap,
     ) -> Self {
-        let encoding = map.encoding.clone();
+        // Every encoding the map can put bytes in: the default plus
+        // each exception's. A composed map (Q8_0 band + a Q6_K layer)
+        // states both, so a promotion can select either honestly.
+        let mut can_represent_as = vec![map.encoding.clone()];
+        for e in &map.exceptions {
+            if let Some(enc) = &e.encoding {
+                if !can_represent_as.contains(enc) {
+                    can_represent_as.push(enc.clone());
+                }
+            }
+        }
         Self {
             model: model.into(),
             source,
             object: object.into(),
             ledger: CompilationLedger::new(map.name.clone()),
             map,
-            can_represent_as: vec![encoding],
+            can_represent_as,
             // Compiled bytes are not authority. Nothing but a promotion
             // moves this.
             selected_representation: "source".into(),
@@ -291,6 +303,58 @@ pub fn compile_expert_bank(
         .open(out)?;
     let mut outcome = CompileOutcome::default();
 
+    // The compiled layer set decides each layer's base in the segment,
+    // so it is derived ONCE, from the whole scope this run was handed —
+    // a per-tensor derivation would let two runs over different subsets
+    // of one map write the same layer at two bases.
+    let mut compiled_layers: Vec<u32> = Vec::new();
+    let mut geometry: Option<(usize, usize)> = None;
+    for t in tensors {
+        // Geometry is a property of the family, not of the scope: a
+        // w2-only map still needs the gate/up shape to place banks.
+        if let Some(proj) = projection_of(&t.name) {
+            if matches!(proj, "w1" | "w3" | "gate_proj" | "up_proj") {
+                let [rows, cols] = t.shape[..] else {
+                    // Refuse the malformed tensor BY NAME here rather
+                    // than skipping it — a skip would surface later as
+                    // "no gate/up tensor", a message that denies this
+                    // tensor exists.
+                    return Err(VindexError::Parse(format!(
+                        "tensor `{}` is not a matrix: {:?}",
+                        t.name, t.shape
+                    )));
+                };
+                geometry = Some((cols, rows)); // (hidden, inter)
+            }
+        }
+        if matches!(index.map.resolve(role, &t.name), Precision::Source) {
+            continue;
+        }
+        if let Some(layer) = layer_of(&t.name) {
+            compiled_layers.push(layer);
+        }
+    }
+    compiled_layers.sort_unstable();
+    compiled_layers.dedup();
+    let placement = match (&compiled_layers[..], geometry) {
+        ([], _) => None,
+        (_, Some((hidden, inter))) => Some(CandidatePlacement::resolve(
+            &index.map,
+            role,
+            &compiled_layers,
+            experts,
+            hidden,
+            inter,
+        )?),
+        (_, None) => {
+            return Err(VindexError::Parse(
+                "the scope compiles operands but holds no gate/up tensor to take the \
+                 bank geometry from"
+                    .into(),
+            ))
+        }
+    };
+
     for t in tensors {
         let encoding = match index.map.resolve(role, &t.name) {
             Precision::Source => {
@@ -315,9 +379,22 @@ pub fn compile_expert_bank(
                 t.name, t.shape
             )));
         };
+        let placement = placement
+            .as_ref()
+            .expect("a compiled tensor implies a placement");
         // Strides come from the projection SHAPES, so gate/up and down
-        // are distinguished by geometry rather than by trusting a name.
+        // are distinguished by geometry rather than by trusting a name —
+        // and they must agree with the placement's own derivation, or
+        // this tensor is not the shape its layer's bank was placed for.
         let layout = LayerBankLayout::new(layer, &encoding, experts, cols, rows)?;
+        let placed = placement.layout(layer)?;
+        if *placed != layout {
+            return Err(VindexError::Parse(format!(
+                "tensor `{}`: shape/encoding disagree with the placement's layout for \
+                 layer {layer} ({placed:?} vs {layout:?})",
+                t.name
+            )));
+        }
         let slot = layout.slot(projection, expert)?;
 
         let operand = OperandRef {
@@ -328,9 +405,23 @@ pub fn compile_expert_bank(
         };
         let stored = source.load_stored(&operand)?;
         let source_hash = hash_bytes(&stored.bytes);
-        // Per-projection bank base, so w1/w2/w3 do not overlap.
-        let base = bank_base(&layout, projection)?;
-        let offset = base + slot.offset;
+        // Layer base first (composed maps hold several layers), then
+        // the per-projection bank base so w1/w2/w3 do not overlap.
+        let offset = placement.layer_base(layer)? + bank_base(&layout, projection)? + slot.offset;
+
+        // A seal written under a DIFFERENT placement — a rerun handed a
+        // subset of the map's layers would recompute every base — must
+        // refuse, not silently overwrite another layer's bytes.
+        if let Some(seal) = index.ledger.get(object, &t.name) {
+            if seal.target_offset != offset {
+                return Err(VindexError::Parse(format!(
+                    "tensor `{}` is sealed at offset {} but this run's placement puts it \
+                     at {offset} — the scope differs from the one the ledger was written \
+                     under; pass the map's full layer scope or start a fresh candidate",
+                    t.name, seal.target_offset
+                )));
+            }
+        }
 
         match index
             .ledger

--- a/crates/larql-vindex/src/format/vindex3/represent/compiler_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/compiler_tests.rs
@@ -650,3 +650,215 @@ fn an_unwritable_index_path_is_reported() {
         "a failed index write must be reported"
     );
 }
+
+/// **A composed map holds several layers in ONE candidate, each at its
+/// own encoding, placed disjointly.** L2 at Q8_0 beside L3 at Q6_K:
+/// every L2 seal lands inside [0, q8_layer_bytes), every L3 seal at
+/// q8_layer_bytes onward, no overlaps, and the ledger's total is the
+/// sum of the two encodings' own extents — nothing shared, nothing
+/// invented.
+#[test]
+fn a_composed_map_compiles_two_layers_disjointly_each_at_its_own_encoding() {
+    let dir = tempfile::tempdir().expect("tmp");
+    let out = dir.path().join("bank.bin");
+    let (fake2, t2) = Fake::kimi_layer(2, 0.3);
+    let (fake3, t3) = Fake::kimi_layer(3, 1.7);
+    let mut bytes = fake2.bytes;
+    bytes.extend(fake3.bytes);
+    let fake = Fake { bytes };
+    let tensors: Vec<SourceTensor> = t2.into_iter().chain(t3).collect();
+
+    let map = PrecisionMap {
+        name: "composed-l2q80-l3q6k".into(),
+        encoding: "Q8_0".into(),
+        roles: vec!["expert-weight".into()],
+        exceptions: vec![
+            Exception {
+                projection: None,
+                layers: Some((2, 2)),
+                encoding: Some("Q8_0".into()),
+            },
+            Exception {
+                projection: None,
+                layers: Some((3, 3)),
+                encoding: Some("Q6_K".into()),
+            },
+            Exception {
+                projection: None,
+                layers: None,
+                encoding: None,
+            },
+        ],
+    };
+    let mut idx = index(map);
+    assert_eq!(
+        idx.can_represent_as,
+        vec!["Q8_0".to_string(), "Q6_K".to_string()],
+        "a composed candidate states every encoding it can represent"
+    );
+    let outcome = compile_expert_bank(
+        &fake,
+        &tensors,
+        &opts("target.expert_bank", EXPERTS, &out),
+        &mut idx,
+        &mut |_| {},
+    )
+    .expect("composed compile");
+    assert_eq!(outcome.sealed, 2 * 3 * EXPERTS as usize);
+    assert!(idx.ledger.overlaps().is_empty(), "layers must not collide");
+
+    // Per-matrix bytes from the format's own arithmetic.
+    let q8_matrix = LayerBankLayout::matrix_bytes("Q8_0", INTER, HIDDEN).expect("q8");
+    let q6_matrix = LayerBankLayout::matrix_bytes("Q6_K", INTER, HIDDEN).expect("q6");
+    let q8_layer = 3 * q8_matrix * u64::from(EXPERTS);
+    let q6_layer = 3 * q6_matrix * u64::from(EXPERTS);
+    assert_eq!(idx.ledger.compiled_bytes(), q8_layer + q6_layer);
+
+    for seal in idx.ledger.sealed.values() {
+        let layer: u32 = seal.tensor.split('.').next().unwrap().parse().unwrap();
+        let end = seal.target_offset + seal.target_len;
+        match layer {
+            2 => {
+                assert_eq!(seal.encoding, "Q8_0", "{}", seal.tensor);
+                assert!(end <= q8_layer, "{} spills past its layer", seal.tensor);
+            }
+            3 => {
+                assert_eq!(seal.encoding, "Q6_K", "{}", seal.tensor);
+                assert!(
+                    seal.target_offset >= q8_layer && end <= q8_layer + q6_layer,
+                    "{} is outside its layer's band",
+                    seal.tensor
+                );
+            }
+            other => panic!("unexpected layer {other}"),
+        }
+    }
+}
+
+/// **A rerun handed a SUBSET of the composed scope must refuse, never
+/// silently relocate.** The placement derives layer bases from the
+/// handed scope; re-running with only layer 3's tensors would put its
+/// bank at base 0 — on top of layer 2's bytes. The seal-offset guard
+/// refuses by name instead.
+#[test]
+fn a_rerun_over_a_subset_of_the_composed_scope_is_refused() {
+    let dir = tempfile::tempdir().expect("tmp");
+    let out = dir.path().join("bank.bin");
+    let (fake2, t2) = Fake::kimi_layer(2, 0.3);
+    let (fake3, t3) = Fake::kimi_layer(3, 1.7);
+    let mut bytes = fake2.bytes;
+    bytes.extend(fake3.bytes);
+    let fake = Fake { bytes };
+    let both: Vec<SourceTensor> = t2.into_iter().chain(t3.iter().cloned()).collect();
+
+    let map = PrecisionMap {
+        name: "composed-subset-guard".into(),
+        encoding: "Q8_0".into(),
+        roles: vec!["expert-weight".into()],
+        exceptions: vec![
+            Exception {
+                projection: None,
+                layers: Some((2, 3)),
+                encoding: Some("Q8_0".into()),
+            },
+            Exception {
+                projection: None,
+                layers: None,
+                encoding: None,
+            },
+        ],
+    };
+    let mut idx = index(map);
+    compile_expert_bank(
+        &fake,
+        &both,
+        &opts("target.expert_bank", EXPERTS, &out),
+        &mut idx,
+        &mut |_| {},
+    )
+    .expect("full-scope compile");
+
+    let err = compile_expert_bank(
+        &fake,
+        &t3,
+        &opts("target.expert_bank", EXPERTS, &out),
+        &mut idx,
+        &mut |_| {},
+    )
+    .expect_err("a subset scope recomputes every base and must refuse");
+    let text = format!("{err}");
+    assert!(
+        text.contains("placement") && text.contains("full layer scope"),
+        "the refusal must explain the scope mismatch: {text}"
+    );
+}
+
+/// `CandidatePlacement` itself: single-layer placement is base 0
+/// (byte-compatible with every existing candidate), an unmapped layer
+/// and a per-projection-mixed layer are refused by name.
+#[test]
+fn placement_bases_and_refusals() {
+    let single = PrecisionMap {
+        name: "one".into(),
+        encoding: "Q6_K".into(),
+        roles: vec!["expert-weight".into()],
+        exceptions: vec![],
+    };
+    let p = CandidatePlacement::resolve(&single, Role::ExpertWeight, &[7], EXPERTS, HIDDEN, INTER)
+        .expect("single layer places");
+    assert_eq!(p.layer_base(7).expect("base"), 0, "single layer = base 0");
+    assert!(p.layer_base(8).is_err(), "an unplaced layer is refused");
+
+    // Two layers, one encoding: second base = first extent.
+    let p2 =
+        CandidatePlacement::resolve(&single, Role::ExpertWeight, &[7, 9], EXPERTS, HIDDEN, INTER)
+            .expect("two layers place");
+    let extent = p2.layout(7).expect("layout").layer_bytes().expect("bytes");
+    assert_eq!(p2.layer_base(9).expect("base"), extent);
+
+    // A layer the map does not compile cannot be placed.
+    let scoped = PrecisionMap {
+        name: "scoped".into(),
+        encoding: "Q6_K".into(),
+        roles: vec!["expert-weight".into()],
+        exceptions: vec![
+            Exception {
+                projection: None,
+                layers: Some((7, 7)),
+                encoding: Some("Q6_K".into()),
+            },
+            Exception {
+                projection: None,
+                layers: None,
+                encoding: None,
+            },
+        ],
+    };
+    let err =
+        CandidatePlacement::resolve(&scoped, Role::ExpertWeight, &[8], EXPERTS, HIDDEN, INTER)
+            .expect_err("an out-of-scope layer must refuse");
+    assert!(format!("{err}").contains("compiles none"), "{err}");
+
+    // Mixed encodings WITHIN one layer are not placeable: identity
+    // addressing carries one stride.
+    let mixed = PrecisionMap {
+        name: "mixed".into(),
+        encoding: "Q6_K".into(),
+        roles: vec!["expert-weight".into()],
+        exceptions: vec![
+            Exception {
+                projection: Some("w1".into()),
+                layers: Some((7, 7)),
+                encoding: Some("Q8_0".into()),
+            },
+            Exception {
+                projection: None,
+                layers: Some((7, 7)),
+                encoding: Some("Q6_K".into()),
+            },
+        ],
+    };
+    let err = CandidatePlacement::resolve(&mixed, Role::ExpertWeight, &[7], EXPERTS, HIDDEN, INTER)
+        .expect_err("per-projection mixing within a layer must refuse");
+    assert!(format!("{err}").contains("ONE encoding"), "{err}");
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/physical.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/physical.rs
@@ -434,6 +434,9 @@ impl ExpertLayout {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExpertEncoding {
     Bf16,
+    /// Canonical ggml Q8_0: 34-byte blocks of 32 (f16 scale + 32 int8),
+    /// 8.5 bpw — the precision ladder's rung between BF16 and Q6_K.
+    Q80,
     Q6K,
     Q4K,
 }
@@ -442,6 +445,7 @@ impl ExpertEncoding {
     pub fn name(self) -> &'static str {
         match self {
             ExpertEncoding::Bf16 => "BF16",
+            ExpertEncoding::Q80 => "Q8_0",
             ExpertEncoding::Q6K => "Q6_K",
             ExpertEncoding::Q4K => "Q4_K",
         }
@@ -452,6 +456,7 @@ impl ExpertEncoding {
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "BF16" => Some(ExpertEncoding::Bf16),
+            "Q8_0" => Some(ExpertEncoding::Q80),
             "Q6_K" => Some(ExpertEncoding::Q6K),
             "Q4_K" => Some(ExpertEncoding::Q4K),
             _ => None,
@@ -462,6 +467,14 @@ impl ExpertEncoding {
     pub fn matrix_bytes(self, n: usize, k: usize) -> Result<u64, VindexError> {
         match self {
             ExpertEncoding::Bf16 => Ok((n * k) as u64 * 2),
+            ExpertEncoding::Q80 => {
+                if !k.is_multiple_of(32) {
+                    return Err(VindexError::Parse(format!(
+                        "k={k} is not a whole number of 32-element blocks for Q8_0"
+                    )));
+                }
+                Ok((n * k / 32) as u64 * 34)
+            }
             ExpertEncoding::Q6K | ExpertEncoding::Q4K => {
                 if !k.is_multiple_of(256) {
                     return Err(VindexError::Parse(format!(

--- a/crates/larql-vindex/src/format/vindex3/represent/physical_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/physical_tests.rs
@@ -692,12 +692,27 @@ fn debug_names_the_store_and_encoding() {
     assert_eq!(r.store_id(), "candidate");
     assert_eq!(ExpertEncoding::Q4K.name(), "Q4_K");
     assert_eq!(ExpertEncoding::Q6K.name(), "Q6_K");
+    assert_eq!(ExpertEncoding::Q80.name(), "Q8_0");
     assert_eq!(ExpertEncoding::Bf16.name(), "BF16");
     // Q-format geometry refuses a k that is not whole superblocks.
     assert!(ExpertEncoding::Q6K.matrix_bytes(4, 255).is_err());
     assert_eq!(ExpertEncoding::Q6K.matrix_bytes(4, 256).unwrap(), 4 * 210);
     assert_eq!(ExpertEncoding::Q4K.matrix_bytes(4, 256).unwrap(), 4 * 144);
+    // Q8_0's block is 32 elements, so a k Q6_K refuses can still encode —
+    // and a k that is not whole 32-blocks refuses too.
+    assert!(ExpertEncoding::Q80.matrix_bytes(4, 33).is_err());
+    assert_eq!(ExpertEncoding::Q80.matrix_bytes(4, 96).unwrap(), 4 * 3 * 34);
     assert_eq!(ExpertEncoding::Bf16.matrix_bytes(4, 8).unwrap(), 64);
+    // The name round-trips through parse for every encoding a grouped
+    // kernel reads.
+    for enc in [
+        ExpertEncoding::Bf16,
+        ExpertEncoding::Q80,
+        ExpertEncoding::Q6K,
+        ExpertEncoding::Q4K,
+    ] {
+        assert_eq!(ExpertEncoding::parse(enc.name()), Some(enc));
+    }
 }
 
 /// **Each projection answers about ITS OWN addressing**, including the

--- a/docs/kimi-precision-topology.md
+++ b/docs/kimi-precision-topology.md
@@ -1,0 +1,106 @@
+# Kimi Linear 48B — the PRECISION-1 topology
+
+**The first complete REPRESENT chain: a per-layer precision frontier,
+a composed map earned against a frozen behavioural contract at
+authority scale, and an in-session decode benchmark.** Closed
+2026-08-30 on Kimi-Linear-48B-A3B-Instruct
+(`~/chris-models/Kimi-Linear-48B-A3B-Instruct.aligned.vindex3`).
+
+Contract: **kimi-logit-v3, frozen at `ce6e87a3`** — six authority
+criteria (positions ≥ 4096, KL p99 ≤ 1e-3, covered mass ≥ 0.6, top-1
+mass displaced ≤ 5e-2, top-10 mass p99 ≤ 1e-1, route mixture mass
+p99 ≤ 0.15 / max ≤ 0.25). Evidence bank: 256 × 32-position
+teacher-forced sequences from real prose, identity
+`a73f437aeb1d…` (manifest + per-file SHA256 in
+`~/chris-models/kimi-quality-bank-provenance/`).
+
+## The earned topology
+
+```text
+layers 0–23   BF16      (Q8_0 refused at L19 and below; see frontier)
+layers 24–26  Q8_0      composed map, PASSED v3 at 8192 positions
+```
+
+Composed authority (8192 positions): **kl p99 4.153e-4** (2.4×
+headroom), covered 0.631, top-1 mass max 1.56e-2, top-10 mass p99
+6.15e-2, route mass p99 0.113. Report
+`kimi_map-l24-26q80-8192_report.json`. Counts at that scale — 23
+top-1 flips, 1041 top-10 changes, 163 route flips — would have
+REFUSED under the count-based v1/v2 gates; the consequence contract
+is what makes 8192-position authority reachable at all.
+
+Bytes: expert banks for L24–26 drop 3 × 3.62 GB (BF16) → 3 × 1.93 GB
+(Q8_0), **5.1 GB saved**, all other tensors untouched.
+
+Decode (in-session, interleaved blocks, min-of-N floors, two
+sessions, AC power): baseline BF16 **35.46 / 35.52 tok/s** vs
+candidate **36.44 / 36.27 tok/s** → **1.021–1.028×**; GPU time
+27.0 → 26.4–26.5 ms/token (−2.2%, consistent with the roofline for
+the byte reduction). Harness:
+`opplan/exec/tests/q2a_decode_bench.rs`.
+
+## The per-layer Q8_0 frontier (256-position diagnostics)
+
+```text
+layer  kl p99      verdict
+ 25    2.305e-4    PASS   (confirmed at 8192: 1.446e-4)
+ 24    8.804e-5    PASS
+ 23    7.049e-4    PASS
+ 22    1.569e-4    PASS
+ 21    8.988e-4    PASS   (non-monotone inside the band)
+ 20    4.258e-4    PASS   ← frontier
+ 19    1.144e-3    FAIL   kl alone (14% over)
+ 18    8.906e-4    FAIL   top10_mass alone (0.1042) — kl passes
+ 16    4.962e-3    FAIL   kl + route_mass
+ 13    8.001e-3    FAIL   kl + route_mass
+  6    1.665e-2    FAIL   kl + top10_mass + route_mass
+  1    4.665e-2    FAIL   kl + top10_mass + route_mass
+ 26    1.161e-4    PASS   (Q8_0; Q6_K also passed individually at
+                           8.53e-4 @ 8192 — see below for why the
+                           map still prefers Q8_0 here)
+```
+
+The failure mode rotates at the edge (L18/L19 fail single criteria)
+and enriches with depth. L18/L19 are the balanced-profile seeds.
+
+## Composition is the finding
+
+Individually admissible layers do not compose, and no scalar
+correction fixes that:
+
+```text
+map                       measured    raw Σ      α       verdict
+V1 {20-25:Q8, 26:Q6}      2.489e-3    3.2e-3     0.77    FAIL kl
+V2 {22-25:Q8, 26:Q6}      1.110e-3    ~2.0e-3    0.55    FAIL kl
+V3 {22,24,25,26:Q8}       1.124e-3    5.92e-4    1.90    FAIL kl  (super-additive)
+V4 {24,25,26:Q8}          2.262e-4    4.35e-4    0.52    PASS → 8192 PASS
+```
+
+* V2 and V3 land nearly identical composed KL with raw sums 3.4×
+  apart: the composed tail is dominated by interaction, not member
+  costs.
+* V3 − V4 attributes it: **adding L22 to the late band costs
+  ~9.0e-4 composed against 1.57e-4 solo (~6×)**. The mechanism is
+  the routing cascade — L22's hidden-state displacement flips
+  routes from L23 onward in every map containing it.
+* **L26 composes almost free** (last routed layer — no downstream
+  router to amplify it), which is why the map takes Q8_0 there
+  (1.16e-4) over the individually-cheapest Q6_K (8.53e-4): *the
+  best representation for a scope in isolation need not belong to
+  the best admissible map.* A per-layer recipe cannot discover
+  this; only a composed gate can.
+* Diagnostic→8192 drift on the winner was +84% (2.26e-4 →
+  4.15e-4): the ~7e-4 promotion margin for a 1e-3 gate is not
+  conservatism theatre.
+
+## Reproduction
+
+```text
+bank      scripts/kimi_quality_bank_export.py  (deterministic; verify
+          per-file SHA256 against provenance SHA256SUMS.json)
+compile   LARQL_Q6_MAP="24-26:Q8_0" → represent/compile_real_tests.rs
+quality   q2a_teacher_forced (LARQL_Q2A_SEQUENCES=8 diagnostic,
+          256 authority)
+speed     q2a_decode_bench (both arms in-process, interleaved)
+evidence  ~/chris-models/kimi-quality-bank-provenance/
+```

--- a/scripts/kimi_quality_bank_export.py
+++ b/scripts/kimi_quality_bank_export.py
@@ -65,6 +65,15 @@ def main() -> None:
     ap.add_argument("--sequences", type=int, default=256)
     ap.add_argument("--positions", type=int, default=32)
     ap.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    ap.add_argument(
+        "--start",
+        type=int,
+        default=0,
+        help="token offset of sequence 0 — a HELD-OUT bank uses the same "
+        "stride with a start that lands every window in the gaps between "
+        "the selection bank's windows, so the two banks never share a "
+        "position while sampling the same corpus distribution",
+    )
     ap.add_argument("--stride", type=int, default=0,
                     help="tokens between sequence starts, so they come from genuinely "
                          "different passages rather than adjacent windows. 0 spreads "
@@ -97,8 +106,14 @@ def main() -> None:
     print(f"[bank] embedding table {tuple(embed.shape)}", flush=True)
 
     sequences = []
+    last_needed = args.start + (args.sequences - 1) * stride + args.positions
+    if last_needed > len(ids):
+        raise SystemExit(
+            f"--start {args.start} pushes the last window to {last_needed} tokens "
+            f"but the corpus holds {len(ids)}"
+        )
     for s in range(args.sequences):
-        start = s * stride
+        start = args.start + s * stride
         seq = ids[start : start + args.positions]
         sequences.append(seq)
         rows = embed[torch.tensor(seq, dtype=torch.long)].to(torch.float32)
@@ -112,6 +127,10 @@ def main() -> None:
         "hidden": hidden,
         "vocab_size": int(embed.shape[0]),
         "stride": stride,
+        # Only a held-out bank carries a start: the canonical bank's
+        # manifest bytes predate this knob, and its content-hash identity
+        # must not change under regeneration.
+        **({"start": args.start} if args.start else {}),
         "corpus": str(args.corpus),
         "token_ids": sequences,
         # Teacher forcing is a property of the BANK, not of a runner


### PR DESCRIPTION
## What

The PRECISION-1 rung: Q8_0 expert-bank enablement, composed-map compile/verify/measure
machinery, a two-arm decode benchmark, and the first composed topology to pass the frozen
behavioural contract at authority scale.

## The result

| | |
|---|---|
| Topology | L0-23 BF16, **L24-26 Q8_0** (routed expert banks) |
| Contract | kimi-logit-v3, frozen at ce6e87a3 — **PASS at 8192 positions** |
| KL p99 | 4.153e-4 (limit 1e-3) |
| Bytes | **5.1 GB saved** |
| Decode | 35.46/35.52 → 36.44/36.27 tok/s (in-session BF16 baseline, 2 sessions, min-of-N) |

## Why the composed gate is the point

Four composed maps measured on the same verified evidence bank:

| map | measured kl p99 | Σ member KLs | ratio | verdict |
|---|---|---|---|---|
| {20-25:Q8, 26:Q6} | 2.489e-3 | 3.2e-3 | 0.77 | FAIL |
| {22-25:Q8, 26:Q6} | 1.110e-3 | ~2.0e-3 | 0.55 | FAIL |
| {22,24,25,26:Q8} | 1.124e-3 | 5.92e-4 | **1.90** | FAIL |
| {24,25,26:Q8} | 2.262e-4 | 4.35e-4 | 0.52 | **PASS → 8192 PASS** |

Individually admissible layers do not compose, and no scalar correction fixes it: the
interaction is structural (a substitution's error cascades through downstream routers —
L22 costs ~6x its solo KL beside the late band; L26, with no downstream router, composes
nearly free). L26's individually-cheapest representation (Q6_K, PASS at 8192 on its own)
belongs to no admissible map — the composed search selects Q8_0 there instead. A
per-layer recipe cannot discover any of this.

Full narrative: `docs/kimi-precision-topology.md`. Durable evidence (reports, candidate
index hashes, bench logs, machine-readable `kimi-linear-strict.represent.json`) lives in
the local provenance directory beside the quality bank.

## Gates

fmt clean; clippy clean on all touched files; larql-vindex (gpu, release) 3433 tests,
larql-models 723+, larql-compute 1063, larql-compute-metal 516+ — zero failures;
`cargo check -p larql-cli --no-default-features` clean. The q2a and bench tests are
env-gated (skip in CI); the measured runs are archived in the provenance directory.
