### PR TITLE
feat(cli): larql run <vindex3-container> — the container speaks for itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,9 @@ with the source checkpoint deleted). Whole production models — gpt-oss-20b,
 Gemma 4 26B-A4B, Granite 4.1 3B/8B/30B — encode and execute
 byte-identically to their HF sources, and `larql serve` serves a V3
 container over `/v1/completions` via the V3 runtime (see
-[`docs/vindex3-runtime.md`](docs/vindex3-runtime.md)). VINDEX3 extraction
+[`docs/vindex3-runtime.md`](docs/vindex3-runtime.md)), while
+`larql run <container> [prompt]` executes one from the command line, text
+in and text out, with the tokenizer the container carries. VINDEX3 extraction
 is available on request (`larql extract --generation v3`, LQL
 `EXTRACT ... FORMAT VINDEX3`); the *default* remains VINDEX2 until the M4
 flip — a named decision, made in one place, not yet made (see

--- a/crates/larql-cli/src/commands/primary/mod.rs
+++ b/crates/larql-cli/src/commands/primary/mod.rs
@@ -24,6 +24,7 @@ pub mod rm_cmd;
 pub mod run_cmd;
 pub mod run_cmd_image;
 pub mod run_cmd_speak;
+pub mod run_cmd_vindex3;
 pub mod serve_resolve;
 pub mod shannon_cmd;
 pub mod shannon_trace;

--- a/crates/larql-cli/src/commands/primary/run_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd.rs
@@ -5,9 +5,14 @@
 //! predictions. If no prompt is given, drops into a stdin chat loop — one
 //! line in, one forward pass out, repeat until EOF.
 //!
+//! A VINDEX3 container is routed first, to `run_cmd_vindex3`: it executes
+//! its own program through the VINDEX3 interpreter, with the tokenizer the
+//! container carries, and honours only the flags that apply to it.
+//!
 //! Flag surface:
-//!   <model>         required; vindex directory, `hf://owner/name`, or a
-//!                   cache shorthand (e.g. `gemma-3-4b-it-vindex`).
+//!   <model>         required; vindex directory, VINDEX3 container,
+//!                   `hf://owner/name`, or a cache shorthand
+//!                   (e.g. `gemma-3-4b-it-vindex`).
 //!   [prompt]        optional; enters chat mode if omitted.
 //!   -n, --top N     number of predictions to show (default 10).
 //!   --ffn URL       route FFN to a remote larql-server.
@@ -365,6 +370,14 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
             vindex_path.display()
         )
         .into());
