### PR TITLE
test(vindex3): restore the coverage ratchet after the schema-6 merge

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/encode/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/encode/tests.rs
@@ -177,6 +177,46 @@ fn inadmissible_plan_is_refused() {
     );
 }
 
+/// `encode_graph` runs the same validation as the planned path: a graph
+/// a caller built (or damaged) itself is refused BEFORE any bytes are
+/// written, with the defect named.
+#[test]
+fn a_graph_that_fails_validation_is_refused_before_encode() {
+    use crate::format::vindex3::encode::encode_graph;
+    use crate::format::vindex3::graph::build_from_inventories;
+
+    let (_a, _b, named) = glimmer_system();
+    let mut graph = build_from_inventories(&named).graph;
+    let duplicate = graph.objects[0].clone();
+    graph.objects.push(duplicate);
+    let out = tempfile::tempdir().unwrap();
+    let err = encode_graph(&graph, &named, out.path()).unwrap_err();
+    assert!(
+        err.to_string().contains("failed validation"),
+        "the refusal must say the graph is at fault: {err}"
+    );
+}
+
+/// An object stripped of every representation has nothing to encode —
+/// graph validation does not police representations (that is encode's
+/// concern), so encode itself must refuse and name the object.
+#[test]
+fn an_object_with_no_representation_is_refused_by_name() {
+    use crate::format::vindex3::encode::encode_graph;
+    use crate::format::vindex3::graph::build_from_inventories;
+
+    let (_a, _b, named) = glimmer_system();
+    let mut graph = build_from_inventories(&named).graph;
+    let victim = graph.objects[0].id.clone();
+    graph.objects[0].representations.clear();
+    let out = tempfile::tempdir().unwrap();
+    let err = encode_graph(&graph, &named, out.path()).unwrap_err();
+    assert!(
+        err.to_string().contains("carries no representation") && err.to_string().contains(&victim),
+        "the refusal must name the empty object: {err}"
+    );
+}
+
 /// A corrupted segment byte is caught by `inspect --verify` — with no
 /// source access.
 #[test]

--- a/crates/larql-vindex/src/format/vindex3/graph/tests/surface.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/tests/surface.rs
@@ -260,6 +260,65 @@ fn completeness_defects_display_the_component() {
     };
     assert!(head.to_string().contains("`draft`"));
     assert!(head.to_string().contains("head group"));
