### PR TITLE
Cover lift 2's new seams — the four files the coverage policy caught

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/continuation.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/continuation.rs
@@ -227,6 +227,23 @@ impl LayerContinuationGeometry {
     }
 }
 
+/// What a layer keeps, in words — the one place this vocabulary lives.
+///
+/// A refusal that says "recurrent" for a layer holding a growing latent
+/// cache sends its reader to the wrong seam, so the naming is a function
+/// rather than a phrase repeated at each refusal site.
+pub fn region_name(geometry: &LayerContinuationGeometry) -> &'static str {
+    match geometry {
+        LayerContinuationGeometry::Kv(_) => "sequence-indexed KV rows",
+        LayerContinuationGeometry::LatentKv(_) => {
+            "a per-position LATENT cache, one operator-defined row per position"
+        }
+        LayerContinuationGeometry::Recurrent(_) => "recurrent continuation state",
+        LayerContinuationGeometry::KvAndRecurrent { .. } => "KV rows AND recurrent buffers",
+        LayerContinuationGeometry::Stateless => "no continuation state at all",
+    }
+}
+
 /// Every layer's continuation requirement, in layer order.
 ///
 /// The authoritative seam. [`plan_kv_geometry`](super::kv::plan_kv_geometry)

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/kv.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/kv.rs
@@ -73,18 +73,7 @@ pub fn try_plan_kv_geometry(plan: &ComponentOpPlan) -> Result<Vec<LayerKvGeometr
                 // only alternative to rows when this adapter was
                 // written; a latent cache is a third answer, and a
                 // caller told the wrong one looks for the wrong seam.
