### PR TITLE
BALANCED-SEARCH-2: evidence-aware representation search semantics

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/represent/assessment.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/assessment.rs
@@ -42,22 +42,10 @@ use serde::{Deserialize, Serialize};
 use super::byte_ledger::ByteLedger;
 use super::constraint::{ConstraintVector, LimitKind, Margin};
 use super::execution_cost::{CostPrediction, CostRefusal, ExecutionCostModel};
+pub use super::measurement::EvidenceScale;
+use super::measurement::TailSupportPolicy;
 use super::quality::Criterion;
-
-/// Whether an assessment rests on a diagnostic screen or on
-/// authority-scale evidence.
-///
-/// The distinction exists to stop a ranking becoming an admissibility
-/// claim. A diagnostic bank is cheap enough to run over many candidates
-/// and is how the search explores; it can be scored and sorted, and it
-/// may not admit anything.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum EvidenceScale {
-    /// A short bank, used to rank and to search.
-    Diagnostic,
-    /// A full bank at the contract's own position count.
-    Authority,
-}
+use super::search_evidence::{SearchCalibrationRegistry, SearchEvidence};
 
 /// What a move did to one criterion.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -81,10 +69,47 @@ pub struct MarginalConstraintCost {
     /// fraction, and reporting a huge number would let it be averaged.
     /// Negative when the move freed headroom.
     pub fraction_of_remaining_consumed: Option<f64>,
