### PR TITLE
BALANCED-1: consequence-calibrated contract, cross-family instruments, first earned balanced map

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
@@ -33,21 +33,33 @@ use larql_compute_metal::MetalBackend;
 use serde_json::Value;
 
 use super::q2a_teacher_forced::{
-    env_dir, observation, run_sequence, sequence_embeddings, BANK_ENV, SOURCE_ENV,
+    env_dir, observation, run_sequence, sequence_embeddings, BANK_ENV, CANDIDATE_ENV, SOURCE_ENV,
 };
-use crate::format::vindex3::opplan::exec::kimi_source::KimiSourceModel;
+use crate::format::vindex3::opplan::exec::kimi_source::{CandidateOverlay, KimiSourceModel};
 use crate::format::vindex3::opplan::exec::stack_metal::{DeviceAttn, DeviceLayer, HybridStack};
 use crate::format::vindex3::represent::bank::BankBuilder;
 use crate::format::vindex3::represent::quality::{kimi_logit_v3, Criterion, QualityEvidence};
 
-/// Which KDA layer's projections the candidate arm re-encodes.
-/// Default 25: the depth with the richest expert-side evidence, so the
-/// recurrence-vs-router comparison is at matched depth.
+/// Which KDA layers' projections the candidate arm re-encodes — a
+/// comma list (`"20,21,22,24,25"` is the late band; MLA positions are
+/// refused by the requant itself). Default 25: the depth with the
+/// richest expert-side evidence, so the recurrence-vs-router
+/// comparison is at matched depth.
 const LAYER_ENV: &str = "LARQL_KDA_Q8_LAYER";
-const LAYER_DEFAULT: usize = 25;
+const LAYER_DEFAULT: &str = "25";
+
+fn target_layers() -> Vec<usize> {
+    std::env::var(LAYER_ENV)
+        .unwrap_or_else(|_| LAYER_DEFAULT.into())
+        .split(',')
+        .map(|v| v.trim().parse().expect("layer index"))
+        .collect()
+}
 /// Diagnostic slice, same default as the expert probes.
 const SEQUENCES_ENV: &str = "LARQL_Q2A_SEQUENCES";
 const SEQUENCES_DEFAULT: usize = 8;
+/// Null-arm sequences — the quality runner's own number.
+const NULL_SEQUENCES: usize = 4;
 
 fn env_count(var: &str, default: usize) -> usize {
     std::env::var(var)
@@ -126,36 +138,146 @@ fn layer_bytes(layer: &DeviceLayer) -> usize {
     }
 }
 
-/// `build_stack`, with one hook: the target layer's projections are
-/// re-encoded BEFORE its attention banks are registered — a mutation
-/// after registration would leave the residency declaration pointing at
+/// Build one arm's layers; the target layer (if any) is re-encoded
+/// BEFORE its attention banks are registered — a mutation after
+/// registration would leave the residency declaration pointing at
 /// freed bf16 bytes.
-fn build_stack_with<'a>(
+pub(super) fn build_layers(
     metal: &MetalBackend,
     model: &KimiSourceModel,
-    mutate: Option<usize>,
-) -> (HybridStack<'a>, Option<(usize, usize)>) {
+    mutate: &[usize],
+    overlay: Option<&CandidateOverlay>,
+) -> (Vec<Option<DeviceLayer>>, Vec<(usize, usize)>) {
     let n = model.geometry.num_layers;
-    let mut swapped = None;
+    let mut swapped = Vec::new();
     let mut device: Vec<Option<DeviceLayer>> = Vec::with_capacity(n);
     for i in 0..n {
         let mut d = model
-            .device_layer(metal, i, None)
+            .device_layer(metal, i, overlay)
             .unwrap_or_else(|e| panic!("layer {i} must load: {e}"));
-        if mutate == Some(i) {
-            swapped = Some(requant_kda_projections(&mut d));
+        if mutate.contains(&i) {
+            swapped.push(requant_kda_projections(&mut d));
         }
         device.push(Some(d));
     }
+    (device, swapped)
+}
+
+pub(super) fn assemble<'a>(
+    metal: &MetalBackend,
+    model: &KimiSourceModel,
+    device: Vec<Option<DeviceLayer>>,
+) -> HybridStack<'a> {
     for d in device.iter().flatten() {
         for bank in d.attention_banks() {
             metal.register_weight_region(bank);
         }
     }