-                let region = match geometry {
-                    LayerContinuationGeometry::Recurrent(_) => "recurrent continuation state",
-                    LayerContinuationGeometry::LatentKv(_) => {
-                        "a per-position LATENT cache, one operator-defined row per position"
-                    }
-                    LayerContinuationGeometry::KvAndRecurrent { .. } => {
-                        "KV rows AND recurrent buffers"
-                    }
-                    LayerContinuationGeometry::Kv(_) | LayerContinuationGeometry::Stateless => {
-                        "no KV rows"
-                    }
-                };
+                let region = super::continuation::region_name(geometry);
                 format!(
                     "layer {index} carries {region}, not a plain KV cache; this model \
                      needs `plan_continuation_geometry`, which describes every form"

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/continuation.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/continuation.rs
@@ -644,3 +644,112 @@ fn the_two_region_state_allocates_rows_and_buffer_together() {
     // only the buffer — the region that exists from step zero.
     assert_eq!(state.elements_at(5), 32);
 }
+
+/// **The latent species, exercised end to end at the storage seam** —
+/// the accessors, the allocation, and the arithmetic that separates a
+/// growing cache from a constant-size one.
+///
+/// These are small surfaces, and small surfaces are exactly where a
+/// third species goes wrong quietly: an accessor that answers for the
+/// wrong arm, or an `elements_at` that counts a latent row twice as a
+/// K/V pair would, produce plausible numbers a summary would print
+/// without complaint.
+#[test]
+fn the_latent_species_allocates_reads_and_grows_as_declared() {
+    use super::super::continuation::{LatentKvRows, LayerLatentKvGeometry};
+
+    const WIDTH: usize = 7;
+    let geometry = [
+        LayerContinuationGeometry::LatentKv(LayerLatentKvGeometry { width: WIDTH }),
+        LayerContinuationGeometry::Stateless,
+    ];
+
+    // The geometry answers for its own arm and no other.
+    assert_eq!(geometry[0].latent_kv().map(|l| l.width), Some(WIDTH));
+    assert!(geometry[0].kv().is_none() && geometry[0].kv_side().is_none());
+    assert!(geometry[0].recurrent().is_none());
+    assert!(geometry[1].latent_kv().is_none());
+
+    // ONE row per position, not two: the compression is visible here.
+    assert_eq!(geometry[0].elements_at(0), 0);
+    assert_eq!(geometry[0].elements_at(5), WIDTH * 5);
+
+    let mut state = ContinuationState::prepare(&geometry);
+    let rows = state
+        .layer_mut(0)
+        .latent_kv_mut()
+        .expect("layer 0 keeps latent rows");
+    // `len` and `is_empty` are separate accessors and both are read by
+    // the census, so both are pinned rather than one standing in.
+    assert_eq!(rows.len(), 0);
+    assert!(rows.is_empty() && rows.rows().is_empty());
+    rows.append(vec![1.0; WIDTH]);
+    rows.append(vec![2.0; WIDTH]);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows.rows()[1][0], 2.0);
+
+    // Read-only accessor, and the arms that must NOT answer for it.
+    assert_eq!(state.layer(0).latent_kv().map(LatentKvRows::len), Some(2));
+    assert!(state.layer(0).recurrent().is_none());
+    assert!(state.layer(1).latent_kv().is_none());
+    assert!(state.layer_mut(1).latent_kv_mut().is_none());
+
+    // The runtime state's own accounting learns the width from the rows
+    // it holds — the same convention the KV arm uses.
+    assert_eq!(state.elements_at(2), WIDTH * 2);
+}
+
+/// **The region vocabulary answers for every species** — the words a
+/// refusal uses to send its reader to the right seam.
+///
+/// One assertion per arm, because a single "it refused" would pass with
+/// every message wrong, and the message is the whole value here: a
+/// caller told "recurrent" when the layer keeps a growing latent cache
+/// looks for the wrong provider.
+#[test]
+fn every_continuation_species_names_itself() {
+    use super::super::continuation::{region_name, LayerLatentKvGeometry, RecurrentBufferGeometry};
+
+    let buffer = RecurrentBufferGeometry {
+        shape: vec![2, 2],
+        dtype: super::super::super::gated_delta::StateDtype::Float32,
+        initialization: StateInitialization::Zeros,
+    };
+    let kv = LayerKvGeometry {
+        kv_dim: 4,
+        window: None,
+    };
+    let cases = [
+        (LayerContinuationGeometry::Kv(kv), "KV rows"),
+        (
+            LayerContinuationGeometry::LatentKv(LayerLatentKvGeometry { width: 7 }),
+            "LATENT cache",
+        ),
+        (
+            LayerContinuationGeometry::Recurrent(RecurrentGeometry::single(buffer.clone())),
+            "recurrent",
+        ),
+        (
+            LayerContinuationGeometry::KvAndRecurrent {
+                kv,
+                recurrent: RecurrentGeometry::single(buffer),
+            },
+            "KV rows AND recurrent",
+        ),
+        (
+            LayerContinuationGeometry::Stateless,
+            "no continuation state",
+        ),
+    ];
+    for (geometry, expected) in &cases {
+        assert!(
+            region_name(geometry).contains(expected),
+            "{geometry:?} must name itself as {expected}, said {}",
+            region_name(geometry)
+        );
+    }
+    // No two species share a name — the whole point of naming them.
+    let names: std::collections::BTreeSet<&str> =
+        cases.iter().map(|(g, _)| region_name(g)).collect();
+    assert_eq!(names.len(), cases.len());
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kv.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kv.rs
@@ -314,3 +314,132 @@ fn the_provider_learns_geometry_from_the_plan_and_keeps_the_rows() {
         assert_eq!(kv.values(layer).len(), G_TOKENS.len());
     }
 }
