### PR TITLE
MLA-SHARED-1: the four-family map earned at both banks — MLA absorbed, shared experts refused on economics

### DIFF
--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/mod.rs
@@ -525,6 +525,7 @@ impl MlaBits {
             kv_b_proj: &self.kb,
             o_proj: &self.o,
             kv_a_norm_eps: EPS,
+            projection_encoding: ExpertEncoding::Bf16,
         }
     }
 }

--- a/crates/larql-compute-metal/src/trait_impl/mla/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/mla/mod.rs
@@ -34,8 +34,8 @@
 use metal::{Buffer, ComputeCommandEncoderRef, MTLSize};
 
 use super::bf16_grouped::{encode_grouped, GroupedBinding, GroupedShape};
-use super::kimi_layer::ExpertEncoding;
 use super::grouped_experts::{ExpertOffset, GroupedError, InputLayout};
+use super::kimi_layer::ExpertEncoding;
 use crate::shaders::mla as mla_shader;
 use crate::MetalBackend;
 

--- a/crates/larql-compute-metal/src/trait_impl/mla/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/mla/mod.rs
@@ -34,6 +34,7 @@
 use metal::{Buffer, ComputeCommandEncoderRef, MTLSize};
 
 use super::bf16_grouped::{encode_grouped, GroupedBinding, GroupedShape};
+use super::kimi_layer::ExpertEncoding;
 use super::grouped_experts::{ExpertOffset, GroupedError, InputLayout};
 use crate::shaders::mla as mla_shader;
 use crate::MetalBackend;
@@ -88,6 +89,11 @@ pub struct MlaDeviceWeights<'a> {
     /// `[hidden, heads * v_head_dim]` bf16.
     pub o_proj: &'a [u8],
     pub kv_a_norm_eps: f32,
+    /// Physical representation of the four wide projections — and of
+    /// nothing else: `kv_a_norm` stays f32, and the cache always holds
+    /// decoded latents. Dispatch selects its kernel by this value, the
+    /// same contract as the expert, KDA and head paths.
+    pub projection_encoding: ExpertEncoding,
 }
 
 /// The growing compressed-latent cache, resident for the sequence.