-    let host = (0..n).map(|_| None).collect();
+    let host = (0..device.len()).map(|_| None).collect();
     let mut stack = HybridStack::new(device, host);
     assert!(stack.attach_head(model.head().expect("the head must load")));
-    (stack, swapped)
+    stack
+}
+
+/// The attribution this probe's claim rests on: the arms differ at the
+/// TARGET layer's two projections and NOWHERE else. Expert banks are
+/// mmap-backed, so identity is the pointer; attention banks are owned
+/// copies, so identity is the bytes.
+fn assert_arms_differ_only_at(
+    baseline: &[Option<DeviceLayer>],
+    candidate: &[Option<DeviceLayer>],
+    targets: &[usize],
+    expert_layers: &[u32],
+) {
+    for (i, (b, c)) in baseline.iter().zip(candidate).enumerate() {
+        let (b, c) = (
+            b.as_ref().expect("all-device"),
+            c.as_ref().expect("all-device"),
+        );
+        let compiled_here = expert_layers.contains(&(i as u32));
+        for (name, pb, pc) in [
+            ("gate", &b.bank.gate, &c.bank.gate),
+            ("up", &b.bank.up, &c.bank.up),
+            ("down", &b.bank.down, &c.bank.down),
+        ] {
+            if compiled_here {
+                // The expert overlay substitutes this layer's routed
+                // bank — the same asymmetry q2a proves, restated here
+                // so the cross-family candidate's scope is explicit.
+                assert_eq!(pb.store_id(), "kimi-source-expert-bank", "baseline {name}");
+                assert_eq!(pc.store_id(), "kimi-candidate-bank", "candidate {name}");
+            } else {
+                assert_eq!(
+                    pb.region.region.bytes().as_ptr(),
+                    pc.region.region.bytes().as_ptr(),
+                    "layer {i} {name}: both arms must bind ONE mmap expert region"
+                );
+            }
+        }
+        match (&b.attn, &c.attn) {
+            (
+                DeviceAttn::Kda {
+                    qkv_bank: qb,
+                    o_proj: ob,
+                    encoding: eb,
+                    ..
+                },
+                DeviceAttn::Kda {
+                    qkv_bank: qc,
+                    o_proj: oc,
+                    encoding: ec,
+                    ..
+                },
+            ) if targets.contains(&i) => {
+                assert_eq!(*eb, MetalEncoding::Bf16, "baseline stays bf16");
+                assert_eq!(*ec, MetalEncoding::Q80, "target layer is Q8_0");
+                assert!(qc.len() < qb.len() && oc.len() < ob.len());
+            }
+            (
+                DeviceAttn::Kda {
+                    qkv_bank: qb,
+                    o_proj: ob,
+                    encoding: eb,
+                    ..
+                },
+                DeviceAttn::Kda {
+                    qkv_bank: qc,
+                    o_proj: oc,
+                    encoding: ec,
+                    ..
+                },
+            ) => {
+                assert_eq!((*eb, *ec), (MetalEncoding::Bf16, MetalEncoding::Bf16));
+                assert!(
+                    qb == qc && ob == oc,
+                    "layer {i}: KDA banks must be byte-equal"
+                );
+            }
+            (
+                DeviceAttn::Mla {
+                    q: qb,
+                    kv_a: ab,
+                    kv_b: bb,
+                    o: ob,
+                    ..
+                },
+                DeviceAttn::Mla {
+                    q: qc,
+                    kv_a: ac,
+                    kv_b: bc,
+                    o: oc,
+                    ..
+                },
+            ) => {
+                assert!(!targets.contains(&i), "every target must be a KDA layer");
+                assert!(
+                    qb == qc && ab == ac && bb == bc && ob == oc,
+                    "layer {i}: MLA banks must be byte-equal"
+                );
+            }
+            _ => panic!("layer {i}: the arms disagree on the attention operator"),
+        }
+    }
 }
 
 #[test]