+
+/// **Announcement, not reset** — the contract every region shares.
+///
+/// A provider is announced its geometry before each traversal, and a
+/// prefilled state being resumed must keep what it holds: rows,
+/// recurrent buffers and latent rows alike. Re-announcing is how a long
+/// prompt prefills in chunks and how a decode session continues after
+/// one, so a reset here would silently restart the conversation while
+/// every shape still matched.
+#[test]
+fn re_announcing_the_geometry_keeps_every_region_it_already_holds() {
+    use super::super::continuation::{
+        LayerContinuationGeometry, LayerLatentKvGeometry, RecurrentBufferGeometry,
+        RecurrentGeometry, StateInitialization,
+    };
+    use super::super::kv::{ContinuationProvider, LayerKvGeometry, RowKvState};
+
+    let geometry = [
+        LayerContinuationGeometry::Kv(LayerKvGeometry {
+            kv_dim: 2,
+            window: None,
+        }),
+        LayerContinuationGeometry::Recurrent(RecurrentGeometry::single(RecurrentBufferGeometry {
+            shape: vec![2, 2],
+            dtype: larql_models::inventory::report::RecurrentStateDtype::Float32,
+            initialization: StateInitialization::Zeros,
+        })),
+        LayerContinuationGeometry::LatentKv(LayerLatentKvGeometry { width: 3 }),
+    ];
+
+    let mut provider = RowKvState::default();
+    provider.prepare_continuation(&geometry).unwrap();
+
+    // Fill one of each region, and advance the logical position.
+    provider.append(0, vec![1.0, 2.0], vec![3.0, 4.0]);
+    provider
+        .recurrent_state(1)
+        .unwrap()
+        .buffer_mut(0)
+        .cells_mut()[0] = 9.0;
+    provider
+        .latent_state(2)
+        .unwrap()
+        .append(vec![5.0, 6.0, 7.0]);
+    provider.set_position(1);
+
+    // The same geometry, announced again — as the next traversal does.
+    provider.prepare_continuation(&geometry).unwrap();
+
+    assert_eq!(provider.keys(0), &[vec![1.0, 2.0]], "rows survive");
+    assert_eq!(
+        provider.recurrent_state(1).unwrap().buffer(0).cells()[0],
+        9.0,
+        "recurrent buffers survive"
+    );
+    assert_eq!(
+        provider.latent_state(2).unwrap().rows(),
+        &[vec![5.0, 6.0, 7.0]],
+        "latent rows survive — the region added last is not the one that resets"
+    );
+    assert_eq!(provider.position(), 1, "and so does the logical position");
+
+    // The plain KV announcement takes the same path.
+    provider.prepare(
+        &[LayerKvGeometry {
+            kv_dim: 2,
+            window: None,
+        }; 3],
+    );
+    assert_eq!(provider.keys(0).len(), 1, "still one row after re-prepare");
+}
+
+/// Every refusal says which provider, which layer, and which region —
+/// the three things a caller needs to act on one.
+///
+/// Asserted per variant rather than through one formatted string,
+/// because these messages are the seam's whole diagnostic surface and a
+/// copy-paste between arms is exactly the defect that would survive a
+/// looser test.
+#[test]
+fn each_continuation_refusal_names_provider_layer_and_region() {
+    use super::super::kv::ContinuationError;
+
+    let cases = [
+        (
+            ContinuationError::RecurrentUnsupported {
+                provider: "P",
+                layer: 3,
+            },
+            ["holds no recurrent state", "layer 3"],
+        ),
+        (
+            ContinuationError::NotRecurrent {
+                provider: "P",
+                layer: 3,
+            },
+            ["not a recurrent layer", "dispatch bug"],
+        ),
+        (
+            ContinuationError::LatentUnsupported {
+                provider: "P",
+                layer: 3,
+            },
+            ["no per-position latent cache", "layer 3"],
+        ),
+        (
+            ContinuationError::NotLatent {
+                provider: "P",
+                layer: 3,
+            },
+            ["keeps no latent cache", "dispatch bug"],
+        ),
+    ];
+    for (error, expected) in &cases {
+        let rendered = error.to_string();
+        assert!(rendered.contains('P'), "{rendered}");
+        for phrase in expected {
+            assert!(
+                rendered.contains(phrase),
+                "{error:?} rendered as {rendered}"
+            );
+        }
+    }
+    // The four render differently — a shared message would make the
+    // wrong half of a hybrid look like the missing one.
+    let rendered: std::collections::BTreeSet<String> =
+        cases.iter().map(|(e, _)| e.to_string()).collect();
+    assert_eq!(rendered.len(), cases.len());
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/kda_mla_exec.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/kda_mla_exec.rs
@@ -431,3 +431,153 @@ fn the_kda_mla_stack_executes_and_every_state_species_survives_the_step() {
         "the decode step path diverged from batch prefill"
     );
 }