+    /// **How this dimension was obtained**, which decides whether its
+    /// magnitude may be priced at all. A thin-tailed percentile with a
+    /// good ordering correlation is real evidence and is still not a
+    /// number to spend a budget against.
+    pub search_evidence: SearchEvidence,
+}
+
+/// What a search needs in order to know which of its numbers mean what.
+#[derive(Debug, Clone)]
+pub struct EvidenceContext {
+    pub scale: EvidenceScale,
+    pub registry: SearchCalibrationRegistry,
+    pub tail_policy: TailSupportPolicy,
+}
+
+impl EvidenceContext {
+    /// The context this programme currently has: ROUTE-CAL-1's
+    /// registrations and its five-tail-observation policy.
+    pub fn route_cal_1(scale: EvidenceScale) -> Self {
+        Self {
+            scale,
+            registry: SearchCalibrationRegistry::route_cal_1(),
+            tail_policy: TailSupportPolicy::route_cal_1(),
+        }
+    }
 }
 
 impl MarginalConstraintCost {
-    fn between(before: &Margin, after: &Margin) -> Self {
+    /// Whether this dimension's magnitude may be turned into a fraction
+    /// of a remaining budget.
+    pub fn priceable(&self) -> bool {
+        self.search_evidence.is_priceable()
+    }
+
+    /// Whether it carries evidence usable for ORDERING, which is a
+    /// weaker claim than pricing.
+    pub fn orders(&self) -> bool {
+        self.search_evidence.orders()
+    }
+
+    fn between(before: &Margin, after: &Margin, ctx: &EvidenceContext) -> Self {
         let (b, a) = (before.utilisation(), after.utilisation());
         let delta = match (b, a) {
             (Some(b), Some(a)) => Some(a - b),
@@ -95,6 +120,23 @@ impl MarginalConstraintCost {
             (Some(d), Some(r)) if r > 0.0 => Some(d / r),
             _ => None,
         };
+        // The WEAKER of the two sides governs: a move whose "after" is
+        // well supported but whose "before" was not has no trustworthy
+        // delta.
+        let evidence = {
+            let each = [before, after].map(|m| {
+                ctx.registry.evidence_for(
+                    &m.what,
+                    ctx.scale,
+                    &m.measurement_status(&ctx.tail_policy),
+                )
+            });
+            if each[0].confidence_rank() <= each[1].confidence_rank() {
+                each[0].clone()
+            } else {
+                each[1].clone()
+            }
+        };
         Self {
             criterion: after.criterion,
             what: after.what.clone(),
@@ -103,6 +145,7 @@ impl MarginalConstraintCost {
             delta,
             remaining_before,
             fraction_of_remaining_consumed: fraction,
+            search_evidence: evidence,
         }
     }
 
@@ -122,7 +165,11 @@ impl MarginalConstraintVector {
     /// Pair the two vectors up by the gate's own wording for each
     /// limit. Criteria present in only one are dropped: they cannot
     /// have a before-and-after.
-    pub fn between(before: &ConstraintVector, after: &ConstraintVector) -> Self {
+    pub fn between(
+        before: &ConstraintVector,
+        after: &ConstraintVector,
+        ctx: &EvidenceContext,
+    ) -> Self {
         let costs = after
             .margins
             .iter()
@@ -132,10 +179,18 @@ impl MarginalConstraintVector {
                     .margins
                     .iter()
                     .find(|b| b.what == a.what)
-                    .map(|b| MarginalConstraintCost::between(b, a))
+                    .map(|b| MarginalConstraintCost::between(b, a, ctx))
             })
             .collect();
         Self { costs }
+    }
+
+    /// Dimensions that cost something but may not be priced — the
+    /// candidate's invisible costs. A search that ignored these would
+    /// prefer exactly the candidates whose expensive dimension it
+    /// cannot see.
+    pub fn unpriceable_costs(&self) -> impl Iterator<Item = &MarginalConstraintCost> {
+        self.costs.iter().filter(|c| !c.priceable())
     }
 
     /// **The scarce-resource cost of this move**: the largest fraction
@@ -154,6 +209,7 @@ impl MarginalConstraintVector {
     pub fn scarcest(&self) -> Option<&MarginalConstraintCost> {
         self.costs
             .iter()
+            .filter(|c| c.priceable())
             .filter(|c| c.fraction_of_remaining_consumed.is_some_and(|f| f > 0.0))
             .max_by(|x, y| {
                 let (a, b) = (
@@ -181,8 +237,12 @@ impl MarginalConstraintVector {
     /// ends. Anything this returns true for is unrankable, not free.
     pub fn unscorable(&self) -> bool {
         self.costs.iter().any(|c| {
-            c.fraction_of_remaining_consumed.is_none()
-                && (c.delta.is_none() || c.delta.is_some_and(|d| d > 0.0))
+            // Either the arithmetic could not produce a fraction...
+            (c.priceable()
+                && c.fraction_of_remaining_consumed.is_none()
+                && (c.delta.is_none() || c.delta.is_some_and(|d| d > 0.0)))
+                // ...or the evidence does not license pricing one.
+                || !c.priceable()
         })
     }
 
@@ -326,16 +386,17 @@ impl CandidateAssessment {
     /// difference between the two predictions, which is what the
     /// ranking wants.
     pub fn of(
-        scale: EvidenceScale,
+        ctx: &EvidenceContext,
         costs: &ExecutionCostModel,
         parent: &ByteLedger,
         candidate: &ByteLedger,
         before: ConstraintVector,
         after: ConstraintVector,
     ) -> Result<Self, CostRefusal> {
+        let scale = ctx.scale;
         let parent_cost = costs.predict(parent)?;
         let candidate_cost = costs.predict(candidate)?;
-        let marginal = MarginalConstraintVector::between(&before, &after);
+        let marginal = MarginalConstraintVector::between(&before, &after, ctx);
         let gpu_ms_saved = parent_cost.gpu_ms_per_token - candidate_cost.gpu_ms_per_token;
         let scarce = marginal.scarce_fraction_consumed();
         let score = match scarce {
@@ -436,9 +497,11 @@ impl CandidateAssessment {
         );
         let scarcest = self.marginal.scarcest().map(|c| c.what.clone());
         for c in &self.marginal.costs {
-            let share = match c.fraction_of_remaining_consumed {
-                Some(f) => format!("{:+.0}% of remaining headroom", 100.0 * f),
-                None => "not scored".into(),
+            let share = match (c.priceable(), c.fraction_of_remaining_consumed) {
+                (true, Some(f)) => format!("{:+.0}% of remaining headroom", 100.0 * f),
+                (true, None) => "not scored".into(),
+                (false, _) if c.orders() => "NOT PRICEABLE at this scale (ordering proxy)".into(),
+                (false, _) => "NOT PRICEABLE at this scale (no usable evidence)".into(),
             };
             let mark = if Some(&c.what) == scarcest.as_ref() {
                 "   <- scarce resource"
@@ -452,6 +515,13 @@ impl CandidateAssessment {
                 "\nrank: {:.2} ms per unit of scarce headroom ({:.0}% consumed)\n",
                 s,
                 100.0 * self.ranking_score.scarce_fraction_consumed.unwrap_or(0.0),
+            ),
+            None if self.marginal.unpriceable_costs().next().is_some() => format!(
+                "\nrank: {:+.2} ms GPU, NOT priced — {} of {} dimensions cannot be priced at \
+                 this evidence scale\n",
+                self.ranking_score.gpu_ms_saved,
+                self.marginal.unpriceable_costs().count(),
+                self.marginal.costs.len(),
             ),
             None => format!(
                 "\nrank: {:+.2} ms GPU at no behavioural cost\n",

--- a/crates/larql-vindex/src/format/vindex3/represent/assessment.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/assessment.rs
@@ -1,0 +1,472 @@
+//! **What one move buys, and what fraction of scarce headroom it costs.**
+//!
+//! [`super::constraint`] says which behavioural resource is scarce.
+//! [`super::execution_cost`] says what a map buys in decode time. This
+//! is the bridge: given a parent map and a candidate move, what does
+//! the move buy, and what does it consume?
+//!
+//! The objective BALANCED-SEARCH-2 optimises is unchanged:
+//!
+//! ```text
+//! maximise predicted throughput
+//! subject to the behavioural contract passing
+//! ```
+//!
+//! What lives here is the HEURISTIC that decides which move to try
+//! next. That is a different thing and must not be mistaken for the
+//! objective.
+//!
+//! **Everything is marginal against the current map, never absolute.**
+//! A candidate that leaves routing at 88 % has not "cost 88 %" — the
+//! map was already at 83 %, so the move consumed five of the seventeen
+//! points that remained, which is 29 % of the budget actually
+//! available. Absolute utilisation cannot express that, and a search
+//! ranking on it would keep choosing moves that eat the scarce resource
+//! while reporting a comfortable-looking number.
+//!
+//! ```text
+//! remaining route headroom before   17 %
+//! this move consumes                 5 %
+//! fraction of remaining consumed    5/17 = 29 %
+//! ```
+//!
+//! **The vector is preserved underneath the score.** Collapsing to a
+//! scalar permanently would throw away the interesting case: a move
+//! that costs KL but FREES routing may be unusually attractive when
+//! routing binds, and only the full before/after vectors can say so.
+//! [`CandidateAssessment::ranking_score`] is derived convenience; the
+//! vectors are the evidence.
+
+use serde::{Deserialize, Serialize};
+
+use super::byte_ledger::ByteLedger;
+use super::constraint::{ConstraintVector, LimitKind, Margin};
+use super::execution_cost::{CostPrediction, CostRefusal, ExecutionCostModel};
+use super::quality::Criterion;
+
+/// Whether an assessment rests on a diagnostic screen or on
+/// authority-scale evidence.
+///
+/// The distinction exists to stop a ranking becoming an admissibility
+/// claim. A diagnostic bank is cheap enough to run over many candidates
+/// and is how the search explores; it can be scored and sorted, and it
+/// may not admit anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EvidenceScale {
+    /// A short bank, used to rank and to search.
+    Diagnostic,
+    /// A full bank at the contract's own position count.
+    Authority,
+}
+
+/// What a move did to one criterion.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MarginalConstraintCost {
+    pub criterion: Criterion,
+    /// The gate's own wording for this limit, which is the key: a
+    /// criterion can carry several limits that move independently.
+    pub what: String,
+    /// Utilisation before the move, as a fraction of the limit.
+    pub before: Option<f64>,
+    pub after: Option<f64>,
+    /// `after - before`. Negative means the move FREED headroom.
+    pub delta: Option<f64>,
+    /// Headroom that existed before the move, `1 - before`.
+    pub remaining_before: Option<f64>,
+    /// `delta / remaining_before` — the fraction of the budget that was
+    /// actually available which this move spent.
+    ///
+    /// `None` when either side is unmeasured, or when no headroom
+    /// remained: spending against an exhausted budget is not a
+    /// fraction, and reporting a huge number would let it be averaged.
+    /// Negative when the move freed headroom.
+    pub fraction_of_remaining_consumed: Option<f64>,
+}
+
+impl MarginalConstraintCost {
+    fn between(before: &Margin, after: &Margin) -> Self {
+        let (b, a) = (before.utilisation(), after.utilisation());
+        let delta = match (b, a) {
+            (Some(b), Some(a)) => Some(a - b),
+            _ => None,
+        };
+        let remaining_before = b.map(|b| 1.0 - b);
+        let fraction = match (delta, remaining_before) {
+            (Some(d), Some(r)) if r > 0.0 => Some(d / r),
+            _ => None,
+        };
+        Self {
+            criterion: after.criterion,
+            what: after.what.clone(),
+            before: b,
+            after: a,
+            delta,
+            remaining_before,
+            fraction_of_remaining_consumed: fraction,
+        }
+    }
+
+    /// Whether the move freed headroom on this criterion.
+    pub fn frees(&self) -> bool {
+        self.delta.is_some_and(|d| d < 0.0)
+    }
+}
+
+/// Every criterion's marginal cost for one move.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MarginalConstraintVector {
+    pub costs: Vec<MarginalConstraintCost>,
+}
+
+impl MarginalConstraintVector {
+    /// Pair the two vectors up by the gate's own wording for each
+    /// limit. Criteria present in only one are dropped: they cannot
+    /// have a before-and-after.
+    pub fn between(before: &ConstraintVector, after: &ConstraintVector) -> Self {
+        let costs = after
+            .margins
+            .iter()
+            .filter(|m| m.kind == LimitKind::Ceiling)
+            .filter_map(|a| {
+                before
+                    .margins
+                    .iter()
+                    .find(|b| b.what == a.what)
+                    .map(|b| MarginalConstraintCost::between(b, a))
+            })
+            .collect();
+        Self { costs }
+    }
+
+    /// **The scarce-resource cost of this move**: the largest fraction
+    /// of any criterion's remaining headroom that it consumed.
+    ///
+    /// `None` when the move consumed no headroom anywhere — every
+    /// criterion unchanged or improved. That is a move with no
+    /// behavioural price, not a move with a price of zero, and the
+    /// ranking treats it accordingly.
+    pub fn scarce_fraction_consumed(&self) -> Option<f64> {
+        self.scarcest()?.fraction_of_remaining_consumed
+    }
+
+    /// The criterion that gave up the largest share of its remaining
+    /// headroom. `None` when nothing was consumed.
+    pub fn scarcest(&self) -> Option<&MarginalConstraintCost> {
+        self.costs
+            .iter()
+            .filter(|c| c.fraction_of_remaining_consumed.is_some_and(|f| f > 0.0))
+            .max_by(|x, y| {
+                let (a, b) = (
+                    x.fraction_of_remaining_consumed
+                        .unwrap_or(f64::NEG_INFINITY),
+                    y.fraction_of_remaining_consumed
+                        .unwrap_or(f64::NEG_INFINITY),
+                );
+                a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal)
+            })
+    }
+
+    /// Criteria this move freed headroom on.
+    pub fn freed(&self) -> impl Iterator<Item = &MarginalConstraintCost> {
+        self.costs.iter().filter(|c| c.frees())
+    }
+
+    /// **A cost exists that could not be scored.** Either a criterion
+    /// was already over budget and took more, or its evidence is
+    /// missing on one side of the move.
+    ///
+    /// The distinction this draws is the one a search cannot get wrong:
+    /// `fraction_of_remaining_consumed == None` means BOTH "consumed
+    /// nothing" and "could not be scored", and those rank at opposite
+    /// ends. Anything this returns true for is unrankable, not free.
+    pub fn unscorable(&self) -> bool {
+        self.costs.iter().any(|c| {
+            c.fraction_of_remaining_consumed.is_none()
+                && (c.delta.is_none() || c.delta.is_some_and(|d| d > 0.0))
+        })
+    }
+
+    /// A criterion that was already over budget before the move and
+    /// took more. Not rankable, and a search must not treat it as
+    /// cheap simply because no fraction could be computed.
+    pub fn spent_past_an_exhausted_budget(&self) -> bool {
+        self.costs.iter().any(|c| {
+            c.remaining_before.is_some_and(|r| r <= 0.0) && c.delta.is_some_and(|d| d > 0.0)
+        })
+    }
+}
+
+/// **What kind of move this is**, which decides its rank before any
+/// number does.
+///
+/// These are four genuinely different states, and collapsing any of
+/// them to `0.0`, infinity or `NaN` produces a search that quietly
+/// prefers the wrong thing. `Unscorable` in particular arrives as the
+/// same `None` that `Unpriced` does, and ranks at the opposite end.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MoveClass {
+    /// Buys time and consumes no measurable headroom anywhere.
+    Unpriced,
+    /// Buys time at a measurable cost.
+    Priced,
+    /// Buys time, but a cost could not be scored — a criterion was
+    /// already over budget, or evidence for one is missing.
+    Unscorable,
+    /// Buys no time, however cheap it was.
+    Worthless,
+}
+
+impl MoveClass {
+    /// Higher sorts first. Encoded as a method rather than left to the
+    /// enum's declaration order so that reordering the variants cannot
+    /// silently become search policy.
+    fn tier(self) -> u8 {
+        match self {
+            Self::Unpriced => 3,
+            Self::Priced => 2,
+            Self::Unscorable => 1,
+            Self::Worthless => 0,
+        }
+    }
+}
+
+/// How a move ranks: what it buys over what it costs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RankingScore {
+    pub class: MoveClass,
+    /// GPU ms/token this move saves against the parent map.
+    pub gpu_ms_saved: f64,
+    /// Largest fraction of any criterion's remaining headroom consumed.
+    pub scarce_fraction_consumed: Option<f64>,
+    /// `gpu_ms_saved / scarce_fraction_consumed`.
+    ///
+    /// `None` when the move consumed no headroom — such a move is not
+    /// infinitely good, it is simply unpriced, and it ranks ahead of
+    /// every priced one rather than dividing by zero.
+    pub score: Option<f64>,
+}
+
+impl RankingScore {
+    /// **The ranking policy, stated once.** Higher sorts first.
+    ///
+    /// ```text
+    /// 1. unpriced moves    by physical gain
+    /// 2. priced moves      by gain per unit of scarce headroom
+    /// 3. unscorable moves  by physical gain
+    /// 4. zero-gain moves   by physical gain
+    /// ```
+    ///
+    /// Written down because otherwise `sort_by` becomes the policy by
+    /// accident, and a search whose preference order is an emergent
+    /// property of a comparator is not reproducible.
+    pub fn rank_key(&self) -> (u8, f64, f64) {
+        let within = match (self.class, self.score) {
+            (MoveClass::Priced, Some(s)) => s,
+            _ => self.gpu_ms_saved,
+        };
+        // Lower consumption breaks a tie on the primary key.
+        let frugality = -self.scarce_fraction_consumed.unwrap_or(0.0);
+        (self.class.tier(), within, frugality)
+    }
+
+    /// Descending order — best move first. A TOTAL order: `total_cmp`
+    /// leaves no pair incomparable, so a sort cannot depend on input
+    /// order even if a key were ever `NaN`.
+    pub fn cmp_rank(&self, other: &Self) -> std::cmp::Ordering {
+        let (a, b) = (other.rank_key(), self.rank_key());
+        a.0.cmp(&b.0)
+            .then_with(|| a.1.total_cmp(&b.1))
+            .then_with(|| a.2.total_cmp(&b.2))
+    }
+}
+
+/// Whether a move's evidence lets it enter a map.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Admission {
+    /// Authority-scale evidence, every criterion met. The only variant
+    /// that may enter a final map.
+    Earned,
+    /// Diagnostic-scale evidence with every ceiling met and the
+    /// instrument sound. Rankable and searchable; NOT admissible, and
+    /// deliberately a different word so a ranking cannot be quoted as
+    /// an admission.
+    Estimated,
+    /// A criterion is not met, at whatever scale.
+    Refused { failures: Vec<String> },
+}
+
+/// **One move, assessed: what it buys, what it costs, and on what
+/// evidence.**
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CandidateAssessment {
+    pub parent_map: String,
+    pub candidate_map: String,
+    pub scale: EvidenceScale,
+
+    /// Bytes/token this move removes against the PARENT map.
+    pub bytes_removed_marginal: u64,
+    /// Absolute prediction for the parent map and for the candidate.
+    pub parent_cost: CostPrediction,
+    pub candidate_cost: CostPrediction,
+
+    /// The authoritative evidence, kept whole beneath the score.
+    pub before: ConstraintVector,
+    pub after: ConstraintVector,
+    pub marginal: MarginalConstraintVector,
+
+    pub ranking_score: RankingScore,
+}
+
+impl CandidateAssessment {
+    /// Assess a move from `parent` to `candidate`.
+    ///
+    /// Both ledgers are ABSOLUTE — each against the same baseline
+    /// representation the cost observation was measured against — so
+    /// that each can be priced. The marginal quantities are then the
+    /// difference between the two predictions, which is what the
+    /// ranking wants.
+    pub fn of(
+        scale: EvidenceScale,
+        costs: &ExecutionCostModel,
+        parent: &ByteLedger,
+        candidate: &ByteLedger,
+        before: ConstraintVector,
+        after: ConstraintVector,
+    ) -> Result<Self, CostRefusal> {
+        let parent_cost = costs.predict(parent)?;
+        let candidate_cost = costs.predict(candidate)?;
+        let marginal = MarginalConstraintVector::between(&before, &after);
+        let gpu_ms_saved = parent_cost.gpu_ms_per_token - candidate_cost.gpu_ms_per_token;
+        let scarce = marginal.scarce_fraction_consumed();
+        let score = match scarce {
+            Some(f) if f > 0.0 => Some(gpu_ms_saved / f),
+            _ => None,
+        };
+        // Order matters: a move that buys nothing is worthless whatever
+        // it cost, and an unscorable cost outranks neither.
+        let class = if gpu_ms_saved <= 0.0 {
+            MoveClass::Worthless
+        } else if marginal.unscorable() {
+            MoveClass::Unscorable
+        } else if score.is_some() {
+            MoveClass::Priced
+        } else {
+            MoveClass::Unpriced
+        };
+        Ok(Self {
+            parent_map: parent.candidate_representation.clone(),
+            candidate_map: candidate.candidate_representation.clone(),
+            scale,
+            bytes_removed_marginal: parent
+                .candidate_bytes_per_token()
+                .saturating_sub(candidate.candidate_bytes_per_token()),
+            parent_cost,
+            candidate_cost,
+            before,
+            after,
+            marginal,
+            ranking_score: RankingScore {
+                class,
+                gpu_ms_saved,
+                scarce_fraction_consumed: scarce,
+                score,
+            },
+        })
+    }
+
+    /// **Total order over moves, best first.** [`RankingScore`] decides,
+    /// with the candidate's identity as the final tiebreak so that two
+    /// moves of identical economics always sort the same way and a
+    /// search trace reproduces exactly.
+    pub fn cmp_rank(&self, other: &Self) -> std::cmp::Ordering {
+        self.ranking_score
+            .cmp_rank(&other.ranking_score)
+            .then_with(|| self.candidate_map.cmp(&other.candidate_map))
+    }
+
+    /// The scarce resource before the move.
+    pub fn binding_before(&self) -> Option<&Margin> {
+        self.before.binding()
+    }
+
+    /// The scarce resource after it — which may be a different
+    /// criterion, and a search must recheck rather than assume.
+    pub fn binding_after(&self) -> Option<&Margin> {
+        self.after.binding()
+    }
+
+    /// Whether this move's evidence lets it enter a map.
+    ///
+    /// The position floor is scale-dependent — a diagnostic bank is
+    /// short BY DEFINITION and failing it says nothing about the
+    /// candidate. Coverage is not: a blind diagnostic is still blind,
+    /// and a ranking computed from one is worthless in exactly the way
+    /// an admission from one would be.
+    pub fn admission(&self) -> Admission {
+        let mut failures: Vec<String> = self
+            .after
+            .margins
+            .iter()
+            .filter(|m| {
+                self.scale == EvidenceScale::Authority || m.criterion != Criterion::Positions
+            })
+            .filter(|m| !m.satisfied())
+            .map(|m| m.what.clone())
+            .collect();
+        failures.sort();
+        if !failures.is_empty() {
+            return Admission::Refused { failures };
+        }
+        match self.scale {
+            EvidenceScale::Authority => Admission::Earned,
+            EvidenceScale::Diagnostic => Admission::Estimated,
+        }
+    }
+
+    /// The search trace: why this move ranks where it does, in the form
+    /// a reader can argue with.
+    pub fn describe(&self) -> String {
+        let mut out = format!(
+            "candidate: {} -> {}\n\nphysical:\n  -{:.0} MB/token\n  \
+             predicted {:+.2} ms GPU\n\nbehavioural:\n",
+            self.parent_map,
+            self.candidate_map,
+            self.bytes_removed_marginal as f64 / 1e6,
+            -self.ranking_score.gpu_ms_saved,
+        );
+        let scarcest = self.marginal.scarcest().map(|c| c.what.clone());
+        for c in &self.marginal.costs {
+            let share = match c.fraction_of_remaining_consumed {
+                Some(f) => format!("{:+.0}% of remaining headroom", 100.0 * f),
+                None => "not scored".into(),
+            };
+            let mark = if Some(&c.what) == scarcest.as_ref() {
+                "   <- scarce resource"
+            } else {
+                ""
+            };
+            out.push_str(&format!("  {:<32} {share}{mark}\n", c.what));
+        }
+        out.push_str(&match self.ranking_score.score {
+            Some(s) => format!(
+                "\nrank: {:.2} ms per unit of scarce headroom ({:.0}% consumed)\n",
+                s,
+                100.0 * self.ranking_score.scarce_fraction_consumed.unwrap_or(0.0),
+            ),
+            None => format!(
+                "\nrank: {:+.2} ms GPU at no behavioural cost\n",
+                self.ranking_score.gpu_ms_saved
+            ),
+        });
+        out.push_str(&format!(
+            "evidence: {:?}, {:?}\n",
+            self.scale,
+            self.admission()
+        ));
+        out
+    }
+}
+
+#[cfg(test)]
+#[path = "assessment_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/assessment_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/assessment_tests.rs
@@ -1,0 +1,624 @@
+//! `tests` for [`super`].
+//!
+//! The before/after vectors here are built directly rather than derived
+//! from banks: what this module does is the ARITHMETIC of a move, and
+//! `constraint_tests` already pins the bank-to-vector mapping against
+//! the real measurements. Limits are 1.0 throughout so that an
+//! `observed` value reads as its own utilisation and the fractions in
+//! each assertion can be checked by eye.
+
+use super::super::byte_ledger::{ByteLedger, ScopeBytes};
+use super::super::constraint::Margin;
+use super::super::execution_cost::{m3max_metal_001, ExecutionCostModel};
+use super::*;
+
+const KIMI: &str = "Kimi-Linear-48B-A3B-Instruct";
+const BASELINE_BYTES: u64 = 5_984_976_896;
+
+fn costs() -> ExecutionCostModel {
+    ExecutionCostModel::new(vec![m3max_metal_001()])
+}
+
+fn ledger_removing(fraction: f64) -> ByteLedger {
+    ByteLedger {
+        model: KIMI.into(),
+        baseline_representation: "BF16".into(),
+        candidate_representation: format!("removes {:.1}%", 100.0 * fraction),
+        scopes: vec![ScopeBytes {
+            scope: "whole decoder".into(),
+            family: "whole decoder".into(),
+            baseline_bytes: BASELINE_BYTES,
+            candidate_bytes: BASELINE_BYTES - (BASELINE_BYTES as f64 * fraction) as u64,
+        }],
+    }
+}
+
+fn ceiling(what: &str, criterion: Criterion, utilisation: f64) -> Margin {
+    Margin {
+        criterion,
+        what: what.into(),
+        kind: LimitKind::Ceiling,
+        limit: 1.0,
+        observed: Some(utilisation),
+        vacuous: false,
+    }
+}
+
+fn floor(what: &str, criterion: Criterion, observed: f64, limit: f64) -> Margin {
+    Margin {
+        criterion,
+        what: what.into(),
+        kind: LimitKind::Floor,
+        limit,
+        observed: Some(observed),
+        vacuous: false,
+    }
+}
+
+/// A vector with the two criteria this programme actually watches, plus
+/// sound floors.
+fn vector(kl: f64, route: f64) -> ConstraintVector {
+    ConstraintVector {
+        gate_id: "kimi-logit-balanced-v1".into(),
+        margins: vec![
+            ceiling("kl p99", Criterion::KlP99, kl),
+            ceiling(
+                "routed mixture moved at p99",
+                Criterion::RouteDisplacement,
+                route,
+            ),
+            floor("positions", Criterion::Positions, 8192.0, 4096.0),
+            floor(
+                "covered mass at the worst position",
+                Criterion::CoveredMass,
+                0.63,
+                0.55,
+            ),
+        ],
+    }
+}
+
+fn assess(
+    scale: EvidenceScale,
+    parent_removes: f64,
+    candidate_removes: f64,
+    before: ConstraintVector,
+    after: ConstraintVector,
+) -> CandidateAssessment {
+    CandidateAssessment::of(
+        scale,
+        &costs(),
+        &ledger_removing(parent_removes),
+        &ledger_removing(candidate_removes),
+        before,
+        after,
+    )
+    .expect("both ledgers are for the measured model")
+}
+
+// ── The correction that made this module marginal. ──
+
+#[test]
+fn cost_is_a_fraction_of_what_remained_not_of_the_limit() {
+    // Routing at 83% moving to 88% has not "cost 88%". Seventeen points
+    // remained and the move took five of them.
+    let a = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.68, 0.88),
+    );
+    let route = a
+        .marginal
+        .costs
+        .iter()
+        .find(|c| c.criterion == Criterion::RouteDisplacement)
+        .expect("paired");
+    assert!((route.remaining_before.expect("scored") - 0.17).abs() < 1e-9);
+    assert!((route.delta.expect("scored") - 0.05).abs() < 1e-9);
+    let f = route.fraction_of_remaining_consumed.expect("scored");
+    assert!((f - 5.0 / 17.0).abs() < 1e-6, "consumed {f}");
+    assert!((a.ranking_score.scarce_fraction_consumed.expect("scored") - f).abs() < 1e-9);
+}
+
+#[test]
+fn a_move_that_frees_the_binding_constraint_outranks_one_that_eats_it() {
+    // The failure mode this ranking exists to avoid. Both moves buy the
+    // same bytes. FREEING costs a point of KL, where 32 points remain;
+    // EATING costs nothing in KL and three points of routing, where
+    // only 17 remain. A naive "cost = absolute KL delta" ranks EATING
+    // first, because its KL cost is zero.
+    let freeing = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.69, 0.80),
+    );
+    let eating = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.68, 0.86),
+    );
+
+    // The naive metric, stated so the comparison is explicit.
+    let kl_delta = |a: &CandidateAssessment| {
+        a.marginal
+            .costs
+            .iter()
+            .find(|c| c.criterion == Criterion::KlP99)
+            .and_then(|c| c.delta)
+            .expect("scored")
+    };
+    assert!(
+        kl_delta(&freeing) > kl_delta(&eating),
+        "the freeing move IS more expensive in absolute KL — that is the trap"
+    );
+
+    // The marginal metric prefers it anyway, because a point of KL out
+    // of 32 remaining is cheap and three points of routing out of 17 is
+    // not.
+    let (f, e) = (
+        freeing.ranking_score.scarce_fraction_consumed.expect("s"),
+        eating.ranking_score.scarce_fraction_consumed.expect("s"),
+    );
+    assert!((f - 1.0 / 32.0).abs() < 1e-6, "freeing consumed {f}");
+    assert!((e - 3.0 / 17.0).abs() < 1e-6, "eating consumed {e}");
+    assert_eq!(
+        freeing.ranking_score.cmp_rank(&eating.ranking_score),
+        std::cmp::Ordering::Less,
+        "freeing must sort ahead of eating"
+    );
+    // And the vector, not the scalar, is what says WHY.
+    assert_eq!(freeing.marginal.freed().count(), 1);
+    assert_eq!(eating.marginal.freed().count(), 0);
+}
+
+#[test]
+fn the_binding_criterion_can_change_across_a_move() {
+    let a = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.90, 0.60),
+    );
+    assert_eq!(
+        a.binding_before().expect("scored").criterion,
+        Criterion::RouteDisplacement
+    );
+    assert_eq!(
+        a.binding_after().expect("scored").criterion,
+        Criterion::KlP99,
+        "a search must recheck what binds after every accepted move"
+    );
+}
+
+// ── Ranking edges. ──
+
+#[test]
+fn a_move_that_consumes_no_headroom_is_unpriced_and_ranks_first() {
+    let free = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.68, 0.83),
+    );
+    assert_eq!(free.ranking_score.scarce_fraction_consumed, None);
+    assert_eq!(
+        free.ranking_score.score, None,
+        "unpriced, not infinitely good"
+    );
+    assert!(free.ranking_score.gpu_ms_saved > 0.0);
+
+    let priced = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.70, 0.85),
+    );
+    assert_eq!(
+        free.ranking_score.cmp_rank(&priced.ranking_score),
+        std::cmp::Ordering::Less
+    );
+}
+
+#[test]
+fn a_move_that_buys_nothing_ranks_last_however_cheap_it_was() {
+    let nothing = assess(
+        EvidenceScale::Authority,
+        0.20,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.68, 0.83),
+    );
+    assert!(nothing.ranking_score.gpu_ms_saved.abs() < 1e-9);
+    let priced = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.70, 0.85),
+    );
+    assert_eq!(
+        nothing.ranking_score.cmp_rank(&priced.ranking_score),
+        std::cmp::Ordering::Greater,
+        "a free lunch that feeds nobody still ranks last"
+    );
+}
+
+#[test]
+fn spending_past_an_exhausted_budget_is_flagged_rather_than_scored_cheap() {
+    // Routing already over its limit, and the move takes more. No
+    // fraction of a negative remainder is meaningful, so it is not
+    // scored — and the flag exists so a search cannot read the
+    // resulting `None` as "costs nothing".
+    let a = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 1.05),
+        vector(0.68, 1.10),
+    );
+    let route = a
+        .marginal
+        .costs
+        .iter()
+        .find(|c| c.criterion == Criterion::RouteDisplacement)
+        .expect("paired");
+    assert!(route.remaining_before.expect("scored") < 0.0);
+    assert_eq!(route.fraction_of_remaining_consumed, None);
+    assert!(a.marginal.spent_past_an_exhausted_budget());
+    assert_eq!(a.ranking_score.scarce_fraction_consumed, None);
+}
+
+// ── A ranking is not an admission. ──
+
+#[test]
+fn diagnostic_evidence_can_be_estimated_but_never_earned() {
+    let d = assess(
+        EvidenceScale::Diagnostic,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.70, 0.85),
+    );
+    assert_eq!(d.admission(), Admission::Estimated);
+    assert_ne!(d.admission(), Admission::Earned);
+    // It is still rankable — that is the whole point of the scale.
+    assert!(d.ranking_score.score.is_some());
+}
+
+#[test]
+fn authority_evidence_with_every_criterion_met_is_earned() {
+    let a = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.70, 0.85),
+    );
+    assert_eq!(a.admission(), Admission::Earned);
+}
+
+#[test]
+fn a_short_bank_is_not_held_against_a_diagnostic_but_is_against_authority() {
+    let short = |kl, route| {
+        let mut v = vector(kl, route);
+        v.margins
+            .iter_mut()
+            .find(|m| m.criterion == Criterion::Positions)
+            .expect("present")
+            .observed = Some(256.0);
+        v
+    };
+    // A diagnostic bank is short BY DEFINITION; failing the position
+    // floor says nothing about the candidate.
+    let d = assess(
+        EvidenceScale::Diagnostic,
+        0.16,
+        0.20,
+        short(0.68, 0.83),
+        short(0.70, 0.85),
+    );
+    assert_eq!(d.admission(), Admission::Estimated);
+    // At authority scale the same bank is exactly what the floor is for.
+    let a = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        short(0.68, 0.83),
+        short(0.70, 0.85),
+    );
+    assert_eq!(
+        a.admission(),
+        Admission::Refused {
+            failures: vec!["positions".into()]
+        }
+    );
+}
+
+#[test]
+fn a_blind_diagnostic_is_refused_at_either_scale() {
+    // Coverage is NOT scale-dependent. A ranking computed from a blind
+    // instrument is worthless in exactly the way an admission from one
+    // would be — and a blind run scores perfectly on every ceiling.
+    let blind = |kl, route| {
+        let mut v = vector(kl, route);
+        v.margins
+            .iter_mut()
+            .find(|m| m.criterion == Criterion::CoveredMass)
+            .expect("present")
+            .observed = Some(2048.0 / 163_840.0);
+        v
+    };
+    for scale in [EvidenceScale::Diagnostic, EvidenceScale::Authority] {
+        let a = assess(scale, 0.16, 0.20, blind(0.0, 0.0), blind(0.0, 0.0));
+        assert_eq!(
+            a.admission(),
+            Admission::Refused {
+                failures: vec!["covered mass at the worst position".into()]
+            },
+            "{scale:?}"
+        );
+    }
+}
+
+// ── The trace. ──
+
+#[test]
+fn the_trace_names_the_scarce_resource_and_the_evidence_scale() {
+    let a = assess(
+        EvidenceScale::Diagnostic,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.70, 0.88),
+    );
+    let t = a.describe();
+    assert!(t.contains("<- scarce resource"), "{t}");
+    let scarce_line = t
+        .lines()
+        .find(|l| l.contains("<- scarce resource"))
+        .expect("marked");
+    assert!(
+        scarce_line.contains("routed mixture"),
+        "routing consumed 5/17 against kl's 2/32 — {scarce_line}"
+    );
+    assert!(t.contains("Diagnostic"), "{t}");
+    assert!(t.contains("Estimated"), "{t}");
+    assert!(t.contains("MB/token"), "{t}");
+}
+
+#[test]
+fn an_unpriced_move_says_so_in_the_trace() {
+    let a = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.60, 0.80),
+    );
+    let t = a.describe();
+    assert!(t.contains("at no behavioural cost"), "{t}");
+    assert!(!t.contains("<- scarce resource"), "{t}");
+}
+
+#[test]
+fn byte_economics_still_do_not_transfer_across_models() {
+    let other = ByteLedger {
+        model: "gpt-oss-20b".into(),
+        ..ledger_removing(0.20)
+    };
+    let r = CandidateAssessment::of(
+        EvidenceScale::Authority,
+        &costs(),
+        &ledger_removing(0.16),
+        &other,
+        vector(0.68, 0.83),
+        vector(0.70, 0.85),
+    );
+    assert!(r.is_err(), "a move may not be priced from another model");
+}
+
+#[test]
+fn the_trace_shows_an_unscorable_criterion_as_unscored_not_as_free() {
+    // Routing was already over budget, so its cost has no fraction. The
+    // trace must SAY that rather than silently omit the line, which
+    // would read as though routing had cost nothing.
+    let a = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 1.05),
+        vector(0.68, 1.10),
+    );
+    let t = a.describe();
+    let route_line = t
+        .lines()
+        .find(|l| l.contains("routed mixture"))
+        .expect("the criterion is still listed");
+    assert!(route_line.contains("not scored"), "{route_line}");
+    assert!(a.marginal.spent_past_an_exhausted_budget());
+    // And it is refused, so no ranking of it can become an admission.
+    assert!(matches!(a.admission(), Admission::Refused { .. }));
+}
+
+// ── The ranking policy, as a total order. ──
+
+#[test]
+fn a_move_that_spent_past_an_exhausted_budget_is_unscorable_not_unpriced() {
+    // The regression this class exists for. Both states arrive as
+    // `scarce_fraction_consumed == None`, and they rank at opposite
+    // ends: consuming nothing is the BEST kind of move, and blowing
+    // past an exhausted budget is nearly the worst. Reading the one as
+    // the other put the single worst move at the top of the list.
+    let exhausted = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 1.05),
+        vector(0.68, 1.10),
+    );
+    assert_eq!(exhausted.ranking_score.scarce_fraction_consumed, None);
+    assert_eq!(exhausted.ranking_score.class, MoveClass::Unscorable);
+
+    let free = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.68, 0.83),
+    );
+    assert_eq!(free.ranking_score.scarce_fraction_consumed, None);
+    assert_eq!(free.ranking_score.class, MoveClass::Unpriced);
+
+    assert_eq!(
+        free.cmp_rank(&exhausted),
+        std::cmp::Ordering::Less,
+        "the same None must not put them in the same tier"
+    );
+}
+
+#[test]
+fn the_four_classes_rank_in_the_stated_order() {
+    let unpriced = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.22,
+        vector(0.68, 0.83),
+        vector(0.68, 0.83),
+    );
+    let priced = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.24,
+        vector(0.68, 0.83),
+        vector(0.70, 0.85),
+    );
+    let unscorable = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.26,
+        vector(0.68, 1.05),
+        vector(0.68, 1.10),
+    );
+    let worthless = assess(
+        EvidenceScale::Authority,
+        0.20,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.68, 0.83),
+    );
+    // Deliberately built so the WORST classes buy the most bytes: a
+    // policy driven by physical gain alone would invert this.
+    assert!(unscorable.ranking_score.gpu_ms_saved > priced.ranking_score.gpu_ms_saved);
+    assert!(priced.ranking_score.gpu_ms_saved > unpriced.ranking_score.gpu_ms_saved);
+
+    let mut all = [
+        worthless.clone(),
+        unscorable.clone(),
+        priced.clone(),
+        unpriced.clone(),
+    ];
+    all.sort_by(CandidateAssessment::cmp_rank);
+    let classes: Vec<MoveClass> = all.iter().map(|a| a.ranking_score.class).collect();
+    assert_eq!(
+        classes,
+        [
+            MoveClass::Unpriced,
+            MoveClass::Priced,
+            MoveClass::Unscorable,
+            MoveClass::Worthless,
+        ]
+    );
+}
+
+#[test]
+fn unpriced_moves_rank_among_themselves_by_physical_gain() {
+    let small = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.18,
+        vector(0.68, 0.83),
+        vector(0.68, 0.83),
+    );
+    let large = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.30,
+        vector(0.68, 0.83),
+        vector(0.68, 0.83),
+    );
+    assert_eq!(large.cmp_rank(&small), std::cmp::Ordering::Less);
+}
+
+#[test]
+fn the_order_is_total_and_reproducible() {
+    // Two moves of IDENTICAL economics must still order deterministically,
+    // or a search trace cannot be reproduced from its inputs.
+    let a = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.70, 0.85),
+    );
+    let mut b = a.clone();
+    b.candidate_map = "zzz identical economics".into();
+    assert_eq!(
+        a.ranking_score.cmp_rank(&b.ranking_score),
+        std::cmp::Ordering::Equal,
+        "the scores really are tied"
+    );
+    assert_eq!(a.cmp_rank(&b), std::cmp::Ordering::Less, "identity decides");
+    assert_eq!(
+        b.cmp_rank(&a),
+        std::cmp::Ordering::Greater,
+        "and is antisymmetric"
+    );
+
+    // A sort is then independent of input order.
+    let mut one = [a.clone(), b.clone()];
+    let mut two = [b, a];
+    one.sort_by(CandidateAssessment::cmp_rank);
+    two.sort_by(CandidateAssessment::cmp_rank);
+    assert_eq!(
+        one.iter()
+            .map(|x| x.candidate_map.clone())
+            .collect::<Vec<_>>(),
+        two.iter()
+            .map(|x| x.candidate_map.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn a_tie_on_score_is_broken_toward_the_more_frugal_move() {
+    // Same gain per unit of scarce headroom, different absolute
+    // consumption. The one that leaves more budget for later moves wins.
+    let frugal = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.68, 0.85),
+    );
+    let spendy = assess(
+        EvidenceScale::Authority,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.80, 0.85),
+    );
+    assert!(
+        frugal.ranking_score.scarce_fraction_consumed.expect("s")
+            < spendy.ranking_score.scarce_fraction_consumed.expect("s")
+    );
+    assert_eq!(frugal.cmp_rank(&spendy), std::cmp::Ordering::Less);
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/assessment_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/assessment_tests.rs
@@ -10,6 +10,7 @@
 use super::super::byte_ledger::{ByteLedger, ScopeBytes};
 use super::super::constraint::Margin;
 use super::super::execution_cost::{m3max_metal_001, ExecutionCostModel};
