### PR TITLE
fix(ci): restore the larql-vindex coverage gate

### DIFF
--- a/crates/larql-vindex/coverage-policy.json
+++ b/crates/larql-vindex/coverage-policy.json
@@ -1,5 +1,5 @@
 {
-  "policy_note": "Default policy is 90% line coverage per source file. The per-file entries below are existing debt baselines from cargo-llvm-cov and should only ratchet upward. 2026-08-27 (CPU-5/6/7): the CPU execution stack added ten files' worth of new code to opplan/exec. Seven were plain under-testing and are now fixed with portable tests - cost.rs and arithmetic.rs and ledger.rs to 100%, backend.rs 99.22%, executor.rs 95.95%. Five entries below are NOT under-testing and must not be chased with more tests. integer.rs and stationary.rs: the bulk is the aarch64 SDOT and stationary kernels, and off aarch64 only the stubs and portable fallbacks compile, so the ubuntu/windows jobs cannot reach them. physical.rs: arithmetic_arm() and q4_classes() are BOTH OnceLock-cached process-wide, so exactly one arm resolves per test binary and the other arms' match arms plus every branch downstream of them are unreachable in that process - lines 196-198, 335-343, 383-397. weights/mod.rs: what remains is load_weight's per-format paths, which need a populated OperandSource rather than a unit test. replay.rs was already a debt baseline and moved 7.2 -> 6.48 because CPU-7 widened the recorded call (positions, grouped, site) without widening its replay. Measured on x86_64 locally, which reproduces the ubuntu job to the decimal (backend/arithmetic/cost/integer/ledger/stationary/weights all matched exactly before this work). Raise these when a case genuinely changes, not to make the gate quieter.",
+  "policy_note": "Default policy is 90% line coverage per source file. The per-file entries below are existing debt baselines from cargo-llvm-cov and should only ratchet upward. 2026-08-27 (CPU-5/6/7): the CPU execution stack added ten files' worth of new code to opplan/exec. Seven were plain under-testing and are now fixed with portable tests - cost.rs and arithmetic.rs and ledger.rs to 100%, backend.rs 99.22%, executor.rs 95.95%. Five entries below are NOT under-testing and must not be chased with more tests. integer.rs and stationary.rs: the bulk is the aarch64 SDOT and stationary kernels, and off aarch64 only the stubs and portable fallbacks compile, so the ubuntu/windows jobs cannot reach them. physical.rs: arithmetic_arm() and q4_classes() are BOTH OnceLock-cached process-wide, so exactly one arm resolves per test binary and the other arms' match arms plus every branch downstream of them are unreachable in that process - lines 196-198, 335-343, 383-397. weights/mod.rs: what remains is load_weight's per-format paths, which need a populated OperandSource rather than a unit test. replay.rs was already a debt baseline and moved 7.2 -> 6.48 because CPU-7 widened the recorded call (positions, grouped, site) without widening its replay. Measured on x86_64 locally, which reproduces the ubuntu job to the decimal (backend/arithmetic/cost/integer/ledger/stationary/weights all matched exactly before this work). Raise these when a case genuinely changes, not to make the gate quieter. 2026-09-01 (BALANCED-SEARCH-2 merge, #366): seven entries added, for TWO different reasons that must not be conflated. (a) DEBT, tracked in issue #367 \u2014 the five gguf/* files landed with #363 at 50.8-88.9% and ~2100 lines carrying 4 inline tests between them; they are baselined AT TODAY'S LEVELS so the gate is green and any drop below today still fails, which is a ratchet and not an exemption. Raise them as tests land; do not lower them. export.rs at 50.8% is the priority. (b) STRUCTURAL, do not chase with more tests \u2014 represent/kda_candidate_real.rs is a #[cfg(test)] driver gated on a real 48B container the ubuntu job does not have, and kda_candidate.rs carries gpu-gated paths that the non-gpu coverage run cannot reach.",
   "include_globs": [
     "crates/larql-vindex/src/**/*.rs"
   ],
@@ -29,6 +29,11 @@
     "crates/larql-vindex/src/format/huggingface/publish/upload.rs": 96.0,
     "crates/larql-vindex/src/format/load.rs": 62.0,
     "crates/larql-vindex/src/format/vindex3/encode/mod.rs": 87.8,
+    "crates/larql-vindex/src/format/vindex3/gguf/emit/mod.rs": 83.0,
+    "crates/larql-vindex/src/format/vindex3/gguf/export.rs": 50.8,
+    "crates/larql-vindex/src/format/vindex3/gguf/preflight/mod.rs": 88.8,
+    "crates/larql-vindex/src/format/vindex3/gguf/vocab.rs": 83.4,
+    "crates/larql-vindex/src/format/vindex3/gguf/walk/mod.rs": 88.5,
     "crates/larql-vindex/src/format/vindex3/opplan/exec/continuation.rs": 86.0,
     "crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/environment.rs": 63.7,
     "crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/integer.rs": 62.0,
@@ -39,6 +44,8 @@
     "crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs": 86.5,
     "crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs": 86.6,
     "crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs": 84.0,
+    "crates/larql-vindex/src/format/vindex3/represent/kda_candidate.rs": 75.2,
+    "crates/larql-vindex/src/format/vindex3/represent/kda_candidate_real.rs": 4.4,
     "crates/larql-vindex/src/format/weights/load/f32.rs": 75.0,
     "crates/larql-vindex/src/format/weights/load/q4k.rs": 57.0,
     "crates/larql-vindex/src/format/weights/write_f32.rs": 58.0,


### PR DESCRIPTION
The `larql-vindex` coverage gate has been red on `main` since #363. A permanently
red gate is worse than no gate: the next genuine coverage regression becomes
indistinguishable from the standing failure.

Seven entries, added for **two different reasons that must not be conflated**.

## Debt — tracked in #367

Five `gguf/*` files landed with ~2,100 lines carrying four inline tests between
them (`emit/`, `preflight/` and `walk/` have none):

| file | lines | tests | coverage |
|---|---|---|---|
| `gguf/export.rs` | 419 | 1 | **50.8 %** |
| `gguf/emit/mod.rs` | 517 | 0 | 83.0 % |
| `gguf/vocab.rs` | 400 | 3 | 83.4 % |
| `gguf/walk/mod.rs` | 434 | 0 | 88.5 % |
| `gguf/preflight/mod.rs` | 346 | 0 | 88.8 % |

Baselined **at today's levels** — a ratchet, not an exemption. The gate is green
now and any drop below today still fails, so regression detection is restored
while the debt stays visible and owned. Raise them as tests land; do not lower
them.

## Structural — do not chase with more tests

`represent/kda_candidate_real.rs` (4.4 %) is a `#[cfg(test)]` driver gated on a
real 48 B container the ubuntu job does not have; `kda_candidate.rs` (75.2 %)
carries gpu-gated paths the non-gpu coverage run cannot reach. Same class as the
`integer.rs` / `stationary.rs` / `physical.rs` entries the policy note already
documents, and the note now says so explicitly.

## Verification

CI's own `scripts/check_coverage_policy.py`, against a measured report:

```
Coverage policy passed: total 93.42% lines, 365 files checked,
304 files at 90.0% default, 61 debt baselines.
```

## Known unrelated reds

`cargo-audit` and `cargo-deny · advisories` (RUSTSEC-2026-0269) are red on `main`
independently of this change. The `bench` gate is separately unreliable — it
flagged a +31 % "regression" in `larql-compute` on a branch that did not touch
that crate; that is shared-runner variance against a `main` baseline and is the
next instrument fix, not addressed here.