+    }
+
+    // A VINDEX3 container executes its own program through the VINDEX3
+    // interpreter — detect early and route, before any VINDEX2-only
+    // reader is asked to open it. A directory that is not a VINDEX3
+    // container falls through so the dense path surfaces its own error.
+    if super::run_cmd_vindex3::is_vindex3_container(&vindex_path) {
+        return super::run_cmd_vindex3::run(&vindex_path, &args);
     }
 
     if args.experts {
@@ -994,8 +1007,9 @@ fn run_with_moe_shards(
 /// only variable is where the expert bytes came from.
 ///
 /// This is a *composed* run, not a VINDEX3 model. A container holding only
-/// routed banks has no tokenizer and no spine; `larql run <vindex3-dir>` is
-/// still correctly refused. Container completeness is a separate rung.
+/// routed banks has no tokenizer and no spine; `larql run <vindex3-dir>`
+/// on one is refused by `run_cmd_vindex3` (no tokenizer, no system graph),
+/// while a complete container executes there as its own program.
 /// The composed Metal serve arm of [`run_with_routed_container`].
 ///
 /// Split out as two whole definitions rather than a `cfg` block inside the

--- a/crates/larql-cli/src/commands/primary/run_cmd_vindex3/mod.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd_vindex3/mod.rs
@@ -1,0 +1,330 @@
+//! `larql run <container> [prompt]` — a VINDEX3 container executes its
+//! own program, text in and text out.
+//!
+//! The container carries its tokenizer (the capability snapshot puts it
+//! there at encode), so this arm has the exact shape of the BitNet one
+//! beside it in `run_cmd`: load the tokenizer, encode the prompt, decode
+//! greedily, stream the decoded text. Everything between encode and
+//! decode belongs to `vindex3_cmd` — the container is prepared by the
+//! one authority on preparing containers and executed by the same
+//! interpreter `larql vindex3 exec` reports on — so an id produced here
+//! is the id that verb would produce for the same ids in. `--emit-ids`
+//! prints both sides, which makes a run an oracle for it.
+//!
+//! What this arm does *not* do is as deliberate as what it does. No chat
+//! template: the prompt is encoded raw, exactly as the BitNet arm does
+//! (a template is a follow-up on both). No sampler: greedy, so a run
+//! doubles as a fixture. And no flag it cannot honour is accepted
+//! silently — the dense path's engine, composition, expert and image
+//! flags are refused by name rather than dropped.
+//!
+//! Weights are loaded once, at model lifetime; every prompt — the one on
+//! the command line, or each line of the chat loop — gets a brand-new
+//! continuation state over them, so nothing from one turn can reach the
+//! next.
+
+use std::io::{self, BufRead, Write};
+use std::path::Path;
+use std::time::Instant;
+
+use larql_inference::layer_graph::generate::{Detokenizer, EosConfig};
+use larql_vindex::format::filenames::TOKENIZER_JSON;
+use larql_vindex::format::generation::{detect_generation, ContainerGeneration};
+use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+use larql_vindex::format::vindex3::opplan::exec::decode::DecodeSession;
+use larql_vindex::format::vindex3::opplan::exec::kv::RowKvState;
+use larql_vindex::format::vindex3::opplan::exec::operands::RepresentationSource;
+use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
+use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
+use larql_vindex::tokenizers::Tokenizer;
+
+use super::run_cmd::{KvCacheKind, RunArgs};
+use super::vindex3_cmd::decode::{greedy_decode, DecodeReport, Flow};
+use super::vindex3_cmd::prepare::{
+    prepare, with_plan_backend, BackendVisitor, PreparedContainer, DEFAULT_COMPONENT, ENGINE_PREFIX,
+};
+use super::vindex3_cmd::ExecBackend;
+
+#[cfg(test)]
+mod tests;
+
+type BoxErr = Box<dyn std::error::Error>;
+
+/// The argmax alone — `--top`'s default, and the only prediction width
+/// this arm produces.
+const SINGLE_PREDICTION: usize = 1;
+
+/// The chat loop's prompt, written to stderr so stdout stays the model's.
+const CHAT_PROMPT: &str = "> ";
+
+/// Whether `dir` is a VINDEX3 container.
+///
+/// Anything that is not — a VINDEX2 vindex, a checkpoint directory, an
+/// unreadable index — answers `false`, so the dense path, which owns
+/// those errors, is the one to raise them.
+pub(crate) fn is_vindex3_container(dir: &Path) -> bool {
+    matches!(detect_generation(dir), Ok(ContainerGeneration::V3))
+}
+
+/// Serve a VINDEX3 container: one prompt to stdout, or the chat loop.
+pub fn run(container: &Path, args: &RunArgs) -> Result<(), BoxErr> {
+    run_to(
+        container,
+        args,
+        &mut io::stdin().lock(),
+        &mut io::stdout().lock(),
+    )
+}
+
+/// [`run`] with its streams injected — the chat loop reads `input`, and
+/// every generated character goes to `out`.
+pub(super) fn run_to(
+    container: &Path,
+    args: &RunArgs,
+    input: &mut dyn BufRead,
+    out: &mut dyn Write,
+) -> Result<(), BoxErr> {
+    refuse_inapplicable_flags(args)?;
+    let backend = select_backend(args.metal)?;
+    let tokenizer_path = container.join(TOKENIZER_JSON);
+    if !tokenizer_path.is_file() {
+        return Err(format!(
+            "{} carries no {TOKENIZER_JSON}: it was encoded from a checkpoint without one, so \
+             text cannot be tokenised here (`larql vindex3 exec --tokens` runs it from ids)",
+            container.display()
+        )
+        .into());
+    }
+    let tokenizer = Tokenizer::from_file(&tokenizer_path)
+        .map_err(|e| format!("load {}: {e}", tokenizer_path.display()))?;
+    let eos = EosConfig::from_vindex_dir(container);
+    let prepared = prepare(
+        container,
+        DEFAULT_COMPONENT,
+        backend,
+        RepresentationSource::Auto,
+    )?;
+    with_plan_backend(
+        backend,
+        Runner {
+            container,
+            args,
+            prepared: &prepared,
+            tokenizer: &tokenizer,
+            eos: &eos,
+            input,
+            out,
+        },
+    )
+}
+
+/// The dense path's flags this arm cannot honour, refused by name.
+///
+/// The container's own program runs through the VINDEX3 interpreter with
+/// its own continuation state; the engine, composition, expert and image
+/// flags all describe the dense VINDEX2 engine. Refused together, so one
+/// message names every flag that has to go.
+fn refuse_inapplicable_flags(args: &RunArgs) -> Result<(), BoxErr> {
+    let set: Vec<&str> = [
+        ("--top", args.top != SINGLE_PREDICTION),
+        ("--kv-cache", args.kv_cache != KvCacheKind::Standard),
+        ("--engine", args.engine.is_some()),
+        ("--ffn", args.ffn.is_some()),
+        ("--routed-from", args.routed_from.is_some()),
+        ("--experts", args.experts),
+        ("--experts-dir", args.experts_dir.is_some()),
+        ("--ops", !args.ops.is_empty()),
+        ("--constrained", args.constrained),
+        ("--moe-shards", args.moe_shards.is_some()),
+        ("--moe-units-manifest", args.moe_units_manifest.is_some()),
+        ("--image", !args.image.is_empty()),
+        ("--mm-weights", args.mm_weights.is_some()),
+    ]
+    .into_iter()
+    .filter_map(|(flag, given)| given.then_some(flag))
+    .collect();
+    if set.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "a VINDEX3 container runs its own program through the VINDEX3 interpreter; these \
+         flags describe the dense VINDEX2 engine and are not honoured here: {}",
+        set.join(", ")
+    )
+    .into())
+}
+
+/// `--metal` names the Metal realisation; otherwise the `larql-compute`
+/// CPU kernels. Split into two whole definitions rather than a `cfg`
+/// block inside one, for the reason `run_cmd::generate_routed_metal`
+/// documents: the `gpu` feature compiles everywhere, the Metal crate
+/// only on macOS, and Cargo cannot express the conjunction.
+#[cfg(all(feature = "gpu", target_os = "macos"))]
+fn select_backend(metal: bool) -> Result<ExecBackend, BoxErr> {
+    Ok(if metal {
+        ExecBackend::Metal
+    } else {
+        ExecBackend::Production
+    })
+}
+
+#[cfg(not(all(feature = "gpu", target_os = "macos")))]
+fn select_backend(metal: bool) -> Result<ExecBackend, BoxErr> {
+    if metal {
+        return Err("--metal needs the `gpu` feature on macOS; this build has neither".into());
+    }
+    Ok(ExecBackend::Production)
+}
+
+/// The run, once the backend is a concrete type.
+struct Runner<'a> {
+    container: &'a Path,
+    args: &'a RunArgs,
+    prepared: &'a PreparedContainer,
+    tokenizer: &'a Tokenizer,
+    eos: &'a EosConfig,
+    input: &'a mut dyn BufRead,
+    out: &'a mut dyn Write,
+}
+
+impl BackendVisitor for Runner<'_> {
+    type Out = ();
+
+    fn visit<B: PlanBackend>(self, backend: &B) -> Result<(), BoxErr> {
+        let loading = Instant::now();
+        // The expensive, immutable half — once, for every prompt.
+        let ops = PreparedOperands::load(
+            &self.prepared.plan,
+            &self.prepared.store,
+            backend,
+            ExecutionSlice::Full,
+        )?;
+        let engine = format!("{ENGINE_PREFIX}-{}", backend.name());
+        if self.args.verbose {
+            eprintln!(
+                "[{engine}] weights resident in {:.1} s",
+                loading.elapsed().as_secs_f64()
+            );
+        }
+        let model = ResidentModel {
+            plan: &self.prepared.plan,
+            ops: &ops,
+            backend,
+            tokenizer: self.tokenizer,
+            eos: self.eos,
+            engine: &engine,
+            args: self.args,
+        };
+        if let Some(prompt) = self.args.prompt.as_deref() {
+            return model.generate(prompt, self.out);
+        }
+        chat_loop(self.container, &model, self.input, self.out)
+    }
+}
+
+/// One loaded model, ready to answer any number of prompts.
+struct ResidentModel<'a, B: PlanBackend> {
+    plan: &'a ComponentOpPlan,
+    ops: &'a PreparedOperands,
+    backend: &'a B,
+    tokenizer: &'a Tokenizer,
+    eos: &'a EosConfig,
+    engine: &'a str,
+    args: &'a RunArgs,
+}
+
+impl<B: PlanBackend> ResidentModel<'_, B> {
+    /// Encode `prompt`, decode up to `--max-tokens` greedily, and stream
+    /// the text to `out` as it is produced. Ends at the first EOS.
+    fn generate(&self, prompt: &str, out: &mut dyn Write) -> Result<(), BoxErr> {
+        let encoded = self
+            .tokenizer
+            .encode(prompt, true)
+            .map_err(|e| format!("encode prompt: {e}"))?;
+        let ids = encoded.get_ids();
+        // A brand-new continuation state per prompt. Not a reset — a
+        // replacement, so there is nothing that *could* carry over.
+        let mut kv = RowKvState::default();
+        let mut session = DecodeSession::over_prepared(self.plan, self.ops, self.backend, &mut kv)?;
+        let mut detok = Detokenizer::new(self.tokenizer);
+        detok.seed(ids);
+        let decoded = greedy_decode(&mut session, ids, self.args.max_tokens, &mut |id, _| {
+            // An EOS id halts before it is decoded at all; a stop
+            // string halts on its surface form, re-decoded with
+            // specials kept when the clean delta is empty.
+            if self.eos.eos_token_ids.contains(&id) {
+                return Ok(Flow::Halt);
+            }
+            let delta = detok.push(id);
+            if self.eos.is_eos_with_tokenizer(id, &delta, self.tokenizer) {
+                return Ok(Flow::Halt);
+            }
+            out.write_all(delta.as_bytes())?;
+            out.flush()?;
+            Ok(Flow::Continue)
+        })?;
+        writeln!(out)?;
+        if self.args.emit_ids {
+            eprintln!("[{}] prompt ids: {:?}", self.engine, ids);
+            eprintln!("[{}] generated ids: {:?}", self.engine, decoded.generated);
+        }
+        if self.args.verbose {
+            eprintln!(
+                "[{}] {} prompt tokens in {:.2} s, {} generated",
+                self.engine,
+                ids.len(),
+                decoded.prompt_seconds,
+                decoded.generated.len(),
+            );
+            if let Some(report) = DecodeReport::from_steps(&decoded.step_seconds) {
+                eprintln!(
+                    "[{}] decode {:.0} ms/token ({:.2} tok/s), steady {:.0} ms/token",
+                    self.engine,
+                    report.mean_seconds_per_token * 1e3,
+                    report.mean_seconds_per_token.recip(),
+                    report.steady_seconds_per_token * 1e3,
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Single-turn chat: one line in, one generation out, until EOF. Each
+/// line is its own prompt — no history, no template — over the one
+/// resident model.
+fn chat_loop<B: PlanBackend>(
+    container: &Path,
+    model: &ResidentModel<'_, B>,
+    input: &mut dyn BufRead,
+    out: &mut dyn Write,
+) -> Result<(), BoxErr> {
+    eprintln!(
+        "larql chat ({}) — {} (Ctrl-D to exit)",
+        model.engine,
+        container
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("container")
+    );
+    loop {
+        eprint!("{CHAT_PROMPT}");
+        io::stderr().flush()?;
+        let mut line = String::new();
+        match input.read_line(&mut line) {
+            Ok(0) => {
+                eprintln!();
+                return Ok(());
+            }
+            Ok(_) => {}
+            Err(e) => return Err(Box::new(e)),
+        }
+        let prompt = line.trim();
+        if prompt.is_empty() {
+            continue;
+        }
+        if let Err(e) = model.generate(prompt, out) {
+            eprintln!("Error: {e}");
+        }
+    }
+}

--- a/crates/larql-cli/src/commands/primary/run_cmd_vindex3/tests/mod.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd_vindex3/tests/mod.rs
@@ -1,0 +1,239 @@
+//! `larql run` on a VINDEX3 container: detection, the refusals, and text
+//! out of the dense fixture through the container's own tokenizer.
+
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use larql_vindex::format::filenames::{GENERATION_CONFIG_JSON, INDEX_JSON, TOKENIZER_JSON};
+use larql_vindex::format::vindex3::fixtures::{
+    dense_f32_model, encode_fixture_container, DENSE_VOCAB,
+};
+
+use super::super::run_cmd::RunArgs;
+use super::{is_vindex3_container, run_to};
+
+/// A prompt that is its own id list under the fixture tokenizer.
+const PROMPT: &str = "[1] [2] [3]";
+
+/// `RunArgs` is `clap::Args`; parsing it through a shell keeps every
+/// default exactly what the binary would have used.
+#[derive(Parser)]
+struct Shell {
+    #[command(flatten)]
+    run: RunArgs,
+}
+
+fn args(argv: &[&str]) -> RunArgs {
+    Shell::parse_from(std::iter::once("larql").chain(argv.iter().copied())).run
+}
+
+/// A WordLevel tokenizer over the fixture's vocabulary: token `[i]` is
+/// id `i`, split on whitespace, joined back with spaces on decode. No
+/// larql-inference dependency and no merges — a prompt is its own ids.
+fn word_level_tokenizer(vocab: usize) -> String {
+    let entries: Vec<String> = (0..vocab).map(|i| format!("\"[{i}]\":{i}")).collect();
+    format!(
+        "{{\"version\":\"1.0\",\"truncation\":null,\"padding\":null,\"added_tokens\":[],\
+         \"normalizer\":null,\"pre_tokenizer\":{{\"type\":\"Whitespace\"}},\
+         \"post_processor\":null,\"decoder\":null,\
+         \"model\":{{\"type\":\"WordLevel\",\"vocab\":{{{}}},\"unk_token\":\"[0]\"}}}}",
+        entries.join(",")
+    )
+}
+
+/// The dense fixture as a container, with or without its tokenizer.
+fn fixture_container(root: &Path, with_tokenizer: bool) -> PathBuf {
+    let checkpoint = root.join("checkpoint");
+    let container = root.join("container");
+    std::fs::create_dir_all(&checkpoint).unwrap();
+    std::fs::create_dir_all(&container).unwrap();
+    encode_fixture_container(dense_f32_model, &checkpoint, &container, "dense");
+    if with_tokenizer {
+        std::fs::write(
+            container.join(TOKENIZER_JSON),
+            word_level_tokenizer(DENSE_VOCAB),
+        )
+        .unwrap();
+    }
+    container
+}
+
+/// Run with `argv` after the model path, feeding `input` to the chat
+/// loop, and return everything written to stdout.
+fn run_capturing(container: &Path, argv: &[&str], input: &str) -> Result<String, String> {
+    let model = container.to_str().unwrap();
+    let a = args(&[&[model], argv].concat());
+    let mut out = Vec::new();
+    let mut input = std::io::Cursor::new(input.as_bytes());
+    run_to(container, &a, &mut input, &mut out).map_err(|e| e.to_string())?;
+    Ok(String::from_utf8(out).unwrap())
+}
+
+/// Every whitespace-separated piece of a line is a fixture token `[n]`
+/// with `n` inside the vocabulary.
+fn assert_fixture_tokens(line: &str, expected: usize) {
+    let pieces: Vec<&str> = line.split_whitespace().collect();
+    assert_eq!(pieces.len(), expected, "{line:?}");
+    for piece in pieces {
+        let inner = piece
+            .strip_prefix('[')
+            .and_then(|p| p.strip_suffix(']'))
+            .unwrap_or_else(|| panic!("{piece:?} is not a fixture token"));
+        let id: usize = inner.parse().unwrap();
+        assert!(id < DENSE_VOCAB, "{piece:?} is outside the vocabulary");
+    }
+}
+
+#[test]
+fn detection_answers_only_for_a_vindex3_container() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    assert!(is_vindex3_container(&container));
+
+    let empty = tempfile::tempdir().unwrap();
+    assert!(!is_vindex3_container(empty.path()));
+    assert!(!is_vindex3_container(&empty.path().join("absent")));
+
+    // A VINDEX2 index is the dense path's business, not this arm's.
+    let v2 = tempfile::tempdir().unwrap();
+    std::fs::write(v2.path().join(INDEX_JSON), r#"{"version": 1}"#).unwrap();
+    assert!(!is_vindex3_container(v2.path()));
+}
+
+#[test]
+fn a_prompt_streams_tokens_from_the_containers_own_tokenizer() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    let out = run_capturing(&container, &[PROMPT, "--max-tokens", "3"], "").unwrap();
+    let line = out
+        .strip_suffix('\n')
+        .expect("the generation ends with a newline");
+    assert_fixture_tokens(line, 3);
+}
+
+#[test]
+fn the_same_prompt_produces_the_same_text() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    let argv = [PROMPT, "--max-tokens", "4"];
+    assert_eq!(
+        run_capturing(&container, &argv, "").unwrap(),
+        run_capturing(&container, &argv, "").unwrap()
+    );
+}
+
+#[test]
+fn emit_ids_and_verbose_report_on_stderr_and_leave_stdout_alone() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    let plain = run_capturing(&container, &[PROMPT, "--max-tokens", "2"], "").unwrap();
+    let chatty = run_capturing(
+        &container,
+        &[PROMPT, "--max-tokens", "2", "--emit-ids", "--verbose"],
+        "",
+    )
+    .unwrap();
+    assert_eq!(plain, chatty);
+}
+
+#[test]
+fn each_chat_turn_starts_from_a_fresh_continuation_state() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    // The first and third turns are the same prompt with a different
+    // turn between them; blank lines are skipped, not answered.
+    let out = run_capturing(
+        &container,
+        &["--max-tokens", "2"],
+        "[1] [2]\n\n[5] [6] [7]\n[1] [2]\n",
+    )
+    .unwrap();
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 3, "{out:?}");
+    for line in &lines {
+        assert_fixture_tokens(line, 2);
+    }
+    assert_eq!(lines[0], lines[2], "state leaked between turns");
+}
+
+#[test]
+fn dense_engine_flags_are_refused_by_name_before_anything_loads() {
+    let root = tempfile::tempdir().unwrap();
+    // No tokenizer, no plan: the refusal has to come first.
+    let container = fixture_container(root.path(), false);
+    let err = run_capturing(
+        &container,
+        &[PROMPT, "--experts", "--top", "5", "--engine", "standard"],
+        "",
+    )
+    .expect_err("dense-engine flags are not honoured");
+    for flag in ["--experts", "--top", "--engine"] {
+        assert!(err.contains(flag), "{err}");
+    }
+    assert!(!err.contains("--max-tokens"), "{err}");
+}
+
+#[test]
+fn a_container_without_a_tokenizer_is_refused() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), false);
+    let err = run_capturing(&container, &[PROMPT], "")
+        .expect_err("text cannot be tokenised without a tokenizer");
+    assert!(err.contains(TOKENIZER_JSON), "{err}");
+}
+
+#[cfg(not(all(feature = "gpu", target_os = "macos")))]
+#[test]
+fn metal_is_refused_where_there_is_no_metal() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    let err = run_capturing(&container, &[PROMPT, "--metal"], "")
+        .expect_err("--metal cannot be honoured on this build");
+    assert!(err.contains("--metal"), "{err}");
+}
+
+#[cfg(all(feature = "gpu", target_os = "macos"))]
+#[test]
+fn metal_serves_the_fixture_through_the_same_shell() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    let out = run_capturing(&container, &[PROMPT, "--max-tokens", "3", "--metal"], "").unwrap();
+    assert_fixture_tokens(out.trim_end(), 3);
+}
+
+/// Point the container's `generation_config.json` at a stop.
+fn declare_stop(container: &Path, config: serde_json::Value) {
+    std::fs::write(container.join(GENERATION_CONFIG_JSON), config.to_string()).unwrap();
+}
+
+#[test]
+fn generation_ends_at_the_containers_declared_eos_before_it_is_printed() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    let argv = [PROMPT, "--max-tokens", "3"];
+    // What the model says with nothing declared, so the stop can be
+    // placed on a token it is known to produce.
+    let free = run_capturing(&container, &argv, "").unwrap();
+    let pieces: Vec<&str> = free.split_whitespace().collect();
+    let (first, second) = (pieces[0].to_string(), pieces[1].to_string());
+    let first_id: u32 = first
+        .trim_matches(|c| c == '[' || c == ']')
+        .parse()
+        .unwrap();
+
+    // By id: the EOS is never decoded, so nothing precedes the newline.
+    declare_stop(&container, serde_json::json!({ "eos_token_id": first_id }));
+    assert_eq!(run_capturing(&container, &argv, "").unwrap(), "\n");
+
+    // By surface form, through the same path the dense engine uses.
+    declare_stop(
+        &container,
+        serde_json::json!({ "stop_strings": [first.clone()] }),
+    );
+    assert_eq!(run_capturing(&container, &argv, "").unwrap(), "\n");
+
+    // A stop on the second token leaves exactly the first one printed.
+    declare_stop(&container, serde_json::json!({ "stop_strings": [second] }));
+    let out = run_capturing(&container, &argv, "").unwrap();
+    assert_eq!(out.trim(), first, "{out:?}");
+}

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/decode.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/decode.rs
@@ -1,0 +1,167 @@
+//! Greedy autoregressive decode over a [`DecodeSession`] — the loop
+//! itself, with the ids handed out as they are produced.
+//!
+//! Sampling is greedy argmax on purpose: generation doubles as a
+//! fixture (same ids in → same ids out per backend), and a sampler
+//! would put a source of randomness between two runs of a parity
+//! comparison. Ids go in and come out as ids; what a caller does with
+//! them — print them, decode them to text, compare them — is the
+//! caller's wrapper, not the loop's.
+//!
+//! The wrapper sees every id through a sink *before* the next step
+//! runs, and can halt the loop from there. That is how an end-of-
+//! sequence token ends a chat turn without the loop knowing what a
+//! tokenizer is.
+
+use std::time::Instant;
+
+use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+use larql_vindex::format::vindex3::opplan::exec::cpu::{ledger, PhysicalProjectionPlan, PlanTally};
+use larql_vindex::format::vindex3::opplan::exec::decode::DecodeSession;
+use larql_vindex::format::vindex3::opplan::exec::timing;
+
+type BoxErr = Box<dyn std::error::Error>;
+
+/// What a sink says after seeing an id: carry on, or stop before the
+/// next step runs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Flow {
+    Continue,
+    Halt,
+}
+
+/// Where each generated id goes the moment it exists. Receives the id
+/// and the logit it was chosen on; an error aborts the decode.
+pub(crate) type TokenSink<'s> = dyn FnMut(u32, f32) -> Result<Flow, BoxErr> + 's;
+
+/// One steady step's weight traffic, priced by the process-wide ledger.
+pub(crate) type PricedStep = (f64, Vec<(PhysicalProjectionPlan, PlanTally)>);
+
+/// What one greedy decode produced, with its phases timed separately —
+/// prompt ingestion and steady decode are different costs and
+/// conflating them is how a decode number lies.
+pub(crate) struct Decoded {
+    /// Every id handed to the sink, in order — including the one the
+    /// sink halted on.
+    pub(crate) generated: Vec<u32>,
+    pub(crate) prompt_seconds: f64,
+    /// Wall seconds of each decode step after the first generated token
+    /// (which the prompt phase produces).
+    pub(crate) step_seconds: Vec<f64>,
+    /// The step the ledger priced, when the decode ran long enough to
+    /// reach it.
+    pub(crate) priced_step: Option<PricedStep>,
+}
+
+/// Ingest the prompt one position at a time, then append the argmax of
+/// each step's logits until `new_tokens` have been produced or the sink
+/// halts.
+///
+/// The session is the caller's: it may be fresh, or continue a
+/// sequence the caller already fed. Nothing is loaded here.
+pub(crate) fn greedy_decode<B: PlanBackend>(
+    session: &mut DecodeSession<'_, B>,
+    prompt: &[u32],
+    new_tokens: usize,
+    sink: &mut TokenSink<'_>,
+) -> Result<Decoded, BoxErr> {
+    if prompt.is_empty() {
+        return Err("prompt holds no tokens — nothing to condition on".into());
+    }
+    // Prompt ingestion: every position must pass through the stack to
+    // fill the continuation state; only the last position's logits are
+    // consumed.
+    let prompt_started = Instant::now();
+    let mut logits = None;
+    for &token in prompt {
+        logits = session.step(token)?.logits;
+    }
+    let prompt_seconds = prompt_started.elapsed().as_secs_f64();
+    let logits = logits.ok_or(NO_HEAD)?;
+    let (mut next, mut value) = argmax(&logits).ok_or(NO_LOGITS)?;
+
+    let mut generated = Vec::with_capacity(new_tokens);
+    let mut step_seconds = Vec::with_capacity(new_tokens);
+    let mut priced_step = None;
+    for step in 0..new_tokens {
+        let id = u32::try_from(next)?;
+        generated.push(id);
+        if sink(id, value)? == Flow::Halt || step + 1 == new_tokens {
+            break;
+        }
+        // Price ONE steady step's weight traffic. Reset immediately
+        // before the step it belongs to: the ledger is process-wide and
+        // has been counting since the prompt.
+        let price_this_step = step + 1 == new_tokens.saturating_sub(1);
+        if price_this_step {
+            ledger().reset();
+            timing::ledger().reset();
+        }
+        let started = Instant::now();
+        let logits = session.step(id)?.logits.ok_or(NO_HEAD)?;
+        (next, value) = argmax(&logits).ok_or(NO_LOGITS)?;
+        step_seconds.push(started.elapsed().as_secs_f64());
+        if price_this_step {
+            priced_step = Some((*step_seconds.last().expect("just pushed"), read_ledger()));
+        }
+    }
+    Ok(Decoded {
+        generated,
+        prompt_seconds,
+        step_seconds,
+        priced_step,
+    })
+}
+
+const NO_HEAD: &str = "plan carries no output head — cannot generate";
+const NO_LOGITS: &str = "output head produced no logits";
+
+/// Snapshot every plan's tally.
+fn read_ledger() -> Vec<(PhysicalProjectionPlan, PlanTally)> {
+    ledger().all().to_vec()
+}
+
+/// Index and value of the largest logit; ties keep the first, matching
+/// the summary path's fold.
+pub(crate) fn argmax(logits: &[f32]) -> Option<(usize, f32)> {
+    logits
+        .iter()
+        .enumerate()
+        .fold(None, |best, (index, &value)| match best {
+            Some((_, best_value)) if value <= best_value => best,
+            _ => Some((index, value)),
+        })
+}
+
+/// The steady-state window is the tail half of the decode steps — after
+/// the page cache and device buffer pools have warmed on the early ones.
+const STEADY_TAIL_DIVISOR: usize = 2;
+
+/// Steady-decode timing over the per-step seconds (prompt ingestion and
+/// weight load are reported separately by the caller).
+#[derive(Debug, PartialEq)]
+pub(crate) struct DecodeReport {
+    pub(crate) decode_tokens: usize,
+    pub(crate) decode_seconds: f64,
+    pub(crate) mean_seconds_per_token: f64,
+    pub(crate) steady_seconds_per_token: f64,
+}
+
+impl DecodeReport {
+    /// `None` when no decode step beyond the first token ran — a single
+    /// forward has no decode rate to report.
+    pub(crate) fn from_steps(step_seconds: &[f64]) -> Option<Self> {
+        if step_seconds.is_empty() {
+            return None;
+        }
+        let decode_seconds: f64 = step_seconds.iter().sum();
+        let steady_len = (step_seconds.len() / STEADY_TAIL_DIVISOR).max(1);
+        let steady = &step_seconds[step_seconds.len() - steady_len..];
+        Some(Self {
+            decode_tokens: step_seconds.len(),
+            decode_seconds,
+            mean_seconds_per_token: decode_seconds / step_seconds.len() as f64,
+            steady_seconds_per_token: steady.iter().sum::<f64>() / steady.len() as f64,
+        })
+    }
+}

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
@@ -10,7 +10,9 @@
 //! Token ids are given explicitly rather than tokenised here. A tokenizer
 //! is part of the fixture, and only one side of a parity comparison may
 //! choose it — `scripts/capture_glimmer_oracle.py` already recorded the
