### PR TITLE
test(vindex3): cover the NVFP4 slab and decode paths

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/mod.rs
@@ -7,6 +7,7 @@ mod executor;
 mod integer;
 mod kernels;
 mod ledger;
+mod nvfp4_slab;
 mod physical;
 mod projection_cost;
 mod q8;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/nvfp4_slab.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/nvfp4_slab.rs
@@ -1,0 +1,167 @@
+//! The NVFP4 slab path: how a compiled pack becomes rows a kernel can
+//! consume, and what it refuses rather than guess.
+//!
+//! This is the seam the fidelity claim rests on. When a quality run says
+//! it measured NVFP4, what it measured is whatever these functions
+//! handed the kernel — so the partitioning has to be exact and the
+//! mismatches have to refuse. A slab that silently handed back the wrong
+//! scales would produce finite, plausible numbers and a fidelity figure
+//! describing a representation nobody asked for.
+//!
+//! Two levels of scale are the whole reason NVFP4 exists and the whole
+//! reason this needs its own test: the E4M3 group scales are per sixteen
+//! elements along the input axis and must be cut alongside the codes,
+//! while the f32 tensor scale is matrix-wide and travels with every slab
+//! unchanged.
+
+use super::super::super::backend::{WeightFormat, WeightSlice};
+use super::super::physical::PhysicalProjectionPlan;
+use super::super::projector::WeightRows;
+use larql_models::quant::nvfp4::{NVFP4_GROUP_BYTES, NVFP4_GROUP_ELEMS};
+
+/// A pack whose bytes are positionally identifiable: code byte `i` holds
+/// `i`, scale byte `i` holds `i`. Nothing here is decoded — these tests
+/// ask which bytes a slab hands over, not what they denote.
+fn pack(rows: usize, k: usize) -> (Vec<u8>, Vec<u8>) {
+    let groups = k / NVFP4_GROUP_ELEMS;
+    let packed = (0..rows * groups * NVFP4_GROUP_BYTES)
+        .map(|i| (i % 251) as u8)
+        .collect();
+    let scales = (0..rows * groups).map(|i| (i % 241) as u8).collect();
+    (packed, scales)
+}
+
+const TENSOR_SCALE: f32 = 0.125;
+
+#[test]
+fn a_pack_becomes_rows_and_reports_them_from_its_own_bytes() {
+    let (packed, scales) = pack(4, 32);
+    let slice = WeightSlice::Nvfp4 {
+        packed: &packed,
+        scales: &scales,
+        tensor_scale: TENSOR_SCALE,
+    };
+    let rows = slice.rows(4, 32).expect("a well-formed pack yields rows");
+    assert_eq!(rows.rows(32), 4, "row count is derived, not asserted");
+    // 32 elements = 2 groups = 16 code bytes per row.
+    assert_eq!(rows.bytes(), 4 * 16 + 4 * 2, "codes plus group scales");
+}
+
+/// The tensor scale is matrix-wide. A slab that rescaled it per
+/// partition would change what the weights denote depending on how the
+/// work was divided.
+#[test]
+fn slicing_rows_cuts_codes_and_scales_together_and_keeps_the_tensor_scale() {
+    let (packed, scales) = pack(4, 32);
+    let all = WeightRows::Nvfp4 {
+        packed: &packed,
+        scales: &scales,
+        tensor_scale: TENSOR_SCALE,
+    };
+
+    let slab = all.slice_rows(32, 2, 2);
+    let WeightRows::Nvfp4 {
+        packed: p,
+        scales: s,
+        tensor_scale,
+    } = slab
+    else {
+        panic!("slicing an NVFP4 slab must yield an NVFP4 slab");
+    };
+
+    assert_eq!(slab.rows(32), 2);
+    assert_eq!(tensor_scale, TENSOR_SCALE, "matrix-wide, never re-derived");
+    // Row 2 starts at code byte 2*16 and scale 2*2 — the two streams cut
+    // at the same row, which is the property that matters.
+    assert_eq!(p, &packed[32..64], "codes start at the requested row");
+    assert_eq!(s, &scales[4..8], "scales start at the SAME row");
+}
+
+/// Groups run along the input axis, so a width that is not a multiple of
+/// the group size means this pack does not describe these rows. The
+/// format's own constant decides, not a policy.
+#[test]
+fn a_width_that_is_not_a_whole_number_of_groups_refuses() {
+    let (packed, scales) = pack(2, 32);
+    let slice = WeightSlice::Nvfp4 {
+        packed: &packed,
+        scales: &scales,
+        tensor_scale: TENSOR_SCALE,
+    };
+    let err = slice
+        .rows(2, NVFP4_GROUP_ELEMS + 1)
+        .expect_err("a partial group must refuse");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not a multiple") && msg.contains("does not describe these rows"),
+        "the refusal must say why, not just fail: {msg}"
+    );
+}
+
+/// A pack too short for the rows asked of it refuses rather than
+/// handing back the rows it happens to have.
+#[test]
+fn a_short_pack_refuses_rather_than_returning_fewer_rows() {
+    let (packed, scales) = pack(2, 32);
+    let slice = WeightSlice::Nvfp4 {
+        packed: &packed,
+        scales: &scales,
+        tensor_scale: TENSOR_SCALE,
+    };
+    assert!(
+        slice.rows(4, 32).is_err(),
+        "four rows from a two-row pack must refuse"
+    );
+}
+
+/// Scales are indexed independently of codes, so a pack with enough
+/// codes and too few scales must refuse too — the arm that would
+/// otherwise hand a worker another row's scales.
+#[test]
+fn enough_codes_but_too_few_scales_still_refuses() {
+    let (packed, scales) = pack(4, 32);
+    let short_scales = &scales[..scales.len() - 1];
+    let slice = WeightSlice::Nvfp4 {
+        packed: &packed,
+        scales: short_scales,
+        tensor_scale: TENSOR_SCALE,
+    };
+    assert!(
+        slice.rows(4, 32).is_err(),
+        "codes alone do not make a slab valid"
+    );
+}
+
+/// **The kernel is chosen by the representation, not by the arm.**
+///
+/// Every other format has an arithmetic arm that can move it between
+/// kernels — Q8 bytes are consumable by a widening f32 kernel and by
+/// SDOT alike, so a policy decides. NVFP4 has no such choice: its two
+/// scale levels are not expressible as the single per-block f32 the
+/// integer paths assume, so there is exactly one kernel and no arm
+/// enters into it.
+///
+/// This is the mechanical half of the claim a fidelity run depends on.
+/// If some arm could route NVFP4 bytes to a kernel that widened them
+/// first, a quality number would describe a representation nobody
+/// requested — and it would still be finite, plausible, and wrong.
+#[test]
+fn nvfp4_has_one_kernel_and_no_arithmetic_arm_can_move_it() {
+    let (packed, scales) = pack(4, 32);
+    let rows = WeightRows::Nvfp4 {
+        packed: &packed,
+        scales: &scales,
+        tensor_scale: TENSOR_SCALE,
+    };
+    let plan = PhysicalProjectionPlan::for_resident(rows, 32);
+    assert_eq!(
+        plan,
+        PhysicalProjectionPlan::FusedNvfp4,
+        "NVFP4 resolves to its own kernel"
+    );
+    assert_eq!(
+        plan.format(),
+        WeightFormat::Nvfp4,
+        "and the plan reports the format it actually runs"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -49,6 +49,7 @@ mod mla_metal;
 mod mla_parity;
 mod mla_refusal;
 mod mrope_parity;
+mod nvfp4_decode;
 mod output_gate_fused;
 mod plan_fixtures;
 mod projection_bench;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/nvfp4_decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/nvfp4_decode.rs
@@ -1,0 +1,99 @@
+//! Decoding a stored NVFP4 pack back to f32, through the format's own
+//! layout and the reference decoder.
+//!
+//! This closes the loop the fidelity claim runs around: values are
+//! quantised, framed into a pack, stored, and read back. If the framing
+//! and the decode disagreed about where the scales begin, everything
+//! downstream would still produce numbers — the decode would simply be
+//! reading group scales as codes — and a quality run would report a
+//! fidelity figure for a representation that never existed.
+//!
+//! The round trip is asserted to a tolerance rather than exactly,
+//! because NVFP4 is lossy by construction and this test is about the
+//! plumbing, not the format's accuracy. What must be exact is the
+//! SHAPE: the same count of values, in the same order.
+
+use crate::format::vindex3::opplan::exec::operands::decode_nvfp4_operand;
+use crate::format::vindex3::represent::nvfp4_pack::{encode, PackLayout};
+
+const ROWS: usize = 3;
+/// A multiple of the 16-element group, as the format requires.
+const K: usize = 32;
+
+fn values() -> Vec<f32> {
+    // A spread wide enough that the two scale levels both do work, and
+    // deterministic so a failure is reproducible.
+    (0..ROWS * K)
+        .map(|i| {
+            let x = (i % 17) as f32 - 8.0;
+            x * 0.03125 * if i % 3 == 0 { 4.0 } else { 1.0 }
+        })
+        .collect()
+}
+
+#[test]
+fn a_pack_round_trips_through_its_own_layout() {
+    let original = values();
+    let shape = [ROWS, K];
+    let layout = PackLayout::derive(&shape, "round-trip").expect("a 16-multiple width is legal");
+    let matrix = larql_models::quant::nvfp4::quantize(&original, ROWS, K).expect("quantise");
+    let stored = encode(&matrix, &layout, "round-trip").expect("frame the pack");
+
+    // The three regions plus the tensor scale, and nothing else.
+    assert_eq!(
+        stored.len(),
+        layout.total_len,
+        "the framed pack is exactly the layout's size"
+    );
+
+    let decoded = decode_nvfp4_operand(&stored, &shape, "round-trip").expect("decode");
+    assert_eq!(
+        decoded.len(),
+        original.len(),
+        "decode returns the shape it was given, not the shape it inferred"
+    );
+
+    // Lossy by construction — but every value must land near its
+    // original, in its original position. A framing error would scatter
+    // them, not merely round them.
+    let worst = original
+        .iter()
+        .zip(&decoded)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    let span = original.iter().fold(0.0f32, |m, v| m.max(v.abs()));
+    assert!(
+        worst <= span * 0.25,
+        "max deviation {worst} is too large for span {span} — this is a framing error, not rounding"
+    );
+}
+
+/// The width is the format's business, not the caller's. A shape that is
+/// not a whole number of groups cannot be framed, and the refusal
+/// happens at layout derivation — before any bytes are written or read.
+#[test]
+fn a_width_that_is_not_a_whole_number_of_groups_cannot_be_laid_out() {
+    let err =
+        PackLayout::derive(&[ROWS, K + 1], "ragged").expect_err("a partial group must refuse");
+    assert!(
+        err.to_string().contains("ragged"),
+        "the refusal names the tensor it refused: {err}"
+    );
+}
+
+/// A payload shorter than its own layout is refused rather than decoded
+/// from whatever bytes happen to be present.
+#[test]
+fn a_truncated_pack_refuses_rather_than_decoding_what_is_there() {
+    let original = values();
+    let shape = [ROWS, K];
+    let layout = PackLayout::derive(&shape, "truncated").unwrap();
+    let matrix = larql_models::quant::nvfp4::quantize(&original, ROWS, K).unwrap();
+    let stored = encode(&matrix, &layout, "truncated").unwrap();
+
+    let short = &stored[..stored.len() - 1];
+    assert!(
+        decode_nvfp4_operand(short, &shape, "truncated").is_err(),
+        "one byte short is still short"
+    );
+}


### PR DESCRIPTION
Pays down the coverage debt #354 merged red, and covers the seam the
fidelity claim rests on.

## Why these tests, and not just any tests

When a quality run reports a number for NVFP4, what it measured is
whatever the slab path handed the kernel. Every failure mode here
produces finite, plausible values attached to a representation that
never ran — the one error a fidelity figure cannot survive and cannot
itself detect. The tests are written around that property rather than
around the uncovered lines:

- Slicing a slab cuts codes and their E4M3 group scales at the **same
  row**, while the f32 tensor scale is matrix-wide and travels
  unchanged. A partition moving one and not the other hands a worker
  the right weights under another row's scales.
- **NVFP4 resolves to one kernel and no arithmetic arm can move it.**
  Every other format has an arm that can route it between kernels;
  NVFP4's two scale levels are not expressible as the single per-block
  f32 the integer paths assume, so there is no choice to get wrong.
- Ragged widths, short packs, and enough-codes-too-few-scales all
  refuse — and the width refusal says why.
- `quantise → encode → decode` round-trips through the format's own
  layout: shape exact, values within tolerance. A framing error would
  scatter values rather than round them, which is what the tolerance
  distinguishes.

## Result

Three files clear their floor:

```
backend.rs    86.99% -> 99.32%
projector.rs  82.61% -> 97.83%
operands.rs   86.99% -> 91.91%
```

Three do not, and are deliberately left alone — each is already the
class the coverage policy documents as *unreachable* rather than
untested:

| file | why |
|---|---|
| `kernels.rs` | uncovered lines are inside `q4_block_dot_neon`, `#[cfg(target_arch = "aarch64")]` — they run on an M-series Mac and do not exist on the ubuntu/windows runners |
| `physical.rs` | the `OnceLock`-cached `arithmetic_arm()` / `q4_classes()` readers; one arm resolves per test binary, the rest unreachable in that process |
| `replay.rs` | the CPU-PERF-3B harness against a real resident model; already a debt baseline that drifts when the recorded call widens |

**Their baselines are not adjusted in this PR, on purpose.** The numbers
to set them from are the ubuntu job's, not this machine's: CI measures
`kernels.rs` at 85.71% where aarch64 measures 89.24%, precisely because
the NEON path does not compile there. Setting a gate from the wrong
architecture is how it becomes quietly wrong. Once this PR's CI reports
real x86_64 figures, the three baselines can be set from those in a
follow-up with the reason recorded.

3,731 tests pass locally.