### PR TITLE
fix(exec): a capture records every projection, and counts only its own

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/projector.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/projector.rs
@@ -163,6 +163,21 @@ pub enum WeightRows<'a> {
 }
 
 impl WeightRows<'_> {
+    /// The address of the PRIMARY weight stream — this slab's identity.
+    ///
+    /// Two live operands cannot share a primary address, so this is what
+    /// distinguishes one caller's projections from another's in a
+    /// process-global record such as [`super::replay`]'s capture.
+    pub fn primary_addr(&self) -> usize {
+        match self {
+            Self::F32(w) => w.as_ptr() as usize,
+            Self::Bf16(w) => w.as_ptr() as usize,
+            Self::Q8 { codes, .. } => codes.as_ptr() as usize,
+            Self::Q4 { packed, .. } => packed.as_ptr() as usize,
+            Self::Nvfp4 { packed, .. } => packed.as_ptr() as usize,
+        }
+    }
+
     /// Rows in this slab, given the column count.
     pub fn rows(&self, in_dim: usize) -> usize {
         match self {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/replay.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/replay.rs
@@ -33,6 +33,7 @@
 //! locality effect from a cost intrinsic to traversing hundreds of
 //! distinct allocations.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 use super::executor::CpuExecutor;
@@ -82,6 +83,16 @@ pub struct Captured {
 }
 
 impl Captured {
+    /// The address of the primary weight stream this call read — the
+    /// operand's identity.
+    ///
+    /// A capture is process-wide, so a caller that must count only the
+    /// calls IT issued selects them with this against its own operands'
+    /// [`WeightRows::primary_addr`].
+    pub fn operand_addr(&self) -> usize {
+        self.primary.0
+    }
+
     /// Rebuild the row view.
     ///
     /// # Safety
@@ -123,13 +134,33 @@ impl Captured {
 
 static CAPTURE: Mutex<Option<Vec<Captured>>> = Mutex::new(None);
 
+/// Whether a recording is open, readable WITHOUT taking the lock.
+///
+/// The idle cost of [`record`] is this one acquire load — cheaper than
+/// the lock probe it replaces — which is what lets that function block
+/// on the mutex when a capture IS open instead of dropping the call.
+///
+/// Acquire/release rather than relaxed so that a thread which observes
+/// the flag set also observes the `Some(..)` that [`start_capture`]
+/// wrote before setting it.
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+
 /// Begin recording projections. Any previous recording is discarded.
+///
+/// **A capture is process-wide.** It records every projection the
+/// process issues while it is open, from any thread — which is the
+/// point, since [`super::executor::CpuExecutor::parallel6`] issues
+/// KDA's q/k/v and gate branches from pool workers. A caller that needs
+/// only its OWN calls must select them by operand; see
+/// [`Captured::operand_addr`].
 pub fn start_capture() {
     *CAPTURE.lock().expect("capture lock") = Some(Vec::new());
+    ACTIVE.store(true, Ordering::Release);
 }
 
 /// Stop recording and take what was captured.
 pub fn take_capture() -> Vec<Captured> {
+    ACTIVE.store(false, Ordering::Release);
     CAPTURE
         .lock()
         .expect("capture lock")
@@ -140,19 +171,32 @@ pub fn take_capture() -> Vec<Captured> {
 /// Record one projection, if recording is on.
 ///
 /// Called from the executor's own `project`, so a captured call is the
-/// call the model made and not a reconstruction of it. Costs one
-/// uncontended lock check per projection while idle.
+/// call the model made and not a reconstruction of it. Costs one acquire
+/// load per projection while idle.
+///
+/// **Every issued projection is recorded, including concurrent ones.**
+/// This previously probed the lock with `try_lock` and returned on
+/// contention, reasoning that a racing worker "would only ever be inside
+/// a projection this call already recorded". Nothing enforces that.
+/// [`super::executor::CpuExecutor::parallel6`] exists precisely to run
+/// six independent branches — KDA's q/k/v, decay-gate, output-gate and
+/// b_proj — on separate pool workers, and those issue DISTINCT
+/// projections; the moment it is wired to a caller that goes through
+/// `project`, a lost probe becomes a silently dropped call in the very
+/// traffic this capture exists to price.
+///
+/// **As of 2026-09-01 that path is latent, not live**: `parallel6` has
+/// no production call site, and the MoE fan-out reaches
+/// `DenseProjector::project_rows` directly rather than through
+/// `project`, so no shipped measurement is known to have lost a call. A
+/// recorder whose correctness rests on no caller ever fanning out is
+/// still the wrong shape, and blocking costs nothing while idle. The
+/// operand is built before the lock is taken, so the section held is one
+/// `push`.
 pub(super) fn record(weight: WeightRows<'_>, x: &[f32], out_dim: usize) {
-    let mut slot = match CAPTURE.try_lock() {
-        Ok(slot) => slot,
-        // A worker thread racing the capture would only ever be inside a
-        // projection this call already recorded; skipping is correct and
-        // cheaper than blocking a decode.
-        Err(_) => return,
-    };
-    let Some(log) = slot.as_mut() else {
+    if !ACTIVE.load(Ordering::Acquire) {
         return;
-    };
+    }
     let mut tensor_scale = 0.0f32;
     let (kind, primary, secondary, tertiary, block) = match weight {
         WeightRows::F32(w) => (Kind::F32, (w.as_ptr() as usize, w.len()), (0, 0), (0, 0), 0),
@@ -202,6 +246,10 @@ pub(super) fn record(weight: WeightRows<'_>, x: &[f32], out_dim: usize) {
                 0,
             )
         }
+    };
+    let mut slot = CAPTURE.lock().expect("capture lock");
+    let Some(log) = slot.as_mut() else {
+        return;
     };
     log.push(Captured {
         kind,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/replay_capture.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/replay_capture.rs
@@ -33,9 +33,23 @@ use crate::format::vindex3::opplan::exec::cpu::executor::shared;
 use crate::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
 use crate::format::vindex3::opplan::exec::cpu::projector::WeightRows;
 use crate::format::vindex3::opplan::exec::cpu::replay::{
-    captured_bytes, replay, start_capture, take_capture, ReplayOrder,
+    captured_bytes, replay, start_capture, take_capture, Captured, ReplayOrder,
 };
 use crate::format::vindex3::opplan::exec::quantise::{Q4_BLOCK, Q8_BLOCK};
+
+/// Serialises the tests that OPEN a capture.
+///
+/// A capture is process-wide and singular: `start_capture` replaces any
+/// recording in progress, and `take_capture` removes it. Two tests
+/// holding one open at the same time therefore take each other's calls,
+/// no matter how carefully each selects its own operands afterwards —
+/// so opening one is mutually exclusive, and every test below that calls
+/// `start_capture` takes THIS lock, not a lock of its own.
+///
+/// Concurrency with tests that merely PROJECT is not excluded here: that
+/// is the process-wide behaviour the capture is specified to have, and
+/// it is handled by selecting on [`WeightRows::primary_addr`].
+static CAPTURE_TESTS: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 const ROWS: usize = 3;
 /// One Q8 block wide, so the blocked formats carry real per-block
@@ -108,6 +122,7 @@ impl Operands {
 /// reconstructs all of it in every diagnostic order.
 #[test]
 fn capture_and_replay_carry_every_representation_the_executor_projects() {
+    let _exclusive = CAPTURE_TESTS.lock().unwrap_or_else(|e| e.into_inner());
     let operands = Operands::build();
     let exec = shared().expect("the CPU executor pool");
     let rows = operands.rows();
@@ -118,21 +133,39 @@ fn capture_and_replay_carry_every_representation_the_executor_projects() {
         }
     };
 
+    // A capture is PROCESS-WIDE: it records every projection the process
+    // issues while it is open, which under `cargo test` includes calls
+    // from whatever sibling test is running on another thread. Counting
+    // those would make this assertion a statement about the scheduler.
+    // So select this test's own calls by operand address, which is
+    // unique per live allocation.
+    let mine = |calls: Vec<Captured>| -> Vec<Captured> {
+        let ours: std::collections::BTreeSet<usize> =
+            rows.iter().map(WeightRows::primary_addr).collect();
+        calls
+            .into_iter()
+            .filter(|c| ours.contains(&c.operand_addr()))
+            .collect()
+    };
+
     // Off by default: the projection runs, nothing is kept. A recorder
     // left on would grow behind every later measurement.
     project_all();
-    assert!(take_capture().is_empty(), "capture is off until started");
+    assert!(
+        mine(take_capture()).is_empty(),
+        "capture is off until started"
+    );
 
     start_capture();
     project_all();
-    let calls = take_capture();
+    let calls = mine(take_capture());
     assert_eq!(
         calls.len(),
         rows.len(),
         "one captured call per projection, in issue order"
     );
     assert!(
-        take_capture().is_empty(),
+        mine(take_capture()).is_empty(),
         "taking a capture ends it — a second take must not re-serve the same calls"
     );
 
@@ -178,8 +211,70 @@ fn capture_and_replay_carry_every_representation_the_executor_projects() {
     start_capture();
     project_all();
     assert_eq!(
-        take_capture().len(),
+        mine(take_capture()).len(),
         rows.len(),
         "a new capture starts empty"
+    );
+}
+
+/// A concurrent projection is captured too, and does not disturb the
+/// caller's own count.
+///
+/// The regression for the Windows CI failure at `8ac0b7a7`, where
+/// `capture_and_replay_carry_every_representation_the_executor_projects`
+/// counted SIX calls for five issued: a capture is process-wide, so a
+/// sibling test projecting on another thread landed inside its window.
+///
+/// Two properties have to hold together, and each fails a different old
+/// defect:
+///
+/// ```text
+///   the foreign call IS recorded      record() no longer drops a call
+///                                     that loses a lock probe — latent
+///                                     today (parallel6 is unwired), a
+///                                     silent under-count the moment it
+///                                     is not
+///   the caller's own count is exact   selecting by operand address
+///                                     isolates it from the scheduler
+/// ```
+#[test]
+fn a_concurrent_projection_is_captured_without_disturbing_the_owner_count() {
+    let _exclusive = CAPTURE_TESTS.lock().unwrap_or_else(|e| e.into_inner());
+    let operands = Operands::build();
+    let foreign = Operands::build();
+    let exec = shared().expect("the CPU executor pool");
+    let rows = operands.rows();
+
+    start_capture();
+    std::thread::scope(|s| {
+        // One projection from ANOTHER thread, guaranteed inside the
+        // window because the scope joins before the capture is taken.
+        s.spawn(|| {
+            let w = foreign.rows()[0];
+            let plan = PhysicalProjectionPlan::for_resident(w, K);
+            exec.project(plan.kernel(), w, &foreign.x, ROWS);
+        });
+        for w in &rows {
+            let plan = PhysicalProjectionPlan::for_resident(*w, K);
+            exec.project(plan.kernel(), *w, &operands.x, ROWS);
+        }
+    });
+    let calls = take_capture();
+
+    let ours: std::collections::BTreeSet<usize> =
+        rows.iter().map(WeightRows::primary_addr).collect();
+    let (mine, theirs): (Vec<Captured>, Vec<Captured>) = calls
+        .into_iter()
+        .partition(|c| ours.contains(&c.operand_addr()));
+
+    assert_eq!(
+        mine.len(),
+        rows.len(),
+        "every projection the owner issued is recorded, none dropped"
+    );
+    assert_eq!(
+        theirs.len(),
+        1,
+        "the concurrent call is recorded too — a capture is process-wide"
     );
 }


### PR DESCRIPTION
Fixes the `larql-vindex` Windows red on `main` at `8ac0b7a7`.

## The established defect

`capture_and_replay_carry_every_representation_the_executor_projects` counted **six calls for five issued**. A capture is process-wide, so a sibling test projecting on another thread landed inside the capture window.

Neither #364 nor #371 caused it: #364 contributes one visibility keyword to the Windows build (everything else it touched is `cfg(all(feature = "gpu", target_os = "macos"))`), the Windows test count is identical at 3554 before and after, and the runner image was unchanged at `windows-2025-vs2026 / 20260819.586`. A latent unsynchronised global fired on its own after fourteen green runs.

**Reproduced locally**: both capture tests fail together in parallel and pass under `--test-threads=1`.

## The latent one, stated as latent

`record` probed with `try_lock` and returned on contention, on this reasoning:

> "A worker thread racing the capture would only ever be inside a projection this call already recorded; skipping is correct."

Nothing enforces that. `CpuExecutor::parallel6` exists to run six independent branches — KDA's q/k/v, decay-gate, output-gate, b_proj — on separate pool workers, and those issue *distinct* projections.

⚠️ **Correction to an earlier draft of this PR body**: I first claimed this had been under-counting `vindex3 generate`'s replay in production. **It has not, and I could not show that it had.** `parallel6` has no production call site, and the MoE fan-out in `kimi_moe_block` reaches `DenseProjector::project_rows` directly rather than through `project`. No shipped measurement is known to have lost a call, and no re-measurement is owed. The drop path is a real hazard the moment anything fans out through `project` — which is what `parallel6` is for — but today it is latent.

## The fix

- `record` gates the idle path on an `AtomicBool` (one acquire load, cheaper than the lock probe it replaces) and builds the operand *before* taking the lock, so the held section is one `push` and blocking is affordable.
- `WeightRows::primary_addr` gives an operand its identity; the test selects its own calls by it.
- The two tests that OPEN a capture share **one** lock rather than one each.

Thread-owner scoping was the first fix considered and rejected: it would drop every worker-issued projection by design, converting a latent hazard into a guaranteed one.

## Verification

Gates per `larql-vindex.yml`: `fmt --check`, `check --all-targets`, `check --examples`, `check --features gpu --all-targets`, `clippy -D warnings`, E0 generation boundary (10 passed), full suite (3560 passed, 0 failed), `--benches`, `cargo check --workspace --all-targets`. Coverage policy passed — `projector.rs` 99.00%, `replay.rs` 98.51%, crate total 93.42%.

`cargo-audit` / `cargo-deny · advisories` are red on RUSTSEC-2026-0269 (wasmtime); that is red on `main` and unrelated to this branch.
