### PR TITLE
refactor(cli): use the VINDEX3 runtime opener as the single authority

### DIFF
--- a/crates/larql-cli/src/commands/primary/run_cmd_vindex3/mod.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd_vindex3/mod.rs
@@ -22,12 +22,19 @@
 //! the command line, or each line of the chat loop — gets a brand-new
 //! continuation state over them, so nothing from one turn can reach the
 //! next.
+//!
+//! The model is named by the container. `index.model` is the identity
+//! authority; the directory name is an explicit fallback for a container
+//! encoded nameless, and [`resolved_display_name`] is the only place
+//! that fallback is decided — the banner and the verbose report both
+//! read it, so neither can grow a second derivation.
 
 use std::io::{self, BufRead, Write};
 use std::path::Path;
 use std::time::Instant;
 
 use larql_inference::layer_graph::generate::{Detokenizer, EosConfig};
+use larql_inference::vindex3::OpenedComponent;
 use larql_vindex::format::filenames::TOKENIZER_JSON;
 use larql_vindex::format::generation::{detect_generation, ContainerGeneration};
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
@@ -41,7 +48,7 @@ use larql_vindex::tokenizers::Tokenizer;
 use super::run_cmd::{KvCacheKind, RunArgs};
 use super::vindex3_cmd::decode::{greedy_decode, DecodeReport, Flow};
 use super::vindex3_cmd::prepare::{
-    prepare, with_plan_backend, BackendVisitor, PreparedContainer, DEFAULT_COMPONENT, ENGINE_PREFIX,
+    prepare, with_plan_backend, BackendVisitor, DEFAULT_COMPONENT, ENGINE_PREFIX,
 };
 use super::vindex3_cmd::ExecBackend;
 
@@ -54,8 +61,30 @@ type BoxErr = Box<dyn std::error::Error>;
 /// this arm produces.
 const SINGLE_PREDICTION: usize = 1;
 
-/// The chat loop's prompt, written to stderr so stdout stays the model's.
+/// The chat loop's prompt, written to the status stream so stdout stays
+/// the model's.
 const CHAT_PROMPT: &str = "> ";
+
+/// What a container that declares no name is called, when even its
+/// directory has no printable name.
+const NAMELESS_CONTAINER: &str = "container";
+
+/// The name a run shows for its model.
+///
+/// The container's own declaration (`index.model`) is the identity
+/// authority and wins whenever it is non-empty. The directory name is
+/// the explicit fallback for a container encoded nameless — the only
+/// path on which filesystem identity may ever be shown as the model's.
+pub(super) fn resolved_display_name(declared: &str, container: &Path) -> String {
+    if !declared.is_empty() {
+        return declared.to_string();
+    }
+    container
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(NAMELESS_CONTAINER)
+        .to_string()
+}
 
 /// Whether `dir` is a VINDEX3 container.
 ///
@@ -73,16 +102,20 @@ pub fn run(container: &Path, args: &RunArgs) -> Result<(), BoxErr> {
         args,
         &mut io::stdin().lock(),
         &mut io::stdout().lock(),
+        &mut io::stderr(),
     )
 }
 
-/// [`run`] with its streams injected — the chat loop reads `input`, and
-/// every generated character goes to `out`.
+/// [`run`] with its streams injected — the chat loop reads `input`,
+/// every generated character goes to `out`, and everything that is
+/// *about* the run (banner, prompt, ids, timings, errors) goes to
+/// `status`, which is stderr in the binary.
 pub(super) fn run_to(
     container: &Path,
     args: &RunArgs,
     input: &mut dyn BufRead,
     out: &mut dyn Write,
+    status: &mut dyn Write,
 ) -> Result<(), BoxErr> {
     refuse_inapplicable_flags(args)?;
     let backend = select_backend(args.metal)?;
@@ -114,6 +147,7 @@ pub(super) fn run_to(
             eos: &eos,
             input,
             out,
+            status,
         },
     )
 }
