### PR TITLE
feat(inference): make the VINDEX3 opener policy-aware

### DIFF
--- a/crates/larql-inference/src/vindex3/mod.rs
+++ b/crates/larql-inference/src/vindex3/mod.rs
@@ -53,7 +53,7 @@ pub use generate::{
     continue_session, continue_session_masked, generate_session, LogitsMask, SessionGeneration,
 };
 pub use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
-pub use runtime::{PreparedVindex3, Vindex3Runtime};
+pub use runtime::{open_component, OpenPolicy, OpenedComponent, PreparedVindex3, Vindex3Runtime};
 pub use session::{LogitsSession, Vindex3Session};
 
 pub use explain::{

--- a/crates/larql-inference/src/vindex3/runtime.rs
+++ b/crates/larql-inference/src/vindex3/runtime.rs
@@ -1,4 +1,13 @@
 //! Opening a VINDEX3 container as an inference runtime.
+//!
+//! [`open_component`] is the **one** opening authority in the workspace:
+//! inspect the container, close the component's plan, bind its operands.
+//! `larql serve`, `larql run` and `larql vindex3 exec` all come through
+//! it, so the same container under the same [`OpenPolicy`] means the same
+//! program bound to the same bytes whichever front door was used. What
+//! *executes* that program — CPU, Metal, an interpreter or a lowering —
+//! is not decided here: that is a realisation, chosen by the caller and
+//! handed in as the backend.
 
 use std::path::Path;
 
@@ -6,7 +15,7 @@ use larql_vindex::format::vindex3::inspect::inspect_container;
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
 use larql_vindex::format::vindex3::opplan::exec::kv::KvState;
 use larql_vindex::format::vindex3::opplan::exec::operands::{
-    OperandOverrides, OperandSource, OperandStore,
+    OperandOverrides, OperandSource, OperandStore, RepresentationSource,
 };
 use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
 use larql_vindex::format::vindex3::opplan::exec::{
@@ -18,20 +27,52 @@ use crate::error::InferenceError;
 
 use super::session::Vindex3Session;
 
-/// Inspect the container, plan `component`'s operations, and open the
-/// operand store — solely from the container's own contents. Kept
-/// outside the generic impl so the whole opening path (and its
-/// refusals) is one instantiation regardless of backend.
-/// What opening a component yields: the executable plan, its operand
-/// store, and the two identities the container declares about itself.
-struct OpenedComponent {
-    plan: ComponentOpPlan,
-    store: OperandStore,
-    model_name: String,
-    family: String,
+/// How a component's operands are bound when it is opened.
+///
+/// Two separate questions, deliberately: `want` is *what* encoding
+/// execution asks for — `None` executes the canonical bytes and never
+/// looks for a compiled pack, so adding packs to a container cannot
+/// change what such a caller runs — and `source` is *whether* the runtime
+/// may manufacture that encoding at load or must find it already
+/// compiled. The default is the canonical program, which is what a
+/// server binds.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OpenPolicy {
+    /// The stored encoding to serve from, if one is compiled.
+    pub want: Option<String>,
+    pub source: RepresentationSource,
 }
 
-fn open_component(container: &Path, component: &str) -> Result<OpenedComponent, InferenceError> {
+/// What opening a component yields: the executable plan, its operand
+/// store, the two identities the container declares about itself, and
+/// the encoding the store was asked for.
+pub struct OpenedComponent {
+    pub plan: ComponentOpPlan,
+    pub store: OperandStore,
+    /// The container's self-declared model name (`index.model`) — the
+    /// identity authority. Callers must not fall back to a directory
+    /// name when this is non-empty.
+    pub model_name: String,
+    /// The model family the container declares.
+    pub family: String,
+    /// [`OpenPolicy::want`], carried so a caller can report what it
+    /// asked for beside what the store bound.
+    pub want: Option<String>,
+}
+
+/// Inspect the container, plan `component`'s operations, and open the
+/// operand store under `policy` — solely from the container's own
+/// contents. Kept outside the generic impl so the whole opening path
+/// (and its refusals) is one instantiation regardless of backend.
+///
+/// A component whose stack does not close refuses to open, with every
+/// defect in the error: an unclosed program is never "best-effort"
+/// executed by anyone.
+pub fn open_component(
+    container: &Path,
+    component: &str,
+    policy: OpenPolicy,
+) -> Result<OpenedComponent, InferenceError> {
     let inspection = inspect_container(container, false)?;
     let outcome = plan_component_ops(&inspection, container, component)?;
     if !outcome.closed() {
@@ -40,7 +81,12 @@ fn open_component(container: &Path, component: &str) -> Result<OpenedComponent, 
     let plan = outcome.plan.ok_or_else(|| {
         InferenceError::Parse(format!("component `{component}` produced no plan"))
     })?;
-    let store = OperandStore::open(container, &inspection)?;
+    let store = OperandStore::open_for(
+        container,
+        &inspection,
+        policy.want.as_deref(),
+        policy.source,
+    )?;
     // The container names itself (`index.model`) — identity travels
     // with the artifact, never a sidecar or a directory name — and
     // declares its own family, which is the only authority a V3
@@ -50,6 +96,7 @@ fn open_component(container: &Path, component: &str) -> Result<OpenedComponent, 
         store,
         model_name: inspection.index.model.clone(),
         family: inspection.index.family.clone(),
+        want: policy.want,
     })
 }
 
@@ -87,15 +134,28 @@ pub struct Vindex3Runtime<B: PlanBackend> {
 }
 
 impl<B: PlanBackend> Vindex3Runtime<B> {
-    /// Open `component` from the container, refusing any closure
-    /// defect (see [`unclosed_component`]'s doc).
+    /// Open `component` from the container as its canonical program —
+    /// [`open_with`](Self::open_with) under the default [`OpenPolicy`].
     pub fn open(container: &Path, component: &str, backend: B) -> Result<Self, InferenceError> {
+        Self::open_with(container, component, backend, OpenPolicy::default())
+    }
+
+    /// Open `component` from the container with its operands bound under
+    /// `policy`, refusing any closure defect (see [`unclosed_component`]'s
+    /// doc). The backend is the realisation; the policy is what it runs.
+    pub fn open_with(
+        container: &Path,
+        component: &str,
+        backend: B,
+        policy: OpenPolicy,
+    ) -> Result<Self, InferenceError> {
         let OpenedComponent {
             plan,
             store,
             model_name,
             family,
-        } = open_component(container, component)?;
+            want: _,
+        } = open_component(container, component, policy)?;
         Ok(Self {
             plan,
             store,

--- a/crates/larql-inference/src/vindex3/tests/mod.rs
+++ b/crates/larql-inference/src/vindex3/tests/mod.rs
@@ -16,6 +16,8 @@
 //! known-different input): a diverged prompt stream must produce
 //! diverged logits, or bit-equality above proves nothing.
 
+mod opener;
+
 use std::path::Path;
 
 use larql_vindex::format::vindex3::fixtures::{

--- a/crates/larql-inference/src/vindex3/tests/opener.rs
+++ b/crates/larql-inference/src/vindex3/tests/opener.rs
@@ -1,0 +1,172 @@
+//! Step-0 gates on the opener: one opening authority with a policy
+//! axis. Default preservation (the canonical program, exactly as the
+//! store opens it), policy parity (the stored NVFP4 pack, exactly as
+//! `larql vindex3 exec --representation-source stored` binds it), the
+//! stored-only refusal, and the container's declared identity.
+
+use std::path::PathBuf;
+
+use larql_vindex::format::filenames::INDEX_JSON;
+use larql_vindex::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
+use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
+use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
+use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use larql_vindex::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4;
+use larql_vindex::format::vindex3::represent::{compile_representation, RepresentSpec};
+
+use super::super::{open_component, OpenPolicy, Vindex3Runtime};
+use super::{container_with, COMPONENT};
+
+/// Artifact name the compiled pair encodes under — deliberately unlike
+/// any directory name, so identity tests cannot pass by coincidence.
+const ARTIFACT: &str = "opener-fixture";
+
+/// The dense fixture encoded, then compiled into a second container that
+/// carries an NVFP4 pack — the exec verb's `--representation-source
+/// stored` subject.
+fn compiled_pair(tmp: &tempfile::TempDir) -> (PathBuf, PathBuf) {
+    let checkpoint = tmp.path().join("ckpt");
+    std::fs::create_dir_all(&checkpoint).unwrap();
+    let src = tmp.path().join("src.vindex3");
+    let out = tmp.path().join("nvfp4.vindex3");
+    encode_fixture_container(dense_f32_model, &checkpoint, &src, ARTIFACT);
+    compile_representation(&src, &out, &RepresentSpec::nvfp4())
+        .expect("the dense fixture is 16-aligned throughout");
+    (src, out)
+}
+
+/// What the exec verb asks for under `--representation-source stored`.
+fn stored_nvfp4() -> OpenPolicy {
+    OpenPolicy {
+        want: Some(DTYPE_NVFP4.to_string()),
+        source: RepresentationSource::Stored,
+    }
+}
+
+#[test]
+fn the_default_policy_binds_the_canonical_program_the_store_opens() {
+    let container = container_with(dense_f32_model);
+    let opened = open_component(container.path(), COMPONENT, OpenPolicy::default()).unwrap();
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let canonical = OperandStore::open(container.path(), &inspection).unwrap();
+    assert_eq!(opened.store.selection(), canonical.selection());
+    assert!(opened.want.is_none());
+    assert!(
+        opened.store.selection().values().all(|s| !s.stored),
+        "the canonical program never binds a pack"
+    );
+}
+
+#[test]
+fn open_is_open_with_under_the_default_policy() {
+    let container = container_with(dense_f32_model);
+    let plain = Vindex3Runtime::open(container.path(), COMPONENT, ReferenceBackend::new()).unwrap();
+    let explicit = Vindex3Runtime::open_with(
+        container.path(),
+        COMPONENT,
+        ReferenceBackend::new(),
+        OpenPolicy::default(),
+    )
+    .unwrap();
+    assert_eq!(plain.plan(), explicit.plan());
+    assert_eq!(plain.model_name(), explicit.model_name());
+    assert_eq!(plain.family(), explicit.family());
+}
+
+#[test]
+fn the_stored_policy_binds_the_compiled_pack_the_exec_verb_binds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_src, out) = compiled_pair(&tmp);
+    let opened = open_component(&out, COMPONENT, stored_nvfp4()).unwrap();
+    // The exec verb's own recipe on the same container.
+    let inspection = inspect_container(&out, false).unwrap();
+    let exec_store = OperandStore::open_for(
+        &out,
+        &inspection,
+        Some(DTYPE_NVFP4),
+        RepresentationSource::Stored,
+    )
+    .unwrap();
+    assert_eq!(opened.store.selection(), exec_store.selection());
+    assert_eq!(opened.want.as_deref(), Some(DTYPE_NVFP4));
+    let from_pack = opened
+        .store
+        .selection()
+        .values()
+        .filter(|s| s.stored)
+        .count();
+    assert!(from_pack > 0, "{:?}", opened.store.selection());
+    // Served entirely from stored bytes: lowering the operands quantises
+    // nothing — the line the exec verb reports as `runtime compile: 0`.
+    PreparedOperands::load(
+        &opened.plan,
+        &opened.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    assert_eq!(opened.store.runtime_quantised(), 0);
+}
+
+#[test]
+fn the_stored_policy_manufactures_nothing_when_the_pack_is_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (src, _out) = compiled_pair(&tmp);
+    // The SOURCE container has no pack. The invariant is about work, not
+    // coverage: the ask is recorded, nothing is bound from a pack, and
+    // lowering the operands quantises nothing — a tensor the policy
+    // cannot serve compiled runs at its stored precision instead.
+    let opened = open_component(&src, COMPONENT, stored_nvfp4()).unwrap();
+    assert_eq!(opened.want.as_deref(), Some(DTYPE_NVFP4));
+    assert!(opened.store.selection().values().all(|s| !s.stored));
+    PreparedOperands::load(
+        &opened.plan,
+        &opened.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .expect("a stored-only policy binds what is there rather than refusing the container");
+    assert_eq!(
+        opened.store.runtime_quantised(),
+        0,
+        "stored-only must never quantise at load"
+    );
+}
+
+#[test]
+fn the_opened_component_carries_the_containers_declared_identity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (src, _out) = compiled_pair(&tmp);
+    let opened = open_component(&src, COMPONENT, OpenPolicy::default()).unwrap();
+    let index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(src.join(INDEX_JSON)).unwrap()).unwrap();
+    assert_eq!(opened.model_name, index["model"].as_str().unwrap());
+    assert_eq!(opened.family, index["family"].as_str().unwrap());
+    assert!(!opened.model_name.is_empty());
+    // Identity travels with the artifact, never with the directory.
+    let directory = src.file_name().unwrap().to_str().unwrap();
+    assert_ne!(opened.model_name, directory);
+}
+
+#[test]
+fn a_container_missing_a_segment_refuses_to_open() {
+    let container = container_with(dense_f32_model);
+    // Inspection reads the index and the graph; only binding the operand
+    // store touches the payload. Remove one segment so the plan closes
+    // and the store cannot open — the refusal must come from the opener,
+    // not from a later step's surprise.
+    let segments = container.path().join("segments");
+    let victim = std::fs::read_dir(&segments)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .find(|p| p.extension().is_some_and(|ext| ext == "bin"))
+        .expect("the encoded fixture has at least one segment");
+    std::fs::remove_file(&victim).unwrap();
+    let err = open_component(container.path(), COMPONENT, OpenPolicy::default())
+        .err()
+        .map(|e| e.to_string())
+        .expect("a container that cannot bind its operands must refuse to open");
+    assert!(!err.is_empty());
+}

--- a/docs/vindex3-runtime.md
+++ b/docs/vindex3-runtime.md
@@ -58,6 +58,16 @@ container.
   contents. A component whose stack does not fully classify into the
   declared operations **refuses to open**, with the closure defects in
   the error: an unclosed program must not be "best-effort" executed.
+- `Vindex3Runtime::open_with(container, component, backend, policy)` — the
+  same opening under an explicit `OpenPolicy { want, source }`: *what*
+  encoding execution asks for (a compiled pack such as NVFP4, or `None`
+  for the canonical bytes) and *whether* the runtime may manufacture it
+  at load. `open` is `open_with` under the default policy. The opener
+  itself is `open_component`, the one opening authority: `larql serve`
+  binds through it today, and `larql run` / `larql vindex3 exec` are
+  being converged onto it so no caller re-implements inspect, plan and
+  store opening. The backend handed in is the realisation, never part
+  of what the container means.
 - `Vindex3Runtime::session()` — an incremental session at position zero.
 - `Vindex3Runtime::session_with_kv(kv)` — a session whose continuation
   state lives in, and outlives the session as, the caller's `KvState`


### PR DESCRIPTION
## What

`larql_inference::vindex3::runtime::open_component` now takes an `OpenPolicy { want, source }` — *what* encoding execution asks for (a compiled pack such as NVFP4, or `None` for the canonical bytes) and *whether* the runtime may manufacture it at load — and returns a public `OpenedComponent { plan, store, model_name, family, want }`. `Vindex3Runtime::open_with` is new; `open` is `open_with` under the default policy, so `larql serve` binds exactly as before.

## Why

Two openers existed: this one (server) and `larql-cli`'s `vindex3_cmd::prepare` (exec, and the new `larql run` arm), which re-implemented inspect → plan → `OperandStore::open_for` with the representation axis on top. This commit gives the runtime opener everything the CLI path needs. It is deliberately **not** yet "one opening authority" — that invariant is achieved by the stacked CLI commit that deletes the duplicate and delegates here (`refactor(cli): use the VINDEX3 runtime opener as the single authority`).

## Gates (`vindex3/tests/opener.rs`, six)

- default policy selects exactly what `OperandStore::open` selects; `want` is `None`
- `open` == `open_with(default)` by plan, model name and family
- stored NVFP4 on a `compile_representation`'d fixture selects exactly what the exec verb's `open_for(NVFP4, Stored)` selects; packs bound; `runtime_quantised() == 0` after `PreparedOperands::load`
- stored-only with the pack **absent** binds stored precision and manufactures nothing — `Stored` promises *no manufacturing*, not "this exact encoding must exist"
- declared identity equals `index.json` `model`/`family` and never the directory name
- a container missing a segment refuses to open

Checks run locally: `cargo fmt --all --check`; `cargo clippy -p larql-inference --lib --tests --benches --no-deps -- -D warnings`; `cargo test -p larql-inference` (1,532 pass); `--no-default-features` check; `cargo clippy -p larql-server --lib --bins --tests --no-deps -- -D warnings` + `cargo test -p larql-server` (575 pass); `cargo check -p larql-cli --bins --tests`; doc link/reference gates. Every line this change touched in `runtime.rs` is covered.

## Docs

`docs/vindex3-runtime.md` gains the `open_with` bullet, worded for what is true at this commit.