+    let norm = CompletenessDefect::MissingNormPlacement {
+        component: "target".to_string(),
+    };
+    assert!(norm.to_string().contains("norm placement"));
+    let operation = CompletenessDefect::MissingOperationSurface {
+        component: "target".to_string(),
+        operation: "attention",
+    };
+    assert!(operation.to_string().contains("`target`"));
+    assert!(operation.to_string().contains("attention group"));
+}
+
+/// **Schema 6: the operation surfaces follow the program — each family
+/// that runs must find its group present.** Stripping a group whose
+/// operators are in the table is a completeness defect naming the
+/// operation; a mixer-only program legitimately carries neither
+/// attention nor FFN and is complete without them.
+#[test]
+fn a_program_that_runs_a_family_requires_its_surface_group() {
+    let (_a, _b, named) = glimmer_pair();
+    let mut built = build_from_inventories(&named);
+    assert!(execution_completeness(&built.graph).is_empty());
+    let strip = |built: &mut crate::format::vindex3::graph::BuiltGraph,
+                 f: &dyn Fn(&mut crate::format::vindex3::graph::ExecutionSurface)| {
+        let target = built
+            .graph
+            .components
+            .iter_mut()
+            .find(|c| c.id == "target")
+            .unwrap();
+        f(target.execution.as_mut().unwrap());
+    };
+    // The target attends and runs an FFN; each group is load-bearing.
+    strip(&mut built, &|s| s.attention = None);
+    let defects = execution_completeness(&built.graph);
+    assert!(
+        defects.iter().any(|d| matches!(
+            d,
+            CompletenessDefect::MissingOperationSurface {
+                operation: "attention",
+                ..
+            }
+        )),
+        "{defects:?}"
+    );
+    let (_a, _b, named) = glimmer_pair();
+    let mut built = build_from_inventories(&named);
+    strip(&mut built, &|s| s.ffn = None);
+    let defects = execution_completeness(&built.graph);
+    assert!(
+        defects.iter().any(|d| matches!(
+            d,
+            CompletenessDefect::MissingOperationSurface {
+                operation: "ffn",
+                ..
+            }
+        )),
+        "{defects:?}"
+    );
 }
 
 /// A component owning a head object whose surface lost its head group is

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/mamba2.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/mamba2.rs
@@ -39,6 +39,13 @@ const M_IN_PROJ_ROWS: usize = 2 * M_D_INNER + 2 * M_STATE + M_HEADS; // 62
 /// tensor whose name ends with it — the lever the closure-at-encode test
 /// pulls.
 fn miniature_mamba2(dir: &Path, skip_suffix: Option<&str>) {
+    miniature_mamba2_with(dir, skip_suffix, false)
+}
+
+/// `spartan` declares `rms_norm: false` and `use_conv_bias: false` and
+/// ships neither optional operand — the mixer's other honest shape,
+/// which closure must accept without them and refuse WITH them.
+fn miniature_mamba2_with(dir: &Path, skip_suffix: Option<&str>, spartan: bool) {
     // Rendered with the bare `Infinity` transformers actually writes, so
     // the fixture exercises the judged non-finite boundary end-to-end
     // rather than the pre-quoted string form.
@@ -62,9 +69,9 @@ fn miniature_mamba2(dir: &Path, skip_suffix: Option<&str>) {
         "time_step_max": 0.1,
         "time_step_rank": 8,
         "rescale_prenorm_residual": false,
-        "rms_norm": true,
+        "rms_norm": !spartan,
         "use_bias": false,
-        "use_conv_bias": true,
+        "use_conv_bias": !spartan,
         "hidden_act": "silu",
         "layer_norm_epsilon": 1e-5,
         "residual_in_fp32": true,
@@ -77,6 +84,9 @@ fn miniature_mamba2(dir: &Path, skip_suffix: Option<&str>) {
     let mut shard = ShardBuilder::new();
     let mut push = |name: String, shape: &[usize], values: Vec<f32>| {
         if skip_suffix.is_some_and(|suffix| name.ends_with(suffix)) {
+            return;
+        }
+        if spartan && (name.ends_with("mixer.conv1d.bias") || name.ends_with("mixer.norm.weight")) {
             return;
         }
         shard.push(&name, shape, &values);
@@ -399,4 +409,66 @@ fn f16_operands_widen_to_f32_exactly() {
     // is why the dtype label, not a guess, selects the decoder; and an
     // unjudged label still refuses.
     assert!(widen("F8_E4M3", &bytes, "probe").is_err());
+}
+
+/// **The mixer's other honest shape: `rms_norm: false`,
+/// `use_conv_bias: false`.** Closure accepts the layer WITHOUT the two
+/// optional operands (requiring them would fabricate work the config
+/// never declared), the plan carries `None` for both, preparation loads
+/// the spartan operand set, execution runs it — and the prepared image
+/// accounts for itself, mixer arms included, in both censuses.
+#[test]
+fn a_spartan_mixer_closes_prepares_executes_and_accounts() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_mamba2_with(dir.path(), None, true);
+    let out = tempfile::tempdir().unwrap();
+    let container = out.path().join("mamba2-spartan.vindex3");
+    encode_checkpoint(dir.path(), &container).expect("the spartan mixer encodes");
+
+    let inspection = inspect_container(&container, false).unwrap();
+    let outcome = plan_component_ops(&inspection, &container, "target").unwrap();
+    assert!(outcome.defects.is_empty(), "{:?}", outcome.defects);
+    let plan = outcome.plan.expect("closure held");
+    for layer in &plan.layers {
+        let LayerAttention::Mamba2(op) = &layer.attention else {
+            panic!("not a mixer: {:?}", layer.attention);
+        };
+        assert!(op.conv1d_bias.is_none(), "use_conv_bias: false");
+        assert!(op.gated_norm.is_none(), "rms_norm: false");
+        assert_eq!(
+            layer.operands_accounted, 7,
+            "nine minus the two declared absent"
+        );
+    }
+
+    let store = OperandStore::open(&container, &inspection).unwrap();
+    let prepared = PreparedOperands::load(
+        &plan,
+        &store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .expect("the spartan operand set prepares");
+    // The image accounts for itself: the mixer's two matrices land in
+    // the census, its glue is counted, and no FFN bytes exist to claim.
+    let residency = prepared.residency_census();
+    assert!(residency.delta.total() > 0, "mixer matrices counted");
+    assert_eq!(residency.ffn.total(), 0, "no FFN exists to count");
+    let allocations = prepared.allocation_census();
+    assert!(allocations.bytes > 0);
+
+    let geometry = plan_continuation_geometry(&plan).expect("declared geometry");
+    let mut provider = RowKvState::default();
+    provider.prepare_continuation(&geometry).unwrap();
+    let logits = crate::format::vindex3::opplan::exec::prefill_plan(
+        &plan,
+        &store,
+        &[3, 17, 5],
+        &ReferenceBackend,
+        &mut provider,
+    )
+    .expect("the spartan mixer executes")
+    .logits
+    .expect("head present");
+    assert!(logits.iter().all(|v| v.is_finite()));
 }


### PR DESCRIPTION
The only red on main: the larql-vindex coverage-policy gate, dipped by the schema-6/Mamba2 merges on three files. This pays the debt in tests rather than lowering floors.

- **graph/complete.rs** 87.67 → 98.63: the `MissingOperationSurface` arms — a program that runs a family requires its surface group (strip attention → defect "attention"; strip ffn → "ffn"), and every completeness defect Displays its component.
- **opplan/exec/prepared.rs** 83.61 → 93.78: `residency_census`/`allocation_census` had no caller in any test. New witness: the spartan mixer (`rms_norm: false`, `use_conv_bias: false`) encodes, closes at 7 operands/layer, prepares with both optionals `None`, executes finitely, and both censuses account for the prepared image (mixer bytes in the delta site, zero FFN bytes).
- **encode/mod.rs** 86.13 → 89.08: a caller-built graph failing validation is refused before any bytes are written, and an object stripped of every representation is refused by name (`validate()` does not police representations — encode does).

Local: `check_coverage_policy.py` passes crate-wide (93.62% lines, 344 files); fmt + clippy clean; full larql-vindex suite green.