@@ -173,7 +295,7 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
         #[cfg(not(target_os = "macos"))]
         return;
     };
-    let layer = env_count(LAYER_ENV, LAYER_DEFAULT);
+    let layers = target_layers();
     let sequences = env_count(SEQUENCES_ENV, SEQUENCES_DEFAULT);
 
     let manifest: Value =
@@ -190,21 +312,70 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
     model
         .register_stores(&metal, &moe_layers)
         .expect("stores register");
-    let (mut baseline, none) = build_stack_with(&metal, &model, None);
-    let (mut candidate, swapped) = build_stack_with(&metal, &model, Some(layer));
-    metal.seal_weight_regions();
-    assert!(none.is_none());
-    let (bf16_bytes, q8_bytes) = swapped.expect("the target layer was re-encoded");
+    // Optional CROSS-FAMILY composition: an expert candidate (compiled
+    // banks, q2a's own overlay machinery) beside the transient KDA
+    // requant. The baseline arm binds neither.
+    let overlay = env_dir(CANDIDATE_ENV).map(|dir| {
+        let o = CandidateOverlay::open(&dir, &source_dir, &g).expect("candidate overlay opens");
+        o.register_store(&metal);
+        o
+    });
+    let expert_layers: Vec<u32> = overlay
+        .as_ref()
+        .map(|o| o.compiled_layers().to_vec())
+        .unwrap_or_default();
+    let (base_layers, none) = build_layers(&metal, &model, &[], None);
+    let (cand_layers, swapped) = build_layers(&metal, &model, &layers, overlay.as_ref());
+    assert!(none.is_empty());
+    assert_eq!(swapped.len(), layers.len(), "every target was re-encoded");
+    let bf16_bytes: usize = swapped.iter().map(|(b, _)| b).sum();
+    let q8_bytes: usize = swapped.iter().map(|(_, q)| q).sum();
     assert!(
         q8_bytes < bf16_bytes,
         "Q8_0 must be smaller than bf16 — the swap did not happen"
     );
+    // Attribution BEFORE assembly: proven on the layers themselves, so
+    // "identical except the targets' projections" is a checked fact,
+    // not a construction argument.
+    assert_arms_differ_only_at(&base_layers, &cand_layers, &layers, &expert_layers);
+    let (null_layers, _) = build_layers(&metal, &model, &[], None);
+    let mut baseline = assemble(&metal, &model, base_layers);
+    let mut candidate = assemble(&metal, &model, cand_layers);
+    let mut null_partner = assemble(&metal, &model, null_layers);
+    metal.seal_weight_regions();
     eprintln!(
-        "[kda-q8] arms loaded in {:.1}s; layer {layer} projections {bf16_bytes} -> \
-         {q8_bytes} bytes ({:.1}% of bf16); everything else identical by construction",
+        "[kda-q8] arms loaded in {:.1}s; layers {layers:?} projections {bf16_bytes} -> \
+         {q8_bytes} bytes ({:.1}% of bf16); every other bank byte-equal or \
+         pointer-identical, PROVEN above",
         t0.elapsed().as_secs_f64(),
         100.0 * q8_bytes as f64 / bf16_bytes as f64,
     );
