### PR TITLE
docs: point the READMEs at vindex3.org, and give vindex its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The model IS the database. Query neural network weights like a graph database. N
 
 LARQL decompiles transformer models into a queryable format called a **vindex** (vector index), then provides **LQL** (Lazarus Query Language) to browse, edit, and recompile the model's knowledge.
 
+**VINDEX3 — the successor container — is specified and explained at [vindex3.org](https://vindex3.org).** The site is where the format is taught, explored and held to its evidence (the Record); this repository is its reference implementation. Install the format-native reader from [vindex3.org/get-started](https://vindex3.org/get-started), and cite the specification via [vindex3.org/cite](https://vindex3.org/cite).
+
 ```sql
 larql> USE "gemma3-4b.vindex";
 Using: gemma3-4b.vindex (34 layers, 348.2K features, relations: 512 types)
@@ -447,7 +449,10 @@ flip — a named decision, made in one place, not yet made (see
 See
 [`crates/larql-vindex/docs/vindex3-format-spec.md`](crates/larql-vindex/docs/vindex3-format-spec.md)
 (the 3.0 Candidate ABI) and [`docs/vindex3-format.md`](docs/vindex3-format.md)
-(the living spec).
+(the living spec) — both explained chapter by chapter at
+[vindex3.org](https://vindex3.org), with the version and its six claims at
+[vindex3.org/3.0](https://vindex3.org/3.0) and the status of every claim at
+[vindex3.org/ladder](https://vindex3.org/ladder).
 
 Three extraction levels:
 
@@ -1084,6 +1089,7 @@ The full surface is documented in [crates/larql-inference/ROADMAP.md](crates/lar
 |---|---|
 | [crates/larql-lql/docs/spec.md](crates/larql-lql/docs/spec.md) | LQL language specification (v0.4) |
 | [crates/larql-vindex/docs/format-spec.md](crates/larql-vindex/docs/format-spec.md) | Vindex file format specification (v0.4, ~98% implemented) |
+| [vindex3.org](https://vindex3.org) | VINDEX3 explained — the specification as chapters, an explorer, and the Record of what is demonstrated; [vindex3.org/3.0](https://vindex3.org/3.0) is the citable version page |
 | [crates/larql-vindex/docs/vindex3-format-spec.md](crates/larql-vindex/docs/vindex3-format-spec.md) | Vindex3 container ABI (`larql-vindex` side — bytes, sections, admission) |
 | [docs/vindex3-format.md](docs/vindex3-format.md) | Vindex3 model-system container spec — the actively updated spec (plan/encode/verify semantics); the ABI doc above governs the on-disk bytes |
 | [docs/vindex3-runtime.md](docs/vindex3-runtime.md) | Vindex3 runtime stack — `Vindex3Runtime`, `LogitsSession`, the KV seam, and V3 serving over `/v1/completions` |

--- a/crates/larql-vindex/README.md
+++ b/crates/larql-vindex/README.md
@@ -6,6 +6,8 @@ The queryable model format. Decompile, browse, edit, and recompile neural networ
 
 A vindex (vector index) is a directory containing a model's weights reorganised for queryability. The model IS the database — each weight matrix is stored once in its optimal format. A VINDEX3 container (3.0 Candidate, graph schema 6) describes a model system by its declared operator program — softmax attention, MLA, KDA, Gated DeltaNet, Mamba2 — and its surfaces follow that program: a pure-SSM model carries no attention surface at all, because it has none.
 
+**VINDEX3 is specified and explained at [vindex3.org](https://vindex3.org)** — the container model, the system graph, the byte layout, representations and authority, each chapter carrying the evidence behind it ([vindex3.org/ladder](https://vindex3.org/ladder)). The normative documents live in this repository ([`docs/vindex3-format-spec.md`](docs/vindex3-format-spec.md) — the 3.0 Candidate ABI — and [`../../docs/vindex3-format.md`](../../docs/vindex3-format.md), the living spec); the site is where they are explained, explored and cited.
+
 ```rust
 use larql_vindex::*;
 

--- a/crates/vindex-cli/README.md
+++ b/crates/vindex-cli/README.md
@@ -1,0 +1,73 @@
+# vindex
+
+The format-native VINDEX3 tool. Every command answers from the container alone —
+`index.json`, the system graph, the segment headers — the same authorities an
+independent implementation would read. No inference runtime, no model registry,
+no network.
+
+**VINDEX3 is specified and explained at [vindex3.org](https://vindex3.org)**;
+[vindex3.org/get-started](https://vindex3.org/get-started) walks this tool from
+install to `verify` with recorded outputs, and the normative documents are
+[`crates/larql-vindex/docs/vindex3-format-spec.md`](../larql-vindex/docs/vindex3-format-spec.md)
+(the 3.0 Candidate ABI) and [`docs/vindex3-format.md`](../../docs/vindex3-format.md)
+(the living spec).
+
+## Install
+
+```bash
+# Prebuilt (macOS arm64)
+curl -L https://github.com/chrishayuk/larql/releases/download/\
+vindex-v0.5.0/vindex-0.5.0-macos-arm64.tar.gz | tar xz
+
+# Or from source
+cargo install --git https://github.com/chrishayuk/larql vindex-cli
+```
+
+`vindex update` installs the latest release, and only ever when asked: no verb
+checks for updates on its own, and nothing phones home. `vindex update --check`
+reports without installing.
+
+## The verbs
+
+| Command | What it answers |
+|---|---|
+| `inspect <container>` | The container reconstructed from itself: identity, census, coherence |
+| `describe <container> <object>` | One logical object in full — bindings, representations, tensor-table head; `--peek <tensor>` decodes the first values |
+| `representations <container>` | The physical directory: what exists as bytes, with recorded fidelity |
+| `layers <container>` | Every layer's token-mixer programme, from the operation plan |
+| `diff <container> <A> <B> <object>` | One object under two representations, decoded and compared value by value — the error derived, never asserted |
+| `represent <container> <out>` | Compile a representation beside the original through the reference compiler. Nothing is destroyed |
+| `precision <container>` | Bits per weight, derived from stored bytes over tensor elements; `--matrix` shows bits per layer × semantic role |
+| `verify <container>` | The container against its own recorded hashes, re-derived from the artifact alone |
+
+Addresses are semantic: `layer.24.ffn.down`, `layer.3.attention.q`,
+`layer.7.mixer`. A layer whose programme has no such operand refuses by naming
+what it does have, rather than inventing a surface.
+
+```
+$ vindex inspect granite-3b.vindex3
+family         granite
+generation     3
+geometry       40 layers · hidden 2560
+authority      canonical
+
+COMPONENT   ROLE          LAYERS   HIDDEN
+target      primarytext       40     2560
+
+graph          4 object(s) · coherent
+```
+
+Every command takes a global `--json`: one result, three projections — terminal
+text, structured JSON, and the designed panels vindex3.org renders from the same
+shape. Exit codes: `1` on `verified: false`, `2` on error.
+
+## What is deliberately not here
+
+Execution, inference, mutation, benchmarking and representation search are
+engine concerns and live in `larql`. VINDEX3 is defined by its documents, not by
+any tool, and an artifact should not require an engine to be understood — this
+binary is the canonical *reader*.
+
+One impurity, recorded honestly: `larql-vindex` is not yet a dependency-light
+core, so this version carries its tree. Carving `vindex-core` out of it is the
+named next step, not a surprise.


### PR DESCRIPTION
The specification is explained, explored and cited at [vindex3.org](https://vindex3.org) — and nothing in this repository said so.

- **Root README** — names the site in the opening paragraph (VINDEX3 is specified there; this repository is its reference implementation), links it beside the two normative documents in the VINDEX3 section, and adds a row to the documentation table.
- **`crates/larql-vindex/README.md`** — same link where the container is introduced, with the normative documents kept as the authority.
- **`crates/vindex-cli/README.md`** — new. The crate had no README: install (tarball + `cargo install --git`), the nine verbs and what each answers, semantic addressing and its refusals, the global `--json` contract, exit codes 1/2, and the doctrine from its own Cargo.toml — including the recorded impurity that `vindex-core` has not been carved out yet.

Documentation only; no code paths touched.