### PR TITLE
Merge vindex-mixer-operator: declared-operator mixer identity and CPU NVFP4

### DIFF
--- a/bench/prompts/quality-bank-1/run_bank.py
+++ b/bench/prompts/quality-bank-1/run_bank.py
@@ -69,7 +69,11 @@ def read_execution_facts(stdout):
     to be recorded, because it is invisible in the numbers until they
     come out as an exact zero.
     """
-    facts = {"executed": None, "source": None, "objects_from_pack": None,
+    # `requested` is what the backend ASKED for; the evidence that it was
+    # actually consumed is `objects_from_pack` being non-zero with
+    # `runtime_compiled` at zero. Naming the first one "executed" would
+    # be the same conflation that produced the false null.
+    facts = {"requested": None, "source": None, "objects_from_pack": None,
              "objects_total": None, "runtime_compiled": 0}
     for line in stdout.splitlines():
         if line.startswith("runtime compile:"):
@@ -77,7 +81,7 @@ def read_execution_facts(stdout):
         elif line.startswith("representation:"):
             # representation: NVFP4  source: stored  objects from a compiled pack: 1/5
             body = line.split("representation:", 1)[1]
-            facts["executed"] = body.split()[0]
+            facts["requested"] = body.split()[0]
             if "source:" in body:
                 facts["source"] = body.split("source:", 1)[1].split()[0]
             if "pack:" in body:
@@ -107,7 +111,7 @@ def assert_candidate_executed_its_representation(container_id, facts, label):
     if not declared:
         return
     want = declared.get("encoding")
-    got = facts.get("executed")
+    got = facts.get("requested")
     if got != want:
         raise SystemExit(
             f"{label}: the candidate's precision map declares `{want}`, but the run "
@@ -118,7 +122,14 @@ def assert_candidate_executed_its_representation(container_id, facts, label):
         )
     if not facts.get("objects_from_pack"):
         raise SystemExit(
-            f"{label}: reported `{want}` but bound no object from a compiled pack."
+            f"{label}: requested `{want}` but bound no object from a compiled pack, so "
+            f"nothing of that representation was actually consumed."
+        )
+    if facts.get("source") == "stored" and facts.get("runtime_compiled"):
+        raise SystemExit(
+            f"{label}: {facts['runtime_compiled']} tensor(s) were quantised at load under "
+            f"`stored`. The arm measured a representation manufactured now, not the one "
+            f"the artifact carries."
         )
 
 

--- a/bench/prompts/quality-bank-1/run_bank.py
+++ b/bench/prompts/quality-bank-1/run_bank.py
@@ -59,6 +59,69 @@ def compiler_provenance():
     }
 
 
+def read_execution_facts(stdout):
+    """What the run actually executed, from the executor's own report.
+
+    `larql vindex3 exec` prints `representation: <enc>  source: <src>
+    objects from a compiled pack: A/B` **only when the backend asked for
+    a compiled encoding at all**. Its absence therefore means the run
+    bound the container's canonical bytes — which is the fact that has
+    to be recorded, because it is invisible in the numbers until they
+    come out as an exact zero.
+    """
+    facts = {"executed": None, "source": None, "objects_from_pack": None,
+             "objects_total": None, "runtime_compiled": 0}
+    for line in stdout.splitlines():
+        if line.startswith("runtime compile:"):
+            facts["runtime_compiled"] = int(line.split(":")[1].strip().split()[0])
+        elif line.startswith("representation:"):
+            # representation: NVFP4  source: stored  objects from a compiled pack: 1/5
+            body = line.split("representation:", 1)[1]
+            facts["executed"] = body.split()[0]
+            if "source:" in body:
+                facts["source"] = body.split("source:", 1)[1].split()[0]
+            if "pack:" in body:
+                ratio = body.rsplit("pack:", 1)[1].strip()
+                if "/" in ratio:
+                    a, b = ratio.split("/", 1)
+                    facts["objects_from_pack"], facts["objects_total"] = int(a), int(b)
+    return facts
+
+
+def assert_candidate_executed_its_representation(container_id, facts, label):
+    """A bank must never be able to compare the reference against itself.
+
+    This exists because it happened. A candidate compiled to NVFP4 was
+    run on a backend that requests no compiled encoding, so it bound the
+    canonical BF16 bytes and scored KL 0.00000 on all 1,740 positions —
+    a result indistinguishable from perfect fidelity, and entirely an
+    artefact of the invocation. `--representation-source stored` did not
+    catch it: that flag forbids *manufacturing* a representation, and
+    binding canonical bytes manufactures nothing.
+
+    So the artifact's declared programme is checked against what the
+    executor says it ran. An arm that cannot prove it executed the
+    representation under test is not evidence.
+    """
+    declared = (container_id or {}).get("precision_map")
+    if not declared:
+        return
+    want = declared.get("encoding")
+    got = facts.get("executed")
+    if got != want:
+        raise SystemExit(
+            f"{label}: the candidate's precision map declares `{want}`, but the run "
+            f"executed {got or 'the canonical representation'}. A candidate that did "
+            f"not execute its own representation cannot be compared against the "
+            f"reference — that is a reference-against-reference run, and it will look "
+            f"like perfect fidelity. Choose a backend that requests `{want}`."
+        )
+    if not facts.get("objects_from_pack"):
+        raise SystemExit(
+            f"{label}: reported `{want}` but bound no object from a compiled pack."
+        )
+
+
 def load_bank():
     path = os.path.join(BANK_DIR, "prompts.json")
     bank = json.load(open(path))
@@ -118,11 +181,7 @@ def run_bank_arm(container, entries, backend, source, dump_dir):
     r = subprocess.run(cmd, capture_output=True, text=True)
     if r.returncode != 0:
         raise SystemExit(f"bank run failed:\n{r.stdout}\n{r.stderr}")
-    compiled = 0
-    for line in r.stdout.splitlines():
-        if line.startswith("runtime compile:"):
-            compiled = int(line.split(":")[1].strip().split()[0])
-    return compiled
+    return read_execution_facts(r.stdout)
 
 
 def run_arm(container, entry, backend, source, dump):
@@ -134,11 +193,7 @@ def run_arm(container, entry, backend, source, dump):
     r = subprocess.run(cmd, capture_output=True, text=True)
     if r.returncode != 0:
         raise SystemExit(f"{entry['id']}: {r.stdout}\n{r.stderr}")
-    compiled = 0
-    for line in r.stdout.splitlines():
-        if line.startswith("runtime compile:"):
-            compiled = int(line.split(":")[1].strip().split()[0])
-    return compiled
+    return read_execution_facts(r.stdout)
 
 
 def softmax_rows(x):
@@ -167,7 +222,10 @@ def cmd_compare(container, outdir, backend, source, label, keep=False):
     meta = json.load(open(os.path.join(outdir, "reference.json")))
     rows = []
     canddir = os.path.join(outdir, f"_cand-{label}")
-    compiled_total = run_bank_arm(container, meta["entries"], backend, source, canddir)
+    facts = run_bank_arm(container, meta["entries"], backend, source, canddir)
+    cand_id = container_identity(container)
+    assert_candidate_executed_its_representation(cand_id, facts, label)
+    compiled_total = facts["runtime_compiled"]
     for i, e in enumerate(meta["entries"]):
         refpath = os.path.join(outdir, e["dump"])
         candpath = os.path.join(canddir, f"{e['id']}.f32")
@@ -228,7 +286,8 @@ def cmd_compare(container, outdir, backend, source, label, keep=False):
     out = {"label": label, "backend": backend, "source": source,
            "payload_bytes": cand_bytes,
            "runtime_compiled_total": compiled_total,
-           "container": container_identity(container),
+           "container": cand_id,
+           "execution": facts,
            "compiler": compiler_provenance(),
            "reference": meta["container"], "rows": rows}
     path = os.path.join(outdir, f"compare-{label}.json")

--- a/bench/prompts/quality-bank-1/run_bank.py
+++ b/bench/prompts/quality-bank-1/run_bank.py
@@ -29,6 +29,36 @@ LARQL = os.environ.get("LARQL", "./target/release/larql")
 BANK_DIR = os.environ.get("QBANK_DIR", HERE)
 
 
+def compiler_provenance():
+    """Which build produced the representation under test.
+
+    The container's digests pin the *artifact* exactly; they say nothing
+    about the code that compiled it. Those are two different facts, and
+    a bank that records only the first cannot answer "was this measured
+    before or after the role-classifier fix?" — a question that changed
+    Qwen3.8's decoder from 6.4138 to 4.5124 bits/weight without touching
+    a single byte of the source checkpoint.
+
+    `dirty` is reported rather than hidden. A result measured against an
+    uncommitted tree is still a result; it is just not one anybody else
+    can reproduce from a SHA, and saying so is the difference between
+    provenance and decoration.
+    """
+    def git(*args):
+        try:
+            return subprocess.run(["git", *args], cwd=HERE, capture_output=True,
+                                  text=True, check=True).stdout.strip()
+        except Exception:
+            return None
+    head = git("rev-parse", "HEAD")
+    status = git("status", "--porcelain")
+    return {
+        "commit": head,
+        "dirty": bool(status) if status is not None else None,
+        "describe": git("describe", "--always", "--dirty"),
+    }
+
+
 def load_bank():
     path = os.path.join(BANK_DIR, "prompts.json")
     bank = json.load(open(path))
@@ -58,6 +88,14 @@ def container_identity(container):
         "authority": idx.get("authority", "canonical"),
         "representations": digests,
         "payload_bytes": sum(v.get("payload_bytes", 0) for v in idx.get("representations", {}).values()),
+        # The programme the compiler was asked to produce, as the
+        # container itself records it: `{name, encoding, roles}`, where
+        # `roles` are the ones compiled and every other role is
+        # preserved. The SHA says which compiler ran; this says what it
+        # was asked for, and a result is only independently intelligible
+        # with both. Two candidates differing by one role name here is
+        # exactly what makes a controlled comparison legible later.
+        "precision_map": idx.get("precision_map"),
     }
 
 
@@ -191,6 +229,7 @@ def cmd_compare(container, outdir, backend, source, label, keep=False):
            "payload_bytes": cand_bytes,
            "runtime_compiled_total": compiled_total,
            "container": container_identity(container),
+           "compiler": compiler_provenance(),
            "reference": meta["container"], "rows": rows}
     path = os.path.join(outdir, f"compare-{label}.json")
     json.dump(out, open(path, "w"))

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
@@ -172,6 +172,14 @@ pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
     let outcome = match args.backend {
         ExecBackend::Reference => run_on(&ReferenceBackend::new(), &args, &tokens, &plan, &store),
         ExecBackend::Production => run_on(&ProductionBackend::new(), &args, &tokens, &plan, &store),
+        // Same kernels as `production`; the difference is upstream, in
+        // `wanted_representation`, which makes the store bind the
+        // compiled NVFP4 pack instead of the canonical bytes. The
+        // projector then dispatches `FusedNvfp4` off the resident
+        // representation, exactly as it dispatches every other arm.
+        ExecBackend::ProductionNvfp4 => {
+            run_on(&ProductionBackend::new(), &args, &tokens, &plan, &store)
+        }
         #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::MetalMxfp4 => {
             let gpu = larql_compute_metal::MetalBackend::new()
@@ -629,9 +637,24 @@ fn summarise(engine: &str, trace: &ExecutionTrace) {
 /// the canonical bytes return `None` and never look for a pack, so adding
 /// packs to a container cannot change what they execute.
 fn wanted_representation(backend: ExecBackend) -> Option<&'static str> {
-    #[cfg(all(feature = "gpu", target_os = "macos"))]
     use larql_vindex::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4;
+    // Exhaustive, with no wildcard arm, and that is the point: `_ =>
+    // None` stood here and a newly added NVFP4 backend silently
+    // inherited "wants nothing", bound the canonical bytes and produced
+    // logits bit-identical to BF16. A run that looks like perfect
+    // fidelity is the exact failure this file must not be able to
+    // express, so a new backend is now a compile error until someone
+    // states which representation it executes.
     match backend {
+        ExecBackend::Reference | ExecBackend::Production => None,
+        ExecBackend::ProductionNvfp4 => Some(DTYPE_NVFP4),
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        ExecBackend::Metal
+        | ExecBackend::MetalMxfp4
+        | ExecBackend::MetalMxfp4All
+        | ExecBackend::MetalLoweredMxfp4
+        | ExecBackend::MetalLoweredMxfp4Ffn
+        | ExecBackend::MetalLoweredF16 => None,
         #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::MetalNvfp4
         | ExecBackend::MetalNvfp4Ffn
@@ -639,6 +662,5 @@ fn wanted_representation(backend: ExecBackend) -> Option<&'static str> {
         | ExecBackend::MetalLowered
         | ExecBackend::MetalLoweredFfn
         | ExecBackend::MetalLoweredNoHead => Some(DTYPE_NVFP4),
-        _ => None,
     }
 }

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -69,6 +69,20 @@ pub enum ExecBackend {
     Reference,
     /// The `larql-compute` kernels.
     Production,
+    /// The `larql-compute` kernels, asking for a compiled NVFP4 pack.
+    ///
+    /// The CPU sibling of the `metal-nvfp4*` arms, and the only way to
+    /// execute an NVFP4 representation of a model the device cannot run.
+    /// Qwen3.8 is the case that forced it: 48 Gated DeltaNet layers with
+    /// no Metal kernel, so before this arm its NVFP4 pack could be
+    /// compiled and verified and then executed nowhere, and its
+    /// behavioural fidelity was unmeasurable in principle.
+    ///
+    /// Separate from [`Self::Production`] rather than a flag on it: the
+    /// backend is what declares which representation execution wants, and
+    /// silently changing that for every existing `production` run would
+    /// reinterpret every result already taken with it.
+    ProductionNvfp4,
     /// GPU matmuls via `larql-compute-metal` (rung 1: matrix work on
     /// the device, elementwise glue on the CPU).
     #[cfg(all(feature = "gpu", target_os = "macos"))]

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -324,14 +324,19 @@ pub struct RepresentArgs {
     #[arg(long = "object")]
     pub objects: Vec<String>,
 
-    /// Compile a role the conservative default preserves. Repeat to name
-    /// several. Roles: decoder-linear, expert-weight, embedding,
-    /// output-head, norm, router, small-vector, unknown.
+    /// Compile a role the conservative default preserves. Repeat to
+    /// name several.
     ///
-    /// The default compiles decoder-linear and expert-weight only —
-    /// the parameter mass — and preserves the surfaces where 4-bit is
-    /// known to be delicate. This flag is how a profile becomes more
+    /// The default compiles the parameter mass — the decoder's and a
+    /// recurrence's bulk projections, and routed experts — and
+    /// preserves the surfaces where 4-bit is known to be delicate or
+    /// where error compounds. This flag is how a profile becomes more
     /// aggressive deliberately rather than by accident.
+    ///
+    /// The role names are not listed here on purpose: this comment
+    /// enumerated them once, and was silently wrong the moment a role
+    /// was added. Pass any name to be refused by one that names the
+    /// current set.
     #[arg(long = "include-role")]
     pub include_roles: Vec<String>,
 
@@ -537,8 +542,21 @@ fn run_represent(args: RepresentArgs) -> Result<(), Box<dyn std::error::Error>> 
 
     let mut roles = larql_vindex::format::vindex3::represent::policy::RolePolicy::default();
     for name in &args.include_roles {
-        let role = larql_vindex::format::vindex3::represent::policy::Role::parse(name)
-            .ok_or_else(|| format!("unknown role `{name}`"))?;
+        let role = larql_vindex::format::vindex3::represent::policy::Role::parse(name).ok_or_else(
+            || {
+                // Derived, never restated: a hand-written list is wrong
+                // one commit after a role is added, and this message is
+                // the only place the caller learns what is valid.
+                let known: Vec<&str> = larql_vindex::format::vindex3::represent::policy::Role::ALL
+                    .iter()
+                    .map(|r| r.name())
+                    .collect();
+                format!(
+                    "unknown role `{name}` — the roles are: {}",
+                    known.join(", ")
+                )
+            },
+        )?;
         roles = roles.including(role);
     }
     let mut protect = larql_vindex::format::vindex3::represent::policy::Protections::default();

--- a/crates/larql-compute/src/cpu/mod.rs
+++ b/crates/larql-compute/src/cpu/mod.rs
@@ -34,6 +34,8 @@ use ndarray::{Array2, ArrayView2};
 /// CPU backend using BLAS (f32) and C kernel (Q4).
 pub struct CpuBackend;
 
+pub mod nvfp4_gemv;
+
 impl MatMul for CpuBackend {
     fn matmul(&self, a: ArrayView2<f32>, b: ArrayView2<f32>) -> Array2<f32> {
         ops::f32_matmul::matmul(a, b)
@@ -41,6 +43,18 @@ impl MatMul for CpuBackend {
 
     fn matmul_transb(&self, a: ArrayView2<f32>, b: ArrayView2<f32>) -> Array2<f32> {
         ops::f32_matmul::matmul_transb(a, b)
+    }
+
+    fn nvfp4_gemv(
+        &self,
+        packed: &[u8],
+        scales: &[u8],
+        tensor_scale: f32,
+        x: &[f32],
+        n: usize,
+        k: usize,
+    ) -> Option<Vec<f32>> {
+        nvfp4_gemv::nvfp4_gemv(packed, scales, tensor_scale, x, n, k)
     }
 }
 

--- a/crates/larql-compute/src/cpu/nvfp4_gemv.rs
+++ b/crates/larql-compute/src/cpu/nvfp4_gemv.rs
@@ -1,0 +1,170 @@
+//! The CPU's NVFP4 gemv.
+//!
+//! Until this existed, `MatMul::nvfp4_gemv` was implemented only on
+//! Metal, so the CPU inherited the trait's `None` and every backend that
+//! asks for NVFP4 was a device backend. That is a real hole rather than
+//! a preference: a model whose token mixer has no device kernel — Qwen3.8
+//! is 48 Gated DeltaNet layers — could have an NVFP4 representation
+//! *compiled and verified* and then no path anywhere able to execute it.
+//! The compiler could produce a program the substrate could not consume.
+//!
+//! The arithmetic here is not a second opinion about the format. It is
+//! the association [`larql_models::quant::nvfp4::dequantize_into`]
+//! documents — `tensor_scale * e4m3(group scale) * e2m1(code)`, in that
+//! order — applied one group at a time instead of into a whole decoded
+//! matrix, so the result matches dequantise-then-multiply exactly rather
+//! than approximately. The tests hold it to that oracle.
+
+use larql_models::quant::fp4::e2m1_to_f32;
+use larql_models::quant::fp8::e4m3_to_f32;
+use larql_models::quant::nvfp4::{NVFP4_GROUP_BYTES, NVFP4_GROUP_ELEMS};
+
+/// `out[n] = W[n, k] · x[k]`, with `W` read straight from the stored
+/// NVFP4 pack.
+///
+/// `None` — never a wrong answer — when the geometry does not describe
+/// this pack: `k` off the group grid, or either stream the wrong length
+/// for `[n, k]`. Silently accepting a short stream would read a
+/// neighbouring row's codes as this row's and return a plausible vector.
+pub fn nvfp4_gemv(
+    packed: &[u8],
+    scales: &[u8],
+    tensor_scale: f32,
+    x: &[f32],
+    n: usize,
+    k: usize,
+) -> Option<Vec<f32>> {
+    if k == 0 || !k.is_multiple_of(NVFP4_GROUP_ELEMS) || x.len() != k {
+        return None;
+    }
+    let groups = k / NVFP4_GROUP_ELEMS;
+    if packed.len() != n * groups * NVFP4_GROUP_BYTES || scales.len() != n * groups {
+        return None;
+    }
+
+    let mut out = vec![0.0f32; n];
+    for (row, slot) in out.iter_mut().enumerate() {
+        let mut acc = 0.0f32;
+        for g in 0..groups {
+            // One multiply per group, not per element: the scale is
+            // constant across the sixteen, and folding it into each
+            // weight is what the reference decoder does.
+            let step = tensor_scale * e4m3_to_f32(scales[row * groups + g]);
+            let base = (row * groups + g) * NVFP4_GROUP_BYTES;
+            let xs = &x[g * NVFP4_GROUP_ELEMS..][..NVFP4_GROUP_ELEMS];
+            for b in 0..NVFP4_GROUP_BYTES {
+                let byte = packed[base + b];
+                // Low nibble first, matching the encoder's pairing.
+                acc += (step * e2m1_to_f32(byte & 0x0F)) * xs[2 * b];
+                acc += (step * e2m1_to_f32((byte >> 4) & 0x0F)) * xs[2 * b + 1];
+            }
+        }
+        *slot = acc;
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backend::MatMul;
+    use crate::cpu::CpuBackend;
+    use larql_models::quant::nvfp4::{dequantize_into, quantize};
+
+    /// Deterministic weights spanning several magnitudes, so groups get
+    /// different scales and a single shared scale cannot pass by luck.
+    fn weights(n: usize, k: usize) -> Vec<f32> {
+        (0..n * k)
+            .map(|i| {
+                let t = (i % 37) as f32 / 37.0 - 0.5;
+                t * (1.0 + (i / k) as f32 * 0.25)
+            })
+            .collect()
+    }
+
+    fn dequantised_gemv(w: &[f32], x: &[f32], n: usize, k: usize) -> Vec<f32> {
+        (0..n)
+            .map(|r| (0..k).map(|c| w[r * k + c] * x[c]).sum())
+            .collect()
+    }
+
+    /// The oracle: decoding the pack and multiplying must give exactly
+    /// what the kernel gives. Not "within a tolerance" — the kernel is
+    /// the same arithmetic in the same association, so any difference is
+    /// a different program, not rounding.
+    #[test]
+    fn the_kernel_equals_dequantise_then_multiply_bit_for_bit() {
+        for (n, k) in [(1, 16), (3, 32), (8, 64), (5, 112)] {
+            let w = weights(n, k);
+            let m = quantize(&w, n, k).expect("quantise");
+            let mut decoded = vec![0.0f32; n * k];
+            dequantize_into(&m, n, k, &mut decoded).expect("dequantise");
+
+            let x: Vec<f32> = (0..k).map(|i| ((i % 11) as f32 - 5.0) / 7.0).collect();
+            let got = CpuBackend
+                .nvfp4_gemv(&m.packed, &m.scales, m.tensor_scale, &x, n, k)
+                .expect("kernel");
+            let want = dequantised_gemv(&decoded, &x, n, k);
+            assert_eq!(got, want, "[{n},{k}] kernel diverged from the decoder");
+        }
+    }
+
+    /// The kernel must be reading the stored codes, not reconstructing
+    /// the original floats: quantisation is lossy, so an exact match
+    /// against the SOURCE weights would mean the test is not testing a
+    /// quantised path at all.
+    #[test]
+    fn the_result_is_lossy_against_the_source_weights() {
+        let (n, k) = (4, 64);
+        let w = weights(n, k);
+        let m = quantize(&w, n, k).expect("quantise");
+        let x: Vec<f32> = (0..k).map(|i| ((i % 11) as f32 - 5.0) / 7.0).collect();
+        let got = CpuBackend
+            .nvfp4_gemv(&m.packed, &m.scales, m.tensor_scale, &x, n, k)
+            .expect("kernel");
+        let exact = dequantised_gemv(&w, &x, n, k);
+        assert_ne!(got, exact, "an exact match means nothing was quantised");
+        for (g, e) in got.iter().zip(&exact) {
+            assert!((g - e).abs() < 0.5 * e.abs().max(1.0), "{g} vs {e}");
+        }
+    }
+
+    /// Geometry that does not describe this pack answers `None` rather
+    /// than reading a neighbouring row's codes as this row's.
+    #[test]
+    fn mismatched_geometry_refuses_instead_of_guessing() {
+        let (n, k) = (4, 64);
+        let m = quantize(&weights(n, k), n, k).expect("quantise");
+        let x = [0.5f32; 64];
+        let call = |xs: &[f32], n, k| {
+            CpuBackend.nvfp4_gemv(&m.packed, &m.scales, m.tensor_scale, xs, n, k)
+        };
+        assert!(call(&x, n, k).is_some(), "the honest geometry works");
+        assert!(call(&x, n + 1, k).is_none(), "too many rows for the stream");
+        assert!(call(&x, n, k * 2).is_none(), "k beyond the stream");
+        assert!(call(&x[..k - 1], n, k).is_none(), "x shorter than k");
+        assert!(call(&[0.5; 24], n, 24).is_none(), "k off the group grid");
+    }
+
+    /// `nvfp4_gemv_multi`'s default fans out to the single kernel; with
+    /// the CPU arm implemented it must now answer rather than collapsing
+    /// to `None` on the first matrix.
+    #[test]
+    fn the_multi_arm_answers_now_that_the_single_one_does() {
+        let (n, k) = (2, 32);
+        let m = quantize(&weights(n, k), n, k).expect("quantise");
+        let x: Vec<f32> = vec![0.25; k];
+        let multi = CpuBackend
+            .nvfp4_gemv_multi(
+                &[
+                    (&m.packed, &m.scales, m.tensor_scale, n, k),
+                    (&m.packed, &m.scales, m.tensor_scale, n, k),
+                ],
+                &x,
+            )
+            .expect("multi");
+        let single = CpuBackend
+            .nvfp4_gemv(&m.packed, &m.scales, m.tensor_scale, &x, n, k)
+            .expect("single");
+        assert_eq!(multi, vec![single.clone(), single]);
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/fixtures_kimi.rs
+++ b/crates/larql-vindex/src/format/vindex3/fixtures_kimi.rs
@@ -1,0 +1,241 @@
+//! A miniature Kimi-Linear-shaped checkpoint: KDA recurrences
+//! interleaved with Multi-Latent Attention, at the `KKKM` cadence the
+//! real 48B carries.
+//!
+//! Its own file because it is the *second* hybrid vocabulary, and the
+//! two must not be read off one another. [`super::fixtures`]'s
+//! `hybrid_lllf_f32_model` is Qwen3.8's shape — Gated DeltaNet against
+//! softmax — where the recurrence fuses q|k|v into one projection and
+//! the full layer is ordinary attention. This one is structurally
+//! different on both sides: KDA splits q/k/v into three projections
+//! through three convolutions with low-rank gate pairs, and its
+//! full-attention layers are MLA, whose `q_proj`/`o_proj` are
+//! byte-identical *spellings* to the softmax set at a different width.
+//!
+//! That collision is the point. A reader that names a mixer by which
+//! tensors it can find, rather than by the operator the graph
+//! declares, resolves this checkpoint to something it is not — which
+//! is exactly what happened: every one of Kimi Linear's 27 layers once
+//! reported as Gated DeltaNet. The fixture exists so that answer
+//! cannot come back green.
+
+use std::path::Path;
+
+use super::fixtures::{lcg_values, norm_values, ShardBuilder};
+
+const HIDDEN: usize = 32;
+const INTER: usize = 64;
+const VOCAB: usize = 64;
+const LAYERS: usize = 4;
+
+/// KDA geometry. `Hv · Dv` is the width every projection and conv
+/// closes at.
+const KDA_HEADS: usize = 4;
+const KDA_HEAD_DIM: usize = 8;
+const KDA_CONV_KERNEL: usize = 4;
+/// Inner rank of the f and g gate factorisations — the low-rank pairs
+/// that have no Gated DeltaNet counterpart.
+const KDA_GATE_RANK: usize = 4;
+
+/// MLA geometry, deliberately asymmetric: the query/key head width and
+/// the value head width differ, so nothing can pass by assuming one
+/// `head_dim` governs the layer.
+const MLA_HEADS: usize = 4;
+const MLA_KV_LORA_RANK: usize = 16;
+const MLA_QK_NOPE_HEAD_DIM: usize = 8;
+const MLA_QK_ROPE_HEAD_DIM: usize = 4;
+const MLA_V_HEAD_DIM: usize = 8;
+
+/// Layers that run KDA. Every other layer is MLA — `KKKM`, one-based
+/// in the config exactly as the checkpoint spells it.
+fn kda_layers() -> Vec<usize> {
+    (0..LAYERS).filter(|l| l % 4 != 3).map(|l| l + 1).collect()
+}
+
+fn full_attn_layers() -> Vec<usize> {
+    (0..LAYERS).filter(|l| l % 4 == 3).map(|l| l + 1).collect()
+}
+
+fn kda_width() -> usize {
+    KDA_HEADS * KDA_HEAD_DIM
+}
+
+fn mla_q_head_dim() -> usize {
+    MLA_QK_NOPE_HEAD_DIM + MLA_QK_ROPE_HEAD_DIM
+}
+
+/// The `KKKM` hybrid: three KDA layers, then one MLA layer.
+pub fn hybrid_kda_mla_f32_model(dir: &Path) {
+    std::fs::write(
+        dir.join("config.json"),
+        serde_json::json!({
+            "architectures": ["KimiLinearForCausalLM"],
+            "model_type": "kimi_linear",
+            "torch_dtype": "float32",
+            "hidden_size": HIDDEN,
+            "intermediate_size": INTER,
+            "num_hidden_layers": LAYERS,
+            "num_attention_heads": MLA_HEADS,
+            "num_key_value_heads": MLA_HEADS,
+            // Deliberately not either operator's real width: an
+            // operator-aware reader never consults it for these layers.
+            "head_dim": 999,
+            "vocab_size": VOCAB,
+            "rope_theta": 10000.0,
+            "rms_norm_eps": 1e-5,
+            "kv_lora_rank": MLA_KV_LORA_RANK,
+            "qk_nope_head_dim": MLA_QK_NOPE_HEAD_DIM,
+            "qk_rope_head_dim": MLA_QK_ROPE_HEAD_DIM,
+            "v_head_dim": MLA_V_HEAD_DIM,
+            "mla_use_nope": true,
+            "linear_attn_config": {
+                "kda_layers": kda_layers(),
+                "full_attn_layers": full_attn_layers(),
+                "num_heads": KDA_HEADS,
+                "head_dim": KDA_HEAD_DIM,
+                "short_conv_kernel_size": KDA_CONV_KERNEL,
+            },
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let mut shard = ShardBuilder::new();
+    shard.push(
+        "model.embed_tokens.weight",
+        &[VOCAB, HIDDEN],
+        &lcg_values(VOCAB * HIDDEN, 1),
+    );
+    shard.push("model.norm.weight", &[HIDDEN], &norm_values(HIDDEN, 2));
+    shard.push(
+        "lm_head.weight",
+        &[VOCAB, HIDDEN],
+        &lcg_values(VOCAB * HIDDEN, 3),
+    );
+    for layer in 0..LAYERS {
+        let seed = 200 + layer as u64 * 32;
+        let prefix = format!("model.layers.{layer}");
+        if layer % 4 == 3 {
+            push_mla_layer(&mut shard, &prefix, seed);
+        } else {
+            push_kda_layer(&mut shard, &prefix, seed);
+        }
+        for (name, s) in [
+            ("input_layernorm", seed + 20),
+            ("post_attention_layernorm", seed + 21),
+        ] {
+            shard.push(
+                &format!("{prefix}.{name}.weight"),
+                &[HIDDEN],
+                &norm_values(HIDDEN, s),
+            );
+        }
+        for (name, rows, cols, s) in [
+            ("gate_proj", INTER, HIDDEN, seed + 22),
+            ("up_proj", INTER, HIDDEN, seed + 23),
+            ("down_proj", HIDDEN, INTER, seed + 24),
+        ] {
+            shard.push(
+                &format!("{prefix}.mlp.{name}.weight"),
+                &[rows, cols],
+                &lcg_values(rows * cols, s),
+            );
+        }
+    }
+    shard.write(dir);
+}
+
+/// KDA's fifteen operands. Three projections, three convs, two
+/// low-rank gate pairs — none of which a Gated DeltaNet layer has.
+fn push_kda_layer(shard: &mut ShardBuilder, prefix: &str, seed: u64) {
+    let w = kda_width();
+    for (name, s) in [("q_proj", seed), ("k_proj", seed + 1), ("v_proj", seed + 2)] {
+        shard.push(
+            &format!("{prefix}.self_attn.{name}.weight"),
+            &[w, HIDDEN],
+            &lcg_values(w * HIDDEN, s),
+        );
+    }
+    for (name, s) in [
+        ("q_conv1d", seed + 3),
+        ("k_conv1d", seed + 4),
+        ("v_conv1d", seed + 5),
+    ] {
+        shard.push(
+            &format!("{prefix}.self_attn.{name}.weight"),
+            &[w, 1, KDA_CONV_KERNEL],
+            &lcg_values(w * KDA_CONV_KERNEL, s),
+        );
+    }
+    for (name, s) in [("f_a_proj", seed + 6), ("g_a_proj", seed + 7)] {
+        shard.push(
+            &format!("{prefix}.self_attn.{name}.weight"),
+            &[KDA_GATE_RANK, HIDDEN],
+            &lcg_values(KDA_GATE_RANK * HIDDEN, s),
+        );
+    }
+    for (name, s) in [("f_b_proj", seed + 8), ("g_b_proj", seed + 9)] {
+        shard.push(
+            &format!("{prefix}.self_attn.{name}.weight"),
+            &[w, KDA_GATE_RANK],
+            &lcg_values(w * KDA_GATE_RANK, s),
+        );
+    }
+    shard.push(
+        &format!("{prefix}.self_attn.b_proj.weight"),
+        &[KDA_HEADS, HIDDEN],
+        &lcg_values(KDA_HEADS * HIDDEN, seed + 10),
+    );
+    shard.push(
+        &format!("{prefix}.self_attn.A_log"),
+        &[KDA_HEADS],
+        &lcg_values(KDA_HEADS, seed + 11),
+    );
+    shard.push(
+        &format!("{prefix}.self_attn.dt_bias"),
+        &[w],
+        &lcg_values(w, seed + 12),
+    );
+    shard.push(
+        &format!("{prefix}.self_attn.o_norm.weight"),
+        &[KDA_HEAD_DIM],
+        &norm_values(KDA_HEAD_DIM, seed + 13),
+    );
+    shard.push(
+        &format!("{prefix}.self_attn.o_proj.weight"),
+        &[HIDDEN, w],
+        &lcg_values(HIDDEN * w, seed + 14),
+    );
+}
+
+/// MLA's five. `q_proj` and `o_proj` are the same spellings a softmax
+/// layer uses, at a width only the operator explains.
+fn push_mla_layer(shard: &mut ShardBuilder, prefix: &str, seed: u64) {
+    let q_rows = MLA_HEADS * mla_q_head_dim();
+    shard.push(
+        &format!("{prefix}.self_attn.q_proj.weight"),
+        &[q_rows, HIDDEN],
+        &lcg_values(q_rows * HIDDEN, seed),
+    );
+    shard.push(
+        &format!("{prefix}.self_attn.kv_a_proj_with_mqa.weight"),
+        &[MLA_KV_LORA_RANK + MLA_QK_ROPE_HEAD_DIM, HIDDEN],
+        &lcg_values((MLA_KV_LORA_RANK + MLA_QK_ROPE_HEAD_DIM) * HIDDEN, seed + 1),
+    );
+    shard.push(
+        &format!("{prefix}.self_attn.kv_a_layernorm.weight"),
+        &[MLA_KV_LORA_RANK],
+        &norm_values(MLA_KV_LORA_RANK, seed + 2),
+    );
+    let kv_b_rows = MLA_HEADS * (MLA_QK_NOPE_HEAD_DIM + MLA_V_HEAD_DIM);
+    shard.push(
+        &format!("{prefix}.self_attn.kv_b_proj.weight"),
+        &[kv_b_rows, MLA_KV_LORA_RANK],
+        &lcg_values(kv_b_rows * MLA_KV_LORA_RANK, seed + 3),
+    );
+    shard.push(
+        &format!("{prefix}.self_attn.o_proj.weight"),
+        &[HIDDEN, MLA_HEADS * MLA_V_HEAD_DIM],
+        &lcg_values(HIDDEN * MLA_HEADS * MLA_V_HEAD_DIM, seed + 4),
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/graph/surface.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/surface.rs
@@ -630,10 +630,24 @@ pub fn surface_from_nested(
     };
     // The epsilon spelling the config declares names the norm kind; a
     // component declaring neither has no norm surface to persist.
+    //
+    // The message says both halves on purpose. A bare `norm_eps` reads
+    // as one absent number a reader might reasonably supply, when what
+    // is actually absent is the *kind* as well: the spelling is the
+    // only evidence of whether this tower runs LayerNorm or RMSNorm,
+    // so a config carrying neither has said nothing about its norm at
+    // all. Qwen3.8's `vision_config` is exactly this — depth, heads,
+    // widths and activation all declared, no epsilon key of either
+    // spelling — and the honest answer is to refuse the surface rather
+    // than pick an epsilon and a kind on the checkpoint's behalf.
     let (kind, eps) = match (nested.norm_kind, nested.norm_eps) {
         (Some(kind), Some(eps)) => (kind, eps),
         _ => {
-            missing.push("norm_eps".to_string());
+            missing.push(
+                "norm_eps (declares neither `layer_norm_eps` nor `rms_norm_eps`, so the \
+                 norm kind is undeclared too — this build will not choose one)"
+                    .to_string(),
+            );
             (NormType::LayerNorm, 0.0)
         }
     };

--- a/crates/larql-vindex/src/format/vindex3/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/mod.rs
@@ -45,6 +45,7 @@ pub mod encode;
 /// integration tests can encode a real container without duplicating
 /// the frozen fixture geometry the executor's parity gates certify.
 pub mod fixtures;
+pub mod fixtures_kimi;
 pub mod graph;
 pub mod import;
 pub mod index;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -320,6 +320,34 @@ impl<'a> WeightSlice<'a> {
                     _ => Err(short(packed.len() * 2)),
                 }
             }
+            WeightSlice::Nvfp4 {
+                packed,
+                scales,
+                tensor_scale,
+            } => {
+                // Groups run along the input axis and the group size is
+                // the format's, not a policy's: `k/16` scale bytes and
+                // `k/2` code bytes per row.
+                const GROUP: usize = 16;
+                if !in_dim.is_multiple_of(GROUP) {
+                    return Err(VindexError::Parse(format!(
+                        "NVFP4 slab: in_dim={in_dim} is not a multiple of the {GROUP}-element \
+                         group, so this pack does not describe these rows"
+                    )));
+                }
+                let groups_per_row = in_dim / GROUP;
+                match (
+                    packed.get(..want / 2),
+                    scales.get(..out_dim * groups_per_row),
+                ) {
+                    (Some(packed), Some(scales)) => Ok(WeightRows::Nvfp4 {
+                        packed,
+                        scales,
+                        tensor_scale: *tensor_scale,
+                    }),
+                    _ => Err(short(packed.len() * 2)),
+                }
+            }
             other => Err(VindexError::Parse(format!(
                 "no CPU projection kernel consumes {} weights — the backend declared a \
                  representation only a device can run, so this refuses rather than converting \

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -150,6 +150,13 @@ pub struct MatrixOperand {
     /// preference: a backend that wants compact bytes where there are
     /// none would have to quantise to get them.
     pub stored_bf16: bool,
+    /// Whether the container holds this operand as a compiled NVFP4
+    /// pack. The same kind of fact as [`Self::stored_bf16`] — physical,
+    /// not a preference — and it outranks the size policy: a pack exists
+    /// because someone compiled it deliberately, so a backend asking for
+    /// anything else would widen bytes that are already in the shape a
+    /// kernel wants.
+    pub stored_nvfp4: bool,
 }
 
 /// A backend's declared format per matrix class.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/arithmetic.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/arithmetic.rs
@@ -51,6 +51,13 @@ pub enum WeightRep {
     /// elements. Step `peak / 7` — **18.1x Q8's at the same block**, and
     /// that ratio is the whole numerical story of the format.
     Q4 { block: usize },
+    /// NVFP4: e2m1 codes with an E4M3 scale per 16 elements and one f32
+    /// tensor scale for the matrix.
+    ///
+    /// No `block` field, unlike [`Self::Q8`] and [`Self::Q4`]: the group
+    /// is 16 by the format's definition, not by a policy's choice, and a
+    /// field would invite a caller to pass a different one.
+    Nvfp4,
 }
 
 /// Over how many elements ONE activation scale applies.
@@ -106,6 +113,7 @@ impl fmt::Display for WeightRep {
             Self::Bf16 => write!(f, "BF16"),
             Self::Q8 { block } => write!(f, "Q8[{block}]"),
             Self::Q4 { block } => write!(f, "Q4[{block}]"),
+            Self::Nvfp4 => write!(f, "NVFP4"),
         }
     }
 }
@@ -162,6 +170,9 @@ pub fn plans_possible_for(rep: WeightRep) -> &'static [PhysicalProjectionPlan] {
             PhysicalProjectionPlan::FusedBf16,
             PhysicalProjectionPlan::Bf16xQ8,
         ],
+        // One kernel, so residency determines execution outright — the
+        // invariant this function exists to expose, satisfied trivially.
+        WeightRep::Nvfp4 => &[PhysicalProjectionPlan::FusedNvfp4],
         WeightRep::Q8 { .. } => &[
             PhysicalProjectionPlan::FusedQ8,
             PhysicalProjectionPlan::Q8xQ8,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/cost.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/cost.rs
@@ -55,28 +55,36 @@ const BYTES_PER_GB: f64 = 1e9;
 /// Every value is from a harness whose bf16 arm reproduces the real
 /// model's projection class to -3.9%, so a ratio taken against it
 /// licenses something.
-pub fn measured_rate_gbps(plan: PhysicalProjectionPlan) -> f64 {
+pub fn measured_rate_gbps(plan: PhysicalProjectionPlan) -> Option<f64> {
     match plan {
         // The literal transcription: a flat 5.6 GB/s at every shape,
         // which is why it is the oracle and not a strategy.
-        PhysicalProjectionPlan::ScalarF32 => 5.6,
+        PhysicalProjectionPlan::ScalarF32 => Some(5.6),
         // Accelerate's sgemv reading from cache — this plan is only ever
         // chosen for operands whose image FITS cache, so the cache-
         // resident rate is the right one.
-        PhysicalProjectionPlan::BlasF32 => 262.0,
-        PhysicalProjectionPlan::FusedBf16 => 121.66,
-        PhysicalProjectionPlan::FusedQ8 => 81.69,
+        PhysicalProjectionPlan::BlasF32 => Some(262.0),
+        PhysicalProjectionPlan::FusedBf16 => Some(121.66),
+        PhysicalProjectionPlan::FusedQ8 => Some(81.69),
         // CPU-4A: Q4 against an f32 activation is SLOWER than Q8, because
         // the kernel was already conversion-bound and Q4 adds a nibble
         // split. 14.40 GB at 36.9 GB/s.
-        PhysicalProjectionPlan::FusedQ4 => 36.9,
-        PhysicalProjectionPlan::Q8xQ8 => 121.02,
-        PhysicalProjectionPlan::Q4xQ8 => 106.59,
+        PhysicalProjectionPlan::FusedQ4 => Some(36.9),
+        // **No rate has been measured for this plan.** `None` rather
+        // than a plausible-looking constant: every other value here
+        // comes from a harness, and one invented number in a table of
+        // measurements poisons every ratio taken against it. NVFP4 is
+        // reached by observation — a compiled pack the loader binds —
+        // so it can genuinely appear in a tally, and the budget omits it
+        // for the same reason it omits a plan with no calls.
+        PhysicalProjectionPlan::FusedNvfp4 => None,
+        PhysicalProjectionPlan::Q8xQ8 => Some(121.02),
+        PhysicalProjectionPlan::Q4xQ8 => Some(106.59),
         // The A1 control runs the exact bf16 kernel over a reconstructed
         // activation, so it streams bf16 bytes at the bf16 rate. It is
         // never a deployment plan and its cost is quoted only so a
         // control run's ledger still adds up.
-        PhysicalProjectionPlan::Bf16xQ8 => 121.66,
+        PhysicalProjectionPlan::Bf16xQ8 => Some(121.66),
     }
 }
 
@@ -124,7 +132,12 @@ pub fn budget(tallies: &[(PhysicalProjectionPlan, PlanTally)]) -> ProjectionBudg
         if tally.calls == 0 {
             continue;
         }
-        let rate = measured_rate_gbps(*plan);
+        // An unmeasured plan is omitted, never given a stand-in rate:
+        // the row would read as a measurement and the totals would carry
+        // a number nobody took.
+        let Some(rate) = measured_rate_gbps(*plan) else {
+            continue;
+        };
         let ms = tally.bytes as f64 / BYTES_PER_GB / rate * 1e3;
         out.rows.push(BudgetRow {
             plan: *plan,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/kernels.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/kernels.rs
@@ -193,6 +193,48 @@ impl DenseProjector for FusedQ4 {
     }
 }
 
+/// NVFP4 resident, decoded in registers — the CPU's arm for a compiled
+/// NVFP4 pack.
+///
+/// Exists because a representation with no execution path is a
+/// representation that cannot be measured. Before it, every backend that
+/// requested NVFP4 was a device backend, so a model whose token mixer
+/// has no device kernel — Qwen3.8's 48 Gated DeltaNet layers — could
+/// have an NVFP4 pack compiled, verified, and then unrunnable anywhere.
+///
+/// The arithmetic is `larql_models::quant::nvfp4::dequantize_into`'s
+/// association, applied a group at a time: the shared CPU kernel this
+/// delegates to is held bit-exact against decode-then-multiply by its
+/// own tests, so this arm and the oracle are the same program.
+pub struct FusedNvfp4;
+
+impl DenseProjector for FusedNvfp4 {
+    fn parallelism(&self) -> CpuParallelism {
+        CpuParallelism::ExternalPool
+    }
+
+    fn project_rows(&self, weight_rows: WeightRows<'_>, x: &[f32], out: &mut [f32]) {
+        let WeightRows::Nvfp4 {
+            packed,
+            scales,
+            tensor_scale,
+        } = weight_rows
+        else {
+            panic!("the fused nvfp4 kernel consumes nvfp4 weights only");
+        };
+        let n = out.len();
+        let Some(values) =
+            larql_compute::cpu::nvfp4_gemv::nvfp4_gemv(packed, scales, tensor_scale, x, n, x.len())
+        else {
+            // The slab's geometry is settled before dispatch, so a
+            // refusal here means the two disagree — which is a bug in
+            // this file, not a runtime condition to absorb.
+            panic!("nvfp4 slab geometry does not describe [{n}, {}]", x.len());
+        };
+        out.copy_from_slice(&values);
+    }
+}
+
 /// One block's unscaled dot. `packed.len() * 2 == x.len()`.
 #[inline]
 fn q4_block_dot(packed: &[u8], x: &[f32]) -> f32 {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/ledger.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/ledger.rs
@@ -262,6 +262,7 @@ pub struct ProjectionLedger {
     // folded into another's counter would make the byte census agree with
     // itself while describing a mixture.
     q8_x_q8: Tally,
+    fused_nvfp4: Tally,
     q4_x_q8: Tally,
     bf16_x_q8: Tally,
     /// The same time, cut by operator class instead of by arithmetic.
@@ -276,6 +277,7 @@ impl ProjectionLedger {
             PhysicalProjectionPlan::FusedBf16 => &self.fused,
             PhysicalProjectionPlan::FusedQ8 => &self.fused_q8,
             PhysicalProjectionPlan::FusedQ4 => &self.fused_q4,
+            PhysicalProjectionPlan::FusedNvfp4 => &self.fused_nvfp4,
             PhysicalProjectionPlan::Q8xQ8 => &self.q8_x_q8,
             PhysicalProjectionPlan::Q4xQ8 => &self.q4_x_q8,
             PhysicalProjectionPlan::Bf16xQ8 => &self.bf16_x_q8,
@@ -414,6 +416,7 @@ impl ProjectionLedger {
             fused: ZERO,
             fused_q8: ZERO,
             fused_q4: ZERO,
+            fused_nvfp4: ZERO,
             q8_x_q8: ZERO,
             q4_x_q8: ZERO,
             bf16_x_q8: ZERO,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/physical.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/physical.rs
@@ -21,7 +21,7 @@
 
 use super::arithmetic::{AccumulatorRep, ActivationRep, Arithmetic, WeightRep};
 use super::integer::{activation_scaling, Bf16xQ8, Q4xQ8, Q8xQ8};
-use super::kernels::{BlasF32, FusedBf16, FusedQ4, FusedQ8, ScalarF32};
+use super::kernels::{BlasF32, FusedBf16, FusedNvfp4, FusedQ4, FusedQ8, ScalarF32};
 use super::projector::{DenseProjector, WeightRows};
 use crate::error::VindexError;
 use crate::format::vindex3::opplan::exec::backend::{MatrixClass, WeightFormat, WeightSlice};
@@ -56,6 +56,15 @@ pub enum PhysicalProjectionPlan {
     /// no `WeightFormat` names it, so a policy answering Q4 would refuse
     /// at load. Listed so `for_resident` stays total.
     FusedQ4,
+    /// NVFP4 resident, decoded in registers.
+    ///
+    /// Reached by OBSERVATION, like [`Self::FusedQ4`]: the residency
+    /// policy never chooses NVFP4: a pack is compiled deliberately by
+    /// `vindex represent` and the loader binds what the container holds.
+    /// This exists so that a compiled pack has somewhere to execute — a
+    /// representation with no execution path cannot be measured, and
+    /// before this arm every NVFP4 backend was a device backend.
+    FusedNvfp4,
     /// f32 resident, BLAS `sgemv`, threaded by the library.
     ///
     /// The right answer for a matrix whose widened image still fits
@@ -209,6 +218,7 @@ impl PhysicalProjectionPlan {
             Self::FusedBf16 | Self::Bf16xQ8 => WeightFormat::Bf16,
             Self::FusedQ8 | Self::Q8xQ8 => WeightFormat::Q8,
             Self::FusedQ4 | Self::Q4xQ8 => WeightFormat::Q4,
+            Self::FusedNvfp4 => WeightFormat::Nvfp4,
         }
     }
 
@@ -247,6 +257,11 @@ impl PhysicalProjectionPlan {
                 activation: ActivationRep::F32,
                 accumulator: AccumulatorRep::F32,
             },
+            Self::FusedNvfp4 => Arithmetic {
+                weight: WeightRep::Nvfp4,
+                activation: ActivationRep::F32,
+                accumulator: AccumulatorRep::F32,
+            },
             // The control holds EXACT weights and an f32 dot; only the
             // activation is quantised, which is the whole of its job.
             Self::Bf16xQ8 => Arithmetic {
@@ -280,6 +295,7 @@ impl PhysicalProjectionPlan {
             Self::FusedBf16 => &FusedBf16,
             Self::FusedQ8 => &FusedQ8,
             Self::FusedQ4 => &FusedQ4,
+            Self::FusedNvfp4 => &FusedNvfp4,
             Self::Q8xQ8 => &Q8xQ8,
             Self::Q4xQ8 => &Q4xQ8,
             Self::Bf16xQ8 => &Bf16xQ8,
@@ -396,6 +412,11 @@ impl PhysicalProjectionPlan {
                 ArithmeticArm::Q4TimesQ8 => Self::Q4xQ8,
                 _ => Self::FusedQ4,
             },
+            // No integer arm consumes NVFP4: its two scale levels are not
+            // expressible as the single per-block f32 the SDOT paths
+            // assume, so there is one kernel and the arm does not enter
+            // into it.
+            WeightRows::Nvfp4 { .. } => Self::FusedNvfp4,
         }
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/projector.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/projector.rs
@@ -142,6 +142,24 @@ pub enum WeightRows<'a> {
     /// f32 it denotes, so widening is `(bits as u32) << 16` — exact, no
     /// rounding, no table.
     Bf16(&'a [u16]),
+    /// NVFP4 straight from a compiled pack: e2m1 codes two to the byte
+    /// (lo nibble first), one E4M3 scale per sixteen elements along the
+    /// input axis, and the single f32 tensor scale both levels are
+    /// expressed relative to.
+    ///
+    /// Two scale levels rather than one because E4M3 cannot represent the
+    /// product — that is the format's whole reason for existing, and it
+    /// is why this cannot be folded into [`Self::Q8`]'s shape.
+    ///
+    /// Reaches the kernel compact, like every other variant here: the
+    /// CPU-1B finding that widening to a scratch matrix costs more than
+    /// the traffic it saves applies with more force to a 4-bit format,
+    /// not less.
+    Nvfp4 {
+        packed: &'a [u8],
+        scales: &'a [u8],
+        tensor_scale: f32,
+    },
 }
 
 impl WeightRows<'_> {
@@ -152,6 +170,7 @@ impl WeightRows<'_> {
             Self::Bf16(w) => w.len() / in_dim,
             Self::Q8 { codes, .. } => codes.len() / in_dim,
             Self::Q4 { packed, .. } => packed.len() * 2 / in_dim,
+            Self::Nvfp4 { packed, .. } => packed.len() * 2 / in_dim,
         }
     }
 
@@ -200,6 +219,22 @@ impl WeightRows<'_> {
                     block: *block,
                 }
             }
+            Self::Nvfp4 {
+                packed,
+                scales,
+                tensor_scale,
+            } => {
+                // Groups run along the input axis, so a row slab is a
+                // contiguous run of both streams. The tensor scale is
+                // matrix-wide and travels with every slab unchanged.
+                let groups = in_dim / larql_models::quant::nvfp4::NVFP4_GROUP_ELEMS;
+                let per_row = groups * larql_models::quant::nvfp4::NVFP4_GROUP_BYTES;
+                Self::Nvfp4 {
+                    packed: &packed[start * per_row..(start + count) * per_row],
+                    scales: &scales[start * groups..(start + count) * groups],
+                    tensor_scale: *tensor_scale,
+                }
+            }
         }
     }
 
@@ -219,6 +254,9 @@ impl WeightRows<'_> {
                 ..
             } => codes.len() + scales.len() * 4 + sums.len() * 2,
             Self::Q4 { packed, scales, .. } => packed.len() + scales.len() * 4,
+            // The tensor scale is one f32 for the whole matrix, not per
+            // row, so it is not counted in a row slab's footprint.
+            Self::Nvfp4 { packed, scales, .. } => packed.len() + scales.len(),
         }
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/replay.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/replay.rs
@@ -46,6 +46,7 @@ enum Kind {
     Bf16,
     Q8,
     Q4,
+    Nvfp4,
 }
 
 /// One projection exactly as the decode issued it.
@@ -66,6 +67,12 @@ pub struct Captured {
     /// path and price a kernel the decode never ran.
     tertiary: (usize, usize),
     block: usize,
+    /// NVFP4's matrix-wide scale. By value because it is one f32 and not
+    /// a stream, and captured rather than defaulted: replaying the codes
+    /// against the wrong tensor scale would price the right kernel over
+    /// numerically different weights, which is exactly the substitution
+    /// this harness exists to rule out.
+    tensor_scale: f32,
     out_dim: usize,
     /// The activation the decode actually projected. Kept by value
     /// because it is tens of KB against tens of MB of weight, and
@@ -99,6 +106,11 @@ impl Captured {
                 packed: std::slice::from_raw_parts(p as *const u8, n),
                 scales: std::slice::from_raw_parts(s as *const f32, m),
                 block: self.block,
+            },
+            Kind::Nvfp4 => WeightRows::Nvfp4 {
+                packed: std::slice::from_raw_parts(p as *const u8, n),
+                scales: std::slice::from_raw_parts(s as *const u8, m),
+                tensor_scale: self.tensor_scale,
             },
         }
     }
@@ -141,6 +153,7 @@ pub(super) fn record(weight: WeightRows<'_>, x: &[f32], out_dim: usize) {
     let Some(log) = slot.as_mut() else {
         return;
     };
+    let mut tensor_scale = 0.0f32;
     let (kind, primary, secondary, tertiary, block) = match weight {
         WeightRows::F32(w) => (Kind::F32, (w.as_ptr() as usize, w.len()), (0, 0), (0, 0), 0),
         WeightRows::Bf16(w) => (
@@ -173,9 +186,26 @@ pub(super) fn record(weight: WeightRows<'_>, x: &[f32], out_dim: usize) {
             (0, 0),
             block,
         ),
+        WeightRows::Nvfp4 {
+            packed,
+            scales,
+            tensor_scale: ts,
+        } => {
+            tensor_scale = ts;
+            (
+                Kind::Nvfp4,
+                (packed.as_ptr() as usize, packed.len()),
+                (scales.as_ptr() as usize, scales.len()),
+                (0, 0),
+                // The group is 16 by the format's definition, not a
+                // policy's choice, so there is no block to carry.
+                0,
+            )
+        }
     };
     log.push(Captured {
         kind,
+        tensor_scale,
         primary,
         secondary,
         tertiary,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/cost.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/cost.rs
@@ -75,9 +75,11 @@ fn a_mixed_plan_is_priced_arithmetic_by_arithmetic() {
         (PhysicalProjectionPlan::Q8xQ8, tally(5_000_000_000, 60)),
         (PhysicalProjectionPlan::FusedBf16, tally(340_000_000, 32)),
     ]);
-    let want = 10.0 / measured_rate_gbps(PhysicalProjectionPlan::Q4xQ8) * 1e3
-        + 5.0 / measured_rate_gbps(PhysicalProjectionPlan::Q8xQ8) * 1e3
-        + 0.34 / measured_rate_gbps(PhysicalProjectionPlan::FusedBf16) * 1e3;
+    let want = 10.0 / measured_rate_gbps(PhysicalProjectionPlan::Q4xQ8).expect("a measured plan")
+        * 1e3
+        + 5.0 / measured_rate_gbps(PhysicalProjectionPlan::Q8xQ8).expect("a measured plan") * 1e3
+        + 0.34 / measured_rate_gbps(PhysicalProjectionPlan::FusedBf16).expect("a measured plan")
+            * 1e3;
     assert!((mixed.synthetic_ms - want).abs() < 1e-6);
     assert_eq!(mixed.total_bytes, 15_340_000_000);
     assert_eq!(
@@ -131,35 +133,35 @@ fn every_arithmetic_carries_a_rate() {
         PhysicalProjectionPlan::Bf16xQ8,
     ];
     for p in all {
-        let r = measured_rate_gbps(p);
+        let r = measured_rate_gbps(p).expect("a measured plan");
         assert!(r > 0.0, "{p:?} has no positive streaming rate");
     }
     // The oracle is the slow literal transcription and the cached BLAS
     // path the fastest; pinning the ordering catches an arm that was
     // given a neighbour's number.
     assert!(
-        measured_rate_gbps(PhysicalProjectionPlan::ScalarF32)
-            < measured_rate_gbps(PhysicalProjectionPlan::FusedQ4),
+        measured_rate_gbps(PhysicalProjectionPlan::ScalarF32).expect("a measured plan")
+            < measured_rate_gbps(PhysicalProjectionPlan::FusedQ4).expect("a measured plan"),
         "the scalar oracle must be the slowest arm"
     );
     assert!(
-        measured_rate_gbps(PhysicalProjectionPlan::BlasF32)
-            > measured_rate_gbps(PhysicalProjectionPlan::Q8xQ8),
+        measured_rate_gbps(PhysicalProjectionPlan::BlasF32).expect("a measured plan")
+            > measured_rate_gbps(PhysicalProjectionPlan::Q8xQ8).expect("a measured plan"),
         "cache-resident sgemv must out-rate the streaming integer kernel"
     );
     // CPU-4A's finding, and the one rate that surprises: Q4 against an
     // f32 activation is SLOWER than Q8, because the kernel was already
     // conversion-bound and the nibble split adds to it.
     assert!(
-        measured_rate_gbps(PhysicalProjectionPlan::FusedQ4)
-            < measured_rate_gbps(PhysicalProjectionPlan::FusedQ8),
+        measured_rate_gbps(PhysicalProjectionPlan::FusedQ4).expect("a measured plan")
+            < measured_rate_gbps(PhysicalProjectionPlan::FusedQ8).expect("a measured plan"),
         "CPU-4A: Q4 x F32 is slower than Q8 x F32, not faster"
     );
     // The control streams bf16 bytes, so it must be priced at the bf16
     // rate exactly — a control priced differently would not be one.
     assert_eq!(
-        measured_rate_gbps(PhysicalProjectionPlan::Bf16xQ8),
-        measured_rate_gbps(PhysicalProjectionPlan::FusedBf16),
+        measured_rate_gbps(PhysicalProjectionPlan::Bf16xQ8).expect("a measured plan"),
+        measured_rate_gbps(PhysicalProjectionPlan::FusedBf16).expect("a measured plan"),
         "the A1 control runs the bf16 kernel and must carry its rate"
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/physical.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/physical.rs
@@ -570,8 +570,10 @@ fn a_plan_agrees_with_itself_about_format_kernel_and_residency() {
     // by `the_oracle_is_not_reachable_by_observation`; what belongs here
     // is that they are priced as different arithmetic.
     assert_ne!(
-        super::super::cost::measured_rate_gbps(PhysicalProjectionPlan::ScalarF32),
-        super::super::cost::measured_rate_gbps(PhysicalProjectionPlan::BlasF32),
+        super::super::cost::measured_rate_gbps(PhysicalProjectionPlan::ScalarF32)
+            .expect("a measured plan"),
+        super::super::cost::measured_rate_gbps(PhysicalProjectionPlan::BlasF32)
+            .expect("a measured plan"),
         "the oracle and the BLAS path must not be priced alike"
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
@@ -687,6 +687,19 @@ impl<'a> OperandSource<'a> {
         self.base.stored_dtype(operand) == Some(DTYPE_BF16)
     }
 
+    /// Whether this operand is held as a compiled NVFP4 pack.
+    ///
+    /// Overlay edits are f32-space facts with no compact form, so an
+    /// overridden operand answers `false` and is served widened — the
+    /// same rule [`Self::is_stored_bf16`] follows, for the same reason.
+    pub fn is_stored_nvfp4(&self, operand: &OperandRef) -> bool {
+        if self.overrides.is_some_and(|o| o.is_overridden(operand)) {
+            return false;
+        }
+        self.base.stored_dtype(operand)
+            == Some(crate::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4)
+    }
+
     /// Load one operand's stored bytes unwidened. Overlay edits are
     /// f32-space facts and cannot be represented in raw stored bytes,
     /// so an overridden operand refuses here rather than serving stale

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
@@ -40,6 +40,18 @@ pub struct OperandStore {
     precision_map: BTreeMap<String, BTreeMap<String, String>>,
     /// The container's precision program, when it states one.
     program: Option<crate::format::vindex3::represent::map::PrecisionMap>,
+    /// Every operand's role as the operation plan binds it, keyed
+    /// `(object, tensor)`.
+    ///
+    /// The conformance check below must resolve a role exactly as the
+    /// representation compiler did, or a legitimately compiled pack
+    /// fails its own check. That is not hypothetical: when the compiler
+    /// moved to plan-derived roles and this path was left on the name
+    /// heuristics, Qwen3.8's `linear_attn.in_proj_qkv` compiled as
+    /// `recurrence-projection` and then refused to load because
+    /// `classify` still called it `unknown`. One resolution, two
+    /// readers.
+    plan_roles: crate::format::vindex3::represent::plan_roles::PlanRoles,
     /// Where representations were allowed to come from.
     source: RepresentationSource,
     /// Process-unique identity — see [`SourceStamp`].
@@ -204,6 +216,9 @@ impl OperandStore {
             selected,
             precision_map,
             program: inspection.index.precision_map.clone(),
+            // Resolved once at open, so every conformance check in the
+            // load path reads the same answer the compiler wrote.
+            plan_roles: crate::format::vindex3::represent::plan_roles::plan_roles(root, inspection),
             source,
             id: next_identity(),
             loads: std::sync::atomic::AtomicU64::new(0),
@@ -252,6 +267,23 @@ impl OperandStore {
     /// The container's precision program, when it declares one.
     pub fn program(&self) -> Option<&crate::format::vindex3::represent::map::PrecisionMap> {
         self.program.as_ref()
+    }
+
+    /// The role the plan binds this tensor to, falling back to the name
+    /// heuristics for anything the plan does not cover — the same order
+    /// the representation compiler resolves in.
+    pub fn role_of(
+        &self,
+        object: &str,
+        tensor: &str,
+        shape: &[usize],
+    ) -> crate::format::vindex3::represent::policy::Role {
+        self.plan_roles
+            .get(&(object.to_string(), tensor.to_string()))
+            .copied()
+            .unwrap_or_else(|| {
+                crate::format::vindex3::represent::policy::classify(object, tensor, shape)
+            })
     }
 
     /// Whether this object's bytes come from a compiled pack.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
@@ -340,8 +340,23 @@ impl OperandStore {
     }
 
     /// Load one operand as f32 values.
+    ///
+    /// A compiled NVFP4 pack decodes here rather than in [`widen`],
+    /// because decoding it needs the operand's SHAPE — the group stream
+    /// is indexed per row — and `widen` sees only bytes and a dtype
+    /// label. Consumers that want the compact form for a kernel take
+    /// [`Self::load_raw`]; this is for the ones that need values, which
+    /// on a recurrence is most of them.
+    ///
+    /// The decode is lossy in exactly the way the pack is: these are the
+    /// 4-bit values, widened, not the checkpoint's originals. That is
+    /// the point — it is what makes an NVFP4 representation measurable
+    /// on a stack the device cannot run.
     pub fn load(&self, operand: &OperandRef) -> Result<Vec<f32>, VindexError> {
         let raw = self.load_raw(operand)?;
+        if raw.dtype == crate::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4 {
+            return decode_nvfp4_operand(&raw.bytes, &operand.shape, &operand.tensor);
+        }
         widen(&raw.dtype, &raw.bytes, &operand.tensor)
     }
 
@@ -402,6 +417,27 @@ impl OperandStore {
 pub struct RawOperand {
     pub dtype: String,
     pub bytes: Vec<u8>,
+}
+
+/// Decode a stored NVFP4 pack to f32, through the format's own layout
+/// and the reference decoder — no second opinion about the arithmetic.
+pub(crate) fn decode_nvfp4_operand(
+    bytes: &[u8],
+    shape: &[usize],
+    name: &str,
+) -> Result<Vec<f32>, VindexError> {
+    use crate::format::vindex3::represent::nvfp4_pack::{split, PackLayout};
+    let layout = PackLayout::derive(shape, name)?;
+    let (packed, scales, tensor_scale) = split(bytes, &layout, name)?;
+    let mut out = vec![0.0f32; layout.rows * layout.k];
+    let matrix = larql_models::quant::nvfp4::Nvfp4Matrix {
+        packed: packed.to_vec(),
+        scales: scales.to_vec(),
+        tensor_scale,
+    };
+    larql_models::quant::nvfp4::dequantize_into(&matrix, layout.rows, layout.k, &mut out)
+        .map_err(|e| VindexError::Parse(format!("tensor `{name}`: NVFP4 decode: {e}")))?;
+    Ok(out)
 }
 
 /// Widen stored bytes to f32 — judged dtypes only, fail-closed.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -453,6 +453,7 @@ fn resolve<B: PlanBackend + ?Sized>(
         class,
         elements: op.shape.iter().product(),
         stored_bf16: store.is_stored_bf16(op),
+        stored_nvfp4: store.is_stored_nvfp4(op),
     })
 }
 
@@ -516,6 +517,10 @@ impl PreparedOperands {
             class: MatrixClass::RoutedExpertBank,
             elements: 0,
             stored_bf16: false,
+            // The bank is widened and sliced into per-expert matrices on
+            // the way in, so no stored form survives for a format to
+            // apply to — the same reason `elements` is 0 here.
+            stored_nvfp4: false,
         });
         let head_format = |op: &OperandRef| resolve(backend, store, MatrixClass::OutputHead, op);
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -689,6 +689,12 @@ impl PlanBackend for ProductionBackend {
             // into per-expert matrices; there are no stored bytes left to
             // keep by the time a format could apply.
             MatrixClass::RoutedExpertBank => WeightFormat::F32,
+            // A compiled pack outranks the size policy. `choose_for`
+            // decides what to MAKE an operand resident as, from its size;
+            // an operand that is already NVFP4 has had that decision made
+            // for it deliberately, and re-deciding here would widen 4-bit
+            // bytes to f32 to satisfy a policy about bf16.
+            _ if operand.stored_nvfp4 => WeightFormat::Nvfp4,
             MatrixClass::AttentionProjection
             | MatrixClass::FfnProjection
             | MatrixClass::OutputHead => PhysicalProjectionPlan::choose_for(

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_device.rs
@@ -672,6 +672,7 @@ fn an_nvfp4_device_backend_executes_and_decodes_the_dense_plan() {
             class: MatrixClass::FfnProjection,
             elements: 0,
             stored_bf16: false,
+            stored_nvfp4: false,
         }),
         WeightFormat::Nvfp4
     );

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
@@ -373,8 +373,14 @@ pub fn load_weight(
                 store.store().program(),
                 store.store().is_stored(&operand.object),
             ) {
-                use crate::format::vindex3::represent::policy::classify;
-                let role = classify(&operand.object, &operand.tensor, &operand.shape);
+                // Resolved through the store, which reads the plan
+                // first and the name heuristics second — the same order
+                // the compiler used. Calling `classify` directly here
+                // was the miss that made a correctly compiled pack fail
+                // its own conformance check.
+                let role = store
+                    .store()
+                    .role_of(&operand.object, &operand.tensor, &operand.shape);
                 if !program.conforms(role, &operand.tensor, &raw.dtype) {
                     return Err(VindexError::Parse(format!(
                         "tensor `{}` is stored as `{}`, which the container's \

--- a/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
@@ -31,7 +31,7 @@ pub mod mamba2;
 pub mod mla;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 use larql_models::config::{
     Activation, AttentionGateSpec, AttentionSinkSpec, ExpertFormat, ExpertRoutingPolicy,

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/conv_qkv.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/conv_qkv.rs
@@ -48,7 +48,7 @@ const H_ATTN_LAYERS: [usize; 2] = [1, 3];
 /// shape: the mamba_ssm key dialect (no `n_groups`, no `rms_norm`), the
 /// `attention_*` block, a base-ambiguous `attention_layers_idx`, and
 /// `mlp_intermediate_size: 0`.
-fn miniature_hybrid(dir: &Path) {
+pub(crate) fn miniature_hybrid(dir: &Path) {
     let config = serde_json::json!({
         "architectures": ["Mamba2ForCausalLM"],
         "torch_dtype": "float32",

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/mamba2.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/mamba2.rs
@@ -38,7 +38,7 @@ const M_IN_PROJ_ROWS: usize = 2 * M_D_INNER + 2 * M_STATE + M_HEADS; // 62
 /// Write the miniature pure-SSM checkpoint. `skip_suffix` drops every
 /// tensor whose name ends with it — the lever the closure-at-encode test
 /// pulls.
-fn miniature_mamba2(dir: &Path, skip_suffix: Option<&str>) {
+pub(crate) fn miniature_mamba2(dir: &Path, skip_suffix: Option<&str>) {
     // Rendered with the bare `Infinity` transformers actually writes, so
     // the fixture exercises the judged non-finite boundary end-to-end
     // rather than the pre-quoted string form.

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/mod.rs
@@ -2,7 +2,7 @@
 //! explicit, and closure blocks on every shortfall.
 
 mod closure;
-mod conv_qkv;
+pub(crate) mod conv_qkv;
 mod coverage_opplan;
 mod gemma4_closure;
 mod kda_op;

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/mod.rs
@@ -7,7 +7,7 @@ mod gemma4_closure;
 mod kda_op;
 mod kimi_mla_closure;
 mod kimi_moe_closure;
-mod mamba2;
+pub(crate) mod mamba2;
 mod mla_op;
 mod plan;
 mod unjudged;

--- a/crates/larql-vindex/src/format/vindex3/represent/compat_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/compat_tests.rs
@@ -24,6 +24,8 @@ use super::*;
 /// human-facing; this fixture then governs `wire_name`, unchanged.
 const GOLDEN_ROLE_WIRE_NAMES: &[(&str, policy::Role)] = &[
     ("decoder-linear", policy::Role::DecoderLinear),
+    ("recurrence-projection", policy::Role::RecurrenceProjection),
+    ("recurrence-control", policy::Role::RecurrenceControl),
     ("expert-weight", policy::Role::ExpertWeight),
     ("embedding", policy::Role::Embedding),
     ("output-head", policy::Role::OutputHead),

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -54,6 +54,9 @@ pub mod gptq;
 pub mod map;
 pub mod nvfp4_pack;
 pub mod physical;
+pub mod plan_roles;
+#[cfg(test)]
+mod plan_roles_tests;
 pub mod policy;
 pub mod quality;
 pub mod selection;
@@ -234,6 +237,10 @@ pub fn compile_representation(
             .map(|o| o.id.clone())
             .collect()
     };
+    // The plan's own operand bindings, which outrank tensor spellings.
+    // Best-effort: a component whose plan does not build contributes
+    // nothing here and its tensors fall back to name classification.
+    let declared_roles = plan_roles::plan_roles(src, &inspection);
     let store = OperandStore::open(src, &inspection)?;
     let source = OperandSource::from(&store);
 
@@ -286,12 +293,24 @@ pub fn compile_representation(
             // Role first, shape second. A tensor the policy preserves is
             // carried whatever its shape; a tensor the policy admits is
             // still refused by the layout if its `k` cannot be grouped.
-            let role = classify_in(
-                primary_text.contains(&entry.object),
-                &entry.object,
-                &t.name,
-                &t.shape,
-            );
+            // The plan first: it bound this tensor to the role its
+            // operator computes with, and that is the container's own
+            // judgement. The name heuristics answer only for what the
+            // plan does not cover — object-level roles, components with
+            // no plan. A shape that cannot hold the encoding is still
+            // refused below, whatever the role says.
+            let role = declared_roles
+                .get(&(entry.object.clone(), t.name.clone()))
+                .copied()
+                .filter(|_| primary_text.contains(&entry.object))
+                .unwrap_or_else(|| {
+                    classify_in(
+                        primary_text.contains(&entry.object),
+                        &entry.object,
+                        &t.name,
+                        &t.shape,
+                    )
+                });
             // Role says the encoding applies; protection says whether to
             // spend it here. A protected tensor is carried, and counted as
             // preserved under its own role so the report says what the map

--- a/crates/larql-vindex/src/format/vindex3/represent/plan_roles.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/plan_roles.rs
@@ -1,0 +1,166 @@
+//! Semantic roles read from the operation plan, not from tensor names.
+//!
+//! [`super::policy::classify_in`] decides a tensor's role by substring —
+//! `_proj.`, `self_attn.`, `attention.`, `mlp.`. That works for the
+//! spellings softmax families happen to use and fails silently for every
+//! other operator, because a name that matches nothing classifies
+//! [`Role::Unknown`] and is carried verbatim.
+//!
+//! Measured on Qwen3.8-27B: its Gated DeltaNet operands are spelled
+//! `linear_attn.in_proj_qkv`, `in_proj_a`, `in_proj_b`, `in_proj_z` —
+//! `_proj_qkv.` is not `_proj.`, so none matched, and **4,050,124,800
+//! weights, 16.6% of the decoder stack, stayed at BF16**. Only
+//! `out_proj` matched, which is why it was the single recurrence column
+//! reading 4.50 in `vindex precision --matrix`. The compiled decoder
+//! measured 6.4138 bits/weight and looked like a precision decision.
+//!
+//! It was not one. `represent/mod.rs` already states the rule this
+//! broke: *"the embedding is BF16 because the policy protects it" and
+//! "the embedding is BF16 because nobody looked" are different facts and
+//! a report that cannot tell them apart is useless.* Nobody had looked,
+//! and the report said `unknown`.
+//!
+//! So the plan answers first. It has bound every operand to the role its
+//! operator computes with — nine for Gated DeltaNet, fifteen for KDA,
+//! five for MLA, eight for Mamba2 — and those bindings are the
+//! container's own judgement, not a guess about a filename. Names remain
+//! the fallback for anything the plan does not cover (object-level roles,
+//! components with no plan, checkpoints whose plan does not build).
+//!
+//! **This module classifies. It does not decide precision.** Which
+//! representation a role receives is [`super::policy::RolePolicy`]'s
+//! answer, stated per role, and the two must not be collapsed — that
+//! collapse is what made a classification accident read as a protection.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use super::policy::Role;
+use crate::format::vindex3::inspect::SystemInspection;
+use crate::format::vindex3::opplan::{
+    plan_component_ops, ComponentOpPlan, LayerAttention, LayerFfn, OperandRef,
+};
+
+/// Every tensor the plan binds, keyed `(object, tensor)`, with the role
+/// its operator gives it.
+pub type PlanRoles = BTreeMap<(String, String), Role>;
+
+/// Read the plan for every component and collect its operand roles.
+///
+/// Best-effort by construction: a component whose plan does not build
+/// contributes nothing and its tensors fall back to name classification,
+/// which is exactly the behaviour before this module existed. A
+/// representation compile must not fail because a plan does not.
+pub fn plan_roles(root: &Path, inspection: &SystemInspection) -> PlanRoles {
+    let mut roles = PlanRoles::new();
+    for component in &inspection.graph.components {
+        let Ok(outcome) = plan_component_ops(inspection, root, &component.id) else {
+            continue;
+        };
+        let Some(plan) = outcome.plan else { continue };
+        collect(&plan, &mut roles);
+    }
+    roles
+}
+
+fn put(roles: &mut PlanRoles, role: Role, op: &OperandRef) {
+    roles.insert((op.object.clone(), op.tensor.clone()), role);
+}
+
+fn collect(plan: &ComponentOpPlan, roles: &mut PlanRoles) {
+    for layer in &plan.layers {
+        collect_attention(&layer.attention, roles);
+        match &layer.ffn {
+            Some(LayerFfn::Dense(f)) => {
+                if let Some(g) = &f.gate {
+                    put(roles, Role::DecoderLinear, g);
+                }
+                put(roles, Role::DecoderLinear, &f.up);
+                put(roles, Role::DecoderLinear, &f.down);
+            }
+            // Routed and hybrid FFNs carve their experts into their own
+            // object, which the expert-bank path already classifies; the
+            // router is named there too. Nothing to add from here.
+            Some(LayerFfn::Routed(_)) | Some(LayerFfn::Hybrid(_)) | None => {}
+        }
+    }
+}
+
+fn collect_attention(attention: &LayerAttention, roles: &mut PlanRoles) {
+    match attention {
+        LayerAttention::Softmax(a) => {
+            for op in [&a.q, &a.k, &a.v, &a.o] {
+                put(roles, Role::DecoderLinear, op);
+            }
+            if let Some(g) = &a.output_gate {
+                put(roles, Role::DecoderLinear, &g.projection);
+            }
+        }
+        // A recurrence's bulk matmuls are ordinary linear work — the same
+        // shape of operation a softmax layer's q/k/v/o are, at the same
+        // scale. Its *control* projections are structurally different:
+        // `in_proj_a` and `in_proj_b` emit the per-head decay and
+        // write-strength that drive the state update rather than
+        // contributing to one position's output.
+        //
+        // Two roles because they are two structurally different
+        // operands, which is a classification fact. Whether that
+        // difference warrants different precision is a separate
+        // question, answered by measurement and not by this file — see
+        // `Role::RecurrenceControl`.
+        LayerAttention::GatedDelta(g) => {
+            for op in [&g.in_proj_qkv, &g.in_proj_z, &g.out_proj] {
+                put(roles, Role::RecurrenceProjection, op);
+            }
+            for op in [&g.in_proj_a, &g.in_proj_b] {
+                put(roles, Role::RecurrenceControl, op);
+            }
+            put(roles, Role::SmallVector, &g.conv1d);
+            put(roles, Role::SmallVector, &g.a_log);
+            put(roles, Role::SmallVector, &g.dt_bias);
+            put(roles, Role::Norm, &g.norm);
+        }
+        LayerAttention::Kda(k) => {
+            for op in [&k.q_proj, &k.k_proj, &k.v_proj, &k.out_proj] {
+                put(roles, Role::RecurrenceProjection, op);
+            }
+            // The gate factorisations and the write-strength projection
+            // are this operator's control path, low-rank and narrow.
+            for op in [
+                &k.f_a_proj,
+                &k.f_b_proj,
+                &k.g_a_proj,
+                &k.g_b_proj,
+                &k.b_proj,
+            ] {
+                put(roles, Role::RecurrenceControl, op);
+            }
+            for op in [&k.q_conv1d, &k.k_conv1d, &k.v_conv1d, &k.a_log, &k.dt_bias] {
+                put(roles, Role::SmallVector, op);
+            }
+            put(roles, Role::Norm, &k.o_norm);
+        }
+        // MLA retains a per-position cache and is not a recurrence: its
+        // operands are ordinary decoder linear work at an unusual width.
+        LayerAttention::Mla(m) => {
+            for op in [&m.q_proj, &m.kv_a_proj, &m.kv_b_proj, &m.out_proj] {
+                put(roles, Role::DecoderLinear, op);
+            }
+            put(roles, Role::Norm, &m.kv_a_norm);
+        }
+        LayerAttention::Mamba2(m) => {
+            for op in [&m.in_proj, &m.out_proj] {
+                put(roles, Role::RecurrenceProjection, op);
+            }
+            for op in [&m.conv1d, &m.a_log, &m.d, &m.dt_bias] {
+                put(roles, Role::SmallVector, op);
+            }
+            if let Some(b) = &m.conv1d_bias {
+                put(roles, Role::SmallVector, b);
+            }
+            if let Some(n) = &m.gated_norm {
+                put(roles, Role::Norm, &n.weight);
+            }
+        }
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/plan_roles_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/plan_roles_tests.rs
@@ -1,0 +1,159 @@
+//! The acceptance test for plan-derived roles: every operand of every
+//! token-mixer vocabulary is named, and none of them classify `Unknown`.
+//!
+//! The bar is deliberately not "the model got smaller". A compile can
+//! shrink for the wrong reason. What has to hold is that the *report*
+//! stops saying `unknown` about tensors the container has always known
+//! the role of, while the tensor names and shapes it reports are
+//! untouched — classification changed, nothing else did.
+
+use std::collections::BTreeSet;
+
+use super::plan_roles::plan_roles;
+use super::policy::{classify_in, Role};
+use crate::format::vindex3::fixtures::{encode_fixture_container, hybrid_lllf_f32_model};
+use crate::format::vindex3::fixtures_kimi::hybrid_kda_mla_f32_model;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::tests::mamba2::miniature_mamba2;
+
+/// The pure-SSM fixture, as a plain writer this file can pass around.
+fn mamba2_f32_model(dir: &std::path::Path) {
+    miniature_mamba2(dir, None);
+}
+
+fn roles_for(write: impl FnOnce(&std::path::Path)) -> Vec<(String, Role)> {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(write, checkpoint.path(), container.path(), "plan-roles");
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let mut out: Vec<(String, Role)> = plan_roles(container.path(), &inspection)
+        .into_iter()
+        .map(|((_, tensor), role)| (tensor, role))
+        .collect();
+    out.sort();
+    out
+}
+
+/// Qwen3.8's vocabulary — the one that was silently stranding 16.6% of
+/// the hero model's decoder stack. `in_proj_qkv`, `in_proj_a`,
+/// `in_proj_b` and `in_proj_z` all classified `Unknown` by name; only
+/// `out_proj` matched the substring test.
+#[test]
+fn gated_delta_operands_are_named_where_the_name_test_saw_nothing() {
+    let roles = roles_for(hybrid_lllf_f32_model);
+    let by_suffix = |suffix: &str| -> Option<Role> {
+        roles
+            .iter()
+            .find(|(t, _)| t.ends_with(suffix))
+            .map(|(_, r)| *r)
+    };
+
+    // The bulk matmuls of the recurrence.
+    for suffix in [
+        "linear_attn.in_proj_qkv.weight",
+        "linear_attn.in_proj_z.weight",
+        "linear_attn.out_proj.weight",
+    ] {
+        assert_eq!(
+            by_suffix(suffix),
+            Some(Role::RecurrenceProjection),
+            "{suffix}"
+        );
+    }
+    // The control path.
+    for suffix in [
+        "linear_attn.in_proj_a.weight",
+        "linear_attn.in_proj_b.weight",
+    ] {
+        assert_eq!(by_suffix(suffix), Some(Role::RecurrenceControl), "{suffix}");
+    }
+
+    // The regression itself, stated as the comparison it is: the name
+    // test still answers `Unknown` for these; the plan does not.
+    for suffix in [
+        "linear_attn.in_proj_qkv.weight",
+        "linear_attn.in_proj_a.weight",
+        "linear_attn.in_proj_b.weight",
+        "linear_attn.in_proj_z.weight",
+    ] {
+        let (name, _) = roles.iter().find(|(t, _)| t.ends_with(suffix)).unwrap();
+        assert_eq!(
+            classify_in(true, "target.decoder_stack", name, &[8, 8]),
+            Role::Unknown,
+            "{suffix} should still be invisible to the name test — if it is not, this test \
+             is no longer measuring the defect it was written for"
+        );
+    }
+}
+
+/// Kimi Linear's vocabulary: KDA against MLA. MLA is not a recurrence —
+/// it keeps a per-position cache — so its operands are decoder-linear,
+/// and reading them as a recurrence's would be the same class of error
+/// one operator over.
+#[test]
+fn kda_and_mla_operands_are_named_and_not_confused_with_each_other() {
+    let roles = roles_for(hybrid_kda_mla_f32_model);
+    let of = |suffix: &str| -> Option<Role> {
+        roles
+            .iter()
+            .find(|(t, _)| t.ends_with(suffix))
+            .map(|(_, r)| *r)
+    };
+    // KDA layer 0.
+    for suffix in ["0.self_attn.q_proj.weight", "0.self_attn.o_proj.weight"] {
+        assert_eq!(of(suffix), Some(Role::RecurrenceProjection), "{suffix}");
+    }
+    for suffix in ["0.self_attn.f_a_proj.weight", "0.self_attn.b_proj.weight"] {
+        assert_eq!(of(suffix), Some(Role::RecurrenceControl), "{suffix}");
+    }
+    // MLA layer 3 — same `q_proj`/`o_proj` spelling, different operator.
+    for suffix in [
+        "3.self_attn.q_proj.weight",
+        "3.self_attn.kv_a_proj_with_mqa.weight",
+        "3.self_attn.kv_b_proj.weight",
+        "3.self_attn.o_proj.weight",
+    ] {
+        assert_eq!(of(suffix), Some(Role::DecoderLinear), "{suffix}");
+    }
+}
+
+/// Mamba2's vocabulary — a third recurrence family, whose whole block is
+/// the mixer and which ships no FFN at all.
+#[test]
+fn mamba2_operands_are_named() {
+    let roles = roles_for(mamba2_f32_model);
+    let of = |suffix: &str| -> Option<Role> {
+        roles
+            .iter()
+            .find(|(t, _)| t.ends_with(suffix))
+            .map(|(_, r)| *r)
+    };
+    assert_eq!(of("mixer.in_proj.weight"), Some(Role::RecurrenceProjection));
+    assert_eq!(
+        of("mixer.out_proj.weight"),
+        Some(Role::RecurrenceProjection)
+    );
+}
+
+/// The invariant that keeps this a classification change: across all
+/// three vocabularies, no operand the plan binds is left `Unknown`.
+#[test]
+fn no_planned_operand_of_any_vocabulary_classifies_unknown() {
+    for (write, name) in [
+        (
+            hybrid_lllf_f32_model as fn(&std::path::Path),
+            "gated-deltanet",
+        ),
+        (hybrid_kda_mla_f32_model as fn(&std::path::Path), "kda/mla"),
+        (mamba2_f32_model as fn(&std::path::Path), "mamba2"),
+    ] {
+        let roles = roles_for(write);
+        assert!(!roles.is_empty(), "{name}: the plan bound no operands");
+        let unknown: BTreeSet<&str> = roles
+            .iter()
+            .filter(|(_, r)| *r == Role::Unknown)
+            .map(|(t, _)| t.as_str())
+            .collect();
+        assert!(unknown.is_empty(), "{name}: still unknown: {unknown:?}");
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/plan_roles_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/plan_roles_tests.rs
@@ -149,9 +149,8 @@ fn mamba2_operands_are_named() {
 #[test]
 fn conv_qkv_operands_are_attention_work_not_recurrence_work() {
     let roles = roles_for(miniature_hybrid);
-    let role_of = |tensor: &str| -> Option<Role> {
-        roles.iter().find(|(t, _)| t == tensor).map(|(_, r)| *r)
-    };
+    let role_of =
+        |tensor: &str| -> Option<Role> { roles.iter().find(|(t, _)| t == tensor).map(|(_, r)| *r) };
 
     // Layers 1 and 3 attend. Their projections are ordinary linear work.
     for layer in [1, 3] {

--- a/crates/larql-vindex/src/format/vindex3/represent/plan_roles_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/plan_roles_tests.rs
@@ -14,6 +14,7 @@ use super::policy::{classify_in, Role};
 use crate::format::vindex3::fixtures::{encode_fixture_container, hybrid_lllf_f32_model};
 use crate::format::vindex3::fixtures_kimi::hybrid_kda_mla_f32_model;
 use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::tests::conv_qkv::miniature_hybrid;
 use crate::format::vindex3::opplan::tests::mamba2::miniature_mamba2;
 
 /// The pure-SSM fixture, as a plain writer this file can pass around.
@@ -137,6 +138,47 @@ fn mamba2_operands_are_named() {
 
 /// The invariant that keeps this a classification change: across all
 /// three vocabularies, no operand the plan binds is left `Unknown`.
+/// Conv-QKV attends by softmax and keeps a per-position cache, so its
+/// two matmuls are ordinary decoder linear work and its depthwise
+/// kernel is the same small-vector shape every other operator's conv
+/// is. The fixture is the OuteAI hybrid: layers 1 and 3 attend, the
+/// rest are Mamba2 — so the same operand *names* carry different roles
+/// in the same model, and the test asserts the split rather than the
+/// names. A wildcard arm that swept conv-QKV in with the recurrences
+/// would compile, and would price an attention block as a recurrence.
+#[test]
+fn conv_qkv_operands_are_attention_work_not_recurrence_work() {
+    let roles = roles_for(miniature_hybrid);
+    let role_of = |tensor: &str| -> Option<Role> {
+        roles.iter().find(|(t, _)| t == tensor).map(|(_, r)| *r)
+    };
+
+    // Layers 1 and 3 attend. Their projections are ordinary linear work.
+    for layer in [1, 3] {
+        for operand in ["in_proj", "out_proj"] {
+            let tensor = format!("{layer}.mixer.{operand}.weight");
+            assert_eq!(role_of(&tensor), Some(Role::DecoderLinear), "{tensor}");
+        }
+        let conv = format!("{layer}.mixer.conv1d.weight");
+        assert_eq!(
+            role_of(&conv),
+            Some(Role::SmallVector),
+            "{conv} — a depthwise kernel no block layout fits"
+        );
+    }
+
+    // The recurrent layers keep the recurrence roles, on identically
+    // named operands. The role follows the operator, not the string.
+    for layer in [0, 2] {
+        let tensor = format!("{layer}.mixer.in_proj.weight");
+        assert_eq!(
+            role_of(&tensor),
+            Some(Role::RecurrenceProjection),
+            "{tensor} — same name, different operator, different role"
+        );
+    }
+}
+
 #[test]
 fn no_planned_operand_of_any_vocabulary_classifies_unknown() {
     for (write, name) in [

--- a/crates/larql-vindex/src/format/vindex3/represent/policy.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/policy.rs
@@ -47,6 +47,42 @@ use std::fmt;
 pub enum Role {
     /// Attention and dense-FFN projections — the bulk of a dense model.
     DecoderLinear,
+    /// The bulk matmuls of a recurrent token mixer: Gated DeltaNet's
+    /// fused `in_proj_qkv`, its `in_proj_z` and `out_proj`; KDA's split
+    /// q/k/v and out; Mamba2's fused `in_proj` and `out_proj`.
+    ///
+    /// The same shape of operation as [`Self::DecoderLinear`] at the same
+    /// scale, and compiled by the same default — its own role because a
+    /// profile must be able to say something different about a
+    /// recurrence than about softmax attention without editing a
+    /// substring list, and because a report that cannot name them cannot
+    /// distinguish "protected" from "unrecognised".
+    RecurrenceProjection,
+    /// A recurrent mixer's *control* path: the narrow projections that
+    /// emit per-head decay and write strength (Gated DeltaNet
+    /// `in_proj_a`/`in_proj_b`, KDA's gate factorisations and `b_proj`).
+    ///
+    /// Preserved by the default profile, which retains the treatment
+    /// these tensors already had while making its reason explicit and
+    /// testable.
+    ///
+    /// **The reason is a prior, not a finding.** The conjecture is that
+    /// error in a bulk projection perturbs one position's contribution
+    /// while error in the decay and write signals perturbs the state
+    /// every later position reads — so it would compound along the
+    /// sequence rather than average out. Qwen3.8 declaring
+    /// `linear_attention.state_dtype: float32` against otherwise-bf16
+    /// weights shows the *architecture* treats the state specially; it
+    /// does not show that these projections need BF16, and nothing here
+    /// should be read as if it did.
+    ///
+    /// Whether the protection buys measurable fidelity is Q-BANK-1's
+    /// question, run as `protect-control` against `true-uniform` —
+    /// `--include-role recurrence-control` is the second arm. The
+    /// experiment is cheap because the decision is small: 23.6M weights
+    /// across Qwen3.8's 48 recurrent layers, under 0.1% of the stack.
+    /// If it does not separate, this role stops being protected.
+    RecurrenceControl,
     /// Routed-expert weights — the bulk of an MoE model.
     ExpertWeight,
     /// Token embedding table.
@@ -76,6 +112,8 @@ impl Role {
     /// Every role, for CLI parsing and exhaustive reporting.
     pub const ALL: &'static [Role] = &[
         Role::DecoderLinear,
+        Role::RecurrenceProjection,
+        Role::RecurrenceControl,
         Role::ExpertWeight,
         Role::Embedding,
         Role::OutputHead,
@@ -90,6 +128,8 @@ impl Role {
     pub fn name(self) -> &'static str {
         match self {
             Role::DecoderLinear => "decoder-linear",
+            Role::RecurrenceProjection => "recurrence-projection",
+            Role::RecurrenceControl => "recurrence-control",
             Role::ExpertWeight => "expert-weight",
             Role::Embedding => "embedding",
             Role::OutputHead => "output-head",
@@ -107,7 +147,10 @@ impl Role {
 
     /// Whether the conservative default compiles this role.
     pub fn in_default_policy(self) -> bool {
-        matches!(self, Role::DecoderLinear | Role::ExpertWeight)
+        matches!(
+            self,
+            Role::DecoderLinear | Role::RecurrenceProjection | Role::ExpertWeight
+        )
     }
 }
 

--- a/crates/vindex-cli/src/lib.rs
+++ b/crates/vindex-cli/src/lib.rs
@@ -13,13 +13,17 @@ use std::path::Path;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
+pub mod mixer;
+use mixer::{layer_range, MixerOperands};
+
 use larql_vindex::format::filenames::INDEX_JSON;
 use larql_vindex::format::vindex3::encode::segment::read_segment_header;
+use larql_vindex::format::vindex3::graph::Component;
 use larql_vindex::format::vindex3::index::{ContainerAuthority, Vindex3Index};
 use larql_vindex::format::vindex3::inspect::{inspect_container, SystemInspection};
 use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
 use larql_vindex::format::vindex3::opplan::{
-    plan_component_ops, ComponentOpPlan, LayerFfn, LayerPlan, OperandRef,
+    plan_component_ops, ComponentOpPlan, LayerFfn, OperandRef,
 };
 use larql_vindex::format::vindex3::represent::nvfp4_pack::{split, PackLayout, DTYPE_NVFP4};
 use larql_vindex::format::vindex3::represent::{compile_representation, RepresentSpec};
@@ -106,23 +110,30 @@ pub fn describe_facts(root: &Path, address: &str, values: usize, peek: Option<&s
         .and_then(|r| r.strip_suffix(".mixer"))
         .and_then(|n| n.parse::<usize>().ok())
     {
-        let (_, plan) = primary_plan(root, &inspection)?;
+        let (component, plan) = primary_plan(root, &inspection)?;
+        let operator = mixer::declared_operator(component, n)?;
         let layer = plan
             .layers
             .get(n)
-            .ok_or_else(|| format!("layer {n} — the plan holds layers 0..{}", plan.layers.len()))?;
-        let operands: Vec<Value> = mixer_operands(layer)
-            .into_iter()
-            .map(|(role, op)| {
-                json!({ "role": role, "tensor": op.tensor, "shape": op.shape, "dtype": op.dtype })
-            })
-            .collect();
+            .ok_or_else(|| layer_range(&format!("layer {n}"), plan.layers.len()))?;
+        let (operands, undescribed) = match mixer::operands(operator, layer) {
+            MixerOperands::Named(ops) => (
+                ops.into_iter()
+                    .map(|(role, op)| {
+                        json!({ "role": role, "tensor": op.tensor, "shape": op.shape, "dtype": op.dtype })
+                    })
+                    .collect::<Vec<Value>>(),
+                None,
+            ),
+            MixerOperands::Undescribed(why) => (Vec::new(), Some(why)),
+        };
         return Ok(json!({
             "container": root.display().to_string(),
             "semantic": address,
-            "mixer": mixer_label(layer),
+            "mixer": mixer::label(operator, mixer::has_output_gate(layer)),
             "layer": n,
             "operands": operands,
+            "undescribed": undescribed,
         }));
     }
     if let Some(resolved) = resolve_semantic(root, &inspection, address) {
@@ -284,24 +295,26 @@ pub fn precision_facts(root: &Path) -> Facts {
 pub fn layers_facts(root: &Path) -> Facts {
     let inspection = inspect_container(root, false).map_err(|e| format!("inspect: {e}"))?;
     let (component, plan) = primary_plan(root, &inspection)?;
-    let rows: Vec<Value> = plan
-        .layers
-        .iter()
-        .map(|l| {
-            let ffn = match &l.ffn {
-                Some(LayerFfn::Dense(_)) => "dense",
-                Some(LayerFfn::Routed(_)) => "routed",
-                Some(LayerFfn::Hybrid(_)) => "hybrid",
-                // A mixer-only (Mamba2) layer: the mixer is the whole
-                // block and no FFN exists to report.
-                None => "absent",
-            };
-            json!({ "layer": l.layer, "mixer": mixer_label(l), "ffn": ffn })
-        })
-        .collect();
+    let mut rows: Vec<Value> = Vec::with_capacity(plan.layers.len());
+    for l in &plan.layers {
+        let ffn = match &l.ffn {
+            Some(LayerFfn::Dense(_)) => "dense",
+            Some(LayerFfn::Routed(_)) => "routed",
+            Some(LayerFfn::Hybrid(_)) => "hybrid",
+            // A mixer-only (Mamba2) layer: the mixer is the whole
+            // block and no FFN exists to report.
+            None => "absent",
+        };
+        let operator = mixer::declared_operator(component, l.layer)?;
+        rows.push(json!({
+            "layer": l.layer,
+            "mixer": mixer::label(operator, mixer::has_output_gate(l)),
+            "ffn": ffn,
+        }));
+    }
     Ok(json!({
         "container": root.display().to_string(),
-        "component": component,
+        "component": component.id,
         "layers": rows,
     }))
 }
@@ -370,25 +383,53 @@ pub fn precision_matrix_facts(root: &Path) -> Facts {
 
     // Group layers by programme; each group's columns are what its
     // programme actually computes with.
+    //
+    // The empty answer means "no column", and it is deliberate for
+    // every per-head or per-channel vector — log decay, timestep
+    // bias, norm weights, the Mamba2 skip. A bits-per-weight matrix
+    // over a `[Hv]` operand says nothing about a representation and
+    // would push a programme's row past readable width; the tensors
+    // are still reachable through `describe layer.N.mixer`.
     let short = |role: &str| -> &'static str {
         match role {
+            // softmax
             "query" => "q",
             "key" => "k",
             "value" => "v",
             "output" => "o",
             "output gate" => "zgate",
+            // gated deltanet
             "fused recurrent q|k|v" => "qkv",
             "decay projection" => "decay",
             "write-strength projection" => "write",
             "output-gate projection" => "zgate",
             "causal conv over q|k|v" => "conv",
+            // kda — split where gated deltanet fuses
+            "query projection" => "q",
+            "key projection" => "k",
+            "value projection" => "v",
+            "causal conv over q" => "qconv",
+            "causal conv over k" => "kconv",
+            "causal conv over v" => "vconv",
+            "decay gate down" => "fa",
+            "decay gate up" => "fb",
+            "output gate down" => "ga",
+            "output gate up" => "gb",
+            // mla — the compressed-kv set
+            "compressed kv projection" => "kv_a",
+            "kv decompression" => "kv_b",
+            // mamba2
+            "fused in-projection z|x|B|C|dt" => "in",
+            "causal conv over x|B|C" => "conv",
+            // shared
             "output projection" => "out",
             _ => "",
         }
     };
     let mut programmes: Vec<(String, Vec<String>, Vec<Value>)> = Vec::new();
     for layer in &plan.layers {
-        let label = mixer_label(layer).to_string();
+        let operator = mixer::declared_operator(component, layer.layer)?;
+        let label = mixer::label(operator, mixer::has_output_gate(layer)).to_string();
         let mut cells = serde_json::Map::new();
         let mut roles: Vec<String> = vec!["gate".into(), "up".into(), "down".into()];
         if let Some(ffn) = layer.ffn.as_ref().and_then(|f| f.dense()) {
@@ -404,14 +445,16 @@ pub fn precision_matrix_facts(root: &Path) -> Facts {
                 cells.insert("down".into(), json!(b));
             }
         }
-        for (role, op) in mixer_operands(layer) {
-            let col = short(role);
-            if col.is_empty() {
-                continue;
-            }
-            roles.push(col.to_string());
-            if let Some(b) = bits_of(&op) {
-                cells.insert(col.to_string(), json!(b));
+        if let MixerOperands::Named(ops) = mixer::operands(operator, layer) {
+            for (role, op) in ops {
+                let col = short(role);
+                if col.is_empty() {
+                    continue;
+                }
+                roles.push(col.to_string());
+                if let Some(b) = bits_of(&op) {
+                    cells.insert(col.to_string(), json!(b));
+                }
             }
         }
         let row = json!({ "layer": layer.layer, "bits": Value::Object(cells) });
@@ -426,10 +469,14 @@ pub fn precision_matrix_facts(root: &Path) -> Facts {
         .layers
         .iter()
         .flat_map(|l| {
-            let mut ops: Vec<String> = mixer_operands(l)
-                .into_iter()
-                .map(|(_, o)| o.object)
-                .collect();
+            let mut ops: Vec<String> = match mixer::declared_operator(component, l.layer)
+                .map(|op| mixer::operands(op, l))
+            {
+                Ok(MixerOperands::Named(named)) => {
+                    named.into_iter().map(|(_, o)| o.object).collect()
+                }
+                _ => Vec::new(),
+            };
             if let Some(ffn) = l.ffn.as_ref().and_then(|f| f.dense()) {
                 if let Some(g) = &ffn.gate {
                     ops.push(g.object.clone());
@@ -456,7 +503,7 @@ pub fn precision_matrix_facts(root: &Path) -> Facts {
         .collect();
     Ok(json!({
         "container": root.display().to_string(),
-        "component": component,
+        "component": component.id,
         "programmes": programmes.into_iter().map(|(label, roles, rows)| json!({
             "label": label,
             "layers": rows.len(),
@@ -600,72 +647,28 @@ fn open_side(
     Ok((store, tensors))
 }
 
-fn primary_plan(
+/// The primary component: the graph node that declares it, and the
+/// operation plan built over it.
+///
+/// Both, because the two answer different questions and neither
+/// substitutes for the other — the node declares what each layer's
+/// token mixer IS, the plan binds the operands that mixer computes
+/// with. See [`mixer`].
+fn primary_plan<'a>(
     root: &Path,
-    inspection: &SystemInspection,
-) -> Result<(String, ComponentOpPlan), String> {
+    inspection: &'a SystemInspection,
+) -> Result<(&'a Component, ComponentOpPlan), String> {
     let component = inspection
         .graph
         .components
         .first()
-        .ok_or("the graph holds no components")?
-        .id
-        .clone();
+        .ok_or("the graph holds no components")?;
     let outcome =
-        plan_component_ops(inspection, root, &component).map_err(|e| format!("plan: {e}"))?;
+        plan_component_ops(inspection, root, &component.id).map_err(|e| format!("plan: {e}"))?;
     let plan = outcome
         .plan
-        .ok_or_else(|| format!("component `{component}` has no plan"))?;
+        .ok_or_else(|| format!("component `{}` has no plan", component.id))?;
     Ok((component, plan))
-}
-
-/// The token mixer's programme label, from the plan — never inferred
-/// from a name.
-fn mixer_label(layer: &LayerPlan) -> &'static str {
-    match layer.attention.softmax() {
-        Some(attn) => {
-            if attn.output_gate.is_some() {
-                "GATED ATTENTION"
-            } else {
-                "SOFTMAX ATTENTION"
-            }
-        }
-        None => "GATED DELTANET",
-    }
-}
-
-/// The mixer's operands, each with the semantic role the plan assigns.
-fn mixer_operands(layer: &LayerPlan) -> Vec<(&'static str, OperandRef)> {
-    match layer.attention.softmax() {
-        Some(attn) => {
-            let mut ops = vec![
-                ("query", attn.q.clone()),
-                ("key", attn.k.clone()),
-                ("value", attn.v.clone()),
-                ("output", attn.o.clone()),
-            ];
-            if let Some(g) = &attn.output_gate {
-                ops.push(("output gate", g.projection.clone()));
-            }
-            ops
-        }
-        None => {
-            let Some(gd) = layer.attention.gated_delta() else {
-                return Vec::new();
-            };
-            vec![
-                ("fused recurrent q|k|v", gd.in_proj_qkv.clone()),
-                ("decay projection", gd.in_proj_a.clone()),
-                ("write-strength projection", gd.in_proj_b.clone()),
-                ("output-gate projection", gd.in_proj_z.clone()),
-                ("causal conv over q|k|v", gd.conv1d.clone()),
-                ("log decay", gd.a_log.clone()),
-                ("timestep bias", gd.dt_bias.clone()),
-                ("gated norm", gd.norm.clone()),
-                ("output projection", gd.out_proj.clone()),
-            ]
-        }
-    }
 }
 
 /// A semantic address, resolved through the container's own operation
@@ -701,7 +704,7 @@ fn resolve_semantic(
         let layer_plan = plan
             .layers
             .get(n)
-            .ok_or_else(|| format!("layer {n} — the plan holds layers 0..{}", plan.layers.len()))?;
+            .ok_or_else(|| layer_range(&format!("layer {n}"), plan.layers.len()))?;
         match family {
             "ffn" => {
                 let ffn = layer_plan
@@ -734,7 +737,18 @@ fn resolve_semantic(
             }
             "attention" => {
                 let attn = layer_plan.attention.softmax().ok_or_else(|| {
-                    format!("layer {n} has no softmax-attention component — its token mixer is GATED DELTANET; try `describe layer.{n}.mixer`")
+                    let mixer = inspection
+                        .graph
+                        .components
+                        .first()
+                        .and_then(|c| mixer::declared_operator(c, n).ok())
+                        .map(|op| mixer::label(op, false))
+                        .unwrap_or("a mixer this container does not name");
+                    format!(
+                        "layer {n} does not attend by softmax — its token mixer is {mixer}, \
+                         so its projections are that operator's, not q/k/v/o; \
+                         try `describe layer.{n}.mixer`"
+                    )
                 })?;
                 let (label, op) = match *role {
                     "q" => ("ATTENTION QUERY PROJECTION", &attn.q),

--- a/crates/vindex-cli/src/main.rs
+++ b/crates/vindex-cli/src/main.rs
@@ -208,11 +208,19 @@ fn render_describe(v: &Value) {
     if let Some(mixer) = v["mixer"].as_str() {
         kv("layer", v["layer"].as_u64().unwrap_or(0));
         kv("token mixer", mixer);
+        // An operator the container names but this release cannot
+        // describe operand-by-operand says so, in place of the empty
+        // table that once stood in for the answer.
+        if let Some(why) = v["undescribed"].as_str() {
+            println!();
+            println!("operands      — {why}");
+            return;
+        }
         println!();
-        println!("{:<28} {:<38} SHAPE", "SEMANTICS", "TENSOR");
+        println!("{:<32} {:<38} SHAPE", "SEMANTICS", "TENSOR");
         for op in v["operands"].as_array().into_iter().flatten() {
             println!(
-                "{:<28} {:<38} {}",
+                "{:<32} {:<38} {}",
                 op["role"].as_str().unwrap_or("?"),
                 op["tensor"].as_str().unwrap_or("?"),
                 serde_json::to_string(&op["shape"]).unwrap_or_default()

--- a/crates/vindex-cli/src/mixer.rs
+++ b/crates/vindex-cli/src/mixer.rs
@@ -1,0 +1,211 @@
+//! The token mixer, as the container declares it.
+//!
+//! Two facts, kept apart on purpose. **Identity** comes from the
+//! graph's `attention[n].operator` — the checkpoint's judgement,
+//! written once at encode time and required on read since
+//! GRAPH_SCHEMA 6. **Operands** come from the op plan, which binds
+//! tensors to the roles that operator computes with.
+//!
+//! Reading identity off the operands instead is the defect this
+//! module exists to prevent. Before it, `mixer_label` matched
+//! `LayerAttention::softmax()` and treated every `None` as Gated
+//! DeltaNet, so Kimi Linear's `KKKM KKKM …` interleave — 20 KDA
+//! layers and 7 MLA — printed as twenty-seven Gated DeltaNet layers,
+//! and `describe layer.3.mixer` answered `GATED DELTANET` over an
+//! empty operand table rather than refusing. A container that knows
+//! exactly what it is was read as something it is not, confidently.
+//!
+//! So every match here is exhaustive over [`LayerOperator`] with no
+//! wildcard arm: a new operator variant is a compile error in this
+//! file, never a silent fall-through to whichever label happens to be
+//! last.
+
+use larql_vindex::format::vindex3::graph::policy::LayerOperator;
+use larql_vindex::format::vindex3::graph::Component;
+use larql_vindex::format::vindex3::opplan::{LayerAttention, LayerPlan, OperandRef};
+
+/// The operator this layer's policy declares, or the reason the
+/// container cannot say.
+///
+/// An absent `attention` table is not "softmax by default" — it is a
+/// component that never declared a per-layer programme, and saying so
+/// is the honest answer.
+pub fn declared_operator(component: &Component, n: usize) -> Result<LayerOperator, String> {
+    let policies = component.attention.as_ref().ok_or_else(|| {
+        format!(
+            "component `{}` declares no per-layer attention policy — this container \
+             cannot say what layer {n}'s token mixer is",
+            component.id
+        )
+    })?;
+    policies
+        .get(n)
+        .map(|p| p.operator)
+        .ok_or_else(|| layer_range(&format!("layer {n}"), policies.len()))
+}
+
+/// The refusal for a layer index the plan does not hold.
+///
+/// Inclusive bounds on purpose: `0..40` is Rust's half-open spelling
+/// and reads to everyone else as forty-one layers, which is a wrong
+/// answer to the question the reader actually asked.
+pub fn layer_range(what: &str, count: usize) -> String {
+    match count {
+        0 => format!("{what} — the plan holds no layers"),
+        1 => format!("{what} — the plan holds layer 0 only"),
+        n => format!("{what} — the plan holds layers 0\u{2013}{}", n - 1),
+    }
+}
+
+/// The programme label for one declared operator.
+///
+/// `output_gate` refines softmax only, and comes from the bound op:
+/// gating is an operand the layer either ships or does not, while
+/// every other name here is the operator's own.
+///
+/// `SOFTMAX ATTENTION` rather than plain `ATTENTION` for the ungated
+/// case, because `GATED ATTENTION` is *also* softmax attention — the
+/// gate is added to the operator, not substituted for it, and a pair
+/// reading `ATTENTION` / `GATED ATTENTION` invites the opposite
+/// reading.
+pub fn label(operator: LayerOperator, output_gate: bool) -> &'static str {
+    match operator {
+        LayerOperator::Softmax => {
+            if output_gate {
+                "GATED ATTENTION"
+            } else {
+                "SOFTMAX ATTENTION"
+            }
+        }
+        LayerOperator::GatedDelta => "GATED DELTANET",
+        LayerOperator::Kda => "KDA",
+        LayerOperator::Mla => "MLA",
+        LayerOperator::Mamba2 => "MAMBA2",
+        // The schema's own word for a declared recurrence whose family
+        // nothing identified. Renaming it to any operator would invent
+        // the fact the variant exists to withhold.
+        LayerOperator::Recurrent => "UNIDENTIFIED RECURRENCE",
+    }
+}
+
+/// What the plan bound for this layer, named as the operator itself
+/// names its operands — or why no such table can be shown.
+pub enum MixerOperands {
+    Named(Vec<(&'static str, OperandRef)>),
+    /// The operator is known; its operand vocabulary is not available
+    /// here. Said out loud rather than rendered as an empty table.
+    Undescribed(String),
+}
+
+/// The mixer's operands under the operator the graph declared.
+///
+/// The plan's own variant must agree with that declaration. When it
+/// does not, the container disagrees with itself and this refuses
+/// naming both sides — a defect worth stopping on, never a preference
+/// to resolve silently.
+pub fn operands(operator: LayerOperator, layer: &LayerPlan) -> MixerOperands {
+    let bound = bound_name(&layer.attention);
+    match (operator, &layer.attention) {
+        (LayerOperator::Softmax, LayerAttention::Softmax(a)) => {
+            let mut ops = vec![
+                ("query", a.q.clone()),
+                ("key", a.k.clone()),
+                ("value", a.v.clone()),
+                ("output", a.o.clone()),
+            ];
+            if let Some(g) = &a.output_gate {
+                ops.push(("output gate", g.projection.clone()));
+            }
+            MixerOperands::Named(ops)
+        }
+        (LayerOperator::GatedDelta, LayerAttention::GatedDelta(g)) => MixerOperands::Named(vec![
+            ("fused recurrent q|k|v", g.in_proj_qkv.clone()),
+            ("decay projection", g.in_proj_a.clone()),
+            ("write-strength projection", g.in_proj_b.clone()),
+            ("output-gate projection", g.in_proj_z.clone()),
+            ("causal conv over q|k|v", g.conv1d.clone()),
+            ("log decay", g.a_log.clone()),
+            ("timestep bias", g.dt_bias.clone()),
+            ("gated norm", g.norm.clone()),
+            ("output projection", g.out_proj.clone()),
+        ]),
+        // Fifteen roles, split where Gated DeltaNet fuses: three
+        // projections through three convs, two low-rank gate pairs.
+        (LayerOperator::Kda, LayerAttention::Kda(k)) => MixerOperands::Named(vec![
+            ("query projection", k.q_proj.clone()),
+            ("key projection", k.k_proj.clone()),
+            ("value projection", k.v_proj.clone()),
+            ("causal conv over q", k.q_conv1d.clone()),
+            ("causal conv over k", k.k_conv1d.clone()),
+            ("causal conv over v", k.v_conv1d.clone()),
+            ("decay gate down", k.f_a_proj.clone()),
+            ("decay gate up", k.f_b_proj.clone()),
+            ("output gate down", k.g_a_proj.clone()),
+            ("output gate up", k.g_b_proj.clone()),
+            ("write-strength projection", k.b_proj.clone()),
+            ("log decay", k.a_log.clone()),
+            ("timestep bias", k.dt_bias.clone()),
+            ("gated norm", k.o_norm.clone()),
+            ("output projection", k.out_proj.clone()),
+        ]),
+        // The compressed-KV set. `query`/`output projection` are
+        // byte-identical suffixes to the softmax pair at a different
+        // width — named by role here, which is the distinction.
+        (LayerOperator::Mla, LayerAttention::Mla(m)) => MixerOperands::Named(vec![
+            ("query projection", m.q_proj.clone()),
+            ("compressed kv projection", m.kv_a_proj.clone()),
+            ("kv latent norm", m.kv_a_norm.clone()),
+            ("kv decompression", m.kv_b_proj.clone()),
+            ("output projection", m.out_proj.clone()),
+        ]),
+        (LayerOperator::Mamba2, LayerAttention::Mamba2(m)) => {
+            let mut ops = vec![
+                ("fused in-projection z|x|B|C|dt", m.in_proj.clone()),
+                ("causal conv over x|B|C", m.conv1d.clone()),
+            ];
+            if let Some(b) = &m.conv1d_bias {
+                ops.push(("conv bias", b.clone()));
+            }
+            ops.push(("log decay", m.a_log.clone()));
+            ops.push(("skip", m.d.clone()));
+            ops.push(("timestep bias", m.dt_bias.clone()));
+            if let Some(n) = &m.gated_norm {
+                ops.push(("gated norm", n.weight.clone()));
+            }
+            ops.push(("output projection", m.out_proj.clone()));
+            MixerOperands::Named(ops)
+        }
+        // Declared, not identified: there is no operand vocabulary to
+        // print, and inventing one from whatever the plan bound is the
+        // original defect wearing a different hat.
+        (LayerOperator::Recurrent, _) => MixerOperands::Undescribed(
+            "the container declares a recurrence whose operator family it does not name — \
+             no operand vocabulary applies"
+                .into(),
+        ),
+        (declared, _) => MixerOperands::Undescribed(format!(
+            "the graph declares {} and the plan bound {bound} — the container disagrees \
+             with itself about this layer",
+            label(declared, false)
+        )),
+    }
+}
+
+/// The plan's own name for what it bound, for the disagreement message.
+fn bound_name(attention: &LayerAttention) -> &'static str {
+    match attention {
+        LayerAttention::Softmax(_) => "SOFTMAX ATTENTION",
+        LayerAttention::GatedDelta(_) => "GATED DELTANET",
+        LayerAttention::Kda(_) => "KDA",
+        LayerAttention::Mla(_) => "MLA",
+        LayerAttention::Mamba2(_) => "MAMBA2",
+    }
+}
+
+/// Whether this layer's bound op carries an attention output gate.
+pub fn has_output_gate(layer: &LayerPlan) -> bool {
+    layer
+        .attention
+        .softmax()
+        .is_some_and(|a| a.output_gate.is_some())
+}

--- a/crates/vindex-cli/tests/facts.rs
+++ b/crates/vindex-cli/tests/facts.rs
@@ -243,11 +243,11 @@ fn the_mixer_is_a_first_class_semantic_component() {
     assert!(roles.contains(&"fused recurrent q|k|v"), "{roles:?}");
     assert!(roles.contains(&"decay projection"), "{roles:?}");
 
+    // Exactly, not "one of these two": a disjunction here passes
+    // whichever answer arrives, and that is how a mixer label derived
+    // from the wrong source survived this suite. See `tests/mixer.rs`.
     let v = describe_facts(dir.path(), "layer.3.mixer", 2, None).unwrap();
-    assert!(
-        v["mixer"] == "SOFTMAX ATTENTION" || v["mixer"] == "GATED ATTENTION",
-        "{v}"
-    );
+    assert_eq!(v["mixer"], "SOFTMAX ATTENTION", "{v}");
 
     let l = layers_facts(dir.path()).unwrap();
     let mixers: Vec<&str> = l["layers"]
@@ -256,9 +256,20 @@ fn the_mixer_is_a_first_class_semantic_component() {
         .iter()
         .filter_map(|r| r["mixer"].as_str())
         .collect();
-    assert_eq!(mixers.len(), 4, "{l}");
-    assert_eq!(mixers[0], "GATED DELTANET", "{l}");
-    assert_ne!(mixers[3], "GATED DELTANET", "{l}");
+    // The whole sequence. `assert_ne!(mixers[3], "GATED DELTANET")`
+    // stood here and passed for the wrong reason: it holds for every
+    // operator that is not Gated DeltaNet, including the several this
+    // build once mislabelled as one.
+    assert_eq!(
+        mixers,
+        vec![
+            "GATED DELTANET",
+            "GATED DELTANET",
+            "GATED DELTANET",
+            "SOFTMAX ATTENTION"
+        ],
+        "{l}"
+    );
 }
 
 #[test]

--- a/crates/vindex-cli/tests/mixer.rs
+++ b/crates/vindex-cli/tests/mixer.rs
@@ -1,0 +1,272 @@
+//! The token mixer, adversarially: two hybrid vocabularies, four
+//! operators, and the assertion that each one is named as itself.
+//!
+//! This file exists because of a specific regression. `mixer_label`
+//! matched the plan's softmax op and treated *every* other layer as
+//! Gated DeltaNet, so on the real Kimi-Linear-48B container — whose
+//! graph records `KKKM KKKM …`, twenty KDA layers and seven MLA —
+//! `vindex layers` printed twenty-seven Gated DeltaNet layers,
+//! `describe layer.3.mixer` answered `GATED DELTANET` over an empty
+//! operand table, and the q/k/v/o refusal asserted a false operator by
+//! name. Three confident wrong answers from a container that recorded
+//! the right one.
+//!
+//! So the assertions here are **exact sequences**, never
+//! `assert_ne!(…, "GATED DELTANET")` or a disjunction over two
+//! acceptable labels: a negative passes for the wrong reason the
+//! moment a third operator appears, which is precisely how the
+//! original defect survived a green suite.
+
+use larql_vindex::format::vindex3::fixtures::{
+    encode_fixture_container, gated_q_f32_model, hybrid_lllf_f32_model,
+};
+use larql_vindex::format::vindex3::fixtures_kimi::hybrid_kda_mla_f32_model;
+use vindex_cli::{describe_facts, layers_facts, precision_matrix_facts};
+
+fn encoded(write: impl FnOnce(&std::path::Path), name: &str) -> tempfile::TempDir {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    encode_fixture_container(write, checkpoint.path(), dir.path(), name);
+    dir
+}
+
+fn mixers(root: &std::path::Path) -> Vec<String> {
+    let v = layers_facts(root).unwrap();
+    v["layers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["mixer"].as_str().unwrap().to_string())
+        .collect()
+}
+
+fn roles(root: &std::path::Path, address: &str) -> Vec<String> {
+    let v = describe_facts(root, address, 2, None).unwrap();
+    assert!(
+        v["undescribed"].is_null(),
+        "{address} rendered no operand table: {v}"
+    );
+    v["operands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|o| o["role"].as_str().unwrap().to_string())
+        .collect()
+}
+
+/// Qwen3.8's vocabulary: a Gated DeltaNet recurrence against gated
+/// softmax attention, at the LLLF cadence.
+#[test]
+fn the_gated_delta_hybrid_names_both_of_its_programmes() {
+    let dir = encoded(hybrid_lllf_f32_model, "vindex-cli-lllf");
+    assert_eq!(
+        mixers(dir.path()),
+        vec![
+            "GATED DELTANET",
+            "GATED DELTANET",
+            "GATED DELTANET",
+            "SOFTMAX ATTENTION",
+        ]
+    );
+
+    assert_eq!(
+        roles(dir.path(), "layer.0.mixer"),
+        vec![
+            "fused recurrent q|k|v",
+            "decay projection",
+            "write-strength projection",
+            "output-gate projection",
+            "causal conv over q|k|v",
+            "log decay",
+            "timestep bias",
+            "gated norm",
+            "output projection",
+        ]
+    );
+    assert_eq!(
+        roles(dir.path(), "layer.3.mixer"),
+        vec!["query", "key", "value", "output"]
+    );
+}
+
+/// The gate is an operand, not an operator: the same softmax mixer
+/// answers `GATED ATTENTION` when the layer ships a fused output gate
+/// and `SOFTMAX ATTENTION` when it does not. Qwen3.8's full-attention
+/// layers are the gated kind, so the label the film shows is this one.
+///
+/// `SOFTMAX ATTENTION` rather than a bare `ATTENTION` for the ungated
+/// case on purpose — gated attention is *also* softmax attention, and
+/// a pair reading `ATTENTION` / `GATED ATTENTION` would suggest the
+/// gate replaces the softmax rather than following it.
+#[test]
+fn the_output_gate_refines_the_softmax_label_without_replacing_it() {
+    let dir = encoded(gated_q_f32_model, "vindex-cli-gated");
+    let seen = mixers(dir.path());
+    assert!(
+        seen.iter().all(|m| m == "GATED ATTENTION"),
+        "every layer of the fused-gate fixture is gated: {seen:?}"
+    );
+    assert!(
+        roles(dir.path(), "layer.0.mixer").contains(&"output gate".to_string()),
+        "the gate must appear as an operand, not only in the label"
+    );
+}
+
+/// Kimi Linear's vocabulary: KDA against MLA, at the `KKKM` cadence.
+/// The container that exposed the defect, in miniature.
+#[test]
+fn the_kda_mla_hybrid_names_both_of_its_programmes() {
+    let dir = encoded(hybrid_kda_mla_f32_model, "vindex-cli-kimi");
+    assert_eq!(mixers(dir.path()), vec!["KDA", "KDA", "KDA", "MLA"]);
+}
+
+/// KDA is fifteen operands split where Gated DeltaNet fuses — the
+/// structural difference that makes reading one as the other bind the
+/// wrong tensors to the wrong roles at plausible shapes.
+#[test]
+fn a_kda_layer_describes_its_own_fifteen_operands() {
+    let dir = encoded(hybrid_kda_mla_f32_model, "vindex-cli-kimi");
+    assert_eq!(
+        roles(dir.path(), "layer.0.mixer"),
+        vec![
+            "query projection",
+            "key projection",
+            "value projection",
+            "causal conv over q",
+            "causal conv over k",
+            "causal conv over v",
+            "decay gate down",
+            "decay gate up",
+            "output gate down",
+            "output gate up",
+            "write-strength projection",
+            "log decay",
+            "timestep bias",
+            "gated norm",
+            "output projection",
+        ]
+    );
+}
+
+/// MLA's five, on a layer whose `q_proj`/`o_proj` are byte-identical
+/// spellings to the softmax set. Naming them by role is the whole
+/// distinction.
+#[test]
+fn an_mla_layer_describes_the_compressed_kv_set_not_qkvo() {
+    let dir = encoded(hybrid_kda_mla_f32_model, "vindex-cli-kimi");
+    assert_eq!(
+        roles(dir.path(), "layer.3.mixer"),
+        vec![
+            "query projection",
+            "compressed kv projection",
+            "kv latent norm",
+            "kv decompression",
+            "output projection",
+        ]
+    );
+}
+
+/// The regression in its purest form: no layer of either hybrid may
+/// answer with an empty operand table. An empty table was the shape
+/// the wrong answer took.
+#[test]
+fn no_layer_of_either_hybrid_answers_with_an_empty_table() {
+    for (write, name) in [
+        (hybrid_lllf_f32_model as fn(&std::path::Path), "lllf"),
+        (hybrid_kda_mla_f32_model as fn(&std::path::Path), "kimi"),
+    ] {
+        let dir = encoded(write, name);
+        for n in 0..4 {
+            let ops = roles(dir.path(), &format!("layer.{n}.mixer"));
+            assert!(!ops.is_empty(), "{name} layer {n} described no operands");
+        }
+    }
+}
+
+/// The q/k/v/o refusal must name the operator the graph declares —
+/// the message that previously asserted GATED DELTANET over an MLA
+/// layer.
+#[test]
+fn the_qkvo_refusal_names_the_operator_the_graph_declares() {
+    let dir = encoded(hybrid_kda_mla_f32_model, "vindex-cli-kimi");
+
+    let kda = describe_facts(dir.path(), "layer.0.attention.q", 2, None).unwrap_err();
+    assert!(kda.contains("token mixer is KDA"), "{kda}");
+    assert!(kda.contains("layer.0.mixer"), "{kda}");
+
+    let mla = describe_facts(dir.path(), "layer.3.attention.q", 2, None).unwrap_err();
+    assert!(mla.contains("token mixer is MLA"), "{mla}");
+    assert!(
+        !mla.contains("GATED DELTANET"),
+        "an MLA layer must never be described as a recurrence: {mla}"
+    );
+}
+
+/// The precision matrix groups by the declared programme, so a hybrid
+/// yields two groups whose columns are each operator's own — never one
+/// group wearing the other's schema.
+#[test]
+fn the_precision_matrix_groups_a_hybrid_by_declared_programme() {
+    let dir = encoded(hybrid_kda_mla_f32_model, "vindex-cli-kimi");
+    let v = precision_matrix_facts(dir.path()).unwrap();
+    let programmes = v["programmes"].as_array().unwrap();
+    let labels: Vec<&str> = programmes
+        .iter()
+        .map(|p| p["label"].as_str().unwrap())
+        .collect();
+    assert_eq!(labels, vec!["KDA", "MLA"], "{v}");
+    assert_eq!(programmes[0]["layers"], 3, "{v}");
+    assert_eq!(programmes[1]["layers"], 1, "{v}");
+
+    let kda_cols: Vec<&str> = programmes[0]["roles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_str().unwrap())
+        .collect();
+    assert!(kda_cols.contains(&"qconv"), "{kda_cols:?}");
+    assert!(kda_cols.contains(&"fa"), "{kda_cols:?}");
+    let mla_cols: Vec<&str> = programmes[1]["roles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_str().unwrap())
+        .collect();
+    assert!(mla_cols.contains(&"kv_a"), "{mla_cols:?}");
+    assert!(mla_cols.contains(&"kv_b"), "{mla_cols:?}");
+    assert!(
+        !mla_cols.contains(&"qconv"),
+        "MLA must not carry KDA's columns: {mla_cols:?}"
+    );
+}
+
+/// An out-of-range layer names an inclusive range. `0..4` is Rust's
+/// half-open spelling and reads to everyone else as five layers.
+#[test]
+fn an_out_of_range_layer_names_an_inclusive_range() {
+    let dir = encoded(hybrid_kda_mla_f32_model, "vindex-cli-kimi");
+    let err = describe_facts(dir.path(), "layer.9.mixer", 2, None).unwrap_err();
+    assert!(err.contains("the plan holds layers 0\u{2013}3"), "{err}");
+}
+
+/// What the gated-attention programme's matrix columns actually are —
+/// pinned because the film shows this table and the script must quote
+/// the columns that render, not the ones it expects.
+#[test]
+fn the_gated_attention_matrix_carries_a_zgate_column() {
+    let dir = encoded(gated_q_f32_model, "vindex-cli-gated");
+    let v = precision_matrix_facts(dir.path()).unwrap();
+    let p = &v["programmes"][0];
+    assert_eq!(p["label"], "GATED ATTENTION", "{v}");
+    let cols: Vec<&str> = p["roles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        cols,
+        vec!["gate", "up", "down", "q", "k", "v", "o", "zgate"],
+        "{v}"
+    );
+}


### PR DESCRIPTION
Merges `vindex-mixer-operator` into `main`. Both of the things the
quantization film's §4:45 and §8:00 rest on were on that branch and
neither was on `main`.

## What this brings

**`131d8e19` — token-mixer identity from the declared operator.**
Before it, `mixer_label` was binary: softmax, or the hardcoded string
`"GATED DELTANET"`. Every non-softmax mixer collapsed to that label.
Verified against the real 92 GB Kimi-Linear container on current `main`:

```
vindex describe $KIMI layer.0.mixer  →  GATED DELTANET   (empty operand table)
vindex describe $KIMI layer.3.mixer  →  GATED DELTANET   (empty operand table)
vindex layers $KIMI                  →  0–26  GATED DELTANET
```

The container is not at fault — its graph correctly declares
`operator: "kda"` for 0,1,2,4… and `"mla"` for 3. The CLI had no
KDA/MLA vocabulary. After the merge:

```
0         KDA                ffn dense
1–2       KDA                ffn routed
3         MLA                ffn routed
```

**`26980601` — NVFP4 on the CPU.** A Gated DeltaNet model can now be
measured in the representation that was requested, rather than being
quietly dequantised to BF16 first.

## Conflicts

Two, both because `main`'s conv-QKV work landed after the branch was
cut. Both resolved toward keeping every fact rather than widening a
match:

- **`tests/mamba2.rs`** — `main` split `miniature_mamba2` into a
  `spartan` variant; the branch made it `pub(crate)` for
  `plan_roles_tests`. Kept both: the split, with the wrapper exported.
- **`LayerAttention::ConvQkv` uncovered** by the branch's new matches.
  `plan_roles` now classifies it explicitly — conv-QKV attends by
  softmax and keeps a per-position cache, so its two matmuls are
  `DecoderLinear` and its depthwise kernel is a `SmallVector`, the same
  shape every other operator's conv is. `mixer.rs` labels it
  `CONV-QKV ATTENTION`, matching the knowledge graph's own name.
  A wildcard arm would have compiled and silently misclassified.

## Verification

`cargo test --release -p larql-vindex -p vindex-cli` — **3,720 passed,
0 failed**, 38 suites. Release build clean.

Every command in the quantization film's script was then run against the
real Qwen3.8-27B and Kimi-Linear containers on this merge: `describe`,
`diff`, `representations`, `layers`, `precision --matrix`, `verify`
(all six representations `ok`), and both documented refusals.