-//! ids this reads back.
+//! ids this reads back. `larql run <container> [prompt]` is the text
+//! shell over the same preparation (`prepare`) and the same interpreter;
+//! its `--emit-ids` prints the ids this verb would be given.
 //!
 //! The backend is a flag over the same plan. That is the point of the
 //! seam: `--backend reference` and `--backend production` execute one
@@ -28,32 +30,28 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use larql_vindex::error::VindexError;
-use larql_vindex::format::vindex3::inspect::inspect_container;
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
-use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
 use larql_vindex::format::vindex3::opplan::exec::prepared::ExecutionSlice;
-use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
-use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
 use larql_vindex::format::vindex3::opplan::exec::{
     execute_plan_streaming, execute_slice, ExecutionTrace, PlaneEvent, ResumePoint,
 };
-use larql_vindex::format::vindex3::opplan::plan_component_ops;
 use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
 use ndarray::Array2;
 
 use super::super::shannon_trace::dump::{
     plane_name, write_plane, LayerDumpManifest, MANIFEST_NAME, PLANE_DTYPE,
 };
-use super::{ExecArgs, ExecBackend};
+use super::prepare::{
+    parse_representation_source, prepare, with_plan_backend, BackendVisitor, PreparedContainer,
+    ENGINE_PREFIX,
+};
+use super::ExecArgs;
 
 /// Extra planes beyond the layer table, matching
 /// `scripts/capture_glimmer_oracle.py`.
 const FINAL_NORM_PLANE: &str = "final_norm.f32";
 const LOGITS_PLANE: &str = "logits.f32";
-
-/// Engine tag prefix; the backend name completes it so a dump can never
-/// be mistaken for one produced by the other realisation.
-const ENGINE_PREFIX: &str = "vindex3";
 
 /// Sidecar recording what fixture an interrupted dump was running, so
 /// `--resume` can refuse to splice two different runs. Written at start;