+
+    // ── Null arm: BF16 against itself must be EXACTLY zero — the same
+    // instrument-integrity gate the quality runner carries. ──
+    {
+        let mut builder = BankBuilder::new();
+        for seq in 0..NULL_SEQUENCES {
+            let rows = sequence_embeddings(&bank_dir, seq, positions, g.hidden);
+            let a = run_sequence(&metal, &mut baseline, &rows, g.hidden);
+            let b = run_sequence(&metal, &mut null_partner, &rows, g.hidden);
+            for (pos, ((la, ta), (lb, tb))) in a.into_iter().zip(b).enumerate() {
+                builder.observe(&observation(seq, pos, &la, &ta, &lb, &tb));
+            }
+        }
+        let null_bank = builder.finish();
+        assert_eq!(
+            null_bank.logits.kl_p99, 0.0,
+            "null arm KL must be exactly zero"
+        );
+        assert_eq!(null_bank.logits.max_logit_delta, 0.0);
+        assert_eq!(null_bank.logits.top1_flips, 0);
+        assert_eq!(null_bank.routing.route_flips, 0);
+        eprintln!(
+            "[kda-q8] null arm: {} positions, everything exactly zero",
+            null_bank.positions
+        );
+    }
 
     let t1 = Instant::now();
     let mut builder = BankBuilder::new();
@@ -256,9 +427,18 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
         let bytes = std::fs::read(bank_dir.join("manifest.json")).expect("bank manifest reads");
         format!("{:x}", Sha256::digest(&bytes))
     };
+    let mut label = layers
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("-");
+    if let Some(o) = &overlay {
+        label = format!("{label}-x-{}", o.index.map.name);
+    }
     let report = serde_json::json!({
-        "run": format!("kda-q8-l{layer}"),
-        "scope": "KDA projections (qkv bank + o_proj) of ONE layer, transient requant — no compiled candidate",
+        "run": format!("kda-q8-l{label}"),
+        "scope": "KDA projections (qkv bank + o_proj), transient requant; optional compiled expert candidate beside it",
+        "expert_candidate": overlay.as_ref().map(|o| o.index.map.name.clone()),
         "gate": evidence.gate,
         "authority_report": evidence.report(),
         "verdict_passed": verdict.passed(),
@@ -272,7 +452,7 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
         "kl_by_position": curve,
         "wall_seconds": t1.elapsed().as_secs_f64(),
     });
