### PR TITLE
NATIVE-KDA-1: native Q8 KDA storage, bit-equal to the earned transient path

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/kimi_source.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/kimi_source.rs
@@ -39,6 +39,7 @@ use crate::format::vindex3::represent::compile::CandidatePlacement;
 use crate::format::vindex3::represent::compiler::{
     bank_base, read_source_identity, CandidateIndex,
 };
+use crate::format::vindex3::represent::kda_candidate::{KdaPlacement, KDA_PROJECTIONS};
 use crate::format::vindex3::represent::physical::{
     EncodedRegion, ExpertBankBinding, ExpertEncoding, ExtentPolicy, PhysicalStore,
     ProjectionAddressing, RoutedProjection, SharedExpertBinding, WeightRegion,
@@ -298,12 +299,39 @@ impl KimiSourceModel {
         })
     }
 
+    /// The eleven small f32 operands a KDA layer carries beside its
+    /// wide projections. `A_log` is stored `[1,1,H,1]` and flattens to
+    /// `[H]`; the conv weights' middle `1` dimension is inert under
+    /// row-major flattening — the only two transforms the proven
+    /// exporter ever applied. Always from the SOURCE stack: no
+    /// candidate kind stores them.
+    fn kda_f32s(&self, layer: usize) -> Result<Vec<Vec<f32>>, VindexError> {
+        let t = |suffix: &str| format!("{layer}.self_attn.{suffix}");
+        [
+            "q_conv1d.weight",
+            "k_conv1d.weight",
+            "v_conv1d.weight",
+            "f_a_proj.weight",
+            "f_b_proj.weight",
+            "g_a_proj.weight",
+            "g_b_proj.weight",
+            "b_proj.weight",
+            "A_log",
+            "dt_bias",
+            "o_norm.weight",
+        ]
+        .iter()
+        .map(|suffix| self.decoder.f32s(&t(suffix)))
+        .collect()
+    }
+
     /// One layer's attention operands, whichever operator the graph
     /// declares for it.
     fn attention(
         &self,
         metal: &MetalBackend,
         layer: usize,
+        kda: Option<&KdaOverlay>,
     ) -> Result<(DeviceAttn, DeviceState), VindexError> {
         let g = &self.geometry;
         let t = |suffix: &str| format!("{layer}.self_attn.{suffix}");
@@ -323,6 +351,23 @@ impl KimiSourceModel {
                 )),
             ));
         }
