### PR TITLE
LMHEAD-1: the output head joins the representation vocabulary — three families, both banks, 40 tok/s

### DIFF
--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/head.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/head.rs
@@ -20,13 +20,17 @@ use super::super::grouped_experts::{ExpertOffset, GroupedError, InputLayout};
 use super::KimiLayerCall;
 use crate::MetalBackend;
 
-/// The head's weights. `weight` is `vocab x hidden` row-major bf16.
+/// The head's weights. `weight` is `vocab x hidden` row-major, in
+/// `encoding` — the same grouped-kernel family every projection in
+/// this crate reads, so the dispatch selects its pipeline by encoding
+/// exactly as the expert and KDA paths do.
 #[derive(Clone, Copy)]
 pub struct KimiHead<'a> {
     pub norm_weight: &'a [f32],
     pub norm_eps: f32,
     pub weight: &'a [u8],
     pub vocab: usize,
+    pub encoding: super::ExpertEncoding,
 }
 
 /// Device scratch for one head evaluation.
@@ -103,8 +107,14 @@ impl MetalBackend {
                 have_bytes: head.weight.len(),
             });
         }
-        // bf16: two bytes a code, one row a vocabulary entry.
-        if head.weight.len() != head.vocab * hidden * 2 {
+        // Bytes at the ENCODING's own stride — the bf16 arithmetic
+        // would over-demand on a quantised head and under-demand the
+        // other way, exactly the failure the KDA validator refuses.
+        let want = head
+            .encoding
+            .matrix_bytes(head.vocab, hidden)
+            .ok_or(GroupedError::KNotSuperblockAligned { k: hidden })?;
+        if head.weight.len() != want {
             return Err(GroupedError::HeadShapeMismatch {
                 vocab: head.vocab,
                 hidden,
@@ -137,7 +147,7 @@ impl MetalBackend {
         self.encode_rms_norm(enc, input, &norm_w, &s.normed, hidden, head.norm_eps);
         encode_grouped(
             enc,
-            self.default_grouped_handle(),
+            self.grouped_handle_for(head.encoding),
             GroupedBinding {
                 w: &w,
                 w_offset,

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/head.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/head.rs
@@ -1,6 +1,7 @@
 //! The model head — final norm plus the vocabulary projection.
 
 use super::*;
+use crate::trait_impl::kimi_layer::ExpertEncoding;
 
 const VOCAB: usize = 5;
 
@@ -33,6 +34,7 @@ fn the_head_matches_a_host_reference() {
                 norm_eps: EPS,
                 weight: &w,
                 vocab: VOCAB,
+                encoding: ExpertEncoding::Bf16,
             },
             &x,
         )
@@ -77,6 +79,7 @@ fn the_head_inside_the_chain_equals_the_head_run_after_it() {
         norm_eps: EPS,
         weight: &w,
         vocab: VOCAB,
+        encoding: ExpertEncoding::Bf16,
     };
 
     let state_a = KdaDeviceState::zeros(&b, shape());
@@ -136,6 +139,7 @@ fn head_shape_faults_are_refused() {
         norm_eps: EPS,
         weight: &w,
         vocab: VOCAB,
+        encoding: ExpertEncoding::Bf16,
     };
 
     let mut truncated = ok;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/kimi_source.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/kimi_source.rs
@@ -550,6 +550,7 @@ impl KimiSourceModel {
             weight: head.bytes("weight")?,
             vocab: self.geometry.vocab,
             norm_eps: self.geometry.rms_eps,
+            encoding: MetalEncoding::Bf16,
         })
     }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/stack_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/stack_metal.rs
@@ -366,6 +366,9 @@ pub struct HybridHead {
     pub weight: Vec<u8>,
     pub vocab: usize,
     pub norm_eps: f32,
+    /// Physical representation of `weight` — the dispatch selects its
+    /// kernel by this, same contract as every projection bank.
+    pub encoding: ExpertEncoding,
 }
 
 impl<'a> HybridStack<'a> {
@@ -510,6 +513,7 @@ impl<'a> HybridStack<'a> {
                             norm_eps: hd.norm_eps,
                             weight: &hd.weight,
                             vocab: hd.vocab,
+                            encoding: hd.encoding,
                         },
                         &h,
                         trace.as_deref_mut(),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/generate_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/generate_metal.rs
@@ -562,6 +562,7 @@ fn sixteen_greedy_tokens_through_the_mixed_metal_stack() {
             weight: lm_head_bf16,
             vocab: vocab_from_head,
             norm_eps: eps as f32,
+            encoding: MetalEncoding::Bf16,
         }),
         "the stack must end on a device layer for the head to ride in its epoch"
     );
@@ -725,6 +726,7 @@ fn the_device_head_matches_the_oracle_from_the_last_layers_output() {
                 norm_eps: eps as f32,
                 weight: &w_bf16,
                 vocab,
+                encoding: MetalEncoding::Bf16,
             },
             &h,
         )
@@ -765,6 +767,7 @@ fn the_device_head_matches_the_oracle_from_the_last_layers_output() {
                 norm_eps: eps as f32,
                 weight: &w_bf16,
                 vocab,
+                encoding: MetalEncoding::Bf16,
             },
             &other,
         )

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
@@ -49,11 +49,25 @@ const LAYER_ENV: &str = "LARQL_KDA_Q8_LAYER";
 const LAYER_DEFAULT: &str = "25";
 
 fn target_layers() -> Vec<usize> {
-    std::env::var(LAYER_ENV)
-        .unwrap_or_else(|_| LAYER_DEFAULT.into())
-        .split(',')
+    let spec = std::env::var(LAYER_ENV).unwrap_or_else(|_| LAYER_DEFAULT.into());
+    if spec.trim().is_empty() {
+        // A HEAD-ONLY probe: no layer scope at all.
+        return Vec::new();
+    }
+    spec.split(',')
         .map(|v| v.trim().parse().expect("layer index"))
         .collect()
+}
+
+/// `LARQL_LMHEAD_Q8=1` re-encodes the candidate arm's OUTPUT HEAD to
+/// Q8_0 — the head's perturbation lands directly at the logits, with
+/// no downstream router or recurrence to mediate it, which makes this
+/// probe a control against the interaction mechanisms measured
+/// everywhere else as much as a lever measurement.
+const LMHEAD_ENV: &str = "LARQL_LMHEAD_Q8";
+
+fn head_q8() -> bool {
+    std::env::var(LMHEAD_ENV).is_ok_and(|v| v == "1")
 }
 /// Diagnostic slice, same default as the expert probes.
 const SEQUENCES_ENV: &str = "LARQL_Q2A_SEQUENCES";
@@ -168,6 +182,18 @@ pub(super) fn assemble<'a>(
     model: &KimiSourceModel,
     device: Vec<Option<DeviceLayer>>,
 ) -> HybridStack<'a> {