@@ -322,7 +328,7 @@ impl MetalBackend {
 
         encode_grouped(
             enc,
-            self.default_grouped_handle(),
+            self.grouped_handle_for(w.projection_encoding),
             GroupedBinding {
                 w: &wq.0,
                 w_offset: wq.1,
@@ -342,6 +348,7 @@ impl MetalBackend {
         // append kernel and nothing crosses to the host.
         self.encode_grouped_at_offset(
             enc,
+            self.grouped_handle_for(w.projection_encoding),
             (&wa.0, wa.1),
             &offsets,
             buf_x,
@@ -364,7 +371,7 @@ impl MetalBackend {
         );
         encode_grouped(
             enc,
-            self.default_grouped_handle(),
+            self.grouped_handle_for(w.projection_encoding),
             GroupedBinding {
                 w: &wb.0,
                 w_offset: wb.1,
@@ -382,7 +389,7 @@ impl MetalBackend {
         self.encode_mla_attention(enc, s, &state.cache, shape, visible);
         encode_grouped(
             enc,
-            self.default_grouped_handle(),
+            self.grouped_handle_for(w.projection_encoding),
             GroupedBinding {
                 w: &wo.0,
                 w_offset: wo.1,
@@ -405,6 +412,7 @@ impl MetalBackend {
     fn encode_grouped_at_offset(
         &self,
         enc: &ComputeCommandEncoderRef,
+        handle: &crate::kernels::KernelHandle,
         w: (&Buffer, u64),
         offsets: &Buffer,
         x: &Buffer,
@@ -412,7 +420,6 @@ impl MetalBackend {
         out_offset: u64,
         shape: GroupedShape,
     ) {
-        let handle = self.default_grouped_handle();
         let (n32, k32, stride) = (shape.n as u32, shape.k as u32, 0u32);
         enc.set_compute_pipeline_state(&handle.state);
         enc.set_buffer(0, Some(w.0), w.1);

--- a/crates/larql-compute-metal/src/trait_impl/mla/tests.rs
+++ b/crates/larql-compute-metal/src/trait_impl/mla/tests.rs
@@ -91,6 +91,7 @@ impl Weights {
             kv_b_proj: &self.kb_bytes,
             o_proj: &self.o_bytes,
             kv_a_norm_eps: EPS,
+            projection_encoding: ExpertEncoding::Bf16,
         }
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/kimi_source.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/kimi_source.rs
@@ -343,6 +343,7 @@ impl KimiSourceModel {
                     kv_b: self.decoder.bytes(&t("kv_b_proj.weight"))?,
                     o: self.decoder.bytes(&t("o_proj.weight"))?,
                     kv_a_norm: self.decoder.f32s(&t("kv_a_layernorm.weight"))?,
+                    encoding: MetalEncoding::Bf16,
                 },
                 DeviceState::Mla(MlaDeviceState::with_capacity(
                     metal,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/stack_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/stack_metal.rs
@@ -73,6 +73,8 @@ pub enum DeviceAttn {
         kv_b: Vec<u8>,
         o: Vec<u8>,
         kv_a_norm: Vec<f32>,
+        /// Physical representation of the four wide projections.
+        encoding: ExpertEncoding,
     },
 }
 
@@ -202,6 +204,7 @@ impl DeviceLayer {
                     kv_b,
                     o,
                     kv_a_norm,
+                    encoding,
                 },
                 DeviceState::Mla(state),
             ) => AttentionSpec::Mla {
@@ -212,6 +215,7 @@ impl DeviceLayer {
                     kv_b_proj: kv_b,
                     o_proj: o,
                     kv_a_norm_eps: self.mla_norm_eps,
+                    projection_encoding: *encoding,
                 },
                 shape: self.mla_shape,
                 state,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/generate_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/generate_metal.rs
@@ -277,6 +277,7 @@ fn attention_for(
                 kv_b: mla("kv_b_proj"),
                 o: mla("o_proj"),
                 kv_a_norm: read_f32(dir, &format!("layer{i}_mla_kv_a_norm")),
+                encoding: MetalEncoding::Bf16,
             },
             DeviceState::Mla(MlaDeviceState::with_capacity(
                 metal,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
@@ -41,14 +41,16 @@ use crate::format::vindex3::represent::bank::BankBuilder;
 use crate::format::vindex3::represent::physical::{
     EncodedRegion, ExpertEncoding as PhysEncoding, PhysicalStore, SharedExpertBinding,
 };
-use crate::format::vindex3::represent::quality::{kimi_logit_v3, Criterion, QualityEvidence};
+use crate::format::vindex3::represent::quality::{
+    kimi_logit_balanced_v1, kimi_logit_v3, Criterion, QualityEvidence,
+};
 
 /// Which KDA layers' projections the candidate arm re-encodes — a
 /// comma list (`"20,21,22,24,25"` is the late band; MLA positions are
 /// refused by the requant itself). Default 25: the depth with the
 /// richest expert-side evidence, so the recurrence-vs-router
 /// comparison is at matched depth.
-const LAYER_ENV: &str = "LARQL_KDA_Q8_LAYER";
+pub(super) const LAYER_ENV: &str = "LARQL_KDA_Q8_LAYER";
 const LAYER_DEFAULT: &str = "25";
 
 fn target_layers() -> Vec<usize> {
@@ -67,18 +69,18 @@ fn target_layers() -> Vec<usize> {
 /// no downstream router or recurrence to mediate it, which makes this
 /// probe a control against the interaction mechanisms measured
 /// everywhere else as much as a lever measurement.
-const LMHEAD_ENV: &str = "LARQL_LMHEAD_Q8";
+pub(super) const LMHEAD_ENV: &str = "LARQL_LMHEAD_Q8";
 
 /// MLA layers whose four wide projections the candidate arm re-encodes
 /// (comma list). The recurrence-free sibling of the KDA scope — the
 /// latent cache always holds decoded values whatever this says.
-const MLA_ENV: &str = "LARQL_MLA_Q8_LAYER";
+pub(super) const MLA_ENV: &str = "LARQL_MLA_Q8_LAYER";
 /// Layers whose SHARED-expert branch the candidate arm re-encodes
 /// (comma list). Zero kernel work: the shared dispatch has been
 /// encoding-aware since the expert rung — only these bytes were not.
-const SHARED_ENV: &str = "LARQL_SHARED_Q8_LAYER";
+pub(super) const SHARED_ENV: &str = "LARQL_SHARED_Q8_LAYER";
 
-fn layer_list(var: &str) -> Vec<usize> {
+pub(super) fn layer_list(var: &str) -> Vec<usize> {
     let Ok(spec) = std::env::var(var) else {
         return Vec::new();
     };
@@ -90,7 +92,7 @@ fn layer_list(var: &str) -> Vec<usize> {
         .collect()
 }
 
-fn head_q8() -> bool {
+pub(super) fn head_q8() -> bool {
     std::env::var(LMHEAD_ENV).is_ok_and(|v| v == "1")
 }
 /// Diagnostic slice, same default as the expert probes.
@@ -642,6 +644,12 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
         bank: bank.clone(),
     };
     let verdict = evidence.verdict();
+    // v3 is the strict authority every earlier cell cited; balanced-v1
+    // is the frozen contract a COMPOSED map is admitted under. Both
+    // travel in the artifact so a reader never has to re-derive the
+    // verdict this run's claim rests on from the bank by hand.
+    let balanced_gate = kimi_logit_balanced_v1();
+    let balanced = balanced_gate.evaluate(&bank);
     let bank_manifest_sha256 = {
         use sha2::{Digest, Sha256};
         let bytes = std::fs::read(bank_dir.join("manifest.json")).expect("bank manifest reads");
@@ -664,7 +672,7 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
         label = format!("{label}-shared{}", tag.join("-"));
     }
     if q8h {
-        label = if label.is_empty() || label == "" {
+        label = if label.is_empty() {
             "headq8".into()
         } else {
             format!("{label}-headq8")
@@ -678,6 +686,10 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
         "authority_report": evidence.report(),
         "verdict_passed": verdict.passed(),
         "verdict_failures": verdict.failures.iter()
+            .map(|(c, d)| format!("{}: {d}", c.name())).collect::<Vec<_>>(),
+        "balanced_gate": balanced_gate,
+        "verdict_balanced_v1_passed": balanced.passed(),
+        "verdict_balanced_v1_failures": balanced.failures.iter()
             .map(|(c, d)| format!("{}: {d}", c.name())).collect::<Vec<_>>(),
         "bank_manifest_sha256": bank_manifest_sha256,
         "bank": bank,
@@ -694,7 +706,8 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
     )
     .expect("report writes");
     eprintln!("{}", evidence.report());
-    eprintln!("[kda-q8] verdict: {verdict:?} — report at {path}");
+    eprintln!("[kda-q8] verdict (v3): {verdict:?}");
+    eprintln!("[kda-q8] verdict (balanced-v1): {balanced:?} — report at {path}");
 
     if bank.positions < 4096 {
         assert!(!verdict.passed(), "sub-4096 positions can never pass v3");

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
@@ -38,6 +38,9 @@ use super::q2a_teacher_forced::{
 use crate::format::vindex3::opplan::exec::kimi_source::{CandidateOverlay, KimiSourceModel};
 use crate::format::vindex3::opplan::exec::stack_metal::{DeviceAttn, DeviceLayer, HybridStack};
 use crate::format::vindex3::represent::bank::BankBuilder;
+use crate::format::vindex3::represent::physical::{
+    EncodedRegion, ExpertEncoding as PhysEncoding, PhysicalStore, SharedExpertBinding,
+};
 use crate::format::vindex3::represent::quality::{kimi_logit_v3, Criterion, QualityEvidence};
 
 /// Which KDA layers' projections the candidate arm re-encodes — a
@@ -65,6 +68,27 @@ fn target_layers() -> Vec<usize> {
 /// probe a control against the interaction mechanisms measured
 /// everywhere else as much as a lever measurement.
 const LMHEAD_ENV: &str = "LARQL_LMHEAD_Q8";
+
+/// MLA layers whose four wide projections the candidate arm re-encodes
+/// (comma list). The recurrence-free sibling of the KDA scope — the
+/// latent cache always holds decoded values whatever this says.
+const MLA_ENV: &str = "LARQL_MLA_Q8_LAYER";
+/// Layers whose SHARED-expert branch the candidate arm re-encodes
+/// (comma list). Zero kernel work: the shared dispatch has been
+/// encoding-aware since the expert rung — only these bytes were not.
+const SHARED_ENV: &str = "LARQL_SHARED_Q8_LAYER";
+
+fn layer_list(var: &str) -> Vec<usize> {
+    let Ok(spec) = std::env::var(var) else {
+        return Vec::new();
+    };
+    if spec.trim().is_empty() {
+        return Vec::new();
+    }
+    spec.split(',')
+        .map(|v| v.trim().parse().expect("layer index"))
+        .collect()
+}
 
 fn head_q8() -> bool {
     std::env::var(LMHEAD_ENV).is_ok_and(|v| v == "1")
@@ -152,6 +176,73 @@ fn layer_bytes(layer: &DeviceLayer) -> usize {
     }
 }
 
+/// Re-encode an MLA layer's four wide projections in place.
+fn requant_mla_projections(layer: &mut DeviceLayer) -> (usize, usize) {
+    let DeviceAttn::Mla {
+        q,
+        kv_a,
+        kv_b,
+        o,
+        encoding,
+        ..
+    } = &mut layer.attn
+    else {
+        panic!("the MLA target layer must be MLA — check the interleave");
+    };
+    let before = q.len() + kv_a.len() + kv_b.len() + o.len();
+    for m in [q, kv_a, kv_b, o] {
+        *m = quantize_q8_0(&widen_bf16(m));
+    }
+    *encoding = MetalEncoding::Q80;
+    let after = match &layer.attn {
+        DeviceAttn::Mla {
+            q, kv_a, kv_b, o, ..
+        } => q.len() + kv_a.len() + kv_b.len() + o.len(),
+        _ => unreachable!(),
+    };
+    (before, after)
+}
+
+/// Re-encode a layer's shared-expert branch into an owned Q8_0 store.
+/// The routed bank, router and everything else stay untouched.
+fn requant_shared(layer_idx: usize, layer: &mut DeviceLayer) -> (usize, usize) {
+    let shared = layer
+        .bank
+        .shared
+        .as_ref()
+        .expect("the shared target layer declares a shared expert");
+    let mut bytes = Vec::new();
+    let mut tensors = std::collections::BTreeMap::new();
+    let mut before = 0usize;
+    let parts = [
+        ("gate", shared.gate.region.bytes().to_vec()),
+        ("up", shared.up.region.bytes().to_vec()),
+        ("down", shared.down.region.bytes().to_vec()),
+    ];
+    for (name, src) in &parts {
+        before += src.len();
+        let q = quantize_q8_0(&widen_bf16(src));
+        tensors.insert((*name).to_string(), (bytes.len() as u64, q.len() as u64));
+        bytes.extend(q);
+    }
+    let after = bytes.len();
+    let store = std::sync::Arc::new(PhysicalStore::owned(
+        format!("probe-shared-q8-l{layer_idx}"),
+        bytes,
+        tensors,
+    ));
+    let reg = |name: &str| EncodedRegion {
+        region: store.region(name).expect("just inserted"),
+        encoding: PhysEncoding::Q80,
+    };
+    layer.bank.shared = Some(SharedExpertBinding {
+        gate: reg("gate"),
+        up: reg("up"),
+        down: reg("down"),
+    });
+    (before, after)
+}
+
 /// Build one arm's layers; the target layer (if any) is re-encoded
 /// BEFORE its attention banks are registered — a mutation after
 /// registration would leave the residency declaration pointing at
@@ -162,6 +253,19 @@ pub(super) fn build_layers(
     mutate: &[usize],
     overlay: Option<&CandidateOverlay>,
 ) -> (Vec<Option<DeviceLayer>>, Vec<(usize, usize)>) {
+    build_layers_scoped(metal, model, mutate, &[], &[], overlay)
+}
+
+/// [`build_layers`], with every transient scope the probe knows:
+/// KDA projections, MLA projections and shared-expert branches.
+pub(super) fn build_layers_scoped(
+    metal: &MetalBackend,
+    model: &KimiSourceModel,
+    kda: &[usize],
+    mla: &[usize],
+    shared: &[usize],
+    overlay: Option<&CandidateOverlay>,
+) -> (Vec<Option<DeviceLayer>>, Vec<(usize, usize)>) {
     let n = model.geometry.num_layers;
     let mut swapped = Vec::new();
     let mut device: Vec<Option<DeviceLayer>> = Vec::with_capacity(n);
@@ -169,8 +273,14 @@ pub(super) fn build_layers(
         let mut d = model
             .device_layer(metal, i, overlay)
             .unwrap_or_else(|e| panic!("layer {i} must load: {e}"));
-        if mutate.contains(&i) {
+        if kda.contains(&i) {
             swapped.push(requant_kda_projections(&mut d));
+        }
+        if mla.contains(&i) {
+            swapped.push(requant_mla_projections(&mut d));
+        }
+        if shared.contains(&i) {
+            swapped.push(requant_shared(i, &mut d));
         }
         device.push(Some(d));
     }
@@ -225,6 +335,8 @@ fn assert_arms_differ_only_at(
     baseline: &[Option<DeviceLayer>],
     candidate: &[Option<DeviceLayer>],
     targets: &[usize],
+    mla_targets: &[usize],
+    shared_targets: &[usize],
     expert_layers: &[u32],
 ) {
     for (i, (b, c)) in baseline.iter().zip(candidate).enumerate() {
@@ -233,6 +345,30 @@ fn assert_arms_differ_only_at(
             c.as_ref().expect("all-device"),
         );
         let compiled_here = expert_layers.contains(&(i as u32));
+        match (&b.bank.shared, &c.bank.shared) {
+            (Some(sb), Some(sc)) if shared_targets.contains(&i) => {
+                assert_eq!(sc.gate.encoding, PhysEncoding::Q80, "layer {i} shared gate");
+                assert!(
+                    sc.gate.region.bytes().len() < sb.gate.region.bytes().len(),
+                    "layer {i}: the shared swap did not happen"
+                );
+            }
+            (Some(sb), Some(sc)) => {
+                for (nm, rb, rc) in [
+                    ("gate", &sb.gate, &sc.gate),
+                    ("up", &sb.up, &sc.up),
+                    ("down", &sb.down, &sc.down),
+                ] {
+                    assert_eq!(
+                        rb.region.bytes().as_ptr(),
+                        rc.region.bytes().as_ptr(),
+                        "layer {i} shared {nm}: both arms must bind ONE region"
+                    );
+                }
+            }
+            (None, None) => {}
+            _ => panic!("layer {i}: the arms disagree on the shared branch"),
+        }
         for (name, pb, pc) in [
             ("gate", &b.bank.gate, &c.bank.gate),
             ("up", &b.bank.up, &c.bank.up),
@@ -307,11 +443,21 @@ fn assert_arms_differ_only_at(
                     ..
                 },
             ) => {
-                assert!(!targets.contains(&i), "every target must be a KDA layer");
                 assert!(
-                    qb == qc && ab == ac && bb == bc && ob == oc,
-                    "layer {i}: MLA banks must be byte-equal"
+                    !targets.contains(&i),
+                    "every KDA target must be a KDA layer"
                 );
+                if mla_targets.contains(&i) {
+                    assert!(
+                        qc.len() < qb.len() && oc.len() < ob.len(),
+                        "layer {i}: the MLA swap did not happen"
+                    );
+                } else {
+                    assert!(
+                        qb == qc && ab == ac && bb == bc && ob == oc,
+                        "layer {i}: MLA banks must be byte-equal"
+                    );
+                }
             }
             _ => panic!("layer {i}: the arms disagree on the attention operator"),
         }
@@ -363,14 +509,31 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
         .map(|o| o.compiled_layers().to_vec())
         .unwrap_or_default();
     let q8h = head_q8();
+    let mla_layers = layer_list(MLA_ENV);
+    let shared_layers = layer_list(SHARED_ENV);
     assert!(
-        !layers.is_empty() || overlay.is_some() || q8h,
+        !layers.is_empty()
+            || overlay.is_some()
+            || q8h
+            || !mla_layers.is_empty()
+            || !shared_layers.is_empty(),
         "an empty scope with no overlay and no head flag measures nothing"
     );
     let (base_layers, none) = build_layers(&metal, &model, &[], None);
-    let (cand_layers, swapped) = build_layers(&metal, &model, &layers, overlay.as_ref());
+    let (cand_layers, swapped) = build_layers_scoped(
+        &metal,
+        &model,
+        &layers,
+        &mla_layers,
+        &shared_layers,
+        overlay.as_ref(),
+    );
     assert!(none.is_empty());
-    assert_eq!(swapped.len(), layers.len(), "every target was re-encoded");
+    assert_eq!(
+        swapped.len(),
+        layers.len() + mla_layers.len() + shared_layers.len(),
+        "every target was re-encoded"
+    );
     let bf16_bytes: usize = swapped.iter().map(|(b, _)| b).sum();
     let q8_bytes: usize = swapped.iter().map(|(_, q)| q).sum();
     assert!(
@@ -380,7 +543,14 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
     // Attribution BEFORE assembly: proven on the layers themselves, so
     // "identical except the targets' projections" is a checked fact,
     // not a construction argument.
-    assert_arms_differ_only_at(&base_layers, &cand_layers, &layers, &expert_layers);
+    assert_arms_differ_only_at(
+        &base_layers,
+        &cand_layers,
+        &layers,
+        &mla_layers,
+        &shared_layers,
+        &expert_layers,
+    );
     let (null_layers, _) = build_layers(&metal, &model, &[], None);
     let mut baseline = assemble(&metal, &model, base_layers);
     let mut candidate = assemble_with_head(&metal, &model, cand_layers, q8h);
@@ -419,6 +589,13 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
             null_bank.positions
         );
     }
+    // The null partner is a THIRD full stack (~17 GB of wired
+    // attention banks) needed only for the instrument check above.
+    // Holding it through the measurement pushed the process against
+    // the wired-collector wall at four-family scale — the mid-run
+    // flat-instrument episode — so it is released here, before the
+    // long run begins.
+    drop(null_partner);
 
     let t1 = Instant::now();
     let mut builder = BankBuilder::new();
@@ -477,6 +654,14 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
         .join("-");
     if let Some(o) = &overlay {
         label = format!("{label}-x-{}", o.index.map.name);
+    }
+    if !mla_layers.is_empty() {
+        let tag: Vec<String> = mla_layers.iter().map(|l| l.to_string()).collect();
+        label = format!("{label}-mla{}", tag.join("-"));
+    }
+    if !shared_layers.is_empty() {
+        let tag: Vec<String> = shared_layers.iter().map(|l| l.to_string()).collect();
+        label = format!("{label}-shared{}", tag.join("-"));
     }
     if q8h {
         label = if label.is_empty() || label == "" {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_two_layer.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_two_layer.rs
@@ -207,6 +207,7 @@ impl Layer {
                     kv_b_proj: kv_b,
                     o_proj: o,
                     kv_a_norm_eps: fx.mla_eps,
+                    projection_encoding: ExpertEncoding::Bf16,
                 },
                 shape: fx.mla_shape(),
                 state,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mla_metal.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mla_metal.rs
@@ -26,6 +26,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+use larql_compute_metal::trait_impl::kimi_layer::ExpertEncoding;
 use larql_compute_metal::trait_impl::mla::{MlaDeviceState, MlaDeviceWeights, MlaShape};
 use larql_compute_metal::MetalBackend;
 use larql_models::config::MlaGeometry;
@@ -112,6 +113,7 @@ impl Fixture {
             kv_b_proj: &self.kv_b_bytes,
             o_proj: &self.o_bytes,
             kv_a_norm_eps: self.eps as f32,
+            projection_encoding: ExpertEncoding::Bf16,
         }
     }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_decode_bench.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_decode_bench.rs
@@ -21,10 +21,15 @@
 //!   one-command-buffer-per-token step serving takes, logits readback
 //!   included, instrumentation off (`forward`, not `forward_traced`).
 //!
+//! The candidate map is the compiled expert overlay plus whichever
+//! TRANSIENT scopes the quality probe's own environment variables
+//! name, so the arm that is timed is the arm that was judged:
+//!
 //! ```text
-//! LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.aligned.vindex3 \
-//! LARQL_KIMI_Q6_CANDIDATE=/tmp/kimi-map-l24-26q80.vindex3 \
+//! LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.lift2.vindex3 \
+//! LARQL_KIMI_Q6_CANDIDATE=/tmp/kimi-map-l20-26q80-lift2.vindex3 \
 //! LARQL_KIMI_QUALITY_BANK=~/chris-models/qbanks/kimi-quality-bank-256x32 \
+//! LARQL_KDA_Q8_LAYER=20,21,22,24,25 LARQL_MLA_Q8_LAYER=23,26 LARQL_LMHEAD_Q8=1 \
 //!   cargo test -p larql-vindex --features gpu --release --lib \
 //!   q2a_decode_bench -- --nocapture
 //! ```
@@ -35,7 +40,10 @@ use larql_compute::backend::ComputeBackend;
 use larql_compute_metal::MetalBackend;
 use serde_json::Value;
 
-use super::kda_q8_real::{assemble, assemble_with_head, build_layers};
+use super::kda_q8_real::{
+    assemble, assemble_with_head, build_layers, build_layers_scoped, head_q8, layer_list,
+    LAYER_ENV, MLA_ENV, SHARED_ENV,
+};
 use super::q2a_teacher_forced::{
     build_stack, env_dir, sequence_embeddings, BANK_ENV, CANDIDATE_ENV, SOURCE_ENV,
 };
@@ -135,49 +143,69 @@ fn decode_rate_of_the_candidate_map_beside_its_own_bf16_baseline() {
         .register_stores(&metal, &moe_layers)
         .expect("stores register");
     overlay.register_store(&metal);
-    // Optional TRANSIENT KDA scope beside the compiled expert overlay.
-    // The device executes real Q8_0 buffers through the real quantised
-    // kernels either way, so the decode timing is real; only the
-    // STORAGE is transient — which makes this a **Q8 EXECUTION
-    // PREVIEW**: valid for decode compute economics and steady-state
-    // tok/s, NOT a measurement of native artifact size, cold-load,
-    // disk traffic or materialisation overhead.
-    let kda_layers: Vec<usize> = std::env::var("LARQL_KDA_Q8_LAYER")
-        .map(|v| {
-            v.split(',')
-                .map(|x| x.trim().parse().expect("layer index"))
-                .collect()
-        })
-        .unwrap_or_default();
-    let (mut baseline, mut candidate) = if kda_layers.is_empty() {
-        (
-            build_stack(&metal, &model, None),
-            build_stack(&metal, &model, Some(&overlay)),
-        )
-    } else {
+    // Optional TRANSIENT scopes beside the compiled expert overlay —
+    // the same probe vocabulary the quality runner judges: KDA and MLA
+    // projections, shared-expert branches, the output head. The device
+    // executes real Q8_0 buffers through the real quantised kernels
+    // either way, so the decode timing is real; only the STORAGE is
+    // transient — which makes this a **Q8 EXECUTION PREVIEW**: valid
+    // for decode compute economics and steady-state tok/s, NOT a
+    // measurement of native artifact size, cold-load, disk traffic or
+    // materialisation overhead.
+    let kda_layers = layer_list(LAYER_ENV);
+    let mla_layers = layer_list(MLA_ENV);
+    let shared_layers = layer_list(SHARED_ENV);
+    let q8_head = head_q8();
+    // The head counts: a map whose only transient member is the head
+    // would otherwise time two arms that differ in nothing.
+    let transient =
+        !kda_layers.is_empty() || !mla_layers.is_empty() || !shared_layers.is_empty() || q8_head;
+    let (mut baseline, mut candidate) = if transient {
         let (base, _) = build_layers(&metal, &model, &[], None);
-        let (cand, swapped) = build_layers(&metal, &model, &kda_layers, Some(&overlay));
+        let (cand, swapped) = build_layers_scoped(
+            &metal,
+            &model,
+            &kda_layers,
+            &mla_layers,
+            &shared_layers,
+            Some(&overlay),
+        );
         assert_eq!(
             swapped.len(),
-            kda_layers.len(),
-            "every KDA target re-encoded"
+            kda_layers.len() + mla_layers.len() + shared_layers.len(),
+            "every transient target re-encoded"
         );
-        let q8_head = std::env::var("LARQL_LMHEAD_Q8").is_ok_and(|v| v == "1");
         (
             assemble(&metal, &model, base),
             assemble_with_head(&metal, &model, cand, q8_head),
         )
+    } else {
+        (
+            build_stack(&metal, &model, None),
+            build_stack(&metal, &model, Some(&overlay)),
+        )
     };
     metal.seal_weight_regions();
+    let mut transient_scope = String::new();
+    for (name, layers) in [
+        ("KDA", &kda_layers),
+        ("MLA", &mla_layers),
+        ("shared", &shared_layers),
+    ] {
+        if !layers.is_empty() {
+            transient_scope.push_str(&format!(" + TRANSIENT {name} Q8_0 at {layers:?}"));
+        }
+    }
+    if q8_head {
+        transient_scope.push_str(" + TRANSIENT head Q8_0");
+    }
+    if !transient_scope.is_empty() {
+        transient_scope.push_str(" (Q8 execution preview)");
+    }
     eprintln!(
-        "[bench] both arms loaded in {:.1}s; candidate scope {}{}",
+        "[bench] both arms loaded in {:.1}s; candidate scope {}{transient_scope}",
         t0.elapsed().as_secs_f64(),
         overlay.scope(),
-        if kda_layers.is_empty() {
-            String::new()
-        } else {
-            format!(" + TRANSIENT KDA Q8_0 at {kda_layers:?} (Q8 execution preview)")
-        }
     );
 
     // Enough distinct rows that a block never re-times one hot row, cycled

--- a/crates/larql-vindex/src/format/vindex3/represent/physical.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/physical.rs
@@ -204,7 +204,7 @@ impl PhysicalStore {
         self.all()
     }
 
-    fn region(self: &Arc<Self>, tensor: &str) -> Option<WeightRegion> {
+    pub(crate) fn region(self: &Arc<Self>, tensor: &str) -> Option<WeightRegion> {
         let (offset, len) = *self.tensors.get(tensor)?;
         let start = self.payload_start + offset;
         (start + len <= self.all().len() as u64).then(|| WeightRegion {

--- a/docs/kimi-precision-topology.md
+++ b/docs/kimi-precision-topology.md
@@ -6,6 +6,11 @@ authority scale, and an in-session decode benchmark.** Closed
 2026-08-30 on Kimi-Linear-48B-A3B-Instruct
 (`~/chris-models/Kimi-Linear-48B-A3B-Instruct.aligned.vindex3`).
 
+PRECISION-1 mapped one byte family (routed experts). The second
+chapter below — **the whole-decoder topology** — extends the map to
+every byte family the decoder reads, under a contract calibrated
+afterwards from measured consequences.
+
 Contract: **kimi-logit-v3, frozen at `ce6e87a3`** — six authority
 criteria (positions ≥ 4096, KL p99 ≤ 1e-3, covered mass ≥ 0.6, top-1
 mass displaced ≤ 5e-2, top-10 mass p99 ≤ 1e-1, route mixture mass
@@ -104,3 +109,336 @@ quality   q2a_teacher_forced (LARQL_Q2A_SEQUENCES=8 diagnostic,
 speed     q2a_decode_bench (both arms in-process, interleaved)
 evidence  ~/chris-models/kimi-quality-bank-provenance/
 ```
+
+---
+
+# The whole-decoder topology — MLA-SHARED-1
+
+**Every byte family in the decoder measured against one frozen
+behavioural contract, and the first family REFUSED on economics
+rather than on capability.** Closed 2026-08-31 on the same model and
+the same two banks.
+
+PRECISION-1 above answered *which layers* of one family (routed
+experts) tolerate a cheaper representation. This chapter answers the
+next question: *which families*, and at what price per byte. Five
+byte families make up the decoder's active read per token; four are
+now admitted under one composed map and one is supported by the
+engine but declined by the economics.
+
+## The active byte ledger, BF16
+
+Per decoded token, at BF16, geometry from the container
+(27 layers, layer 0 dense; 256 experts of 3 × 2304 × 1024 per MoE
+layer, 8 routed per token; MLA at layers {3,7,11,15,19,23,26}, KDA at
+the other 20; vocabulary 163,840):
+
+| family | per token | share |
+|---|---|---|
+| routed experts (8 of 256 × 26 layers) | 2.944 GB | 49.2 % |
+| KDA projections (20 layers × 75.5 MB) | 1.510 GB | 25.2 % |
+| output head (2304 × 163840) | 0.755 GB | 12.6 % |
+| MLA projections (7 layers × 58.2 MB) | 0.408 GB | 6.8 % |
+| shared experts (26 layers × 14.2 MB) | 0.368 GB | 6.1 % |
+| **total** | **5.985 GB** | |
+
+The checkpoint is 97 % experts; the *token* is not. That asymmetry is
+why a whole-decoder representation map beats an expert-only one, and
+it is the reason this chapter exists.
+
+## The five families, measured
+
+Every cell below is one scope re-encoded to Q8_0 against a BF16
+baseline arm otherwise byte-identical, judged on the 256 × 32
+selection bank, `kl p99` from the frozen consequence metrics:
+
+| family | cheapest cell | costliest cell measured | shape with depth |
+|---|---|---|---|
+| routed experts | L26 1.16e-4 | L1 4.67e-2 | late plateau, enriches with depth |
+| KDA projections | L22 8.07e-5 | L13 1.49e-2 | late plateau, NON-MONOTONE teens |
+| output head | 7.13e-4 (no depth axis) | — | direct consequence, no mediation |
+| MLA projections | L23 5.75e-5 | tower 2.61e-2 | late plateau, **sharp interior cliff** |
+| shared experts | L25 1.24e-3 | — | (economically refused before mapping) |
+
+The KDA row's qualifier is measured, not hedging: its band from L16
+to L18 does not order with depth (L16 3.98e-4 sits BELOW both L17
+2.36e-3 and L18 1.25e-3), the same non-monotonicity the expert
+frontier showed at L21. The plateau and the eventual cliff are robust;
+the exact edge inside the band is not, which is why a frontier is
+found by measuring cells rather than by bisection.
+
+**The same shape recurs in four independent families.** Late scopes
+are nearly free; the cost enriches with depth; the composed map takes
+late members only. That is now a property of the model, not of a
+family — and it is what makes a search over scopes tractable.
+
+### The MLA depth curve
+
+MLA is not intrinsically sensitive — it is intrinsically *positional*:
+
+```text
+layer   kl p99      bytes saved   reading
+ 23     5.751e-5    27.3 MB       the cheapest cell of ANY family at any depth
+ 26     1.237e-4    27.3 MB       plateau — the last MLA layer
+ 19     8.433e-4    27.3 MB       15x jump: the cliff edge
+ 15     1.064e-3    27.3 MB       marginal refusal
+ 11     3.699e-3    27.3 MB       boundary characterisation
+ all 7  2.614e-2    191.1 MB      450x the L23 cell — early MLA is brutal
+```
+
+The tower cell's token-distance curve ACCUMULATES (2.6e-4 → 2.9e-3
+across positions) where the late cells' does not: early-MLA error is
+carried forward, not absorbed. By the jump rule — take the plateau,
+stop at the first order-of-magnitude step — the admitted scope is
+**MLA{23,26}**, and the topology is allowed to be non-contiguous.
+
+## The shared experts: a useful rejection
+
+The shared branch is fully supported: its dispatch has been
+encoding-aware since the expert rung, so admitting it costs no kernel
+work at all. It is declined anyway, and the reason is the point:
+
+| scope | behavioural cost | bytes saved | cost per MB saved |
+|---|---|---|---|
+| MLA L23 | 5.75e-5 | 27.3 MB | **2.1e-6 / MB** |
+| shared L25 | 1.240e-3 | 6.6 MB | **1.9e-4 / MB** |
+| shared {24,25} | 1.092e-3 | 13.3 MB | 8.2e-5 / MB |
+
+**~90x worse per byte than MLA.** The shared pair even composes
+sub-additively — {24,25} costs LESS than L25 alone, a genuine
+absorption result — and it still loses, because the budget it consumes
+buys far more elsewhere. The engine can produce this representation;
+it should not.
+
+This is the first refusal in the programme that is not a capability
+statement. A per-layer "quantise what passes" recipe would have taken
+the shared branch. An optimizer with a byte model declines it.
+
+## The composed four-family map
+
+```text
+routed experts   L20-26            Q8_0   (compiled candidate banks)
+KDA projections  L20,21,22,24,25   Q8_0   (transient requant)
+MLA projections  L23,26            Q8_0   (transient requant)
+output head                        Q8_0   (transient requant)
+shared experts                     BF16   REFUSED on economics
+everything else                    BF16
+```
+
+Bytes removed per token: experts 371.6 MB + KDA 176.9 MB + head
+353.9 MB + MLA 54.6 MB = **957 MB, 16.0 % of the BF16 ledger.**
+
+Composition is again sub-additive, and the newest family is the
+clearest case:
+
+```text
+map                                 diagnostic kl p99   delta    solo cost of the addition
+experts L20-26 + KDA x5                    2.4321e-3    —
+  + output head                            2.4006e-3    -1.3 %   7.13e-4
+  + MLA{23,26}                             2.4762e-3    +3.1 %   5.75e-5 + 1.24e-4
+```
+
+Both additions are ABSORBED. The head's 7.13e-4 solo cost moved the
+composed p99 by −1.3 % — a rank statistic over 256 positions does not
+resolve a change that small, so the honest reading is *no measurable
+composed cost*, not a negative one. MLA{23,26} added 3.1 % to a map
+already at 2.4e-3 while removing another 117 MB of BF16 scope.
+
+Late-scope perturbations across families do not stack. The mechanism
+is the one PRECISION-1 identified: composed cost is dominated by
+whether a perturbation reaches a downstream router, and by L20+ there
+is little routing left to disturb. It is why the map can keep gaining
+families almost for free, and why the same families refuse flatly when
+taken early.
+
+*(The 256-position diagnostic is the first 8 sequences of the same
+bank the 8,192-position run uses — a SCREEN, not an independent
+sample. Only the authority runs below are verdicts.)*
+
+## Authority: both banks, 8,192 positions, `kimi-logit-balanced-v1`
+
+The composed four-family map judged against the frozen contract, on
+the selection bank AND the held-out bank (zero window overlap, never
+used to choose any scope), with the three-family map beside it so the
+price of the fourth family is legible:
+
+| criterion | limit | three-family | four-family | budget used |
+|---|---|---|---|---|
+| **selection bank** | | | | |
+| kl p99 | 3.5e-3 | 2.4006e-3 | **2.3791e-3** | 68.0 % |
+| top-1 mass displaced (max) | 0.12 | 9.415e-2 | **5.546e-2** | 46.2 % |
+| top-10 mass displaced p99 | 0.12 | 7.134e-2 | **6.465e-2** | 53.9 % |
+| route mixture mass p99 | 0.15 | 0.1258 | **0.1248** | 83.2 % |
+| route mixture mass max | 0.25 | 0.1993 | **0.1993** | 79.7 % |
+| covered mass | ≥ 0.55 | 0.6315 | **0.6315** | — |
+| **held-out bank** | | | | |
+| kl p99 | 3.5e-3 | 2.6378e-3 | **2.6174e-3** | 74.8 % |
+| top-1 mass displaced (max) | 0.12 | 5.8313e-2 | **5.8313e-2** | 48.6 % |
+| top-10 mass displaced p99 | 0.12 | 6.904e-2 | **6.881e-2** | 57.3 % |
+| route mixture mass p99 | 0.15 | 0.1262 | **0.1257** | 83.8 % |
+| route mixture mass max | 0.25 | 0.2099 | **0.2099** | 84.0 % |
+| covered mass | ≥ 0.55 | 0.5773 | **0.5773** | — |
+
+**PASS on both banks, no failed criterion.** Counts move by at most
+2 %: route flips 1296→1305 and 1260→1270, top-1 flips 130→129 and
+124→122, top-10 changes 2515→2527 and 2322→2341.
+
+The strongest statement is on the held-out bank, where **both max
+statistics are identical to the three-family map** — `top1_mass`
+5.8313e-2 and `route_max` 0.2099 to four decimals. The worst single
+overturn and the worst single routing displacement in the whole
+8,192-position measurement are the same events, unchanged, after
+adding a family. On the selection bank the worst top-1 overturn's
+severity fell 0.094 → 0.055 while the flip count went 130 → 129; with
+counts flat that is one position reshuffling, not an improvement.
+
+**MLA{23,26} is behaviourally absorbed at authority scale while
+removing 117 MB of BF16 scope per token.** That is what free
+composition looks like when it is real.
+
+### The route budget is the binding constraint
+
+The criteria do not deplete together:
+
+```text
+kl p99                68-75 % of limit    plenty
+top-1 mass displaced  46-49 % of limit    plenty
+top-10 mass p99       54-57 % of limit    plenty
+route mixture p99     83-84 % of limit    BINDING
+route mixture max     80-84 % of limit    BINDING
+```
+
+Route mixture mass is the only criterion measuring a DISCRETE
+consequence — which experts were selected. KL and the mass-displacement
+metrics degrade smoothly and average over 8,192 positions; a route
+either moves or it does not. That is a structural reason to expect the
+route budget to keep binding as breadth grows, and it is why a search
+over representations should rank candidates against the vector of
+remaining margins rather than a scalar bytes-per-KL: a candidate that
+is cheap on logits but moves routing spends the scarce resource.
+
+### Promotion drift
+
+```text
+map                                256-position     8192-position    drift
+PRECISION-1 narrow (experts 24-26)      2.262e-4         4.153e-4      +84 %
+four-family broad                       2.4762e-3        2.3791e-3     -3.9 %
+```
+
+A broad perturbation's diagnostic estimate was well calibrated where a
+narrow one's was not — plausibly because a broadly distributed
+perturbation populates the consequence tail densely enough that 256
+positions already sample it. **Recorded as a search heuristic only**
+(N = 2, and the diagnostic is a subset of the authority bank, not an
+independent sample). No gate changes on it; full-bank composed
+authority remains the only admission.
+
+## Decode: the cost model scored against the machine
+
+The prediction was REGISTERED before the run, from the byte ledger
+alone: 957 MB of the 5.985 GB per-token BF16 read removed (16.0 %),
+predicted **1.15-1.16x**. Two sessions, both arms in one process,
+interleaved blocks with alternating order, per-arm minimum:
+
+| session | baseline | candidate | wall speedup | GPU ms/token | GPU speedup |
+|---|---|---|---|---|---|
+| 1 | 35.81 tok/s | **40.79 tok/s** | 1.139x | 26.87 → 23.43 | 1.147x |
+| 2 | 35.16 tok/s | **40.52 tok/s** | 1.153x | 26.97 → 23.56 | 1.145x |
+
+**Measured 1.139-1.153x wall, 1.146x GPU. The registered prediction
+was 1.15-1.16x — accurate to about 1 %, and on the optimistic side:
+the GPU measure sits just BELOW the predicted band, not inside it.**
+The model is a good planner and not yet a calibrated one.
+
+Read the GPU column, not the wall column, when scoring the byte model.
+GPU time is the stable instrument here — four blocks per arm land
+within 0.05 ms in session 1 — while wall time carries 1-6.6 ms/token
+of intermittent non-GPU overhead. The min-of-N floor exists to strip
+exactly that, and it works: both arms' floor blocks carry ~1.05 ms of
+overhead, so the floors compare like with like.
+
+The conversion is the reusable number:
+
+```text
+bytes removed        16.0 %
+GPU time removed     12.7 %
+conversion           0.79   (0.80 session 1, 0.79 session 2)
+```
+
+**About 80 % of removed bytes became GPU time.** A pure-bandwidth
+roofline would have predicted 1.190x; the decode step is not purely
+bandwidth bound, and ~0.8 is the discount this machine applies. That single
+number is what makes the next search's predictions cheap: bytes are
+computable from a map without running anything.
+
+
+## Instrument hazards — two catalogued flat signatures
+
+Two four-family authority runs on 2026-08-31 returned numbers that are
+NOT verdicts. Both were refused by the `covered_mass` criterion, which
+is precisely what it exists for: a run that could only "pass" by being
+blind must fail.
+
+| signature | reading |
+|---|---|
+| `kl_p99` exactly 0.0, `covered_mass` exactly `TOP_N/vocab` (2048/163840 = 0.0125) | the GPU completed command buffers without executing them — both arms constant, coverage at the uniform-distribution floor |
+| `covered_mass` 0.0297 with `top10_mass_displaced` p99 exactly 1.0 | a MIXED bank: the instrument degraded PART WAY THROUGH a ~25-minute run |
+
+Root cause: the probe held a THIRD full stack (`null_partner`, ~17 GB
+of wired attention banks) needed only by the 2-minute null arm, through
+the entire measurement. At four-family scale that tipped the process
+over the wired-collector wall mid-run. It is now dropped immediately
+after the null arm.
+
+Two lessons are load-bearing:
+
+* **An up-front guard cannot protect a long run.** The second episode
+  passed a diagnostic-scale guard at t0 and degraded 25 minutes later.
+  Instrument health is checked after EVERY stage, and a contaminated
+  stage refuses to be promoted to provenance.
+* **`covered_mass` is not a formality.** Without it, the flat run
+  reports `kl_p99 = 0.0` — a perfect score — and the map would have
+  been admitted on a measurement of nothing.
+
+Quarantined artifacts and their signatures are kept under
+`~/chris-models/kimi-quality-bank-provenance/QUARANTINE.md`.
+
+## Reproduction
+
+```text
+banks      selection ~/chris-models/qbanks/kimi-quality-bank-256x32
+           held-out  ~/chris-models/qbanks/kimi-quality-bank-heldout-256x32
+source     ~/chris-models/Kimi-Linear-48B-A3B-Instruct.lift2.vindex3
+experts    LARQL_Q6_MAP="20-26:Q8_0" -> represent/compile_real_tests.rs
+           (/tmp/kimi-map-l20-26q80-lift2.vindex3, ~2.5 min, resumable)
+quality    kda_q8_real, scopes by env:
+             LARQL_KDA_Q8_LAYER=20,21,22,24,25
+             LARQL_MLA_Q8_LAYER=23,26
+             LARQL_LMHEAD_Q8=1
+             LARQL_KIMI_Q6_CANDIDATE=<expert candidate>
+           LARQL_Q2A_SEQUENCES=8 diagnostic / 256 authority
+speed      q2a_decode_bench, same scope environment, two sessions
+evidence   ~/chris-models/kimi-quality-bank-provenance/
+             kimi_full4-{guard-256,selection-8192,heldout-8192}_report.json
+```
+
+Every report carries its bank's `manifest.json` SHA-256, the gate it
+was judged by, AND the `balanced-v1` verdict — a claim of
+admissibility never has to be re-derived from the bank by hand.
+
+## What this closes, and what it opens
+
+Four byte families are now admissible under one frozen behavioural
+contract, and the fifth is refused by an economic argument the engine
+could have ignored. Q8_0 was the INSTRUMENT that mapped the topology,
+not the destination: every family showed the same late-plateau /
+interior-cliff shape, which is what makes a search tractable.
+
+The manual phase ends here. What follows is an optimization problem,
+not an exploration one: a candidate option is
+`(scope, representation, bytes saved, solo cost, measured interaction
+terms, kernel economics)`, and the objective is to maximise predicted
+decode rate subject to a composed `balanced-v1` PASS — ranked against
+the vector of remaining margins, with the full-bank composed gate
+staying authoritative. Q6 and Q4 are where the remaining budget gets
+spent.


### PR DESCRIPTION
## What

**The fourth byte family joins the representation vocabulary, and the fifth is
refused on economics.** MLA projections and shared-expert branches become
encodable scopes; the composed four-family map is judged at 8,192 positions on
both banks under `kimi-logit-balanced-v1` and benchmarked.

Five families make up the decoder's BF16 read per token — routed experts 49.2 %,
KDA projections 25.2 %, output head 12.6 %, MLA projections 6.8 %, shared
experts 6.1 %. Four are now admitted under one frozen contract.

## The engine change

- **MLA encoding threading** — the fourth verbatim application of the pattern:
  `MlaDeviceWeights`/`DeviceAttn::Mla` carry a projection encoding (four wide
  projections only; `kv_a_norm` stays f32, the latent cache always holds decoded
  values); all three MLA grouped dispatches plus the at-offset cache write select
  their kernel by encoding.
- **Shared experts needed zero kernel work** — their dispatch has been
  encoding-aware since the expert rung; only the bytes were BF16.
- **The bench harness learned the same scopes** — it timed KDA and the head but
  could not see MLA or shared, so a four-family map could be judged for quality
  and not for speed. It now shares one scope-parsing surface with the quality
  probe, and a head-only map no longer silently times two identical arms.
- **The report carries the contract it is judged by** — both the strict `v3`
  verdict and the `balanced-v1` verdict travel in every report, so a claim of
  admissibility no longer has to be re-derived from the bank by hand.

## The measurement

**MLA depth curve** — the fourth family with the same shape every other family showed:

```text
L23 5.75e-5  |  L26 1.24e-4  (plateau)
L19 8.43e-4  (the 15x jump)  |  L15 1.06e-3  |  L11 3.70e-3
all 7 MLA layers  2.61e-2  — 450x the L23 cell
```

The tower's token-distance curve ACCUMULATES (2.6e-4 → 2.9e-3) where the late
cells' does not. Scope chosen by the jump rule: **MLA{23,26}**, non-contiguous
by design.

**Shared experts refused on economics, not capability.** Their dispatch has been
encoding-aware since the expert rung, so admitting them costs no kernel work:

| scope | cost | bytes saved | cost per MB |
|---|---|---|---|
| MLA L23 | 5.75e-5 | 27.3 MB | 2.1e-6 |
| shared L25 | 1.240e-3 | 6.6 MB | 1.9e-4 |

~90x worse per byte. The pair {24,25} even composes sub-additively (1.09e-3 vs
1.24e-3 solo) and still loses. **The first refusal in this programme that is an
optimizer's judgement rather than an engine limitation.**

**Authority — both banks, 8,192 positions, `kimi-logit-balanced-v1`: PASS, no
failed criterion.**

| criterion | limit | three-family | four-family | budget |
|---|---|---|---|---|
| *selection* kl p99 | 3.5e-3 | 2.4006e-3 | 2.3791e-3 | 68.0 % |
| top-1 mass displaced max | 0.12 | 9.415e-2 | 5.546e-2 | 46.2 % |
| top-10 mass p99 | 0.12 | 7.134e-2 | 6.465e-2 | 53.9 % |
| route mixture p99 / max | 0.15 / 0.25 | 0.1258 / 0.1993 | 0.1248 / 0.1993 | 83.2 / 79.7 % |
| *held-out* kl p99 | 3.5e-3 | 2.6378e-3 | 2.6174e-3 | 74.8 % |
| top-1 mass displaced max | 0.12 | 5.8313e-2 | 5.8313e-2 | 48.6 % |
| route mixture p99 / max | 0.15 / 0.25 | 0.1262 / 0.2099 | 0.1257 / 0.2099 | 83.8 / 84.0 % |

**MLA{23,26} is behaviourally absorbed.** On the held-out bank both max
statistics are IDENTICAL to the three-family map to four decimals — the worst
single overturn and the worst single routing displacement in 8,192 positions are
the same events, unchanged, after adding a family. Counts move ≤ 2 %. On the
selection bank the worst top-1 severity fell 0.094 → 0.055 while the flip count
went 130 → 129: one position reshuffling, not an improvement, and not claimed as
one.

**The route budget is the binding constraint** (83-84 % of limit against KL's
68-75 %). It is the only criterion measuring a discrete consequence — which
experts got selected — so it does not average out over 8,192 positions the way
KL and mass displacement do.

**Decode — the cost model scored against the machine.** Prediction registered
BEFORE the run from the byte ledger alone: 957 MB of the 5.985 GB per-token BF16
read removed (16.0 %), predicted 1.15-1.16x.

| session | baseline | candidate | wall | GPU ms/token | GPU speedup |
|---|---|---|---|---|---|
| 1 | 35.81 tok/s | **40.79 tok/s** | 1.139x | 26.87 → 23.43 | 1.147x |
| 2 | 35.16 tok/s | **40.52 tok/s** | 1.153x | 26.97 → 23.56 | 1.145x |

Measured **1.146x GPU, 1.139-1.153x wall**. The prediction was accurate to ~1 %
but **on the optimistic side — the GPU measure sits just below the band, not
inside it.** Score the GPU column: it is stable to 0.05 ms across blocks while
wall carries 1-6.6 ms/token of intermittent non-GPU overhead. Conversion:
16.0 % of bytes removed → 12.7 % of GPU time removed, **0.79-0.80**, against a
1.190x pure-bandwidth roofline.

## Instrument hazards catalogued

Two flat-instrument episodes were diagnosed and are frozen as evidence under
`kimi-quality-bank-provenance/QUARANTINE.md`:

| signature | reading |
|---|---|
| `kl_p99` exactly 0.0, coverage exactly `TOP_N/vocab` | the GPU completed command buffers without executing them |
| coverage far under the bank's floor, `top10_mass_displaced` p99 exactly 1.0 | the instrument degraded PART WAY THROUGH a ~25 minute run |

The `CoveredMass` criterion refused both — a run that could only "pass" by being
blind is exactly what it exists to catch. Root cause: the probe held a third
full stack (`null_partner`, ~17 GB of wired attention banks) needed only by the
2-minute null arm through the entire measurement. It is now dropped immediately
after the null arm, and the authority chain checks instrument health after
EVERY stage rather than only up front.

## Gates

All `larql-vindex` CI gates green, verified on an ISOLATED worktree holding HEAD
plus only this diff — the shared worktree currently carries another in-flight
change whose modules are not yet declared, so a gate run there would not have
been attributable:

```text
fmt · check --all-targets · check --examples · check --features gpu --all-targets
clippy --all-targets -D warnings · e0_generation_boundary (10)
cargo test -p larql-vindex (3418 lib + all integration binaries)
benches compile · gpu lib tests (3469 passed, 4 ignored)
```

Note for a follow-up, not fixed here: `cargo clippy --features gpu` — which CI does
NOT run — reports 4 pre-existing errors in `kimi_moe_metal/grouped/represent/`.
GPU-gated test code is currently unlinted by CI. A fifth, in the file this PR
touches (a condition duplicated with `is_empty()`), is fixed.

## What this opens

Four byte families admissible under one frozen contract; the fifth declined on
bytes-per-behavioural-cost. Q8_0 was the INSTRUMENT that mapped the topology,
not the destination — every family showed the same late-plateau / interior-cliff
shape, which is what makes a search tractable. The manual phase ends here.
BALANCED-SEARCH-2 optimizes codec choice under the **vector** of behavioural
constraints, not a scalar bytes-per-KL, with the full-bank composed gate
authoritative.