@@ -74,46 +72,14 @@ pub(super) struct ResumeSidecar {
 
 pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
     let tokens = parse_tokens(&args.tokens)?;
-    let inspection = inspect_container(&args.container, false)?;
-    let outcome = plan_component_ops(&inspection, &args.container, &args.component)?;
-    if !outcome.defects.is_empty() {
-        for defect in &outcome.defects {
-            eprintln!("defect: {defect}");
-        }
-        return Err(format!(
-            "component `{}` does not close: {} defect(s)",
-            args.component,
-            outcome.defects.len()
-        )
-        .into());
-    }
-    let plan = outcome
-        .plan
-        .ok_or_else(|| format!("component `{}` produced no plan", args.component))?;
-    // What execution wants, and whether it may be manufactured now, are
-    // separate questions — see `--representation-source`.
-    let source = match args.representation_source.as_str() {
-        "auto" => RepresentationSource::Auto,
-        "stored" => RepresentationSource::Stored,
-        "transient" => RepresentationSource::Transient,
-        other => {
-            return Err(format!(
-                "unknown --representation-source `{other}`; expected auto, stored or transient"
-            )
-            .into())
-        }
-    };
-    // The encoding a compiled pack would have to carry for this backend.
-    // `None` on arms that execute the canonical bytes directly, which then
-    // never look for a pack.
-    let want = wanted_representation(args.backend);
-    let store = OperandStore::open_for(&args.container, &inspection, want, source)?;
+    let source = parse_representation_source(&args.representation_source)?;
+    let PreparedContainer { plan, store, want } =
+        prepare(&args.container, &args.component, args.backend, source)?;
 
     let from_pack = store.selection().values().filter(|s| s.stored).count();
-    if want.is_some() {
+    if let Some(want) = want {
         println!(
-            "representation: {}  source: {}  objects from a compiled pack: {}/{}",
-            want.unwrap_or("-"),
+            "representation: {want}  source: {}  objects from a compiled pack: {}/{}",
             args.representation_source,
             from_pack,
             store.selection().len()
@@ -122,184 +88,39 @@ pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     #[cfg(all(feature = "gpu", target_os = "macos"))]
     {
-        use larql_vindex::format::vindex3::opplan::exec::backend::{WeightFormat, WeightFormats};
-        // The lowered path's per-class policy. Same scheduling for every
-        // arm — one command buffer per token — so a comparison between
-        // them prices the *representation*, which the pre-lowering
-        // numbers could not (they mixed kernel families and starvation).
-        let lowered = match args.backend {
-            ExecBackend::MetalLowered => {
-                Some((WeightFormats::uniform(WeightFormat::Nvfp4), "nvfp4-all"))
-            }
-            ExecBackend::MetalLoweredFfn => Some((
-                WeightFormats {
-                    attention: WeightFormat::F16,
-                    ffn: WeightFormat::Nvfp4,
-                    head: WeightFormat::F16,
-                },
-                "nvfp4-ffn",
-            )),
-            ExecBackend::MetalLoweredNoHead => Some((
-                WeightFormats {
-                    attention: WeightFormat::Nvfp4,
-                    ffn: WeightFormat::Nvfp4,
-                    head: WeightFormat::F16,
-                },
-                "nvfp4-no-head",
-            )),
-            ExecBackend::MetalLoweredMxfp4 => {
-                Some((WeightFormats::uniform(WeightFormat::Mxfp4), "mxfp4-all"))
-            }
-            ExecBackend::MetalLoweredF16 => {
-                Some((WeightFormats::uniform(WeightFormat::F16), "f16-all"))
-            }
-            ExecBackend::MetalLoweredMxfp4Ffn => Some((
-                WeightFormats {
-                    attention: WeightFormat::F16,
-                    ffn: WeightFormat::Mxfp4,
-                    head: WeightFormat::F16,
-                },
-                "mxfp4-ffn",
-            )),
-            _ => None,
-        };
-        if let Some((formats, label)) = lowered {
+        if let Some((formats, label)) = super::prepare::lowered_formats(args.backend) {
             let r = super::lowered::run_lowered(&args, &tokens, &plan, &store, formats, label);
             report_representation_work(&store, want, r.is_ok());
             return r;
         }
     }
-    let outcome = match args.backend {
-        ExecBackend::Reference => run_on(&ReferenceBackend::new(), &args, &tokens, &plan, &store),
-        ExecBackend::Production => run_on(&ProductionBackend::new(), &args, &tokens, &plan, &store),
-        // Same kernels as `production`; the difference is upstream, in
-        // `wanted_representation`, which makes the store bind the
-        // compiled NVFP4 pack instead of the canonical bytes. The
-        // projector then dispatches `FusedNvfp4` off the resident
-        // representation, exactly as it dispatches every other arm.
-        ExecBackend::ProductionNvfp4 => {
-            run_on(&ProductionBackend::new(), &args, &tokens, &plan, &store)
-        }
-        #[cfg(all(feature = "gpu", target_os = "macos"))]
-        ExecBackend::MetalMxfp4 => {
-            let gpu = larql_compute_metal::MetalBackend::new()
-                .ok_or("no Metal device available for --backend metal-mxfp4")?;
-            // FFN-only MXFP4 — the gpt-oss precedent. The gates
-            // falsified the wider presets on the 6-token fixture:
-            // all-MXFP4 flipped the argmax (top-2 gap 0.08 vs
-            // upstream's 1.13) and an f16 head alone did not recover
-            // it (gap 0.01) — 4-bit attention projections accumulate
-            // ~14% rel_rms across 52 layers. Attention and head stay
-            // f16; the FFN bulk (~3/4 of the bytes) is quantised.
-            use larql_vindex::format::vindex3::opplan::exec::backend::{
-                WeightFormat, WeightFormats,
-            };
-            let backend =
-                larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::with_formats(
-                    gpu,
-                    "metal-q1-mxfp4-ffn",
-                    WeightFormats {
-                        attention: WeightFormat::F16,
-                        ffn: WeightFormat::Mxfp4,
-                        head: WeightFormat::F16,
-                    },
-                );
-            run_on(&backend, &args, &tokens, &plan, &store)
-        }
-        #[cfg(all(feature = "gpu", target_os = "macos"))]
-        ExecBackend::MetalLowered
-        | ExecBackend::MetalLoweredFfn
-        | ExecBackend::MetalLoweredNoHead
-        | ExecBackend::MetalLoweredMxfp4
-        | ExecBackend::MetalLoweredMxfp4Ffn
-        | ExecBackend::MetalLoweredF16 => unreachable!("handled above"),
-        #[cfg(all(feature = "gpu", target_os = "macos"))]
-        ExecBackend::MetalMxfp4All => {
-            let gpu = larql_compute_metal::MetalBackend::new()
-                .ok_or("no Metal device available for --backend metal-mxfp4-all")?;
-            // The control arm: the preset Q1 falsified. Its job is to
-            // fail, so that a Q2 arm holding the prediction is evidence
-            // about the format rather than about the harness.
-            use larql_vindex::format::vindex3::opplan::exec::backend::{
-                WeightFormat, WeightFormats,
-            };
-            let backend =
-                larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::with_formats(
-                    gpu,
-                    "metal-q1-mxfp4-all",
-                    WeightFormats::uniform(WeightFormat::Mxfp4),
-                );
-            run_on(&backend, &args, &tokens, &plan, &store)
-        }
-        #[cfg(all(feature = "gpu", target_os = "macos"))]
-        ExecBackend::MetalNvfp4 | ExecBackend::MetalNvfp4Ffn | ExecBackend::MetalNvfp4NoHead => {
-            let gpu = larql_compute_metal::MetalBackend::new()
-                .ok_or("no Metal device available for the nvfp4 backends")?;
-            // The VINDEX3-Q2 ladder. Q1 established that *this model's*
-            // attention does not survive MXFP4; NVFP4 keeps the same
-            // e2m1 elements and changes only the scale geometry, which a
-            // weight-reconstruction sweep with an equal-bit-budget
-            // control (E8M0 at group 16) isolated as the whole source of
-            // the difference. Arm A is the one that matters — it is the
-            // ~17 GB regime — and B and C exist so a failure says which
-            // class it came from rather than only that it failed.
-            use larql_vindex::format::vindex3::opplan::exec::backend::{
-                WeightFormat, WeightFormats,
-            };
-            let (name, formats) = match args.backend {
-                // A — everything 4-bit.
-                ExecBackend::MetalNvfp4 => (
-                    "metal-q2-nvfp4-all",
-                    WeightFormats::uniform(WeightFormat::Nvfp4),
-                ),
-                // B — attention and FFN 4-bit, head wide. Isolates the
-                // head, which Q1's second rung showed was not the whole
-                // story under MXFP4.
-                ExecBackend::MetalNvfp4NoHead => (
-                    "metal-q2-nvfp4-no-head",
-                    WeightFormats {
-                        attention: WeightFormat::Nvfp4,
-                        ffn: WeightFormat::Nvfp4,
-                        head: WeightFormat::F16,
-                    },
-                ),
-                // C — the Q1-passing partition, re-run under NVFP4, so
-                // the two formats are compared at the same class split.
-                _ => (
-                    "metal-q2-nvfp4-ffn",
-                    WeightFormats {
-                        attention: WeightFormat::F16,
-                        ffn: WeightFormat::Nvfp4,
-                        head: WeightFormat::F16,
-                    },
-                ),
-            };
-            let backend =
-                larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::with_formats(
-                    gpu, name, formats,
-                );
-            run_on(&backend, &args, &tokens, &plan, &store)
-        }
-        #[cfg(all(feature = "gpu", target_os = "macos"))]
-        ExecBackend::Metal => {
-            // vindex never links Metal: the CLI injects the concrete
-            // device through larql-compute's MatMul seam. f16 weights so
-            // the Metal buffer cache keeps the model resident (r2); the
-            // engine tag names the realisation so a dump can never be
-            // mistaken for the f32 r1 lowering.
-            let gpu = larql_compute_metal::MetalBackend::new()
-                .ok_or("no Metal device available for --backend metal")?;
-            let backend =
-                larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::new(
-                    gpu,
-                    "metal-r3-f16",
-                    larql_vindex::format::vindex3::opplan::exec::backend::WeightFormat::F16,
-                );
-            run_on(&backend, &args, &tokens, &plan, &store)
-        }
-    };
+    let outcome = with_plan_backend(
+        args.backend,
+        ExecVisitor {
+            args: &args,
+            tokens: &tokens,
+            plan: &plan,
+            store: &store,
+        },
+    );
     report_representation_work(&store, want, outcome.is_ok());
     outcome
+}
+
+/// The exec verb's work, once the backend is a concrete type.
+struct ExecVisitor<'a> {
+    args: &'a ExecArgs,
+    tokens: &'a [u32],
+    plan: &'a ComponentOpPlan,
+    store: &'a OperandStore,
+}
+
+impl BackendVisitor for ExecVisitor<'_> {
+    type Out = ();
+
+    fn visit<B: PlanBackend>(self, backend: &B) -> Result<(), Box<dyn std::error::Error>> {
+        run_on(backend, self.args, self.tokens, self.plan, self.store)
+    }
 }
 
 /// Say how much of the representation the runtime had to manufacture.
@@ -372,6 +193,7 @@ fn run_on<B: PlanBackend>(
         (Some(dir), _) => run_dump(dir, &engine, args, tokens, plan, store, backend),
         (None, Some(new_tokens)) => {
             super::generate::run_generate(backend, &engine, tokens, new_tokens, plan, store)
+                .map(|_generated| ())
         }
         (None, None) => {
             let trace = execute_slice(plan, store, tokens, backend, slice)?;
@@ -621,46 +443,12 @@ fn summarise(engine: &str, trace: &ExecutionTrace) {
         trace.embedded.first().map(Vec::len).unwrap_or(0),
     );
     match &trace.logits {
-        Some(logits) => match super::generate::argmax(logits) {
+        Some(logits) => match super::decode::argmax(logits) {
             Some((best, value)) => {
                 println!("logits: {}, argmax {best} ({value:+.4})", logits.len());
             }
             None => println!("logits: empty"),
         },
         None => println!("logits: none (plan carries no output head)"),
-    }
-}
-
-/// The stored encoding a backend could be served from, if one is compiled.
-///
-/// Only the NVFP4 arms have a compiled counterpart today. Arms that run
-/// the canonical bytes return `None` and never look for a pack, so adding
-/// packs to a container cannot change what they execute.
-fn wanted_representation(backend: ExecBackend) -> Option<&'static str> {
-    use larql_vindex::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4;
-    // Exhaustive, with no wildcard arm, and that is the point: `_ =>
-    // None` stood here and a newly added NVFP4 backend silently
-    // inherited "wants nothing", bound the canonical bytes and produced
-    // logits bit-identical to BF16. A run that looks like perfect
-    // fidelity is the exact failure this file must not be able to
-    // express, so a new backend is now a compile error until someone
-    // states which representation it executes.
-    match backend {
-        ExecBackend::Reference | ExecBackend::Production => None,
-        ExecBackend::ProductionNvfp4 => Some(DTYPE_NVFP4),
-        #[cfg(all(feature = "gpu", target_os = "macos"))]
-        ExecBackend::Metal
-        | ExecBackend::MetalMxfp4
-        | ExecBackend::MetalMxfp4All
-        | ExecBackend::MetalLoweredMxfp4
-        | ExecBackend::MetalLoweredMxfp4Ffn
-        | ExecBackend::MetalLoweredF16 => None,
-        #[cfg(all(feature = "gpu", target_os = "macos"))]
-        ExecBackend::MetalNvfp4
-        | ExecBackend::MetalNvfp4Ffn
-        | ExecBackend::MetalNvfp4NoHead
-        | ExecBackend::MetalLowered
-        | ExecBackend::MetalLoweredFfn
-        | ExecBackend::MetalLoweredNoHead => Some(DTYPE_NVFP4),
     }
 }

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/generate.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/generate.rs
@@ -1,38 +1,36 @@
 //! `larql vindex3 exec --generate N` — greedy autoregressive decode
-//! from the container's own program.
+//! from the container's own program, with the research report around it.
 //!
 //! Runs on a [`DecodeSession`]: every operand is loaded once (in the
 //! backend's declared weight format, so a device buffer cache can keep
 //! the model resident) and each token advances one position against the
-//! session's KV cache. The phases are timed separately — weight load,
-//! prompt ingestion, first generated token, steady decode — because
-//! they are different costs and conflating them is how a decode number
-//! lies.
+//! session's KV cache. The loop itself is [`greedy_decode`]; this file
+//! is what the exec verb wraps around it — the per-token trace, the
+//! phase timings (weight load, prompt ingestion, first generated token,
+//! steady decode, reported separately because they are different costs
+//! and conflating them is how a decode number lies), the residency and
+//! allocation censuses, the weight-traffic ledger and the optional
+//! projection replay.
 //!
-//! Sampling is greedy argmax on purpose: generation doubles as a
-//! fixture (same ids in → same ids out per backend), and a sampler
-//! would put a source of randomness between two runs of a parity
-//! comparison. Token ids go in and come out as ids — a tokenizer is
-//! part of the fixture and lives outside this binary.
+//! Token ids go in and come out as ids — a tokenizer is part of the
+//! fixture and lives outside this verb. `larql run` is the wrapper that
+//! owns one.
 
 use std::time::Instant;
 
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
-use larql_vindex::format::vindex3::opplan::exec::cpu::{
-    self, ledger, PhysicalProjectionPlan, PlanTally,
-};
+use larql_vindex::format::vindex3::opplan::exec::cpu::{self, PhysicalProjectionPlan, PlanTally};
 use larql_vindex::format::vindex3::opplan::exec::decode::DecodeSession;
 use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
 use larql_vindex::format::vindex3::opplan::exec::prepared::{AllocationCensus, ResidencyCensus};
 use larql_vindex::format::vindex3::opplan::exec::timing;
 use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
 
-/// The steady-state window is the tail half of the decode steps — after
-/// the page cache and device buffer pools have warmed on the early ones.
-const STEADY_TAIL_DIVISOR: usize = 2;
+use super::decode::{greedy_decode, DecodeReport, Flow};
 
-/// Greedy decode: ingest the prompt one position at a time, then append
-/// the argmax of each step's logits.
+/// Greedy decode with the exec verb's report. Returns the generated ids
+/// (the prompt excluded), so a caller has them as data and not only as
+/// lines on the console.
 pub(super) fn run_generate<B: PlanBackend>(
     backend: &B,
     engine: &str,
@@ -40,12 +38,12 @@ pub(super) fn run_generate<B: PlanBackend>(
     new_tokens: usize,
     plan: &ComponentOpPlan,
     store: &OperandStore,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
     // Admission BEFORE any work: this is the only point at which the
     // load average is about the machine rather than about us.
     let replaying = std::env::var("LARQL_REPLAY_PROJECTIONS").is_ok();
     if replaying && !admitted(cpu::environment::Phase::BeforeWork)? {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let loading = Instant::now();
@@ -55,61 +53,30 @@ pub(super) fn run_generate<B: PlanBackend>(
     report_residency(&session.residency_census());
     report_allocations(&session.allocation_census());
 
-    // Prompt ingestion: every position must pass through the stack to
-    // fill the KV cache; only the last position's logits are consumed.
-    let prompt_started = Instant::now();
-    let mut logits = None;
-    for &token in prompt {
-        logits = session.step(token)?.logits;
-    }
-    let prompt_seconds = prompt_started.elapsed().as_secs_f64();
-    let logits = logits.ok_or("plan carries no output head — cannot generate")?;
-    let (mut next, mut value) = argmax(&logits).ok_or("output head produced no logits")?;
-
-    let mut ids = prompt.to_vec();
-    let mut step_seconds = Vec::with_capacity(new_tokens);
-    let mut priced_step: Option<(f64, Vec<(PhysicalProjectionPlan, PlanTally)>)> = None;
-    for step in 0..new_tokens {
-        ids.push(next as u32);
+    let mut emitted = 0usize;
+    let decoded = greedy_decode(&mut session, prompt, new_tokens, &mut |id, value| {
+        emitted += 1;
         eprintln!(
-            "token {:>3}/{new_tokens}  id {next:<8} ({value:+.3})  context {}",
-            step + 1,
-            ids.len(),
+            "token {emitted:>3}/{new_tokens}  id {id:<8} ({value:+.3})  context {}",
+            prompt.len() + emitted,
         );
-        if step + 1 == new_tokens {
-            break;
-        }
-        // Price ONE steady step's weight traffic. Reset immediately
-        // before the step it belongs to: the ledger is process-wide and
-        // has been counting since the prompt.
-        let price_this_step = step + 1 == new_tokens.saturating_sub(1);
-        if price_this_step {
-            ledger().reset();
-            timing::ledger().reset();
-        }
-        let started = Instant::now();
-        let logits = session
-            .step(next as u32)?
-            .logits
-            .ok_or("plan carries no output head — cannot generate")?;
-        (next, value) = argmax(&logits).ok_or("output head produced no logits")?;
-        step_seconds.push(started.elapsed().as_secs_f64());
-        if price_this_step {
-            priced_step = Some((*step_seconds.last().expect("just pushed"), read_ledger()));
-        }
-    }
+        Ok(Flow::Continue)
+    })?;
+    let generated = decoded.generated;
+    let sequence: Vec<u32> = prompt.iter().chain(&generated).copied().collect();
 
     println!("engine: {engine}");
     println!("prompt tokens: {}", prompt.len());
-    println!("generated ids: {}", join_ids(&ids[prompt.len()..]));
-    println!("sequence ids: {}", join_ids(&ids));
+    println!("generated ids: {}", join_ids(&generated));
+    println!("sequence ids: {}", join_ids(&sequence));
     println!("weights loaded: {load_seconds:.1} s");
     println!(
-        "prompt: {} tokens in {prompt_seconds:.1} s ({:.0} ms/token) — first new token ready",
+        "prompt: {} tokens in {:.1} s ({:.0} ms/token) — first new token ready",
         prompt.len(),
-        prompt_seconds * 1e3 / prompt.len().max(1) as f64,
+        decoded.prompt_seconds,
+        decoded.prompt_seconds * 1e3 / prompt.len().max(1) as f64,
     );
-    if let Some(report) = DecodeReport::from_steps(&step_seconds) {
+    if let Some(report) = DecodeReport::from_steps(&decoded.step_seconds) {
         println!("decode tokens: {}", report.decode_tokens);
         println!("decode elapsed: {:.1} s", report.decode_seconds);
         println!(
@@ -144,14 +111,14 @@ pub(super) fn run_generate<B: PlanBackend>(
             );
         }
     }
-    if let Some((seconds, tallies)) = priced_step {
+    if let Some((seconds, tallies)) = decoded.priced_step {
         report_projections(seconds, &tallies);
         report_leaves(seconds);
     }
     if replaying {
         replay_projections(&mut session)?;
     }
-    Ok(())
+    Ok(generated)
 }
 
 /// The prepared image's bytes, site by site.
@@ -432,52 +399,6 @@ const UNATTRIBUTED_LIMIT: f64 = 5.0;
 /// prediction that omitted it would improve without bound as the weights
 /// shrank.
 const NON_PROJECTION_FLOOR_MS: [f64; 2] = [17.0, 24.0];
-
-/// Snapshot every plan's tally.
-fn read_ledger() -> Vec<(PhysicalProjectionPlan, PlanTally)> {
-    ledger().all().to_vec()
-}
-
-/// Index and value of the largest logit; ties keep the first, matching
-/// the summary path's fold.
-pub(super) fn argmax(logits: &[f32]) -> Option<(usize, f32)> {
-    logits
-        .iter()
-        .enumerate()
-        .fold(None, |best, (index, &value)| match best {
-            Some((_, best_value)) if value <= best_value => best,
-            _ => Some((index, value)),
-        })
-}
-
-/// Steady-decode timing over the per-step seconds (prompt ingestion and
-/// weight load are reported separately by the caller).
-#[derive(Debug, PartialEq)]
-pub(super) struct DecodeReport {
-    pub(super) decode_tokens: usize,
-    pub(super) decode_seconds: f64,
-    pub(super) mean_seconds_per_token: f64,
-    pub(super) steady_seconds_per_token: f64,
-}
-
-impl DecodeReport {
-    /// `None` when no decode step beyond the first token ran — a single
-    /// forward has no decode rate to report.
-    pub(super) fn from_steps(step_seconds: &[f64]) -> Option<Self> {
-        if step_seconds.is_empty() {
-            return None;
-        }
-        let decode_seconds: f64 = step_seconds.iter().sum();
-        let steady_len = (step_seconds.len() / STEADY_TAIL_DIVISOR).max(1);
-        let steady = &step_seconds[step_seconds.len() - steady_len..];
-        Some(Self {
-            decode_tokens: step_seconds.len(),
-            decode_seconds,
-            mean_seconds_per_token: decode_seconds / step_seconds.len() as f64,
-            steady_seconds_per_token: steady.iter().sum::<f64>() / steady.len() as f64,
-        })
-    }
-}
 
 /// Comma-separated ids, the same shape `--tokens` accepts, so a run's
 /// output can be fed straight back in as a prompt.

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -187,8 +187,10 @@ pub struct ExecArgs {
 
     /// Greedy-decode this many new tokens after the prompt, printing
     /// per-step timing and a decode report instead of a single-forward
-    /// summary. Every step re-runs the full forward — the interpreter
-    /// has no KV cache yet, and the report says so.
+    /// summary. Runs on a `DecodeSession`: operands are loaded once and
+    /// each token advances one position against the session's
+    /// continuation state (KV cache, or recurrent state), so the report
+    /// prices weight load, prompt ingestion and steady decode separately.
     #[arg(long, conflicts_with_all = ["dump_layers", "resume"])]
     pub generate: Option<usize>,
 
@@ -446,12 +448,14 @@ pub fn run(cmd: Vindex3Command) -> Result<(), Box<dyn std::error::Error>> {
 mod artifact;
 mod bank;
 mod consequence;
+pub(crate) mod decode;
 mod exec;
 mod generate;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
 mod lowered;
 mod ops;
 mod optional_op;
+pub(crate) mod prepare;
 mod sensitivity;
 mod teacher_force;
 use exec::run_exec;

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/prepare.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/prepare.rs
@@ -1,0 +1,339 @@
+//! Opening a container for execution — the one authority on how a
+//! container gets prepared.
+//!
+//! `larql vindex3 exec` and `larql run <container>` execute the same
+//! program through the same interpreter; they differ only in what wraps
+//! it (token ids and a research report, or text and a stream). Both
+//! therefore come through here: inspect the container, close the
+//! component's plan, bind the operands the chosen backend wants, and
+//! hand the backend — as a concrete type, chosen exactly once — to a
+//! [`BackendVisitor`]. A second copy of this sequence would be a second
+//! authority on what a container *is* when it runs, and the two would
+//! drift.
+
+use std::path::Path;
+
+use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
+use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use larql_vindex::format::vindex3::opplan::plan_component_ops;
+use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
+
+use super::ExecBackend;
+
+type BoxErr = Box<dyn std::error::Error>;
+
+/// The component a container executes when the caller names none — the
+/// same default `larql vindex3 exec --component` declares.
+pub(crate) const DEFAULT_COMPONENT: &str = "target";
+
+/// Engine tag prefix; the backend name completes it so a dump or a
+/// transcript can never be mistaken for one produced by another
+/// realisation.
+pub(crate) const ENGINE_PREFIX: &str = "vindex3";
+
+/// A container opened for execution: the plan closed, the operands bound.
+pub(crate) struct PreparedContainer {
+    pub(crate) plan: ComponentOpPlan,
+    pub(crate) store: OperandStore,
+    /// The encoding a compiled pack would have to carry for the backend
+    /// this was prepared for. `None` on arms that execute the canonical
+    /// bytes directly, which then never look for a pack.
+    pub(crate) want: Option<&'static str>,
+}
+
+/// Inspect, plan and bind — everything that has to happen before a
+/// backend can be handed the program.
+///
+/// A component that does not close is refused here, with every defect
+/// printed, so no caller can execute a partial plan.
+pub(crate) fn prepare(
+    container: &Path,
+    component: &str,
+    backend: ExecBackend,
+    source: RepresentationSource,
+) -> Result<PreparedContainer, BoxErr> {
+    let inspection = inspect_container(container, false)?;
+    let outcome = plan_component_ops(&inspection, container, component)?;
+    if !outcome.defects.is_empty() {
+        for defect in &outcome.defects {
+            eprintln!("defect: {defect}");
+        }
+        return Err(format!(
+            "component `{component}` does not close: {} defect(s)",
+            outcome.defects.len()
+        )
+        .into());
+    }
+    let plan = outcome
+        .plan
+        .ok_or_else(|| format!("component `{component}` produced no plan"))?;
+    let want = wanted_representation(backend);
+    let store = OperandStore::open_for(container, &inspection, want, source)?;
+    Ok(PreparedContainer { plan, store, want })
+}
+
+/// Parse `--representation-source`.
+///
+/// What execution wants, and whether it may be manufactured now, are
+/// separate questions; this is the second one.
+pub(crate) fn parse_representation_source(spec: &str) -> Result<RepresentationSource, BoxErr> {
+    match spec {
+        "auto" => Ok(RepresentationSource::Auto),
+        "stored" => Ok(RepresentationSource::Stored),
+        "transient" => Ok(RepresentationSource::Transient),
+        other => Err(format!(
+            "unknown --representation-source `{other}`; expected auto, stored or transient"
+        )
+        .into()),
+    }
+}
+
+/// The stored encoding a backend could be served from, if one is compiled.
+///
+/// Only the NVFP4 arms have a compiled counterpart today. Arms that run
+/// the canonical bytes return `None` and never look for a pack, so adding
+/// packs to a container cannot change what they execute.
+pub(crate) fn wanted_representation(backend: ExecBackend) -> Option<&'static str> {
+    use larql_vindex::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4;
+    // Exhaustive, with no wildcard arm, and that is the point: `_ =>
+    // None` stood here and a newly added NVFP4 backend silently
+    // inherited "wants nothing", bound the canonical bytes and produced
+    // logits bit-identical to BF16. A run that looks like perfect
+    // fidelity is the exact failure this file must not be able to
+    // express, so a new backend is now a compile error until someone
+    // states which representation it executes.
+    match backend {
+        ExecBackend::Reference | ExecBackend::Production => None,
+        ExecBackend::ProductionNvfp4 => Some(DTYPE_NVFP4),
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        ExecBackend::Metal
+        | ExecBackend::MetalMxfp4
+        | ExecBackend::MetalMxfp4All
+        | ExecBackend::MetalLoweredMxfp4
+        | ExecBackend::MetalLoweredMxfp4Ffn
+        | ExecBackend::MetalLoweredF16 => None,
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        ExecBackend::MetalNvfp4
+        | ExecBackend::MetalNvfp4Ffn
+        | ExecBackend::MetalNvfp4NoHead
+        | ExecBackend::MetalLowered
+        | ExecBackend::MetalLoweredFfn
+        | ExecBackend::MetalLoweredNoHead => Some(DTYPE_NVFP4),
+    }
+}
+
+/// The lowered path's per-class policy, for the arms that take it.
+///
+/// Same scheduling for every arm — one command buffer per token — so a
+/// comparison between them prices the *representation*, which the
+/// pre-lowering numbers could not (they mixed kernel families and
+/// starvation). `None` for every interpreted arm.
+#[cfg(all(feature = "gpu", target_os = "macos"))]
+pub(super) fn lowered_formats(
+    backend: ExecBackend,
+) -> Option<(
+    larql_vindex::format::vindex3::opplan::exec::backend::WeightFormats,
+    &'static str,
+)> {
+    use larql_vindex::format::vindex3::opplan::exec::backend::{WeightFormat, WeightFormats};
+    match backend {
+        ExecBackend::MetalLowered => {
+            Some((WeightFormats::uniform(WeightFormat::Nvfp4), "nvfp4-all"))
+        }
+        ExecBackend::MetalLoweredFfn => Some((
+            WeightFormats {
+                attention: WeightFormat::F16,
+                ffn: WeightFormat::Nvfp4,
+                head: WeightFormat::F16,
+            },
+            "nvfp4-ffn",
+        )),
+        ExecBackend::MetalLoweredNoHead => Some((
+            WeightFormats {
+                attention: WeightFormat::Nvfp4,
+                ffn: WeightFormat::Nvfp4,
+                head: WeightFormat::F16,
+            },
+            "nvfp4-no-head",
+        )),
+        ExecBackend::MetalLoweredMxfp4 => {
+            Some((WeightFormats::uniform(WeightFormat::Mxfp4), "mxfp4-all"))
+        }
+        ExecBackend::MetalLoweredF16 => {
+            Some((WeightFormats::uniform(WeightFormat::F16), "f16-all"))
+        }
+        ExecBackend::MetalLoweredMxfp4Ffn => Some((
+            WeightFormats {
+                attention: WeightFormat::F16,
+                ffn: WeightFormat::Mxfp4,
+                head: WeightFormat::F16,
+            },
+            "mxfp4-ffn",
+        )),
+        ExecBackend::Reference
+        | ExecBackend::Production
+        | ExecBackend::ProductionNvfp4
+        | ExecBackend::Metal
+        | ExecBackend::MetalMxfp4
+        | ExecBackend::MetalMxfp4All
+        | ExecBackend::MetalNvfp4
+        | ExecBackend::MetalNvfp4NoHead
+        | ExecBackend::MetalNvfp4Ffn => None,
+    }
+}
+
+/// Work that runs against a backend chosen at runtime.
+///
+/// The backends are distinct concrete types and the interpreter is
+/// generic over them, so the choice cannot be a trait object; it is made
+/// once, in [`with_plan_backend`], and the visitor sees the concrete
+/// type.
+pub(crate) trait BackendVisitor {
+    type Out;
+    fn visit<B: PlanBackend>(self, backend: &B) -> Result<Self::Out, BoxErr>;
+}
+
+/// Construct the interpreted backend `backend` names and hand it to
+/// `visitor` — the single place a `--backend` value becomes a type.
+///
+/// The lowered arms are not interpreted backends and are refused here:
+/// they run through `lowered::run_lowered`, which the exec verb reaches
+/// via [`lowered_formats`] before it comes this way.
+pub(crate) fn with_plan_backend<V: BackendVisitor>(
+    backend: ExecBackend,
+    visitor: V,
+) -> Result<V::Out, BoxErr> {
+    match backend {
+        ExecBackend::Reference => visitor.visit(&ReferenceBackend::new()),
+        ExecBackend::Production => visitor.visit(&ProductionBackend::new()),
+        // Same kernels as `production`; the difference is upstream, in
+        // `wanted_representation`, which makes the store bind the
+        // compiled NVFP4 pack instead of the canonical bytes. The
+        // projector then dispatches `FusedNvfp4` off the resident
+        // representation, exactly as it dispatches every other arm.
+        ExecBackend::ProductionNvfp4 => visitor.visit(&ProductionBackend::new()),
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        ExecBackend::MetalMxfp4 => {
+            let gpu = larql_compute_metal::MetalBackend::new()
+                .ok_or("no Metal device available for --backend metal-mxfp4")?;
+            // FFN-only MXFP4 — the gpt-oss precedent. The gates
+            // falsified the wider presets on the 6-token fixture:
+            // all-MXFP4 flipped the argmax (top-2 gap 0.08 vs
+            // upstream's 1.13) and an f16 head alone did not recover
+            // it (gap 0.01) — 4-bit attention projections accumulate
+            // ~14% rel_rms across 52 layers. Attention and head stay
+            // f16; the FFN bulk (~3/4 of the bytes) is quantised.
+            use larql_vindex::format::vindex3::opplan::exec::backend::{
+                WeightFormat, WeightFormats,
+            };
+            let backend =
+                larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::with_formats(
+                    gpu,
+                    "metal-q1-mxfp4-ffn",
+                    WeightFormats {
+                        attention: WeightFormat::F16,
+                        ffn: WeightFormat::Mxfp4,
+                        head: WeightFormat::F16,
+                    },
+                );
+            visitor.visit(&backend)
+        }
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        ExecBackend::MetalLowered
+        | ExecBackend::MetalLoweredFfn
+        | ExecBackend::MetalLoweredNoHead
+        | ExecBackend::MetalLoweredMxfp4
+        | ExecBackend::MetalLoweredMxfp4Ffn
+        | ExecBackend::MetalLoweredF16 => Err(format!(
+            "`{backend:?}` is a lowered arm: it does not execute through the interpreter"
+        )
+        .into()),
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        ExecBackend::MetalMxfp4All => {
+            let gpu = larql_compute_metal::MetalBackend::new()
+                .ok_or("no Metal device available for --backend metal-mxfp4-all")?;
+            // The control arm: the preset Q1 falsified. Its job is to
+            // fail, so that a Q2 arm holding the prediction is evidence
+            // about the format rather than about the harness.
+            use larql_vindex::format::vindex3::opplan::exec::backend::{
+                WeightFormat, WeightFormats,
+            };
+            let backend =
+                larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::with_formats(
+                    gpu,
+                    "metal-q1-mxfp4-all",
+                    WeightFormats::uniform(WeightFormat::Mxfp4),
+                );
+            visitor.visit(&backend)
+        }
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        ExecBackend::MetalNvfp4 | ExecBackend::MetalNvfp4Ffn | ExecBackend::MetalNvfp4NoHead => {
+            let gpu = larql_compute_metal::MetalBackend::new()
+                .ok_or("no Metal device available for the nvfp4 backends")?;
+            // The VINDEX3-Q2 ladder. Q1 established that *this model's*
+            // attention does not survive MXFP4; NVFP4 keeps the same
+            // e2m1 elements and changes only the scale geometry, which a
+            // weight-reconstruction sweep with an equal-bit-budget
+            // control (E8M0 at group 16) isolated as the whole source of
+            // the difference. Arm A is the one that matters — it is the
+            // ~17 GB regime — and B and C exist so a failure says which
+            // class it came from rather than only that it failed.
+            use larql_vindex::format::vindex3::opplan::exec::backend::{
+                WeightFormat, WeightFormats,
+            };
+            let (name, formats) = match backend {
+                // A — everything 4-bit.
+                ExecBackend::MetalNvfp4 => (
+                    "metal-q2-nvfp4-all",
+                    WeightFormats::uniform(WeightFormat::Nvfp4),
+                ),
+                // B — attention and FFN 4-bit, head wide. Isolates the
+                // head, which Q1's second rung showed was not the whole
+                // story under MXFP4.
+                ExecBackend::MetalNvfp4NoHead => (
+                    "metal-q2-nvfp4-no-head",
+                    WeightFormats {
+                        attention: WeightFormat::Nvfp4,
+                        ffn: WeightFormat::Nvfp4,
+                        head: WeightFormat::F16,
+                    },
+                ),
+                // C — the Q1-passing partition, re-run under NVFP4, so
+                // the two formats are compared at the same class split.
+                _ => (
+                    "metal-q2-nvfp4-ffn",
+                    WeightFormats {
+                        attention: WeightFormat::F16,
+                        ffn: WeightFormat::Nvfp4,
+                        head: WeightFormat::F16,
+                    },
+                ),
+            };
+            let backend =
+                larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::with_formats(
+                    gpu, name, formats,
+                );
+            visitor.visit(&backend)
+        }
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        ExecBackend::Metal => {
+            // vindex never links Metal: the CLI injects the concrete
+            // device through larql-compute's MatMul seam. f16 weights so
+            // the Metal buffer cache keeps the model resident (r2); the
+            // engine tag names the realisation so a dump can never be
+            // mistaken for the f32 r1 lowering.
+            let gpu = larql_compute_metal::MetalBackend::new()
+                .ok_or("no Metal device available for --backend metal")?;
+            let backend =
+                larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::new(
+                    gpu,
+                    "metal-r3-f16",
+                    larql_vindex::format::vindex3::opplan::exec::backend::WeightFormat::F16,
+                );
+            visitor.visit(&backend)
+        }
+    }
+}

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/decode.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/decode.rs
@@ -1,0 +1,218 @@
+//! The greedy loop and the preparation seam: ids come out through the
+//! sink, the sink can halt the loop, and a container is prepared and
+//! dispatched by the one authority both verbs share.
+
+use std::path::Path;
+
+use larql_vindex::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
+use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+use larql_vindex::format::vindex3::opplan::exec::decode::DecodeSession;
+use larql_vindex::format::vindex3::opplan::exec::operands::RepresentationSource;
+use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use larql_vindex::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4;
+
+use super::super::decode::{greedy_decode, Flow};
+use super::super::prepare::{
+    parse_representation_source, prepare, wanted_representation, with_plan_backend, BackendVisitor,
+    PreparedContainer, DEFAULT_COMPONENT,
+};
+use super::super::ExecBackend;
+
+const PROMPT: [u32; 3] = [1, 2, 3];
+const NEW_TOKENS: usize = 4;
+
+/// The dense fixture, encoded and prepared for the reference arm.
+fn prepared_dense(root: &Path) -> PreparedContainer {
+    let checkpoint = root.join("checkpoint");
+    let container = root.join("container");
+    std::fs::create_dir_all(&checkpoint).unwrap();
+    std::fs::create_dir_all(&container).unwrap();
+    encode_fixture_container(dense_f32_model, &checkpoint, &container, "dense");
+    prepare(
+        &container,
+        DEFAULT_COMPONENT,
+        ExecBackend::Reference,
+        RepresentationSource::Auto,
+    )
+    .unwrap()
+}
+
+#[test]
+fn the_sink_sees_every_id_the_loop_returns() {
+    let root = tempfile::tempdir().unwrap();
+    let prepared = prepared_dense(root.path());
+    let backend = ReferenceBackend::new();
+    let mut session = DecodeSession::new(&prepared.plan, &prepared.store, &backend).unwrap();
+    let mut seen = Vec::new();
+    let decoded = greedy_decode(&mut session, &PROMPT, NEW_TOKENS, &mut |id, _| {
+        seen.push(id);
+        Ok(Flow::Continue)
+    })
+    .unwrap();
+    assert_eq!(decoded.generated, seen);
+    assert_eq!(decoded.generated.len(), NEW_TOKENS);
+    // The first generated token comes out of the prompt phase; every
+    // later one is a timed decode step.
+    assert_eq!(decoded.step_seconds.len(), NEW_TOKENS - 1);
+    assert_eq!(session.position(), PROMPT.len() + NEW_TOKENS - 1);
+}
+
+#[test]
+fn a_halting_sink_ends_the_decode_before_the_next_step() {
+    let root = tempfile::tempdir().unwrap();
+    let prepared = prepared_dense(root.path());
+    let backend = ReferenceBackend::new();
+    let mut session = DecodeSession::new(&prepared.plan, &prepared.store, &backend).unwrap();
+    let mut seen = 0usize;
+    let decoded = greedy_decode(&mut session, &PROMPT, NEW_TOKENS, &mut |_, _| {
+        seen += 1;
+        Ok(if seen == 2 {
+            Flow::Halt
+        } else {
+            Flow::Continue
+        })
+    })
+    .unwrap();
+    // The halting id is still reported — the sink saw it — and no step
+    // ran after it.
+    assert_eq!(decoded.generated.len(), 2);
+    assert_eq!(decoded.step_seconds.len(), 1);
+    assert_eq!(session.position(), PROMPT.len() + 1);
+}
+
+#[test]
+fn zero_new_tokens_ingests_the_prompt_and_generates_nothing() {
+    let root = tempfile::tempdir().unwrap();
+    let prepared = prepared_dense(root.path());
+    let backend = ReferenceBackend::new();
+    let mut session = DecodeSession::new(&prepared.plan, &prepared.store, &backend).unwrap();
+    let decoded = greedy_decode(&mut session, &PROMPT, 0, &mut |_, _| {
+        panic!("nothing should reach the sink")
+    })
+    .unwrap();
+    assert!(decoded.generated.is_empty());
+    assert!(decoded.step_seconds.is_empty());
+    assert!(decoded.priced_step.is_none());
+    assert_eq!(session.position(), PROMPT.len());
+}
+
+#[test]
+fn an_empty_prompt_is_refused() {
+    let root = tempfile::tempdir().unwrap();
+    let prepared = prepared_dense(root.path());
+    let backend = ReferenceBackend::new();
+    let mut session = DecodeSession::new(&prepared.plan, &prepared.store, &backend).unwrap();
+    let err = greedy_decode(&mut session, &[], NEW_TOKENS, &mut |_, _| {
+        Ok(Flow::Continue)
+    })
+    .err()
+    .expect("an empty prompt has nothing to condition on");
+    assert!(err.to_string().contains("no tokens"), "{err}");
+    assert_eq!(session.position(), 0);
+}
+
+#[test]
+fn a_sink_error_aborts_the_decode() {
+    let root = tempfile::tempdir().unwrap();
+    let prepared = prepared_dense(root.path());
+    let backend = ReferenceBackend::new();
+    let mut session = DecodeSession::new(&prepared.plan, &prepared.store, &backend).unwrap();
+    let err = greedy_decode(&mut session, &PROMPT, NEW_TOKENS, &mut |_, _| {
+        Err("the stream closed".into())
+    })
+    .err()
+    .expect("a sink failure is the decode's failure");
+    assert_eq!(err.to_string(), "the stream closed");
+}
+
+#[test]
+fn the_loop_is_deterministic_across_fresh_sessions() {
+    let root = tempfile::tempdir().unwrap();
+    let prepared = prepared_dense(root.path());
+    let backend = ReferenceBackend::new();
+    let run = || {
+        let mut session = DecodeSession::new(&prepared.plan, &prepared.store, &backend).unwrap();
+        greedy_decode(&mut session, &PROMPT, NEW_TOKENS, &mut |_, _| {
+            Ok(Flow::Continue)
+        })
+        .unwrap()
+        .generated
+    };
+    assert_eq!(run(), run());
+}
+
+/// A visitor that reports which realisation it was handed.
+struct NameOf;
+
+impl BackendVisitor for NameOf {
+    type Out = String;
+
+    fn visit<B: PlanBackend>(self, backend: &B) -> Result<String, Box<dyn std::error::Error>> {
+        Ok(backend.name().to_string())
+    }
+}
+
+#[test]
+fn the_dispatch_hands_the_visitor_the_named_realisation() {
+    assert_eq!(
+        with_plan_backend(ExecBackend::Reference, NameOf).unwrap(),
+        "reference-f32"
+    );
+    assert_eq!(
+        with_plan_backend(ExecBackend::Production, NameOf).unwrap(),
+        "production-larql-compute"
+    );
+    // Same kernels as `production`; the representation is chosen upstream.
+    assert_eq!(
+        with_plan_backend(ExecBackend::ProductionNvfp4, NameOf).unwrap(),
+        "production-larql-compute"
+    );
+}
+
+#[cfg(all(feature = "gpu", target_os = "macos"))]
+#[test]
+fn a_lowered_arm_is_refused_by_the_interpreter_dispatch() {
+    let err = with_plan_backend(ExecBackend::MetalLowered, NameOf)
+        .expect_err("a lowered arm does not run through the interpreter");
+    assert!(err.to_string().contains("lowered"), "{err}");
+}
+
+#[test]
+fn the_canonical_arms_want_no_pack_and_the_nvfp4_arm_wants_its_encoding() {
+    assert_eq!(wanted_representation(ExecBackend::Reference), None);
+    assert_eq!(wanted_representation(ExecBackend::Production), None);
+    assert_eq!(
+        wanted_representation(ExecBackend::ProductionNvfp4),
+        Some(DTYPE_NVFP4)
+    );
+}
+
+#[test]
+fn the_source_policy_names_three_values_and_refuses_the_rest() {
+    assert!(matches!(
+        parse_representation_source("auto").unwrap(),
+        RepresentationSource::Auto
+    ));
+    assert!(matches!(
+        parse_representation_source("stored").unwrap(),
+        RepresentationSource::Stored
+    ));
+    assert!(matches!(
+        parse_representation_source("transient").unwrap(),
+        RepresentationSource::Transient
+    ));
+    let err = parse_representation_source("cached").err().unwrap();
+    assert!(err.to_string().contains("cached"), "{err}");
+}
+
+#[test]
+fn a_directory_that_is_not_a_container_cannot_be_prepared() {
+    let root = tempfile::tempdir().unwrap();
+    assert!(prepare(
+        root.path(),
+        DEFAULT_COMPONENT,
+        ExecBackend::Reference,
+        RepresentationSource::Auto,
+    )
+    .is_err());
+}

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/generate.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/generate.rs
@@ -2,7 +2,7 @@
 //! report's timing math, and one end-to-end greedy decode over the
 //! encoded fixture.
 
-use super::super::generate::{argmax, DecodeReport};
+use super::super::decode::{argmax, DecodeReport};
 use super::super::{run, EncodeArgs, ExecArgs, ExecBackend, Vindex3Command};
 use super::fixture_dir;
 

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/mod.rs
@@ -1,6 +1,7 @@
 //! CLI-level gates for the vindex3 verbs.
 
 mod calibration_digest;
+mod decode;
 mod exec_resume;
 mod generate;
 mod sizes;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -110,7 +110,7 @@ larql run <MODEL> [PROMPT] [OPTIONS]
 
 | Flag | Description | Default |
 |---|---|---|
-| `<MODEL>` | Vindex dir, `hf://owner/name`, `owner/name`, or cache shorthand | — |
+| `<MODEL>` | Vindex dir, VINDEX3 container, `hf://owner/name`, `owner/name`, or cache shorthand | — |
 | `[PROMPT]` | Prompt text; omit to enter chat mode | — |
 | `-n, --max-tokens <N>` | Max tokens to generate autoregressively | 64 |
 | `--top <N>` | Show the top-K prediction table per step instead of just the argmax (implied by `--verbose`) | 1 |
@@ -130,6 +130,25 @@ larql run <MODEL> [PROMPT] [OPTIONS]
 | `--ops <NAME[,…]>` | Restrict `--experts` to a comma-separated subset of op names | all |
 | `--constrained` | Run constrained-decoding mode (require all generated tokens to satisfy declared ops) | false |
 | `-v, --verbose` | Verbose load / timing output | false |
+| `--emit-ids` | Print the prompt token ids and the generated ids to stderr, so the run can serve as an id-level oracle for `larql vindex3 exec --tokens` on the same model (VINDEX3 containers; `--routed-from --metal` composed runs) | false |
+
+**VINDEX3 containers.** A container written by `larql vindex3 encode` is
+detected from its `index.json` generation and routed to its own arm: the
+container's program runs through the VINDEX3 interpreter — the same one
+`larql vindex3 exec` reports on, prepared by the same code — with the
+tokenizer the container carries. Decode is greedy, the prompt is encoded
+raw (no chat template), and generation stops at the first EOS from the
+container's `generation_config.json` or at `--max-tokens`. `--metal`
+selects the Metal realisation (macOS, `gpu` feature); otherwise the
+`larql-compute` CPU kernels run. Weights load once; each prompt — one on
+the command line, or every line of chat mode — starts from a fresh
+continuation state. Flags that describe the dense VINDEX2 engine
+(`--top`, `--kv-cache`, `--engine`, `--ffn`, `--routed-from`,
+`--moe-shards`, `--moe-units-manifest`, `--experts`, `--experts-dir`,
+`--ops`, `--constrained`, `--image`, `--mm-weights`) are refused by name
+rather than ignored. A container encoded from a checkpoint that had no
+`tokenizer.json` cannot tokenise text and is refused; run it from ids
+with `larql vindex3 exec --tokens`.
 
 Examples:
 
@@ -138,6 +157,8 @@ larql run gemma-3-4b-it-vindex "The capital of France is"
 larql run chrishayuk/gemma-3-4b-it-vindex           # chat mode
 larql run hf://chrishayuk/gemma-3-4b-it-vindex      # explicit HF
 larql run gemma4-31b.vindex --ffn http://server:8080 "…"
+larql run qwen3-0.6b.vindex3 "The capital of France is"   # VINDEX3 container
+larql run qwen3-0.6b.vindex3 --metal --emit-ids "…"       # Metal; ids to stderr
 ```
 
 ### `larql chat`
@@ -1914,7 +1935,7 @@ larql vindex3 <SUBCOMMAND> [OPTIONS]
 | `inspect <container>` | Reconstruct and check a container solely from its own contents — no source checkpoint, no architecture registry. `--verify` re-hashes every segment; `--execution-complete` additionally requires every component with executable objects to carry the surface those operations read. |
 | `verify <artifacts...> --container <DIR>` | Prove source ≡ encoded: four-authority semantic comparison plus per-representation byte equivalence, both ends re-hashed now. Exits non-zero on any disagreement. |
 | `ops <container>` | Emit the generic operation plan of one component, solely from the container. Operand closure is the gate: every stack tensor must classify into a role a declared op consumes, with the geometry the surface states. Exits non-zero on any closure defect. |
-| `exec <container> --tokens <IDS>` | Execute one component's own program from the container alone. `--dump-layers` writes per-layer hidden states in the `shannon layer-dump` format so `layer-diff` can compare against an upstream trace. |
+| `exec <container> --tokens <IDS>` | Execute one component's own program from the container alone. `--dump-layers` writes per-layer hidden states in the `shannon layer-dump` format so `layer-diff` can compare against an upstream trace. `larql run <container> [prompt]` is the text-in/text-out shell over the same interpreter. |
 
 **`larql vindex3 exec`** flags:
 
@@ -1926,7 +1947,7 @@ larql vindex3 <SUBCOMMAND> [OPTIONS]
 | `--backend <B>` | Numerical realisation: `reference` (naive f32), `production` (`larql-compute` kernels), plus Metal arms on macOS with the `gpu` feature (`metal`, `metal-mxfp4`, `metal-nvfp4`, `metal-lowered`, …) — same program, same interpreter, only the arithmetic differs | reference |
 | `--dump-layers <DIR>` | Write per-layer planes + manifest here instead of a summary. Planes are written as each layer completes, so an interrupted run leaves everything it finished | — |
 | `--resume` | Continue an interrupted `--dump-layers` run from its last complete plane. The recorded fixture (tokens, container, engine) must match | false |
-| `--generate <N>` | Greedy-decode N new tokens after the prompt, printing per-step timing and a decode report. Every step re-runs the full forward — the interpreter has no KV cache | — |
+| `--generate <N>` | Greedy-decode N new tokens after the prompt, printing per-step timing and a decode report. Runs on a `DecodeSession`: operands load once and each token advances one position against the session's continuation state (KV cache, or recurrent state), so weight load, prompt ingestion and steady decode are priced separately | — |
 | `--logit-dump <PATH>` | Step the tokens through one position at a time and write every position's logits as `[positions, vocab]` f32 (teacher forcing — what a KL/NLL gate needs; `--generate` cannot supply it) | — |
 | `--profile` | Lowered backends only, requires `--generate`: attribute each decode token's GPU time to its stage classes and print the ledger against the bytes each class reads | false |
 

--- a/docs/vindex3-registry-design.md
+++ b/docs/vindex3-registry-design.md
@@ -62,6 +62,14 @@ qwen3.8` cannot actually execute yet regardless of what the resolver
 returns — that gap is pre-existing and out of scope here (§7 says not
 to wire runtime lifecycle in this rung).
 
+> **Closed 2026-09-01.** `run_cmd::run` now detects a VINDEX3 container
+> from its `index.json` generation before any VINDEX2-only reader opens
+> it, and routes to `run_cmd_vindex3`: the container is prepared through
+> `vindex3_cmd::prepare` — the one authority `larql vindex3 exec` also
+> uses — and text streams through the tokenizer the container carries.
+> The resolver consolidation above is still open; the execution gap is
+> not.
+
 **The local cache has no persisted manifest at all — the filesystem
 *is* the registry.** `~/.cache/larql/local/` is a directory of
 symlinks (`<name>.vindex` → target dir); `~/.cache/huggingface/hub/`
@@ -255,7 +263,8 @@ the CLI needing to pass it anywhere yet).
 follow-ups): consolidating the three existing resolvers into calling
 the new one; wiring `--profile` through to `Vindex3Runtime::open`;
 fixing `larql pull`'s VINDEX2-fixed-file-list download so a VINDEX3
-repo actually round-trips; giving `larql run` a VINDEX3 execution path.
+repo actually round-trips; giving `larql run` a VINDEX3 execution path
+(done 2026-09-01, `run_cmd_vindex3`).
 
 ## 8. Confirmed architecture decisions (2026-08-23)
 


### PR DESCRIPTION
## What

`larql run <vindex3-container> [prompt]` — text in, text out, from the container's own program. `run()` detects a VINDEX3 container from its `index.json` generation before any VINDEX2-only reader opens it and routes to `run_cmd_vindex3`: the container's tokenizer, greedy decode through the same interpreter `larql vindex3 exec` reports on, text streamed as it is produced, EOS from the container's `generation_config.json`. Weights load once; every prompt (and every chat line) gets a fresh continuation state.

- `--metal` selects the Metal realisation (macOS, `gpu` feature); otherwise the `larql-compute` CPU kernels.
- Dense-engine flags (`--top`, `--kv-cache`, `--engine`, `--ffn`, `--routed-from`, `--moe-*`, `--experts*`, `--ops`, `--constrained`, `--image`, `--mm-weights`) are refused **by name**, in one message, never ignored.
- `--emit-ids` prints prompt and generated ids to stderr, so a run doubles as an id-level oracle for `vindex3 exec --tokens`.
- A container encoded without `tokenizer.json` is refused with a pointer to `vindex3 exec --tokens`.

## Structure

The setup `run_exec` owned (inspect → plan → operand store → backend choice) moves to `vindex3_cmd/prepare.rs` behind a `BackendVisitor` (backends are distinct concrete types, so the choice is made once and the visitor sees the type). The greedy loop moves to `vindex3_cmd/decode.rs` with a token sink that can halt the turn; `run_generate` is now the exec verb's report wrapper and returns the ids. **Note:** `prepare` is a second opener beside `larql_inference::vindex3::runtime::open_component` (#381 made that one policy-aware); the stacked PR deletes this duplicate and delegates — that is the step that makes the opener the single authority.

## Witness (release build, "The capital of France is", 12 tokens)

| container | backend | output | tok/s | ids vs `vindex3 exec --tokens` |
|---|---|---|---|---|
| oute-mamba2attn-250m | production (CPU) | " the city of Paris." | 82 | identical |
| qwen3-4b | `--metal` | " Paris. The capital of Germany is Berlin." | 17.4 | identical |

## Gates

21 new tests (loop, dispatch, detection, refusals, EOS by id and by stop string, chat-turn isolation, Metal on the fixture). `cargo fmt --all --check`; clippy `--bins --tests --no-deps -- -D warnings` under default features and `--no-default-features`; `cargo test -p larql-cli` in both shapes (805 CPU-only); `registry check`; doc link/reference gates. Coverage in the CI shape: `decode.rs` 100%, run arm 91.5%+, `prepare.rs` 82% (the untested arm is the pre-existing "plan does not close" refusal, which needs binary-segment surgery to reach).

## Docs

`docs/cli.md` (run section + exec table), `docs/vindex3-registry-design.md` (the recorded gap is closed), README (one sentence). The stale "no KV cache" statement on `exec --generate` is corrected.