+
+/// **A provider that knows recurrences but not caches is refused before
+/// any output** — and told which region it is missing.
+///
+/// The realistic migration case: every provider in the tree could hold
+/// recurrent buffers before MLA executed, and a latent cache is the new
+/// requirement. Refusing at announcement, rather than at the layer, is
+/// what stops a caller being handed the first two layers of a model and
+/// having no way to tell that from a finished one.
+#[test]
+fn a_provider_without_latent_rows_is_refused_at_announcement() {
+    use crate::format::vindex3::inspect::inspect_container;
+    use crate::format::vindex3::opplan::exec::continuation::{LatentKvRows, RecurrentState};
+    use crate::format::vindex3::opplan::exec::kv::{
+        ContinuationError, ContinuationProvider, LayerKvGeometry, RowKvState,
+    };
+    use crate::format::vindex3::opplan::exec::operands::OperandStore;
+    use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+    use crate::format::vindex3::opplan::plan_component_ops;
+
+    /// Holds rows and recurrent buffers — everything that existed
+    /// before the latent cache did — and says plainly it holds no cache.
+    #[derive(Default)]
+    struct NoLatent(RowKvState);
+    impl ContinuationProvider for NoLatent {
+        fn prepare(&mut self, layers: &[LayerKvGeometry]) {
+            self.0.prepare(layers)
+        }
+        fn append(&mut self, layer: usize, key: Vec<f32>, value: Vec<f32>) {
+            self.0.append(layer, key, value)
+        }
+        fn keys(&self, layer: usize) -> &[Vec<f32>] {
+            self.0.keys(layer)
+        }
+        fn values(&self, layer: usize) -> &[Vec<f32>] {
+            self.0.values(layer)
+        }
+        fn position(&self) -> usize {
+            self.0.position()
+        }
+        fn set_position(&mut self, position: usize) {
+            self.0.set_position(position)
+        }
+        fn prepare_continuation(
+            &mut self,
+            layers: &[crate::format::vindex3::opplan::exec::continuation::LayerContinuationGeometry],
+        ) -> Result<(), ContinuationError> {
+            // Allocates the recurrent side happily; the latent side is
+            // simply not something this provider has.
+            self.0.prepare_continuation(layers)
+        }
+        fn recurrent_state(
+            &mut self,
+            layer: usize,
+        ) -> Result<&mut RecurrentState, ContinuationError> {
+            self.0.recurrent_state(layer)
+        }
+        fn latent_state(&mut self, layer: usize) -> Result<&mut LatentKvRows, ContinuationError> {
+            Err(ContinuationError::LatentUnsupported {
+                provider: "NoLatent",
+                layer,
+            })
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    miniature_kimi(dir.path());
+    let out = tempfile::tempdir().unwrap();
+    let container = out.path().join("kimi-mini.vindex3");
+    encode_checkpoint(dir.path(), &container).unwrap();
+    let inspection = inspect_container(&container, false).unwrap();
+    let plan = plan_component_ops(&inspection, &container, "target")
+        .unwrap()
+        .plan
+        .expect("closure held");
+    let store = OperandStore::open(&container, &inspection).unwrap();
+
+    let mut provider = NoLatent::default();
+    let err = crate::format::vindex3::opplan::exec::prefill_plan(
+        &plan,
+        &store,
+        &[3u32, 17],
+        &ReferenceBackend,
+        &mut provider,
+    )
+    .expect_err("this stack keeps caches this provider cannot hold");
+    let message = err.to_string();
+    assert!(
+        message.contains("latent"),
+        "the refusal must name the LATENT region, not the recurrent one it does hold: {message}"
+    );
+    assert!(
+        message.contains(&MLA_LAYERS[0].to_string()),
+        "and which layer required it: {message}"
+    );
+    // The recurrent layers are not the complaint: this provider holds
+    // those, and a refusal naming layer 0 would be the old
+    // not-softmax-therefore-recurrent reading coming back.
+    assert!(
+        !message.contains("no recurrent state"),
+        "the recurrent side was available: {message}"
+    );
+}
+
+/// **The census counts each operator where it belongs** — KDA's four
+/// wide projections as recurrence traffic, MLA's four as attention, and
+/// both operators' small operands as glue.
+///
+/// Residency is reported by site, not as one total, because a total is
+/// satisfied just as well by a stack that halved its FFN and left its
+/// mixers widened.
+#[test]
+fn the_residency_census_places_both_operators() {
+    use crate::format::vindex3::inspect::inspect_container;
+    use crate::format::vindex3::opplan::exec::operands::OperandStore;
+    use crate::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
+    use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+    use crate::format::vindex3::opplan::plan_component_ops;
+
+    let dir = tempfile::tempdir().unwrap();
+    miniature_kimi(dir.path());
+    let out = tempfile::tempdir().unwrap();
+    let container = out.path().join("kimi-mini.vindex3");
+    encode_checkpoint(dir.path(), &container).unwrap();
+    let inspection = inspect_container(&container, false).unwrap();
+    let plan = plan_component_ops(&inspection, &container, "target")
+        .unwrap()
+        .plan
+        .expect("closure held");
+    let store = OperandStore::open(&container, &inspection).unwrap();
+    let prepared =
+        PreparedOperands::load(&plan, &store, &ReferenceBackend, ExecutionSlice::Full).unwrap();
+
+    let census = prepared.residency_census();
+    // KDA's q/k/v/o — the whole of a KDA layer's matrix traffic —
+    // counted with the recurrences, MLA's with attention.
+    let kda_matrix = 2 * (3 * K_WIDTH * HIDDEN + HIDDEN * K_WIDTH) * 4;
+    let mla_matrix = 2
+        * (M_HEADS * M_Q_HEAD_DIM * HIDDEN
+            + M_CACHE_WIDTH * HIDDEN
+            + M_HEADS * (M_NOPE + M_V) * M_LATENT
+            + HIDDEN * M_HEADS * M_V)
+        * 4;
+    assert_eq!(census.delta.total(), kda_matrix, "KDA's four projections");
+    assert_eq!(census.attention.total(), mla_matrix, "MLA's four");
+    // The small operands are glue, not matrix traffic: the convolution
+    // taps, gate factorisations, decay parameters and both norms.
+    assert!(census.glue.widened_f32 > 0, "conv taps and gates are glue");
+    assert!(census.ffn.total() > 0, "the dense FFN is its own site");
+}


### PR DESCRIPTION
`larql-vindex`'s coverage policy failed on main after #356. Six files were named; **four were mine** and are fixed here. Two — `cpu/kernels.rs` and `cpu/replay.rs` — have been failing since `821a17eb`, two merges before this branch's base, and are untouched here (diagnosis at the bottom).

Each dip was a real gap, not an accounting artefact:

- **The latent species at the storage seam** — allocation, both accessors, the arms that must *not* answer for it, and `elements_at` counting one row per position rather than a K/V pair.
- **The region vocabulary** — extracted from the KV adapter's refusal into `continuation::region_name`, so the words live once, with a test that every species names itself and no two share a name. A caller told "recurrent" when the layer keeps a growing cache looks for the wrong seam.
- **Announcement is not a reset** — a provider re-announced the same geometry keeps its rows, its recurrent buffers *and* its latent rows. That contract is what lets a long prompt prefill in chunks; the region added last is not the one that resets.
- **Every refusal names provider, layer and region**, asserted per variant. A copy-paste between arms is exactly the defect a looser test survives.
- **Two on the real witness:** a provider that holds recurrences but no latent cache is refused *at announcement*, before any output, naming the latent region and the MLA layer that required it — the migration case, since every provider in the tree could hold recurrent buffers before MLA executed. And the residency census places KDA's four projections with the recurrences and MLA's four with attention.

Local measurement (x86 reproduces the ubuntu job; five of six percentages matched CI exactly before this change): `continuation.rs`, `kv.rs`, `exec/mod.rs` and `prepared.rs` all clear their floors. larql-vindex 3406 tests, clippy `-D warnings` clean, fmt clean.

## Still red on main, not from this branch

- `cpu/kernels.rs` 85.71% vs 90.00% — `FusedNvfp4::project_rows` (lines ~212–235) has no test reaching it on the x86 path.
- `cpu/replay.rs` 5.47% vs 6.40% — the recorded-call widening, already noted in the policy file's own baseline note.

Both first appear at `821a17eb`. Whoever owns that arc has the shorter path to them; happy to take them if preferred.