### PR TITLE
fix(represent): the margin and the registry share one typed vocabulary (BS2-F2)

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/represent/assessment.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/assessment.rs
@@ -45,6 +45,7 @@ use super::execution_cost::{CostPrediction, CostRefusal, ExecutionCostModel};
 pub use super::measurement::EvidenceScale;
 use super::measurement::TailSupportPolicy;
 use super::quality::Criterion;
+use super::quality::Statistic;
 use super::search_evidence::{SearchCalibrationRegistry, SearchEvidence};
 
 /// What a move did to one criterion.
@@ -53,7 +54,7 @@ pub struct MarginalConstraintCost {
     pub criterion: Criterion,
     /// The gate's own wording for this limit, which is the key: a
     /// criterion can carry several limits that move independently.
-    pub what: String,
+    pub what: Statistic,
     /// Utilisation before the move, as a fraction of the limit.
     pub before: Option<f64>,
     pub after: Option<f64>,
@@ -126,7 +127,7 @@ impl MarginalConstraintCost {
         let evidence = {
             let each = [before, after].map(|m| {
                 ctx.registry.evidence_for(
-                    &m.what,
+                    m.what,
                     ctx.scale,
                     &m.measurement_status(&ctx.tail_policy),
                 )
@@ -139,7 +140,7 @@ impl MarginalConstraintCost {
         };
         Self {
             criterion: after.criterion,
-            what: after.what.clone(),
+            what: after.what,
             before: b,
             after: a,
             delta,
@@ -472,7 +473,7 @@ impl CandidateAssessment {
                 self.scale == EvidenceScale::Authority || m.criterion != Criterion::Positions
             })
             .filter(|m| !m.satisfied())
-            .map(|m| m.what.clone())
+            .map(|m| m.what.label().to_string())
             .collect();
         failures.sort();
         if !failures.is_empty() {
@@ -495,7 +496,7 @@ impl CandidateAssessment {
             self.bytes_removed_marginal as f64 / 1e6,
             -self.ranking_score.gpu_ms_saved,
         );
-        let scarcest = self.marginal.scarcest().map(|c| c.what.clone());
+        let scarcest = self.marginal.scarcest().map(|c| c.what);
         for c in &self.marginal.costs {
             let share = match (c.priceable(), c.fraction_of_remaining_consumed) {
                 (true, Some(f)) => format!("{:+.0}% of remaining headroom", 100.0 * f),
@@ -503,7 +504,7 @@ impl CandidateAssessment {
                 (false, _) if c.orders() => "NOT PRICEABLE at this scale (ordering proxy)".into(),
                 (false, _) => "NOT PRICEABLE at this scale (no usable evidence)".into(),
             };
-            let mark = if Some(&c.what) == scarcest.as_ref() {
+            let mark = if Some(c.what) == scarcest {
                 "   <- scarce resource"
             } else {
                 ""

--- a/crates/larql-vindex/src/format/vindex3/represent/assessment_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/assessment_tests.rs
@@ -11,6 +11,7 @@ use super::super::byte_ledger::{ByteLedger, ScopeBytes};
 use super::super::constraint::Margin;
 use super::super::execution_cost::{m3max_metal_001, ExecutionCostModel};
 use super::super::measurement::TailSupport;
+use super::super::quality::Statistic;
 use super::*;
 
 const KIMI: &str = "Kimi-Linear-48B-A3B-Instruct";
@@ -34,20 +35,20 @@ fn ledger_removing(fraction: f64) -> ByteLedger {
     }
 }
 
-fn ceiling(what: &str, criterion: Criterion, utilisation: f64) -> Margin {
+fn ceiling(what: Statistic, criterion: Criterion, utilisation: f64) -> Margin {
     // Well-supported by default; the thin-tail cases construct their own.
     ceiling_with(what, criterion, utilisation, Some(2000))
 }
 
 fn ceiling_with(
-    what: &str,
+    what: Statistic,
     criterion: Criterion,
     utilisation: f64,
     observations: Option<u64>,
 ) -> Margin {
     Margin {
         criterion,
-        what: what.into(),
+        what,
         kind: LimitKind::Ceiling,
         limit: 1.0,
         observed: Some(utilisation),
@@ -59,10 +60,10 @@ fn ceiling_with(
     }
 }
 
-fn floor(what: &str, criterion: Criterion, observed: f64, limit: f64) -> Margin {
+fn floor(what: Statistic, criterion: Criterion, observed: f64, limit: f64) -> Margin {
     Margin {
         criterion,
-        what: what.into(),
+        what,
         kind: LimitKind::Floor,
         limit,
         observed: Some(observed),
@@ -77,19 +78,14 @@ fn vector(kl: f64, route: f64) -> ConstraintVector {
     ConstraintVector {
         gate_id: "kimi-logit-balanced-v1".into(),
         margins: vec![
-            ceiling("kl p99", Criterion::KlP99, kl),
+            ceiling(Statistic::KlP99, Criterion::KlP99, kl),
             ceiling(
-                "routed mixture moved at p99",
+                Statistic::RouteMixtureMassP99,
                 Criterion::RouteDisplacement,
                 route,
             ),
-            floor("positions", Criterion::Positions, 8192.0, 4096.0),
-            floor(
-                "covered mass at the worst position",
-                Criterion::CoveredMass,
-                0.63,
-                0.55,
-            ),
+            floor(Statistic::Positions, Criterion::Positions, 8192.0, 4096.0),
+            floor(Statistic::CoveredMass, Criterion::CoveredMass, 0.63, 0.55),
         ],
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/constraint.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/constraint.rs
@@ -39,7 +39,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::measurement::{MeasurementStatus, TailSupport, TailSupportPolicy};
-use super::quality::{Criterion, QualityBank, QualityGate};
+use super::quality::{Criterion, QualityBank, QualityGate, Statistic};
 
 /// Whether a limit is a ceiling the candidate spends against, or a
 /// floor the measurement itself has to clear.
@@ -56,10 +56,12 @@ pub enum LimitKind {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Margin {
     pub criterion: Criterion,
-    /// Which limit this is, in the gate's own words — `Criterion` is
-    /// coarser than the gate: `RouteDisplacement` carries both a p99
-    /// and a max limit, and they can bind independently.
-    pub what: String,
+    /// Which limit this is — `Criterion` is coarser than the gate:
+    /// `RouteDisplacement` carries both a p99 and a max limit, and they
+    /// can bind independently. TYPED, because this is the join key the
+    /// calibration registry and a candidate's proxies look up on; see
+    /// [`Statistic`] for what a free string cost.
+    pub what: Statistic,
     pub kind: LimitKind,
     pub limit: f64,
     /// `None` when the bank did not record this quantity. That is NOT
@@ -152,11 +154,11 @@ impl ConstraintVector {
     pub fn of(gate: &QualityGate, bank: &QualityBank) -> Self {
         let mut margins = Vec::new();
         let mut ceiling =
-            |criterion, what: &str, limit: Option<f64>, observed, vacuous, tail_support| {
+            |criterion, what: Statistic, limit: Option<f64>, observed, vacuous, tail_support| {
                 if let Some(limit) = limit {
                     margins.push(Margin {
                         criterion,
-                        what: what.into(),
+                        what,
                         kind: LimitKind::Ceiling,
                         limit,
                         observed,
@@ -175,7 +177,7 @@ impl ConstraintVector {
         // kl is DENSE: every position contributes a value.
         ceiling(
             Criterion::KlP99,
-            "kl p99",
+            Statistic::KlP99,
             Some(gate.kl_p99_max),
             Some(bank.logits.kl_p99),
             false,
@@ -184,19 +186,19 @@ impl ConstraintVector {
         for (criterion, what, limit, got) in [
             (
                 Criterion::Top1Flips,
-                "top-1 flips",
+                Statistic::Top1Flips,
                 gate.top1_flip_max,
                 bank.logits.top1_flips,
             ),
             (
                 Criterion::Top10Changes,
-                "top-10 changes",
+                Statistic::Top10Changes,
                 gate.top10_change_max,
                 bank.logits.top10_changes,
             ),
             (
                 Criterion::RouteFlips,
-                "route flips",
+                Statistic::RouteFlips,
                 gate.route_flip_max,
                 bank.routing.route_flips,
             ),
@@ -223,7 +225,7 @@ impl ConstraintVector {
         for (criterion, what, limit, observed, changes, support) in [
             (
                 Criterion::Top1Displacement,
-                "top-1 probability given up",
+                Statistic::Top1MassDisplaced,
                 gate.top1_mass_displaced_max,
                 bank.top1_mass_displaced.map(|d| d.max),
                 bank.logits.top1_flips,
@@ -231,7 +233,7 @@ impl ConstraintVector {
             ),
             (
                 Criterion::TopKDisplacement,
-                "top-10 mass displaced at p99",
+                Statistic::Top10MassDisplacedP99,
                 gate.top10_mass_displaced_p99_max,
                 bank.top10_mass_displaced.map(|d| d.p99),
                 bank.logits.top10_changes,
@@ -239,7 +241,7 @@ impl ConstraintVector {
             ),
             (
                 Criterion::RouteDisplacement,
-                "routed mixture moved at p99",
+                Statistic::RouteMixtureMassP99,
                 gate.route_mixture_mass_p99_max,
                 bank.routing.route_weight_mass_moved.map(|d| d.p99),
                 bank.routing.route_flips,
@@ -250,7 +252,7 @@ impl ConstraintVector {
             ),
             (
                 Criterion::RouteDisplacement,
-                "routed mixture moved at max",
+                Statistic::RouteMixtureMassMax,
                 gate.route_mixture_mass_max,
                 bank.routing.route_weight_mass_moved.map(|d| d.max),
                 bank.routing.route_flips,
@@ -265,7 +267,7 @@ impl ConstraintVector {
         // are conditions without which the ceilings above mean nothing.
         margins.push(Margin {
             criterion: Criterion::Positions,
-            what: "positions".into(),
+            what: Statistic::Positions,
             kind: LimitKind::Floor,
             limit: gate.positions_min as f64,
             observed: Some(bank.positions as f64),
@@ -275,7 +277,7 @@ impl ConstraintVector {
         if let Some(required) = gate.covered_mass_min {
             margins.push(Margin {
                 criterion: Criterion::CoveredMass,
-                what: "covered mass at the worst position".into(),
+                what: Statistic::CoveredMass,
                 kind: LimitKind::Floor,
                 limit: required,
                 observed: bank.min_covered_mass,

--- a/crates/larql-vindex/src/format/vindex3/represent/constraint_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/constraint_tests.rs
@@ -8,6 +8,7 @@
 //! resource is scarce should be tested against the measurement that
 //! made the question worth asking.
 
+use super::super::quality::Statistic;
 use super::super::quality::{
     kimi_logit_balanced_v1, kimi_logit_v1, Distribution, LogitEvidence, QualityBank, QualityGate,
     RoutingEvidence,
@@ -323,7 +324,7 @@ fn headroom_is_what_is_left_of_a_budget_and_floors_have_none() {
     let v = ConstraintVector::of(&kimi_logit_balanced_v1(), &four_family_selection());
     let route = v
         .spendable()
-        .find(|m| m.what == "routed mixture moved at p99")
+        .find(|m| m.what == Statistic::RouteMixtureMassP99)
         .expect("judged");
     // 1 - 0.1248/0.15: about a sixth of the route budget is left, which
     // is the number a search should be allocating against.
@@ -377,7 +378,7 @@ fn a_zero_budget_is_judged_but_never_ranked() {
         ..kimi_logit_v1()
     };
     let v = ConstraintVector::of(&gate, &four_family_selection());
-    for what in ["top-1 flips", "route flips"] {
+    for what in [Statistic::Top1Flips, Statistic::RouteFlips] {
         let m = v.spendable().find(|m| m.what == what).expect("judged");
         assert_eq!(m.limit, 0.0);
         assert_eq!(
@@ -416,7 +417,7 @@ fn a_zero_budget_that_was_never_spent_does_not_poison_the_ranking() {
     let v = ConstraintVector::of(&gate, &bank);
     let m = v
         .spendable()
-        .find(|m| m.what == "top-1 flips")
+        .find(|m| m.what == Statistic::Top1Flips)
         .expect("judged");
     assert!(m.satisfied(), "zero spent against a zero budget is fine");
     assert_eq!(
@@ -428,5 +429,56 @@ fn a_zero_budget_that_was_never_spent_does_not_poison_the_ranking() {
         v.binding().expect("scored").criterion,
         Criterion::Top1Flips,
         "an unrankable criterion must never be reported as the scarce one"
+    );
+}
+
+/// **BS2-F2.** A margin's key looks the calibration up — the registry
+/// and the constraint vector share ONE vocabulary.
+///
+/// The defect this pins: the registry keyed `"route flip rate"` while
+/// `ConstraintVector::of` emitted `"route flips"`. The lookup missed,
+/// `evidence_for` fell through to its `is_priceable()` arm, and route
+/// flips — a COUNT, so always `Measured` — came back `Direct`. The one
+/// statistic ROUTE-CAL-1 calibrated as ordering-ONLY was silently
+/// PRICED, which is the failure the ladder exists to prevent. Two of
+/// the four keys did match, so nothing looked wrong.
+///
+/// A free string could drift again; `Statistic` cannot. This test would
+/// not have caught the original defect had it passed its own literal to
+/// both sides — which is exactly what the fixtures did — so it takes the
+/// key from a REAL margin built by `ConstraintVector::of`.
+#[test]
+fn a_counted_proxy_is_ordered_never_priced_when_keyed_from_a_real_margin() {
+    use super::super::measurement::{EvidenceScale, MeasurementStatus, TailSupportPolicy};
+    use super::super::search_evidence::{SearchCalibrationRegistry, SearchEvidence};
+
+    // A gate that DOES limit route flips, so the vector emits that margin.
+    let gate = QualityGate {
+        route_flip_max: Some(64),
+        ..kimi_logit_v1()
+    };
+    let v = ConstraintVector::of(&gate, &four_family_selection());
+    let m = v
+        .margins
+        .iter()
+        .find(|m| m.criterion == Criterion::RouteFlips)
+        .expect("the gate limits route flips, so a margin exists");
+
+    // A count has no tail to be thin: it IS well measured.
+    let status = m.measurement_status(&TailSupportPolicy::route_cal_1());
+    assert_eq!(status, MeasurementStatus::Measured);
+
+    // And is STILL only a proxy. Before the typed key this returned
+    // Direct, because the lookup missed and `Measured` is priceable.
+    let r = SearchCalibrationRegistry::route_cal_1();
+    let e = r.evidence_for(m.what, EvidenceScale::Diagnostic, &status);
+    assert!(
+        matches!(e, SearchEvidence::OrderingProxy { .. }),
+        "a well-measured COUNT is still ordering-only evidence, got {e:?}"
+    );
+    assert!(e.orders());
+    assert!(
+        !e.is_priceable(),
+        "BS2-F2: a calibrated proxy must never become price"
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/promotion.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/promotion.rs
@@ -38,6 +38,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::assessment::{CandidateAssessment, MoveClass};
+use super::quality::Statistic;
 use super::search_evidence::SearchEvidence;
 
 /// Which way a proxy points for the criterion it stands in for.
@@ -55,9 +56,9 @@ pub enum ProxyRisk {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProxyObservation {
     /// The proxy itself, e.g. `"route flip rate"`.
-    pub statistic: String,
+    pub statistic: Statistic,
     /// The contract criterion it stands in for.
-    pub for_criterion: String,
+    pub for_criterion: Statistic,
     pub parent: f64,
     pub candidate: f64,
     /// Why this proxy may be believed for ordering. Anything that is
@@ -130,7 +131,7 @@ impl PromotionCandidate {
     }
 
     /// Proxy evidence for one unpriceable criterion, if any is usable.
-    pub fn proxy_for(&self, criterion: &str) -> Option<&ProxyObservation> {
+    pub fn proxy_for(&self, criterion: Statistic) -> Option<&ProxyObservation> {
         self.proxies
             .iter()
             .find(|p| p.for_criterion == criterion && p.usable())
@@ -153,7 +154,7 @@ impl PromotionCandidate {
             if c.orders() {
                 continue;
             }
-            match self.proxy_for(&c.what).map(ProxyObservation::risk) {
+            match self.proxy_for(c.what).map(ProxyObservation::risk) {
                 Some(ProxyRisk::Benign) => {}
                 Some(ProxyRisk::Elevated) => {
                     if worst != PromotionReadiness::Uninformed {
@@ -224,7 +225,7 @@ impl PromotionCandidate {
                 if c.orders() {
                     return format!("{} unpriceable, orders itself", c.what);
                 }
-                match self.proxy_for(&c.what) {
+                match self.proxy_for(c.what) {
                     Some(p) => format!("{} unpriceable, {} {:?}", c.what, p.statistic, p.risk()),
                     None => format!("{} unpriceable, no proxy", c.what),
                 }

--- a/crates/larql-vindex/src/format/vindex3/represent/promotion_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/promotion_tests.rs
@@ -6,6 +6,7 @@ use super::super::constraint::{ConstraintVector, LimitKind, Margin};
 use super::super::execution_cost::{m3max_metal_001, ExecutionCostModel};
 use super::super::measurement::{EvidenceScale, TailSupport};
 use super::super::quality::Criterion;
+use super::super::quality::Statistic;
 use super::*;
 
 const KIMI: &str = "Kimi-Linear-48B-A3B-Instruct";
@@ -26,9 +27,9 @@ fn ledger(fraction: f64, name: &str) -> ByteLedger {
 }
 
 fn vector(kl: f64, route: f64) -> ConstraintVector {
-    let ceiling = |what: &str, criterion, u: f64| Margin {
+    let ceiling = |what: Statistic, criterion, u: f64| Margin {
         criterion,
-        what: what.into(),
+        what,
         kind: LimitKind::Ceiling,
         limit: 1.0,
         observed: Some(u),
@@ -41,9 +42,9 @@ fn vector(kl: f64, route: f64) -> ConstraintVector {
     ConstraintVector {
         gate_id: "kimi-logit-balanced-v1".into(),
         margins: vec![
-            ceiling("kl p99", Criterion::KlP99, kl),
+            ceiling(Statistic::KlP99, Criterion::KlP99, kl),
             ceiling(
-                "routed mixture moved at p99",
+                Statistic::RouteMixtureMassP99,
                 Criterion::RouteDisplacement,
                 route,
             ),
@@ -65,8 +66,8 @@ fn candidate(name: &str, removes: f64, kl_after: f64, route_after: f64) -> Candi
 
 fn flip_rate(parent: f64, cand: f64) -> ProxyObservation {
     ProxyObservation {
-        statistic: "route flip rate".into(),
-        for_criterion: "routed mixture moved at p99".into(),
+        statistic: Statistic::RouteFlips,
+        for_criterion: Statistic::RouteMixtureMassP99,
         parent,
         candidate: cand,
         evidence: SearchEvidence::OrderingProxy {
@@ -159,7 +160,7 @@ fn the_weakest_unpriceable_dimension_decides_not_the_average() {
     );
     assert_eq!(a.readiness(), PromotionReadiness::ProxySupported);
     let mut orphan = flip_rate(0.16, 0.15);
-    orphan.for_criterion = "some other criterion".into();
+    orphan.for_criterion = Statistic::Top10Changes;
     let b = PromotionCandidate::new(candidate("b", 0.22, 0.70, 0.84), vec![orphan]);
     assert_eq!(
         b.readiness(),

--- a/crates/larql-vindex/src/format/vindex3/represent/quality.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/quality.rs
@@ -267,6 +267,62 @@ pub enum Criterion {
     CoveredMass,
 }
 
+/// The exact quantity a [`super::constraint::Margin`] reports — the JOIN
+/// KEY between a constraint vector, the calibration registry, and a
+/// candidate's proxy observations.
+///
+/// **Finer than [`Criterion`] on purpose.** `RouteDisplacement` carries
+/// both a p99 and a max limit and they bind independently: at 256
+/// positions the p99 is a maximum wearing a percentile's name while the
+/// max is exactly what it says, so keying evidence on the criterion
+/// would hand the thin percentile the max's confidence.
+///
+/// **An enum and not a string, on purpose.** BS2-F2: the registry keyed
+/// `"route flip rate"` while the vector emitted `"route flips"`. The
+/// lookup missed, `SearchCalibrationRegistry::evidence_for` fell through
+/// to its `is_priceable()` arm, and a COUNT — always `Measured` —
+/// returned `Direct`. That silently PRICED the one statistic ROUTE-CAL-1
+/// calibrated as ordering-only, which is the failure the whole evidence
+/// ladder exists to prevent. Two of the three keys matched, so the
+/// mechanism looked like it worked. A typed key cannot drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Statistic {
+    KlP99,
+    Top1Flips,
+    Top10Changes,
+    RouteFlips,
+    Top1MassDisplaced,
+    Top10MassDisplacedP99,
+    RouteMixtureMassP99,
+    RouteMixtureMassMax,
+    Positions,
+    CoveredMass,
+}
+
+impl Statistic {
+    /// The human label, for traces. Not a key — nothing joins on this.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::KlP99 => "kl p99",
+            Self::Top1Flips => "top-1 flips",
+            Self::Top10Changes => "top-10 changes",
+            Self::RouteFlips => "route flips",
+            Self::Top1MassDisplaced => "top-1 probability given up",
+            Self::Top10MassDisplacedP99 => "top-10 mass displaced at p99",
+            Self::RouteMixtureMassP99 => "routed mixture moved at p99",
+            Self::RouteMixtureMassMax => "routed mixture moved at max",
+            Self::Positions => "positions",
+            Self::CoveredMass => "covered mass at the worst position",
+        }
+    }
+}
+
+impl std::fmt::Display for Statistic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
 impl Criterion {
     pub fn name(self) -> &'static str {
         match self {

--- a/crates/larql-vindex/src/format/vindex3/represent/search_evidence.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/search_evidence.rs
@@ -44,6 +44,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::measurement::{EvidenceScale, MeasurementStatus};
+use super::quality::Statistic;
 
 /// How a search may use one statistic at one evidence scale.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -96,7 +97,7 @@ pub struct SearchCalibration {
     /// The statistic, in the gate's own wording where it is a contract
     /// criterion — `"kl p99"`, `"routed mixture moved at p99"` — or its
     /// own name where it is a proxy, `"route flip rate"`.
-    pub statistic: String,
+    pub statistic: Statistic,
     pub scale: EvidenceScale,
     pub verdict: SearchEvidence,
     /// Paired diagnostic/authority observations behind the verdict.
@@ -119,7 +120,7 @@ impl SearchCalibrationRegistry {
         Self { entries }
     }
 
-    pub fn lookup(&self, statistic: &str, scale: EvidenceScale) -> Option<&SearchCalibration> {
+    pub fn lookup(&self, statistic: Statistic, scale: EvidenceScale) -> Option<&SearchCalibration> {
         self.entries
             .iter()
             .find(|e| e.statistic == statistic && e.scale == scale)
@@ -141,7 +142,7 @@ impl SearchCalibrationRegistry {
     /// to be unmeasured.
     pub fn evidence_for(
         &self,
-        statistic: &str,
+        statistic: Statistic,
         scale: EvidenceScale,
         status: &MeasurementStatus,
     ) -> SearchEvidence {
@@ -161,7 +162,7 @@ impl SearchCalibrationRegistry {
         Self::new(vec![
             SearchCalibration {
                 id: "ROUTE-CAL-1".into(),
-                statistic: "kl p99".into(),
+                statistic: Statistic::KlP99,
                 scale: EvidenceScale::Diagnostic,
                 verdict: SearchEvidence::OrderingProxy {
                     calibration: "ROUTE-CAL-1".into(),
@@ -176,7 +177,7 @@ impl SearchCalibrationRegistry {
             },
             SearchCalibration {
                 id: "ROUTE-CAL-1".into(),
-                statistic: "routed mixture moved at p99".into(),
+                statistic: Statistic::RouteMixtureMassP99,
                 scale: EvidenceScale::Diagnostic,
                 verdict: SearchEvidence::Unusable,
                 pairs: 7,
@@ -189,7 +190,7 @@ impl SearchCalibrationRegistry {
             },
             SearchCalibration {
                 id: "ROUTE-CAL-1".into(),
-                statistic: "route flip rate".into(),
+                statistic: Statistic::RouteFlips,
                 scale: EvidenceScale::Diagnostic,
                 verdict: SearchEvidence::OrderingProxy {
                     calibration: "ROUTE-CAL-1".into(),
@@ -204,7 +205,7 @@ impl SearchCalibrationRegistry {
             },
             SearchCalibration {
                 id: "ROUTE-CAL-1".into(),
-                statistic: "top-10 mass displaced at p99".into(),
+                statistic: Statistic::Top10MassDisplacedP99,
                 scale: EvidenceScale::Diagnostic,
                 verdict: SearchEvidence::Unusable,
                 pairs: 0,

--- a/crates/larql-vindex/src/format/vindex3/represent/search_evidence_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/search_evidence_tests.rs
@@ -1,6 +1,7 @@
 //! `tests` for [`super`].
 
 use super::super::measurement::{MeasurementStatus, TailSupport, TailSupportPolicy};
+use super::super::quality::Statistic;
 use super::*;
 
 fn thin() -> MeasurementStatus {
@@ -25,9 +26,9 @@ fn measurement_and_usefulness_are_orthogonal() {
     // them.
     let r = SearchCalibrationRegistry::route_cal_1();
     assert_eq!(thin(), thin(), "identical measurement status");
-    let kl = r.evidence_for("kl p99", EvidenceScale::Diagnostic, &thin());
+    let kl = r.evidence_for(Statistic::KlP99, EvidenceScale::Diagnostic, &thin());
     let route = r.evidence_for(
-        "routed mixture moved at p99",
+        Statistic::RouteMixtureMassP99,
         EvidenceScale::Diagnostic,
         &thin(),
     );
@@ -39,7 +40,7 @@ fn measurement_and_usefulness_are_orthogonal() {
 fn an_ordering_proxy_may_not_be_priced_against_the_contract() {
     // The trap this exists to close: correlation is not magnitude.
     let r = SearchCalibrationRegistry::route_cal_1();
-    let kl = r.evidence_for("kl p99", EvidenceScale::Diagnostic, &thin());
+    let kl = r.evidence_for(Statistic::KlP99, EvidenceScale::Diagnostic, &thin());
     assert!(kl.orders(), "it does order candidates — rho +0.857");
     assert!(
         !kl.is_priceable(),
@@ -54,7 +55,7 @@ fn a_well_measured_statistic_can_still_be_only_a_proxy() {
     // mass. A registration must be able to lower, not only raise.
     let r = SearchCalibrationRegistry::route_cal_1();
     let e = r.evidence_for(
-        "route flip rate",
+        Statistic::RouteFlips,
         EvidenceScale::Diagnostic,
         &MeasurementStatus::Measured,
     );
@@ -70,12 +71,12 @@ fn an_unregistered_thin_percentile_is_unusable_not_usable() {
     // expensive dimension it could not see.
     let r = SearchCalibrationRegistry::route_cal_1();
     assert_eq!(
-        r.evidence_for("some future p99", EvidenceScale::Diagnostic, &thin()),
+        r.evidence_for(Statistic::Top1Flips, EvidenceScale::Diagnostic, &thin()),
         SearchEvidence::Unusable
     );
     // And a directly supported one needs no registration.
     assert_eq!(
-        r.evidence_for("some future p99", EvidenceScale::Authority, &supported()),
+        r.evidence_for(Statistic::Top1Flips, EvidenceScale::Authority, &supported()),
         SearchEvidence::Direct
     );
 }
@@ -84,7 +85,7 @@ fn an_unregistered_thin_percentile_is_unusable_not_usable() {
 fn top10_is_unusable_by_absence_of_evidence_and_says_so() {
     let r = SearchCalibrationRegistry::route_cal_1();
     let e = r
-        .lookup("top-10 mass displaced at p99", EvidenceScale::Diagnostic)
+        .lookup(Statistic::Top10MassDisplacedP99, EvidenceScale::Diagnostic)
         .expect("registered");
     assert_eq!(e.verdict, SearchEvidence::Unusable);
     assert_eq!(e.pairs, 0, "no paired calibration has been run");
@@ -146,7 +147,7 @@ fn authority_scale_route_mass_is_priced_directly() {
     // calibration needed, the measurement carries it.
     let r = SearchCalibrationRegistry::route_cal_1();
     let e = r.evidence_for(
-        "routed mixture moved at p99",
+        Statistic::RouteMixtureMassP99,
         EvidenceScale::Authority,
         &supported(),
     );


### PR DESCRIPTION
**BS2-F2** — found by the real-bank integration smoke test that BALANCED-SEARCH-2's pre-registration demanded, before rung 4 starts.

## The defect

The calibration registry keyed `"route flip rate"`. `ConstraintVector::of` emitted `"route flips"`. They never matched, so `lookup` missed and `evidence_for` fell through:

```rust
if let Some(e) = self.lookup(statistic, scale) { return e.verdict; }
if status.is_priceable() { Direct } else { Unusable }
```

A route-flips margin is a **count**, counts have no tail to be thin, so `measurement_status` is `Measured`, so `is_priceable()` is true — and the statistic ROUTE-CAL-1 established as **ordering-only** came back **`Direct`**.

That is the invariant the whole evidence ladder exists to protect, violated by the exact statistic the doctrine named it about: *a proxy affects promotion class and never becomes price, or `route_flip_rate` slowly becomes a shadow behavioural contract.*

**Demonstrated, not argued** — the same scenario run against pre-fix code:

```text
PRE   margin.what="route flips"  evidence=Direct         priceable=true
POST  Statistic::RouteFlips      evidence=OrderingProxy  priceable=false
```

Two of the four registry keys *did* match (`kl p99`, `routed mixture moved at p99`), which is what made the mechanism look like it worked.

## The fix

`Statistic` — a typed vocabulary — replaces the free string on all three joins:

| join | was | now |
|---|---|---|
| `Margin::what` | `String` | `Statistic` |
| `SearchCalibration::statistic` | `String` | `Statistic` |
| `ProxyObservation::for_criterion` | `String` | `Statistic` |

That third one had the same latent defect: `proxy_for` joins on the same string, and a mismatch silently yields "no proxy" — which ranks `Uninformed`, *below* `ProxyRisky`.

`Statistic` is deliberately finer than `Criterion`: `RouteDisplacement` carries both a p99 and a max limit that bind independently, and at 256 positions the p99 is a maximum wearing a percentile's name while the max is exactly what it says.

`Admission::Refused` keeps its `Vec<String>` — it reports, it does not join, and keeping it preserves the refusal report's alphabetical ordering.

## Why the fixtures missed it

They passed their own literal to both sides of the join, so they were green throughout. The new regression test takes its key from a margin `ConstraintVector::of` actually built.

## Not addressed: BS2-F1

No gate sets `route_flip_max` — `kimi_logit_v3` sets it `None` and `balanced-v1` inherits that — so in practice this margin is absent entirely. v3's doc says it *"keeps the counts as DIAGNOSTICS and drops them as authority"*, but there is no diagnostic-side vehicle, so a criterion kept "as a diagnostic" produces no margin. **That is a gate-design question, and it had to come second**: setting `route_flip_max` first would have started pricing a proxy.

## Verification

`fmt --check`, `clippy -D warnings`, E0 (10 passed), full suite (3618 passed, 0 failed), `cargo check --workspace --all-targets`. Coverage policy passed — `search_evidence.rs` 100.00%, `constraint.rs` 99.43%, `assessment.rs` 99.20%, `promotion.rs` 97.09%, `quality.rs` 96.52%; crate 93.45%.