+    assemble_with_head(metal, model, device, false)
+}
+
+/// `assemble`, optionally re-encoding the head to Q8_0. Returns with
+/// the swap PROVEN: a candidate arm that silently kept the bf16 head
+/// would measure nothing.
+pub(super) fn assemble_with_head<'a>(
+    metal: &MetalBackend,
+    model: &KimiSourceModel,
+    device: Vec<Option<DeviceLayer>>,
+    q8_head: bool,
+) -> HybridStack<'a> {
     for d in device.iter().flatten() {
         for bank in d.attention_banks() {
             metal.register_weight_region(bank);
@@ -175,7 +201,19 @@ pub(super) fn assemble<'a>(
     }
     let host = (0..device.len()).map(|_| None).collect();
     let mut stack = HybridStack::new(device, host);
-    assert!(stack.attach_head(model.head().expect("the head must load")));
+    let mut head = model.head().expect("the head must load");
+    if q8_head {
+        let before = head.weight.len();
+        head.weight = quantize_q8_0(&widen_bf16(&head.weight));
+        head.encoding = MetalEncoding::Q80;
+        assert!(head.weight.len() < before, "the head swap did not happen");
+        eprintln!(
+            "[kda-q8] output head re-encoded Q8_0: {before} -> {} bytes ({:.1}%)",
+            head.weight.len(),
+            100.0 * head.weight.len() as f64 / before as f64
+        );
+    }
+    assert!(stack.attach_head(head));
     stack
 }
 
@@ -324,6 +362,11 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
         .as_ref()
         .map(|o| o.compiled_layers().to_vec())
         .unwrap_or_default();
+    let q8h = head_q8();
+    assert!(
+        !layers.is_empty() || overlay.is_some() || q8h,
+        "an empty scope with no overlay and no head flag measures nothing"
+    );
     let (base_layers, none) = build_layers(&metal, &model, &[], None);
     let (cand_layers, swapped) = build_layers(&metal, &model, &layers, overlay.as_ref());
     assert!(none.is_empty());
@@ -331,7 +374,7 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
     let bf16_bytes: usize = swapped.iter().map(|(b, _)| b).sum();
     let q8_bytes: usize = swapped.iter().map(|(_, q)| q).sum();
     assert!(
-        q8_bytes < bf16_bytes,
+        layers.is_empty() || q8_bytes < bf16_bytes,
         "Q8_0 must be smaller than bf16 — the swap did not happen"
     );
     // Attribution BEFORE assembly: proven on the layers themselves, so