@@ -180,11 +214,12 @@ fn select_backend(metal: bool) -> Result<ExecBackend, BoxErr> {
 struct Runner<'a> {
     container: &'a Path,
     args: &'a RunArgs,
-    prepared: &'a PreparedContainer,
+    prepared: &'a OpenedComponent,
     tokenizer: &'a Tokenizer,
     eos: &'a EosConfig,
     input: &'a mut dyn BufRead,
     out: &'a mut dyn Write,
+    status: &'a mut dyn Write,
 }
 
 impl BackendVisitor for Runner<'_> {
@@ -200,11 +235,14 @@ impl BackendVisitor for Runner<'_> {
             ExecutionSlice::Full,
         )?;
         let engine = format!("{ENGINE_PREFIX}-{}", backend.name());
+        let identity = resolved_display_name(&self.prepared.model_name, self.container);
         if self.args.verbose {
-            eprintln!(
-                "[{engine}] weights resident in {:.1} s",
+            writeln!(
+                self.status,
+                "[{engine}] {identity} ({}): weights resident in {:.1} s",
+                self.prepared.family,
                 loading.elapsed().as_secs_f64()
-            );
+            )?;
         }
         let model = ResidentModel {
             plan: &self.prepared.plan,
@@ -216,9 +254,9 @@ impl BackendVisitor for Runner<'_> {
             args: self.args,
         };
         if let Some(prompt) = self.args.prompt.as_deref() {
-            return model.generate(prompt, self.out);
+            return model.generate(prompt, self.out, self.status);
         }
-        chat_loop(self.container, &model, self.input, self.out)
+        chat_loop(&identity, &model, self.input, self.out, self.status)
     }
 }
 
@@ -236,7 +274,12 @@ struct ResidentModel<'a, B: PlanBackend> {
 impl<B: PlanBackend> ResidentModel<'_, B> {
     /// Encode `prompt`, decode up to `--max-tokens` greedily, and stream
     /// the text to `out` as it is produced. Ends at the first EOS.
-    fn generate(&self, prompt: &str, out: &mut dyn Write) -> Result<(), BoxErr> {
+    fn generate(
+        &self,
+        prompt: &str,
+        out: &mut dyn Write,
+        status: &mut dyn Write,
+    ) -> Result<(), BoxErr> {
         let encoded = self
             .tokenizer
             .encode(prompt, true)
@@ -265,25 +308,31 @@ impl<B: PlanBackend> ResidentModel<'_, B> {
         })?;
         writeln!(out)?;
         if self.args.emit_ids {
-            eprintln!("[{}] prompt ids: {:?}", self.engine, ids);
-            eprintln!("[{}] generated ids: {:?}", self.engine, decoded.generated);
+            writeln!(status, "[{}] prompt ids: {:?}", self.engine, ids)?;
+            writeln!(
+                status,
+                "[{}] generated ids: {:?}",
+                self.engine, decoded.generated
+            )?;
         }
         if self.args.verbose {
-            eprintln!(
+            writeln!(
+                status,
                 "[{}] {} prompt tokens in {:.2} s, {} generated",
                 self.engine,
                 ids.len(),
                 decoded.prompt_seconds,
                 decoded.generated.len(),
-            );
+            )?;
             if let Some(report) = DecodeReport::from_steps(&decoded.step_seconds) {
-                eprintln!(
+                writeln!(
+                    status,
                     "[{}] decode {:.0} ms/token ({:.2} tok/s), steady {:.0} ms/token",
                     self.engine,
                     report.mean_seconds_per_token * 1e3,
                     report.mean_seconds_per_token.recip(),
                     report.steady_seconds_per_token * 1e3,
-                );
+                )?;
             }
         }
         Ok(())
