### PR TITLE
The witness generates: rung-4 parity recorded, SERVE-HYBRID lands, the corpus catches up

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,30 +418,36 @@ gemma3-4b.vindex/
 ```
 
 **Container generations.** `index.json`'s `version` is the sole discriminator —
-schemas 1–2 are **VINDEX2** (what `extract` writes, and what every published
-vindex is today), schema 3 is **VINDEX3**, the successor container for sparse
-models. One binary reads both; `larql show` and `larql verify` dispatch on the
-version and describe each generation in its own terms rather than flattening
-one into the other.
+schemas 1–2 are **VINDEX2** (what `extract` writes by default, and what every
+published vindex is today), schemas 3–4 are **VINDEX3**, the 3.0 Candidate
+container for model systems. One binary reads both; `larql show` and
+`larql verify` dispatch on the version and describe each generation in its own
+terms rather than flattening one into the other.
 
-**VINDEX3 is executable and servable; `extract` still writes VINDEX2.**
-The `larql vindex3` command family (`plan`, `encode`, `inspect`, `verify`,
-`ops`, `exec` — `larql-cli` `commands/primary/vindex3_cmd/`) plans a model
-system from HF checkpoints, encodes it into a self-contained container,
-proves source ≡ encoded, and executes the container's own program with no
-architecture registry. Whole production models — gpt-oss-20b, Gemma 4
-26B-A4B, Granite 4.1 3B/8B/30B — encode and execute byte-identically to
-their HF sources, and `larql serve` serves a V3 container over
-`/v1/completions` via the V3 runtime (see
-[`docs/vindex3-runtime.md`](docs/vindex3-runtime.md)). What has *not*
-changed: `larql extract` has no VINDEX3 path — `index.json.version` is
-still hardcoded to 2, so everything the extract pipeline below writes, and
-every published vindex today, is VINDEX2. New extractions default to
-VINDEX3 only once the ABI freezes **and** the E0 preservation matrix
-passes (§12.1). See
+**VINDEX3 is a 3.0 Candidate Specification — executable, servable, and
+reachable from every extraction surface; the *default* extraction is still
+VINDEX2.** The `larql vindex3` command family (`plan`, `encode`, `inspect`,
+`verify`, `ops`, `exec` — `larql-cli` `commands/primary/vindex3_cmd/`) plans
+a model system from HF checkpoints, encodes it into a self-contained
+container, proves source ≡ encoded, and executes the container's own
+declared operator program with no architecture registry. Since graph
+schema 6, **surfaces follow the program**: a component's attention and FFN
+surface groups exist iff its declared per-layer operators run those
+operations — proven live by a pure-SSM witness (mamba2-780m: 48 declared
+Mamba2 operators, zero attention surfaces, generating through ordinary LQL
+with the source checkpoint deleted). Whole production models — gpt-oss-20b,
+Gemma 4 26B-A4B, Granite 4.1 3B/8B/30B — encode and execute
+byte-identically to their HF sources, and `larql serve` serves a V3
+container over `/v1/completions` via the V3 runtime (see
+[`docs/vindex3-runtime.md`](docs/vindex3-runtime.md)). VINDEX3 extraction
+is available on request (`larql extract --generation v3`, LQL
+`EXTRACT ... FORMAT VINDEX3`); the *default* remains VINDEX2 until the M4
+flip — a named decision, made in one place, not yet made (see
+[`docs/vindex-generation-policy.md`](docs/vindex-generation-policy.md)).
+See
 [`crates/larql-vindex/docs/vindex3-format-spec.md`](crates/larql-vindex/docs/vindex3-format-spec.md)
-(container ABI) and [`docs/vindex3-format.md`](docs/vindex3-format.md)
-(model-system container spec).
+(the 3.0 Candidate ABI) and [`docs/vindex3-format.md`](docs/vindex3-format.md)
+(the living spec).
 
 Three extraction levels:
 

--- a/crates/larql-kv/src/vindex3/mod.rs
+++ b/crates/larql-kv/src/vindex3/mod.rs
@@ -34,7 +34,12 @@
 //! write, never alongside them, so the served bits are the stored
 //! bits by construction.
 
-use larql_vindex::format::vindex3::opplan::exec::kv::{KvState, LayerKvGeometry};
+use larql_vindex::format::vindex3::opplan::exec::continuation::{
+    LayerContinuationGeometry, RecurrentState,
+};
+use larql_vindex::format::vindex3::opplan::exec::kv::{
+    ContinuationError, KvState, LayerKvGeometry,
+};
 use ndarray::Array2;
 
 use crate::cache::KvCache;
@@ -71,8 +76,18 @@ impl LayerRows {
 /// conversation state crossing the `larql-kv` boundary intact.
 pub struct CanonicalKvState {
     cache: KvCache,
-    geometry: Vec<LayerKvGeometry>,
+    /// Per layer, ABSOLUTE index: `Some` where the plan declares KV rows,
+    /// `None` on a recurrent layer (whose state lives in
+    /// [`Self::recurrent`] instead). Absolute indexing is load-bearing —
+    /// filtering to a KV subset is exactly how a hybrid stack's layer 7
+    /// would read layer 3's rows.
+    geometry: Vec<Option<LayerKvGeometry>>,
     rows: Vec<LayerRows>,
+    /// SERVE-HYBRID: the recurrent layers' durable buffers, absolute
+    /// index, allocated from the plan's declared geometry at
+    /// [`prepare_continuation`](KvState::prepare_continuation). A
+    /// KV-only program allocates none and behaves exactly as before.
+    recurrent: Vec<Option<RecurrentState>>,
 }
 
 impl Default for CanonicalKvState {
@@ -88,6 +103,7 @@ impl CanonicalKvState {
             cache: KvCache::with_layers(0),
             geometry: Vec::new(),
             rows: Vec::new(),
+            recurrent: Vec::new(),
         }
     }
 
@@ -111,6 +127,7 @@ impl CanonicalKvState {
             cache,
             geometry: Vec::new(),
             rows,
+            recurrent: Vec::new(),
         }
     }
 
@@ -128,13 +145,14 @@ impl CanonicalKvState {
     /// The plan-declared geometry this provider was prepared with —
     /// row width and sliding/full window per layer, read from the
     /// executable program, never from `ModelArchitecture`.
-    pub fn geometry(&self) -> &[LayerKvGeometry] {
-        &self.geometry
+    pub fn geometry(&self) -> Vec<LayerKvGeometry> {
+        self.geometry.iter().flatten().cloned().collect()
     }
 }
 
 impl KvState for CanonicalKvState {
     fn prepare(&mut self, layers: &[LayerKvGeometry]) {
+        let layers_opt: Vec<Option<LayerKvGeometry>> = layers.iter().cloned().map(Some).collect();
         if self.geometry.is_empty() {
             if self.cache.layers.is_empty() {
                 self.cache = KvCache::with_layers(layers.len());
@@ -161,18 +179,73 @@ impl KvState for CanonicalKvState {
                     }
                 }
             }
-            self.geometry = layers.to_vec();
+            self.geometry = layers_opt;
         } else {
             // A resumed provider: same program, same geometry.
             assert_eq!(
-                self.geometry, layers,
+                self.geometry, layers_opt,
                 "resumed KV state was prepared for a different program geometry"
             );
         }
     }
 
+    /// The FULL geometry, KV and recurrent alike (SERVE-HYBRID).
+    ///
+    /// Overrides the KV-only default, which filters to the KV subset and
+    /// therefore breaks absolute layer indexing the moment any layer is
+    /// recurrent. A KV-only program delegates to [`KvState::prepare`],
+    /// which already handles fresh, adopted and resumed caches alike; a
+    /// program with recurrence keeps every layer in its absolute slot —
+    /// KV layers size the cache, recurrent layers allocate their
+    /// declared buffers beside it, and a resumed provider keeps both,
+    /// because that persistence IS the continuation.
+    fn prepare_continuation(
+        &mut self,
+        layers: &[LayerContinuationGeometry],
+    ) -> Result<(), ContinuationError> {
+        if self.recurrent.is_empty() {
+            self.recurrent = layers
+                .iter()
+                .map(|g| g.recurrent().map(RecurrentState::zeros))
+                .collect();
+        } else {
+            assert_eq!(
+                self.recurrent.len(),
+                layers.len(),
+                "resumed state holds {} layers but the plan declares {}",
+                self.recurrent.len(),
+                layers.len()
+            );
+        }
+        let all_kv: Option<Vec<LayerKvGeometry>> = layers.iter().map(|g| g.kv().cloned()).collect();
+        if let Some(kv) = all_kv {
+            self.prepare(&kv);
+            return Ok(());
+        }
+        let kv_opt: Vec<Option<LayerKvGeometry>> = layers.iter().map(|g| g.kv().cloned()).collect();
+        if self.geometry.is_empty() {
+            assert!(
+                self.cache.layers.is_empty(),
+                "an adopted canonical cache carries KV-only history; preparing it for a \
+                 program with recurrent layers would claim state the cache never held"
+            );
+            self.cache = KvCache::with_layers(layers.len());
+            self.rows = vec![LayerRows::default(); layers.len()];
+            self.geometry = kv_opt;
+        } else {
+            assert_eq!(
+                self.geometry, kv_opt,
+                "resumed KV state was prepared for a different program geometry"
+            );
+        }
+        Ok(())
+    }
+
     fn append(&mut self, layer: usize, key: Vec<f32>, value: Vec<f32>) {
-        let kv_dim = self.geometry[layer].kv_dim;
+        let kv_dim = self.geometry[layer]
+            .as_ref()
+            .unwrap_or_else(|| panic!("layer {layer} is recurrent; it appends no KV row"))
+            .kv_dim;
         assert_eq!(
             key.len(),
             kv_dim,
@@ -232,29 +305,25 @@ impl KvState for CanonicalKvState {
         self.cache.next_position = position;
     }
 
-    /// **Explicitly unsupported, not absent.**
+    /// The layer's durable recurrent buffers (SERVE-HYBRID) — allocated
+    /// at `prepare_continuation` from the plan's declared geometry, kept
+    /// across prefills and steps.
     ///
-    /// The canonical cache holds per-position K/V rows and nothing else,
-    /// so a hybrid stack reaching the serving path fails closed here and
-    /// names which side is missing. Returning `None` would make this
-    /// indistinguishable from "this layer needs no state" and let a
-    /// 48-recurrent-layer model serve from zeroed buffers — a different
-    /// model, reported as this one.
-    ///
-    /// SERVE-HYBRID replaces this with real buffers and re-establishes
-    /// serving parity; until then the refusal is the correct answer.
-    fn recurrent_state(
-        &mut self,
-        layer: usize,
-    ) -> Result<
-        &mut larql_vindex::format::vindex3::opplan::exec::continuation::RecurrentState,
-        larql_vindex::format::vindex3::opplan::exec::kv::ContinuationError,
-    > {
-        Err(
-            larql_vindex::format::vindex3::opplan::exec::kv::ContinuationError::RecurrentUnsupported {
+    /// Still fail-closed in both remaining directions: a provider that
+    /// was never announced the full geometry refuses rather than
+    /// conjuring buffers, and a KV layer asked for recurrent state is a
+    /// dispatch defect named as such — never "empty state".
+    fn recurrent_state(&mut self, layer: usize) -> Result<&mut RecurrentState, ContinuationError> {
+        match self.recurrent.get_mut(layer) {
+            Some(Some(state)) => Ok(state),
+            Some(None) => Err(ContinuationError::NotRecurrent {
                 provider: "CanonicalKvState",
                 layer,
-            },
-        )
+            }),
+            None => Err(ContinuationError::RecurrentUnsupported {
+                provider: "CanonicalKvState",
+                layer,
+            }),
+        }
     }
 }

--- a/crates/larql-kv/src/vindex3/tests/mod.rs
+++ b/crates/larql-kv/src/vindex3/tests/mod.rs
@@ -359,3 +359,53 @@ fn recurrent_state_is_explicitly_unsupported_not_absent() {
         other => panic!("must refuse with the provider and layer named: {other:?}"),
     }
 }
+
+/// **SERVE-HYBRID: the canonical provider holds recurrent buffers where
+/// the program declares them — and only there.** A mixed KV+recurrent
+/// geometry prepares both sides at absolute indices; the KV layer still
+/// refuses `recurrent_state` by name (a dispatch defect, never "empty
+/// state"); and a resumed preparation keeps the mutated buffers, because
+/// that persistence is the continuation.
+#[test]
+fn recurrent_layers_get_buffers_and_kv_layers_still_refuse() {
+    use larql_vindex::format::vindex3::opplan::exec::continuation::{
+        LayerContinuationGeometry, RecurrentBufferGeometry, RecurrentGeometry, StateInitialization,
+    };
+    use larql_vindex::format::vindex3::opplan::exec::kv::ContinuationError;
+
+    let geometry = vec![
+        LayerContinuationGeometry::Kv(LayerKvGeometry {
+            kv_dim: 4,
+            window: None,
+        }),
+        LayerContinuationGeometry::Recurrent(RecurrentGeometry::single(RecurrentBufferGeometry {
+            shape: vec![2, 3],
+            dtype: larql_vindex::format::vindex3::opplan::gated_delta::StateDtype::Float32,
+            initialization: StateInitialization::Zeros,
+        })),
+    ];
+    let mut provider = CanonicalKvState::new();
+    provider.prepare_continuation(&geometry).unwrap();
+
+    // The recurrent layer serves its declared buffer, zero-initialised.
+    let state = provider.recurrent_state(1).expect("declared recurrent");
+    assert_eq!(state.buffer(0).cells().len(), 6);
+    state.buffer_mut(0).cells_mut()[0] = 7.0;
+
+    // The KV layer refuses by name — not with an empty buffer.
+    assert!(matches!(
+        provider.recurrent_state(0),
+        Err(ContinuationError::NotRecurrent { layer: 0, .. })
+    ));
+    // And it still takes rows, at its absolute index.
+    provider.append(0, vec![1.0; 4], vec![2.0; 4]);
+    assert_eq!(provider.keys(0).len(), 1);
+
+    // Resume: the same program keeps the mutated state.
+    provider.prepare_continuation(&geometry).unwrap();
+    assert_eq!(
+        provider.recurrent_state(1).unwrap().buffer(0).cells()[0],
+        7.0,
+        "a resumed preparation must not reset the continuation"
+    );
+}

--- a/crates/larql-vindex/README.md
+++ b/crates/larql-vindex/README.md
@@ -4,7 +4,7 @@ The queryable model format. Decompile, browse, edit, and recompile neural networ
 
 ## What is a Vindex?
 
-A vindex (vector index) is a directory containing a transformer model's weights reorganised for queryability. The model IS the database — each weight matrix is stored once in its optimal format.
+A vindex (vector index) is a directory containing a model's weights reorganised for queryability. The model IS the database — each weight matrix is stored once in its optimal format. A VINDEX3 container (3.0 Candidate, graph schema 6) describes a model system by its declared operator program — softmax attention, MLA, KDA, Gated DeltaNet, Mamba2 — and its surfaces follow that program: a pure-SSM model carries no attention surface at all, because it has none.
 
 ```rust
 use larql_vindex::*;

