### PR TITLE
feat(vindex3): the conv-QKV executor and the two-region continuation — hybrid parity at the oracle floor

### DIFF
--- a/crates/larql-kv/src/vindex3/mod.rs
+++ b/crates/larql-kv/src/vindex3/mod.rs
@@ -222,7 +222,13 @@ impl KvState for CanonicalKvState {
             self.prepare(&kv);
             return Ok(());
         }
-        let kv_opt: Vec<Option<LayerKvGeometry>> = layers.iter().map(|g| g.kv().cloned()).collect();
+        // `kv_side`, not `kv`: a conv-QKV attention layer keeps rows AND
+        // a conv history, and this provider genuinely serves both — its
+        // buffer was allocated above, its rows are sized here. The
+        // KV-only projection stays `kv()` so a provider that took the
+        // default still fails closed on such a layer.
+        let kv_opt: Vec<Option<LayerKvGeometry>> =
+            layers.iter().map(|g| g.kv_side().cloned()).collect();
         if self.geometry.is_empty() {
             assert!(
                 self.cache.layers.is_empty(),

--- a/crates/larql-vindex/src/format/vindex3/graph/policy.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/policy.rs
@@ -151,10 +151,10 @@ impl LayerOperator {
     /// arrow, and it is the one a plan cannot infer from the checkpoint.
     pub fn has_executor(&self) -> bool {
         match self {
-            Self::Softmax | Self::GatedDelta | Self::Mamba2 => true,
+            Self::Softmax | Self::GatedDelta | Self::Mamba2 | Self::ConvQkvAttention => true,
             // Represented, not executable — the operand contract is
             // complete and no executor consumes it yet.
-            Self::Kda | Self::Mla | Self::ConvQkvAttention => false,
+            Self::Kda | Self::Mla => false,
             Self::Recurrent => false,
         }
     }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/continuation.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/continuation.rs
@@ -121,6 +121,15 @@ pub enum LayerContinuationGeometry {
     Kv(LayerKvGeometry),
     /// Constant in the sequence.
     Recurrent(RecurrentGeometry),
+    /// Grows with the sequence AND keeps fixed buffers beside it — the
+    /// conv-QKV attention shape: a real per-position KV cache plus a
+    /// conv history over the pre-conv fused QKV. Its own variant, not a
+    /// flag on [`Self::Kv`]: a provider that can hold only rows must
+    /// fail closed on this layer, never quietly allocate half of it.
+    KvAndRecurrent {
+        kv: LayerKvGeometry,
+        recurrent: RecurrentGeometry,
+    },
     /// Nothing survives this layer.
     ///
     /// No judged operator produces this yet — it is here because "this
@@ -141,10 +150,18 @@ impl LayerContinuationGeometry {
             // K and V, one row of `kv_dim` each, per position.
             Self::Kv(kv) => kv.kv_dim * 2 * positions,
             Self::Recurrent(r) => r.elements(),
+            Self::KvAndRecurrent { kv, recurrent } => {
+                kv.kv_dim * 2 * positions + recurrent.elements()
+            }
             Self::Stateless => 0,
         }
     }
 
+    /// The KV geometry of a layer that keeps ONLY rows. Deliberately
+    /// `None` on [`Self::KvAndRecurrent`]: this accessor is what the
+    /// KV-only provider default projects through, and answering the
+    /// hybrid's KV half there would allocate the cache while silently
+    /// dropping the conv history — half a continuation that looks whole.
     pub fn kv(&self) -> Option<&LayerKvGeometry> {
         match self {
             Self::Kv(kv) => Some(kv),
@@ -152,9 +169,20 @@ impl LayerContinuationGeometry {
         }
     }
 
+    /// The KV side wherever one exists — [`Self::Kv`] and
+    /// [`Self::KvAndRecurrent`] alike. For providers and consumers that
+    /// genuinely serve both regions; a KV-only path must keep using
+    /// [`Self::kv`].
+    pub fn kv_side(&self) -> Option<&LayerKvGeometry> {
+        match self {
+            Self::Kv(kv) | Self::KvAndRecurrent { kv, .. } => Some(kv),
+            _ => None,
+        }
+    }
+
     pub fn recurrent(&self) -> Option<&RecurrentGeometry> {
         match self {
-            Self::Recurrent(r) => Some(r),
+            Self::Recurrent(r) | Self::KvAndRecurrent { recurrent: r, .. } => Some(r),
             _ => None,
         }
     }
@@ -183,21 +211,21 @@ pub fn plan_continuation_geometry(
             // dtype, and KDA is in that position for every checkpoint
             // observed so far. Execution is out of scope for the rung that
             // introduced this operator; refusing is what keeps it out.
-            // Conv-QKV attention's continuation is TWO regions — a real
-            // per-position KV cache AND a fixed conv history over the
-            // pre-conv fused QKV — and this planner's vocabulary cannot
-            // state both on one layer yet. Refused rather than flattened
-            // to the KV half: a provider that allocated only the cache
-            // would silently run the conv with no history, which is a
-            // different operator.
-            LayerAttention::ConvQkv(op) => Err(format!(
-                "conv-QKV attention layer: a {}-wide KV cache AND a [{}, {}] conv history \
-                 persist per layer, and no continuation vocabulary states both yet — \
-                 refusing to flatten to the cache alone",
-                op.geometry.num_kv_heads * op.geometry.head_dim,
-                op.geometry.qkv_rows(),
-                op.geometry.conv_kernel,
-            )),
+            // Conv-QKV attention's continuation is TWO regions: a real
+            // per-position KV cache (K/V cached post-conv, post-rotary)
+            // AND a conv history holding the last `conv_kernel` positions
+            // of the PRE-conv fused QKV — the reference's own cache
+            // shape (`conv_states[layer]`: full kernel width,
+            // left-padded). fp32 for the same transcribed reason the
+            // mixer's regions are: the reference executor computes in
+            // f32 over widened operands.
+            LayerAttention::ConvQkv(op) => Ok(LayerContinuationGeometry::KvAndRecurrent {
+                kv: LayerKvGeometry {
+                    kv_dim: op.geometry.num_kv_heads * op.geometry.head_dim,
+                    window: None,
+                },
+                recurrent: super::conv_qkv::conv_history_geometry(op),
+            }),
             LayerAttention::Kda(op) => Err(format!(
                 "KDA layer: {} state elements, but no state precision is declared for this \
                  operator — refusing to choose one",
@@ -293,6 +321,12 @@ pub enum LayerContinuationState {
     Kv(LayerKvRows),
     /// A fixed-size buffer the operator reads and rewrites in place.
     Recurrent(RecurrentState),
+    /// Both regions, on one layer — rows AND a fixed buffer, the
+    /// conv-QKV attention shape.
+    Hybrid {
+        rows: LayerKvRows,
+        state: RecurrentState,
+    },
     Stateless,
 }
 
@@ -455,6 +489,12 @@ impl ContinuationState {
                     LayerContinuationGeometry::Recurrent(r) => {
                         LayerContinuationState::Recurrent(RecurrentState::zeros(r))
                     }
+                    LayerContinuationGeometry::KvAndRecurrent { recurrent, .. } => {
+                        LayerContinuationState::Hybrid {
+                            rows: LayerKvRows::default(),
+                            state: RecurrentState::zeros(recurrent),
+                        }
+                    }
                     LayerContinuationGeometry::Stateless => LayerContinuationState::Stateless,
                 })
                 .collect(),
@@ -501,6 +541,12 @@ impl ContinuationState {
                 }
                 LayerContinuationState::Recurrent(r) => {
                     (0..r.len()).map(|i| r.buffer(i).cells().len()).sum()
+                }
+                LayerContinuationState::Hybrid { rows, state } => {
+                    rows.keys.first().map_or(0, |r| r.len()) * 2 * positions
+                        + (0..state.len())
+                            .map(|i| state.buffer(i).cells().len())
+                            .sum::<usize>()
                 }
                 LayerContinuationState::Stateless => 0,
             })

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/conv_qkv.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/conv_qkv.rs
@@ -1,0 +1,293 @@
+//! Reference conv-QKV attention: the hybrid block, written to be read.
+//!
+//! Deliberately slow and literal, the same posture as [`super::mamba2`]:
+//! this exists so someone can put it beside `Mamba2Attention.forward` in
+//! `modeling_mamba2attn.py` and compare it stage by stage. Speed is a
+//! later rung's problem.
+//!
+//! The operator is fully defined by its persisted semantics — the
+//! [`ConvQkvOp`]'s geometry and operands. Nothing here knows a family
+//! name: fused projection width, conv kernel, rotary width and base, GQA
+//! head counts and bias presence all come from the op, so a container is
+//! sufficient to execute this layer with no source lookup — the deletion
+//! invariant, held per operator.
+//!
+//! Precision is a judgment, not a default: the reference upcasts
+//! attention scores to fp32 for the softmax (`attn_weights ...
+//! dtype=torch.float32`), and this executor computes every stage in f32
+//! over widened operands — so the f32 conv history is a transcription of
+//! the reference's own compute precision, recorded at
+//! [`conv_history_geometry`].
+
+// Explicit index loops on purpose, matching the reference's named axes —
+// verification against `Mamba2Attention.forward` is the point of the file.
+#![allow(clippy::needless_range_loop)]
+
+use super::super::conv_qkv::ConvQkvOp;
+use super::continuation::{
+    RecurrentBufferGeometry, RecurrentGeometry, RecurrentState, StateInitialization,
+};
+use super::cpu::WeightRows;
+use super::gated_delta::DenseProjections;
+use super::timing::{timed, OpClass};
+
+/// Buffer indices this operator assigns. One buffer: the conv history.
+/// (The K/V rows live on the provider's KV side — the layer's OTHER
+/// continuation region.)
+pub const CONV_HISTORY: usize = 0;
+
+/// The fixed half of this operator's continuation, in the engine's
+/// generic terms: the causal conv's history over the FULL fused QKV —
+/// the last `conv_kernel` positions of the PRE-conv projection, exactly
+/// the window the reference cache keeps (`conv_states[layer]`, full
+/// kernel width, left-padded). The KV half is declared beside it by the
+/// continuation planner; this function owns only the buffer shape.
+pub fn conv_history_geometry(op: &ConvQkvOp) -> RecurrentGeometry {
+    RecurrentGeometry::single(RecurrentBufferGeometry {
+        shape: vec![op.geometry.qkv_rows(), op.geometry.conv_kernel],
+        dtype: super::super::gated_delta::StateDtype::Float32,
+        initialization: StateInitialization::Zeros,
+    })
+}
+
+/// The four operands in their resident representations, resolved by the
+/// caller through the `ConvQkvOp` — the single architecture authority.
+pub struct ConvQkvWeights<'a> {
+    /// The two DENSE projections, in whatever representation they are
+    /// resident as.
+    pub in_proj: WeightRows<'a>,
+    pub out_proj: WeightRows<'a>,
+    /// The depthwise convolution taps, always f32: `[qkv_rows · kernel]`.
+    pub conv1d: &'a [f32],
+    /// `[qkv_rows]` — present iff `use_conv_bias`.
+    pub conv1d_bias: Option<&'a [f32]>,
+}
+
+/// Every boundary the operator crosses, kept so a disagreement names its
+/// own stage instead of being debugged backwards from the layer output.
+#[derive(Debug, Default)]
+pub struct ConvQkvPlanes {
+    /// Post-conv fused QKV (NO activation follows the conv): `[T][qkv_rows]`.
+    pub conv: Vec<Vec<f32>>,
+    /// Concatenated attention output, pre-`out_proj`: `[T][Hq·Dh]`.
+    pub attn: Vec<Vec<f32>>,
+    /// `[T][hidden]`.
+    pub output: Vec<Vec<f32>>,
+    /// This batch's K rows, post-conv post-rotary: `[T][Hkv·Dh]`. The
+    /// caller appends them to the provider — the executor computes, the
+    /// provider persists, and the split keeps this function ignorant of
+    /// how rows are stored.
+    pub keys: Vec<Vec<f32>>,
+    /// This batch's V rows: `[T][Hkv·Dh]`.
+    pub values: Vec<Vec<f32>>,
+}
+
+/// The whole operator: hidden states in, layer output out, conv history
+/// advanced. `past_keys`/`past_values` are the rows already persisted
+/// for this layer (empty at sequence start); `base` is the absolute
+/// position of `hidden[0]` — the rotary angle is a function of absolute
+/// position, so a decode step at position 40 must not rotate like a
+/// prefill at position 0.
+///
+/// Stage order is the specification, from `Mamba2Attention.forward`:
+///
+/// ```text
+/// in_proj → fused qkv                    (bias iff use_attention_qkv_bias)
+/// causal conv over the FULL qkv, + bias  (NO activation — unlike the mixer)
+/// split q | k | v                        (head_dim · Hq | · Hkv | · Hkv)
+/// partial rotary on the leading rotary_dim dims of q and k
+///   (rotate-half, inv_freq over the rotary width, absolute positions)
+/// append k, v to the cache; GQA: q head h reads kv head h / (Hq/Hkv)
+/// scores = q·k / √head_dim over the causal prefix, softmax in f32
+/// out = scores · v, heads concatenated → out_proj
+/// ```
+#[allow(clippy::too_many_arguments)]
+pub fn layer_forward_with(
+    op: &ConvQkvOp,
+    w: &ConvQkvWeights<'_>,
+    hidden: &[Vec<f32>],
+    state: &mut RecurrentState,
+    past_keys: &[Vec<f32>],
+    past_values: &[Vec<f32>],
+    base: usize,
+    proj: &dyn DenseProjections,
+) -> ConvQkvPlanes {
+    let g = op.geometry;
+    let (heads, kv_heads, head_dim) = (g.num_heads, g.num_kv_heads, g.head_dim);
+    let qkv_rows = g.qkv_rows();
+    let kernel = g.conv_kernel;
+    let rotary = g.rotary_dim;
+    let q_width = heads * head_dim;
+    let kv_width = kv_heads * head_dim;
+    let heads_per_kv = heads / kv_heads;
+    let t_len = hidden.len();
+    let mut planes = ConvQkvPlanes::default();
+    let _site = super::cpu::ledger::in_site(super::cpu::ledger::Site::Attention);
+
+    // Stage 1: the fused projection, for every position. The declared
+    // bias switches are `false` on the judged checkpoint; a `true` was
+    // blocked at admission (no bias role is judged yet), so no bias is
+    // added here — by declaration, not omission.
+    let rows: Vec<&[f32]> = hidden.iter().map(Vec::as_slice).collect();
+    let mixed: Vec<Vec<f32>> = proj.project_many(w.in_proj, &rows, qkv_rows);
+
+    // Stage 2: depthwise causal convolution over the FULL fused QKV,
+    // then the bias — and nothing else: the reference applies no
+    // activation here, where the mixer's conv applies SiLU. The window
+    // reaches back `kernel-1` positions, which may lie before this
+    // batch: the durable history answers there, and its zeros are
+    // correct at sequence start because the buffer was initialised to
+    // zeros.
+    let history_len = kernel - 1;
+    let history: Vec<f32> = state.buffer(CONV_HISTORY).cells().to_vec();
+    let past = |c: usize, back: usize| -> f32 {
+        // `back` = 1 means the position immediately before the batch.
+        let slot = kernel - back;
+        history[c * kernel + slot]
+    };
+    let mut conv: Vec<Vec<f32>> = vec![vec![0.0; qkv_rows]; t_len];
+    let convolution = timed(OpClass::DeltaConv);
+    for c in 0..qkv_rows {
+        let taps = &w.conv1d[c * kernel..(c + 1) * kernel];
+        let bias = w.conv1d_bias.map_or(0.0, |b| b[c]);
+        for t in 0..t_len {
+            let mut acc = 0.0f32;
+            for (i, tap) in taps.iter().enumerate() {
+                let offset = t as isize - (kernel as isize - 1) + i as isize;
+                if offset < 0 {
+                    let back = (-offset) as usize;
+                    if back <= history_len {
+                        acc += tap * past(c, back);
+                    }
+                    continue;
+                }
+                if (offset as usize) < t_len {
+                    acc += tap * mixed[offset as usize][c];
+                }
+            }
+            conv[t][c] = acc + bias;
+        }
+    }
+    drop(convolution);
+
+    // Stage 3: split q|k|v and rotate the leading `rotary_dim` dims of
+    // each q and k head — rotate-half convention, frequencies over the
+    // ROTARY width (`theta^(-2i/rotary_dim)`), at ABSOLUTE positions.
+    let half = rotary / 2;
+    let inv_freq: Vec<f32> = (0..half)
+        .map(|i| (g.rope_theta as f32).powf(-(2.0 * i as f32) / rotary as f32))
+        .collect();
+    let rotate = |head: &mut [f32], position: usize| {
+        for (i, freq) in inv_freq.iter().enumerate() {
+            let angle = position as f32 * freq;
+            let (sin, cos) = angle.sin_cos();
+            let a = head[i];
+            let b = head[half + i];
+            head[i] = a * cos - b * sin;
+            head[half + i] = b * cos + a * sin;
+        }
+    };
+    let gates = timed(OpClass::DeltaGates);
+    let mut queries: Vec<Vec<f32>> = Vec::with_capacity(t_len);
+    for t in 0..t_len {
+        let position = base + t;
+        let mut q = conv[t][..q_width].to_vec();
+        let mut k = conv[t][q_width..q_width + kv_width].to_vec();
+        let v = conv[t][q_width + kv_width..].to_vec();
+        for h in 0..heads {
+            rotate(&mut q[h * head_dim..h * head_dim + rotary], position);
+        }
+        for h in 0..kv_heads {
+            rotate(&mut k[h * head_dim..h * head_dim + rotary], position);
+        }
+        queries.push(q);
+        planes.keys.push(k);
+        planes.values.push(v);
+    }
+    drop(gates);
+
+    // Stage 4: causal softmax attention over the persisted prefix plus
+    // this batch, scores in f32 at 1/√head_dim, GQA by head grouping.
+    let attention = timed(OpClass::DeltaRecurrence);
+    let scale = 1.0 / (head_dim as f32).sqrt();
+    let key_at = |index: usize| -> &[f32] {
+        if index < past_keys.len() {
+            &past_keys[index]
+        } else {
+            &planes.keys[index - past_keys.len()]
+        }
+    };
+    let value_at = |index: usize| -> &[f32] {
+        if index < past_values.len() {
+            &past_values[index]
+        } else {
+            &planes.values[index - past_values.len()]
+        }
+    };
+    for t in 0..t_len {
+        let visible = past_keys.len() + t + 1;
+        let q = &queries[t];
+        let mut out = vec![0.0f32; q_width];
+        for h in 0..heads {
+            let kv_head = h / heads_per_kv;
+            let q_head = &q[h * head_dim..(h + 1) * head_dim];
+            let mut scores = vec![0.0f32; visible];
+            let mut max = f32::NEG_INFINITY;
+            for (index, score) in scores.iter_mut().enumerate() {
+                let k_row = key_at(index);
+                let k_head = &k_row[kv_head * head_dim..(kv_head + 1) * head_dim];
+                let dot: f32 = q_head.iter().zip(k_head).map(|(a, b)| a * b).sum();
+                *score = dot * scale;
+                max = max.max(*score);
+            }
+            let mut denom = 0.0f32;
+            for score in scores.iter_mut() {
+                *score = (*score - max).exp();
+                denom += *score;
+            }
+            let out_head = &mut out[h * head_dim..(h + 1) * head_dim];
+            for (index, score) in scores.iter().enumerate() {
+                let weight = score / denom;
+                let v_row = value_at(index);
+                let v_head = &v_row[kv_head * head_dim..(kv_head + 1) * head_dim];
+                for d in 0..head_dim {
+                    out_head[d] += weight * v_head[d];
+                }
+            }
+        }
+        planes.attn.push(out);
+        planes.conv.push(conv[t].clone());
+    }
+    drop(attention);
+
+    // Stage 5: one traversal of `out_proj` for every position.
+    if let Some(width) = hidden.first().map(Vec::len) {
+        let attn_rows: Vec<&[f32]> = planes.attn.iter().map(Vec::as_slice).collect();
+        planes.output = proj.project_many(w.out_proj, &attn_rows, width);
+    }
+
+    // Roll the convolution history forward: the last `kernel` positions
+    // of the PRE-convolution fused QKV, oldest first — the same window
+    // the reference cache keeps.
+    {
+        let history = state.buffer_mut(CONV_HISTORY);
+        let cells = history.cells_mut();
+        for c in 0..qkv_rows {
+            for slot in 0..kernel {
+                let back = kernel - 1 - slot;
+                let value = if back < t_len {
+                    mixed[t_len - 1 - back][c]
+                } else {
+                    let older = back - t_len;
+                    if older < history_len {
+                        past(c, older + 1)
+                    } else {
+                        0.0
+                    }
+                };
+                cells[c * kernel + slot] = value;
+            }
+        }
+    }
+    planes
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -365,6 +365,31 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
                     );
                     planes.output.remove(0)
                 }
+                super::prepared::PreparedAttention::ConvQkv(ops) => {
+                    // Two regions, borrowed in phases: past rows copied
+                    // out, conv history advanced by the forward, the
+                    // step's row appended after — same choreography as
+                    // the batch path, at one position.
+                    let past_keys: Vec<Vec<f32>> = self.kv.state().keys(index).to_vec();
+                    let past_values: Vec<Vec<f32>> = self.kv.state().values(index).to_vec();
+                    let base = position;
+                    let recurrent = self.kv.state_mut().recurrent_state(index)?;
+                    let projector = self.backend.dense_projector();
+                    let mut planes = super::conv_qkv::layer_forward_with(
+                        &ops.op,
+                        &ops.weights()?,
+                        &inputs,
+                        recurrent,
+                        &past_keys,
+                        &past_values,
+                        base,
+                        projector,
+                    );
+                    let key = planes.keys.remove(0);
+                    let value = planes.values.remove(0);
+                    self.kv.state_mut().append(index, key, value);
+                    planes.output.remove(0)
+                }
                 super::prepared::PreparedAttention::Softmax(sops) => {
                     let call = sops.call(
                         layer

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -20,6 +20,7 @@
 
 pub mod backend;
 pub mod continuation;
+pub mod conv_qkv;
 pub mod cpu;
 pub mod decode;
 pub mod device;
@@ -586,6 +587,38 @@ fn execute_layer<B: PlanBackend + ?Sized, K: KvState + ?Sized>(
                 backend.dense_projector(),
             )
             .output
+        }
+        PreparedAttention::ConvQkv(ops) => {
+            let Some((provider, layer_index)) = kv else {
+                return Err(VindexError::Parse(format!(
+                    "layer {} keeps a KV cache and a conv history, and this traversal \
+                     was given no provider to hold either",
+                    layer.layer
+                )));
+            };
+            // Two regions, one provider, borrowed in phases: the rows
+            // already persisted are copied out first (the reference
+            // executor is deliberately literal — speed is a later
+            // rung's problem), the conv history is advanced by the
+            // forward, and the batch's new rows are appended after.
+            let past_keys: Vec<Vec<f32>> = provider.keys(layer_index).to_vec();
+            let past_values: Vec<Vec<f32>> = provider.values(layer_index).to_vec();
+            let base = provider.position();
+            let state = provider.recurrent_state(layer_index)?;
+            let planes = conv_qkv::layer_forward_with(
+                &ops.op,
+                &ops.weights()?,
+                &inputs,
+                state,
+                &past_keys,
+                &past_values,
+                base,
+                backend.dense_projector(),
+            );
+            for (key, value) in planes.keys.into_iter().zip(planes.values) {
+                provider.append(layer_index, key, value);
+            }
+            planes.output
         }
         PreparedAttention::Softmax(ops) => {
             let attention_op = layer

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -217,6 +217,7 @@ pub(super) enum PreparedAttention {
     Softmax(Box<AttentionOperands>),
     GatedDelta(Box<GatedDeltaOperands>),
     Mamba2(Box<Mamba2Operands>),
+    ConvQkv(Box<ConvQkvOperands>),
 }
 
 impl PreparedAttention {
@@ -229,7 +230,7 @@ impl PreparedAttention {
     fn weight_slices(&self) -> Vec<WeightSlice<'_>> {
         match self {
             Self::Softmax(ops) => ops.weight_slices(),
-            Self::GatedDelta(_) | Self::Mamba2(_) => Vec::new(),
+            Self::GatedDelta(_) | Self::Mamba2(_) | Self::ConvQkv(_) => Vec::new(),
         }
     }
 }
@@ -400,6 +401,58 @@ impl Mamba2Operands {
     }
 }
 
+/// The four operands a conv-QKV attention layer reads, loaded once —
+/// the same matrix/glue split as the mixer's: two dense projections
+/// against kilobytes of conv taps.
+pub(super) struct ConvQkvOperands {
+    pub(super) op: super::super::conv_qkv::ConvQkvOp,
+    in_proj: LoadedWeight,
+    out_proj: LoadedWeight,
+    conv1d: Vec<f32>,
+    conv1d_bias: Option<Vec<f32>>,
+}
+
+impl ConvQkvOperands {
+    fn load(
+        op: &super::super::conv_qkv::ConvQkvOp,
+        store: OperandSource<'_>,
+        format: FormatFor<'_>,
+    ) -> Result<Self, VindexError> {
+        let matrix = |r: &OperandRef| load_weight(store, r, format(r));
+        let glue = |r: &OperandRef| store.load(r);
+        Ok(Self {
+            op: op.clone(),
+            in_proj: matrix(&op.in_proj)?,
+            out_proj: matrix(&op.out_proj)?,
+            conv1d: glue(&op.conv1d)?,
+            conv1d_bias: op.conv1d_bias.as_ref().map(glue).transpose()?,
+        })
+    }
+
+    /// The two matrices, for residency accounting.
+    pub(super) fn loaded_matrices(&self) -> [&LoadedWeight; 2] {
+        [&self.in_proj, &self.out_proj]
+    }
+
+    /// The f32 operands that are not matrix traffic.
+    pub(super) fn glue_bytes(&self) -> usize {
+        std::mem::size_of_val(&self.conv1d[..])
+            + self
+                .conv1d_bias
+                .as_ref()
+                .map_or(0, |v| std::mem::size_of_val(&v[..]))
+    }
+
+    pub(super) fn weights(&self) -> Result<super::conv_qkv::ConvQkvWeights<'_>, VindexError> {
+        Ok(super::conv_qkv::ConvQkvWeights {
+            in_proj: matrix_rows(&self.in_proj, &self.op.in_proj)?,
+            out_proj: matrix_rows(&self.out_proj, &self.op.out_proj)?,
+            conv1d: &self.conv1d,
+            conv1d_bias: self.conv1d_bias.as_deref(),
+        })
+    }
+}
+
 /// A resident matrix as row ranges, cut to the geometry the op declares.
 ///
 /// The geometry comes from the OP and never from the slice length: a
@@ -555,18 +608,9 @@ impl PreparedOperands {
                                 .to_string(),
                         ))
                     }