@@ -294,26 +343,24 @@ impl<B: PlanBackend> ResidentModel<'_, B> {
 /// line is its own prompt — no history, no template — over the one
 /// resident model.
 fn chat_loop<B: PlanBackend>(
-    container: &Path,
+    identity: &str,
     model: &ResidentModel<'_, B>,
     input: &mut dyn BufRead,
     out: &mut dyn Write,
+    status: &mut dyn Write,
 ) -> Result<(), BoxErr> {
-    eprintln!(
-        "larql chat ({}) — {} (Ctrl-D to exit)",
-        model.engine,
-        container
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("container")
-    );
+    writeln!(
+        status,
+        "larql chat ({}) — {identity} (Ctrl-D to exit)",
+        model.engine
+    )?;
     loop {
-        eprint!("{CHAT_PROMPT}");
-        io::stderr().flush()?;
+        write!(status, "{CHAT_PROMPT}")?;
+        status.flush()?;
         let mut line = String::new();
         match input.read_line(&mut line) {
             Ok(0) => {
-                eprintln!();
+                writeln!(status)?;
                 return Ok(());
             }
             Ok(_) => {}
@@ -323,8 +370,8 @@ fn chat_loop<B: PlanBackend>(
         if prompt.is_empty() {
             continue;
         }
-        if let Err(e) = model.generate(prompt, out) {
-            eprintln!("Error: {e}");
+        if let Err(e) = model.generate(prompt, out, status) {
+            writeln!(status, "Error: {e}")?;
         }
     }
 }

--- a/crates/larql-cli/src/commands/primary/run_cmd_vindex3/tests/mod.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd_vindex3/tests/mod.rs
@@ -10,7 +10,7 @@ use larql_vindex::format::vindex3::fixtures::{
 };
 
 use super::super::run_cmd::RunArgs;
-use super::{is_vindex3_container, run_to};
+use super::{is_vindex3_container, resolved_display_name, run_to};
 
 /// A prompt that is its own id list under the fixture tokenizer.
 const PROMPT: &str = "[1] [2] [3]";
@@ -28,13 +28,20 @@ fn args(argv: &[&str]) -> RunArgs {
 }
 
 /// A WordLevel tokenizer over the fixture's vocabulary: token `[i]` is
-/// id `i`, split on whitespace, joined back with spaces on decode. No
-/// larql-inference dependency and no merges — a prompt is its own ids.
+/// id `i`, joined back with spaces on decode. No larql-inference
+/// dependency and no merges — a prompt is its own ids.
+///
+/// Split on whitespace ONLY (`WhitespaceSplit`). The `Whitespace`
+/// pre-tokenizer also splits at punctuation, which turned `[1]` into
+/// three unknown pieces and every prompt into a run of id 0 — and every
+/// test still passed, because none of them looked at the ids until the
+/// status stream was captured. `ids_and_timings_go_to_the_status_stream`
+/// now pins the encoding.
 fn word_level_tokenizer(vocab: usize) -> String {
     let entries: Vec<String> = (0..vocab).map(|i| format!("\"[{i}]\":{i}")).collect();
     format!(
         "{{\"version\":\"1.0\",\"truncation\":null,\"padding\":null,\"added_tokens\":[],\
-         \"normalizer\":null,\"pre_tokenizer\":{{\"type\":\"Whitespace\"}},\
+         \"normalizer\":null,\"pre_tokenizer\":{{\"type\":\"WhitespaceSplit\"}},\
          \"post_processor\":null,\"decoder\":null,\
          \"model\":{{\"type\":\"WordLevel\",\"vocab\":{{{}}},\"unk_token\":\"[0]\"}}}}",
         entries.join(",")
@@ -59,14 +66,45 @@ fn fixture_container(root: &Path, with_tokenizer: bool) -> PathBuf {
 }
 
 /// Run with `argv` after the model path, feeding `input` to the chat
-/// loop, and return everything written to stdout.
-fn run_capturing(container: &Path, argv: &[&str], input: &str) -> Result<String, String> {
+/// loop, and return everything written to stdout and to the status
+/// stream, separately.
+fn run_capturing_with_status(
+    container: &Path,
+    argv: &[&str],
+    input: &str,
+) -> Result<(String, String), String> {
     let model = container.to_str().unwrap();
     let a = args(&[&[model], argv].concat());
     let mut out = Vec::new();
+    let mut status = Vec::new();
     let mut input = std::io::Cursor::new(input.as_bytes());
-    run_to(container, &a, &mut input, &mut out).map_err(|e| e.to_string())?;
-    Ok(String::from_utf8(out).unwrap())
+    run_to(container, &a, &mut input, &mut out, &mut status).map_err(|e| e.to_string())?;
+    Ok((
+        String::from_utf8(out).unwrap(),
+        String::from_utf8(status).unwrap(),
+    ))
+}
+
+/// [`run_capturing_with_status`], stdout only.
+fn run_capturing(container: &Path, argv: &[&str], input: &str) -> Result<String, String> {
+    run_capturing_with_status(container, argv, input).map(|(out, _)| out)
+}
+
+/// The fixture container's declared name, read from its own index.
+fn declared_name(container: &Path) -> String {
+    let index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(container.join(INDEX_JSON)).unwrap())
+            .unwrap();
+    index["model"].as_str().unwrap().to_string()
+}
+
+/// Rewrite the fixture container's declared name to `name`.
+fn declare_name(container: &Path, name: &str) {
+    let path = container.join(INDEX_JSON);
+    let mut index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    index["model"] = serde_json::Value::String(name.to_string());
+    std::fs::write(&path, index.to_string()).unwrap();
 }
 
 /// Every whitespace-separated piece of a line is a fixture token `[n]`
@@ -236,4 +274,68 @@ fn generation_ends_at_the_containers_declared_eos_before_it_is_printed() {
     declare_stop(&container, serde_json::json!({ "stop_strings": [second] }));
     let out = run_capturing(&container, &argv, "").unwrap();
     assert_eq!(out.trim(), first, "{out:?}");
+}
+
+#[test]
+fn the_declared_name_wins_and_the_directory_is_the_explicit_fallback() {
+    let dir = Path::new("/models/qwen3-0.6b.vindex3");
+    assert_eq!(resolved_display_name("Qwen3-0.6B", dir), "Qwen3-0.6B");
+    assert_eq!(resolved_display_name("", dir), "qwen3-0.6b.vindex3");
+    assert_eq!(resolved_display_name("", Path::new("/")), "container");
+}
+
+#[test]
+fn the_banner_and_the_verbose_report_show_the_containers_declared_name() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    let declared = declared_name(&container);
+    let directory = container.file_name().unwrap().to_str().unwrap().to_string();
+    assert!(!declared.is_empty() && declared != directory);
+
+    // Chat mode: the banner names the model; verbose names it again on
+    // the load line. Both come from one helper, so both say the same.
+    let (_, status) = run_capturing_with_status(&container, &["--verbose"], "").unwrap();
+    assert!(
+        status.contains(&format!("— {declared} (Ctrl-D to exit)")),
+        "{status}"
+    );
+    assert!(status.contains(&format!("] {declared} (")), "{status}");
+    assert!(
+        !status.contains(&format!("— {directory} (")),
+        "filesystem identity leaked into the banner: {status}"
+    );
+    assert!(
+        !status.contains(&format!("] {directory} (")),
+        "filesystem identity leaked into the verbose report: {status}"
+    );
+}
+
+#[test]
+fn a_nameless_container_falls_back_to_its_directory_and_says_so_once() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    declare_name(&container, "");
+    let directory = container.file_name().unwrap().to_str().unwrap().to_string();
+    let (_, status) = run_capturing_with_status(&container, &["--verbose"], "").unwrap();
+    assert!(
+        status.contains(&format!("— {directory} (Ctrl-D to exit)")),
+        "{status}"
+    );
+    assert!(status.contains(&format!("] {directory} (")), "{status}");
+}
+
+#[test]
+fn ids_and_timings_go_to_the_status_stream() {
+    let root = tempfile::tempdir().unwrap();
+    let container = fixture_container(root.path(), true);
+    let (out, status) = run_capturing_with_status(
+        &container,
+        &[PROMPT, "--max-tokens", "2", "--emit-ids", "--verbose"],
+        "",
+    )
+    .unwrap();
+    assert_fixture_tokens(out.trim_end(), 2);
+    assert!(status.contains("prompt ids: [1, 2, 3]"), "{status}");
+    assert!(status.contains("generated ids: ["), "{status}");
+    assert!(status.contains("prompt tokens in"), "{status}");
 }

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
@@ -42,9 +42,10 @@ use ndarray::Array2;
 use super::super::shannon_trace::dump::{
     plane_name, write_plane, LayerDumpManifest, MANIFEST_NAME, PLANE_DTYPE,
 };
+use larql_inference::vindex3::OpenedComponent;
+
 use super::prepare::{
-    parse_representation_source, prepare, with_plan_backend, BackendVisitor, PreparedContainer,
-    ENGINE_PREFIX,
+    parse_representation_source, prepare, with_plan_backend, BackendVisitor, ENGINE_PREFIX,
 };
 use super::ExecArgs;
 
@@ -73,11 +74,12 @@ pub(super) struct ResumeSidecar {
 pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
     let tokens = parse_tokens(&args.tokens)?;
     let source = parse_representation_source(&args.representation_source)?;
-    let PreparedContainer { plan, store, want } =
-        prepare(&args.container, &args.component, args.backend, source)?;
+    let OpenedComponent {
+        plan, store, want, ..
+    } = prepare(&args.container, &args.component, args.backend, source)?;
 
     let from_pack = store.selection().values().filter(|s| s.stored).count();
-    if let Some(want) = want {
+    if let Some(want) = &want {
         println!(
             "representation: {want}  source: {}  objects from a compiled pack: {}/{}",
             args.representation_source,
@@ -90,7 +92,7 @@ pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
     {
         if let Some((formats, label)) = super::prepare::lowered_formats(args.backend) {
             let r = super::lowered::run_lowered(&args, &tokens, &plan, &store, formats, label);
-            report_representation_work(&store, want, r.is_ok());
+            report_representation_work(&store, want.as_deref(), r.is_ok());
             return r;
         }
     }
@@ -103,7 +105,7 @@ pub fn run_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
             store: &store,
         },
     );
-    report_representation_work(&store, want, outcome.is_ok());
+    report_representation_work(&store, want.as_deref(), outcome.is_ok());
     outcome
 }
 

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/prepare.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/prepare.rs
@@ -1,25 +1,24 @@
-//! Opening a container for execution — the one authority on how a
-//! container gets prepared.
+//! The CLI's policy over the one VINDEX3 opener.
 //!
 //! `larql vindex3 exec` and `larql run <container>` execute the same
 //! program through the same interpreter; they differ only in what wraps
-//! it (token ids and a research report, or text and a stream). Both
-//! therefore come through here: inspect the container, close the
-//! component's plan, bind the operands the chosen backend wants, and
-//! hand the backend — as a concrete type, chosen exactly once — to a
-//! [`BackendVisitor`]. A second copy of this sequence would be a second
-//! authority on what a container *is* when it runs, and the two would
-//! drift.
+//! it (token ids and a research report, or text and a stream). Neither
+//! opens a container itself: `larql_inference`'s `open_component` is the
+//! single authority on what a container *is* when it runs — inspect,
+//! close the plan, bind the operands — and `larql serve` binds through
+//! the same call. What this module owns is the CLI's side of that line:
+//! which encoding a `--backend` asks for, whether the runtime may
+//! manufacture it, and handing the chosen backend — a concrete type,
+//! chosen exactly once — to a [`BackendVisitor`]. Realisation is not
+//! interpretation, so it stays here.
 
 use std::path::Path;
 
-use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_inference::vindex3::{open_component, OpenPolicy, OpenedComponent};
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
-use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
+use larql_vindex::format::vindex3::opplan::exec::operands::RepresentationSource;
 use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
 use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
-use larql_vindex::format::vindex3::opplan::plan_component_ops;
-use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
 
 use super::ExecBackend;
 
@@ -34,45 +33,23 @@ pub(crate) const DEFAULT_COMPONENT: &str = "target";
 /// realisation.
 pub(crate) const ENGINE_PREFIX: &str = "vindex3";
 
-/// A container opened for execution: the plan closed, the operands bound.
-pub(crate) struct PreparedContainer {
-    pub(crate) plan: ComponentOpPlan,
-    pub(crate) store: OperandStore,
-    /// The encoding a compiled pack would have to carry for the backend
-    /// this was prepared for. `None` on arms that execute the canonical
-    /// bytes directly, which then never look for a pack.
-    pub(crate) want: Option<&'static str>,
-}
-
-/// Inspect, plan and bind — everything that has to happen before a
-/// backend can be handed the program.
+/// Open `container`'s `component` for `backend`.
 ///
-/// A component that does not close is refused here, with every defect
-/// printed, so no caller can execute a partial plan.
+/// The CLI decides the policy — the encoding this backend executes and
+/// whether it may be manufactured at load — and the runtime opener does
+/// everything else, refusing a component that does not close with every
+/// defect in the error.
 pub(crate) fn prepare(
     container: &Path,
     component: &str,
     backend: ExecBackend,
     source: RepresentationSource,
-) -> Result<PreparedContainer, BoxErr> {
-    let inspection = inspect_container(container, false)?;
-    let outcome = plan_component_ops(&inspection, container, component)?;
-    if !outcome.defects.is_empty() {
-        for defect in &outcome.defects {
-            eprintln!("defect: {defect}");
-        }
-        return Err(format!(
-            "component `{component}` does not close: {} defect(s)",
-            outcome.defects.len()
-        )
-        .into());
-    }
-    let plan = outcome
-        .plan
-        .ok_or_else(|| format!("component `{component}` produced no plan"))?;
-    let want = wanted_representation(backend);
-    let store = OperandStore::open_for(container, &inspection, want, source)?;
-    Ok(PreparedContainer { plan, store, want })
+) -> Result<OpenedComponent, BoxErr> {
+    let policy = OpenPolicy {
+        want: wanted_representation(backend).map(str::to_string),
+        source,
+    };
+    Ok(open_component(container, component, policy)?)
 }
 
 /// Parse `--representation-source`.

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/decode.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/decode.rs
@@ -12,9 +12,11 @@ use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
 use larql_vindex::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4;
 
 use super::super::decode::{greedy_decode, Flow};
+use larql_inference::vindex3::OpenedComponent;
+
 use super::super::prepare::{
     parse_representation_source, prepare, wanted_representation, with_plan_backend, BackendVisitor,
-    PreparedContainer, DEFAULT_COMPONENT,
+    DEFAULT_COMPONENT,
 };
 use super::super::ExecBackend;
 
@@ -22,7 +24,7 @@ const PROMPT: [u32; 3] = [1, 2, 3];
 const NEW_TOKENS: usize = 4;
 
 /// The dense fixture, encoded and prepared for the reference arm.
-fn prepared_dense(root: &Path) -> PreparedContainer {
+fn prepared_dense(root: &Path) -> OpenedComponent {
     let checkpoint = root.join("checkpoint");
     let container = root.join("container");
     std::fs::create_dir_all(&checkpoint).unwrap();
@@ -215,4 +217,50 @@ fn a_directory_that_is_not_a_container_cannot_be_prepared() {
         RepresentationSource::Auto,
     )
     .is_err());
+}
+
+/// The one-opening-authority invariant, pinned at the source: the CLI's
+/// preparation names no inspection, no plan construction and no operand
+/// store opening of its own. Everything a container *is* when it runs
+/// comes from `larql_inference::vindex3::open_component`.
+#[test]
+fn the_cli_preparation_opens_nothing_itself() {
+    let source = include_str!("../prepare.rs");
+    for forbidden in [
+        "inspect_container(",
+        "plan_component_ops(",
+        "OperandStore::open",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "prepare.rs re-implements the opener: found `{forbidden}`"
+        );
+    }
+    assert!(source.contains("open_component("));
+}
+
+/// The CLI's policy reaches the store: what `--representation-source`
+/// asks for is what the opened store was bound under, and the opener's
+/// declared identity comes back with it.
+#[test]
+fn the_prepared_store_carries_the_requested_source_policy() {
+    let root = tempfile::tempdir().unwrap();
+    let checkpoint = root.path().join("checkpoint");
+    let container = root.path().join("container");
+    std::fs::create_dir_all(&checkpoint).unwrap();
+    std::fs::create_dir_all(&container).unwrap();
+    encode_fixture_container(dense_f32_model, &checkpoint, &container, "dense");
+    let opened = prepare(
+        &container,
+        DEFAULT_COMPONENT,
+        ExecBackend::ProductionNvfp4,
+        RepresentationSource::Transient,
+    )
+    .unwrap();
+    assert_eq!(
+        opened.store.representation_source(),
+        RepresentationSource::Transient
+    );
+    assert_eq!(opened.want.as_deref(), Some(DTYPE_NVFP4));
+    assert_eq!(opened.model_name, "dense");
 }

--- a/docs/vindex3-runtime.md
+++ b/docs/vindex3-runtime.md
@@ -63,11 +63,10 @@ container.
   encoding execution asks for (a compiled pack such as NVFP4, or `None`
   for the canonical bytes) and *whether* the runtime may manufacture it
   at load. `open` is `open_with` under the default policy. The opener
-  itself is `open_component`, the one opening authority: `larql serve`
-  binds through it today, and `larql run` / `larql vindex3 exec` are
-  being converged onto it so no caller re-implements inspect, plan and
-  store opening. The backend handed in is the realisation, never part
-  of what the container means.
+  itself is `open_component`, the one opening authority: `larql serve`,
+  `larql run` and `larql vindex3 exec` all bind through it, and no
+  caller re-implements inspect, plan and store opening. The backend
+  handed in is the realisation, never part of what the container means.
 - `Vindex3Runtime::session()` — an incremental session at position zero.
 - `Vindex3Runtime::session_with_kv(kv)` — a session whose continuation
   state lives in, and outlives the session as, the caller's `KvState`


### PR DESCRIPTION
## What

Closes step 0 of the Explorer roadmap: **one VINDEX3 opening authority.** Stacked on #382; base is `run-vindex3`.

`vindex3_cmd::prepare` no longer inspects, plans or opens an operand store of its own. It turns `--backend` / `--representation-source` into an `OpenPolicy` and calls `larql_inference::vindex3::open_component` (#381), the opener `larql serve` already binds through. So `larql serve`, `larql run` and `larql vindex3 exec` now open a container through one path — same plan, same representation binding, same declared identity. Realisation (CPU / Metal / lowered) stays in the CLI, as agreed: it is not part of what a container means.

`larql run` names its model from the container: `resolved_display_name` is the one place identity is decided — `index.model` wins when non-empty, the directory name is the explicit fallback for a nameless container — and both the chat banner and the verbose report read it. Status output (banner, prompt, ids, timings, errors) goes through an injectable writer (stderr in the binary), which is what makes identity testable at the `larql run` surface.

## The four invariants, as tests

1. **One opening authority** — `prepare.rs` is pinned at the source to contain no `inspect_container(`, `plan_component_ops(` or `OperandStore::open` (`the_cli_preparation_opens_nothing_itself`).
2. **Policy parity** — the requested source policy reaches the opened store and the NVFP4 want travels with it (`the_prepared_store_carries_the_requested_source_policy`); the stored-NVFP4 selection equality with the exec verb's recipe is pinned in #381's opener tests.
3. **Default preservation** — the server is untouched; its 575 tests and the 14 runtime tests run on the default policy.
4. **Identity authority** — declared name in banner and verbose line, never the directory (`the_banner_and_the_verbose_report_show_the_containers_declared_name`); nameless container falls back to its directory, once (`a_nameless_container_falls_back_to_its_directory_and_says_so_once`); the helper's two cases (`the_declared_name_wins_and_the_directory_is_the_explicit_fallback`).

## A fixture defect this found

`ids_and_timings_go_to_the_status_stream` captured the prompt ids for the first time and they were `[0, 0, 0, 0, 0, 0, 0, 0, 0]`: the test tokenizer's `Whitespace` pre-tokenizer splits `[1]` at the brackets into three unknown pieces. Every earlier test passed because none asserted the ids. The fixture now uses `WhitespaceSplit` and the encoding is asserted (`[1, 2, 3]`). The decode pipeline was exercised throughout; the comment claiming the prompt was its own ids was not true until now.

## Gates

`cargo fmt --all --check`; clippy `--bins --tests --no-deps -- -D warnings` under default features and `--no-default-features`; `cargo test -p larql-cli` (817) and `--no-default-features` (812); `registry check`; doc link/reference gates. Release-build witness on real containers below.

| container | backend | output | ids vs `vindex3 exec --tokens` | verbose identity line |
|---|---|---|---|---|
| oute-mamba2attn-250m.vindex3 | production (CPU) | " the city of Paris." | identical (same ids as #382) | `oute-mamba2attn-250m (mamba2)` |
| qwen3-4b.vindex3 | `--metal` | " Paris. The capital of Germany is Berlin." | identical (same ids as #382) | `Qwen3-4B (qwen3)` — the declared name, not the directory |

## Docs

`docs/vindex3-runtime.md`: the opener bullet now states that all three front doors bind through `open_component`.