--- a/crates/larql-vindex/docs/vindex3-format-spec.md
+++ b/crates/larql-vindex/docs/vindex3-format-spec.md
@@ -1115,9 +1115,14 @@ declaration-only), the container encoded with all 434 operands closing
 at encode, carries 48 `mamba2` operators with **no attention and no FFN
 surface anywhere**, and opens through ordinary LQL with the source
 checkpoint deleted — `STATS` reports `0 sliding / 0 full / 48
-recurrent`, continuation as recurrent state only, and `INFER` refuses by
-name (`represented but not executable`) until the generic executor
-lands; `state-spaces/mamba2attn-2.7b` — six attention layers at
+recurrent`, continuation as recurrent state only. **The generic executor
+landed the same day and paritied**: teacher-forced against the banked
+fp32 reference on three prompt lengths (one crossing the SSD chunk
+boundary), all 430 scored positions agree within 7.6e-4 max-abs — ~3.6×
+the reference's own step-vs-scan fp bound — with argmax exact at every
+position and all three 32-token greedy trajectories reproduced
+token-for-token; ordinary `INFER … GENERATE` then reproduces the
+reference continuation word-for-word with the source checkpoint hidden; `state-spaces/mamba2attn-2.7b` — six attention layers at
 declared indices among Mamba2 blocks: the A/B proving surfaces exist
 only where the declared program uses them, and that KV and SSM state
 coexist per-operation; then `tiiuae/Falcon3-Mamba-7B-Instruct` as the

--- a/docs/vindex3-ontology-drill.md
+++ b/docs/vindex3-ontology-drill.md
@@ -414,3 +414,23 @@ conversion of `state-spaces/mamba2-780m`; the original repos ship
   2's state-schema facts (F5, F6) remain open, additive within the v6
   span; the Mamba2 continuation arm refuses state precision exactly as
   KDA's does, for the same reason.
+
+- **2026-08-30, later the same day — the witness generates.** The
+  generic Mamba2 executor (`exec/mamba2.rs`, transcribed stage-by-stage
+  from the reference's `torch_forward`, fp32 state as a judgment
+  transcribed from the reference's own `.float()` casts) runs the mixer
+  through the ordinary prepared-operands / prefill / decode /
+  continuation path — no family loader anywhere. Rung-4 parity against
+  the banked fp32 oracle: short 5+32 max|Δ| 6.9e-4 · medium 29+32
+  5.2e-4 · long 300+32 7.6e-4, argmax exact at all 430 positions,
+  all three 32-token greedy trajectories token-for-token — the bound
+  being pure fp32 reassociation over the oracle's own 2.1e-4
+  step-vs-scan floor. The canonical KV provider grew its SERVE-HYBRID
+  half (recurrent buffers beside the cache, allocated from the plan's
+  declared geometry, refusing by name in both remaining directions), and
+  ordinary LQL then generated the reference's greedy continuation
+  word-for-word from the container alone, source checkpoint deleted:
+  the deletion invariant, visible. In-tree gates: the miniature witness
+  executes (bitwise determinism, prefix equivalence across the
+  batch↔decode seam), the hand-computed recurrence, dt-clamp bounds,
+  conv causality by impulse, and the mixed KV+recurrent provider test.


### PR DESCRIPTION
The follow-up PR #347 promised: the full teacher-forced parity verdict, the seam it flushed out, and the stale public prose.

## Rung-4 parity — PASSED
Against the banked fp32 oracle, all three prompts (one crossing the SSD chunk boundary):

```
short   5+32   max|Δ| 6.9e-4   argmax  37/37   trajectory exact
medium 29+32   max|Δ| 5.2e-4   argmax  61/61   trajectory exact
long  300+32   max|Δ| 7.6e-4   argmax 332/332  trajectory exact
```

430 scored positions, full 50,288-logit vectors, every argmax exact, every 32-token greedy continuation token-for-token — the bound being pure fp32 reassociation over the oracle's own 2.1e-4 step-vs-scan floor.

## SERVE-HYBRID's provider half
The first live LQL run found the next honest refusal: `CanonicalKvState` held per-position rows and nothing else, so `INFER` on the pure-SSM container refused rather than running stateless — the named placeholder doing its job. `prepare_continuation` now overrides the KV-only default (which filters to the KV subset and would break absolute layer indexing on any recurrent layer), allocates each recurrent layer's declared buffers beside the cache, and keeps them across preparations. KV-only programs delegate to the existing `prepare` unchanged; `recurrent_state` stays fail-closed in both remaining directions.

**Result — the deletion invariant, visible to a user:** encode → delete the source checkpoint → `USE` → `INFER "The capital of France is" GENERATE 32` reproduces the reference's greedy continuation word-for-word from the artifact alone.

## The corpus catches up
The spec's witness paragraph and the drill closure log record the numbers. The top-level README stops claiming `extract` has no VINDEX3 path (M2 landed `--generation v3`; the M4 default flip is what remains, and the paragraph now says exactly that) and gains the schema-6 sentence; the crate README stops defining a vindex as transformer weights — the strongest witness in the tree now has none.

## Gates
Workspace sweep green (206 suites), fmt/clippy/doc-links clean; new in-tree test pins the mixed KV+recurrent provider (buffers where declared, refusal by name on a KV layer, persistence across resume).