-                    // Same posture again: represented, not executable.
-                    // The conv-QKV operands are bound and the geometry is
-                    // stated; the executor (and the two-region
-                    // continuation it needs — KV cache AND conv history)
-                    // is the next rung.
-                    LayerAttention::ConvQkv(_) => {
-                        return Err(VindexError::Parse(
-                            "conv-QKV attention layers are represented but not \
-                             executable: no executor exists for this operator"
-                                .to_string(),
-                        ))
-                    }
+                    LayerAttention::ConvQkv(op) => PreparedAttention::ConvQkv(Box::new(
+                        ConvQkvOperands::load(op, store, &attention_format)?,
+                    )),
                     LayerAttention::Mamba2(op) => PreparedAttention::Mamba2(Box::new(
                         Mamba2Operands::load(op, store, &attention_format)?,
                     )),
@@ -697,6 +741,15 @@ impl PreparedOperands {
                     }
                     census.glue.widened_f32 += ops.glue_bytes();
                 }
+                PreparedAttention::ConvQkv(ops) => {
+                    // Attention matrix traffic — the block attends, and
+                    // its fused QKV/out projections are what a device
+                    // backend would hold resident on that site.
+                    for w in ops.loaded_matrices() {
+                        census.attention.add(w);
+                    }
+                    census.glue.widened_f32 += ops.glue_bytes();
+                }
             }
             if let Some(ffn) = &layer.ffn {
                 for w in ffn.loaded_matrices() {
@@ -731,6 +784,9 @@ impl PreparedOperands {
                     ops.loaded_matrices().iter().for_each(|w| add(w))
                 }
                 PreparedAttention::Mamba2(ops) => ops.loaded_matrices().iter().for_each(|w| add(w)),
+                PreparedAttention::ConvQkv(ops) => {
+                    ops.loaded_matrices().iter().for_each(|w| add(w))
+                }
             }
             if let Some(ffn) = &layer.ffn {
                 ffn.loaded_matrices().iter().for_each(|w| add(w));

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/continuation.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/continuation.rs
@@ -309,6 +309,9 @@ fn the_runtime_state_allocates_what_the_geometry_asked_for() {
                     "layer {index} preallocated KV rows before any position"
                 );
             }
+            LayerContinuationState::Hybrid { .. } => {
+                panic!("layer {index} is hybrid; this fixture declares none")
+            }
             LayerContinuationState::Stateless => panic!("layer {index} is stateless"),
         }
     }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/continuation.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/continuation.rs