+        // A compiled KDA candidate substitutes the four wide projections
+        // and NOTHING else — the f32 operands below still come from the
+        // source stack, exactly as the behavioural evidence was earned.
+        if let Some(binding) = kda.and_then(|o| o.binding(layer as u32)) {
+            let b = binding?;
+            let f32s = self.kda_f32s(layer)?;
+            return Ok((
+                DeviceAttn::Kda {
+                    qkv_bank: b.qkv_bank,
+                    qkv_offsets: b.qkv_offsets,
+                    o_proj: b.o_proj,
+                    encoding: b.encoding,
+                    f32s,
+                },
+                DeviceState::Kda(KdaDeviceState::zeros(metal, g.kda)),
+            ));
+        }
         let (q, k, v) = (
             self.decoder.bytes(&t("q_proj.weight"))?,
             self.decoder.bytes(&t("k_proj.weight"))?,
@@ -340,26 +385,7 @@ impl KimiSourceModel {
         for b in [&q, &k, &v] {
             qkv_bank.extend_from_slice(b);
         }
-        // `KdaDeviceWeights`'s own field order. `A_log` is stored
-        // `[1,1,H,1]` and flattens to `[H]`; the conv weights' middle
-        // `1` dimension is inert under row-major flattening — the only
-        // two transforms the proven exporter ever applied.
-        let f32s: Vec<Vec<f32>> = [
-            "q_conv1d.weight",
-            "k_conv1d.weight",
-            "v_conv1d.weight",
-            "f_a_proj.weight",
-            "f_b_proj.weight",
-            "g_a_proj.weight",
-            "g_b_proj.weight",
-            "b_proj.weight",
-            "A_log",
-            "dt_bias",
-            "o_norm.weight",
-        ]
-        .iter()
-        .map(|suffix| self.decoder.f32s(&t(suffix)))
-        .collect::<Result<_, _>>()?;
+        let f32s = self.kda_f32s(layer)?;
         Ok((
             DeviceAttn::Kda {
                 qkv_bank,
@@ -387,8 +413,21 @@ impl KimiSourceModel {
         layer: usize,
         overlay: Option<&CandidateOverlay>,
     ) -> Result<DeviceLayer, VindexError> {
+        self.device_layer_with_kda(metal, layer, overlay, None)
+    }
+
+    /// [`Self::device_layer`], with a KDA candidate riding beside the
+    /// expert candidate — the two substitute DISJOINT operand families,
+    /// so their composition needs no arbitration.
+    pub fn device_layer_with_kda(
+        &self,
+        metal: &MetalBackend,
+        layer: usize,
+        overlay: Option<&CandidateOverlay>,
+        kda: Option<&KdaOverlay>,
+    ) -> Result<DeviceLayer, VindexError> {
         let g = &self.geometry;
-        let (attn, state) = self.attention(metal, layer)?;
+        let (attn, state) = self.attention(metal, layer, kda)?;
         let common = |bank, router_weight, router_bias, inter, top_k, dense| {
             DeviceLayer {
                 attn,
@@ -926,4 +965,155 @@ pub fn verify_complete(
         }
     }
     Ok((layers, projections, placement))
+}
+
+/// One compiled KDA layer's binding, copied out of the candidate bank.
+pub struct KdaBinding {
+    pub qkv_bank: Vec<u8>,
+    pub qkv_offsets: [ExpertOffset; 3],
+    pub o_proj: Vec<u8>,
+    pub encoding: MetalEncoding,
+}
+
+/// A compiled KDA candidate beside the source container — the second
+/// overlay kind. Opening PROVES completeness: every compiled layer's
+/// four projections sealed at exactly the placement's offsets, before
+/// any byte is served.
+pub struct KdaOverlay {
+    pub index: CandidateIndex,
+    bank: Vec<u8>,
+    placement: KdaPlacement,
+}
+
+impl KdaOverlay {
+    pub fn open(
+        dir: &Path,
+        source_dir: &Path,
+        geometry: &KimiGeometry,
+    ) -> Result<Self, VindexError> {
+        let index: CandidateIndex = serde_json::from_slice(&std::fs::read(dir.join("index.json"))?)
+            .map_err(|e| VindexError::Parse(format!("kda candidate index: {e}")))?;
+        index.source.verify(&read_source_identity(source_dir)?)?;
+        let object = "target.kda_bank";
+        let mut layers: Vec<u32> = index
+            .ledger
+            .sealed
+            .values()
+            .filter(|seal| seal.object == object)
+            .filter_map(|seal| layer_of(&seal.tensor))
+            .collect();
+        layers.sort_unstable();
+        layers.dedup();
+        let width = geometry.kda.num_heads * geometry.kda.head_dim;
+        let placement = KdaPlacement::resolve(
+            &index.map,
+            Role::DecoderLinear,
+            &layers,
+            width,
+            geometry.hidden,
+        )?;
+        // Completeness: all four projections per layer, at the
+        // placement's own offsets — a missing or relocated seal refuses
+        // here, not as garbage bytes mid-decode.
+        for &layer in &layers {
+            let layout = placement.layout(layer)?;
+            let base = placement.layer_base(layer)?;
+            for proj in KDA_PROJECTIONS {
+                let tensor = format!("{layer}.self_attn.{proj}.weight");
+                let seal = index.ledger.get(object, &tensor).ok_or_else(|| {
+                    VindexError::Parse(format!(
+                        "KDA candidate has no seal for `{tensor}` — the bank is incomplete"
+                    ))
+                })?;
+                let (off, len) = layout.slot(proj)?;
+                if seal.target_offset != base + off || seal.target_len != len {
+                    return Err(VindexError::Parse(format!(
+                        "`{tensor}` sealed at {}+{} but the placement puts it at {}+{len}",
+                        seal.target_offset,
+                        seal.target_len,
+                        base + off
+                    )));
+                }
+            }
+        }
+        let bank = std::fs::read(dir.join("segments").join(format!("{object}.bin")))?;
+        Ok(Self {
+            index,
+            bank,
+            placement,
+        })
+    }
+
+    pub fn compiled_layers(&self) -> Vec<u32> {
+        self.placement.layers().collect()
+    }
+
+    /// The compiled binding for `layer`, or `None` when this candidate
+    /// does not hold it. Bytes are verified against the seals' hashes
+    /// on every call — 200 MB hashes in milliseconds, and a bank whose
+    /// file was truncated or edited must refuse, not decode noise.
+    pub fn binding(&self, layer: u32) -> Option<Result<KdaBinding, VindexError>> {
+        if !self.placement.layers().any(|l| l == layer) {
+            return None;
+        }
+        Some(self.binding_inner(layer))
+    }
+
+    fn binding_inner(&self, layer: u32) -> Result<KdaBinding, VindexError> {
+        let layout = self.placement.layout(layer)?;
+        let base = self.placement.layer_base(layer)?;
+        let object = "target.kda_bank";
+        let slice = |proj: &str| -> Result<Vec<u8>, VindexError> {
+            let (off, len) = layout.slot(proj)?;
+            let start = (base + off) as usize;
+            let end = start + len as usize;
+            let bytes = self.bank.get(start..end).ok_or_else(|| {
+                VindexError::Parse(format!(
+                    "KDA bank file ends before layer {layer} `{proj}` ({end} > {})",
+                    self.bank.len()
+                ))
+            })?;
+            let tensor = format!("{layer}.self_attn.{proj}.weight");
+            let seal = self
+                .index
+                .ledger
+                .get(object, &tensor)
+                .expect("open() proved completeness");
+            let hash = crate::format::vindex3::represent::compile::hash_bytes(bytes);
+            if hash != seal.target_hash {
+                return Err(VindexError::Parse(format!(
+                    "`{tensor}`: bank bytes hash {hash} but the seal says {} — the bank \
+                     and its ledger disagree",
+                    seal.target_hash
+                )));
+            }
+            Ok(bytes.to_vec())
+        };
+        let q = slice("q_proj")?;
+        let stride = q.len() as u32;
+        let mut qkv_bank = q;
+        qkv_bank.extend_from_slice(&slice("k_proj")?);
+        qkv_bank.extend_from_slice(&slice("v_proj")?);
+        let encoding = match layout.encoding.as_str() {
+            "BF16" => MetalEncoding::Bf16,
+            "Q8_0" => MetalEncoding::Q80,
+            "Q6_K" => MetalEncoding::Q6K,
+            "Q4_K" => MetalEncoding::Q4K,
+            other => {
+                return Err(VindexError::Parse(format!(
+                    "KDA candidate encodes `{other}`, which no grouped kernel reads"
+                )))
+            }
+        };
+        Ok(KdaBinding {
+            qkv_bank,
+            qkv_offsets: [
+                ExpertOffset(0),
+                ExpertOffset(stride),
+                ExpertOffset(2 * stride),
+            ],
+            o_proj: slice("o_proj")?,
+            encoding,
+        })
+    }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_native_parity.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_native_parity.rs
@@ -1,0 +1,156 @@
+//! **NATIVE-KDA-1's gate: stored Q8 versus transient Q8, BIT-EQUAL.**
+//!
+//! The transient arm re-encodes the source's bf16 projections at load;
+//! the native arm reads bytes a compiler sealed to disk. Same intended
+//! bytes, same kernels — so the tolerance is ZERO: any difference in
+//! the banks or in one logit means the representation pipeline is
+//! lying somewhere (encoder drift between the arena and the loader's
+//! requant, a placement error, a truncated read), never "quantisation
+//! error". This is the same no-tolerance posture the REPRESENT verb
+//! established for stored-vs-transient compilation.
+//!
+//! ```text
+//! LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.s6.vindex3 \
+//! LARQL_KIMI_QUALITY_BANK=~/chris-models/qbanks/kimi-quality-bank-256x32 \
+//! LARQL_KIMI_KDA_CANDIDATE=/tmp/kimi-kda-l20-25q80.vindex3 \
+//!   cargo test -p larql-vindex --features gpu --release --lib \
+//!   kda_native_parity -- --nocapture
+//! ```
+
+use std::path::PathBuf;
+
+use larql_compute::backend::ComputeBackend;
+use larql_compute_metal::MetalBackend;
+use serde_json::Value;
+
+use super::kda_q8_real::build_layers;
+use super::q2a_teacher_forced::{env_dir, run_sequence, sequence_embeddings, BANK_ENV, SOURCE_ENV};
+use crate::format::vindex3::opplan::exec::kimi_source::{KdaOverlay, KimiSourceModel};
+use crate::format::vindex3::opplan::exec::stack_metal::{DeviceAttn, DeviceLayer, HybridStack};
+
+const KDA_CANDIDATE_ENV: &str = "LARQL_KIMI_KDA_CANDIDATE";
+/// Sequences for the end-to-end logit comparison. Two is enough: the
+/// claim is bitwise identity of an already-proven computation, not a
+/// statistical bound.
+const SEQUENCES: usize = 2;
+
+#[test]
+fn native_kda_bytes_and_logits_are_bit_equal_to_the_transient_arm() {
+    let (Some(source_dir), Some(bank_dir), Some(kda_dir)) = (
+        env_dir(SOURCE_ENV),
+        env_dir(BANK_ENV),
+        std::env::var_os(KDA_CANDIDATE_ENV).map(PathBuf::from),
+    ) else {
+        eprintln!("skipped: set {SOURCE_ENV}, {BANK_ENV} and {KDA_CANDIDATE_ENV}");
+        return;
+    };
+    let Some(metal) = MetalBackend::new() else {
+        #[cfg(target_os = "macos")]
+        panic!("MetalBackend::new() returned None on macOS — the shader library failed");
+        #[cfg(not(target_os = "macos"))]
+        return;
+    };
+    let manifest: Value =
+        serde_json::from_slice(&std::fs::read(bank_dir.join("manifest.json")).expect("manifest"))
+            .expect("bank manifest parses");
+    let positions = manifest["positions"].as_u64().unwrap() as usize;
+
+    let model = KimiSourceModel::open(&source_dir).expect("source container opens");
+    let g = model.geometry.clone();
+    let overlay = KdaOverlay::open(&kda_dir, &source_dir, &g).expect("kda overlay opens");
+    let layers = overlay.compiled_layers();
+    assert!(!layers.is_empty());
+    eprintln!(
+        "[kda-native] candidate `{}` holds layers {layers:?}",
+        overlay.index.map.name
+    );
+    let moe_layers: Vec<u32> = (g.dense_prefix_layers..g.num_layers)
+        .map(|l| l as u32)
+        .collect();
+    model
+        .register_stores(&metal, &moe_layers)
+        .expect("stores register");
+
+    // Transient arm: the probe's own requant-at-load.
+    let targets: Vec<usize> = layers.iter().map(|&l| l as usize).collect();
+    let (transient, swapped) = build_layers(&metal, &model, &targets, None);
+    assert_eq!(swapped.len(), targets.len());
+    // Native arm: bytes a compiler sealed to disk, verified against the
+    // ledger at open and at every binding read.
+    let native: Vec<Option<DeviceLayer>> = (0..g.num_layers)
+        .map(|i| {
+            Some(
+                model
+                    .device_layer_with_kda(&metal, i, None, Some(&overlay))
+                    .unwrap_or_else(|e| panic!("layer {i} must load: {e}")),
+            )
+        })
+        .collect();
+
+    // ── The core claim, checked at the BYTES before any kernel runs:
+    //    every compiled layer's bank, offsets and encoding identical
+    //    between the arms. This is where an arena-vs-loader encoder
+    //    drift would surface, named by layer. ──
+    for (i, (t, n)) in transient.iter().zip(&native).enumerate() {
+        let (t, n) = (t.as_ref().unwrap(), n.as_ref().unwrap());
+        if let (
+            DeviceAttn::Kda {
+                qkv_bank: tq,
+                qkv_offsets: to,
+                o_proj: tp,
+                encoding: te,
+                ..
+            },
+            DeviceAttn::Kda {
+                qkv_bank: nq,
+                qkv_offsets: no,
+                o_proj: np,
+                encoding: ne,
+                ..
+            },
+        ) = (&t.attn, &n.attn)
+        {
+            assert_eq!(te, ne, "layer {i}: encodings differ");
+            assert_eq!(to, no, "layer {i}: qkv offsets differ");
+            assert!(tq == nq, "layer {i}: qkv banks are not byte-equal");
+            assert!(tp == np, "layer {i}: o_proj banks are not byte-equal");
+        }
+    }
+    eprintln!(
+        "[kda-native] every compiled layer's banks BYTE-EQUAL between transient and \
+         native arms"
+    );
+
+    // ── And the end-to-end seal: identical logits, bitwise. ──
+    let assemble = |layers: Vec<Option<DeviceLayer>>| -> HybridStack<'_> {
+        for d in layers.iter().flatten() {
+            for bank in d.attention_banks() {
+                metal.register_weight_region(bank);
+            }
+        }
+        let host = (0..layers.len()).map(|_| None).collect();
+        let mut stack = HybridStack::new(layers, host);
+        assert!(stack.attach_head(model.head().expect("head loads")));
+        stack
+    };
+    let mut a = assemble(transient);
+    let mut b = assemble(native);
+    metal.seal_weight_regions();
+    for seq in 0..SEQUENCES {
+        let rows = sequence_embeddings(&bank_dir, seq, positions, g.hidden);
+        let la = run_sequence(&metal, &mut a, &rows, g.hidden);
+        let lb = run_sequence(&metal, &mut b, &rows, g.hidden);
+        for (pos, ((va, _), (vb, _))) in la.into_iter().zip(lb).enumerate() {
+            assert!(
+                va.iter().zip(&vb).all(|(x, y)| x.to_bits() == y.to_bits()),
+                "seq {seq} pos {pos}: logits differ bitwise — the pipeline is lying \
+                 somewhere between the compiler and the loader"
+            );
+        }
+    }
+    eprintln!(
+        "[kda-native] {SEQUENCES} sequences x {positions} positions: logits BIT-EQUAL. \
+         Native KDA storage serves exactly the bytes the transient experiment earned \
+         its evidence with."
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -27,6 +27,8 @@ mod gated_delta_tiny;
 mod hybrid_traversal;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
 mod kda_metal;
+#[cfg(all(feature = "gpu", target_os = "macos"))]
+mod kda_native_parity;
 mod kda_parity;
 mod kda_parity_real;
 #[cfg(all(feature = "gpu", target_os = "macos"))]

--- a/crates/larql-vindex/src/format/vindex3/represent/compile_real_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/compile_real_tests.rs
@@ -172,7 +172,7 @@ fn scope_projections() -> Vec<String> {
 }
 
 /// Reads operands straight out of a segment file.
-struct SegmentSource {
+pub(super) struct SegmentSource {
     path: PathBuf,
     payload_start: u64,
     offsets: std::collections::BTreeMap<String, (u64, u64)>,
@@ -183,7 +183,19 @@ impl SegmentSource {
         container: &std::path::Path,
         layers: &[u32],
     ) -> Result<(Self, Vec<SourceTensor>), VindexError> {
-        let path = container.join("segments").join(format!("{OBJECT}.bin"));
+        Self::open_object(container, OBJECT, layers, |_| true)
+    }
+
+    /// The same reader over any segment, with a NAME filter — the KDA
+    /// candidate reads `target.decoder_stack`, whose tensors are mostly
+    /// not in any candidate's scope.
+    pub(super) fn open_object(
+        container: &std::path::Path,
+        object: &str,
+        layers: &[u32],
+        keep: impl Fn(&str) -> bool,
+    ) -> Result<(Self, Vec<SourceTensor>), VindexError> {
+        let path = container.join("segments").join(format!("{object}.bin"));
         let (header, payload_start) =
             crate::format::vindex3::encode::segment::read_segment_header(&path)?;
         let mut offsets = std::collections::BTreeMap::new();
@@ -191,6 +203,7 @@ impl SegmentSource {
         for t in header.tensors {
             if crate::format::vindex3::represent::policy::layer_of(&t.name)
                 .is_some_and(|l| layers.contains(&l))
+                && keep(&t.name)
             {
                 tensors.push(SourceTensor {
                     name: t.name.clone(),
@@ -284,7 +297,7 @@ fn layer_q6(layer: u32, projections: &[String], encoding: &str) -> PrecisionMap 
 }
 
 /// The source's own identity, plus where it was found.
-fn source_dependency(
+pub(super) fn source_dependency(
     container: &std::path::Path,
 ) -> Result<super::compiler::SourceDependency, VindexError> {
     Ok(super::compiler::SourceDependency {

--- a/crates/larql-vindex/src/format/vindex3/represent/kda_candidate.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/kda_candidate.rs
@@ -1,0 +1,368 @@
+//! **Native storage for KDA projections — the second candidate family.**
+//!
+//! A KDA candidate is its OWN candidate object (`target.kda_bank`,
+//! its own index, map and seals), never a variant grafted into the
+//! expert bank's placement: that machinery is expert-shaped through
+//! and through (expert slots, identity addressing over a population),
+//! while a KDA layer holds exactly four matrices. The loader composes
+//! the two candidate kinds side by side — the same architecture the
+//! transient-requant probe proved behaviourally, made physical.
+//!
+//! Layout per compiled layer, in fixed order:
+//!
+//! ```text
+//! q_proj  [width, hidden]   base 0
+//! k_proj  [width, hidden]   base 1·qkv_stride
+//! v_proj  [width, hidden]   base 2·qkv_stride
+//! o_proj  [hidden, width]   base 3·qkv_stride
+//! ```
+//!
+//! The two strides are computed separately even where an encoding
+//! makes them equal — `o_proj` transposes the reduction axis, and an
+//! encoding whose block constraint holds for `hidden` but not `width`
+//! (or vice versa) must refuse on the axis that actually violates it.
+//!
+//! Deliberately NOT stored: the convolutions, the low-rank decay and
+//! output gates, `b_proj`, `A_log`, `dt_bias`, `o_norm`. They are a
+//! few megabytes a layer against ~75, they feed the numerically
+//! delicate recurrence, and every behavioural result this candidate
+//! kind rests on was earned with them untouched.
+
+use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
+
+use super::arena::{RepresentationArena, SourceOperands};
+use super::compile::{hash_bytes, LayerBankLayout, OperandSeal, Pending};
+use super::compiler::{write_index_atomically, CandidateIndex, CompileOutcome, SourceTensor};
+use super::map::{Precision, PrecisionMap};
+use super::policy::{layer_of, projection_of, Role};
+use crate::error::VindexError;
+use crate::format::vindex3::opplan::OperandRef;
+
+/// The four projections a KDA layer stores, in bank order.
+pub const KDA_PROJECTIONS: [&str; 4] = ["q_proj", "k_proj", "v_proj", "o_proj"];
+
+/// One compiled KDA layer's shape in the bank.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KdaLayerLayout {
+    pub layer: u32,
+    pub encoding: String,
+    /// Bytes one `[width, hidden]` projection occupies.
+    pub qkv_stride: u64,
+    /// Bytes the `[hidden, width]` output projection occupies.
+    pub o_stride: u64,
+}
+
+impl KdaLayerLayout {
+    pub fn new(
+        layer: u32,
+        encoding: &str,
+        width: usize,
+        hidden: usize,
+    ) -> Result<Self, VindexError> {
+        Ok(Self {
+            layer,
+            encoding: encoding.to_string(),
+            qkv_stride: LayerBankLayout::matrix_bytes(encoding, width, hidden)?,
+            o_stride: LayerBankLayout::matrix_bytes(encoding, hidden, width)?,
+        })
+    }
+
+    /// A projection's `(offset, len)` within this layer's extent.
+    pub fn slot(&self, projection: &str) -> Result<(u64, u64), VindexError> {
+        match projection {
+            "q_proj" => Ok((0, self.qkv_stride)),
+            "k_proj" => Ok((self.qkv_stride, self.qkv_stride)),
+            "v_proj" => Ok((2 * self.qkv_stride, self.qkv_stride)),
+            "o_proj" => Ok((3 * self.qkv_stride, self.o_stride)),
+            other => Err(VindexError::Parse(format!(
+                "`{other}` is not a KDA projection this bank stores"
+            ))),
+        }
+    }
+
+    /// This layer's whole extent in the candidate segment.
+    pub fn layer_bytes(&self) -> u64 {
+        3 * self.qkv_stride + self.o_stride
+    }
+}
+
+/// Where each compiled layer's four-slot bank begins — the KDA
+/// counterpart of `CandidatePlacement`, and like it the ONE definition
+/// the compiler, the completeness verifier and the loader all share.
+#[derive(Debug, Clone)]
+pub struct KdaPlacement {
+    placed: Vec<(KdaLayerLayout, u64)>,
+}
+
+impl KdaPlacement {
+    /// Resolve placement for `layers` under `map`, at the family's
+    /// projection geometry.
+    ///
+    /// A layer whose four projections resolve to different encodings is
+    /// refused by name — one layer, one encoding, same as the expert
+    /// bank. A layer the map does not compile is refused too.
+    pub fn resolve(
+        map: &PrecisionMap,
+        role: Role,
+        layers: &[u32],
+        width: usize,
+        hidden: usize,
+    ) -> Result<Self, VindexError> {
+        let mut sorted: Vec<u32> = layers.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        if sorted.is_empty() {
+            return Err(VindexError::Parse(
+                "a KDA placement over no layers places nothing".into(),
+            ));
+        }
+        let mut placed = Vec::with_capacity(sorted.len());
+        let mut base = 0u64;
+        for layer in sorted {
+            let mut encodings: Vec<(&str, String)> = Vec::new();
+            for proj in KDA_PROJECTIONS {
+                let tensor = format!("{layer}.self_attn.{proj}.weight");
+                if let Precision::Compiled(enc) = map.resolve(role, &tensor) {
+                    encodings.push((proj, enc.to_string()));
+                }
+            }
+            let Some((_, encoding)) = encodings.first() else {
+                return Err(VindexError::Parse(format!(
+                    "layer {layer} is in the KDA placement but map `{}` compiles none of \
+                     its projections",
+                    map.name
+                )));
+            };
+            if let Some((proj, other)) = encodings.iter().find(|(_, e)| e != encoding) {
+                return Err(VindexError::Parse(format!(
+                    "layer {layer}: `{}` resolves to {encoding} but `{proj}` to {other} — \
+                     a KDA layer bank carries ONE encoding",
+                    encodings[0].0
+                )));
+            }
+            let layout = KdaLayerLayout::new(layer, encoding, width, hidden)?;
+            let extent = layout.layer_bytes();
+            placed.push((layout, base));
+            base = base
+                .checked_add(extent)
+                .ok_or_else(|| VindexError::Parse("KDA placement overflows u64".into()))?;
+        }
+        Ok(Self { placed })
+    }
+
+    pub fn layers(&self) -> impl Iterator<Item = u32> + '_ {
+        self.placed.iter().map(|(l, _)| l.layer)
+    }
+
+    pub fn layout(&self, layer: u32) -> Result<&KdaLayerLayout, VindexError> {
+        self.placed
+            .iter()
+            .find(|(l, _)| l.layer == layer)
+            .map(|(l, _)| l)
+            .ok_or_else(|| {
+                VindexError::Parse(format!("layer {layer} is not in this KDA placement"))
+            })
+    }
+
+    pub fn layer_base(&self, layer: u32) -> Result<u64, VindexError> {
+        self.placed
+            .iter()
+            .find(|(l, _)| l.layer == layer)
+            .map(|(_, b)| *b)
+            .ok_or_else(|| {
+                VindexError::Parse(format!("layer {layer} is not in this KDA placement"))
+            })
+    }
+}
+
+/// Compile a KDA candidate bank: the same seal/resume/checkpoint
+/// discipline as `compile_expert_bank`, over the four-slot layout.
+///
+/// `tensors` is the scope — every `{layer}.self_attn.{q,k,v,o}_proj`
+/// the map might compile. Anything else in the list is refused by
+/// name: a KDA bank that silently skipped a tensor would leave the
+/// caller believing it was compiled.
+pub fn compile_kda_bank(
+    source: &dyn SourceOperands,
+    tensors: &[SourceTensor],
+    object: &str,
+    out: &Path,
+    checkpoint: Option<(&Path, u64)>,
+    index: &mut CandidateIndex,
+    progress: &mut dyn FnMut(&CompileOutcome),
+) -> Result<CompileOutcome, VindexError> {
+    let role = Role::DecoderLinear;
+    let arena = RepresentationArena::new(index.map.clone());
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(out)?;
+    let mut outcome = CompileOutcome::default();
+
+    // Placement is derived ONCE from the whole handed scope, exactly as
+    // the expert compiler does — a per-tensor derivation would let two
+    // runs over subsets write one layer at two bases.
+    let mut compiled_layers: Vec<u32> = Vec::new();
+    let mut geometry: Option<(usize, usize)> = None;
+    for t in tensors {
+        match projection_of(&t.name) {
+            Some("q_proj" | "k_proj" | "v_proj") => {
+                let [rows, cols] = t.shape[..] else {
+                    return Err(VindexError::Parse(format!(
+                        "tensor `{}` is not a matrix: {:?}",
+                        t.name, t.shape
+                    )));
+                };
+                geometry = Some((rows, cols)); // (width, hidden)
+            }
+            Some("o_proj") => {}
+            other => {
+                return Err(VindexError::Parse(format!(
+                    "tensor `{}` (projection {other:?}) is not a KDA projection — a KDA \
+                     scope holds q/k/v/o_proj and nothing else",
+                    t.name
+                )));
+            }
+        }
+        if matches!(index.map.resolve(role, &t.name), Precision::Source) {
+            continue;
+        }
+        if let Some(layer) = layer_of(&t.name) {
+            compiled_layers.push(layer);
+        }
+    }
+    compiled_layers.sort_unstable();
+    compiled_layers.dedup();
+    let placement = match (&compiled_layers[..], geometry) {
+        ([], _) => None,
+        (_, Some((width, hidden))) => Some(KdaPlacement::resolve(
+            &index.map,
+            role,
+            &compiled_layers,
+            width,
+            hidden,
+        )?),
+        (_, None) => {
+            return Err(VindexError::Parse(
+                "the scope compiles operands but holds no q/k/v tensor to take the bank \
+                 geometry from"
+                    .into(),
+            ))
+        }
+    };
+
+    for t in tensors {
+        let encoding = match index.map.resolve(role, &t.name) {
+            Precision::Source => {
+                outcome.source_precision += 1;
+                continue;
+            }
+            Precision::Compiled(enc) => enc.to_string(),
+        };
+        let (Some(layer), Some(projection)) = (layer_of(&t.name), projection_of(&t.name)) else {
+            return Err(VindexError::Parse(format!(
+                "tensor `{}` carries no layer/projection, so it has no place in a KDA bank",
+                t.name
+            )));
+        };
+        let placement = placement
+            .as_ref()
+            .expect("a compiled tensor implies a placement");
+        let layout = placement.layout(layer)?;
+        // The tensor's own shape must produce the placed strides — a
+        // transposed or truncated projection refuses here, by name,
+        // instead of landing plausibly at the wrong extent.
+        let [rows, cols] = t.shape[..] else {
+            return Err(VindexError::Parse(format!(
+                "tensor `{}` is not a matrix: {:?}",
+                t.name, t.shape
+            )));
+        };
+        let expect = LayerBankLayout::matrix_bytes(&encoding, rows, cols)?;
+        let (slot_offset, slot_len) = layout.slot(projection)?;
+        if expect != slot_len {
+            return Err(VindexError::Parse(format!(
+                "tensor `{}`: shape {:?} occupies {expect} bytes in {encoding} but the \
+                 placement reserved {slot_len} — the shape is not the one this layer's \
+                 bank was placed for",
+                t.name, t.shape
+            )));
+        }
+        let offset = placement.layer_base(layer)? + slot_offset;
+
+        let operand = OperandRef {
+            object: object.to_string(),
+            tensor: t.name.clone(),
+            dtype: String::new(),
+            shape: t.shape.clone(),
+        };
+        let stored = source.load_stored(&operand)?;
+        let source_hash = hash_bytes(&stored.bytes);
+
+        if let Some(seal) = index.ledger.get(object, &t.name) {
+            if seal.target_offset != offset {
+                return Err(VindexError::Parse(format!(
+                    "tensor `{}` is sealed at offset {} but this run's placement puts it \
+                     at {offset} — pass the map's full layer scope or start a fresh \
+                     candidate",
+                    t.name, seal.target_offset
+                )));
+            }
+        }
+        match index
+            .ledger
+            .pending(object, &t.name, &source_hash, &encoding)
+        {
+            None => {
+                outcome.resumed += 1;
+                progress(&outcome);
+                continue;
+            }
+            Some(Pending::Absent | Pending::SourceChanged | Pending::EncodingChanged) => {}
+        }
+
+        let materialised = arena.resolve(source, role, &operand)?;
+        if materialised.bytes.len() as u64 != slot_len {
+            return Err(VindexError::Parse(format!(
+                "tensor `{}`: encoder produced {} bytes, layout reserved {slot_len}",
+                t.name,
+                materialised.bytes.len(),
+            )));
+        }
+        file.seek(SeekFrom::Start(offset))?;
+        file.write_all(&materialised.bytes)?;
+        index.ledger.seal(OperandSeal {
+            object: object.to_string(),
+            tensor: t.name.clone(),
+            encoding: encoding.clone(),
+            source_hash,
+            target_hash: hash_bytes(&materialised.bytes),
+            target_offset: offset,
+            target_len: slot_len,
+        });
+        outcome.sealed += 1;
+        outcome.bytes_written += slot_len;
+        if let Some((path, every)) = checkpoint {
+            if every > 0 && (outcome.sealed as u64).is_multiple_of(every) {
+                file.flush()?;
+                write_index_atomically(index, path)?;
+            }
+        }
+        progress(&outcome);
+    }
+    file.flush()?;
+    if let Some((path, _)) = checkpoint {
+        write_index_atomically(index, path)?;
+    }
+    Ok(outcome)
+}
+
+#[cfg(test)]
+#[path = "kda_candidate_tests.rs"]
+mod tests;
+
+#[cfg(test)]
+#[path = "kda_candidate_real.rs"]
+mod real;

--- a/crates/larql-vindex/src/format/vindex3/represent/kda_candidate_real.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/kda_candidate_real.rs
@@ -1,0 +1,157 @@
+//! **The KDA candidate, compiled from the real container.**
+//!
+//! Gated on `LARQL_KIMI_VINDEX3`. The scope is `LARQL_KDA_MAP` — the
+//! same inclusive-band spelling the expert driver reads
+//! (`"20-22:Q8_0,24-25:Q8_0"`), over KDA layers only: an MLA layer in
+//! the band is refused naturally, because MLA ships no separate
+//! k/v_proj and its q_proj geometry disagrees with the placement's.
+//!
+//! ```text
+//! LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.s6.vindex3 \
+//! LARQL_KDA_MAP="20-22:Q8_0,24-25:Q8_0" \
+//! LARQL_KDA_CANDIDATE_OUT=/tmp/kimi-kda-l20-25q80.vindex3 \
+//!   cargo test -p larql-vindex --features gpu --release \
+//!   compile_the_kda_candidate -- --nocapture
+//! ```
+
+use std::path::PathBuf;
+
+use super::super::compile_real_tests::{source_dependency, SegmentSource};
+use super::super::compiler::CandidateIndex;
+use super::super::map::{Exception, PrecisionMap};
+use super::{compile_kda_bank, KDA_PROJECTIONS};
+
+const CONTAINER_ENV: &str = "LARQL_KIMI_VINDEX3";
+const MAP_ENV: &str = "LARQL_KDA_MAP";
+const OUT_ENV: &str = "LARQL_KDA_CANDIDATE_OUT";
+const OBJECT: &str = "target.kda_bank";
+
+fn bands() -> Option<Vec<((u32, u32), String)>> {
+    let spec = std::env::var(MAP_ENV).ok().filter(|v| !v.is_empty())?;
+    Some(
+        spec.split(',')
+            .map(|band| {
+                let (range, enc) = band
+                    .split_once(':')
+                    .unwrap_or_else(|| panic!("{MAP_ENV}: `{band}` is not `LAYERS:ENCODING`"));
+                let (lo, hi) = match range.split_once('-') {
+                    Some((a, b)) => (a.trim().parse().unwrap(), b.trim().parse().unwrap()),
+                    None => {
+                        let l: u32 = range.trim().parse().unwrap();
+                        (l, l)
+                    }
+                };
+                assert!(lo <= hi, "{MAP_ENV}: band `{band}` is inverted");
+                ((lo, hi), enc.trim().to_string())
+            })
+            .collect(),
+    )
+}
+
+#[test]
+fn compile_the_kda_candidate() {
+    let Some(container) = std::env::var_os(CONTAINER_ENV).map(PathBuf::from) else {
+        eprintln!("skipped: set {CONTAINER_ENV} to the source .vindex3");
+        return;
+    };
+    let Some(bands) = bands() else {
+        eprintln!("skipped: set {MAP_ENV} to a band spec like 20-22:Q8_0");
+        return;
+    };
+    let out_dir = std::env::var_os(OUT_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::temp_dir().join("kimi-kda-candidate.vindex3"));
+    std::fs::create_dir_all(out_dir.join("segments")).expect("out dir");
+    let bank = out_dir.join("segments").join(format!("{OBJECT}.bin"));
+
+    let layers: Vec<u32> = bands.iter().flat_map(|((lo, hi), _)| *lo..=*hi).collect();
+    let (source, tensors) =
+        SegmentSource::open_object(&container, "target.decoder_stack", &layers, |name| {
+            KDA_PROJECTIONS
+                .iter()
+                .any(|p| name.ends_with(&format!("self_attn.{p}.weight")))
+        })
+        .expect("decoder stack opens");
+    assert_eq!(
+        tensors.len(),
+        layers.len() * 4,
+        "each KDA layer must hold exactly q/k/v/o_proj — an MLA layer in the band \
+         breaks this count (MLA ships no separate k/v_proj)"
+    );
+
+    let name = format!(
+        "kimi-kda-{}",
+        bands
+            .iter()
+            .map(|((lo, hi), enc)| {
+                let tag = enc.to_lowercase().replace('_', "");
+                if lo == hi {
+                    format!("l{lo}{tag}")
+                } else {
+                    format!("l{lo}-{hi}{tag}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("-")
+    );
+    let map = PrecisionMap {
+        name: name.clone(),
+        encoding: "BF16".into(),
+        roles: vec!["decoder-linear".into()],
+        exceptions: bands
+            .iter()
+            .map(|((lo, hi), enc)| Exception {
+                projection: None,
+                layers: Some((*lo, *hi)),
+                encoding: Some(enc.clone()),
+            })
+            .collect(),
+    };
+    let index_path = out_dir.join("index.json");
+    let mut index = std::fs::read(&index_path)
+        .ok()
+        .and_then(|b| serde_json::from_slice::<CandidateIndex>(&b).ok())
+        .filter(|i: &CandidateIndex| i.map.name == map.name)
+        .unwrap_or_else(|| {
+            CandidateIndex::new(
+                "Kimi-Linear-48B-A3B-Instruct",
+                source_dependency(&container).expect("source index"),
+                OBJECT,
+                map,
+            )
+        });
+
+    let start = std::time::Instant::now();
+    let mut last = std::time::Instant::now();
+    let outcome = compile_kda_bank(
+        &source,
+        &tensors,
+        OBJECT,
+        &bank,
+        Some((&index_path, 8)),
+        &mut index,
+        &mut |o| {
+            if last.elapsed().as_secs() >= 5 {
+                eprintln!(
+                    "[kda-compile]   {} sealed, {} resumed, {:.2} GB written",
+                    o.sealed,
+                    o.resumed,
+                    o.bytes_written as f64 / 1e9
+                );
+                last = std::time::Instant::now();
+            }
+        },
+    )
+    .expect("compiles");
+    let _ =
+        crate::format::vindex3::represent::compiler::write_index_atomically(&index, &index_path);
+    let on_disk = std::fs::metadata(&bank).map(|m| m.len()).unwrap_or(0);
+    eprintln!(
+        "[kda-compile] {name}: {} sealed, {} resumed; {:.3} GB in {:.1}s; bank file {:.3} GB",
+        outcome.sealed,
+        outcome.resumed,
+        outcome.bytes_written as f64 / 1e9,
+        start.elapsed().as_secs_f64(),
+        on_disk as f64 / 1e9,
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/kda_candidate_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/kda_candidate_tests.rs
@@ -1,0 +1,224 @@
+//! Synthetic proof for the KDA candidate family — same discipline as
+//! `compiler_tests`: a hand-built fake source through the REAL compile
+//! path, at a 32-aligned geometry small enough to reason about.
+
+use std::collections::BTreeMap;
+
+use super::super::arena::{SourceOperands, StoredOperand};
+use super::super::compiler::{SourceDependency, SourceIdentity};
+use super::super::map::{Exception, PrecisionMap};
+use super::*;
+
+/// Q8_0 needs every reduction axis %32: qkv k = HIDDEN, o k = WIDTH.
+const WIDTH: usize = 32;
+const HIDDEN: usize = 64;
+const OBJECT: &str = "target.kda_bank";
+
+struct Fake {
+    bytes: BTreeMap<String, Vec<u8>>,
+}
+
+impl Fake {
+    fn layers(layers: &[u32]) -> (Self, Vec<SourceTensor>) {
+        let mut bytes = BTreeMap::new();
+        let mut tensors = Vec::new();
+        for &layer in layers {
+            for (proj, rows, cols) in [
+                ("q_proj", WIDTH, HIDDEN),
+                ("k_proj", WIDTH, HIDDEN),
+                ("v_proj", WIDTH, HIDDEN),
+                ("o_proj", HIDDEN, WIDTH),
+            ] {
+                let name = format!("{layer}.self_attn.{proj}.weight");
+                let v: Vec<u8> = (0..rows * cols)
+                    .flat_map(|i| {
+                        let f = ((i as f32) * 0.017 + layer as f32).sin();
+                        ((f.to_bits() >> 16) as u16).to_le_bytes()
+                    })
+                    .collect();
+                bytes.insert(name.clone(), v);
+                tensors.push(SourceTensor {
+                    name,
+                    shape: vec![rows, cols],
+                });
+            }
+        }
+        (Self { bytes }, tensors)
+    }
+}
+
+impl SourceOperands for Fake {
+    fn load_stored(&self, operand: &OperandRef) -> Result<StoredOperand, VindexError> {
+        Ok(StoredOperand {
+            dtype: "BF16".into(),
+            bytes: self
+                .bytes
+                .get(&operand.tensor)
+                .ok_or_else(|| VindexError::Parse(format!("no `{}`", operand.tensor)))?
+                .clone(),
+        })
+    }
+}
+
+fn map_for(exceptions: Vec<Exception>) -> PrecisionMap {
+    PrecisionMap {
+        name: "kda-native-test".into(),
+        encoding: "BF16".into(),
+        roles: vec!["decoder-linear".into()],
+        exceptions,
+    }
+}
+
+fn band(lo: u32, hi: u32, encoding: &str) -> Exception {
+    Exception {
+        projection: None,
+        layers: Some((lo, hi)),
+        encoding: Some(encoding.into()),
+    }
+}
+
+fn index(map: PrecisionMap) -> CandidateIndex {
+    CandidateIndex::new(
+        "Kimi-Linear-48B-A3B-Instruct",
+        SourceDependency {
+            identity: SourceIdentity {
+                manifest_hash: "m".repeat(64),
+                graph_hash: "g".repeat(64),
+                segments: BTreeMap::from([("target.decoder_stack.bin".into(), "a".repeat(64))]),
+            },
+            locator_hint: "/somewhere/source.vindex3".into(),
+        },
+        OBJECT,
+        map,
+    )
+}
+
+/// The four slots land disjoint, in order, at the strides the encoding
+/// dictates — and a two-layer bank places the second layer at exactly
+/// the first's extent.
+#[test]
+fn the_four_slots_are_disjoint_and_layers_stack() {
+    let map = map_for(vec![band(1, 2, "Q8_0")]);
+    let placement = KdaPlacement::resolve(&map, Role::DecoderLinear, &[1, 2], WIDTH, HIDDEN)
+        .expect("placement resolves");
+    let l1 = placement.layout(1).expect("layer 1 placed");
+    let per = LayerBankLayout::matrix_bytes("Q8_0", WIDTH, HIDDEN).unwrap();
+    assert_eq!(l1.slot("q_proj").unwrap(), (0, per));
+    assert_eq!(l1.slot("k_proj").unwrap(), (per, per));
+    assert_eq!(l1.slot("v_proj").unwrap(), (2 * per, per));
+    assert_eq!(l1.slot("o_proj").unwrap().0, 3 * per);
+    assert!(
+        l1.slot("w1").is_err(),
+        "an expert spelling has no slot here"
+    );
+    assert_eq!(placement.layer_base(2).unwrap(), l1.layer_bytes());
+}
+
+/// End to end through the real compile path: every compiled projection
+/// sealed at its placed offset, bytes at those offsets decode back to
+/// the source values within the Q8_0 roundtrip bound, and a rerun
+/// resumes every seal instead of recompiling.
+#[test]
+fn a_kda_bank_compiles_seals_and_resumes() {
+    let dir = tempfile::tempdir().expect("tmp");
+    let out = dir.path().join("kda_bank.bin");
+    let (fake, tensors) = Fake::layers(&[1, 2]);
+    let mut idx = index(map_for(vec![band(1, 2, "Q8_0")]));
+
+    let outcome = compile_kda_bank(&fake, &tensors, OBJECT, &out, None, &mut idx, &mut |_| {})
+        .expect("compiles");
+    assert_eq!(outcome.sealed, 8, "4 projections x 2 layers");
+    assert_eq!(outcome.resumed, 0);
+
+    // Bytes on disk equal the arena's own answer for one slot.
+    let placement =
+        KdaPlacement::resolve(&idx.map, Role::DecoderLinear, &[1, 2], WIDTH, HIDDEN).unwrap();
+    let l2 = placement.layout(2).unwrap();
+    let (o, len) = l2.slot("v_proj").unwrap();
+    let base = placement.layer_base(2).unwrap();
+    let disk = std::fs::read(&out).unwrap();
+    let seal = idx
+        .ledger
+        .get(OBJECT, "2.self_attn.v_proj.weight")
+        .expect("sealed");
+    assert_eq!(seal.target_offset, base + o);
+    assert_eq!(seal.target_len, len);
+    assert_eq!(
+        hash_bytes(&disk[(base + o) as usize..(base + o + len) as usize]),
+        seal.target_hash,
+        "the sealed hash is the hash of the bytes at the sealed offset"
+    );
+
+    let again = compile_kda_bank(&fake, &tensors, OBJECT, &out, None, &mut idx, &mut |_| {})
+        .expect("recompiles");
+    assert_eq!(again.sealed, 0);
+    assert_eq!(again.resumed, 8, "a second pass resumes, never rewrites");
+}
+
+/// A scope holding anything but the four projections is refused BY
+/// NAME — a bank that silently skipped a tensor would leave the caller
+/// believing it was compiled.
+#[test]
+fn a_non_kda_tensor_in_the_scope_is_refused_by_name() {
+    let dir = tempfile::tempdir().expect("tmp");
+    let out = dir.path().join("kda_bank.bin");
+    let (fake, mut tensors) = Fake::layers(&[1]);
+    tensors.push(SourceTensor {
+        name: "1.block_sparse_moe.experts.0.w1.weight".into(),
+        shape: vec![WIDTH, HIDDEN],
+    });
+    let mut idx = index(map_for(vec![band(1, 1, "Q8_0")]));
+    let err = compile_kda_bank(&fake, &tensors, OBJECT, &out, None, &mut idx, &mut |_| {})
+        .expect_err("must refuse");
+    assert!(format!("{err}").contains("w1"), "{err}");
+}
+
+/// A transposed projection — right bytes, wrong axes — refuses at the
+/// placement check instead of landing plausibly at the wrong extent.
+/// The geometry is chosen so the byte COUNT would match: only the
+/// per-axis block constraint and stride derivation can catch it.
+#[test]
+fn a_transposed_projection_is_refused() {
+    let dir = tempfile::tempdir().expect("tmp");
+    let out = dir.path().join("kda_bank.bin");
+    let (fake, mut tensors) = Fake::layers(&[1]);
+    // Swap q_proj's declared axes.
+    let q = tensors
+        .iter_mut()
+        .find(|t| t.name.ends_with("q_proj.weight"))
+        .unwrap();
+    q.shape = vec![HIDDEN, WIDTH];
+    let mut idx = index(map_for(vec![band(1, 1, "Q6_K")]));
+    // Q6_K needs k % 256 — neither axis satisfies it, so the refusal
+    // must name the constraint rather than accept the transpose.
+    let err = compile_kda_bank(&fake, &tensors, OBJECT, &out, None, &mut idx, &mut |_| {})
+        .expect_err("must refuse");
+    assert!(format!("{err}").contains("256"), "{err}");
+}
+
+/// Per-layer encodings compose in one bank exactly as the expert
+/// placement allows — and a layer with MIXED encodings is refused.
+#[test]
+fn per_layer_encodings_place_and_mixed_within_a_layer_refuses() {
+    let map = map_for(vec![band(1, 1, "Q8_0"), band(2, 2, "BF16")]);
+    let p = KdaPlacement::resolve(&map, Role::DecoderLinear, &[1, 2], WIDTH, HIDDEN)
+        .expect("two encodings, two layers");
+    assert_eq!(p.layout(1).unwrap().encoding, "Q8_0");
+    assert_eq!(p.layout(2).unwrap().encoding, "BF16");
+
+    let mixed = map_for(vec![
+        Exception {
+            projection: Some("q_proj".into()),
+            layers: Some((1, 1)),
+            encoding: Some("Q8_0".into()),
+        },
+        Exception {
+            projection: Some("o_proj".into()),
+            layers: Some((1, 1)),
+            encoding: Some("BF16".into()),
+        },
+    ]);
+    let err = KdaPlacement::resolve(&mixed, Role::DecoderLinear, &[1], WIDTH, HIDDEN)
+        .expect_err("mixed encodings within one layer must refuse");
+    assert!(format!("{err}").contains("ONE encoding"), "{err}");
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -51,6 +51,7 @@ pub mod compile;
 pub mod compiler;
 pub mod experiment;
 pub mod gptq;
+pub mod kda_candidate;
 pub mod map;
 pub mod nvfp4_pack;
 pub mod physical;


### PR DESCRIPTION
## What

NATIVE-KDA-1: KDA projections become a second native candidate family — compiled, sealed,
verified, loaded, and gated **bit-equal** against the transient path every behavioural
result was earned on.

## Design

A KDA candidate is its own candidate object (`target.kda_bank`: own index, map, seals) —
the expert bank's placement machinery is expert-shaped (identity addressing over a
population), while a KDA layer holds exactly four matrices. The loader composes the two
candidate kinds side by side (`device_layer_with_kda`), which is the architecture the
cross-family probe already proved behaviourally, made physical. The f32 recurrence
operands are never stored by any candidate kind.

## The gate

`kda_native_parity`: every compiled layer's banks **byte-equal** between the
transient-requant arm and the compiler-sealed native arm — proving the arena encoder and
the loader's quantizer are one function — then 64 teacher-forced positions of logits
**bit-equal** end to end. Zero tolerance, zero difference. This also carries the balanced
flagship's measured decode economics (1.074×) over to native storage *by proof*: bit-equal
bytes execute identically.

## Numbers

Real cut from the lift2 container: `kimi-kda-l20-22q80-l24-25q80` — 20 seals, **201 MB
native vs 377 MB of BF16 replaced**, 1.8 s compile, kill-resumable, completeness proven at
open, bytes re-hashed against seals on every read.

## Gates

fmt/clippy clean; larql-vindex (gpu, release) 3469 + 110, zero failures; no-gpu
--all-targets clean; 5 synthetic compiler gates + the parity gate green.