+use super::super::measurement::TailSupport;
 use super::*;
 
 const KIMI: &str = "Kimi-Linear-48B-A3B-Instruct";
@@ -34,6 +35,16 @@ fn ledger_removing(fraction: f64) -> ByteLedger {
 }
 
 fn ceiling(what: &str, criterion: Criterion, utilisation: f64) -> Margin {
+    // Well-supported by default; the thin-tail cases construct their own.
+    ceiling_with(what, criterion, utilisation, Some(2000))
+}
+
+fn ceiling_with(
+    what: &str,
+    criterion: Criterion,
+    utilisation: f64,
+    observations: Option<u64>,
+) -> Margin {
     Margin {
         criterion,
         what: what.into(),
@@ -41,6 +52,10 @@ fn ceiling(what: &str, criterion: Criterion, utilisation: f64) -> Margin {
         limit: 1.0,
         observed: Some(utilisation),
         vacuous: false,
+        tail_support: observations.map(|observations| TailSupport {
+            quantile: 0.99,
+            observations,
+        }),
     }
 }
 
@@ -52,6 +67,7 @@ fn floor(what: &str, criterion: Criterion, observed: f64, limit: f64) -> Margin 
         limit,
         observed: Some(observed),
         vacuous: false,
+        tail_support: None,
     }
 }
 
