### PR TITLE
feat(represent): what a search observes, stated apart from what a contract admits (BS2-F1)

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/replay_capture.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/replay_capture.rs
@@ -272,9 +272,15 @@ fn a_concurrent_projection_is_captured_without_disturbing_the_owner_count() {
         rows.len(),
         "every projection the owner issued is recorded, none dropped"
     );
-    assert_eq!(
-        theirs.len(),
-        1,
+    // Identify the concurrent call by ITS operand, not by counting.
+    // `theirs` also collects whatever sibling tests projected during the
+    // window — a capture is process-wide, which is this test's own
+    // premise, so asserting `theirs.len() == 1` asserted an exclusivity
+    // that does not exist. It held under `cargo test` and broke under
+    // `cargo llvm-cov`, where the slower run let 19 sibling calls land.
+    let foreign_addr = foreign.rows()[0].primary_addr();
+    assert!(
+        theirs.iter().any(|c| c.operand_addr() == foreign_addr),
         "the concurrent call is recorded too — a capture is process-wide"
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/constraint.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/constraint.rs
@@ -90,13 +90,7 @@ impl Margin {
     /// A non-percentile is `Measured` whenever it was observed at all:
     /// counts and maxima do not have tails to be thin.
     pub fn measurement_status(&self, policy: &TailSupportPolicy) -> MeasurementStatus {
-        if self.observed.is_none() {
-            return MeasurementStatus::NotObserved;
-        }
-        match self.tail_support {
-            Some(s) => policy.status(Some(s)),
-            None => MeasurementStatus::Measured,
-        }
+        policy.status_of(self.observed.is_some(), self.tail_support)
     }
 
     /// Fraction of this criterion's budget the candidate consumed, for

--- a/crates/larql-vindex/src/format/vindex3/represent/constraint_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/constraint_tests.rs
@@ -432,27 +432,25 @@ fn a_zero_budget_that_was_never_spent_does_not_poison_the_ranking() {
     );
 }
 
-/// **BS2-F2.** A margin's key looks the calibration up — the registry
-/// and the constraint vector share ONE vocabulary.
+/// **BS2-F2 + BS2-F1.** A margin's key looks the calibration up — the
+/// registry and the constraint vector share ONE vocabulary — and a
+/// bounded COUNT is still not priceable at diagnostic scale.
 ///
-/// The defect this pins: the registry keyed `"route flip rate"` while
+/// BS2-F2: the registry keyed `"route flip rate"` while
 /// `ConstraintVector::of` emitted `"route flips"`. The lookup missed,
-/// `evidence_for` fell through to its `is_priceable()` arm, and route
-/// flips — a COUNT, so always `Measured` — came back `Direct`. The one
-/// statistic ROUTE-CAL-1 calibrated as ordering-ONLY was silently
-/// PRICED, which is the failure the ladder exists to prevent. Two of
-/// the four keys did match, so nothing looked wrong.
+/// `evidence_for` fell through, and a count — always `Measured` — came
+/// back `Direct`, PRICING a statistic ROUTE-CAL-1 had calibrated as
+/// ordering-only. A typed [`Statistic`] cannot drift like that.
 ///
-/// A free string could drift again; `Statistic` cannot. This test would
-/// not have caught the original defect had it passed its own literal to
-/// both sides — which is exactly what the fixtures did — so it takes the
-/// key from a REAL margin built by `ConstraintVector::of`.
+/// BS2-F1 then showed the fall-through itself was wrong at diagnostic
+/// scale, which is what this pins: a count SCALES with sample size, so
+/// 46 flips over 256 positions is not a fraction of a bound written for
+/// 8,192, however well measured it is. Transfer must be earned.
 #[test]
-fn a_counted_proxy_is_ordered_never_priced_when_keyed_from_a_real_margin() {
+fn a_bounded_count_is_well_measured_and_still_not_priceable_at_diagnostic_scale() {
     use super::super::measurement::{EvidenceScale, MeasurementStatus, TailSupportPolicy};
     use super::super::search_evidence::{SearchCalibrationRegistry, SearchEvidence};
 
-    // A gate that DOES limit route flips, so the vector emits that margin.
     let gate = QualityGate {
         route_flip_max: Some(64),
         ..kimi_logit_v1()
@@ -462,23 +460,24 @@ fn a_counted_proxy_is_ordered_never_priced_when_keyed_from_a_real_margin() {
         .margins
         .iter()
         .find(|m| m.criterion == Criterion::RouteFlips)
-        .expect("the gate limits route flips, so a margin exists");
+        .expect("the gate bounds route flips, so a margin exists");
+    assert_eq!(m.what, Statistic::RouteFlips, "one typed vocabulary");
 
     // A count has no tail to be thin: it IS well measured.
     let status = m.measurement_status(&TailSupportPolicy::route_cal_1());
     assert_eq!(status, MeasurementStatus::Measured);
 
-    // And is STILL only a proxy. Before the typed key this returned
-    // Direct, because the lookup missed and `Measured` is priceable.
+    // And is STILL unusable as a diagnostic price.
     let r = SearchCalibrationRegistry::route_cal_1();
-    let e = r.evidence_for(m.what, EvidenceScale::Diagnostic, &status);
-    assert!(
-        matches!(e, SearchEvidence::OrderingProxy { .. }),
-        "a well-measured COUNT is still ordering-only evidence, got {e:?}"
+    assert_eq!(
+        r.evidence_for(m.what, EvidenceScale::Diagnostic, &status),
+        SearchEvidence::Unusable,
+        "well measured at 256 positions is not transferable to an 8,192-position bound"
     );
-    assert!(e.orders());
-    assert!(
-        !e.is_priceable(),
-        "BS2-F2: a calibrated proxy must never become price"
+
+    // At the scale the bound was written for, it is exactly what it says.
+    assert_eq!(
+        r.evidence_for(m.what, EvidenceScale::Authority, &status),
+        SearchEvidence::Direct
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/diagnostic.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/diagnostic.rs
@@ -1,0 +1,220 @@
+//! **BS2-F1 — what a search may OBSERVE, stated independently of what a
+//! contract ADMITS.**
+//!
+//! The real-bank smoke test found `route flip rate` — the one statistic
+//! ROUTE-CAL-1 established as transferring across scale — absent from
+//! the diagnostic vector entirely. The cause was structural, not a bug
+//! in any one function:
+//!
+//! ```text
+//! before   diagnostic dimensions := statistics the CONTRACT bounds
+//!          so anything the contract does not judge is invisible
+//!
+//! after    diagnostic dimensions := an explicit DiagnosticPolicy
+//! ```
+//!
+//! The tempting repair — give `balanced-v1` a route-flip limit so the
+//! search can see it — is the one that must be refused. It would turn an
+//! INSTRUMENTATION requirement into behavioural policy, and freeze into
+//! a contract a number that was only ever earned as an ordering proxy.
+//!
+//! # The two invariants
+//!
+//! **A diagnostic statistic does not become an authority criterion
+//! merely by being observed or predictive.** [`DiagnosticReading`]
+//! therefore has no `limit`, no `utilisation` and no `headroom`: there
+//! is no bound to divide by, so a price cannot be computed here even by
+//! mistake. That is a type boundary, not a discipline.
+//!
+//! **An authority criterion need not be directly usable at diagnostic
+//! scale.** `routed mixture moved at p99` is observed by both, and at
+//! 256 positions its 46 events make it `Unusable` — the contract still
+//! judges it at authority scale, unchanged.
+//!
+//! The relation between the two schemas is many-to-many, and neither
+//! side owns the other:
+//!
+//! ```text
+//! diagnostic kl p99             ──→ authority kl p99
+//! diagnostic route flip rate    ──→ authority routed mixture mass
+//! diagnostic routed mixture p99 ──→ authority routed mixture mass
+//!                                   (but Unusable at this scale)
+//! ```
+//!
+//! Which authority behaviour a proxy informs is recorded where it is
+//! used, on [`super::promotion::ProxyObservation::for_criterion`], not
+//! here — a policy says what to look at, not what to conclude.
+
+use serde::{Deserialize, Serialize};
+
+use super::measurement::{MeasurementStatus, TailSupport, TailSupportPolicy};
+use super::quality::{QualityBank, Statistic};
+use super::search_evidence::{SearchCalibrationRegistry, SearchEvidence};
+
+/// Why a statistic is observed at diagnostic scale.
+///
+/// Records the RELATIONSHIP to the contract without granting one: a
+/// `SearchEvidence` observation is not a criterion in waiting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ObservationPurpose {
+    /// The contract judges this same statistic; reading it early says
+    /// where the candidate stands, subject to the registry's verdict on
+    /// whether this scale supports it.
+    ContractPreview,
+    /// Observed ONLY to order candidates. The contract does not judge
+    /// it and must not begin to because it proved useful.
+    SearchEvidence,
+}
+
+/// One statistic a policy asks to be observed. **No bound** — that is
+/// the whole point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiagnosticObservation {
+    pub statistic: Statistic,
+    pub purpose: ObservationPurpose,
+}
+
+/// What a search observes, declared independently of any contract.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DiagnosticPolicy {
+    pub id: String,
+    pub observations: Vec<DiagnosticObservation>,
+}
+
+impl DiagnosticPolicy {
+    pub fn observes(&self, statistic: Statistic) -> bool {
+        self.observations.iter().any(|o| o.statistic == statistic)
+    }
+
+    /// **`bs2-kimi-v1`** — what rung 4 needs to see on a Kimi bank.
+    ///
+    /// Seeded with the contract's own magnitudes as previews, plus the
+    /// one observation that exists ONLY here: `route flip rate`, a count
+    /// statistic whose flips-per-position transfer at 0.89-1.02 for any
+    /// map with at least forty diagnostic events, where the same bank's
+    /// mixture-mass p99 rests on 46 events and is wrong on two of five
+    /// moves.
+    ///
+    /// Adding to this list is cheap and reversible BY DESIGN: it cannot
+    /// change what `balanced-v1` admits, so a new observable never
+    /// re-opens a frozen contract.
+    pub fn bs2_kimi_v1() -> Self {
+        use ObservationPurpose::{ContractPreview, SearchEvidence};
+        Self {
+            id: "bs2-kimi-v1".into(),
+            observations: vec![
+                DiagnosticObservation {
+                    statistic: Statistic::KlP99,
+                    purpose: ContractPreview,
+                },
+                DiagnosticObservation {
+                    statistic: Statistic::Top1MassDisplaced,
+                    purpose: ContractPreview,
+                },
+                DiagnosticObservation {
+                    statistic: Statistic::Top10MassDisplacedP99,
+                    purpose: ContractPreview,
+                },
+                DiagnosticObservation {
+                    statistic: Statistic::RouteMixtureMassP99,
+                    purpose: ContractPreview,
+                },
+                DiagnosticObservation {
+                    statistic: Statistic::RouteFlipRate,
+                    purpose: SearchEvidence,
+                },
+            ],
+        }
+    }
+}
+
+/// One statistic as a bank actually reports it.
+///
+/// **Deliberately without a bound.** A reading cannot be turned into a
+/// fraction of a budget because there is no budget here to divide by —
+/// see this module's first invariant.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct DiagnosticReading {
+    pub statistic: Statistic,
+    pub purpose: ObservationPurpose,
+    /// `None` when the bank did not record it. Not zero: an unobserved
+    /// quantity is unobserved.
+    pub observed: Option<f64>,
+    pub tail_support: Option<TailSupport>,
+}
+
+impl DiagnosticReading {
+    /// Whether the evidence supports the statistic this reading reports.
+    pub fn measurement_status(&self, policy: &TailSupportPolicy) -> MeasurementStatus {
+        policy.status_of(self.observed.is_some(), self.tail_support)
+    }
+
+    /// How a search may USE this reading — which is never as a price
+    /// unless the registry says the scale earns it.
+    pub fn evidence(
+        &self,
+        registry: &SearchCalibrationRegistry,
+        policy: &TailSupportPolicy,
+    ) -> SearchEvidence {
+        registry.evidence_for(
+            self.statistic,
+            super::measurement::EvidenceScale::Diagnostic,
+            &self.measurement_status(policy),
+        )
+    }
+}
+
+/// Everything a policy asked to see, as one bank reports it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DiagnosticVector {
+    pub policy_id: String,
+    pub readings: Vec<DiagnosticReading>,
+}
+
+impl DiagnosticVector {
+    /// Read `bank` through `policy`. **No gate is consulted**, which is
+    /// the coupling BS2-F1 severed.
+    pub fn of(policy: &DiagnosticPolicy, bank: &QualityBank) -> Self {
+        Self {
+            policy_id: policy.id.clone(),
+            readings: policy
+                .observations
+                .iter()
+                .map(|o| {
+                    let (observed, tail_support) = o.statistic.observe(bank);
+                    DiagnosticReading {
+                        statistic: o.statistic,
+                        purpose: o.purpose,
+                        observed,
+                        tail_support,
+                    }
+                })
+                .collect(),
+        }
+    }
+
+    pub fn reading(&self, statistic: Statistic) -> Option<&DiagnosticReading> {
+        self.readings.iter().find(|r| r.statistic == statistic)
+    }
+
+    /// The readings a search may order on, with the evidence that says
+    /// so. Excludes anything the registry judges `Unusable` at this
+    /// scale.
+    pub fn ordering(
+        &self,
+        registry: &SearchCalibrationRegistry,
+        policy: &TailSupportPolicy,
+    ) -> Vec<(&DiagnosticReading, SearchEvidence)> {
+        self.readings
+            .iter()
+            .map(|r| (r, r.evidence(registry, policy)))
+            .filter(|(_, e)| e.orders())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+#[path = "diagnostic_tests.rs"]
+// `pub(crate)` so the promotion tests can share this module's 256-position
+// bank rather than keeping a second copy of it that could drift.
+pub(crate) mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/diagnostic_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/diagnostic_tests.rs
@@ -1,0 +1,238 @@
+//! The five properties BS2-F1 has to establish, plus the conformance
+//! check that keeps the two schemas honest about the same numbers.
+
+use super::super::constraint::ConstraintVector;
+use super::super::measurement::{EvidenceScale, MeasurementStatus, TailSupportPolicy};
+use super::super::quality::{
+    kimi_logit_balanced_v1, Criterion, LogitEvidence, QualityBank, QualityGate, RoutingEvidence,
+    Statistic,
+};
+use super::super::search_evidence::{SearchCalibrationRegistry, SearchEvidence};
+use super::*;
+
+/// A 256-position diagnostic bank with the shape the real Kimi guard
+/// bank has: 46 route-change events behind a mixture-mass p99, which is
+/// a maximum wearing a percentile's name.
+pub(in crate::format::vindex3::represent) fn guard_256() -> QualityBank {
+    QualityBank {
+        positions: 256,
+        logits: LogitEvidence {
+            kl_p50: 6.2998e-5,
+            kl_p95: 6.8794e-4,
+            kl_p99: 2.4762e-3,
+            max_logit_delta: 1.1154,
+            top1_flips: 2,
+            top10_changes: 74,
+        },
+        routing: RoutingEvidence {
+            route_flips: 46,
+            positions_with_route_change: 34,
+            layers_with_route_change: 7,
+            first_layer_with_route_change: Some(20),
+            route_margin: None,
+            route_weight_mass_moved: None,
+        },
+        min_covered_mass: Some(0.7814),
+        top1_mass_displaced: None,
+        top10_mass_displaced: None,
+        top10_margin: None,
+        top10_candidate_margin: None,
+        top10_rank_displacement: None,
+        top1_margin: None,
+        top1_candidate_margin: None,
+    }
+}
+
+/// **(1)** The observable the contract does not bound is nonetheless
+/// observed — which is the whole of BS2-F1.
+#[test]
+fn route_flip_rate_is_observed_although_no_gate_bounds_it() {
+    let gate = kimi_logit_balanced_v1();
+    assert!(
+        gate.route_flip_max.is_none(),
+        "the contract stays frozen: it does NOT bound route flips"
+    );
+    let authority = ConstraintVector::of(&gate, &guard_256());
+    assert!(
+        !authority
+            .margins
+            .iter()
+            .any(|m| m.criterion == Criterion::RouteFlips),
+        "and so has no route-flip margin"
+    );
+
+    let d = DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &guard_256());
+    let r = d
+        .reading(Statistic::RouteFlipRate)
+        .expect("BS2-F1: the search sees it anyway");
+    assert_eq!(r.purpose, ObservationPurpose::SearchEvidence);
+    assert_eq!(r.observed, Some(46.0 / 256.0));
+}
+
+/// **(2)** Instrumentation cannot move the contract. Adding or removing
+/// an observation leaves admission bit-identical.
+#[test]
+fn changing_the_diagnostic_policy_cannot_change_admission() {
+    let gate = kimi_logit_balanced_v1();
+    let bank = guard_256();
+    let before = ConstraintVector::of(&gate, &bank);
+
+    let mut widened = DiagnosticPolicy::bs2_kimi_v1();
+    widened.observations.push(DiagnosticObservation {
+        statistic: Statistic::Top10Changes,
+        purpose: ObservationPurpose::SearchEvidence,
+    });
+    let mut narrowed = DiagnosticPolicy::bs2_kimi_v1();
+    narrowed.observations.clear();
+
+    for p in [&widened, &narrowed] {
+        let _ = DiagnosticVector::of(p, &bank);
+        let after = ConstraintVector::of(&gate, &bank);
+        assert_eq!(before, after, "the contract does not hear the instrument");
+        assert_eq!(before.admissible(), after.admissible());
+        assert_eq!(before.sound(), after.sound());
+    }
+}
+
+/// **(3)** And the converse: a contract criterion is not diagnostic
+/// evidence just for being a criterion. The policy is explicit, so a
+/// gate that grows a bound grows no observation.
+#[test]
+fn an_authority_criterion_does_not_become_diagnostic_evidence() {
+    let bounded = QualityGate {
+        route_flip_max: Some(64),
+        ..kimi_logit_balanced_v1()
+    };
+    let authority = ConstraintVector::of(&bounded, &guard_256());
+    assert!(
+        authority
+            .margins
+            .iter()
+            .any(|m| m.what == Statistic::RouteFlips),
+        "the gate now bounds the COUNT, so a margin exists"
+    );
+
+    let d = DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &guard_256());
+    assert!(
+        d.reading(Statistic::RouteFlips).is_none(),
+        "but the policy never asked for the count, so the search does not see it"
+    );
+    assert!(
+        !DiagnosticPolicy::bs2_kimi_v1().observes(Statistic::RouteFlips),
+        "observation is declared, never inferred from a bound"
+    );
+}
+
+/// **(4)** It orders, and it is never a price — at the scale it was
+/// calibrated for.
+#[test]
+fn route_flip_rate_orders_and_is_never_priced() {
+    let d = DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &guard_256());
+    let r = d.reading(Statistic::RouteFlipRate).expect("observed");
+    let policy = TailSupportPolicy::route_cal_1();
+    let registry = SearchCalibrationRegistry::route_cal_1();
+
+    // A rate over every position is dense: no thin tail, well measured.
+    assert_eq!(r.measurement_status(&policy), MeasurementStatus::Measured);
+
+    let e = r.evidence(&registry, &policy);
+    assert!(
+        matches!(e, SearchEvidence::OrderingProxy { .. }),
+        "well measured and STILL only a proxy, got {e:?}"
+    );
+    assert!(e.orders());
+    assert!(!e.is_priceable(), "a proxy never becomes price");
+}
+
+/// **(4b)** The second invariant, from the other side: a contract
+/// criterion that this scale cannot support is refused as evidence here
+/// while remaining a criterion there.
+#[test]
+fn an_authority_criterion_may_be_unusable_at_diagnostic_scale() {
+    let registry = SearchCalibrationRegistry::route_cal_1();
+    let thin = MeasurementStatus::InsufficientTailSupport {
+        observations: 46,
+        required: 500,
+    };
+    assert_eq!(
+        registry.evidence_for(
+            Statistic::RouteMixtureMassP99,
+            EvidenceScale::Diagnostic,
+            &thin
+        ),
+        SearchEvidence::Unusable
+    );
+    assert_eq!(
+        registry.evidence_for(
+            Statistic::RouteMixtureMassP99,
+            EvidenceScale::Authority,
+            &MeasurementStatus::Measured
+        ),
+        SearchEvidence::Direct,
+        "the contract judges it unchanged at the scale it was written for"
+    );
+}
+
+/// The two schemas must never DISAGREE about what a number is. BS2-F2
+/// was two vocabularies drifting; two bank extractions would drift the
+/// same way, so there is only one, and this pins that it is shared.
+#[test]
+fn both_schemas_read_the_same_bank_identically() {
+    let bank = guard_256();
+    let gate = QualityGate {
+        route_flip_max: Some(64),
+        ..kimi_logit_balanced_v1()
+    };
+    let authority = ConstraintVector::of(&gate, &bank);
+    let d = DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &bank);
+
+    let mut compared = 0;
+    for r in &d.readings {
+        if let Some(m) = authority.margins.iter().find(|m| m.what == r.statistic) {
+            assert_eq!(m.observed, r.observed, "{} value", r.statistic);
+            assert_eq!(m.tail_support, r.tail_support, "{} tail", r.statistic);
+            compared += 1;
+        }
+    }
+    assert!(compared >= 3, "the schemas do overlap: {compared} shared");
+}
+
+/// **The payoff.** What rung 4 can actually rank on, at 256 positions.
+///
+/// Before BS2-F1 the answer was `kl p99` ALONE — the two mixture-mass
+/// percentiles rest on 74 and 46 events and are `Unusable` at this
+/// scale, and the one statistic that does survive a small bank was not
+/// in the vector at all. Ranking on a single proxy is the dependence
+/// the evidence ladder exists to prevent, so this is the property that
+/// says the instrumentation surface is now adequate to start.
+#[test]
+fn the_search_can_order_on_two_independent_dimensions_not_one() {
+    let d = DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &guard_256());
+    let orderable: Vec<Statistic> = d
+        .ordering(
+            &SearchCalibrationRegistry::route_cal_1(),
+            &TailSupportPolicy::route_cal_1(),
+        )
+        .into_iter()
+        .map(|(r, _)| r.statistic)
+        .collect();
+
+    assert_eq!(
+        orderable,
+        vec![Statistic::KlP99, Statistic::RouteFlipRate],
+        "a dense percentile and a count-derived rate — and nothing that \
+         needs a tail this bank cannot supply"
+    );
+    // Both order; neither may be spent.
+    for (r, e) in d.ordering(
+        &SearchCalibrationRegistry::route_cal_1(),
+        &TailSupportPolicy::route_cal_1(),
+    ) {
+        assert!(e.orders(), "{}", r.statistic);
+        assert!(
+            !e.is_priceable(),
+            "{} must never be priced here",
+            r.statistic
+        );
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/measurement.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measurement.rs
@@ -145,6 +145,27 @@ impl TailSupportPolicy {
         (self.min_tail_observations / tail).ceil() as u64
     }
 
+    /// Judge one reported STATISTIC: whether it was observed at all,
+    /// and its tail support if it is a percentile.
+    ///
+    /// The single derivation, shared by
+    /// [`super::constraint::Margin::measurement_status`] and
+    /// [`super::diagnostic::DiagnosticReading::measurement_status`].
+    /// Two copies would drift — a non-percentile's `None` support means
+    /// "no tail to be thin", while [`Self::status`]'s `None` means "no
+    /// percentile recorded", and reading one as the other silently
+    /// turns a well-measured COUNT into `NotObserved`.
+    pub fn status_of(&self, observed: bool, support: Option<TailSupport>) -> MeasurementStatus {
+        if !observed {
+            return MeasurementStatus::NotObserved;
+        }
+        match support {
+            Some(s) => self.status(Some(s)),
+            // Counts and maxima do not have tails to be thin.
+            None => MeasurementStatus::Measured,
+        }
+    }
+
     /// Judge one reported percentile.
     pub fn status(&self, support: Option<TailSupport>) -> MeasurementStatus {
         let Some(s) = support else {

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -52,6 +52,7 @@ pub mod byte_ledger;
 pub mod compile;
 pub mod compiler;
 pub mod constraint;
+pub mod diagnostic;
 pub mod execution_cost;
 pub mod experiment;
 pub mod gptq;

--- a/crates/larql-vindex/src/format/vindex3/represent/promotion_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/promotion_tests.rs
@@ -66,7 +66,7 @@ fn candidate(name: &str, removes: f64, kl_after: f64, route_after: f64) -> Candi
 
 fn flip_rate(parent: f64, cand: f64) -> ProxyObservation {
     ProxyObservation {
-        statistic: Statistic::RouteFlips,
+        statistic: Statistic::RouteFlipRate,
         for_criterion: Statistic::RouteMixtureMassP99,
         parent,
         candidate: cand,
@@ -220,4 +220,43 @@ fn a_proxy_is_a_direction_and_never_a_magnitude() {
     // No route price appears anywhere in the assessment.
     assert_eq!(c.assessment.ranking_score.scarce_fraction_consumed, None);
     assert_eq!(c.assessment.ranking_score.score, None);
+}
+
+/// **(5)** A candidate is CLASSIFIED by the proxy and never priced by
+/// it: readiness improves, and no route-flip cost exists to spend.
+#[test]
+fn the_proxy_classifies_a_candidate_without_pricing_it() {
+    use super::super::diagnostic::{DiagnosticPolicy, DiagnosticVector};
+    use super::super::measurement::TailSupportPolicy;
+    use super::super::search_evidence::SearchCalibrationRegistry;
+    let bank = super::super::diagnostic::tests::guard_256();
+    let d = DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &bank);
+    let r = d.reading(Statistic::RouteFlipRate).expect("observed");
+    let evidence = r.evidence(
+        &SearchCalibrationRegistry::route_cal_1(),
+        &TailSupportPolicy::route_cal_1(),
+    );
+
+    let proxy = ProxyObservation {
+        statistic: Statistic::RouteFlipRate,
+        for_criterion: Statistic::RouteMixtureMassP99,
+        parent: 0.180,
+        candidate: 0.176,
+        evidence,
+    };
+    let candidate = PromotionCandidate::new(candidate("c", 0.22, 0.70, 0.84), vec![proxy]);
+    assert_eq!(
+        candidate.readiness(),
+        PromotionReadiness::ProxySupported,
+        "the search may PREFER on it"
+    );
+    assert!(
+        !candidate
+            .assessment
+            .marginal
+            .costs
+            .iter()
+            .any(|c| c.what == Statistic::RouteFlipRate || c.what == Statistic::RouteFlips),
+        "and there is no route-flip cost anywhere to spend against a budget"
+    );
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/quality.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/quality.rs
@@ -30,6 +30,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::measurement::TailSupport;
+
 /// Acceptance criteria, identified so a claim can name what it passed.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QualityGate {
@@ -291,6 +293,12 @@ pub enum Statistic {
     Top1Flips,
     Top10Changes,
     RouteFlips,
+    /// Route flips per POSITION — what ROUTE-CAL-1 actually measured
+    /// transferring across scale (0.89-1.02 for every map with >= 40
+    /// diagnostic events), and a different quantity from the raw
+    /// [`Self::RouteFlips`] count a contract might one day bound.
+    /// Diagnostic-only: no gate reads it, by design (BS2-F1).
+    RouteFlipRate,
     Top1MassDisplaced,
     Top10MassDisplacedP99,
     RouteMixtureMassP99,
@@ -307,12 +315,63 @@ impl Statistic {
             Self::Top1Flips => "top-1 flips",
             Self::Top10Changes => "top-10 changes",
             Self::RouteFlips => "route flips",
+            Self::RouteFlipRate => "route flips per position",
             Self::Top1MassDisplaced => "top-1 probability given up",
             Self::Top10MassDisplacedP99 => "top-10 mass displaced at p99",
             Self::RouteMixtureMassP99 => "routed mixture moved at p99",
             Self::RouteMixtureMassMax => "routed mixture moved at max",
             Self::Positions => "positions",
             Self::CoveredMass => "covered mass at the worst position",
+        }
+    }
+}
+
+impl Statistic {
+    /// Read this statistic off a bank: its value, and the observations
+    /// behind its tail if it is a percentile.
+    ///
+    /// **The single mapping from a statistic to the bank.** Authority
+    /// margins and diagnostic readings are built by different code for
+    /// different purposes, but they must not DISAGREE about what a
+    /// number is — BS2-F2 was two vocabularies drifting apart, and two
+    /// bank extractions would drift the same way.
+    pub fn observe(self, bank: &QualityBank) -> (Option<f64>, Option<TailSupport>) {
+        let p99 = |observations: u64| {
+            Some(TailSupport {
+                quantile: 0.99,
+                observations,
+            })
+        };
+        match self {
+            // Dense: every position contributes a value.
+            Self::KlP99 => (Some(bank.logits.kl_p99), p99(bank.positions)),
+            Self::Top1Flips => (Some(bank.logits.top1_flips as f64), None),
+            Self::Top10Changes => (Some(bank.logits.top10_changes as f64), None),
+            Self::RouteFlips => (Some(bank.routing.route_flips as f64), None),
+            // A rate over ALL positions is dense, so it has no thin tail
+            // — which is exactly why it survives a small bank.
+            Self::RouteFlipRate => (
+                (bank.positions > 0)
+                    .then(|| bank.routing.route_flips as f64 / bank.positions as f64),
+                None,
+            ),
+            Self::Top1MassDisplaced => (bank.top1_mass_displaced.map(|d| d.max), None),
+            Self::Top10MassDisplacedP99 => (
+                bank.top10_mass_displaced.map(|d| d.p99),
+                bank.top10_mass_displaced.map(|d| d.count).and_then(p99),
+            ),
+            Self::RouteMixtureMassP99 => (
+                bank.routing.route_weight_mass_moved.map(|d| d.p99),
+                bank.routing
+                    .route_weight_mass_moved
+                    .map(|d| d.count)
+                    .and_then(p99),
+            ),
+            Self::RouteMixtureMassMax => {
+                (bank.routing.route_weight_mass_moved.map(|d| d.max), None)
+            }
+            Self::Positions => (Some(bank.positions as f64), None),
+            Self::CoveredMass => (bank.min_covered_mass, None),
         }
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/search_evidence.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/search_evidence.rs
@@ -140,6 +140,19 @@ impl SearchCalibrationRegistry {
     /// the failure this whole layer exists to prevent is a search
     /// preferring a candidate because its expensive dimension happened
     /// to be unmeasured.
+    ///
+    /// **At [`EvidenceScale::Diagnostic`] the fall-through never reaches
+    /// `Direct`.** Being well measured at a small scale does not make a
+    /// number transferable, and the previous default said otherwise: a
+    /// COUNT is always `Measured` — counts have no tail to be thin — so
+    /// an unregistered bounded count came back directly priceable. It
+    /// would then be spent against a budget written for a different
+    /// sample size, and a count SCALES with positions: 46 route flips
+    /// over 256 positions against a bound set for 8,192 is not 72 % of
+    /// anything. Magnitude transfer at diagnostic scale is a claim that
+    /// has to be EARNED by a calibration, which is what the registry
+    /// records — so an unregistered statistic is `Unusable` here, and
+    /// the way to change that is to measure the transfer.
     pub fn evidence_for(
         &self,
         statistic: Statistic,
@@ -149,10 +162,15 @@ impl SearchCalibrationRegistry {
         if let Some(e) = self.lookup(statistic, scale) {
             return e.verdict.clone();
         }
-        if status.is_priceable() {
-            SearchEvidence::Direct
-        } else {
-            SearchEvidence::Unusable
+        match scale {
+            EvidenceScale::Authority => {
+                if status.is_priceable() {
+                    SearchEvidence::Direct
+                } else {
+                    SearchEvidence::Unusable
+                }
+            }
+            EvidenceScale::Diagnostic => SearchEvidence::Unusable,
         }
     }
 
@@ -190,7 +208,7 @@ impl SearchCalibrationRegistry {
             },
             SearchCalibration {
                 id: "ROUTE-CAL-1".into(),
-                statistic: Statistic::RouteFlips,
+                statistic: Statistic::RouteFlipRate,
                 scale: EvidenceScale::Diagnostic,
                 verdict: SearchEvidence::OrderingProxy {
                     calibration: "ROUTE-CAL-1".into(),

--- a/crates/larql-vindex/src/format/vindex3/represent/search_evidence_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/search_evidence_tests.rs
@@ -55,7 +55,7 @@ fn a_well_measured_statistic_can_still_be_only_a_proxy() {
     // mass. A registration must be able to lower, not only raise.
     let r = SearchCalibrationRegistry::route_cal_1();
     let e = r.evidence_for(
-        Statistic::RouteFlips,
+        Statistic::RouteFlipRate,
         EvidenceScale::Diagnostic,
         &MeasurementStatus::Measured,
     );


### PR DESCRIPTION
**BS2-F1.** Stacked on #376 — merge that first.

`balanced-v1` is **untouched**, and that is the point.

## The coupling, severed

```text
before   diagnostic dimensions := statistics the CONTRACT bounds
         ⇒ anything the contract does not judge is invisible

after    diagnostic dimensions := an explicit DiagnosticPolicy
```

The obvious repair — give `balanced-v1` a route-flip limit so the search can see it — is the one that had to be refused. It would turn an *instrumentation* requirement into behavioural policy, and freeze into a contract a number earned only as an ordering proxy.

## The two invariants

**A diagnostic statistic does not become an authority criterion merely by being observed or predictive.** `DiagnosticReading` has no `limit`, no `utilisation`, no `headroom` — there is no bound to divide by, so a price cannot be computed there even by mistake. A type boundary, not a discipline.

**An authority criterion need not be usable at diagnostic scale.** `routed mixture moved at p99` rests on 46 events at 256 positions and stays `Unusable`; the contract judges it unchanged at 8,192.

The relation is many-to-many, and which authority behaviour a proxy informs is recorded where it is used (`ProxyObservation::for_criterion`), not in the policy — a policy says what to look at, never what to conclude.

## Two things the tests forced

These are worth more than the plumbing.

**The diagnostic fall-through was wrong.** `evidence_for` returned `Direct` for any well-measured unregistered statistic — and a **count is always `Measured`**, since counts have no tail to be thin. So a bounded count came back directly priceable, to be spent against a budget written for a different sample size. **46 flips over 256 positions is not 72 % of a bound set for 8,192.** At diagnostic scale the fall-through now never reaches `Direct`; magnitude transfer must be earned by a calibration.

**`MeasurementStatus` had two derivations, and writing the second reproduced BS2-F2's mistake within the hour.** `TailSupportPolicy::status` reads `None` as "no percentile recorded", while an observed non-percentile means "no tail to be thin" — reading one as the other turned a well-measured count into `NotObserved`. There is now one shared `status_of`, used by both `Margin` and `DiagnosticReading`.

## `RouteFlipRate` is its own statistic

Flips-per-position is what ROUTE-CAL-1 measured transferring (0.89–1.02 for any map with ≥ 40 events), and it is a different quantity from the raw `RouteFlips` count a contract might one day bound. The calibration now keys the rate.

## The five properties, as tests

1. `route_flip_rate` is observed although no gate bounds it.
2. Adding or removing an observation cannot change `balanced-v1` admission.
3. A gate growing a bound grows no observation — declaration, never inference.
4. `route_flip_rate` orders and is never priced; and its converse, a contract criterion may be `Unusable` here.
5. The proxy **classifies** a candidate (`ProxySupported`) while no route-flip cost exists anywhere to spend.

Plus a conformance test that both schemas read the same bank identically, and:

**The payoff** — at 256 positions the search can now order on **`kl p99` and `route flip rate`**. Before this it was `kl` alone, which is the single-proxy dependence the ladder exists to prevent.

## Verification

`fmt`, `clippy -D warnings`, E0 (10 passed), full suite (3626 passed, 0 failed), `cargo check --workspace --all-targets`. Coverage policy passed — `diagnostic.rs` 100.00%, `constraint.rs` 100.00%, `search_evidence.rs` 98.95%, `measurement.rs` 97.50%; crate 93.45%.