@@ -340,7 +383,7 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
     assert_arms_differ_only_at(&base_layers, &cand_layers, &layers, &expert_layers);
     let (null_layers, _) = build_layers(&metal, &model, &[], None);
     let mut baseline = assemble(&metal, &model, base_layers);
-    let mut candidate = assemble(&metal, &model, cand_layers);
+    let mut candidate = assemble_with_head(&metal, &model, cand_layers, q8h);
     let mut null_partner = assemble(&metal, &model, null_layers);
     metal.seal_weight_regions();
     eprintln!(
@@ -434,6 +477,13 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
         .join("-");
     if let Some(o) = &overlay {
         label = format!("{label}-x-{}", o.index.map.name);
+    }
+    if q8h {
+        label = if label.is_empty() || label == "" {
+            "headq8".into()
+        } else {
+            format!("{label}-headq8")
+        };
     }
     let report = serde_json::json!({
         "run": format!("kda-q8-l{label}"),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_decode_bench.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_decode_bench.rs
@@ -35,7 +35,7 @@ use larql_compute::backend::ComputeBackend;
 use larql_compute_metal::MetalBackend;
 use serde_json::Value;
 
-use super::kda_q8_real::{assemble, build_layers};
+use super::kda_q8_real::{assemble, assemble_with_head, build_layers};
 use super::q2a_teacher_forced::{
     build_stack, env_dir, sequence_embeddings, BANK_ENV, CANDIDATE_ENV, SOURCE_ENV,
 };
@@ -162,9 +162,10 @@ fn decode_rate_of_the_candidate_map_beside_its_own_bf16_baseline() {
             kda_layers.len(),
             "every KDA target re-encoded"
         );
+        let q8_head = std::env::var("LARQL_LMHEAD_Q8").is_ok_and(|v| v == "1");
         (
             assemble(&metal, &model, base),
-            assemble(&metal, &model, cand),
+            assemble_with_head(&metal, &model, cand, q8_head),
         )
     };
     metal.seal_weight_regions();


### PR DESCRIPTION
## What

LMHEAD-1: the output head becomes the third representable byte family — probed, composed,
earned at both banks under the frozen balanced contract, and benchmarked past 40 tok/s
against a pre-registered prediction.

## The mechanism result

The head was already a single-slot grouped dispatch, so the KDA pattern applied verbatim:
`KimiHead`/`HybridHead` carry an encoding, validation runs at the encoding's own stride,
the dispatch selects its pipeline by encoding. Head-only Q8_0 measured the predicted
signature exactly — **KL p99 7.125e-4, one argmax flip, zero route flips, flat
token-distance curve**: pure direct logit displacement, no cascade, no recurrent carry.
The probe doubled as a control on every interaction mechanism measured elsewhere. 755 →
401 MB.

## The composition result

Added to the balanced flagship, the head is absorbed entirely (2.432e-3 → 2.401e-3
composed). The three-family map — experts L20-26, KDA L20,21,22,24,25, output head, all
Q8_0, ~19% of decode traffic — passes **every kimi-logit-balanced-v1 criterion at 8,192
positions on BOTH banks**, including the held-out bank the search never touched.
kimi-logit-v3 refuses it: the strict and balanced contracts doing different jobs, visibly.

## The number — and the property that matters more

| | |
|---|---|
| BF16 (in-session floors) | 35.65 / 35.11 tok/s |
| three-family balanced | **40.44 / 39.45 tok/s** |
| speedup | 1.134× / 1.124× (pre-registered prediction: 1.11-1.12×) |
| GPU time | 26.5-27.2 → 23.5-24.1 ms/token (−11.1-11.5% vs −11.6% modeled) |

The optimizer has now predicted decode performance correctly across three increasingly
broad physical maps (experts; experts+KDA; experts+KDA+head). **Decode performance is
predictable from the physical byte plan to within a small error once the calibrated
fixed-overhead term is included** — a system property, not a fitted curiosity.

Ladder to date: ~35.4 BF16 → 36.3 strict → 38.5 two-family → **~40.0 three-family** —
roughly 13% real throughput without yet touching Q6/Q4 or the MLA/shared traffic.

## Gates

fmt/clippy clean both crates; larql-vindex (gpu, release) 3469 + 110 and
larql-compute-metal full suite, zero failures; no-gpu --all-targets clean. Evidence
(1A/1B reports, both authority runs, bench logs) persisted beside the quality bank.