-    let path = format!("/tmp/kimi_kda-q8-l{layer}_report.json");
+    let path = format!("/tmp/kimi_kda-q8-l{label}_report.json");
     std::fs::write(
         &path,
         serde_json::to_vec_pretty(&report).expect("serialises"),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_decode_bench.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_decode_bench.rs
@@ -35,6 +35,7 @@ use larql_compute::backend::ComputeBackend;
 use larql_compute_metal::MetalBackend;
 use serde_json::Value;
 
+use super::kda_q8_real::{assemble, build_layers};
 use super::q2a_teacher_forced::{
     build_stack, env_dir, sequence_embeddings, BANK_ENV, CANDIDATE_ENV, SOURCE_ENV,
 };
@@ -134,13 +135,48 @@ fn decode_rate_of_the_candidate_map_beside_its_own_bf16_baseline() {
         .register_stores(&metal, &moe_layers)
         .expect("stores register");
     overlay.register_store(&metal);
-    let mut baseline = build_stack(&metal, &model, None);
-    let mut candidate = build_stack(&metal, &model, Some(&overlay));
+    // Optional TRANSIENT KDA scope beside the compiled expert overlay.
+    // The device executes real Q8_0 buffers through the real quantised
+    // kernels either way, so the decode timing is real; only the
+    // STORAGE is transient — which makes this a **Q8 EXECUTION
+    // PREVIEW**: valid for decode compute economics and steady-state
+    // tok/s, NOT a measurement of native artifact size, cold-load,
+    // disk traffic or materialisation overhead.
+    let kda_layers: Vec<usize> = std::env::var("LARQL_KDA_Q8_LAYER")
+        .map(|v| {
+            v.split(',')
+                .map(|x| x.trim().parse().expect("layer index"))
+                .collect()
+        })
+        .unwrap_or_default();
+    let (mut baseline, mut candidate) = if kda_layers.is_empty() {
+        (
+            build_stack(&metal, &model, None),
+            build_stack(&metal, &model, Some(&overlay)),
+        )
+    } else {
+        let (base, _) = build_layers(&metal, &model, &[], None);
+        let (cand, swapped) = build_layers(&metal, &model, &kda_layers, Some(&overlay));
+        assert_eq!(
+            swapped.len(),
+            kda_layers.len(),
+            "every KDA target re-encoded"
+        );
+        (
+            assemble(&metal, &model, base),
+            assemble(&metal, &model, cand),
+        )
+    };
     metal.seal_weight_regions();
     eprintln!(
-        "[bench] both arms loaded in {:.1}s; candidate scope {}",
+        "[bench] both arms loaded in {:.1}s; candidate scope {}{}",
         t0.elapsed().as_secs_f64(),
-        overlay.scope()
+        overlay.scope(),
+        if kda_layers.is_empty() {
+            String::new()
+        } else {
+            format!(" + TRANSIENT KDA Q8_0 at {kda_layers:?} (Q8 execution preview)")
+        }
     );
 
     // Enough distinct rows that a block never re-times one hot row, cycled

--- a/crates/larql-vindex/src/format/vindex3/represent/quality.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/quality.rs
@@ -720,6 +720,54 @@ pub fn kimi_logit_v3() -> QualityGate {
     }
 }
 
+/// **`kimi-logit-balanced-v1` — noticeable but bounded movement,
+/// calibrated from a measured consequence ladder on TWO banks.**
+///
+/// Not a relaxation ratio over v3: every limit is drawn from the
+/// empirical gap between the last candidate whose changes stayed
+/// small and local and the first whose consequences changed character,
+/// measured at 8,192 positions on the selection bank AND the held-out
+/// bank (zero window overlap, never used to choose topology):
+///
+/// | anchor @ 8192 | kl p99 (sel/held) | worst top-1 give-up | verdict here |
+/// |---|---|---|---|
+/// | strict map (experts 24-26 + KDA 24,25, all Q8_0) | 5.99e-4 / — | 0.020 | PASS |
+/// | wide map (+ KDA 21,22) | 9.65e-4 / 1.23e-3 | 0.055 / 0.028 | PASS |
+/// | flagship (experts 20-26 + KDA 20-25 plateau) | 2.38e-3 / 2.60e-3 | 0.094 / 0.058 | PASS |
+/// | B3 (experts 16-26) | 4.74e-3 / — | 0.181, 63 severe overturns | **FAIL** |
+///
+/// The ladder's ORDERING reproduced on the held-out bank with
+/// magnitudes shifting ±30-50%, so each limit carries bank-to-bank
+/// margin above the flagship's worst bank rather than sitting on one
+/// measurement:
+///
+/// | criterion | limit | why |
+/// |---|---|---|
+/// | `kl_p99_max` | 3.5e-3 | flagship worst bank 2.60e-3 × drift margin; refuses B3's 4.74e-3 |
+/// | `top1_mass_displaced_max` | 0.12 | flagship worst bank 0.094 × margin; refuses B3's 0.181 — the character change IS this dimension |
+/// | `top10_mass_displaced_p99_max` | 0.12 | flagship 0.076 both banks + margin |
+/// | route limits | unchanged from v3 | measured NON-discriminating in the corridor (p99 0.126-0.134 from strict to B3) — no evidence justifies loosening |
+/// | `covered_mass_min` | 0.55 | the held-out bank's flattest position covers 0.577 at top-2048 — a property of that bank, not of any candidate; 0.60 would make the held-out bank unusable while 0.55 still refuses a blind instrument |
+///
+/// KL is bounded but is deliberately NOT the definition — B3 taught
+/// that a diagnostic-benign map can hide dozens of confident overturns
+/// that only authority scale reveals, and the wide map taught that a
+/// single overturn's severity (0.055) can exceed strict's whole budget
+/// while everything else stays local. The contract boundary is where
+/// high-consequence top-1 overturns become materially larger and more
+/// frequent, and it was chosen on the held-out bank: the selection
+/// bank chose the corridor; the held-out bank chose the contract.
+pub fn kimi_logit_balanced_v1() -> QualityGate {
+    QualityGate {
+        id: "kimi-logit-balanced-v1".into(),
+        kl_p99_max: 3.5e-3,
+        covered_mass_min: Some(0.55),
+        top1_mass_displaced_max: Some(0.12),
+        top10_mass_displaced_p99_max: Some(0.12),
+        ..kimi_logit_v3()
+    }
+}
+
 #[cfg(test)]
 #[path = "quality_tests.rs"]
 mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/quality_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/quality_tests.rs
@@ -580,3 +580,102 @@ fn the_report_names_authority_and_diagnostics_separately() {
     assert!(v1.report().contains("discrete_counts"));
     assert!(!v1.verdict().passed(), "v1 rejects this bank on counts");
 }
+
+// ── kimi-logit-balanced-v1: the frozen calibration, as executable
+//    anchors. Each bank below carries the MEASURED values of one
+//    8,192-position characterization from the calibration ladder
+//    (worst bank where two were measured), so the boundary the gate
+//    draws is checked against the exact evidence it was drawn from. ──
+
+fn dist(p99: f64, max: f64) -> Distribution {
+    Distribution {
+        count: 100,
+        min: 1e-6,
+        p50: p99 / 10.0,
+        p95: p99 / 2.0,
+        p99,
+        max,
+    }
+}
+
+/// One calibration anchor's authority-scale evidence.
+fn anchor_bank(kl_p99: f64, top1_max: f64, top10_p99: f64, covered: f64) -> QualityBank {
+    QualityBank {
+        positions: 8192,
+        logits: LogitEvidence {
+            kl_p50: kl_p99 / 100.0,
+            kl_p95: kl_p99 / 3.0,
+            kl_p99,
+            max_logit_delta: 1.0,
+            top1_flips: 30,
+            top10_changes: 1000,
+        },
+        routing: RoutingEvidence {
+            route_flips: 200,
+            positions_with_route_change: 150,
+            layers_with_route_change: 8,
+            first_layer_with_route_change: Some(20),
+            route_margin: Some(dist(5e-3, 5e-2)),
+            route_weight_mass_moved: Some(dist(0.13, 0.21)),
+        },
+        min_covered_mass: Some(covered),
+        top10_margin: Some(dist(0.1, 1.0)),
+        top10_candidate_margin: Some(dist(0.1, 1.0)),
+        top10_mass_displaced: Some(dist(top10_p99, top10_p99 * 2.0)),
+        top10_rank_displacement: None,
+        top1_margin: Some(dist(0.02, 0.5)),
+        top1_candidate_margin: Some(dist(0.02, 0.5)),
+        top1_mass_displaced: Some(dist(top1_max / 2.0, top1_max)),
+    }
+}
+
+/// The ladder, exactly as measured: strict, wide and the flagship pass
+/// balanced-v1; B3 — the map whose consequences changed character — is
+/// refused on BOTH of the dimensions that define the boundary.
+#[test]
+fn balanced_v1_draws_the_line_where_the_ladder_did() {
+    let g = kimi_logit_balanced_v1();
+    // strict map: sel 5.99e-4 kl, worst top-1 give-up 0.020.
+    assert!(g
+        .evaluate(&anchor_bank(5.99e-4, 0.020, 6.2e-2, 0.631))
+        .passed());
+    // wide map, worst bank: kl 1.233e-3 (held-out), top1 0.055 (sel).
+    assert!(g
+        .evaluate(&anchor_bank(1.233e-3, 0.055, 7.5e-2, 0.577))
+        .passed());
+    // flagship, worst bank each dimension: kl 2.60e-3, top1 0.094.
+    assert!(g
+        .evaluate(&anchor_bank(2.60e-3, 0.094, 7.6e-2, 0.577))
+        .passed());
+    // B3: kl 4.74e-3, worst give-up 0.181 — refused on both.
+    let v = g.evaluate(&anchor_bank(4.74e-3, 0.181, 6.2e-2, 0.631));
+    assert!(!v.passed());
+    let names: Vec<_> = v.failures.iter().map(|(c, _)| *c).collect();
+    assert!(names.contains(&Criterion::KlP99));
+    assert!(names.contains(&Criterion::Top1Displacement));
+}
+
+/// Balanced loosens NOTHING it has no evidence for: the route limits
+/// are v3's own (measured non-discriminating in the corridor), the
+/// positions floor stands, and the covered-mass floor moves only far
+/// enough to admit the held-out bank's own flattest position.
+#[test]
+fn balanced_v1_inherits_what_the_corridor_did_not_discriminate() {
+    let g = kimi_logit_balanced_v1();
+    assert_eq!(
+        g.route_mixture_mass_p99_max,
+        kimi_logit_v3().route_mixture_mass_p99_max
+    );
+    assert_eq!(
+        g.route_mixture_mass_max,
+        kimi_logit_v3().route_mixture_mass_max
+    );
+    assert_eq!(g.positions_min, kimi_logit_v3().positions_min);
+    assert_eq!(g.covered_mass_min, Some(0.55));
+    // A diagnostic-scale bank still cannot pass balanced.
+    let mut b = anchor_bank(1.0e-3, 0.03, 6e-2, 0.63);
+    b.positions = 256;
+    assert!(!g.evaluate(&b).passed());
+    // And a blind instrument is still refused.
+    assert!(!g.evaluate(&anchor_bank(1.0e-3, 0.03, 6e-2, 0.50)).passed());
+}


### PR DESCRIPTION
## What

BALANCED-1: the calibrated behavioural contract, the instruments that calibrated it, and
the first earned balanced map with its measured economics.

## kimi-logit-balanced-v1

A quality tier defined from behavioural consequences — not bit-width, perplexity, or a
guessed KL relaxation. Calibrated from an authority-scale consequence ladder measured on
two banks; the held-out bank (zero window overlap with the selection bank, never used to
choose topology) chose the contract:

| anchor @ 8192 | kl p99 (sel/held) | worst top-1 give-up | balanced-v1 |
|---|---|---|---|
| strict map | 5.99e-4 / — | 0.020 | PASS |
| wide map | 9.65e-4 / 1.23e-3 | 0.055 / 0.028 | PASS |
| flagship | 2.38e-3 / 2.60e-3 | 0.094 / 0.058 | PASS |
| B3 | 4.74e-3 | 0.181 · 63 confident overturns | **FAIL — the character change** |

Limits carry measured bank-to-bank drift margin; route limits stay at v3's values
(measured non-discriminating from strict to B3). Two anchor tests encode the ladder.
Strict (kimi-logit-v3) is untouched and permanent: the optimizer moves, the goalposts
don't.

## Instruments

- KDA probe: multi-layer scopes, cross-family composition (compiled expert candidate +
  transient KDA requant, dual-scope byte-level attribution), token-distance KL curve.
- Decode bench: Q8 EXECUTION PREVIEW arm — real Q8_0 device buffers through the real
  kernels; decode economics valid, artifact/cold-load explicitly out of scope until
  storage is native.

## First earned balanced map

experts{L20-26} + KDA{L20,21,22,24,25}, all Q8_0 — twelve quantized layer-scopes across
two tensor families. PASSES balanced-v1 on both banks. 38.5 tok/s beside its own 35.9
in-session BF16 baseline (1.074×); GPU 26.7 → 24.8 ms/token — measured −6.9% against
−7.1% modeled from the decode-byte ledger. The cost model now predicts wall-clock once
its measured ~1.2 ms/token fixed-overhead term is included.

## Gates

fmt, clippy clean; larql-vindex (gpu, release) 3421 + 110, zero failures; no-gpu
--all-targets clean. Evidence and calibration record persisted beside the quality bank.
