### PR TITLE
feat(represent): proxy evidence orders promotion without becoming price (R4-F1)

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/represent/assessment.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/assessment.rs
@@ -281,7 +281,7 @@ impl MoveClass {
     /// Higher sorts first. Encoded as a method rather than left to the
     /// enum's declaration order so that reordering the variants cannot
     /// silently become search policy.
-    fn tier(self) -> u8 {
+    pub(super) fn tier(self) -> u8 {
         match self {
             Self::Unpriced => 3,
             Self::Priced => 2,

--- a/crates/larql-vindex/src/format/vindex3/represent/decision.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/decision.rs
@@ -1,0 +1,418 @@
+//! **R4-F1 — proxy evidence orders promotion without becoming price.**
+//!
+//! Rung 4's first run ranked four one-step moves and printed
+//! `PROMOTE: e26`, matching the pre-registered prediction. Reversing the
+//! input list printed `PROMOTE: e20`, from identical reports. All four
+//! `rank_key`s were byte-identical — `tier=1 within=0.702202900
+//! frugality=-0.0` — because `within` falls back to `gpu_ms_saved` for
+//! any non-`Priced` class and every one-step move removed the same
+//! bytes. `cmp_rank` returned `Equal`, and a stable sort handed back
+//! INPUT ORDER.
+//!
+//! At diagnostic scale nothing is priceable BY DESIGN, so that tie is
+//! not an edge case; it is the normal state. Meanwhile both calibrated
+//! ordering proxies separated the four candidates monotonically and
+//! unanimously. **The evidence existed and the comparator could not see
+//! it.**
+//!
+//! # The invariant
+//!
+//! > Determinism may order indistinguishable candidates for DISPLAY; it
+//! > may never convert indistinguishability into evidence for
+//! > PROMOTION.
+//!
+//! [`display_order`] may use candidate identity as its final tie-break.
+//! [`decide_promotion`] is not given identity at all, so it cannot.
+//!
+//! # Ordinal, never scalar
+//!
+//! An [`OrderingProxy`] licenses ORDER and not MAGNITUDE. A numeric
+//! proxy term added to [`RankingScore`] would smuggle magnitude back in
+//! through the comparator — "A is 1.7x better than B" is exactly the
+//! claim ROUTE-CAL-1 refused to make. So this layer compares ranks:
+//!
+//! ```text
+//! physical economics   can say how much a move buys
+//! proxy evidence       can say A should be tried before B
+//! neither says         "A is 1.7x better than B"
+//! ```
+//!
+//! # When proxies disagree
+//!
+//! There is no empirical basis for how many places of kl are worth one
+//! place of routing, so a conflict is REFUSED rather than scalarised —
+//! [`PromotionDecision::Ambiguous`] names the frontier and why. The
+//! search can then seek more evidence or spend authority under an
+//! explicitly different exploration policy, which is a decision someone
+//! makes on purpose rather than one a comparator makes by accident.
+//!
+//! [`OrderingProxy`]: super::search_evidence::SearchEvidence::OrderingProxy
+//! [`RankingScore`]: super::assessment::RankingScore
+
+use std::cmp::Ordering;
+
+use serde::{Deserialize, Serialize};
+
+use super::diagnostic::DiagnosticVector;
+use super::measurement::TailSupportPolicy;
+use super::promotion::{PromotionCandidate, PromotionReadiness};
+use super::quality::Statistic;
+use super::search_evidence::SearchCalibrationRegistry;
+
+/// One candidate in a search round: what it is, how it was assessed, and
+/// what the diagnostic scale actually observed of it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchCandidate {
+    pub id: String,
+    pub promotion: PromotionCandidate,
+    pub diagnostic: DiagnosticVector,
+}
+
+impl SearchCandidate {
+    /// The statistics BOTH candidates observed and that ORDER at this
+    /// scale. A statistic one of them is silent on cannot rank them, and
+    /// one the registry judges `Unusable` here must not.
+    fn comparable(
+        &self,
+        other: &Self,
+        registry: &SearchCalibrationRegistry,
+        policy: &TailSupportPolicy,
+    ) -> Vec<Statistic> {
+        self.diagnostic
+            .readings
+            .iter()
+            .filter(|r| {
+                r.observed.is_some()
+                    && r.evidence(registry, policy).orders()
+                    && other.diagnostic.reading(r.statistic).is_some_and(|o| {
+                        o.observed.is_some() && o.evidence(registry, policy).orders()
+                    })
+            })
+            .map(|r| r.statistic)
+            .collect()
+    }
+
+    /// Ordinal comparison on one statistic. `Less` means `self` is
+    /// better.
+    fn order_on(&self, other: &Self, s: Statistic) -> Option<Ordering> {
+        let a = self.diagnostic.reading(s)?.observed?;
+        let b = other.diagnostic.reading(s)?.observed?;
+        Some(s.order(a, b))
+    }
+
+    /// Authority dimensions no diagnostic evidence can speak to: an
+    /// unpriceable cost that does not order itself and has no proxy
+    /// standing in for it.
+    ///
+    /// These are what makes a candidate `Uninformed`, and naming them is
+    /// the condition on which `Uninformed` may still be measured.
+    pub fn unresolved_dimensions(&self) -> Vec<Statistic> {
+        let mut out: Vec<Statistic> = self
+            .promotion
+            .assessment
+            .marginal
+            .unpriceable_costs()
+            .filter(|c| !c.orders() && self.promotion.proxy_for(c.what).is_none())
+            .map(|c| c.what)
+            .collect();
+        out.sort_by_key(|s| s.label());
+        out.dedup();
+        out
+    }
+
+    /// **`self` proxy-dominates `other`**: no worse on every comparable
+    /// proxy, and strictly better on at least one.
+    ///
+    /// Vacuously false when nothing is comparable — an absence of
+    /// evidence never dominates.
+    pub fn proxy_dominates(
+        &self,
+        other: &Self,
+        registry: &SearchCalibrationRegistry,
+        policy: &TailSupportPolicy,
+    ) -> bool {
+        let shared = self.comparable(other, registry, policy);
+        if shared.is_empty() {
+            return false;
+        }
+        let mut strictly_better = false;
+        for s in shared {
+            match self.order_on(other, s) {
+                Some(Ordering::Greater) => return false,
+                Some(Ordering::Less) => strictly_better = true,
+                _ => {}
+            }
+        }
+        strictly_better
+    }
+}
+
+/// Why a round could not name one candidate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AmbiguityReason {
+    /// Proxies point different ways and nothing licenses trading one
+    /// against the other.
+    ConflictingOrderingProxies,
+    /// Nothing on the frontier could be compared at all — the search
+    /// knows it does not know, which outranks a confident guess.
+    NoOrderingEvidence,
+    /// Every comparable proxy says the candidates are equal, and no
+    /// physical difference separates them either.
+    IndistinguishableOnEveryProxy,
+}
+
+/// Why a round had nothing to promote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NoPromotableCandidate {
+    EmptySet,
+    /// Every move buys nothing, whatever its evidence.
+    EveryMoveWorthless,
+}
+
+/// What justified a promotion. Never "it sorted first".
+#[derive(Debug, Clone, PartialEq)]
+pub struct PromotionEvidence {
+    /// Candidates this one proxy-dominates.
+    pub dominated: Vec<String>,
+    /// The proxies that did the separating.
+    pub deciding: Vec<Statistic>,
+    pub readiness: PromotionReadiness,
+    /// True when the proxies tied and physical gain broke it — a
+    /// legitimate later stage, recorded so a trace never has to guess
+    /// which stage decided.
+    pub decided_by_physical_gain: bool,
+    /// **Authority dimensions the diagnostic scale could not speak to.**
+    ///
+    /// Named explicitly because selection is not prediction: these are
+    /// exactly the criteria on which this candidate might still be
+    /// refused, and a trace that omitted them would read as confidence.
+    pub unresolved: Vec<Statistic>,
+}
+
+/// The outcome of one search round.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PromotionDecision {
+    /// **Selected to MEASURE, not predicted admissible.**
+    ///
+    /// The candidate earned the next authority run because the evidence
+    /// distinguishes it — never because the unresolved dimensions are
+    /// assumed benign. `Uninformed` readiness is ELIGIBLE here by
+    /// design: authority is the mechanism that resolves dimensions the
+    /// diagnostic scale cannot see, so refusing to measure them would
+    /// silently rewrite the doctrine into "diagnostic must predict every
+    /// authority dimension before authority may run", which at 256
+    /// positions is impossible for the mass tails.
+    ///
+    /// ```text
+    /// Uninformed  !=  safe
+    /// Uninformed  !=  admissible
+    /// Uninformed  ==  diagnostic evidence cannot speak about every
+    ///                 authority dimension
+    /// ```
+    ///
+    /// The policy, stated once:
+    ///
+    /// ```text
+    /// Uninformed may be selected for authority IFF
+    ///   it is otherwise promotable (its class buys something),
+    ///   the missing dimensions are EXPLICIT (`unresolved`),
+    ///   and no better-evidenced candidate outranks it (the frontier).
+    /// ```
+    ///
+    /// Never `Uninformed => refuse`, and never
+    /// `Uninformed => assume the missing dimensions are free`.
+    SelectForAuthority {
+        candidate: String,
+        evidence: PromotionEvidence,
+    },
+    Ambiguous {
+        candidates: Vec<String>,
+        reason: AmbiguityReason,
+    },
+    None {
+        reason: NoPromotableCandidate,
+    },
+}
+
+/// **Deterministic order for a TABLE, best first.** Identity is the
+/// final tie-break, which is fine here and forbidden in
+/// [`decide_promotion`].
+///
+/// Dominance COUNT is used as an ordinal summary so the table reads
+/// best-first. Sorting on `cmp_rank` alone put the WORST candidate at
+/// the top of the Rung-4 trace — every key tied, so identity decided,
+/// and `e20` sorted before `e26`. A summary is legitimate here precisely
+/// because display is not evidence: this number never reaches
+/// [`decide_promotion`], which compares candidates pairwise.
+pub fn display_order<'a>(
+    candidates: &'a [SearchCandidate],
+    registry: &SearchCalibrationRegistry,
+    policy: &TailSupportPolicy,
+) -> Vec<&'a SearchCandidate> {
+    let dominates = |c: &SearchCandidate| {
+        candidates
+            .iter()
+            .filter(|o| !std::ptr::eq(*o, c) && c.proxy_dominates(o, registry, policy))
+            .count()
+    };
+    let mut out: Vec<&SearchCandidate> = candidates.iter().collect();
+    out.sort_by(|a, b| {
+        b.promotion
+            .assessment
+            .ranking_score
+            .class
+            .tier()
+            .cmp(&a.promotion.assessment.ranking_score.class.tier())
+            .then_with(|| dominates(b).cmp(&dominates(a)))
+            .then_with(|| {
+                b.promotion
+                    .assessment
+                    .ranking_score
+                    .gpu_ms_saved
+                    .total_cmp(&a.promotion.assessment.ranking_score.gpu_ms_saved)
+            })
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    out
+}
+
+/// **The staged comparator.** Class, then proxy ordering, then physical
+/// gain, then frugality — and never identity.
+///
+/// Physical gain may separate candidates the proxies called EQUAL. It
+/// may not overrule a proxy CONFLICT: that is refused, because trading
+/// kl places against routing places is a claim no calibration supports.
+pub fn decide_promotion(
+    candidates: &[SearchCandidate],
+    registry: &SearchCalibrationRegistry,
+    policy: &TailSupportPolicy,
+) -> PromotionDecision {
+    if candidates.is_empty() {
+        return PromotionDecision::None {
+            reason: NoPromotableCandidate::EmptySet,
+        };
+    }
+    // 1. Promotion class.
+    let best_tier = candidates
+        .iter()
+        .map(|c| c.promotion.assessment.ranking_score.class.tier())
+        .max()
+        .unwrap_or(0);
+    if best_tier == 0 {
+        return PromotionDecision::None {
+            reason: NoPromotableCandidate::EveryMoveWorthless,
+        };
+    }
+    let pool: Vec<&SearchCandidate> = candidates
+        .iter()
+        .filter(|c| c.promotion.assessment.ranking_score.class.tier() == best_tier)
+        .collect();
+
+    // 2. Proxy ordering: the non-dominated frontier.
+    let frontier: Vec<&SearchCandidate> = pool
+        .iter()
+        .filter(|c| {
+            !pool
+                .iter()
+                .any(|o| !std::ptr::eq(*o, **c) && o.proxy_dominates(c, registry, policy))
+        })
+        .copied()
+        .collect();
+
+    if frontier.len() == 1 {
+        let winner = frontier[0];
+        let mut dominated: Vec<String> = pool
+            .iter()
+            .filter(|o| !std::ptr::eq(**o, winner) && winner.proxy_dominates(o, registry, policy))
+            .map(|o| o.id.clone())
+            .collect();
+        // The RECORD is sorted too. The decision was already invariant,
+        // but a trace that differs between runs of the same round is not
+        // reproducible, and identity is allowed to order a record.
+        dominated.sort();
+        let deciding = pool
+            .iter()
+            .find(|o| !std::ptr::eq(**o, winner))
+            .map(|o| winner.comparable(o, registry, policy))
+            .unwrap_or_default();
+        return PromotionDecision::SelectForAuthority {
+            candidate: winner.id.clone(),
+            evidence: PromotionEvidence {
+                dominated,
+                deciding,
+                readiness: winner.promotion.readiness(),
+                decided_by_physical_gain: false,
+                unresolved: winner.unresolved_dimensions(),
+            },
+        };
+    }
+
+    // The frontier did not settle it. WHY decides what happens next.
+    let mut any_comparable = false;
+    let mut any_difference = false;
+    for (i, a) in frontier.iter().enumerate() {
+        for b in frontier.iter().skip(i + 1) {
+            let shared = a.comparable(b, registry, policy);
+            if !shared.is_empty() {
+                any_comparable = true;
+            }
+            if shared
+                .iter()
+                .any(|s| a.order_on(b, *s) != Some(Ordering::Equal))
+            {
+                any_difference = true;
+            }
+        }
+    }
+    let ids = |v: &[&SearchCandidate]| {
+        let mut o: Vec<String> = v.iter().map(|c| c.id.clone()).collect();
+        o.sort();
+        o
+    };
+    if !any_comparable {
+        // Silence, not equality. Refuse.
+        return PromotionDecision::Ambiguous {
+            candidates: ids(&frontier),
+            reason: AmbiguityReason::NoOrderingEvidence,
+        };
+    }
+    if any_difference {
+        // The proxies point different ways. Do NOT scalarise.
+        return PromotionDecision::Ambiguous {
+            candidates: ids(&frontier),
+            reason: AmbiguityReason::ConflictingOrderingProxies,
+        };
+    }
+
+    // 3./4. The proxies AGREE these are equal. Physical evidence may
+    // separate them; identity may not.
+    let best_gain = frontier
+        .iter()
+        .map(|c| c.promotion.assessment.ranking_score.gpu_ms_saved)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let by_gain: Vec<&SearchCandidate> = frontier
+        .iter()
+        .filter(|c| c.promotion.assessment.ranking_score.gpu_ms_saved == best_gain)
+        .copied()
+        .collect();
+    if by_gain.len() == 1 {
+        return PromotionDecision::SelectForAuthority {
+            candidate: by_gain[0].id.clone(),
+            evidence: PromotionEvidence {
+                dominated: Vec::new(),
+                deciding: Vec::new(),
+                readiness: by_gain[0].promotion.readiness(),
+                decided_by_physical_gain: true,
+                unresolved: by_gain[0].unresolved_dimensions(),
+            },
+        };
+    }
+    PromotionDecision::Ambiguous {
+        candidates: ids(&by_gain),
+        reason: AmbiguityReason::IndistinguishableOnEveryProxy,
+    }
+}
+
+#[cfg(test)]
+#[path = "decision_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/decision_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/decision_tests.rs
@@ -1,0 +1,273 @@
+//! R4-F1. The permutation control is the one that would have caught the
+//! original defect; the rest pin the doctrine it exposed.
+
+use super::super::assessment::{CandidateAssessment, EvidenceContext};
+use super::super::byte_ledger::{ByteLedger, ScopeBytes};
+use super::super::constraint::ConstraintVector;
+use super::super::diagnostic::{DiagnosticPolicy, DiagnosticVector};
+use super::super::execution_cost::{m3max_metal_001, ExecutionCostModel};
+use super::super::measurement::EvidenceScale;
+use super::super::promotion::PromotionCandidate;
+use super::super::quality::{kimi_logit_balanced_v1, QualityBank};
+use super::*;
+
+const BASE: u64 = 13_480_000_000;
+
+fn bank(kl: f64, flips: u64) -> QualityBank {
+    let mut b = super::super::diagnostic::tests::guard_256();
+    b.logits.kl_p99 = kl;
+    b.routing.route_flips = flips;
+    b
+}
+
+fn ledger(name: &str, bytes: u64) -> ByteLedger {
+    ByteLedger {
+        model: "Kimi-Linear-48B-A3B-Instruct".into(),
+        baseline_representation: "Q8_0".into(),
+        candidate_representation: name.into(),
+        scopes: vec![ScopeBytes {
+            scope: "experts".into(),
+            family: "routed experts".into(),
+            baseline_bytes: BASE,
+            candidate_bytes: bytes,
+        }],
+    }
+}
+
+/// A candidate whose diagnostic bank says `kl`/`flips`, removing `bytes`.
+fn candidate(id: &str, kl: f64, flips: u64, bytes: u64) -> SearchCandidate {
+    let b = bank(kl, flips);
+    let gate = kimi_logit_balanced_v1();
+    let parent = bank(2.4762e-3, 46);
+    let a = CandidateAssessment::of(
+        &EvidenceContext::route_cal_1(EvidenceScale::Diagnostic),
+        &ExecutionCostModel::new(vec![m3max_metal_001()]),
+        &ledger("parent", BASE),
+        &ledger(id, bytes),
+        ConstraintVector::of(&gate, &parent),
+        ConstraintVector::of(&gate, &b),
+    )
+    .expect("same model");
+    SearchCandidate {
+        id: id.into(),
+        promotion: PromotionCandidate::new(a, vec![]),
+        diagnostic: DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &b),
+    }
+}
+
+fn reg() -> SearchCalibrationRegistry {
+    SearchCalibrationRegistry::route_cal_1()
+}
+fn pol() -> TailSupportPolicy {
+    TailSupportPolicy::route_cal_1()
+}
+
+/// The four real Rung-4 candidates, by their measured diagnostics.
+fn rung4_set() -> Vec<SearchCandidate> {
+    vec![
+        candidate("e26", 2.6551e-3, 46, 13_040_000_000),
+        candidate("e24", 2.9993e-3, 51, 13_040_000_000),
+        candidate("e23", 3.6266e-3, 58, 13_040_000_000),
+        candidate("e20", 5.0994e-3, 71, 13_040_000_000),
+    ]
+}
+
+/// **THE control.** The original defect printed `PROMOTE: e26` for one
+/// input order and `PROMOTE: e20` for the reverse, from identical
+/// reports, because every `rank_key` tied and a stable sort returned
+/// input order. A decision must not depend on call order.
+#[test]
+fn the_promotion_decision_is_invariant_under_input_permutation() {
+    let (r, p) = (reg(), pol());
+    let forward = rung4_set();
+    let mut reversed = rung4_set();
+    reversed.reverse();
+
+    let a = decide_promotion(&forward, &r, &p);
+    let b = decide_promotion(&reversed, &r, &p);
+    assert_eq!(a, b, "the decision changed when only the ORDER changed");
+
+    match a {
+        PromotionDecision::SelectForAuthority { candidate, .. } => assert_eq!(candidate, "e26"),
+        other => panic!("expected a promotion, got {other:?}"),
+    }
+}
+
+/// The pre-registered ordering, recovered from the evidence rather than
+/// from the order the candidates were supplied in.
+#[test]
+fn the_measured_rung4_set_recovers_the_pre_registered_order() {
+    let (r, p) = (reg(), pol());
+    let c = rung4_set();
+    // e26 < e24 < e23 < e20, by dominance and transitively.
+    for (better, worse) in [(0, 1), (1, 2), (2, 3), (0, 3)] {
+        assert!(
+            c[better].proxy_dominates(&c[worse], &r, &p),
+            "{} should dominate {}",
+            c[better].id,
+            c[worse].id
+        );
+        assert!(
+            !c[worse].proxy_dominates(&c[better], &r, &p),
+            "dominance must not be symmetric"
+        );
+    }
+}
+
+/// A conflict is REFUSED, not scalarised: there is no basis for trading
+/// kl places against routing places.
+#[test]
+fn conflicting_proxies_are_refused_rather_than_traded_off() {
+    let (r, p) = (reg(), pol());
+    // a: best kl, worst flips. b: worse kl, best flips.
+    let set = vec![
+        candidate("a", 2.0e-3, 80, 13_040_000_000),
+        candidate("b", 4.0e-3, 40, 13_040_000_000),
+    ];
+    assert!(!set[0].proxy_dominates(&set[1], &r, &p));
+    assert!(!set[1].proxy_dominates(&set[0], &r, &p));
+    match decide_promotion(&set, &r, &p) {
+        PromotionDecision::Ambiguous {
+            candidates, reason, ..
+        } => {
+            assert_eq!(candidates, vec!["a".to_string(), "b".to_string()]);
+            assert_eq!(reason, AmbiguityReason::ConflictingOrderingProxies);
+        }
+        other => panic!("a conflict must not resolve: {other:?}"),
+    }
+}
+
+/// Proxies that AGREE the candidates are equal leave physical gain free
+/// to separate them — a legitimate later stage, and recorded as such.
+#[test]
+fn physical_gain_may_separate_what_the_proxies_call_equal() {
+    let (r, p) = (reg(), pol());
+    let set = vec![
+        candidate("small", 3.0e-3, 50, 13_400_000_000),
+        candidate("big", 3.0e-3, 50, 12_000_000_000),
+    ];
+    match decide_promotion(&set, &r, &p) {
+        PromotionDecision::SelectForAuthority {
+            candidate,
+            evidence,
+            ..
+        } => {
+            assert_eq!(candidate, "big", "more bytes removed");
+            assert!(evidence.decided_by_physical_gain);
+        }
+        other => panic!("expected gain to decide: {other:?}"),
+    }
+}
+
+/// Identical on evidence AND on gain: refuse. Identity must not promote.
+#[test]
+fn indistinguishable_candidates_are_refused_not_ordered_by_identity() {
+    let (r, p) = (reg(), pol());
+    let set = vec![
+        candidate("aaa", 3.0e-3, 50, 13_040_000_000),
+        candidate("zzz", 3.0e-3, 50, 13_040_000_000),
+    ];
+    match decide_promotion(&set, &r, &p) {
+        PromotionDecision::Ambiguous {
+            candidates, reason, ..
+        } => {
+            assert_eq!(candidates, vec!["aaa".to_string(), "zzz".to_string()]);
+            assert_eq!(reason, AmbiguityReason::IndistinguishableOnEveryProxy);
+        }
+        other => panic!("identity must not promote: {other:?}"),
+    }
+    // ...while DISPLAY may order them deterministically, by identity.
+    let shown: Vec<&str> = display_order(&set, &r, &p)
+        .iter()
+        .map(|c| c.id.as_str())
+        .collect();
+    let mut rev = set.clone();
+    rev.reverse();
+    let shown_rev: Vec<&str> = display_order(&rev, &r, &p)
+        .iter()
+        .map(|c| c.id.as_str())
+        .collect();
+    assert_eq!(shown, shown_rev, "display order is deterministic");
+    assert_eq!(shown, vec!["aaa", "zzz"]);
+}
+
+#[test]
+fn an_empty_round_promotes_nothing() {
+    match decide_promotion(&[], &reg(), &pol()) {
+        PromotionDecision::None { reason } => assert_eq!(reason, NoPromotableCandidate::EmptySet),
+        other => panic!("{other:?}"),
+    }
+}
+
+/// The table reads BEST FIRST. Sorting on `cmp_rank` alone put `e20` —
+/// the worst candidate — at the top, because every key tied and identity
+/// decided.
+#[test]
+fn the_display_table_reads_best_first_and_is_deterministic() {
+    let (r, p) = (reg(), pol());
+    let set = rung4_set();
+    let ids = |v: &[SearchCandidate]| -> Vec<String> {
+        display_order(v, &r, &p)
+            .iter()
+            .map(|c| c.id.clone())
+            .collect()
+    };
+    let mut rev = set.clone();
+    rev.reverse();
+    assert_eq!(ids(&set), vec!["e26", "e24", "e23", "e20"]);
+    assert_eq!(
+        ids(&set),
+        ids(&rev),
+        "display order is permutation-invariant too"
+    );
+}
+
+/// **`Uninformed` is eligible for authority, and says what it cannot
+/// see.** Gating it out would silently rewrite the doctrine into
+/// "diagnostic must predict every authority dimension before authority
+/// may run", which at 256 positions is impossible for the mass tails —
+/// and authority is the mechanism that resolves them.
+///
+/// Selection is not prediction: the decision must NAME the dimensions it
+/// could not speak to, or a trace reads as confidence.
+#[test]
+fn uninformed_may_be_selected_for_authority_and_names_what_it_cannot_see() {
+    let (r, p) = (reg(), pol());
+    let set = rung4_set();
+    let winner = &set[0];
+    assert_eq!(
+        winner.promotion.readiness(),
+        PromotionReadiness::Uninformed,
+        "the real Rung-4 set is Uninformed — nothing speaks to the mass tails"
+    );
+
+    match decide_promotion(&set, &r, &p) {
+        PromotionDecision::SelectForAuthority {
+            candidate,
+            evidence,
+            ..
+        } => {
+            assert_eq!(candidate, "e26");
+            assert_eq!(evidence.readiness, PromotionReadiness::Uninformed);
+            assert!(
+                !evidence.unresolved.is_empty(),
+                "an Uninformed selection MUST name the dimensions it cannot see"
+            );
+            // Exactly the criteria the diagnostic scale is silent on.
+            assert!(evidence
+                .unresolved
+                .contains(&Statistic::Top10MassDisplacedP99));
+            assert!(evidence
+                .unresolved
+                .contains(&Statistic::RouteMixtureMassP99));
+            // ...and never the ones that DID decide it.
+            for s in &evidence.deciding {
+                assert!(
+                    !evidence.unresolved.contains(s),
+                    "{s} both decided and is unresolved"
+                );
+            }
+        }
+        other => panic!("Uninformed must be eligible to measure: {other:?}"),
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -52,6 +52,7 @@ pub mod byte_ledger;
 pub mod compile;
 pub mod compiler;
 pub mod constraint;
+pub mod decision;
 pub mod diagnostic;
 pub mod execution_cost;
 pub mod experiment;
@@ -70,6 +71,7 @@ pub mod quality;
 pub mod search_evidence;
 pub mod selection;
 pub mod source_bank;
+pub mod statistic;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{Read, Seek, SeekFrom};

--- a/crates/larql-vindex/src/format/vindex3/represent/quality.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/quality.rs
@@ -30,8 +30,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::measurement::TailSupport;
-
 /// Acceptance criteria, identified so a claim can name what it passed.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QualityGate {
@@ -184,6 +182,8 @@ impl Distribution {
     }
 }
 
+pub use super::statistic::{Better, Statistic};
+
 /// One bank of measurements over a fixed token sequence.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QualityBank {
@@ -267,119 +267,6 @@ pub enum Criterion {
     /// gets `None` must fail rather than assume the truncation was
     /// wide enough.
     CoveredMass,
-}
-
-/// The exact quantity a [`super::constraint::Margin`] reports — the JOIN
-/// KEY between a constraint vector, the calibration registry, and a
-/// candidate's proxy observations.
-///
-/// **Finer than [`Criterion`] on purpose.** `RouteDisplacement` carries
-/// both a p99 and a max limit and they bind independently: at 256
-/// positions the p99 is a maximum wearing a percentile's name while the
-/// max is exactly what it says, so keying evidence on the criterion
-/// would hand the thin percentile the max's confidence.
-///
-/// **An enum and not a string, on purpose.** BS2-F2: the registry keyed
-/// `"route flip rate"` while the vector emitted `"route flips"`. The
-/// lookup missed, `SearchCalibrationRegistry::evidence_for` fell through
-/// to its `is_priceable()` arm, and a COUNT — always `Measured` —
-/// returned `Direct`. That silently PRICED the one statistic ROUTE-CAL-1
-/// calibrated as ordering-only, which is the failure the whole evidence
-/// ladder exists to prevent. Two of the three keys matched, so the
-/// mechanism looked like it worked. A typed key cannot drift.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Statistic {
-    KlP99,
-    Top1Flips,
-    Top10Changes,
-    RouteFlips,
-    /// Route flips per POSITION — what ROUTE-CAL-1 actually measured
-    /// transferring across scale (0.89-1.02 for every map with >= 40
-    /// diagnostic events), and a different quantity from the raw
-    /// [`Self::RouteFlips`] count a contract might one day bound.
-    /// Diagnostic-only: no gate reads it, by design (BS2-F1).
-    RouteFlipRate,
-    Top1MassDisplaced,
-    Top10MassDisplacedP99,
-    RouteMixtureMassP99,
-    RouteMixtureMassMax,
-    Positions,
-    CoveredMass,
-}
-
-impl Statistic {
-    /// The human label, for traces. Not a key — nothing joins on this.
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::KlP99 => "kl p99",
-            Self::Top1Flips => "top-1 flips",
-            Self::Top10Changes => "top-10 changes",
-            Self::RouteFlips => "route flips",
-            Self::RouteFlipRate => "route flips per position",
-            Self::Top1MassDisplaced => "top-1 probability given up",
-            Self::Top10MassDisplacedP99 => "top-10 mass displaced at p99",
-            Self::RouteMixtureMassP99 => "routed mixture moved at p99",
-            Self::RouteMixtureMassMax => "routed mixture moved at max",
-            Self::Positions => "positions",
-            Self::CoveredMass => "covered mass at the worst position",
-        }
-    }
-}
-
-impl Statistic {
-    /// Read this statistic off a bank: its value, and the observations
-    /// behind its tail if it is a percentile.
-    ///
-    /// **The single mapping from a statistic to the bank.** Authority
-    /// margins and diagnostic readings are built by different code for
-    /// different purposes, but they must not DISAGREE about what a
-    /// number is — BS2-F2 was two vocabularies drifting apart, and two
-    /// bank extractions would drift the same way.
-    pub fn observe(self, bank: &QualityBank) -> (Option<f64>, Option<TailSupport>) {
-        let p99 = |observations: u64| {
-            Some(TailSupport {
-                quantile: 0.99,
-                observations,
-            })
-        };
-        match self {
-            // Dense: every position contributes a value.
-            Self::KlP99 => (Some(bank.logits.kl_p99), p99(bank.positions)),
-            Self::Top1Flips => (Some(bank.logits.top1_flips as f64), None),
-            Self::Top10Changes => (Some(bank.logits.top10_changes as f64), None),
-            Self::RouteFlips => (Some(bank.routing.route_flips as f64), None),
-            // A rate over ALL positions is dense, so it has no thin tail
-            // — which is exactly why it survives a small bank.
-            Self::RouteFlipRate => (
-                (bank.positions > 0)
-                    .then(|| bank.routing.route_flips as f64 / bank.positions as f64),
-                None,
-            ),
-            Self::Top1MassDisplaced => (bank.top1_mass_displaced.map(|d| d.max), None),
-            Self::Top10MassDisplacedP99 => (
-                bank.top10_mass_displaced.map(|d| d.p99),
-                bank.top10_mass_displaced.map(|d| d.count).and_then(p99),
-            ),
-            Self::RouteMixtureMassP99 => (
-                bank.routing.route_weight_mass_moved.map(|d| d.p99),
-                bank.routing
-                    .route_weight_mass_moved
-                    .map(|d| d.count)
-                    .and_then(p99),
-            ),
-            Self::RouteMixtureMassMax => {
-                (bank.routing.route_weight_mass_moved.map(|d| d.max), None)
-            }
-            Self::Positions => (Some(bank.positions as f64), None),
-            Self::CoveredMass => (bank.min_covered_mass, None),
-        }
-    }
-}
-
-impl std::fmt::Display for Statistic {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.label())
-    }
 }
 
 impl Criterion {

--- a/crates/larql-vindex/src/format/vindex3/represent/statistic.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/statistic.rs
@@ -1,0 +1,182 @@
+//! The statistic vocabulary — the join key between a constraint vector,
+//! the calibration registry, and a candidate's proxy observations.
+//!
+//! Lives apart from [`super::quality`] because that module owns the
+//! CONTRACT (gates, criteria, verdicts) while this owns what a bank
+//! REPORTS, and because BS2-F1 gave the diagnostic side statistics the
+//! contract never bounds.
+
+use serde::{Deserialize, Serialize};
+
+use super::measurement::TailSupport;
+use super::quality::QualityBank;
+
+/// The exact quantity a [`super::constraint::Margin`] reports — the JOIN
+/// KEY between a constraint vector, the calibration registry, and a
+/// candidate's proxy observations.
+///
+/// **Finer than [`Criterion`] on purpose.** `RouteDisplacement` carries
+/// both a p99 and a max limit and they bind independently: at 256
+/// positions the p99 is a maximum wearing a percentile's name while the
+/// max is exactly what it says, so keying evidence on the criterion
+/// would hand the thin percentile the max's confidence.
+///
+/// **An enum and not a string, on purpose.** BS2-F2: the registry keyed
+/// `"route flip rate"` while the vector emitted `"route flips"`. The
+/// lookup missed, `SearchCalibrationRegistry::evidence_for` fell through
+/// to its `is_priceable()` arm, and a COUNT — always `Measured` —
+/// returned `Direct`. That silently PRICED the one statistic ROUTE-CAL-1
+/// calibrated as ordering-only, which is the failure the whole evidence
+/// ladder exists to prevent. Two of the three keys matched, so the
+/// mechanism looked like it worked. A typed key cannot drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Statistic {
+    KlP99,
+    Top1Flips,
+    Top10Changes,
+    RouteFlips,
+    /// Route flips per POSITION — what ROUTE-CAL-1 actually measured
+    /// transferring across scale (0.89-1.02 for every map with >= 40
+    /// diagnostic events), and a different quantity from the raw
+    /// [`Self::RouteFlips`] count a contract might one day bound.
+    /// Diagnostic-only: no gate reads it, by design (BS2-F1).
+    RouteFlipRate,
+    Top1MassDisplaced,
+    Top10MassDisplacedP99,
+    RouteMixtureMassP99,
+    RouteMixtureMassMax,
+    Positions,
+    CoveredMass,
+}
+
+impl Statistic {
+    /// The human label, for traces. Not a key — nothing joins on this.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::KlP99 => "kl p99",
+            Self::Top1Flips => "top-1 flips",
+            Self::Top10Changes => "top-10 changes",
+            Self::RouteFlips => "route flips",
+            Self::RouteFlipRate => "route flips per position",
+            Self::Top1MassDisplaced => "top-1 probability given up",
+            Self::Top10MassDisplacedP99 => "top-10 mass displaced at p99",
+            Self::RouteMixtureMassP99 => "routed mixture moved at p99",
+            Self::RouteMixtureMassMax => "routed mixture moved at max",
+            Self::Positions => "positions",
+            Self::CoveredMass => "covered mass at the worst position",
+        }
+    }
+}
+
+impl Statistic {
+    /// Read this statistic off a bank: its value, and the observations
+    /// behind its tail if it is a percentile.
+    ///
+    /// **The single mapping from a statistic to the bank.** Authority
+    /// margins and diagnostic readings are built by different code for
+    /// different purposes, but they must not DISAGREE about what a
+    /// number is — BS2-F2 was two vocabularies drifting apart, and two
+    /// bank extractions would drift the same way.
+    pub fn observe(self, bank: &QualityBank) -> (Option<f64>, Option<TailSupport>) {
+        let p99 = |observations: u64| {
+            Some(TailSupport {
+                quantile: 0.99,
+                observations,
+            })
+        };
+        match self {
+            // Dense: every position contributes a value.
+            Self::KlP99 => (Some(bank.logits.kl_p99), p99(bank.positions)),
+            Self::Top1Flips => (Some(bank.logits.top1_flips as f64), None),
+            Self::Top10Changes => (Some(bank.logits.top10_changes as f64), None),
+            Self::RouteFlips => (Some(bank.routing.route_flips as f64), None),
+            // A rate over ALL positions is dense, so it has no thin tail
+            // — which is exactly why it survives a small bank.
+            Self::RouteFlipRate => (
+                (bank.positions > 0)
+                    .then(|| bank.routing.route_flips as f64 / bank.positions as f64),
+                None,
+            ),
+            Self::Top1MassDisplaced => (bank.top1_mass_displaced.map(|d| d.max), None),
+            Self::Top10MassDisplacedP99 => (
+                bank.top10_mass_displaced.map(|d| d.p99),
+                bank.top10_mass_displaced.map(|d| d.count).and_then(p99),
+            ),
+            Self::RouteMixtureMassP99 => (
+                bank.routing.route_weight_mass_moved.map(|d| d.p99),
+                bank.routing
+                    .route_weight_mass_moved
+                    .map(|d| d.count)
+                    .and_then(p99),
+            ),
+            Self::RouteMixtureMassMax => {
+                (bank.routing.route_weight_mass_moved.map(|d| d.max), None)
+            }
+            Self::Positions => (Some(bank.positions as f64), None),
+            Self::CoveredMass => (bank.min_covered_mass, None),
+        }
+    }
+}
+
+impl std::fmt::Display for Statistic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Which way is BETTER for a statistic.
+///
+/// **One canonical derivation.** An ordinal comparison needs to know
+/// which end is good, and deriving that from a gate's [`LimitKind`]
+/// would work only for statistics a contract happens to bound —
+/// `RouteFlipRate` is bounded by nothing and still has an unambiguous
+/// direction. Two places deciding this would drift, which is the
+/// failure BS2-F2 and BS2-F1b both were.
+///
+/// [`LimitKind`]: super::constraint::LimitKind
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Better {
+    /// A cost: less movement is better.
+    Lower,
+    /// A sufficiency: more is better.
+    Higher,
+}
+
+impl Statistic {
+    /// Which direction is better for this statistic.
+    pub fn better(self) -> Better {
+        match self {
+            // Every consequence magnitude and every change count is a
+            // cost — the candidate moved the model, and less is less.
+            Self::KlP99
+            | Self::Top1Flips
+            | Self::Top10Changes
+            | Self::RouteFlips
+            | Self::RouteFlipRate
+            | Self::Top1MassDisplaced
+            | Self::Top10MassDisplacedP99
+            | Self::RouteMixtureMassP99
+            | Self::RouteMixtureMassMax => Better::Lower,
+            // Sufficiency conditions on the MEASUREMENT, not costs the
+            // candidate pays: more positions and wider coverage are
+            // strictly more evidence.
+            Self::Positions | Self::CoveredMass => Better::Higher,
+        }
+    }
+
+    /// Order `self`'s value against `other`'s, in BETTER-FIRST terms:
+    /// `Less` means `a` is the better of the two.
+    ///
+    /// Ordinal only. It reports WHICH is better and never by how much —
+    /// see [`super::search_evidence::SearchEvidence::OrderingProxy`].
+    pub fn order(self, a: f64, b: f64) -> std::cmp::Ordering {
+        match self.better() {
+            Better::Lower => a.total_cmp(&b),
+            Better::Higher => b.total_cmp(&a),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "statistic_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/statistic_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/statistic_tests.rs
@@ -1,0 +1,137 @@
+//! Exhaustive over the vocabulary: every statistic reads off a bank,
+//! names itself, and knows which way is better. A closed vocabulary
+//! deserves a closed test — a wildcard arm here would let a new variant
+//! ship with no direction and no reader.
+
+use super::super::diagnostic::tests::guard_256;
+use super::super::quality::Distribution;
+use super::*;
+
+/// Every variant, written out. Adding one to the enum without adding it
+/// here fails the count assertion below rather than passing silently.
+const ALL: [Statistic; 11] = [
+    Statistic::KlP99,
+    Statistic::Top1Flips,
+    Statistic::Top10Changes,
+    Statistic::RouteFlips,
+    Statistic::RouteFlipRate,
+    Statistic::Top1MassDisplaced,
+    Statistic::Top10MassDisplacedP99,
+    Statistic::RouteMixtureMassP99,
+    Statistic::RouteMixtureMassMax,
+    Statistic::Positions,
+    Statistic::CoveredMass,
+];
+
+fn dist(p99: f64, max: f64, count: u64) -> Distribution {
+    Distribution {
+        count,
+        min: 0.0,
+        p50: 0.0,
+        p95: 0.0,
+        p99,
+        max,
+    }
+}
+
+/// A bank with every optional field POPULATED, so no `observe` arm can
+/// pass by returning `None`.
+fn full_bank() -> QualityBank {
+    let mut b = guard_256();
+    b.top1_mass_displaced = Some(dist(0.004, 0.0053, 2));
+    b.top10_mass_displaced = Some(dist(0.0789, 0.0789, 74));
+    b.routing.route_weight_mass_moved = Some(dist(0.1028, 0.1028, 46));
+    b
+}
+
+#[test]
+fn every_statistic_reads_a_value_off_a_populated_bank() {
+    let b = full_bank();
+    for s in ALL {
+        let (v, _) = s.observe(&b);
+        assert!(v.is_some(), "{s} read nothing off a fully populated bank");
+    }
+    assert_eq!(ALL.len(), 11, "a new Statistic must be added to ALL");
+}
+
+#[test]
+fn only_percentiles_carry_tail_support() {
+    let b = full_bank();
+    for s in ALL {
+        let (_, tail) = s.observe(&b);
+        let expected = matches!(
+            s,
+            Statistic::KlP99 | Statistic::Top10MassDisplacedP99 | Statistic::RouteMixtureMassP99
+        );
+        assert_eq!(tail.is_some(), expected, "{s} tail support");
+    }
+}
+
+#[test]
+fn an_unrecorded_optional_reads_none_rather_than_zero() {
+    let mut b = full_bank();
+    b.top1_mass_displaced = None;
+    b.top10_mass_displaced = None;
+    b.routing.route_weight_mass_moved = None;
+    b.min_covered_mass = None;
+    for s in [
+        Statistic::Top1MassDisplaced,
+        Statistic::Top10MassDisplacedP99,
+        Statistic::RouteMixtureMassP99,
+        Statistic::RouteMixtureMassMax,
+        Statistic::CoveredMass,
+    ] {
+        assert_eq!(s.observe(&b).0, None, "{s} must be None, never 0.0");
+    }
+}
+
+#[test]
+fn the_rate_is_flips_over_positions_and_refuses_an_empty_bank() {
+    let mut b = full_bank();
+    b.routing.route_flips = 46;
+    b.positions = 256;
+    assert_eq!(
+        Statistic::RouteFlipRate.observe(&b).0,
+        Some(46.0 / 256.0),
+        "the RATE, not the count"
+    );
+    b.positions = 0;
+    assert_eq!(
+        Statistic::RouteFlipRate.observe(&b).0,
+        None,
+        "no positions is not a rate of zero"
+    );
+}
+
+#[test]
+fn costs_are_lower_better_and_sufficiencies_are_higher_better() {
+    for s in ALL {
+        let expected = match s {
+            Statistic::Positions | Statistic::CoveredMass => Better::Higher,
+            _ => Better::Lower,
+        };
+        assert_eq!(s.better(), expected, "{s}");
+    }
+}
+
+#[test]
+fn order_reports_which_is_better_in_both_directions() {
+    use std::cmp::Ordering;
+    // A cost: less movement wins.
+    assert_eq!(Statistic::KlP99.order(1.0, 2.0), Ordering::Less);
+    assert_eq!(Statistic::KlP99.order(2.0, 1.0), Ordering::Greater);
+    assert_eq!(Statistic::KlP99.order(1.0, 1.0), Ordering::Equal);
+    // A sufficiency: more evidence wins.
+    assert_eq!(Statistic::CoveredMass.order(0.8, 0.6), Ordering::Less);
+    assert_eq!(Statistic::CoveredMass.order(0.6, 0.8), Ordering::Greater);
+    assert_eq!(Statistic::Positions.order(8192.0, 256.0), Ordering::Less);
+}
+
+#[test]
+fn every_label_is_distinct_and_display_matches_it() {
+    let labels: std::collections::BTreeSet<&str> = ALL.iter().map(|s| s.label()).collect();
+    assert_eq!(labels.len(), ALL.len(), "labels must identify uniquely");
+    for s in ALL {
+        assert_eq!(s.to_string(), s.label());
+    }
+}


### PR DESCRIPTION
**R4-F1** — found by Rung 4's first real search against the Kimi bank.

## The defect

The driver printed **`PROMOTE: e26`**, matching the pre-registered prediction. Reversing the input list printed **`PROMOTE: e20`**, from identical reports.

All four rank keys were byte-identical:

```text
e26/e24/e23/e20   tier=1  within=0.702202900  frugality=-0.000000000
```

`rank_key() = (class.tier(), within, frugality)`, and `within` falls back to `gpu_ms_saved` for any non-`Priced` class. Every one-step move removed the same bytes ⇒ exact tie ⇒ `cmp_rank` returns `Equal` ⇒ a stable sort returns input order.

At diagnostic scale nothing is priceable **by design**, so this tie is the normal state, not an edge case. Meanwhile both calibrated proxies separated the candidates monotonically and unanimously. **The evidence existed and the comparator could not see it.**

## The invariant

> Determinism may order indistinguishable candidates for **display**; it may never convert indistinguishability into evidence for **promotion**.

`display_order` may use identity as its final tie-break. `decide_promotion` is not given identity at all, so it *cannot* — structural, not a discipline.

## Ordinal, never scalar

An `OrderingProxy` licenses order and not magnitude, so a numeric proxy term in `RankingScore` would smuggle magnitude back in through the comparator.

```text
physical economics   can say how much a move buys
proxy evidence       can say A should be tried before B
neither says         "A is 1.7x better than B"
```

**A proxy-dominates B** iff no worse on every comparable proxy and strictly better on at least one. Comparability requires both candidates to have observed the statistic *and* the registry to say it orders at this scale.

The staged comparator: class → proxy ordering → physical gain → frugality. **Conflicts are refused, not traded off** — no calibration says how many places of kl buy one place of routing, so the frontier returns `Ambiguous{ConflictingOrderingProxies}`. Physical gain may separate candidates the proxies call *equal*, recorded as `decided_by_physical_gain` so a trace never has to guess which stage decided.

## Selection is not prediction

The variant is **`SelectForAuthority`**, not `Promote`, and its evidence names the authority dimensions the diagnostic scale could not speak to. `Uninformed` is **eligible by design** — authority is the mechanism that resolves those dimensions, so gating it out would silently rewrite the doctrine into *"diagnostic must predict every authority dimension before authority may run"*, which at 256 positions is impossible for the mass tails.

```text
Uninformed  !=  safe
Uninformed  !=  admissible
Uninformed  ==  diagnostic evidence cannot speak about every
                authority dimension
```

The policy, stated once: *Uninformed may be selected for authority iff it is otherwise promotable, the missing dimensions are explicit, and no better-evidenced candidate outranks it.* Never `Uninformed => refuse`, and never `Uninformed => assume the missing dimensions are free`.

## Result on the real reports — no new GPU work

```text
SELECT FOR AUTHORITY: e26      (identical from both permutations)
  reason      : uniquely proxy-dominant on all comparable evidence
  dominates   : ["e20", "e23", "e24"]
  deciding    : ["kl p99", "route flips per position"]
  UNRESOLVED  : ["routed mixture moved at max", "routed mixture moved at p99",
                 "top-1 probability given up", "top-10 mass displaced at p99"]
  readiness   : Uninformed
  by gain?    : false

  MEANING: selected to MEASURE, not predicted admissible.
```

`display_order` recovers the pre-registered `e26 < e24 < e23 < e20`.

## Two things the tests caught

The decision was permutation-invariant **before the evidence record was** — `dominated` echoed input order, so the same round produced different traces. And sorting the table on `cmp_rank` alone put the **worst** candidate first, because every key tied and identity decided.

## Also

`Statistic` moves to its own module with a canonical `better()`/`order()` — one derivation of which end is good, since deriving it from a gate's `LimitKind` only works for statistics a contract bounds, and `RouteFlipRate` is bounded by nothing. `quality.rs` also hit 888 lines in #376, over the 800 cap; it is back to 775.

## Verification

`fmt`, `clippy -D warnings`, E0 (10 passed), full suite (3648 passed, 0 failed), `cargo check --workspace --all-targets`. Coverage policy passed — `statistic.rs` 100.00%, `decision.rs` 96.40%; crate 93.49%.