@@ -86,7 +102,7 @@ fn assess(
     after: ConstraintVector,
 ) -> CandidateAssessment {
     CandidateAssessment::of(
-        scale,
+        &EvidenceContext::route_cal_1(scale),
         &costs(),
         &ledger_removing(parent_removes),
         &ledger_removing(candidate_removes),
@@ -290,8 +306,17 @@ fn diagnostic_evidence_can_be_estimated_but_never_earned() {
     );
     assert_eq!(d.admission(), Admission::Estimated);
     assert_ne!(d.admission(), Admission::Earned);
-    // It is still rankable — that is the whole point of the scale.
-    assert!(d.ranking_score.score.is_some());
+    // But it is NOT priced. Under ROUTE-CAL-1 no criterion balanced-v1
+    // judges is priceable from a 256-position bank: kl is an ordering
+    // proxy and route mass p99 is unusable. The candidate is therefore
+    // Unscorable — which now means "cannot be priced at this evidence
+    // scale", not "the search knows nothing about it".
+    assert_eq!(d.ranking_score.class, MoveClass::Unscorable);
+    assert_eq!(d.ranking_score.score, None);
+    assert_eq!(
+        d.marginal.unpriceable_costs().count(),
+        d.marginal.costs.len()
+    );
 }
 
 #[test]
@@ -374,7 +399,7 @@ fn a_blind_diagnostic_is_refused_at_either_scale() {
 #[test]
 fn the_trace_names_the_scarce_resource_and_the_evidence_scale() {
     let a = assess(
-        EvidenceScale::Diagnostic,
+        EvidenceScale::Authority,
         0.16,
         0.20,
         vector(0.68, 0.83),
@@ -390,9 +415,27 @@ fn the_trace_names_the_scarce_resource_and_the_evidence_scale() {
         scarce_line.contains("routed mixture"),
         "routing consumed 5/17 against kl's 2/32 — {scarce_line}"
     );
-    assert!(t.contains("Diagnostic"), "{t}");
-    assert!(t.contains("Estimated"), "{t}");
+    assert!(t.contains("Authority"), "{t}");
+    assert!(t.contains("Earned"), "{t}");
     assert!(t.contains("MB/token"), "{t}");
+}
+
+#[test]
+fn a_diagnostic_trace_says_it_is_not_priced_rather_than_showing_a_number() {
+    let d = assess(
+        EvidenceScale::Diagnostic,
+        0.16,
+        0.20,
+        vector(0.68, 0.83),
+        vector(0.70, 0.88),
+    );
+    let t = d.describe();
+    assert!(t.contains("NOT priced"), "{t}");
+    assert!(t.contains("NOT PRICEABLE at this scale"), "{t}");
+    assert!(
+        !t.contains("<- scarce resource"),
+        "nothing is scarce if nothing is priced — {t}"
+    );
 }
 
 #[test]
@@ -416,7 +459,7 @@ fn byte_economics_still_do_not_transfer_across_models() {
         ..ledger_removing(0.20)
     };
     let r = CandidateAssessment::of(
-        EvidenceScale::Authority,
+        &EvidenceContext::route_cal_1(EvidenceScale::Authority),
         &costs(),
         &ledger_removing(0.16),
         &other,

--- a/crates/larql-vindex/src/format/vindex3/represent/byte_ledger.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/byte_ledger.rs
@@ -1,0 +1,146 @@
+//! **What a representation map costs to read, per token.**
+//!
+//! The intrinsic half of the economics, and the only half that is a
+//! property of the model rather than of a machine: how many bytes the
+//! decoder reads for one token under a baseline representation, and how
+//! many under a candidate. No hardware, no backend, no coefficient —
+//! those belong to [`super::execution_cost`], which is where the
+//! provenance lives.
+//!
+//! Keeping the two apart is the point. A byte count is a fact that
+//! survives a new machine; a byte count multiplied by a measured
+//! conversion factor is an observation that does not, and code that
+//! cannot tell them apart will eventually quote the second as if it
+//! were the first.
+//!
+//! ```text
+//! routed experts (8 of 256 x 26 layers)   2.944 GB   49.2 %
+//! KDA projections (20 layers)             1.510 GB   25.2 %
+//! output head                             0.755 GB   12.6 %
+//! MLA projections (7 layers)              0.408 GB    6.8 %
+//! shared experts (26 layers)              0.368 GB    6.1 %
+//! ```
+//!
+//! That is Kimi-Linear-48B-A3B at BF16 — the ledger which showed that a
+//! checkpoint 97 % experts by size is only 49 % experts by TOKEN, and
+//! so that a whole-decoder map beats an expert-only one.
+//!
+//! **Scopes are supplied, not derived.** A ledger is a list of the
+//! scopes the decoder actually reads and what each costs under both
+//! representations. It does not attempt to infer that from geometry,
+//! because "which layers are MLA" and "how many experts are routed" are
+//! model-shape questions whose wrong answer would be silent, and a
+//! wrong byte count propagates into every prediction downstream.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+/// One scope's contribution to the per-token read, under both
+/// representations.
+///
+/// `candidate_bytes == baseline_bytes` is the normal case: most of a
+/// map is unchanged, and a ledger that listed only the changed scopes
+/// could not compute what fraction of the whole was removed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScopeBytes {
+    /// The scope itself, e.g. `"routed experts L20-26"`.
+    pub scope: String,
+    /// The byte family it belongs to, e.g. `"routed experts"`. Breadth
+    /// is counted in families as well as scopes, because taking four
+    /// layers of one family is a different kind of change from taking
+    /// one layer of each of four.
+    pub family: String,
+    pub baseline_bytes: u64,
+    pub candidate_bytes: u64,
+}
+
+impl ScopeBytes {
+    /// Bytes this scope no longer reads. Saturating, so a candidate
+    /// that grew reports zero removed rather than an underflow.
+    pub fn removed(&self) -> u64 {
+        self.baseline_bytes.saturating_sub(self.candidate_bytes)
+    }
+
+    /// Whether this scope's representation changed at all.
+    pub fn changed(&self) -> bool {
+        self.candidate_bytes != self.baseline_bytes
+    }
+}
+
+/// The per-token read of a whole decoder, under a baseline
+/// representation and a candidate one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ByteLedger {
+    /// Which model this is a ledger for — a prediction may not be
+    /// carried from one model to another, and this is what lets that be
+    /// checked rather than assumed.
+    pub model: String,
+    /// Names of the two representations, for the record.
+    pub baseline_representation: String,
+    pub candidate_representation: String,
+    /// EVERY scope the decoder reads per token, changed or not.
+    pub scopes: Vec<ScopeBytes>,
+}
+
+impl ByteLedger {
+    pub fn baseline_bytes_per_token(&self) -> u64 {
+        self.scopes.iter().map(|s| s.baseline_bytes).sum()
+    }
+
+    pub fn candidate_bytes_per_token(&self) -> u64 {
+        self.scopes.iter().map(|s| s.candidate_bytes).sum()
+    }
+
+    pub fn bytes_removed(&self) -> u64 {
+        self.baseline_bytes_per_token()
+            .saturating_sub(self.candidate_bytes_per_token())
+    }
+
+    /// Removed bytes as a fraction of the baseline read — the quantity
+    /// a throughput prediction is a function of.
+    ///
+    /// Zero for an empty ledger rather than `NaN`: nothing read is
+    /// nothing saved, and a `NaN` here would propagate silently.
+    pub fn fraction_removed(&self) -> f64 {
+        let baseline = self.baseline_bytes_per_token();
+        if baseline == 0 {
+            return 0.0;
+        }
+        self.bytes_removed() as f64 / baseline as f64
+    }
+
+    /// **Breadth, in families.** Distinct families with at least one
+    /// changed scope.
+    pub fn families_changed(&self) -> BTreeSet<&str> {
+        self.scopes
+            .iter()
+            .filter(|s| s.changed())
+            .map(|s| s.family.as_str())
+            .collect()
+    }
+
+    /// **Breadth, in scopes.** How many individual scopes moved.
+    pub fn scopes_changed(&self) -> usize {
+        self.scopes.iter().filter(|s| s.changed()).count()
+    }
+
+    /// What each family contributes to the baseline read, largest
+    /// first — the table that says where the bytes actually are, as
+    /// opposed to where the checkpoint's size is.
+    pub fn baseline_by_family(&self) -> Vec<(&str, u64)> {
+        let mut totals: std::collections::BTreeMap<&str, u64> = std::collections::BTreeMap::new();
+        for s in &self.scopes {
+            *totals.entry(s.family.as_str()).or_default() += s.baseline_bytes;
+        }
+        let mut rows: Vec<(&str, u64)> = totals.into_iter().collect();
+        rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+        rows
+    }
+}
+
+#[cfg(test)]
+#[path = "byte_ledger_tests.rs"]
+// Visible to `execution_cost`'s tests: they share ONE measured Kimi
+// ledger, so the two modules cannot drift apart on what the map costs.
+pub(super) mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/byte_ledger_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/byte_ledger_tests.rs
@@ -1,0 +1,186 @@
+//! `tests` for [`super`].
+
+use super::*;
+
+fn scope(scope: &str, family: &str, baseline: u64, candidate: u64) -> ScopeBytes {
+    ScopeBytes {
+        scope: scope.into(),
+        family: family.into(),
+        baseline_bytes: baseline,
+        candidate_bytes: candidate,
+    }
+}
+
+/// **The measured Kimi-Linear-48B-A3B ledger**, BF16 baseline against
+/// the four-family Q8_0 map: 27 layers with layer 0 dense, 256 experts
+/// of 3 x 2304 x 1024 per MoE layer with 8 routed per token, MLA at
+/// layers {3,7,11,15,19,23,26} and KDA at the other 20, vocabulary
+/// 163,840. Byte figures from the probe's own reports.
+pub(in crate::format::vindex3::represent) fn kimi_four_family() -> ByteLedger {
+    ByteLedger {
+        model: "Kimi-Linear-48B-A3B-Instruct".into(),
+        baseline_representation: "BF16".into(),
+        candidate_representation: "experts L20-26 + KDA{20,21,22,24,25} + MLA{23,26} + head, Q8_0"
+            .into(),
+        scopes: vec![
+            scope(
+                "routed experts L0-19",
+                "routed experts",
+                2_151_677_952,
+                2_151_677_952,
+            ),
+            scope(
+                "routed experts L20-26",
+                "routed experts",
+                792_723_456,
+                421_134_336,
+            ),
+            scope(
+                "KDA projections x15",
+                "KDA projections",
+                1_132_462_080,
+                1_132_462_080,
+            ),
+            scope(
+                "KDA{20,21,22,24,25}",
+                "KDA projections",
+                377_487_360,
+                200_540_160,
+            ),
+            scope(
+                "MLA projections x5",
+                "MLA projections",
+                291_143_680,
+                291_143_680,
+            ),
+            scope("MLA{23,26}", "MLA projections", 116_457_472, 61_868_032),
+            scope("output head", "output head", 754_974_720, 401_080_320),
+            scope(
+                "shared experts x26",
+                "shared experts",
+                368_050_176,
+                368_050_176,
+            ),
+        ],
+    }
+}
+
+#[test]
+fn the_checkpoint_is_experts_and_the_token_is_not() {
+    let l = kimi_four_family();
+    assert_eq!(l.baseline_bytes_per_token(), 5_984_976_896);
+    let shares: Vec<(&str, f64)> = l
+        .baseline_by_family()
+        .into_iter()
+        .map(|(f, b)| (f, 100.0 * b as f64 / l.baseline_bytes_per_token() as f64))
+        .collect();
+    // 97% of the CHECKPOINT is experts; 49% of the TOKEN is. That gap
+    // is the whole argument for a whole-decoder map over an
+    // expert-only one, so it is pinned here rather than in prose.
+    let expected = [
+        ("routed experts", 49.2),
+        ("KDA projections", 25.2),
+        ("output head", 12.6),
+        ("MLA projections", 6.8),
+        ("shared experts", 6.1),
+    ];
+    assert_eq!(shares.len(), expected.len());
+    for ((got_f, got_pct), (want_f, want_pct)) in shares.iter().zip(expected) {
+        assert_eq!(*got_f, want_f);
+        assert!(
+            (got_pct - want_pct).abs() < 0.05,
+            "{want_f}: {got_pct:.1}% vs {want_pct}%"
+        );
+    }
+}
+
+#[test]
+fn the_four_family_map_removes_the_measured_fraction() {
+    let l = kimi_four_family();
+    assert_eq!(l.candidate_bytes_per_token(), 5_027_956_736);
+    assert_eq!(l.bytes_removed(), 957_020_160);
+    assert!((l.fraction_removed() - 0.15990).abs() < 1e-5);
+}
+
+#[test]
+fn breadth_is_counted_in_families_and_in_scopes() {
+    let l = kimi_four_family();
+    assert_eq!(
+        l.families_changed().into_iter().collect::<Vec<_>>(),
+        [
+            "KDA projections",
+            "MLA projections",
+            "output head",
+            "routed experts"
+        ],
+        "shared experts were refused on economics, so the map has four families"
+    );
+    assert_eq!(l.scopes_changed(), 4, "four scope entries moved");
+}
+
+#[test]
+fn unchanged_scopes_still_count_toward_the_baseline() {
+    // A ledger listing only the CHANGED scopes could not say what
+    // fraction of the whole was removed, which is the one number a
+    // throughput prediction is a function of.
+    let full = kimi_four_family();
+    let changed_only = ByteLedger {
+        scopes: full
+            .scopes
+            .iter()
+            .filter(|s| s.changed())
+            .cloned()
+            .collect(),
+        ..full.clone()
+    };
+    assert_eq!(changed_only.bytes_removed(), full.bytes_removed());
+    assert!(
+        changed_only.fraction_removed() > 2.0 * full.fraction_removed(),
+        "dropping the unchanged scopes inflates the fraction — {:.3} vs {:.3}",
+        changed_only.fraction_removed(),
+        full.fraction_removed()
+    );
+}
+
+#[test]
+fn an_empty_ledger_reports_zero_rather_than_a_nan() {
+    let l = ByteLedger {
+        model: "nothing".into(),
+        baseline_representation: "BF16".into(),
+        candidate_representation: "BF16".into(),
+        scopes: Vec::new(),
+    };
+    assert_eq!(l.baseline_bytes_per_token(), 0);
+    assert_eq!(l.fraction_removed(), 0.0);
+    assert!(l.fraction_removed().is_finite());
+    assert_eq!(l.scopes_changed(), 0);
+}
+
+#[test]
+fn a_representation_that_grew_removes_nothing_rather_than_underflowing() {
+    // Not hypothetical: a codec with per-block scales can exceed BF16
+    // on a narrow tensor.
+    let l = ByteLedger {
+        model: "m".into(),
+        baseline_representation: "BF16".into(),
+        candidate_representation: "wider".into(),
+        scopes: vec![scope("s", "f", 1_000, 1_400)],
+    };
+    assert_eq!(l.bytes_removed(), 0);
+    assert_eq!(l.fraction_removed(), 0.0);
+    assert_eq!(l.scopes[0].removed(), 0);
+    assert!(l.scopes[0].changed(), "it did change — it just grew");
+    assert_eq!(l.scopes_changed(), 1);
+}
+
+#[test]
+fn a_map_that_changes_nothing_has_no_breadth() {
+    let mut l = kimi_four_family();
+    for s in &mut l.scopes {
+        s.candidate_bytes = s.baseline_bytes;
+    }
+    assert_eq!(l.bytes_removed(), 0);
+    assert_eq!(l.fraction_removed(), 0.0);
+    assert_eq!(l.scopes_changed(), 0);
+    assert!(l.families_changed().is_empty());
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/constraint.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/constraint.rs
@@ -38,6 +38,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::measurement::{MeasurementStatus, TailSupport, TailSupportPolicy};
 use super::quality::{Criterion, QualityBank, QualityGate};
 
 /// Whether a limit is a ceiling the candidate spends against, or a
@@ -71,9 +72,31 @@ pub struct Margin {
     /// criterion measures, so there was nothing to record a magnitude
     /// for. Only then does `observed: None` mean "cost zero".
     pub vacuous: bool,
+    /// For a PERCENTILE, the observations behind its tail. `None` for a
+    /// statistic that is not a percentile — a count, a maximum, a mean —
+    /// where the question does not arise.
+    ///
+    /// Carried because a p99 over forty-six observations is a maximum
+    /// wearing a percentile's name, and the margin is the last place
+    /// that fact is still recoverable.
+    pub tail_support: Option<TailSupport>,
 }
 
 impl Margin {
+    /// Whether the evidence supports the statistic this margin reports.
+    ///
+    /// A non-percentile is `Measured` whenever it was observed at all:
+    /// counts and maxima do not have tails to be thin.
+    pub fn measurement_status(&self, policy: &TailSupportPolicy) -> MeasurementStatus {
+        if self.observed.is_none() {
+            return MeasurementStatus::NotObserved;
+        }
+        match self.tail_support {
+            Some(s) => policy.status(Some(s)),
+            None => MeasurementStatus::Measured,
+        }
+    }
+
     /// Fraction of this criterion's budget the candidate consumed, for
     /// ceilings — `1.0` is exactly at the limit.
     ///
@@ -128,25 +151,35 @@ impl ConstraintVector {
     /// The standing of `bank` against every criterion `gate` judges.
     pub fn of(gate: &QualityGate, bank: &QualityBank) -> Self {
         let mut margins = Vec::new();
-        let mut ceiling = |criterion, what: &str, limit: Option<f64>, observed, vacuous| {
-            if let Some(limit) = limit {
-                margins.push(Margin {
-                    criterion,
-                    what: what.into(),
-                    kind: LimitKind::Ceiling,
-                    limit,
-                    observed,
-                    vacuous,
-                });
-            }
+        let mut ceiling =
+            |criterion, what: &str, limit: Option<f64>, observed, vacuous, tail_support| {
+                if let Some(limit) = limit {
+                    margins.push(Margin {
+                        criterion,
+                        what: what.into(),
+                        kind: LimitKind::Ceiling,
+                        limit,
+                        observed,
+                        vacuous,
+                        tail_support,
+                    });
+                }
+            };
+        let p99 = |observations: u64| {
+            Some(TailSupport {
+                quantile: 0.99,
+                observations,
+            })
         };
 
+        // kl is DENSE: every position contributes a value.
         ceiling(
             Criterion::KlP99,
             "kl p99",
             Some(gate.kl_p99_max),
             Some(bank.logits.kl_p99),
             false,
+            p99(bank.positions),
         );
         for (criterion, what, limit, got) in [
             (
@@ -168,12 +201,14 @@ impl ConstraintVector {
                 bank.routing.route_flips,
             ),
         ] {
+            // Raw counts are not percentiles.
             ceiling(
                 criterion,
                 what,
                 limit.map(|l| l as f64),
                 Some(got as f64),
                 false,
+                None,
             );
         }
         // Each consequence magnitude sits beside the COUNT whose being
@@ -181,13 +216,18 @@ impl ConstraintVector {
         // them here, in one table, is what lets a reader check the
         // correspondence — the alternative is a second function that
         // re-derives it from the criterion and needs a wildcard arm.
-        for (criterion, what, limit, observed, changes) in [
+        // Each consequence magnitude sits beside the COUNT whose being
+        // zero makes its absence vacuous rather than missing, and beside
+        // the tail support of the statistic it reports. A MAX has no
+        // tail to be thin; a p99 over a handful of events is a max.
+        for (criterion, what, limit, observed, changes, support) in [
             (
                 Criterion::Top1Displacement,
                 "top-1 probability given up",
                 gate.top1_mass_displaced_max,
                 bank.top1_mass_displaced.map(|d| d.max),
                 bank.logits.top1_flips,
+                None,
             ),
             (
                 Criterion::TopKDisplacement,
@@ -195,6 +235,7 @@ impl ConstraintVector {
                 gate.top10_mass_displaced_p99_max,
                 bank.top10_mass_displaced.map(|d| d.p99),
                 bank.logits.top10_changes,
+                bank.top10_mass_displaced.map(|d| d.count).and_then(&p99),
             ),
             (
                 Criterion::RouteDisplacement,
@@ -202,6 +243,10 @@ impl ConstraintVector {
                 gate.route_mixture_mass_p99_max,
                 bank.routing.route_weight_mass_moved.map(|d| d.p99),
                 bank.routing.route_flips,
+                bank.routing
+                    .route_weight_mass_moved
+                    .map(|d| d.count)
+                    .and_then(&p99),
             ),
             (
                 Criterion::RouteDisplacement,
@@ -209,10 +254,11 @@ impl ConstraintVector {
                 gate.route_mixture_mass_max,
                 bank.routing.route_weight_mass_moved.map(|d| d.max),
                 bank.routing.route_flips,
+                None,
             ),
         ] {
             let vacuous = observed.is_none() && changes == 0;
-            ceiling(criterion, what, limit, observed, vacuous);
+            ceiling(criterion, what, limit, observed, vacuous, support);
         }
 
         // The floors. Neither is a resource a candidate spends; both
@@ -224,6 +270,7 @@ impl ConstraintVector {
             limit: gate.positions_min as f64,
             observed: Some(bank.positions as f64),
             vacuous: false,
+            tail_support: None,
         });
         if let Some(required) = gate.covered_mass_min {
             margins.push(Margin {
@@ -233,6 +280,7 @@ impl ConstraintVector {
                 limit: required,
                 observed: bank.min_covered_mass,
                 vacuous: false,
+                tail_support: None,
             });
         }
 

--- a/crates/larql-vindex/src/format/vindex3/represent/constraint.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/constraint.rs
@@ -1,0 +1,302 @@
+//! **What a candidate spends, criterion by criterion.**
+//!
+//! A behavioural contract is not one number, and the criteria in it do
+//! not deplete together. Measured on the four-family Kimi map at 8,192
+//! positions under `kimi-logit-balanced-v1`:
+//!
+//! ```text
+//! kl p99                68 % of limit    plenty
+//! top-1 mass displaced  46 % of limit    plenty
+//! top-10 mass p99       54 % of limit    plenty
+//! route mixture p99     83 % of limit    BINDING
+//! route mixture max     80 % of limit    BINDING
+//! ```
+//!
+//! Ranking candidates by "bytes saved per unit KL" implicitly treats
+//! the remaining budget as one scalar pool. It is not. A candidate that
+//! looks cheap on logits but moves routing spends the resource that is
+//! actually scarce, and a candidate with slightly worse KL and no route
+//! movement may be strictly better for the map. This module is the type
+//! that makes that difference expressible.
+//!
+//! **Not every limit is a budget.** Two of them are conditions on the
+//! MEASUREMENT rather than costs the candidate pays:
+//!
+//! ```text
+//! kl, displacement, counts   CEILING   the candidate spends these
+//! positions, covered mass    FLOOR     the instrument must clear these
+//! ```
+//!
+//! Conflating the two is not pedantry — it is the difference between a
+//! verdict and an accident. A blind instrument reports `kl_p99 = 0.0`,
+//! a perfect score on every ceiling, and is caught only by the floors.
+//! That happened twice while this map was being earned; see
+//! `docs/kimi-precision-topology.md`. So `binding()` ranks ceilings
+//! only, and floors are asked about separately through [`sound`].
+//!
+//! [`sound`]: ConstraintVector::sound
+
+use serde::{Deserialize, Serialize};
+
+use super::quality::{Criterion, QualityBank, QualityGate};
+
+/// Whether a limit is a ceiling the candidate spends against, or a
+/// floor the measurement itself has to clear.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LimitKind {
+    /// Higher observed values are worse; the budget is `limit`.
+    Ceiling,
+    /// Lower observed values are worse; `limit` is a minimum.
+    Floor,
+}
+
+/// One criterion's standing: what the gate asks, what the bank
+/// measured, and how much of the budget that leaves.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Margin {
+    pub criterion: Criterion,
+    /// Which limit this is, in the gate's own words — `Criterion` is
+    /// coarser than the gate: `RouteDisplacement` carries both a p99
+    /// and a max limit, and they can bind independently.
+    pub what: String,
+    pub kind: LimitKind,
+    pub limit: f64,
+    /// `None` when the bank did not record this quantity. That is NOT
+    /// zero: an unmeasured consequence is unmeasured, and a candidate
+    /// whose evidence is silent about a criterion cannot be ranked on
+    /// it. See [`Margin::satisfied`] for the one case where silence is
+    /// legitimately a pass.
+    pub observed: Option<f64>,
+    /// True when the bank recorded no change at all of the kind this
+    /// criterion measures, so there was nothing to record a magnitude
+    /// for. Only then does `observed: None` mean "cost zero".
+    pub vacuous: bool,
+}
+
+impl Margin {
+    /// Fraction of this criterion's budget the candidate consumed, for
+    /// ceilings — `1.0` is exactly at the limit.
+    ///
+    /// `None` for floors (a floor is not a budget) and for a criterion
+    /// the bank did not measure. A vacuous ceiling consumed nothing, so
+    /// it reports `0.0`.
+    pub fn utilisation(&self) -> Option<f64> {
+        if self.kind != LimitKind::Ceiling || self.limit <= 0.0 {
+            return None;
+        }
+        match self.observed {
+            Some(got) => Some(got / self.limit),
+            None if self.vacuous => Some(0.0),
+            None => None,
+        }
+    }
+
+    /// How much of this criterion's budget is left, as a fraction.
+    /// Negative when the limit is already exceeded.
+    pub fn headroom(&self) -> Option<f64> {
+        self.utilisation().map(|u| 1.0 - u)
+    }
+
+    /// Whether this criterion is currently met.
+    ///
+    /// An unmeasured criterion is NOT satisfied unless it is vacuous —
+    /// the gate's own rule, and the reason a gate that asks for
+    /// coverage and gets nothing must refuse rather than assume the
+    /// truncation was wide enough.
+    pub fn satisfied(&self) -> bool {
+        match (self.observed, self.kind) {
+            (Some(got), LimitKind::Ceiling) => got <= self.limit,
+            (Some(got), LimitKind::Floor) => got >= self.limit,
+            (None, _) => self.vacuous,
+        }
+    }
+}
+
+/// Every criterion a gate judges, with what the bank spent against it.
+///
+/// Built from the same gate and bank a [`QualityGate::evaluate`] call
+/// would use, and agreeing with it criterion for criterion — pinned by
+/// a congruence test rather than by shared code, so a drift between the
+/// two tables fails a test instead of silently mis-ranking candidates.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConstraintVector {
+    pub gate_id: String,
+    pub margins: Vec<Margin>,
+}
+
+impl ConstraintVector {
+    /// The standing of `bank` against every criterion `gate` judges.
+    pub fn of(gate: &QualityGate, bank: &QualityBank) -> Self {
+        let mut margins = Vec::new();
+        let mut ceiling = |criterion, what: &str, limit: Option<f64>, observed, vacuous| {
+            if let Some(limit) = limit {
+                margins.push(Margin {
+                    criterion,
+                    what: what.into(),
+                    kind: LimitKind::Ceiling,
+                    limit,
+                    observed,
+                    vacuous,
+                });
+            }
+        };
+
+        ceiling(
+            Criterion::KlP99,
+            "kl p99",
+            Some(gate.kl_p99_max),
+            Some(bank.logits.kl_p99),
+            false,
+        );
+        for (criterion, what, limit, got) in [
+            (
+                Criterion::Top1Flips,
+                "top-1 flips",
+                gate.top1_flip_max,
+                bank.logits.top1_flips,
+            ),
+            (
+                Criterion::Top10Changes,
+                "top-10 changes",
+                gate.top10_change_max,
+                bank.logits.top10_changes,
+            ),
+            (
+                Criterion::RouteFlips,
+                "route flips",
+                gate.route_flip_max,
+                bank.routing.route_flips,
+            ),
+        ] {
+            ceiling(
+                criterion,
+                what,
+                limit.map(|l| l as f64),
+                Some(got as f64),
+                false,
+            );
+        }
+        // Each consequence magnitude sits beside the COUNT whose being
+        // zero makes its absence vacuous rather than missing. Pairing
+        // them here, in one table, is what lets a reader check the
+        // correspondence — the alternative is a second function that
+        // re-derives it from the criterion and needs a wildcard arm.
+        for (criterion, what, limit, observed, changes) in [
+            (
+                Criterion::Top1Displacement,
+                "top-1 probability given up",
+                gate.top1_mass_displaced_max,
+                bank.top1_mass_displaced.map(|d| d.max),
+                bank.logits.top1_flips,
+            ),
+            (
+                Criterion::TopKDisplacement,
+                "top-10 mass displaced at p99",
+                gate.top10_mass_displaced_p99_max,
+                bank.top10_mass_displaced.map(|d| d.p99),
+                bank.logits.top10_changes,
+            ),
+            (
+                Criterion::RouteDisplacement,
+                "routed mixture moved at p99",
+                gate.route_mixture_mass_p99_max,
+                bank.routing.route_weight_mass_moved.map(|d| d.p99),
+                bank.routing.route_flips,
+            ),
+            (
+                Criterion::RouteDisplacement,
+                "routed mixture moved at max",
+                gate.route_mixture_mass_max,
+                bank.routing.route_weight_mass_moved.map(|d| d.max),
+                bank.routing.route_flips,
+            ),
+        ] {
+            let vacuous = observed.is_none() && changes == 0;
+            ceiling(criterion, what, limit, observed, vacuous);
+        }
+
+        // The floors. Neither is a resource a candidate spends; both
+        // are conditions without which the ceilings above mean nothing.
+        margins.push(Margin {
+            criterion: Criterion::Positions,
+            what: "positions".into(),
+            kind: LimitKind::Floor,
+            limit: gate.positions_min as f64,
+            observed: Some(bank.positions as f64),
+            vacuous: false,
+        });
+        if let Some(required) = gate.covered_mass_min {
+            margins.push(Margin {
+                criterion: Criterion::CoveredMass,
+                what: "covered mass at the worst position".into(),
+                kind: LimitKind::Floor,
+                limit: required,
+                observed: bank.min_covered_mass,
+                vacuous: false,
+            });
+        }
+
+        Self {
+            gate_id: gate.id.clone(),
+            margins,
+        }
+    }
+
+    /// Criteria the candidate SPENDS against — ceilings only.
+    pub fn spendable(&self) -> impl Iterator<Item = &Margin> {
+        self.margins.iter().filter(|m| m.kind == LimitKind::Ceiling)
+    }
+
+    /// **The scarce resource: the ceiling closest to its limit.**
+    ///
+    /// This is what a search should rank against. Bytes saved per unit
+    /// of KL is the wrong objective when KL is at 68 % of budget and
+    /// route movement is at 83 %: the next candidate is admitted or
+    /// refused by the route limit, whatever it does to KL.
+    ///
+    /// `None` when no ceiling could be scored — every one of them
+    /// unmeasured, which is a statement about the evidence, not about
+    /// the candidate.
+    pub fn binding(&self) -> Option<&Margin> {
+        self.spendable()
+            .filter(|m| m.utilisation().is_some())
+            .max_by(|a, b| {
+                let (x, y) = (
+                    a.utilisation().unwrap_or(f64::NEG_INFINITY),
+                    b.utilisation().unwrap_or(f64::NEG_INFINITY),
+                );
+                x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal)
+            })
+    }
+
+    /// Worst utilisation recorded for `criterion` — worst, because
+    /// `Criterion` is coarser than the gate and one criterion can carry
+    /// several limits that bind independently.
+    pub fn utilisation_of(&self, criterion: Criterion) -> Option<f64> {
+        self.spendable()
+            .filter(|m| m.criterion == criterion)
+            .filter_map(|m| m.utilisation())
+            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+    }
+
+    /// Whether the MEASUREMENT is sound — every floor cleared.
+    ///
+    /// Asked separately from the ceilings on purpose. A blind
+    /// instrument passes every ceiling perfectly, and the floors are
+    /// the only thing standing between that and a promoted map.
+    pub fn sound(&self) -> bool {
+        self.margins
+            .iter()
+            .filter(|m| m.kind == LimitKind::Floor)
+            .all(Margin::satisfied)
+    }
+
+    /// Whether every criterion — ceiling and floor — is met.
+    pub fn admissible(&self) -> bool {
+        self.margins.iter().all(Margin::satisfied)
+    }
+}
+
+#[cfg(test)]
+#[path = "constraint_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/constraint_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/constraint_tests.rs
@@ -1,0 +1,432 @@
+//! `tests` for [`super`].
+//!
+//! The banks here are not invented. `four_family_selection` and
+//! `four_family_heldout` carry the numbers the composed Kimi map
+//! actually measured at 8,192 positions on 2026-08-31, and
+//! `flat_instrument` carries the numbers one of the two catalogued
+//! blind-instrument episodes produced. A type whose job is to say which
+//! resource is scarce should be tested against the measurement that
+//! made the question worth asking.
+
+use super::super::quality::{
+    kimi_logit_balanced_v1, kimi_logit_v1, Distribution, LogitEvidence, QualityBank, QualityGate,
+    RoutingEvidence,
+};
+use super::*;
+
+fn dist(p99: f64, max: f64) -> Option<Distribution> {
+    Some(Distribution {
+        count: 1,
+        min: 0.0,
+        p50: 0.0,
+        p95: 0.0,
+        p99,
+        max,
+    })
+}
+
+/// The four-family map on the SELECTION bank: experts L20-26 x KDA
+/// {20,21,22,24,25} x MLA{23,26} x output head, all Q8_0, 8,192
+/// positions. `kimi_full4-selection-8192_report.json`.
+fn four_family_selection() -> QualityBank {
+    QualityBank {
+        positions: 8192,
+        logits: LogitEvidence {
+            kl_p50: 0.0,
+            kl_p95: 0.0,
+            kl_p99: 2.3791e-3,
+            max_logit_delta: 0.0,
+            top1_flips: 129,
+            top10_changes: 2527,
+        },
+        routing: RoutingEvidence {
+            route_flips: 1305,
+            positions_with_route_change: 0,
+            layers_with_route_change: 0,
+            first_layer_with_route_change: None,
+            route_margin: None,
+            route_weight_mass_moved: dist(0.1248, 0.1993),
+        },
+        min_covered_mass: Some(0.6315),
+        top10_margin: None,
+        top10_candidate_margin: None,
+        top10_mass_displaced: dist(0.064652, 0.064652),
+        top10_rank_displacement: None,
+        top1_margin: None,
+        top1_candidate_margin: None,
+        top1_mass_displaced: dist(0.055463, 0.055463),
+    }
+}
+
+/// The same map on the HELD-OUT bank, which chose no scope.
+/// `kimi_full4-heldout-8192_report.json`.
+fn four_family_heldout() -> QualityBank {
+    QualityBank {
+        positions: 8192,
+        logits: LogitEvidence {
+            kl_p99: 2.6174e-3,
+            top1_flips: 122,
+            top10_changes: 2341,
+            ..four_family_selection().logits
+        },
+        routing: RoutingEvidence {
+            route_flips: 1270,
+            route_weight_mass_moved: dist(0.1257, 0.2099),
+            ..four_family_selection().routing
+        },
+        min_covered_mass: Some(0.5773),
+        top10_mass_displaced: dist(0.068805, 0.068805),
+        top1_mass_displaced: dist(0.058313, 0.058313),
+        ..four_family_selection()
+    }
+}
+
+/// One of the two catalogued blind-instrument episodes: the GPU
+/// completed command buffers without executing them, so both arms were
+/// constant and coverage sat at the uniform floor `TOP_N/vocab`
+/// (2048/163840). Every CEILING is perfect. Only a floor catches it.
+fn flat_instrument() -> QualityBank {
+    QualityBank {
+        positions: 8192,
+        logits: LogitEvidence {
+            kl_p50: 0.0,
+            kl_p95: 0.0,
+            kl_p99: 0.0,
+            max_logit_delta: 0.0,
+            top1_flips: 0,
+            top10_changes: 0,
+        },
+        routing: RoutingEvidence {
+            route_flips: 0,
+            positions_with_route_change: 0,
+            layers_with_route_change: 0,
+            first_layer_with_route_change: None,
+            route_margin: None,
+            route_weight_mass_moved: None,
+        },
+        min_covered_mass: Some(2048.0 / 163_840.0),
+        top10_margin: None,
+        top10_candidate_margin: None,
+        top10_mass_displaced: None,
+        top10_rank_displacement: None,
+        top1_margin: None,
+        top1_candidate_margin: None,
+        top1_mass_displaced: None,
+    }
+}
+
+// ── The finding this type exists for. ──
+
+#[test]
+fn route_movement_is_the_binding_constraint_on_the_four_family_map() {
+    for (name, bank) in [
+        ("selection", four_family_selection()),
+        ("held-out", four_family_heldout()),
+    ] {
+        let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &bank);
+        let binding = v.binding().expect("every ceiling was measured");
+        assert_eq!(
+            binding.criterion,
+            Criterion::RouteDisplacement,
+            "{name}: the scarce resource is routing, not KL"
+        );
+        assert!(
+            binding.utilisation().expect("scored") > 0.8,
+            "{name}: routing should sit above 80% of its limit"
+        );
+    }
+}
+
+#[test]
+fn kl_has_far_more_headroom_than_routing_does() {
+    let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &four_family_selection());
+    let kl = v.utilisation_of(Criterion::KlP99).expect("kl scored");
+    let route = v
+        .utilisation_of(Criterion::RouteDisplacement)
+        .expect("route scored");
+    // 2.3791e-3 / 3.5e-3 and 0.1248 / 0.15.
+    assert!((kl - 0.6797).abs() < 1e-3, "kl utilisation was {kl}");
+    assert!(
+        (route - 0.8320).abs() < 1e-3,
+        "route utilisation was {route}"
+    );
+    assert!(
+        route > kl,
+        "the scalar 'quality cost' framing hides exactly this ordering"
+    );
+}
+
+#[test]
+fn a_criterion_carrying_two_limits_reports_the_worse_one() {
+    // balanced-v1 judges routed mixture mass at BOTH p99 (0.15) and max
+    // (0.25). On the held-out bank p99 is at 83.8% and max at 84.0%, so
+    // the coarser `Criterion` key must not average or pick the first.
+    let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &four_family_heldout());
+    let worst = v
+        .utilisation_of(Criterion::RouteDisplacement)
+        .expect("scored");
+    let both: Vec<f64> = v
+        .spendable()
+        .filter(|m| m.criterion == Criterion::RouteDisplacement)
+        .filter_map(|m| m.utilisation())
+        .collect();
+    assert_eq!(both.len(), 2, "both route limits are judged");
+    assert!((worst - both.iter().cloned().fold(f64::MIN, f64::max)).abs() < 1e-12);
+}
+
+// ── The floors are not budgets. ──
+
+#[test]
+fn a_blind_instrument_passes_every_ceiling_and_is_still_refused() {
+    let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &flat_instrument());
+    for m in v.spendable() {
+        assert!(
+            m.satisfied(),
+            "{}: a constant-logit run spends nothing",
+            m.what
+        );
+    }
+    assert!(
+        !v.sound(),
+        "coverage at TOP_N/vocab is the uniform floor — the run saw nothing"
+    );
+    assert!(
+        !v.admissible(),
+        "a perfect score on every budget must not be admissible when the \
+         measurement itself is unsound"
+    );
+}
+
+#[test]
+fn binding_ranks_ceilings_only_and_never_reports_a_floor() {
+    let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &flat_instrument());
+    // Coverage is at 1.25% of a 55% floor — catastrophically the worst
+    // number in the vector — and must still not be "the binding
+    // constraint", which names a resource to spend less of.
+    let binding = v.binding().expect("ceilings were scored");
+    assert_ne!(binding.criterion, Criterion::CoveredMass);
+    assert_eq!(binding.kind, LimitKind::Ceiling);
+}
+
+#[test]
+fn a_sound_measurement_clears_both_floors() {
+    for bank in [four_family_selection(), four_family_heldout()] {
+        let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &bank);
+        assert!(v.sound());
+        assert!(v.admissible());
+    }
+}
+
+// ── Unmeasured is not zero. ──
+
+#[test]
+fn an_unmeasured_consequence_is_not_ranked_and_not_satisfied() {
+    let mut bank = four_family_selection();
+    // Flips happened, so a displacement magnitude SHOULD exist; the
+    // bank simply failed to record it. That is missing evidence.
+    bank.top1_mass_displaced = None;
+    let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &bank);
+    let m = v
+        .spendable()
+        .find(|m| m.criterion == Criterion::Top1Displacement)
+        .expect("the gate judges it");
+    assert!(!m.vacuous, "129 top-1 flips is not 'nothing changed'");
+    assert_eq!(m.utilisation(), None, "unmeasured is not zero");
+    assert!(!m.satisfied(), "silence is not a pass");
+    assert!(!v.admissible());
+}
+
+#[test]
+fn a_vacuous_consequence_costs_nothing() {
+    let mut bank = four_family_selection();
+    // Nothing routed differently, so there is no magnitude to record.
+    bank.routing.route_flips = 0;
+    bank.routing.route_weight_mass_moved = None;
+    let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &bank);
+    for m in v
+        .spendable()
+        .filter(|m| m.criterion == Criterion::RouteDisplacement)
+    {
+        assert!(m.vacuous);
+        assert_eq!(m.utilisation(), Some(0.0));
+        assert!(m.satisfied());
+    }
+    // With routing spending nothing, the scarce resource moves.
+    assert_eq!(
+        v.binding().expect("scored").criterion,
+        Criterion::KlP99,
+        "the binding criterion is a property of the candidate, not a constant"
+    );
+}
+
+// ── The drift guard. ──
+
+#[test]
+fn the_margin_table_agrees_with_the_gate_criterion_for_criterion() {
+    let gate = kimi_logit_balanced_v1();
+    for (name, bank) in [
+        ("four-family selection", four_family_selection()),
+        ("four-family held-out", four_family_heldout()),
+        ("flat instrument", flat_instrument()),
+        ("unmeasured displacement", {
+            let mut b = four_family_selection();
+            b.top1_mass_displaced = None;
+            b
+        }),
+        ("short bank", {
+            let mut b = four_family_selection();
+            b.positions = 256;
+            b
+        }),
+    ] {
+        let v = ConstraintVector::of(&gate, &bank);
+        let verdict = gate.evaluate(&bank);
+        assert_eq!(
+            v.admissible(),
+            verdict.passed(),
+            "{name}: the vector and the gate disagree on the verdict"
+        );
+        for m in &v.margins {
+            let gate_failed = verdict.failures.iter().any(|(c, _)| *c == m.criterion);
+            let margin_failed = v
+                .margins
+                .iter()
+                .filter(|o| o.criterion == m.criterion)
+                .any(|o| !o.satisfied());
+            assert_eq!(
+                margin_failed, gate_failed,
+                "{name}: {} disagrees with the gate",
+                m.what
+            );
+        }
+    }
+}
+
+#[test]
+fn every_criterion_the_gate_judges_appears_in_the_vector() {
+    let gate = kimi_logit_balanced_v1();
+    let v = ConstraintVector::of(&gate, &four_family_selection());
+    // balanced-v1: kl, three displacement limits (route twice),
+    // positions, covered mass. It judges no raw counts.
+    assert_eq!(v.spendable().count(), 5);
+    assert_eq!(v.margins.len(), 7);
+    assert!(v
+        .margins
+        .iter()
+        .all(|m| m.criterion != Criterion::Top1Flips));
+}
+
+// ── The accessors a search actually ranks with. ──
+
+#[test]
+fn headroom_is_what_is_left_of_a_budget_and_floors_have_none() {
+    let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &four_family_selection());
+    let route = v
+        .spendable()
+        .find(|m| m.what == "routed mixture moved at p99")
+        .expect("judged");
+    // 1 - 0.1248/0.15: about a sixth of the route budget is left, which
+    // is the number a search should be allocating against.
+    let left = route.headroom().expect("a ceiling has headroom");
+    assert!((left - 0.1680).abs() < 1e-3, "headroom was {left}");
+    assert!((left + route.utilisation().expect("scored") - 1.0).abs() < 1e-12);
+
+    // A floor is not a budget: there is nothing to spend and nothing
+    // left, and reporting a number here would invite ranking against it.
+    let floor = v
+        .margins
+        .iter()
+        .find(|m| m.criterion == Criterion::CoveredMass)
+        .expect("balanced-v1 asks for coverage");
+    assert_eq!(floor.kind, LimitKind::Floor);
+    assert_eq!(floor.utilisation(), None);
+    assert_eq!(floor.headroom(), None);
+    assert!(floor.satisfied(), "0.6315 clears the 0.55 floor");
+}
+
+#[test]
+fn headroom_goes_negative_once_a_budget_is_overspent() {
+    let mut bank = four_family_selection();
+    // B3 (experts 16-26) — the map whose consequences changed character,
+    // and the candidate balanced-v1 was calibrated to refuse.
+    bank.logits.kl_p99 = 4.735e-3;
+    let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &bank);
+    let kl = v
+        .spendable()
+        .find(|m| m.criterion == Criterion::KlP99)
+        .expect("judged");
+    assert!(kl.utilisation().expect("scored") > 1.0);
+    assert!(kl.headroom().expect("scored") < 0.0);
+    assert!(!kl.satisfied());
+    assert!(!v.admissible());
+    // Overspent, so it is also the scarcest thing in the vector.
+    assert_eq!(v.binding().expect("scored").criterion, Criterion::KlP99);
+}
+
+#[test]
+fn a_zero_budget_is_judged_but_never_ranked() {
+    // No gate in this crate sets a zero ceiling, and the type must not
+    // assume that stays true. `observed / 0.0` is either infinity or —
+    // when nothing was observed either — NaN, and a NaN utilisation
+    // sorts arbitrarily against every other criterion, which would
+    // silently mis-rank the whole vector rather than fail. A zero
+    // budget is therefore JUDGED but never RANKED.
+    let gate = QualityGate {
+        top1_flip_max: Some(0),
+        route_flip_max: Some(0),
+        ..kimi_logit_v1()
+    };
+    let v = ConstraintVector::of(&gate, &four_family_selection());
+    for what in ["top-1 flips", "route flips"] {
+        let m = v.spendable().find(|m| m.what == what).expect("judged");
+        assert_eq!(m.limit, 0.0);
+        assert_eq!(
+            m.utilisation(),
+            None,
+            "{what}: a fraction of a zero budget is not a number"
+        );
+        assert_eq!(m.headroom(), None);
+        assert!(!m.satisfied(), "{what}: 129 and 1305 are over zero");
+    }
+    assert!(!v.admissible());
+    // Ranking still works off the criteria that CAN be scored, instead
+    // of collapsing because one of them is unrankable. Under v1 that is
+    // top-10 CHANGES — 2527 against a limit of 82, thirty-one times
+    // over, where kl is only 2.4x over. Which is the count-based
+    // gate's whole problem, and why v3 stopped judging on counts: the
+    // scarce resource it names is the one that cannot tell a near-tie
+    // reordering from an overturned decision.
+    assert_eq!(
+        v.binding().expect("scored").criterion,
+        Criterion::Top10Changes
+    );
+}
+
+#[test]
+fn a_zero_budget_that_was_never_spent_does_not_poison_the_ranking() {
+    // The NaN case specifically: limit 0 AND observed 0. Satisfied —
+    // nothing was spent — but still unrankable, and `binding()` must
+    // return a real criterion rather than this one.
+    let gate = QualityGate {
+        top1_flip_max: Some(0),
+        ..kimi_logit_v1()
+    };
+    let mut bank = four_family_selection();
+    bank.logits.top1_flips = 0;
+    let v = ConstraintVector::of(&gate, &bank);
+    let m = v
+        .spendable()
+        .find(|m| m.what == "top-1 flips")
+        .expect("judged");
+    assert!(m.satisfied(), "zero spent against a zero budget is fine");
+    assert_eq!(
+        m.utilisation(),
+        None,
+        "0.0 / 0.0 must not reach the ranking"
+    );
+    assert_ne!(
+        v.binding().expect("scored").criterion,
+        Criterion::Top1Flips,
+        "an unrankable criterion must never be reported as the scarce one"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/execution_cost.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/execution_cost.rs
@@ -1,0 +1,408 @@
+//! **What a byte reduction actually bought, and where that was measured.**
+//!
+//! [`super::byte_ledger`] says how many bytes a map removes. This says
+//! what removing them did to decode time — and that is not a property
+//! of the map. It is a property of a machine, a backend, a build, a
+//! baseline and a BREADTH, and the only honest way to hold it is as an
+//! observation with provenance rather than as a constant.
+//!
+//! Three things are deliberately kept apart:
+//!
+//! ```text
+//! physical fact         bytes/token for a representation map
+//! observation           this byte reduction produced this GPU-time
+//!                       reduction, on this machine, at this breadth
+//! planner coefficient   beta = gpu fraction removed / byte fraction
+//!                       removed — DERIVED from an observation, never
+//!                       an input
+//! ```
+//!
+//! Only the first is intrinsic. Writing `const BETA: f64 = 0.80` would
+//! promote one measurement to a law of the backend, and this programme
+//! has already been taught what that costs: a `~45 GB` wired-memory
+//! wall inferred from a single episode was contradicted at 79 GB the
+//! next day, and a scalar reading of the BEHAVIOURAL budget hid the
+//! fact that route movement binds at 83 % while KL sits at 68 %.
+//!
+//! **Beta is currently measured at exactly one breadth.** The model
+//! therefore reports [`CalibrationStatus::Provisional`] and every
+//! prediction carries that status plus the id of the observation it
+//! came from. That is the whole point: a search may use it, and may not
+//! forget where it came from.
+//!
+//! **Deliberately not modelled yet.** No regression, no confidence
+//! interval, no piecewise curve. With one observation those would be
+//! decoration over a single point. The sophistication here is in
+//! preserving provenance, not in the arithmetic — which is
+//! `gpu_removed ≈ beta × bytes_removed` and nothing more. When there
+//! are five or ten observations across breadths and codecs,
+//! [`ExecutionCostModel`] can learn a curve without the search API
+//! changing.
+
+use serde::{Deserialize, Serialize};
+
+use super::byte_ledger::ByteLedger;
+
+/// How much a prediction from this model can be relied on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CalibrationStatus {
+    /// Beta has not been shown to hold across breadths — either there
+    /// is one observation, or every observation sits at effectively the
+    /// same byte fraction, so their agreement says nothing about
+    /// whether beta varies.
+    Provisional,
+    /// Beta has been measured at separated breadths.
+    Calibrated,
+}
+
+/// Two observations count as separate operating points only when their
+/// byte fractions differ by more than this.
+///
+/// Five percentage points. Below that, two measurements are probing the
+/// same point on any curve beta might have, and agreement between them
+/// is not evidence that beta is flat — which is the specific claim
+/// [`CalibrationStatus::Calibrated`] makes.
+const DISTINCT_BREADTH_MIN_SEPARATION: f64 = 0.05;
+
+/// **One measurement of what a byte reduction bought.**
+///
+/// Every field is either provenance or a measured quantity. The derived
+/// quantities — byte fraction removed, GPU fraction removed, beta — are
+/// METHODS rather than fields, so a stored record cannot disagree with
+/// its own inputs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionCostObservation {
+    /// Stable id a prediction can name, e.g. `"m3max-metal-001"`.
+    pub id: String,
+
+    // ── Where ──
+    pub machine: String,
+    pub device: String,
+    pub backend: String,
+    /// Commit the measured binary was built from. A kernel change moves
+    /// beta, and without this a later reader cannot tell whether an
+    /// observation predates one.
+    pub compiler_commit: String,
+
+    // ── What ──
+    pub model_identity: String,
+    pub baseline_representation: String,
+    pub candidate_representation: String,
+
+    // ── Breadth, so beta(breadth) is an askable question ──
+    /// Families with at least one changed scope.
+    pub families_changed: Vec<String>,
+    /// Individual scopes that moved.
+    pub scopes_changed: u32,
+
+    // ── Physical ──
+    pub baseline_bytes_per_token: u64,
+    pub candidate_bytes_per_token: u64,
+
+    // ── Measured ──
+    pub baseline_gpu_ms_per_token: f64,
+    pub candidate_gpu_ms_per_token: f64,
+    /// Wall time per token that is NOT GPU time, at the measured floor.
+    ///
+    /// Recorded because a later model will need it to separate fixed
+    /// cost from variable, and because tokens/second is a wall figure:
+    /// a GPU-time prediction alone cannot produce one.
+    ///
+    /// **One number for both arms, which ASSUMES the overhead does not
+    /// depend on the map.** In the measurement behind
+    /// [`m3max_metal_001`] the two arms' floors carried 1.05 ms and
+    /// 1.09 ms, so the assumption is worth about 0.1 % on a predicted
+    /// wall speedup. Held here rather than hidden: if a backend ever
+    /// makes overhead depend on the representation, this field is the
+    /// one that has to become two.
+    pub fixed_overhead_ms: f64,
+
+    // ── How ──
+    pub benchmark_protocol: String,
+    /// Files a reader can go and check.
+    pub evidence: Vec<String>,
+}
+
+impl ExecutionCostObservation {
+    /// Fraction of the baseline per-token read this candidate removed.
+    pub fn byte_fraction_removed(&self) -> f64 {
+        if self.baseline_bytes_per_token == 0 {
+            return 0.0;
+        }
+        self.baseline_bytes_per_token
+            .saturating_sub(self.candidate_bytes_per_token) as f64
+            / self.baseline_bytes_per_token as f64
+    }
+
+    /// Fraction of baseline GPU time per token this candidate removed.
+    pub fn gpu_fraction_removed(&self) -> f64 {
+        if self.baseline_gpu_ms_per_token <= 0.0 {
+            return 0.0;
+        }
+        (self.baseline_gpu_ms_per_token - self.candidate_gpu_ms_per_token)
+            / self.baseline_gpu_ms_per_token
+    }
+
+    /// **Beta — how much of a removed byte becomes removed GPU time.**
+    ///
+    /// `None` when nothing was removed, because beta is then `0/0`. A
+    /// pure-bandwidth-bound decode would give `1.0`; anything less is
+    /// the share of the step that is not bandwidth.
+    pub fn bytes_to_gpu_factor(&self) -> Option<f64> {
+        let bytes = self.byte_fraction_removed();
+        if bytes <= 0.0 {
+            return None;
+        }
+        Some(self.gpu_fraction_removed() / bytes)
+    }
+}
+
+/// Whether a prediction sits inside the range of breadths that were
+/// actually measured.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum Breadth {
+    /// The ledger's byte fraction is close to a measured one.
+    Measured,
+    /// It is not. Beta is being carried somewhere it has never been
+    /// checked, which is exactly where a curve would show up.
+    Extrapolated {
+        /// Byte fraction of the nearest observation.
+        nearest_measured_fraction: f64,
+    },
+}
+
+/// A predicted decode cost, inseparable from the evidence it came from.
+///
+/// There is no constructor that takes a bare coefficient. A search can
+/// only obtain one of these from [`ExecutionCostModel::predict`], which
+/// means every predicted throughput in this programme can name the
+/// observation behind it and say whether that observation has been
+/// replicated.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CostPrediction {
+    pub gpu_ms_per_token: f64,
+    pub wall_ms_per_token: f64,
+    pub tokens_per_second: f64,
+    /// Against the baseline of the observation used.
+    pub speedup: f64,
+    /// Id of the observation this came from.
+    pub calibration_id: String,
+    pub status: CalibrationStatus,
+    pub breadth: Breadth,
+}
+
+impl CostPrediction {
+    /// One line a report or a `.represent` record can carry verbatim,
+    /// so a predicted figure never appears without its epistemic
+    /// status.
+    pub fn describe(&self) -> String {
+        let status = match self.status {
+            CalibrationStatus::Provisional => "provisional",
+            CalibrationStatus::Calibrated => "calibrated",
+        };
+        let breadth = match self.breadth {
+            Breadth::Measured => String::new(),
+            Breadth::Extrapolated {
+                nearest_measured_fraction,
+            } => format!(
+                ", extrapolated from a breadth of {:.1}%",
+                100.0 * nearest_measured_fraction
+            ),
+        };
+        format!(
+            "predicted {:.1} tok/s ({:.2}x) using {} execution-cost observation `{}`{breadth}",
+            self.tokens_per_second, self.speedup, status, self.calibration_id,
+        )
+    }
+}
+
+/// Why a cost could not be predicted.
+///
+/// One variant per missing fact, so a refusal says which measurement to
+/// go and take — the same shape [`super::selection`] uses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CostRefusal {
+    /// Nothing has been measured on this machine at all.
+    NoObservations,
+    /// Every observation is of a different model. Byte economics do not
+    /// transfer across models: the families, their shares and the
+    /// kernels all differ.
+    DifferentModel {
+        ledger_model: String,
+        observed_models: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for CostRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoObservations => write!(
+                f,
+                "no execution-cost observation has been recorded — run the decode benchmark"
+            ),
+            Self::DifferentModel {
+                ledger_model,
+                observed_models,
+            } => write!(
+                f,
+                "no observation for {ledger_model}; measured models are {}",
+                observed_models.join(", ")
+            ),
+        }
+    }
+}
+
+/// **The measured execution cost of this backend, as evidence.**
+///
+/// A bag of observations plus the rule for reading them. It gains
+/// resolution by accumulating measurements, not by fitting a better
+/// curve to the ones it has.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionCostModel {
+    pub observations: Vec<ExecutionCostObservation>,
+}
+
+impl ExecutionCostModel {
+    pub fn new(observations: Vec<ExecutionCostObservation>) -> Self {
+        Self { observations }
+    }
+
+    /// Whether beta has been shown to hold across separated breadths.
+    ///
+    /// Not a count of observations: ten measurements at the same byte
+    /// fraction still say nothing about whether beta varies with
+    /// breadth, which is the specific thing a planner extrapolates on.
+    pub fn status(&self) -> CalibrationStatus {
+        let mut fractions: Vec<f64> = self
+            .observations
+            .iter()
+            .filter(|o| o.bytes_to_gpu_factor().is_some())
+            .map(|o| o.byte_fraction_removed())
+            .collect();
+        fractions.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let separated = fractions
+            .windows(2)
+            .any(|w| w[1] - w[0] > DISTINCT_BREADTH_MIN_SEPARATION);
+        if separated {
+            CalibrationStatus::Calibrated
+        } else {
+            CalibrationStatus::Provisional
+        }
+    }
+
+    /// Predict what `ledger`'s candidate representation costs to decode.
+    ///
+    /// Uses the observation of the same model whose breadth is nearest
+    /// the ledger's — nearest, not fitted, because with one measured
+    /// point a fit is a straight line through it and a pretence.
+    pub fn predict(&self, ledger: &ByteLedger) -> Result<CostPrediction, CostRefusal> {
+        if self.observations.is_empty() {
+            return Err(CostRefusal::NoObservations);
+        }
+        let wanted = ledger.fraction_removed();
+        let chosen = self
+            .observations
+            .iter()
+            .filter(|o| o.model_identity == ledger.model)
+            .filter(|o| o.bytes_to_gpu_factor().is_some())
+            .min_by(|a, b| {
+                let (x, y) = (
+                    (a.byte_fraction_removed() - wanted).abs(),
+                    (b.byte_fraction_removed() - wanted).abs(),
+                );
+                x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal)
+            });
+        let Some(o) = chosen else {
+            return Err(CostRefusal::DifferentModel {
+                ledger_model: ledger.model.clone(),
+                observed_models: self
+                    .observations
+                    .iter()
+                    .map(|o| o.model_identity.clone())
+                    .collect(),
+            });
+        };
+
+        let beta = o.bytes_to_gpu_factor().expect("filtered to Some above");
+        let gpu = o.baseline_gpu_ms_per_token * (1.0 - beta * wanted);
+        let wall = gpu + o.fixed_overhead_ms;
+        let baseline_wall = o.baseline_gpu_ms_per_token + o.fixed_overhead_ms;
+        let measured = o.byte_fraction_removed();
+        Ok(CostPrediction {
+            gpu_ms_per_token: gpu,
+            wall_ms_per_token: wall,
+            tokens_per_second: if wall > 0.0 { 1000.0 / wall } else { 0.0 },
+            speedup: if wall > 0.0 {
+                baseline_wall / wall
+            } else {
+                0.0
+            },
+            calibration_id: o.id.clone(),
+            status: self.status(),
+            breadth: if (wanted - measured).abs() <= DISTINCT_BREADTH_MIN_SEPARATION {
+                Breadth::Measured
+            } else {
+                Breadth::Extrapolated {
+                    nearest_measured_fraction: measured,
+                }
+            },
+        })
+    }
+}
+
+/// **The one execution-cost observation this programme has measured.**
+///
+/// Apple M3 Max (40-core GPU), Metal, on Kimi-Linear-48B-A3B: the
+/// four-family Q8_0 map against its own BF16 baseline, both arms in one
+/// process, interleaved blocks with alternating order, per-arm minimum
+/// over four blocks of 128 tokens, two sessions, on AC power.
+///
+/// ```text
+/// bytes removed     957.0 MB of 5.985 GB   15.99 %
+/// GPU time removed  26.87 -> 23.43 ms      12.80 %
+/// beta                                     0.8006
+/// ```
+///
+/// Session 2 measured 26.97 -> 23.56 ms, beta 0.7907. The figures here
+/// are session 1's floors; the two sessions agree on beta to 0.01,
+/// which is why one record is honest and a spread is not yet worth
+/// modelling.
+///
+/// **This is one breadth.** A prediction made from it at a very
+/// different byte fraction is an extrapolation and says so.
+pub fn m3max_metal_001() -> ExecutionCostObservation {
+    ExecutionCostObservation {
+        id: "m3max-metal-001".into(),
+        machine: "Mac15,8".into(),
+        device: "Apple M3 Max (40-core GPU)".into(),
+        backend: "metal".into(),
+        compiler_commit: "a477765a".into(),
+        model_identity: "Kimi-Linear-48B-A3B-Instruct".into(),
+        baseline_representation: "BF16".into(),
+        candidate_representation: "experts L20-26 + KDA{20,21,22,24,25} + MLA{23,26} + head, Q8_0"
+            .into(),
+        families_changed: vec![
+            "routed experts".into(),
+            "KDA projections".into(),
+            "MLA projections".into(),
+            "output head".into(),
+        ],
+        scopes_changed: 15,
+        baseline_bytes_per_token: 5_984_976_896,
+        candidate_bytes_per_token: 5_027_956_736,
+        baseline_gpu_ms_per_token: 26.87,
+        candidate_gpu_ms_per_token: 23.43,
+        fixed_overhead_ms: 1.05,
+        benchmark_protocol: "both arms in-process, interleaved blocks with alternating order, \
+                             per-arm minimum of 4 x 128 tokens, 2 sessions, AC power"
+            .into(),
+        evidence: vec![
+            "kimi-quality-bank-provenance/bench-full4-session1.log".into(),
+            "kimi-quality-bank-provenance/bench-full4-session2.log".into(),
+        ],
+    }
+}
+
+#[cfg(test)]
+#[path = "execution_cost_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/execution_cost_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/execution_cost_tests.rs
@@ -1,0 +1,273 @@
+//! `tests` for [`super`].
+
+use super::super::byte_ledger::ByteLedger;
+use super::*;
+
+/// The measured Kimi ledger, shared with the byte-ledger tests so the
+/// two modules cannot drift apart on what the map costs.
+fn kimi_ledger() -> ByteLedger {
+    super::super::byte_ledger::tests::kimi_four_family()
+}
+
+/// A second observation, at a DIFFERENT breadth. Not measured — it
+/// exists only to exercise the calibration rule, and says so.
+fn hypothetical_at(id: &str, fraction: f64, beta: f64) -> ExecutionCostObservation {
+    let baseline_bytes = 1_000_000_000u64;
+    let baseline_gpu = 20.0;
+    ExecutionCostObservation {
+        id: id.into(),
+        candidate_bytes_per_token: baseline_bytes - (baseline_bytes as f64 * fraction) as u64,
+        baseline_bytes_per_token: baseline_bytes,
+        baseline_gpu_ms_per_token: baseline_gpu,
+        candidate_gpu_ms_per_token: baseline_gpu * (1.0 - beta * fraction),
+        ..m3max_metal_001()
+    }
+}
+
+// ── The observation itself. ──
+
+#[test]
+fn beta_is_derived_from_the_measurement_and_matches_the_bench() {
+    let o = m3max_metal_001();
+    assert!((o.byte_fraction_removed() - 0.15990).abs() < 1e-5);
+    assert!((o.gpu_fraction_removed() - 0.12802).abs() < 1e-5);
+    // 0.8006 in session 1; session 2 measured 0.7907 independently.
+    let beta = o.bytes_to_gpu_factor().expect("bytes were removed");
+    assert!((beta - 0.8006).abs() < 1e-3, "beta was {beta}");
+    assert!(
+        beta < 1.0,
+        "a pure-bandwidth-bound decode would give 1.0; the shortfall IS the finding"
+    );
+}
+
+#[test]
+fn a_candidate_that_removes_nothing_has_no_beta() {
+    // 0/0, and a NaN beta would propagate into every prediction.
+    let o = ExecutionCostObservation {
+        candidate_bytes_per_token: m3max_metal_001().baseline_bytes_per_token,
+        ..m3max_metal_001()
+    };
+    assert_eq!(o.byte_fraction_removed(), 0.0);
+    assert_eq!(o.bytes_to_gpu_factor(), None);
+}
+
+#[test]
+fn the_observation_records_its_breadth_and_its_provenance() {
+    let o = m3max_metal_001();
+    // Breadth, so beta(breadth) is answerable later rather than assumed
+    // flat now.
+    assert_eq!(o.families_changed.len(), 4);
+    assert_eq!(o.scopes_changed, 15);
+    // Provenance a later reader can chase or invalidate.
+    assert!(!o.compiler_commit.is_empty(), "a kernel change moves beta");
+    assert_eq!(o.evidence.len(), 2, "both bench sessions");
+    assert!(o.benchmark_protocol.contains("interleaved"));
+}
+
+// ── Calibration status is about BREADTH, not about count. ──
+
+#[test]
+fn one_observation_is_provisional() {
+    let m = ExecutionCostModel::new(vec![m3max_metal_001()]);
+    assert_eq!(m.status(), CalibrationStatus::Provisional);
+}
+
+#[test]
+fn many_observations_at_one_breadth_are_still_provisional() {
+    // The trap this rule exists to refuse: ten measurements at the same
+    // byte fraction agree with each other and say nothing whatever
+    // about whether beta varies with breadth.
+    let m = ExecutionCostModel::new(
+        (0..10)
+            .map(|i| hypothetical_at(&format!("same-{i}"), 0.16, 0.80))
+            .collect(),
+    );
+    assert_eq!(m.status(), CalibrationStatus::Provisional);
+}
+
+#[test]
+fn two_separated_breadths_are_calibrated() {
+    let m = ExecutionCostModel::new(vec![
+        hypothetical_at("low", 0.08, 0.80),
+        hypothetical_at("high", 0.32, 0.72),
+    ]);
+    assert_eq!(m.status(), CalibrationStatus::Calibrated);
+}
+
+#[test]
+fn an_empty_model_is_provisional_and_refuses_to_predict() {
+    let m = ExecutionCostModel::default();
+    assert_eq!(m.status(), CalibrationStatus::Provisional);
+    assert_eq!(m.predict(&kimi_ledger()), Err(CostRefusal::NoObservations));
+}
+
+// ── Prediction. ──
+
+#[test]
+fn predicting_the_ledger_it_was_measured_on_returns_the_measurement() {
+    // The round trip. If this drifts, the arithmetic and the record
+    // have come apart.
+    let m = ExecutionCostModel::new(vec![m3max_metal_001()]);
+    let p = m.predict(&kimi_ledger()).expect("same model");
+    let o = m3max_metal_001();
+    assert!(
+        (p.gpu_ms_per_token - o.candidate_gpu_ms_per_token).abs() < 1e-6,
+        "predicted {} vs measured {}",
+        p.gpu_ms_per_token,
+        o.candidate_gpu_ms_per_token
+    );
+    // Wall, and therefore tok/s, needs the fixed overhead — a GPU-time
+    // prediction alone cannot produce a throughput figure.
+    assert!((p.wall_ms_per_token - (23.43 + 1.05)).abs() < 1e-6);
+    assert!(
+        (p.tokens_per_second - 40.85).abs() < 0.05,
+        "predicted {} tok/s",
+        p.tokens_per_second
+    );
+    // The round trip is EXACT in GPU time, by construction, and only
+    // approximate in wall time. The model carries ONE fixed overhead
+    // and so assumes it is arm-independent; the bench actually measured
+    // 1.05 ms on the baseline arm and 1.09 ms on the candidate, which
+    // is why the predicted wall speedup is 1.140 against a measured
+    // 1.139. Pinned rather than hidden: 0.1% is the size of that
+    // assumption, and if a future backend makes overhead depend on the
+    // map, this is the test that will say so.
+    assert!(
+        (p.speedup - 1.1405).abs() < 1e-3,
+        "speedup was {}",
+        p.speedup
+    );
+    assert!(
+        (p.speedup - 1.139).abs() < 3e-3,
+        "and it must stay close to the measured wall speedup"
+    );
+    assert_eq!(p.breadth, Breadth::Measured);
+}
+
+#[test]
+fn a_prediction_carries_its_evidence_and_its_status() {
+    let m = ExecutionCostModel::new(vec![m3max_metal_001()]);
+    let p = m.predict(&kimi_ledger()).expect("same model");
+    assert_eq!(p.calibration_id, "m3max-metal-001");
+    assert_eq!(p.status, CalibrationStatus::Provisional);
+    let line = p.describe();
+    assert!(line.contains("provisional"), "{line}");
+    assert!(line.contains("m3max-metal-001"), "{line}");
+    assert!(line.contains("tok/s"), "{line}");
+}
+
+#[test]
+fn a_breadth_far_from_any_measurement_is_flagged_as_extrapolated() {
+    // Halving the whole decoder is nowhere near the 16% that was
+    // measured, and beta may well not be flat out there.
+    let mut l = kimi_ledger();
+    for s in &mut l.scopes {
+        s.candidate_bytes = s.baseline_bytes / 2;
+    }
+    let m = ExecutionCostModel::new(vec![m3max_metal_001()]);
+    let p = m.predict(&l).expect("same model");
+    match p.breadth {
+        Breadth::Extrapolated {
+            nearest_measured_fraction,
+        } => assert!((nearest_measured_fraction - 0.15990).abs() < 1e-5),
+        Breadth::Measured => panic!("50% removed is not the 16% that was measured"),
+    }
+    assert!(p.describe().contains("extrapolated"), "{}", p.describe());
+}
+
+#[test]
+fn byte_economics_do_not_transfer_across_models() {
+    let l = ByteLedger {
+        model: "some-other-model".into(),
+        ..kimi_ledger()
+    };
+    let m = ExecutionCostModel::new(vec![m3max_metal_001()]);
+    match m.predict(&l) {
+        Err(CostRefusal::DifferentModel { ledger_model, .. }) => {
+            assert_eq!(ledger_model, "some-other-model");
+        }
+        other => panic!("expected a refusal naming the model, got {other:?}"),
+    }
+}
+
+#[test]
+fn prediction_picks_the_observation_nearest_the_breadth_asked_for() {
+    // Nearest, not fitted: with the points this programme has, a fit is
+    // a straight line through one of them wearing a lab coat.
+    let m = ExecutionCostModel::new(vec![
+        ExecutionCostObservation {
+            id: "far".into(),
+            ..hypothetical_at("far", 0.45, 0.60)
+        },
+        ExecutionCostObservation {
+            id: "near".into(),
+            ..hypothetical_at("near", 0.17, 0.80)
+        },
+    ]);
+    // Both are recorded against the Kimi identity by `hypothetical_at`.
+    let p = m.predict(&kimi_ledger()).expect("same model");
+    assert_eq!(p.calibration_id, "near");
+}
+
+#[test]
+fn a_map_that_removes_nothing_predicts_the_baseline() {
+    let mut l = kimi_ledger();
+    for s in &mut l.scopes {
+        s.candidate_bytes = s.baseline_bytes;
+    }
+    let m = ExecutionCostModel::new(vec![m3max_metal_001()]);
+    let p = m.predict(&l).expect("same model");
+    assert!((p.gpu_ms_per_token - 26.87).abs() < 1e-6);
+    assert!((p.speedup - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn a_refusal_says_which_measurement_to_go_and_take() {
+    assert!(CostRefusal::NoObservations
+        .to_string()
+        .contains("run the decode benchmark"));
+    let r = CostRefusal::DifferentModel {
+        ledger_model: "gpt-oss-20b".into(),
+        observed_models: vec!["Kimi-Linear-48B-A3B-Instruct".into()],
+    };
+    assert!(r.to_string().contains("gpt-oss-20b"));
+    assert!(r.to_string().contains("Kimi-Linear-48B-A3B-Instruct"));
+}
+
+#[test]
+fn a_degenerate_observation_reports_zero_rather_than_a_nan() {
+    // Nothing in the crate builds these, and that is exactly why the
+    // guards are here: a NaN beta or a NaN speedup does not fail, it
+    // propagates and then sorts arbitrarily wherever it lands.
+    let empty = ExecutionCostObservation {
+        baseline_bytes_per_token: 0,
+        candidate_bytes_per_token: 0,
+        baseline_gpu_ms_per_token: 0.0,
+        candidate_gpu_ms_per_token: 0.0,
+        fixed_overhead_ms: 0.0,
+        ..m3max_metal_001()
+    };
+    assert_eq!(empty.byte_fraction_removed(), 0.0);
+    assert_eq!(empty.gpu_fraction_removed(), 0.0);
+    assert_eq!(empty.bytes_to_gpu_factor(), None);
+    // And it cannot be used to predict: with no beta there is nothing
+    // to predict WITH, so the model looks past it.
+    let m = ExecutionCostModel::new(vec![empty]);
+    assert!(matches!(
+        m.predict(&kimi_ledger()),
+        Err(CostRefusal::DifferentModel { .. })
+    ));
+}
+
+#[test]
+fn a_calibrated_prediction_says_so() {
+    let m = ExecutionCostModel::new(vec![
+        hypothetical_at("low", 0.08, 0.80),
+        hypothetical_at("high", 0.32, 0.72),
+    ]);
+    let p = m.predict(&kimi_ledger()).expect("same model");
+    assert_eq!(p.status, CalibrationStatus::Calibrated);
+    let line = p.describe();
+    assert!(line.contains("calibrated"), "{line}");
+    assert!(!line.contains("provisional"), "{line}");
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/measurement.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measurement.rs
@@ -35,6 +35,21 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Whether an assessment rests on a diagnostic screen or on
+/// authority-scale evidence.
+///
+/// Lives here rather than beside the assessment because it is a
+/// property of the EVIDENCE: a scale is the thing a statistic's support
+/// is judged at, and the calibration registry has to key on it without
+/// depending on anything that consumes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EvidenceScale {
+    /// A short bank, used to rank and to search.
+    Diagnostic,
+    /// A full bank at the contract's own position count.
+    Authority,
+}
+
 /// Whether a reported statistic is supported by its evidence.
 ///
 /// The three states are distinct in the way that matters to a search:

--- a/crates/larql-vindex/src/format/vindex3/represent/measurement.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measurement.rs
@@ -1,0 +1,151 @@
+//! **Whether a number is a measurement of the thing it is named after.**
+//!
+//! A percentile is only measurable at a scale that supplies enough
+//! observations in its tail. Nearest-rank p99 of *n* values is the
+//! LARGEST value whenever *n* < 100 — so a "p99" over ninety
+//! observations is a maximum wearing a percentile's name, and a search
+//! that prices a candidate on it is pricing a single event.
+//!
+//! ```text
+//! tail support = observations x (1 - quantile)
+//!
+//! p99 over    100 observations ->   1 expected tail observation
+//! p99 over    500 observations ->   5
+//! p99 over  1,000 observations ->  10
+//! ```
+//!
+//! This was found the expensive way. ROUTE-CAL-1 (2026-08-31): a
+//! 256-position diagnostic bank observes 1-105 route-change events, so
+//! its `route_mass_p99` was the maximum in twenty-four of twenty-six
+//! reports, and repeated values across unrelated maps turned out to be
+//! the SAME worst event recurring rather than candidates agreeing. The
+//! consequence was not noise, it was a sign error: the diagnostic
+//! reported the most expensive route move in the programme as free.
+//!
+//! The abstraction is not about routing. Any p95, p99 or p999 criterion
+//! screened at reduced scale has this problem, and the point of putting
+//! it here is that a future criterion inherits the protection without
+//! anyone remembering to ask.
+//!
+//! **A threshold is a policy, not a fact.** [`TailSupportPolicy`]
+//! carries its own provenance so that a number refused for thin support
+//! can be traced to the decision that refused it, and so that
+//! tightening it later is a visible change rather than an edited
+//! constant.
+
+use serde::{Deserialize, Serialize};
+
+/// Whether a reported statistic is supported by its evidence.
+///
+/// The three states are distinct in the way that matters to a search:
+/// a number that was never observed, a number observed too thinly to
+/// mean what it is called, and a number that stands.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MeasurementStatus {
+    /// The evidence supports the statistic.
+    Measured,
+    /// The statistic was computed, but too few observations fall in its
+    /// tail for it to be the quantity it is named after.
+    InsufficientTailSupport { observations: u64, required: u64 },
+    /// Nothing was observed at all.
+    NotObserved,
+}
+
+impl MeasurementStatus {
+    /// Whether this number may be used to PRICE a candidate.
+    ///
+    /// Deliberately not called `is_ok`: a thinly supported percentile is
+    /// not a small cost, it is an unknown one, and the difference is
+    /// what stops a search preferring candidates whose expensive
+    /// dimension happens to be unmeasured.
+    pub fn is_priceable(&self) -> bool {
+        matches!(self, Self::Measured)
+    }
+}
+
+/// How many observations a percentile has behind its tail.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct TailSupport {
+    /// e.g. `0.99`.
+    pub quantile: f64,
+    /// Observations the statistic was computed over — for a criterion
+    /// measured only where something CHANGED, that is the number of
+    /// changes, not the number of positions.
+    pub observations: u64,
+}
+
+impl TailSupport {
+    /// Observations expected to fall above the quantile.
+    ///
+    /// The quantity that decides whether a percentile is a percentile:
+    /// below one, it is the maximum; below a handful, it is one or two
+    /// events with a percentile's name on it.
+    pub fn expected_tail_observations(&self) -> f64 {
+        self.observations as f64 * (1.0 - self.quantile)
+    }
+}
+
+/// **How much tail a percentile needs before it may price a candidate.**
+///
+/// A named, provenance-carrying policy rather than a constant, because
+/// the number is a judgement about how much sparsity a search will
+/// tolerate and not a law. Recording where it came from means a refusal
+/// can be argued with.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TailSupportPolicy {
+    /// Expected tail observations required.
+    pub min_tail_observations: f64,
+    /// Why this number.
+    pub provenance: String,
+}
+
+impl TailSupportPolicy {
+    /// **The first policy: five expected tail observations.**
+    ///
+    /// Not a statistical law. Nearest-rank p99 stops literally being
+    /// the maximum at a hundred observations, but one observation
+    /// defining a tail is not a tail — it is technically a percentile
+    /// and useless for ranking. Five makes the semantics honest: below
+    /// this, the estimate is too sparsely supported to price a
+    /// candidate, and the assessment says so rather than reporting a
+    /// small number.
+    ///
+    /// For p99 that is roughly five hundred relevant observations.
+    pub fn route_cal_1() -> Self {
+        Self {
+            min_tail_observations: 5.0,
+            provenance: "ROUTE-CAL-1 (2026-08-31): a 256-position diagnostic observed 1-105 \
+                         route-change events and reported the most expensive route move in the \
+                         programme as free"
+                .into(),
+        }
+    }
+
+    /// Observations needed for `quantile` under this policy.
+    pub fn required_observations(&self, quantile: f64) -> u64 {
+        let tail = 1.0 - quantile;
+        if tail <= 0.0 {
+            return u64::MAX;
+        }
+        (self.min_tail_observations / tail).ceil() as u64
+    }
+
+    /// Judge one reported percentile.
+    pub fn status(&self, support: Option<TailSupport>) -> MeasurementStatus {
+        let Some(s) = support else {
+            return MeasurementStatus::NotObserved;
+        };
+        if s.expected_tail_observations() >= self.min_tail_observations {
+            MeasurementStatus::Measured
+        } else {
+            MeasurementStatus::InsufficientTailSupport {
+                observations: s.observations,
+                required: self.required_observations(s.quantile),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "measurement_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/measurement_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measurement_tests.rs
@@ -1,0 +1,101 @@
+//! `tests` for [`super`].
+
+use super::*;
+
+#[test]
+fn a_p99_over_too_few_observations_is_the_maximum() {
+    // The arithmetic behind the whole module: nearest-rank p99 of n
+    // values is the largest one until n reaches 100.
+    for n in [1u64, 5, 46, 99] {
+        let s = TailSupport {
+            quantile: 0.99,
+            observations: n,
+        };
+        assert!(
+            s.expected_tail_observations() < 1.0,
+            "{n} observations cannot put one above p99"
+        );
+    }
+    assert!(
+        (TailSupport {
+            quantile: 0.99,
+            observations: 100
+        })
+        .expected_tail_observations()
+            >= 1.0
+    );
+}
+
+#[test]
+fn the_policy_requires_five_hundred_observations_for_a_p99() {
+    let p = TailSupportPolicy::route_cal_1();
+    assert_eq!(p.required_observations(0.99), 500);
+    assert_eq!(p.required_observations(0.95), 100);
+    assert_eq!(p.required_observations(0.999), 5000);
+}
+
+#[test]
+fn the_measured_route_evidence_is_judged_as_route_cal_1_found_it() {
+    let p = TailSupportPolicy::route_cal_1();
+    // The four-family map's own route evidence, at both scales.
+    let diagnostic = p.status(Some(TailSupport {
+        quantile: 0.99,
+        observations: 46,
+    }));
+    assert_eq!(
+        diagnostic,
+        MeasurementStatus::InsufficientTailSupport {
+            observations: 46,
+            required: 500
+        }
+    );
+    assert!(!diagnostic.is_priceable());
+    let authority = p.status(Some(TailSupport {
+        quantile: 0.99,
+        observations: 1303,
+    }));
+    assert_eq!(authority, MeasurementStatus::Measured);
+    assert!(authority.is_priceable());
+}
+
+#[test]
+fn nothing_observed_is_distinct_from_thinly_observed() {
+    let p = TailSupportPolicy::route_cal_1();
+    assert_eq!(p.status(None), MeasurementStatus::NotObserved);
+    assert!(!p.status(None).is_priceable());
+    // Both are unpriceable, and they are different facts: one candidate
+    // moved no routing at all, the other moved some and was not watched
+    // long enough to say how much.
+    assert_ne!(
+        p.status(None),
+        p.status(Some(TailSupport {
+            quantile: 0.99,
+            observations: 46
+        }))
+    );
+}
+
+#[test]
+fn the_policy_carries_the_reason_it_exists() {
+    // A refusal must be traceable to the decision that refused it,
+    // rather than to an edited constant.
+    let p = TailSupportPolicy::route_cal_1();
+    assert!(p.provenance.contains("ROUTE-CAL-1"));
+    assert!(p.min_tail_observations > 0.0);
+}
+
+#[test]
+fn a_degenerate_quantile_demands_the_impossible_rather_than_dividing_by_zero() {
+    let p = TailSupportPolicy::route_cal_1();
+    assert_eq!(p.required_observations(1.0), u64::MAX);
+    assert_eq!(
+        p.status(Some(TailSupport {
+            quantile: 1.0,
+            observations: u64::MAX
+        })),
+        MeasurementStatus::InsufficientTailSupport {
+            observations: u64::MAX,
+            required: u64::MAX
+        }
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -49,6 +49,7 @@ pub mod arena;
 pub mod bank;
 pub mod compile;
 pub mod compiler;
+pub mod constraint;
 pub mod experiment;
 pub mod gptq;
 pub mod kda_candidate;

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -65,6 +65,7 @@ pub mod plan_roles;
 mod plan_roles_tests;
 pub mod policy;
 pub mod quality;
+pub mod search_evidence;
 pub mod selection;
 pub mod source_bank;
 

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -46,6 +46,7 @@
 //! at all: a profile cannot turn one encoding's bytes into another's.
 
 pub mod arena;
+pub mod assessment;
 pub mod bank;
 pub mod byte_ledger;
 pub mod compile;

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -47,9 +47,11 @@
 
 pub mod arena;
 pub mod bank;
+pub mod byte_ledger;
 pub mod compile;
 pub mod compiler;
 pub mod constraint;
+pub mod execution_cost;
 pub mod experiment;
 pub mod gptq;
 pub mod kda_candidate;

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -57,6 +57,7 @@ pub mod experiment;
 pub mod gptq;
 pub mod kda_candidate;
 pub mod map;
+pub mod measurement;
 pub mod nvfp4_pack;
 pub mod physical;
 pub mod plan_roles;

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -64,6 +64,7 @@ pub mod plan_roles;
 #[cfg(test)]
 mod plan_roles_tests;
 pub mod policy;
+pub mod promotion;
 pub mod quality;
 pub mod search_evidence;
 pub mod selection;

--- a/crates/larql-vindex/src/format/vindex3/represent/promotion.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/promotion.rs
@@ -1,0 +1,239 @@
+//! **Which candidate to measure next, when some of its costs cannot be
+//! priced.**
+//!
+//! [`super::assessment`] prices what the evidence licenses pricing. At
+//! diagnostic scale, under ROUTE-CAL-1, that is currently nothing:
+//! `kl p99` is an ordering proxy and `routed mixture moved at p99` is
+//! unusable, so every candidate comes back [`MoveClass::Unscorable`].
+//!
+//! That leaves a hole, and it is the statistical twin of the
+//! exhausted-budget bug: **an unpriced dimension must not create an
+//! advantage by being invisible.** Two candidates whose route cost is
+//! equally unpriceable will tier equally and then sort on physical
+//! gain — so the one that moves routing hardest wins, precisely because
+//! nothing could see it.
+//!
+//! ```text
+//! A   gain 1.00 ms   kl 5%   route p99 unscorable   route proxy DANGEROUS
+//! B   gain 0.90 ms   kl 6%   route p99 unscorable   route proxy benign
+//! ```
+//!
+//! A must not win. The proxy has to change its class, not its score —
+//! turning ROUTE-CAL-1's rho +0.991 flip-rate result into an
+//! approximate route-mass number would be the exact conflation of
+//! ordering with magnitude that [`super::search_evidence`] exists to
+//! prevent.
+//!
+//! So pricing and proxy ordering stay separate, and the search combines
+//! them in stages rather than in a formula:
+//!
+//! ```text
+//! 1. priceable      economics decide
+//! 2. proxy-supported   every unpriceable dimension has benign proxy evidence
+//! 3. proxy-risky       a proxy warns
+//! 4. uninformed        an unpriceable dimension nobody can speak to
+//! 5. worthless         buys nothing, whatever its evidence
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use super::assessment::{CandidateAssessment, MoveClass};
+use super::search_evidence::SearchEvidence;
+
+/// Which way a proxy points for the criterion it stands in for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProxyRisk {
+    /// The proxy did not worsen.
+    Benign,
+    /// The proxy worsened, so the criterion it stands in for probably
+    /// did too. Not a magnitude — a direction.
+    Elevated,
+}
+
+/// An ordering-only observation standing in for a criterion that cannot
+/// be priced at this evidence scale.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProxyObservation {
+    /// The proxy itself, e.g. `"route flip rate"`.
+    pub statistic: String,
+    /// The contract criterion it stands in for.
+    pub for_criterion: String,
+    pub parent: f64,
+    pub candidate: f64,
+    /// Why this proxy may be believed for ordering. Anything that is
+    /// not an ordering proxy or better carries no weight.
+    pub evidence: SearchEvidence,
+}
+
+impl ProxyObservation {
+    pub fn delta(&self) -> f64 {
+        self.candidate - self.parent
+    }
+
+    /// The direction only. A magnitude here would be a route-mass
+    /// estimate wearing a flip rate's clothes.
+    pub fn risk(&self) -> ProxyRisk {
+        if self.evidence.orders() && self.delta() > 0.0 {
+            ProxyRisk::Elevated
+        } else {
+            ProxyRisk::Benign
+        }
+    }
+
+    /// Whether this observation may be believed at all.
+    pub fn usable(&self) -> bool {
+        self.evidence.orders()
+    }
+}
+
+/// How ready a candidate is to be promoted to an authority measurement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PromotionReadiness {
+    /// Every dimension the contract judges was priceable.
+    Priceable,
+    /// Some dimension was not priceable, and every such dimension has
+    /// benign proxy evidence.
+    ProxySupported,
+    /// A proxy warns about an unpriceable dimension.
+    ProxyRisky,
+    /// An unpriceable dimension that no proxy can speak to. The search
+    /// knows it does not know.
+    Uninformed,
+}
+
+impl PromotionReadiness {
+    /// Higher promotes first.
+    fn tier(self) -> u8 {
+        match self {
+            Self::Priceable => 3,
+            Self::ProxySupported => 2,
+            Self::ProxyRisky => 1,
+            Self::Uninformed => 0,
+        }
+    }
+}
+
+/// A candidate, its assessment, and whatever proxy evidence speaks to
+/// the parts of it that could not be priced.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PromotionCandidate {
+    pub assessment: CandidateAssessment,
+    pub proxies: Vec<ProxyObservation>,
+}
+
+impl PromotionCandidate {
+    pub fn new(assessment: CandidateAssessment, proxies: Vec<ProxyObservation>) -> Self {
+        Self {
+            assessment,
+            proxies,
+        }
+    }
+
+    /// Proxy evidence for one unpriceable criterion, if any is usable.
+    pub fn proxy_for(&self, criterion: &str) -> Option<&ProxyObservation> {
+        self.proxies
+            .iter()
+            .find(|p| p.for_criterion == criterion && p.usable())
+    }
+
+    /// **How ready this candidate is**, decided by the weakest
+    /// unpriceable dimension rather than the average.
+    pub fn readiness(&self) -> PromotionReadiness {
+        let unpriceable: Vec<&super::assessment::MarginalConstraintCost> =
+            self.assessment.marginal.unpriceable_costs().collect();
+        if unpriceable.is_empty() {
+            return PromotionReadiness::Priceable;
+        }
+        let mut worst = PromotionReadiness::ProxySupported;
+        for c in unpriceable {
+            // A dimension whose OWN evidence orders is its own proxy —
+            // diagnostic kl cannot be priced and can still say which of
+            // two candidates is worse. Only a dimension nothing can
+            // order needs an external stand-in.
+            if c.orders() {
+                continue;
+            }
+            match self.proxy_for(&c.what).map(ProxyObservation::risk) {
+                Some(ProxyRisk::Benign) => {}
+                Some(ProxyRisk::Elevated) => {
+                    if worst != PromotionReadiness::Uninformed {
+                        worst = PromotionReadiness::ProxyRisky;
+                    }
+                }
+                None => worst = PromotionReadiness::Uninformed,
+            }
+        }
+        worst
+    }
+
+    /// Tier for ranking. A move that buys nothing ranks last whatever
+    /// its evidence, so worthlessness outranks every readiness.
+    fn tier(&self) -> u8 {
+        if self.assessment.ranking_score.class == MoveClass::Worthless {
+            return 0;
+        }
+        self.readiness().tier() + 1
+    }
+
+    /// Sum of usable proxy deltas — the secondary key WITHIN a tier,
+    /// where lower is preferred. Never combined with the economics into
+    /// one number, because their units are not comparable and pretending
+    /// otherwise is how a proxy becomes a price.
+    fn proxy_pressure(&self) -> f64 {
+        self.proxies
+            .iter()
+            .filter(|p| p.usable())
+            .map(ProxyObservation::delta)
+            .sum()
+    }
+
+    /// **Total order, best first.**
+    ///
+    /// Readiness tier, then the assessment's own economics, then proxy
+    /// pressure, then the candidate's identity so a search trace
+    /// reproduces exactly.
+    pub fn cmp_rank(&self, other: &Self) -> std::cmp::Ordering {
+        other
+            .tier()
+            .cmp(&self.tier())
+            .then_with(|| {
+                self.assessment
+                    .ranking_score
+                    .cmp_rank(&other.assessment.ranking_score)
+            })
+            .then_with(|| self.proxy_pressure().total_cmp(&other.proxy_pressure()))
+            .then_with(|| {
+                self.assessment
+                    .candidate_map
+                    .cmp(&other.assessment.candidate_map)
+            })
+    }
+
+    /// Why this candidate ranks where it does, in one line a search
+    /// trace can carry.
+    pub fn why(&self) -> String {
+        let r = self.readiness();
+        let unpriced: Vec<&super::assessment::MarginalConstraintCost> =
+            self.assessment.marginal.unpriceable_costs().collect();
+        if unpriced.is_empty() {
+            return format!("{r:?}: every judged dimension was priceable");
+        }
+        let detail: Vec<String> = unpriced
+            .iter()
+            .map(|c| {
+                if c.orders() {
+                    return format!("{} unpriceable, orders itself", c.what);
+                }
+                match self.proxy_for(&c.what) {
+                    Some(p) => format!("{} unpriceable, {} {:?}", c.what, p.statistic, p.risk()),
+                    None => format!("{} unpriceable, no proxy", c.what),
+                }
+            })
+            .collect();
+        format!("{r:?}: {}", detail.join("; "))
+    }
+}
+
+#[cfg(test)]
+#[path = "promotion_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/promotion_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/promotion_tests.rs
@@ -1,0 +1,222 @@
+//! `tests` for [`super`].
+
+use super::super::assessment::{CandidateAssessment, EvidenceContext};
+use super::super::byte_ledger::{ByteLedger, ScopeBytes};
+use super::super::constraint::{ConstraintVector, LimitKind, Margin};
+use super::super::execution_cost::{m3max_metal_001, ExecutionCostModel};
+use super::super::measurement::{EvidenceScale, TailSupport};
+use super::super::quality::Criterion;
+use super::*;
+
+const KIMI: &str = "Kimi-Linear-48B-A3B-Instruct";
+const BASELINE_BYTES: u64 = 5_984_976_896;
+
+fn ledger(fraction: f64, name: &str) -> ByteLedger {
+    ByteLedger {
+        model: KIMI.into(),
+        baseline_representation: "BF16".into(),
+        candidate_representation: name.into(),
+        scopes: vec![ScopeBytes {
+            scope: "whole decoder".into(),
+            family: "whole decoder".into(),
+            baseline_bytes: BASELINE_BYTES,
+            candidate_bytes: BASELINE_BYTES - (BASELINE_BYTES as f64 * fraction) as u64,
+        }],
+    }
+}
+
+fn vector(kl: f64, route: f64) -> ConstraintVector {
+    let ceiling = |what: &str, criterion, u: f64| Margin {
+        criterion,
+        what: what.into(),
+        kind: LimitKind::Ceiling,
+        limit: 1.0,
+        observed: Some(u),
+        vacuous: false,
+        tail_support: Some(TailSupport {
+            quantile: 0.99,
+            observations: 46,
+        }),
+    };
+    ConstraintVector {
+        gate_id: "kimi-logit-balanced-v1".into(),
+        margins: vec![
+            ceiling("kl p99", Criterion::KlP99, kl),
+            ceiling(
+                "routed mixture moved at p99",
+                Criterion::RouteDisplacement,
+                route,
+            ),
+        ],
+    }
+}
+
+fn candidate(name: &str, removes: f64, kl_after: f64, route_after: f64) -> CandidateAssessment {
+    CandidateAssessment::of(
+        &EvidenceContext::route_cal_1(EvidenceScale::Diagnostic),
+        &ExecutionCostModel::new(vec![m3max_metal_001()]),
+        &ledger(0.16, "parent"),
+        &ledger(removes, name),
+        vector(0.68, 0.83),
+        vector(kl_after, route_after),
+    )
+    .expect("same model")
+}
+
+fn flip_rate(parent: f64, cand: f64) -> ProxyObservation {
+    ProxyObservation {
+        statistic: "route flip rate".into(),
+        for_criterion: "routed mixture moved at p99".into(),
+        parent,
+        candidate: cand,
+        evidence: SearchEvidence::OrderingProxy {
+            calibration: "ROUTE-CAL-1".into(),
+        },
+    }
+}
+
+// ── The invariant. ──
+
+#[test]
+fn an_unpriced_dimension_cannot_create_an_advantage_by_being_invisible() {
+    // A buys MORE and costs LESS on the one dimension anybody can
+    // price. Its route cost is unpriceable at this scale — and the
+    // flip-rate proxy says it moves routing hard.
+    let a = PromotionCandidate::new(
+        candidate("A dangerous", 0.24, 0.73, 0.95),
+        vec![flip_rate(0.16, 0.31)],
+    );
+    // B buys less, costs marginally more on kl, and its proxy is benign.
+    let b = PromotionCandidate::new(
+        candidate("B benign", 0.22, 0.74, 0.84),
+        vec![flip_rate(0.16, 0.15)],
+    );
+
+    // Everything an economics-only ranking can see favours A.
+    assert!(
+        a.assessment.ranking_score.gpu_ms_saved > b.assessment.ranking_score.gpu_ms_saved,
+        "A buys more"
+    );
+    assert_eq!(
+        a.assessment
+            .ranking_score
+            .cmp_rank(&b.assessment.ranking_score),
+        std::cmp::Ordering::Less,
+        "and on economics alone A would win"
+    );
+
+    // It must not, because the reason its route cost looks like nothing
+    // is that nothing could measure it.
+    assert_eq!(a.readiness(), PromotionReadiness::ProxyRisky);
+    assert_eq!(b.readiness(), PromotionReadiness::ProxySupported);
+    assert_eq!(
+        b.cmp_rank(&a),
+        std::cmp::Ordering::Less,
+        "B must promote first"
+    );
+    assert!(a.why().contains("Elevated"), "{}", a.why());
+}
+
+#[test]
+fn no_proxy_at_all_is_worse_than_a_warning_proxy() {
+    // "Nobody has measured this" ranks below "a proxy says it is bad",
+    // because a warning is information and silence is not.
+    let risky = PromotionCandidate::new(
+        candidate("risky", 0.22, 0.70, 0.90),
+        vec![flip_rate(0.16, 0.30)],
+    );
+    let uninformed = PromotionCandidate::new(candidate("uninformed", 0.22, 0.70, 0.90), vec![]);
+    assert_eq!(risky.readiness(), PromotionReadiness::ProxyRisky);
+    assert_eq!(uninformed.readiness(), PromotionReadiness::Uninformed);
+    assert_eq!(risky.cmp_rank(&uninformed), std::cmp::Ordering::Less);
+    assert!(
+        uninformed.why().contains("no proxy"),
+        "{}",
+        uninformed.why()
+    );
+}
+
+#[test]
+fn an_unusable_proxy_carries_no_weight() {
+    // ROUTE-CAL-1 marked diagnostic route mass p99 Unusable. Offering it
+    // AS a proxy must not launder it into evidence.
+    let mut p = flip_rate(0.16, 0.15);
+    p.evidence = SearchEvidence::Unusable;
+    let c = PromotionCandidate::new(candidate("c", 0.22, 0.70, 0.84), vec![p]);
+    assert_eq!(
+        c.readiness(),
+        PromotionReadiness::Uninformed,
+        "an unusable observation is not a benign one"
+    );
+}
+
+#[test]
+fn the_weakest_unpriceable_dimension_decides_not_the_average() {
+    // One benign proxy must not offset one missing.
+    let a = PromotionCandidate::new(
+        candidate("a", 0.22, 0.70, 0.84),
+        vec![flip_rate(0.16, 0.15)],
+    );
+    assert_eq!(a.readiness(), PromotionReadiness::ProxySupported);
+    let mut orphan = flip_rate(0.16, 0.15);
+    orphan.for_criterion = "some other criterion".into();
+    let b = PromotionCandidate::new(candidate("b", 0.22, 0.70, 0.84), vec![orphan]);
+    assert_eq!(
+        b.readiness(),
+        PromotionReadiness::Uninformed,
+        "a proxy for a different criterion speaks to nothing here"
+    );
+}
+
+#[test]
+fn a_worthless_move_ranks_last_whatever_its_evidence() {
+    let worthless = PromotionCandidate::new(
+        candidate("worthless", 0.16, 0.68, 0.83),
+        vec![flip_rate(0.16, 0.10)],
+    );
+    let uninformed = PromotionCandidate::new(candidate("uninformed", 0.22, 0.70, 0.90), vec![]);
+    assert_eq!(
+        worthless.assessment.ranking_score.class,
+        MoveClass::Worthless
+    );
+    assert_eq!(
+        uninformed.cmp_rank(&worthless),
+        std::cmp::Ordering::Less,
+        "even the least informed real gain beats a move that buys nothing"
+    );
+}
+
+#[test]
+fn the_order_is_total_and_reproducible() {
+    let mk = |n: &str| {
+        PromotionCandidate::new(candidate(n, 0.22, 0.70, 0.84), vec![flip_rate(0.16, 0.15)])
+    };
+    let (a, b) = (mk("aaa"), mk("zzz"));
+    assert_eq!(a.cmp_rank(&b), std::cmp::Ordering::Less, "identity decides");
+    assert_eq!(b.cmp_rank(&a), std::cmp::Ordering::Greater);
+    let mut one = [a.clone(), b.clone()];
+    let mut two = [b, a];
+    one.sort_by(PromotionCandidate::cmp_rank);
+    two.sort_by(PromotionCandidate::cmp_rank);
+    let names = |v: &[PromotionCandidate]| {
+        v.iter()
+            .map(|c| c.assessment.candidate_map.clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(names(&one), names(&two));
+}
+
+#[test]
+fn a_proxy_is_a_direction_and_never_a_magnitude() {
+    // The conflation search_evidence exists to prevent: rho +0.991 is
+    // good enough to say "worse", not good enough to say "worse by
+    // this much of the remaining budget".
+    let big = flip_rate(0.16, 0.90);
+    let small = flip_rate(0.16, 0.17);
+    assert_eq!(big.risk(), ProxyRisk::Elevated);
+    assert_eq!(small.risk(), ProxyRisk::Elevated);
+    let c = PromotionCandidate::new(candidate("c", 0.22, 0.70, 0.90), vec![big]);
+    // No route price appears anywhere in the assessment.
+    assert_eq!(c.assessment.ranking_score.scarce_fraction_consumed, None);
+    assert_eq!(c.assessment.ranking_score.score, None);
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/search_evidence.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/search_evidence.rs
@@ -1,0 +1,224 @@
+//! **How a search may use a statistic, which is not the same question
+//! as whether that statistic was measured.**
+//!
+//! [`super::measurement`] answers the first question and answers it
+//! strictly: a p99 over forty-six observations is
+//! `InsufficientTailSupport`, and no amount of correlation makes the
+//! missing tail observations appear. This module answers the second.
+//!
+//! ```text
+//! the STATISTIC decides whether it was measured
+//! the EVIDENCE decides whether an imperfect statistic is still useful
+//! ```
+//!
+//! Those are orthogonal, and collapsing them is a specific trap:
+//!
+//! ```text
+//! thin tail + good rank correlation  ->  "Measured, provisionally"   WRONG
+//! ```
+//!
+//! That conflates predictive utility with measurement adequacy.
+//! Diagnostic `kl p99` correlates with authority ordering at rho
+//! +0.857 over seven paired maps, which is good evidence for *"A or B
+//! first?"*. It is NOT evidence that a diagnostic reading of 2.4e-3
+//! means authority will be near 2.4e-3 — and that is precisely what
+//! pricing a candidate against a 3.5e-3 budget would assume. The same
+//! programme measured promotion drift of +84 % on one map and -3.9 %
+//! on another.
+//!
+//! So the ladder has four rungs, and only the top two may produce a
+//! number a contract is priced against:
+//!
+//! ```text
+//! Direct              enough support to price against the contract
+//! CalibratedEstimate  magnitude transfer demonstrated across breadths
+//! OrderingProxy       useful for ordering; magnitude not trusted
+//! Unusable            no demonstrated search value
+//! ```
+//!
+//! **`Unscorable` therefore stops meaning "the search knows nothing".**
+//! It means this authority constraint cannot be priced numerically at
+//! this evidence scale — while the search may still hold calibrated
+//! proxy evidence about which candidate to measure next.
+
+use serde::{Deserialize, Serialize};
+
+use super::assessment::EvidenceScale;
+use super::measurement::MeasurementStatus;
+
+/// How a search may use one statistic at one evidence scale.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SearchEvidence {
+    /// Directly supported: may be priced against the contract.
+    Direct,
+    /// Thinly supported, but magnitude transfer has been demonstrated
+    /// across breadths. May be priced, provisionally, naming the
+    /// calibration.
+    CalibratedEstimate { calibration: String },
+    /// Useful for ORDERING candidates. The magnitude is not trusted, so
+    /// it may not be turned into a fraction of a remaining budget.
+    OrderingProxy { calibration: String },
+    /// No demonstrated search value.
+    Unusable,
+}
+
+impl SearchEvidence {
+    /// Whether a number from this evidence may be priced against the
+    /// contract — turned into a fraction of remaining headroom.
+    pub fn is_priceable(&self) -> bool {
+        matches!(self, Self::Direct | Self::CalibratedEstimate { .. })
+    }
+
+    /// Whether it may be used to order candidates, which is a weaker
+    /// claim and true of everything above `Unusable`.
+    pub fn orders(&self) -> bool {
+        !matches!(self, Self::Unusable)
+    }
+
+    /// Position on the ladder, higher being stronger. Exists so that a
+    /// search cannot accidentally prefer weaker evidence, and so the
+    /// ladder's order is stated once rather than implied by variant
+    /// declaration order.
+    pub fn confidence_rank(&self) -> u8 {
+        match self {
+            Self::Direct => 3,
+            Self::CalibratedEstimate { .. } => 2,
+            Self::OrderingProxy { .. } => 1,
+            Self::Unusable => 0,
+        }
+    }
+}
+
+/// One recorded finding about how a statistic behaves at a scale.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchCalibration {
+    /// The calibration this came from, e.g. `"ROUTE-CAL-1"`.
+    pub id: String,
+    /// The statistic, in the gate's own wording where it is a contract
+    /// criterion — `"kl p99"`, `"routed mixture moved at p99"` — or its
+    /// own name where it is a proxy, `"route flip rate"`.
+    pub statistic: String,
+    pub scale: EvidenceScale,
+    pub verdict: SearchEvidence,
+    /// Paired diagnostic/authority observations behind the verdict.
+    pub pairs: u32,
+    /// Rank correlation, where one was computed.
+    pub rank_correlation: Option<f64>,
+    /// What was found, in a sentence a reader can disagree with.
+    pub finding: String,
+}
+
+/// **The registry: what this programme has learned about its own
+/// instruments.**
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SearchCalibrationRegistry {
+    pub entries: Vec<SearchCalibration>,
+}
+
+impl SearchCalibrationRegistry {
+    pub fn new(entries: Vec<SearchCalibration>) -> Self {
+        Self { entries }
+    }
+
+    pub fn lookup(&self, statistic: &str, scale: EvidenceScale) -> Option<&SearchCalibration> {
+        self.entries
+            .iter()
+            .find(|e| e.statistic == statistic && e.scale == scale)
+    }
+
+    /// **The bridge.** What a search may do with `statistic` at `scale`,
+    /// given how well the evidence supports it.
+    ///
+    /// A registration WINS where one exists, in both directions: it can
+    /// raise a thin measurement to an ordering proxy, and it can lower
+    /// a perfectly well measured one — route flip rate is a sound count
+    /// statistic that is still only a PROXY, because the contract judges
+    /// mixture mass and not flips.
+    ///
+    /// Without a registration the measurement decides, and an
+    /// unregistered thin percentile is `Unusable` rather than usable —
+    /// the failure this whole layer exists to prevent is a search
+    /// preferring a candidate because its expensive dimension happened
+    /// to be unmeasured.
+    pub fn evidence_for(
+        &self,
+        statistic: &str,
+        scale: EvidenceScale,
+        status: &MeasurementStatus,
+    ) -> SearchEvidence {
+        if let Some(e) = self.lookup(statistic, scale) {
+            return e.verdict.clone();
+        }
+        if status.is_priceable() {
+            SearchEvidence::Direct
+        } else {
+            SearchEvidence::Unusable
+        }
+    }
+
+    /// **What ROUTE-CAL-1 established**, as the registry a search starts
+    /// from. Every entry names its evidence; none is an assumption.
+    pub fn route_cal_1() -> Self {
+        Self::new(vec![
+            SearchCalibration {
+                id: "ROUTE-CAL-1".into(),
+                statistic: "kl p99".into(),
+                scale: EvidenceScale::Diagnostic,
+                verdict: SearchEvidence::OrderingProxy {
+                    calibration: "ROUTE-CAL-1".into(),
+                },
+                pairs: 7,
+                rank_correlation: Some(0.857),
+                finding: "diagnostic kl orders candidates well, but magnitude transfer is NOT \
+                          established — the same programme measured promotion drift of +84% on a \
+                          narrow map and -3.9% on a broad one, so a diagnostic reading may not be \
+                          priced against the contract's budget"
+                    .into(),
+            },
+            SearchCalibration {
+                id: "ROUTE-CAL-1".into(),
+                statistic: "routed mixture moved at p99".into(),
+                scale: EvidenceScale::Diagnostic,
+                verdict: SearchEvidence::Unusable,
+                pairs: 7,
+                rank_correlation: Some(0.606),
+                finding: "a 256-position bank observes 1-105 route-change events, so its p99 is \
+                          the MAXIMUM; it reported the most expensive route move in the programme \
+                          (strict->wide, 32.1% of remaining budget) as free, and got the sign \
+                          wrong on two of five moves"
+                    .into(),
+            },
+            SearchCalibration {
+                id: "ROUTE-CAL-1".into(),
+                statistic: "route flip rate".into(),
+                scale: EvidenceScale::Diagnostic,
+                verdict: SearchEvidence::OrderingProxy {
+                    calibration: "ROUTE-CAL-1".into(),
+                },
+                pairs: 7,
+                rank_correlation: Some(0.991),
+                finding: "flips per position transfer at a ratio of 0.89-1.02 for every map with \
+                          at least 40 diagnostic events — a COUNT statistic survives the sample \
+                          size where a TAIL statistic does not. Usable to order and to screen; \
+                          never to admit, because the contract judges mixture mass and not flips"
+                    .into(),
+            },
+            SearchCalibration {
+                id: "ROUTE-CAL-1".into(),
+                statistic: "top-10 mass displaced at p99".into(),
+                scale: EvidenceScale::Diagnostic,
+                verdict: SearchEvidence::Unusable,
+                pairs: 0,
+                rank_correlation: None,
+                finding: "thin-tailed at diagnostic scale (74 observations on the four-family \
+                          map) and NO paired calibration has been run — unusable by default \
+                          rather than by measurement, and the way to change that is to measure it"
+                    .into(),
+            },
+        ])
+    }
+}
+
+#[cfg(test)]
+#[path = "search_evidence_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/search_evidence.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/search_evidence.rs
@@ -43,8 +43,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::assessment::EvidenceScale;
-use super::measurement::MeasurementStatus;
+use super::measurement::{EvidenceScale, MeasurementStatus};
 
 /// How a search may use one statistic at one evidence scale.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/larql-vindex/src/format/vindex3/represent/search_evidence_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/search_evidence_tests.rs
@@ -1,0 +1,155 @@
+//! `tests` for [`super`].
+
+use super::super::measurement::{MeasurementStatus, TailSupport, TailSupportPolicy};
+use super::*;
+
+fn thin() -> MeasurementStatus {
+    TailSupportPolicy::route_cal_1().status(Some(TailSupport {
+        quantile: 0.99,
+        observations: 46,
+    }))
+}
+
+fn supported() -> MeasurementStatus {
+    TailSupportPolicy::route_cal_1().status(Some(TailSupport {
+        quantile: 0.99,
+        observations: 1303,
+    }))
+}
+
+#[test]
+fn measurement_and_usefulness_are_orthogonal() {
+    // The point of the whole layer. Diagnostic kl is thin-tailed AND
+    // useful; diagnostic route mass is thin-tailed AND useless. The
+    // measurement status is identical; only the calibration separates
+    // them.
+    let r = SearchCalibrationRegistry::route_cal_1();
+    assert_eq!(thin(), thin(), "identical measurement status");
+    let kl = r.evidence_for("kl p99", EvidenceScale::Diagnostic, &thin());
+    let route = r.evidence_for(
+        "routed mixture moved at p99",
+        EvidenceScale::Diagnostic,
+        &thin(),
+    );
+    assert!(matches!(kl, SearchEvidence::OrderingProxy { .. }));
+    assert_eq!(route, SearchEvidence::Unusable);
+}
+
+#[test]
+fn an_ordering_proxy_may_not_be_priced_against_the_contract() {
+    // The trap this exists to close: correlation is not magnitude.
+    let r = SearchCalibrationRegistry::route_cal_1();
+    let kl = r.evidence_for("kl p99", EvidenceScale::Diagnostic, &thin());
+    assert!(kl.orders(), "it does order candidates — rho +0.857");
+    assert!(
+        !kl.is_priceable(),
+        "but a diagnostic 2.4e-3 may NOT be turned into a fraction of a 3.5e-3 budget"
+    );
+}
+
+#[test]
+fn a_well_measured_statistic_can_still_be_only_a_proxy() {
+    // Route flip rate is a sound count statistic — no tail problem at
+    // all — and is STILL a proxy, because the contract judges mixture
+    // mass. A registration must be able to lower, not only raise.
+    let r = SearchCalibrationRegistry::route_cal_1();
+    let e = r.evidence_for(
+        "route flip rate",
+        EvidenceScale::Diagnostic,
+        &MeasurementStatus::Measured,
+    );
+    assert!(matches!(e, SearchEvidence::OrderingProxy { .. }));
+    assert!(!e.is_priceable(), "flips are not the criterion");
+    assert!(e.orders());
+}
+
+#[test]
+fn an_unregistered_thin_percentile_is_unusable_not_usable() {
+    // The default must fail safe. A search that treated an unmeasured
+    // dimension as cheap would prefer exactly the candidates whose
+    // expensive dimension it could not see.
+    let r = SearchCalibrationRegistry::route_cal_1();
+    assert_eq!(
+        r.evidence_for("some future p99", EvidenceScale::Diagnostic, &thin()),
+        SearchEvidence::Unusable
+    );
+    // And a directly supported one needs no registration.
+    assert_eq!(
+        r.evidence_for("some future p99", EvidenceScale::Authority, &supported()),
+        SearchEvidence::Direct
+    );
+}
+
+#[test]
+fn top10_is_unusable_by_absence_of_evidence_and_says_so() {
+    let r = SearchCalibrationRegistry::route_cal_1();
+    let e = r
+        .lookup("top-10 mass displaced at p99", EvidenceScale::Diagnostic)
+        .expect("registered");
+    assert_eq!(e.verdict, SearchEvidence::Unusable);
+    assert_eq!(e.pairs, 0, "no paired calibration has been run");
+    assert!(
+        e.finding.contains("way to change that is to measure it"),
+        "an absence of evidence must read as a TODO, not as a property of the statistic"
+    );
+}
+
+#[test]
+fn the_ladder_is_ordered_and_stated_once() {
+    let proxy = SearchEvidence::OrderingProxy {
+        calibration: "x".into(),
+    };
+    let est = SearchEvidence::CalibratedEstimate {
+        calibration: "x".into(),
+    };
+    let ranks: Vec<u8> = [
+        SearchEvidence::Direct,
+        est.clone(),
+        proxy.clone(),
+        SearchEvidence::Unusable,
+    ]
+    .iter()
+    .map(SearchEvidence::confidence_rank)
+    .collect();
+    assert_eq!(ranks, [3, 2, 1, 0], "strictly descending");
+    // Only the top two may produce a number a contract is priced on.
+    assert!(SearchEvidence::Direct.is_priceable());
+    assert!(est.is_priceable());
+    assert!(!proxy.is_priceable());
+    assert!(!SearchEvidence::Unusable.is_priceable());
+    // Everything above Unusable can at least order.
+    assert!(proxy.orders());
+    assert!(!SearchEvidence::Unusable.orders());
+}
+
+#[test]
+fn every_registration_names_its_evidence() {
+    // A registry entry without evidence is an assumption with a
+    // citation field.
+    for e in SearchCalibrationRegistry::route_cal_1().entries {
+        assert!(!e.id.is_empty());
+        assert!(!e.finding.is_empty(), "{}", e.statistic);
+        match e.verdict {
+            SearchEvidence::Unusable => {}
+            _ => assert!(
+                e.rank_correlation.is_some() && e.pairs > 0,
+                "{} claims search value and must show the measurement",
+                e.statistic
+            ),
+        }
+    }
+}
+
+#[test]
+fn authority_scale_route_mass_is_priced_directly() {
+    // The contract criterion at the scale it was written for: no
+    // calibration needed, the measurement carries it.
+    let r = SearchCalibrationRegistry::route_cal_1();
+    let e = r.evidence_for(
+        "routed mixture moved at p99",
+        EvidenceScale::Authority,
+        &supported(),
+    );
+    assert_eq!(e, SearchEvidence::Direct);
+    assert!(e.is_priceable());
+}


### PR DESCRIPTION
## What

The semantics of an evidence-aware representation search. Six commits, each
independently green, together forming one foundation — and deliberately no
consumer: the first real-bank integration is the next rung, not this PR.

One invariant runs through all of it:

> **Diagnostic chooses what to measure next; authority decides what is admissible.**

## The six

| commit | |
|---|---|
| `b3b1deaf` | **constraint vector** — a behavioural budget is not a scalar |
| `c88265d0` | **byte ledger + execution cost** — beta is measured, not assumed |
| `72776ba4` | **candidate assessment** — a move is priced marginally, against what remains |
| `486eef4b` | **tail support** — a percentile needs a scale that supplies its tail |
| `c145136c` | **search-evidence ladder** — measurement adequacy ≠ predictive utility |
| `be460e40` | **the wiring** — an unpriced dimension may not win by being invisible |

## Why each exists

**The budget is a vector.** Measured on the four-family Kimi map at 8,192
positions: kl at 68 % of limit, top-1 mass 46 %, top-10 54 % — and route mixture
mass at **83 %**. Ranking on "bytes per unit KL" spends the resource that is not
scarce. `binding()` names the one that is.

**Ceilings and floors are different things.** kl, displacement and counts are
budgets a candidate spends; positions and covered mass are conditions on the
MEASUREMENT. A blind instrument scores perfectly on every ceiling — `kl_p99 =
0.0` is a perfect KL — and is caught only by a floor. That happened twice while
the four-family map was being earned.

**Beta is an observation, not a constant.** 957 MB of 5.985 GB removed (16.0 %)
bought 12.8 % of GPU time — beta 0.80. Writing `const BETA = 0.80` would promote
one measurement to a law of the backend; this programme already paid for that
once with a ~45 GB wired-memory wall that was contradicted at 79 GB the next day.
`ExecutionCostModel` reports **Provisional** and says why, and calibration status
is about BREADTH rather than count: ten observations at the same byte fraction
establish repeatability, not transferability.

**Everything marginal.** A candidate leaving routing at 88 % has not cost 88 % —
the map was at 83 %, so it took five of the seventeen points that remained. The
test that justifies it: a move that FREES the binding constraint at a cost of one
KL point (of 32 remaining) outranks one costing no KL at all that takes three
route points (of 17). A naive absolute-KL ranking inverts that, and the test
asserts it would.

**A percentile needs a tail.** Nearest-rank p99 of *n* values is the LARGEST
whenever n < 100. ROUTE-CAL-1 found a 256-position bank observing 1–105
route-change events, so its `route_mass_p99` was the maximum in 24 of 26 reports
— and it reported the most expensive route move in the programme as free.

**Measurement adequacy and predictive utility are orthogonal.** Diagnostic kl is
thin-tailed AND correlates with authority ordering at ρ +0.857. That is evidence
for "A or B first?", not evidence that a diagnostic 2.4e-3 means authority will
be near 2.4e-3 — which is what pricing against a 3.5e-3 budget assumes. Four
rungs, of which only the top two may produce a number a contract is priced on:
`Direct`, `CalibratedEstimate`, `OrderingProxy`, `Unusable`. A registration wins
in both directions: route flip rate has no tail problem at all and is still only
a proxy, because the contract judges mixture mass and not flips.

**An unpriced dimension may not win by being invisible.** Two candidates whose
route cost is equally unpriceable tier equally and then sort on physical gain —
so the one that moves routing hardest wins because nothing could see it.
`promotion.rs` closes it with a class, never a score.

## Deliberately not done

- `balanced-v1` is **unchanged**. No goalposts moved after seeing search data.
- `CalibratedEstimate` is **unpopulated** — no magnitude-transfer evidence exists,
  and the variant is worth more empty than guessed at.
- Diagnostic `top-10 mass p99` is registered `Unusable` with `pairs: 0` and
  wording that reads as a measurement someone should run, not a property of the
  statistic. A test asserts that wording.
- **No consumer.** Nothing constructs any of this from a real bank yet. That is
  the next rung, and it is the first thing neither reasoning nor fixture coverage
  can settle: a fixture written by the author of `ConstraintVector::of` can encode
  the same mistaken assumption twice and stay green.

## Gates

`fmt --all` · `check --all-targets` · `check --examples` ·
`clippy --all-targets -D warnings` · `e0_generation_boundary` ·
`cargo test -p larql-vindex` (3559 lib + all integration binaries) · `benches`.
Per-file coverage: constraint 100 %, execution_cost 99.3 %, assessment 98.9 %,
byte_ledger 97.9 %; crate 93.4 % against a 71 % floor.

Each of the six was verified green independently before commit.