@@ -16,8 +16,8 @@ use super::super::continuation::{
     LayerContinuationState, RecurrentBufferGeometry, RecurrentGeometry, RecurrentState,
     StateInitialization,
 };
-use super::super::kv::LayerKvGeometry;
 use super::super::kv::try_plan_kv_geometry;
+use super::super::kv::LayerKvGeometry;
 use crate::format::vindex3::opplan::{ComponentOpPlan, GatedDeltaOp, LayerAttention};
 use larql_models::inventory::report::RecurrentStateDtype;
 
@@ -409,7 +409,11 @@ fn two_region_geometry() -> LayerContinuationGeometry {
 #[test]
 fn a_two_region_layer_grows_on_one_side_only() {
     let g = two_region_geometry();
-    assert_eq!(g.elements_at(0), 32, "the buffer exists before any position");
+    assert_eq!(
+        g.elements_at(0),
+        32,
+        "the buffer exists before any position"
+    );
     assert_eq!(g.elements_at(10), 10 * 4 * 2 + 32);
     // And the pure variants keep their own answers beside it.
     let kv = LayerContinuationGeometry::Kv(LayerKvGeometry {
@@ -425,10 +429,7 @@ fn a_two_region_layer_grows_on_one_side_only() {
     });
     assert_eq!(r.elements(), 32);
     assert_eq!(r.bytes(), 128, "f32 cells");
-    assert_eq!(
-        LayerContinuationGeometry::Recurrent(r).elements_at(10),
-        32
-    );
+    assert_eq!(LayerContinuationGeometry::Recurrent(r).elements_at(10), 32);
 }
 
 /// **`kv()` refuses the two-region layer; `kv_side()` serves it.** The
@@ -440,7 +441,10 @@ fn a_two_region_layer_grows_on_one_side_only() {
 #[test]
 fn the_kv_accessor_refuses_what_the_kv_side_accessor_serves() {
     let g = two_region_geometry();
-    assert!(g.kv().is_none(), "kv() must not hand out half a continuation");
+    assert!(
+        g.kv().is_none(),
+        "kv() must not hand out half a continuation"
+    );
     assert_eq!(g.kv_side().map(|kv| kv.kv_dim), Some(4));
     assert_eq!(
         g.recurrent().map(|r| r.elements()),
@@ -516,21 +520,19 @@ fn a_kv_only_provider_refuses_the_two_region_layer() {
 /// geometry promised.
 #[test]
 fn the_two_region_state_allocates_rows_and_buffer_together() {
-    let geometry = [
-        two_region_geometry(),
-        LayerContinuationGeometry::Stateless,
-    ];
+    let geometry = [two_region_geometry(), LayerContinuationGeometry::Stateless];
     let state = ContinuationState::prepare(&geometry);
-    let LayerContinuationState::Hybrid { rows, state: buffer } = state.layer(0) else {
+    let LayerContinuationState::Hybrid {
+        rows,
+        state: buffer,
+    } = state.layer(0)
+    else {
         panic!("layer 0 must hold both regions: {:?}", state.layer(0));
     };
     assert!(rows.keys().is_empty() && rows.values().is_empty());
     assert_eq!(buffer.buffer(0).cells().len(), 32);
     assert!(buffer.buffer(0).cells().iter().all(|c| *c == 0.0));
-    assert!(matches!(
-        state.layer(1),
-        LayerContinuationState::Stateless
-    ));
+    assert!(matches!(state.layer(1), LayerContinuationState::Stateless));
     // The runtime state's KV width is learned from appended rows (the
     // same convention the pure-KV arm holds), so a fresh state counts
     // only the buffer — the region that exists from step zero.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/continuation.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/continuation.rs
@@ -13,8 +13,10 @@
 
 use super::super::continuation::{
     plan_continuation_geometry, ContinuationState, LayerContinuationGeometry,
-    LayerContinuationState, RecurrentBufferGeometry, StateInitialization,
+    LayerContinuationState, RecurrentBufferGeometry, RecurrentGeometry, RecurrentState,
+    StateInitialization,
 };
+use super::super::kv::LayerKvGeometry;
 use super::super::kv::try_plan_kv_geometry;
 use crate::format::vindex3::opplan::{ComponentOpPlan, GatedDeltaOp, LayerAttention};
 use larql_models::inventory::report::RecurrentStateDtype;
@@ -382,4 +384,155 @@ fn a_recurrent_state_refuses_the_wrong_number_of_cells() {
     assert!(RecurrentBuffer::from_cells(&g, vec![0.0; 20]).is_ok());
     let err = RecurrentBuffer::from_cells(&g, vec![0.0; 19]).expect_err("19 != 4*5");
     assert!(err.contains("19") && err.contains("20"), "{err}");
+}
+
+// ── The two-region shape (KvAndRecurrent) — the hybrid conv-QKV
+//    attention layer's continuation, in the vocabulary's own terms ──
+
+fn two_region_geometry() -> LayerContinuationGeometry {
+    LayerContinuationGeometry::KvAndRecurrent {
+        kv: LayerKvGeometry {
+            kv_dim: 4,
+            window: None,
+        },
+        recurrent: RecurrentGeometry::single(RecurrentBufferGeometry {
+            shape: vec![16, 2],
+            dtype: RecurrentStateDtype::Float32,
+            initialization: StateInitialization::Zeros,
+        }),
+    }
+}
+
+/// **The two-region layer's arithmetic is the sum of its claims**: the
+/// KV half scales with positions, the conv history does not — the same
+/// asymmetry the pure variants state, on one layer.
+#[test]
+fn a_two_region_layer_grows_on_one_side_only() {
+    let g = two_region_geometry();
+    assert_eq!(g.elements_at(0), 32, "the buffer exists before any position");
+    assert_eq!(g.elements_at(10), 10 * 4 * 2 + 32);
+    // And the pure variants keep their own answers beside it.
+    let kv = LayerContinuationGeometry::Kv(LayerKvGeometry {
+        kv_dim: 4,
+        window: None,
+    });
+    assert_eq!(kv.elements_at(10), 80);
+    assert_eq!(LayerContinuationGeometry::Stateless.elements_at(10), 0);
+    let r = RecurrentGeometry::single(RecurrentBufferGeometry {
+        shape: vec![16, 2],
+        dtype: RecurrentStateDtype::Float32,
+        initialization: StateInitialization::Zeros,
+    });
+    assert_eq!(r.elements(), 32);
+    assert_eq!(r.bytes(), 128, "f32 cells");
+    assert_eq!(
+        LayerContinuationGeometry::Recurrent(r).elements_at(10),
+        32
+    );
+}
+
+/// **`kv()` refuses the two-region layer; `kv_side()` serves it.** The
+/// split is the fail-closed contract: `kv()` is what the KV-only
+/// provider default projects through, and answering the hybrid's KV
+/// half there would allocate the cache while silently dropping the conv
+/// history — half a continuation that looks whole. A provider that
+/// genuinely holds both asks through `kv_side()`.
+#[test]
+fn the_kv_accessor_refuses_what_the_kv_side_accessor_serves() {
+    let g = two_region_geometry();
+    assert!(g.kv().is_none(), "kv() must not hand out half a continuation");
+    assert_eq!(g.kv_side().map(|kv| kv.kv_dim), Some(4));
+    assert_eq!(
+        g.recurrent().map(|r| r.elements()),
+        Some(32),
+        "the buffer half answers through the same accessor a pure recurrence uses"
+    );
+    // A pure KV layer answers both spellings identically.
+    let kv = LayerContinuationGeometry::Kv(LayerKvGeometry {
+        kv_dim: 4,
+        window: None,
+    });
+    assert_eq!(kv.kv().map(|k| k.kv_dim), Some(4));
+    assert_eq!(kv.kv_side().map(|k| k.kv_dim), Some(4));
+    assert!(kv.recurrent().is_none());
+}
+
+/// **A KV-only provider fails CLOSED on the two-region layer** — the
+/// default `prepare_continuation` projection refuses rather than
+/// allocating the cache without the conv history. The failure the
+/// accessor split above exists to force.
+#[test]
+fn a_kv_only_provider_refuses_the_two_region_layer() {
+    use super::super::kv::{ContinuationError, ContinuationProvider};
+
+    struct RowsOnly;
+    impl ContinuationProvider for RowsOnly {
+        fn prepare(&mut self, _layers: &[LayerKvGeometry]) {}
+        fn append(&mut self, _layer: usize, _key: Vec<f32>, _value: Vec<f32>) {}
+        fn keys(&self, _layer: usize) -> &[Vec<f32>] {
+            &[]
+        }
+        fn values(&self, _layer: usize) -> &[Vec<f32>] {
+            &[]
+        }
+        fn position(&self) -> usize {
+            0
+        }
+        fn set_position(&mut self, _position: usize) {}
+        fn recurrent_state(
+            &mut self,
+            layer: usize,
+        ) -> Result<&mut RecurrentState, ContinuationError> {
+            Err(ContinuationError::RecurrentUnsupported {
+                provider: "RowsOnly",
+                layer,
+            })
+        }
+    }
+
+    let layers = [
+        LayerContinuationGeometry::Kv(LayerKvGeometry {
+            kv_dim: 4,
+            window: None,
+        }),
+        two_region_geometry(),
+    ];
+    let err = RowsOnly
+        .prepare_continuation(&layers)
+        .expect_err("half a continuation must not be allocated");
+    assert_eq!(
+        err,
+        ContinuationError::RecurrentUnsupported {
+            provider: "a KV-only provider",
+            layer: 1,
+        }
+    );
+    let rendered = err.to_string();
+    assert!(rendered.contains("refusing"), "{rendered}");
+}
+
+/// The runtime state allocates BOTH regions for the two-region layer —
+/// empty rows and a zeroed buffer — and counts them the way the
+/// geometry promised.
+#[test]
+fn the_two_region_state_allocates_rows_and_buffer_together() {
+    let geometry = [
+        two_region_geometry(),
+        LayerContinuationGeometry::Stateless,
+    ];
+    let state = ContinuationState::prepare(&geometry);
+    let LayerContinuationState::Hybrid { rows, state: buffer } = state.layer(0) else {
+        panic!("layer 0 must hold both regions: {:?}", state.layer(0));
+    };
+    assert!(rows.keys().is_empty() && rows.values().is_empty());
+    assert_eq!(buffer.buffer(0).cells().len(), 32);
+    assert!(buffer.buffer(0).cells().iter().all(|c| *c == 0.0));
+    assert!(matches!(
+        state.layer(1),
+        LayerContinuationState::Stateless
+    ));
+    // The runtime state's KV width is learned from appended rows (the
+    // same convention the pure-KV arm holds), so a fresh state counts
+    // only the buffer — the region that exists from step zero.
+    assert_eq!(state.elements_at(5), 32);
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/conv_qkv.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/conv_qkv.rs
@@ -295,20 +295,24 @@ fn stripping_the_conv_qkv_surface_is_a_named_defect() {
     assert_eq!(named.len(), 1, "the missing group must be named: {named:?}");
 }
 
-/// **The hybrid encodes — closure holds over BOTH operand programs —
-/// and execution refuses by name.** The plan carries the two operators
-/// with every operand accounted (5 on an attention layer, 9 on a mixer
-/// layer); preparing it is refused as "represented but not executable",
-/// and the continuation planner refuses to flatten the two-region state
-/// (KV cache AND conv history) to the cache alone. The executor rung
-/// flips both refusals.
+/// **The hybrid executes through the generic path, and its TWO-REGION
+/// continuation survives the step boundary.** Encode closes over both
+/// operand programs; the continuation planner declares KV **and** conv
+/// history on the attention layers; prefill is finite and bitwise
+/// deterministic across fresh states; and the single-token decode path
+/// agrees with batch prefill bitwise — which only holds if the conv
+/// history (pre-conv fused QKV) and the KV rows BOTH carry across the
+/// boundary, at the right rotary angles.
 #[test]
-fn the_hybrid_encodes_and_execution_refuses_by_name() {
+fn the_hybrid_executes_and_both_state_regions_survive_the_step() {
     use crate::format::vindex3::inspect::inspect_container;
-    use crate::format::vindex3::opplan::exec::continuation::plan_continuation_geometry;
+    use crate::format::vindex3::opplan::exec::continuation::{
+        plan_continuation_geometry, LayerContinuationGeometry,
+    };
+    use crate::format::vindex3::opplan::exec::decode::DecodeSession;
+    use crate::format::vindex3::opplan::exec::kv::{ContinuationProvider, RowKvState};
     use crate::format::vindex3::opplan::exec::operands::OperandStore;
-    use crate::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
-    use crate::format::vindex3::opplan::exec::production::ProductionBackend;
+    use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
     use crate::format::vindex3::opplan::{plan_component_ops, LayerAttention};
 
     let dir = tempfile::tempdir().unwrap();
@@ -338,24 +342,68 @@ fn the_hybrid_encodes_and_execution_refuses_by_name() {
         }
     }
 
-    // Represented is not executable: preparation refuses by name.
-    let store = OperandStore::open(&container, &inspection).unwrap();
-    let Err(err) = PreparedOperands::load(
-        &plan,
-        &store,
-        &ProductionBackend::new(),
-        ExecutionSlice::Full,
-    ) else {
-        panic!("no executor exists for this operator yet — load must refuse");
-    };
-    assert!(
-        err.to_string().contains("represented but not executable"),
-        "the refusal must say WHY: {err}"
-    );
+    // The continuation declares BOTH regions on the attention layers —
+    // rows sized by the KV heads, a conv history over the fused QKV.
+    let geometry = plan_continuation_geometry(&plan).expect("two regions, declared");
+    for (index, layer) in geometry.iter().enumerate() {
+        if H_ATTN_LAYERS.contains(&index) {
+            let LayerContinuationGeometry::KvAndRecurrent { kv, recurrent } = layer else {
+                panic!("layer {index} must declare both regions: {layer:?}");
+            };
+            assert_eq!(kv.kv_dim, H_A_KV_HEADS * H_A_HEAD_DIM);
+            assert_eq!(recurrent.buffers.len(), 1);
+            assert_eq!(recurrent.buffers[0].shape, vec![H_A_QKV_ROWS, H_A_CONV]);
+        } else {
+            assert!(
+                matches!(layer, LayerContinuationGeometry::Recurrent(_)),
+                "layer {index}: {layer:?}"
+            );
+        }
+    }
 
-    // And the continuation planner refuses to flatten the two-region
-    // state to the KV half.
-    let err = plan_continuation_geometry(&plan).expect_err("two regions, one vocabulary");
-    assert!(err.contains("conv history"), "{err}");
-    assert!(err.contains("refusing to flatten"), "{err}");
+    let store = OperandStore::open(&container, &inspection).unwrap();
+    let prefill = |tokens: &[u32], provider: &mut RowKvState| -> Vec<f32> {
+        crate::format::vindex3::opplan::exec::prefill_plan(
+            &plan,
+            &store,
+            tokens,
+            &ReferenceBackend,
+            provider,
+        )
+        .expect("the hybrid executes")
+        .logits
+        .expect("the fixture carries an output head")
+    };
+    let fresh = || {
+        let mut p = RowKvState::default();
+        p.prepare_continuation(&geometry).unwrap();
+        p
+    };
+
+    let prompt = [3u32, 17, 5, 9, 12, 1];
+    let mut provider = fresh();
+    let logits = prefill(&prompt, &mut provider);
+    assert_eq!(logits.len(), H_VOCAB);
+    assert!(logits.iter().all(|v| v.is_finite()), "finite logits");
+
+    // Bitwise determinism across a fresh state — state reset is real.
+    let mut again = fresh();
+    assert_eq!(prefill(&prompt, &mut again), logits);
+
+    // The decode path, token by token from an empty state, must land on
+    // the batch answer bitwise: the conv history spans every step
+    // boundary (a window of one would be a different operator), the KV
+    // rows accumulate, and the rotary angle follows the ABSOLUTE
+    // position.
+    let mut session = DecodeSession::new(&plan, &store, &ReferenceBackend).unwrap();
+    let mut stepped = None;
+    for token in prompt {
+        stepped = session.step(token).unwrap().logits;
+    }
+    assert_eq!(session.position(), prompt.len());
+    assert_eq!(
+        stepped.expect("head present"),
+        logits,
+        "the decode step path diverged from batch prefill"
+    );
 }

--- a/scripts/mamba2attn_reference_oracle.py
+++ b/scripts/mamba2attn_reference_oracle.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""HF reference oracle for the Mamba2Attn HYBRID witness (OuteAI rehearsal).
+
+Adapted from mamba2_reference_oracle.py: the checkpoint ships its own
+modeling code (auto_map -> trust_remote_code), and its cache rides the
+standard past_key_values/use_cache interface rather than mamba2's
+cache_params. Everything else -- fp32 substrate, the determinism and
+step-vs-scan self-checks, per-prompt npz + manifest -- is the same
+instrument.
+
+Original doc:
+
+The witness claim is "generates correctly through the generic V3 execution
+path", so the oracle captures more than a sentence: full logits at every
+prefill position, per-layer hidden states, and full logits at every greedy
+decode step. SSM correctness lives in the continuation state — a one-token
+match can conceal a broken state update — so the corpus spans prompt lengths
+(including one crossing the SSD chunk_size boundary) and the script proves
+the reference is self-consistent before anything is paritied against it:
+
+  * determinism  — a fresh second prefill must be bitwise identical;
+  * step-vs-scan — feeding the prompt token-by-token through the recurrent
+    cache must agree with the one-shot chunked-scan prefill. This is the
+    same state update the decode loop uses, checked against the scan.
+
+Precision is a decision, not a default: fp32 is the oracle substrate (the
+parity gate scores against fp32, not the F16 the checkpoint ships in).
+
+Usage:
+  python3 scripts/mamba2_reference_oracle.py ~/chris-models/mamba2-780m-hf \
+      --out ~/chris-models/oracles/mamba2-780m-hf [--steps 32]
+
+Writes per-prompt .npz archives plus manifest.json (token ids, greedy
+continuations, self-check results, library versions).
+"""
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Fixed corpus: short / medium / long-enough-to-cross-chunk_size (256).
+PARAGRAPH = (
+    "The river rises in the high mountains where snow melts slowly through "
+    "the spring months, gathering small streams as it descends past granite "
+    "cliffs and pine forests toward the wide valley floor below. "
+)
+PROMPTS = {
+    "short": "The capital of France is",
+    "medium": (
+        "In 1969 the Apollo 11 mission carried three astronauts to the Moon, "
+        "and the lunar module descended to the Sea of Tranquility, where"
+    ),
+    "long": PARAGRAPH * 8 + "The river finally reaches",
+}
+
+
+def greedy_step_ids(model, cache, logits, pos, steps):
+    """Greedy decode `steps` tokens through the recurrent cache.
+
+    Returns (ids, stepwise full logits). `logits` is the distribution the
+    first generated token is drawn from.
+    """
+    out_ids, out_logits = [], []
+    for _ in range(steps):
+        next_id = int(logits.argmax())
+        out_ids.append(next_id)
+        step = model(
+            torch.tensor([[next_id]]),
+            past_key_values=cache,
+            use_cache=True,
+            cache_position=torch.tensor([pos]),
+        )
+        cache = step.past_key_values
+        logits = step.logits[0, -1].float()
+        out_logits.append(logits.numpy())
+        pos += 1
+    return out_ids, np.stack(out_logits)
+
+
+def stepwise_prefill_logits(model, ids):
+    """Feed the prompt one token at a time through the recurrent cache."""
+    cache = None
+    logits = None
+    for pos in range(ids.shape[1]):
+        out = model(
+            ids[:, pos : pos + 1],
+            past_key_values=cache,
+            use_cache=True,
+            cache_position=torch.tensor([pos]),
+        )
+        cache = out.past_key_values
+        logits = out.logits[0, -1].float()
+    return logits
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("checkpoint")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--steps", type=int, default=32)
+    a = ap.parse_args()
+
+    out_dir = Path(a.out).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    config_path = Path(a.checkpoint).expanduser() / "config.json"
+    config_sha = hashlib.sha256(config_path.read_bytes()).hexdigest()
+
+    tok = AutoTokenizer.from_pretrained(a.checkpoint, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        a.checkpoint, torch_dtype=torch.float32, low_cpu_mem_usage=True, device_map="cpu",
+        trust_remote_code=True
+    ).eval()
+    torch.set_grad_enabled(False)
+
+    manifest = {
+        "checkpoint": a.checkpoint,
+        "config_sha256": config_sha,
+        "dtype": "float32",
+        "torch": torch.__version__,
+        "transformers": __import__("transformers").__version__,
+        "steps": a.steps,
+        "prompts": {},
+    }
+
+    for name, text in PROMPTS.items():
+        ids = tok(text, return_tensors="pt").input_ids
+        n = ids.shape[1]
+        print(f"[{name}] {n} tokens", file=sys.stderr)
+
+        out = model(ids, use_cache=True, output_hidden_states=True)
+        prefill_logits = out.logits[0].float().numpy()  # [n, vocab]
+        hidden = np.stack([h[0].float().numpy() for h in out.hidden_states])
+
+        # Self-check 1: a fresh prefill must be bitwise identical.
+        again = model(ids, use_cache=True)
+        deterministic = bool(torch.equal(out.logits, again.logits))
+
+        # Self-check 2: token-by-token recurrence vs one-shot scan.
+        step_logits = stepwise_prefill_logits(model, ids)
+        scan_logits = out.logits[0, -1].float()
+        step_vs_scan = float((step_logits - scan_logits).abs().max())
+        step_vs_scan_argmax = bool(step_logits.argmax() == scan_logits.argmax())
+
+        gen_ids, decode_logits = greedy_step_ids(
+            model, out.past_key_values, scan_logits, n, a.steps
+        )
+        gen_text = tok.decode(gen_ids)
+        print(f"[{name}] -> {gen_text!r}", file=sys.stderr)
+        print(
+            f"[{name}] deterministic={deterministic} "
+            f"step_vs_scan_max_abs={step_vs_scan:.3e} "
+            f"argmax_agree={step_vs_scan_argmax}",
+            file=sys.stderr,
+        )
+
+        np.savez_compressed(
+            out_dir / f"{name}.npz",
+            input_ids=ids[0].numpy(),
+            prefill_logits=prefill_logits,
+            hidden_states=hidden,
+            generated_ids=np.array(gen_ids),
+            decode_logits=decode_logits,
+        )
+        manifest["prompts"][name] = {
+            "text": text,
+            "input_ids": ids[0].tolist(),
+            "n_tokens": n,
+            "generated_ids": gen_ids,
+            "generated_text": gen_text,
+            "first_token_id": gen_ids[0],
+            "first_token": tok.decode([gen_ids[0]]),
+            "deterministic": deterministic,
+            "step_vs_scan_max_abs": step_vs_scan,
+            "step_vs_scan_argmax_agree": step_vs_scan_argmax,
+        }
+
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    print(f"wrote {out_dir}/manifest.json + {len(PROMPTS)} npz", file=sys.stderr)
+
+
+main()


### PR DESCRIPTION
The executor rung of the OuteAI rehearsal (#350's other half), and the abstraction answer the rehearsal existed to get: **the hybrid runs through the generic path with no family lookup and no schema change.**

- **`exec/conv_qkv.rs`** — the reference executor, transcribed stage-by-stage from the checkpoint's own modeling code and defined entirely by the op's persisted semantics: fused projection width, conv kernel (**no activation** — unlike the mixer's SiLU conv), rotate-half partial rotary over the rotary width at **absolute** positions, f32 softmax, GQA, bias presence by operand. 99.4% line coverage.
- **Two-region continuation** — `LayerContinuationGeometry::KvAndRecurrent`: a per-position KV cache AND a conv history on one layer. `kv()` answers `None` for it deliberately, so a KV-only provider fails closed through the existing guard rather than allocating half a continuation; `kv_side()` serves providers that hold both. `CanonicalKvState` and `RowKvState` allocate rows and buffer at the same absolute layer index. The contract is pinned by four named tests.
- `has_executor(ConvQkvAttention) = true`; prefill, decode-step and both censuses carry the operator; the continuation planner declares the two regions from one source (`conv_history_geometry`).

**Witnessed at three scales:**
- miniature: batch-vs-decode **bitwise** across the step boundary — only possible if conv history and KV rows both persist at the right rotary angles;
- real 250M: encoded (486MB, closure over 274 operands); fp32 oracle banked (deterministic, step-vs-scan ≤4.3e-5); teacher-forced parity short 6+32 max|Δ| 5.6e-5 · medium 41+32 5.5e-5 · long 325+32 6.9e-5, **argmax 468/468**, every trajectory token-for-token;
- source-hidden: `larql lql 'USE …; INFER "The capital of France is" GENERATE 32'` with the checkpoint hidden reproduces the oracle's greedy continuation **id-for-id** (1.07s CPU); `SHOW LAYERS` names `conv-qkv`.

Includes `scripts/mamba2attn_reference_oracle.py` (runs under a pinned transformers 4.44.2 venv — v5 normalizes `rope_scaling: null` into a dict the checkpoint's custom code KeyErrors on).

Gates: larql-vindex 3702 / larql-kv 1286 / models 917 green locally; coverage policy passes crate-wide (93.61%); fmt + clippy clean.