### PR TITLE
Fail closed on measurement-path execution errors

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -150,7 +150,29 @@ jobs:
       #
       # `--locked` matters: without it cargo may resolve a newer dependency
       # than Cargo.lock pins and the job would test a graph nobody ships.
+      #
+      # `RUSTUP_TOOLCHAIN` matters more. `rust-toolchain.toml` pins the
+      # DEVELOPMENT toolchain and rustup honours that file over whatever
+      # `dtolnay/rust-toolchain` installed, so from the day the pin landed
+      # (2026-08-22) this step silently checked at the development version
+      # and the gate was hollow. The env var outranks the file, and the
+      # step before the check refuses to run it under any other compiler.
+      - name: Report the compiler running the gate
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
+        run: |
+          rustc --version
+          cargo --version
+          actual=$(rustc --version | awk '{print $2}')
+          if [ "$actual" != "${{ steps.msrv.outputs.version }}" ]; then
+            echo "::error::MSRV gate would run rustc $actual, not the declared ${{ steps.msrv.outputs.version }}"
+            exit 1
+          fi
+          echo "MSRV gate runs rustc $actual"
+
       - name: Check at declared MSRV
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
         run: cargo check ${{ matrix.args }} --locked
 
   doc-links:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ LQL parser and executor are split: [crates/larql-lql/src/parser/](crates/larql-l
 
 ## Build, test, run
 
-**The toolchain is pinned.** [rust-toolchain.toml](rust-toolchain.toml) fixes it at **1.98.0** with clippy and rustfmt; rustup fetches that version automatically, so do not override it with your own `stable`. This exists because CI installs the newest stable while a developer's `stable` is whenever they last ran `rustup update` — the two drifted to 1.95 vs 1.98, and clippy failed in CI on lints that could not be reproduced locally. (`Cargo.toml`'s `rust-version = 1.88` is the MSRV — a different thing, and not what you build with.)
+**The toolchain is pinned.** [rust-toolchain.toml](rust-toolchain.toml) fixes it at **1.98.0** with clippy and rustfmt; rustup fetches that version automatically, so do not override it with your own `stable`. This exists because CI installs the newest stable while a developer's `stable` is whenever they last ran `rustup update` — the two drifted to 1.95 vs 1.98, and clippy failed in CI on lints that could not be reproduced locally. (`Cargo.toml`'s `rust-version` is the MSRV — a different claim, checked by the `quality` workflow's MSRV job under an explicit `RUSTUP_TOOLCHAIN`, because the toolchain file otherwise overrides the installed MSRV compiler and the gate ran at 1.98 while claiming 1.88 for weeks. Today the two coincide at 1.98: the NEON dot-product intrinsics the VINDEX3 CPU integer path uses stabilised there.)
 
 ```bash
 cargo build --release                             # optimised build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -120,7 +120,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -649,7 +649,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -778,36 +778,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8e1303ae2128891cb59691a74de4547dd208bc8511a2f287cca2b93bb3c728"
+checksum = "6835dba958b2ab7ab523e7e99296e0524317f60430a00cf5850562ef78ea7001"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b2740a5936332028d9a1e8f29a199de2fd386e426d44da5fea70cf8e3f8e75"
+checksum = "0b6e4ce8ee6d899381fbdd9e6561336c651189d46cecaeee09b29e8d80aa786e"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd128d3629fb105e433bda09744c5a2959cd1da04617a455c4cc17dff1ebef"
+checksum = "0cb6d37015df7ea4b60450c1229ad5f5819a1fb27434b063f8e6216dfbd0c42a"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a88f6d5a6cf6fcbc6386415d48948094721dfa4585d6615938b11ca938f20a"
+checksum = "986bea0b0858b55192782120032ce9c15943fa073f186f6e479653c59e62c329"
 dependencies = [
  "serde",
  "serde_derive",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4a357d030bdd586d8fe3da56b394f7f6b6ded506e59f945e7b32b1e126b71"
+checksum = "9f30aeb2de7f97d6f26b4a1642615834daad58e2e4d7c027810010a3a32f22be"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4121e36a8757dea6fb237435ee5095eba25bc13ecc2eaee57eb9bffd4b27784f"
+checksum = "cd5dd137fcdedef33b6fd40edf1ced024460d764ceb75833e8198a843395945c"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -855,24 +855,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5173265fc30b9e42205cf06dfca9a272ee949667ce4115d975ed2c08d466e2f8"
+checksum = "ab54b260ef23a8f0f536679b9fc3b3b3e05353e8d1448f3ab83df02078e8be9b"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6ca8a393e66dc13f915c6f456bdcf496d78fac4995792f7022b7806352d7a4"
+checksum = "3f3e569779ad70537f34a670d444ee3d75ae583b2023913f4682814b0979f7e8"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e609d9ba416bc26d774f343295a1d411515248a6a6d83d5f7492a0dd919569fa"
+checksum = "2ff53acc85f5c5f7d9315ff133a6671d329a0f04aa2d1a8a2e81d59709ccddcb"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a3a277b1a0aff1123f6bae61c080a4bcb6df964829ed427f98e18dff14257f"
+checksum = "ab5976c0ff5bfadf61cd8bda81fea78ee5a07018b9cd03e66c0952c56684928b"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -893,15 +893,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be53dd9b3a4cbeb9ced45c4a543ea8417ccfb334c3ba1cbb2233f4b25fb2531f"
+checksum = "77b4f73d2288e9480fd2d1d9ab576394dce4805443d6148c6d819dbf78865ce4"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca62ab1d9f48cad97da5843b913ccf96c3dfde935af5d750cb5a6d367ccfb262"
+checksum = "fe9650c2baf22fa1e2542a5bdd8152616ec2023d929c4cbb450ff677ad8d9c21"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.13"
+version = "0.123.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13b72860f54a2a19d3756bd47575fd8bddeafd6e5bbbf16372cdfebc482628a"
+checksum = "4ad4f61ae701d73c326d3df08c366b29ad10f1ba06c245092f217b8d2306746b"
 
 [[package]]
 name = "crc32fast"
@@ -1220,7 +1220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2078,7 +2078,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3413,7 +3413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -3433,7 +3433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3452,7 +3452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -3465,7 +3465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -3500,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2662666315cb90dfb4d99a652ee053d4d8598f71c474209e84da031ca56ae5a4"
+checksum = "eb0a4b56042e461cc64456650182938e2d1ede98fa0c8a975027416a2809c414"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3512,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9a7d9ed2618f94b6d054aba3eb2768c9b489fe16b4ef8847fbc6ed41b707bb"
+checksum = "244667bea2e214273442a71f26adb12b88a41f66718fb2c6eea47c00f0dc325f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3644,7 +3644,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4039,7 +4039,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4412,7 +4412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4557,7 +4557,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5390,9 +5390,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d881c5dcff5f230368d84fcf110ca25fe47badc694e7d559c3891492159916"
+checksum = "7d05c745dc0978e589ef295958f3130122afc33d96af6bad3f0f06dbe7ac43a8"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -5437,9 +5437,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b25534a3ff9dd844701c2bc997f76cb1f97bf2af0546a7066ae96f49c2e068"
+checksum = "9fd1d43cfaa1a0859d2f4fccc15e7e571e2a88b357e81bc88ba6c501b83d925d"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -5462,18 +5462,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d02832d760351fb3a1aa99eb8f7b95596c0f4e4e52df1547fcdb295ea5c780c"
+checksum = "515dd7158bf1719b41290cd2e6a2a46ec944484146816992f195af3720e49b3f"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ed6dbe24607573f7bcc59222f3bc2e7f7d31609466055c67b9484045a374a"
+checksum = "dfca017b7daa80ff217c66f105ee20e674d87b7c11dca85bbb9d0146e9f443fb"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -5486,15 +5486,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21aadbf677ee3503ef2580ce3c6955508e90a2810e961739b30f79585af254c"
+checksum = "1c3e218b51d2ef9eb181499e42c691512c1bc11dd6dc7746807a9b2b9290369c"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65821bab751956cddfc6ee957beb13a0e2a6cf682050d75dfb7a0228db2ed499"
+checksum = "5ba1736927b58e50e741e407da7c037c0250f3e213833a09c89dcd8f73ae2eac"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5519,9 +5519,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18cf73e5e8d28a2b30d86454430c7dea3b593598dcbbc0ebb927ca2716222d41"
+checksum = "7b238e4c20bddb900ec0cb380252d63e8d0644fd94de001119574f5921e895d9"
 dependencies = [
  "anyhow",
  "cc",
@@ -5535,9 +5535,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279dc3147ddaa21e5b3d2c0eaff117881c4f937747bdd2379eb361665843bd3"
+checksum = "8f259b13685ad51e3dcf58cb69031279ed0d79c25bc3ccc8b50e7160ed04fbfe"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -5545,9 +5545,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb677944201839c0be19b39b0f19dcd663efbcbc05a09c73f26fec7bdf0331"
+checksum = "41fed85537936b16460bac352ad149052c025db50467c7bc539dd47b31439374"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5557,24 +5557,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a153e184878df396a11f8912444531c2e4d0c7a1d9e9a52b30d9853d89cb9"
+checksum = "82fff10da41d0d15d90ebba70946a0aa16ed0957ae7b77e0b6d2a46e8221e555"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b771494bead25e1f0c4c89a9476dd0b65eacca314ed82125f1e197fbc3f0396b"
+checksum = "e44a8c097bab08d349d57dce1ab818859fefbe261ab3632b38fe127b1b551108"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90199caed6925420434a923861d8ad813689ca8533d2c679f805d12e35b40a4b"
+checksum = "7f40a57d5e7c221ce56391d7dca0a918ba17ea00185462c7facbf534d7745184"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5585,9 +5585,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71687aa834f9cc9eb5b0f97c85184d7dc70b84d32fd8927af0887998a1ba35"
+checksum = "e085bfce1cb2089dbeef6e280a5d598666923d3dcd308712fe429fe43c9d19f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5596,9 +5596,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ba45c0d766dd56257d97702d3284b6f69efdd4c53ca981a0754cc0a139df0"
+checksum = "c4916cd526e1ce294984cc5b70264cfc0ca103b41ca665b58728bde250b6b82f"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5613,9 +5613,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a64d5112c06f9d54b41e61f0b757d3a5a52361bf359f01131cc7cb8551ac73"
+checksum = "39ad2f9d9c3baa70ee4d157b55b4c08e5dc00f1d80aad3692b1e0806393914ea"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -5809,7 +5809,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5820,9 +5820,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.13"
+version = "36.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ea9625459ce35d6a4188cf0f07c9095cbb0e5afd86f711d63955bfc4216e64"
+checksum = "e826c012c68403725e77adf6b904c2ea809e5d464aaf25aa6eda14559300b3df"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,12 @@ chunks_exact_to_as_chunks = "allow"
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.88"
+# MSRV. The NEON dot-product intrinsics (`vdotq_s32` and friends,
+# `stdarch_neon_dotprod`) that the VINDEX3 CPU integer path and the
+# cpu7_probe example use stabilised in 1.98; every toolchain from 1.88 to
+# 1.97 refuses them (bisected 2026-09-01). The quality workflow checks
+# this claim under `RUSTUP_TOOLCHAIN`, so it cannot drift silently again.
+rust-version = "1.98"
 authors = []
 license = "Apache-2.0"
 repository = "https://github.com/chrishayuk/larql"

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/step.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/step.rs
@@ -90,7 +90,10 @@ impl LoweredSession<'_> {
         let p = self.prepared.take()?;
         let mut id = None;
         if p.committed {
-            p.cmd.wait_until_completed();
+            larql_compute_metal::cb_status::wait_or_abort(
+                &p.cmd,
+                "crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/step.rs:quiesce",
+            );
             if let (Some(am), true) = (&self.argmax, p.has_logits) {
                 id = read_u32(&am[2 + p.position % 2]).ok();
                 self.last_device_id = id;
@@ -210,7 +213,14 @@ impl LoweredSession<'_> {
             });
         }
 
-        prepared.cmd.wait_until_completed();
+        // A step whose buffer did not complete has no logits and no
+        // argmax; the refusal carries Metal's own description up through
+        // the step's error channel instead of reading stale scratch.
+        larql_compute_metal::cb_status::wait_checked(
+            &prepared.cmd,
+            "crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/step.rs:step",
+        )
+        .map_err(|detail| VindexError::Parse(format!("metal-lowered step refused: {detail}")))?;
         self.last_gpu_ms = gpu_span_ms(&prepared.cmd);
         if let (Some(samples), Some(ledger)) = (&prepared.samples, self.ledger.as_mut()) {
             if let Some(token) = samples.resolve() {
@@ -248,7 +258,10 @@ impl LoweredSession<'_> {
         // A committed step may still be executing; its buffers cannot
         // rejoin the pool until the GPU is done with them.
         if p.committed {
-            p.cmd.wait_until_completed();
+            larql_compute_metal::cb_status::wait_or_abort(
+                &p.cmd,
+                "crates/larql-cli/src/commands/primary/vindex3_cmd/lowered/step.rs:discard",
+            );
         }
         for buf in p.captures {
             self.gpu.recycle_lowering_scratch(buf);

--- a/crates/larql-compute-metal/README.md
+++ b/crates/larql-compute-metal/README.md
@@ -53,10 +53,20 @@ Two module boundaries are load-bearing rather than tidy:
 - **`diag/` is never on the decode path.** Anything that samples
   timestamps drains the pipeline; keeping it separate is what makes the
   production encoder one uninstrumented encoder.
-- **`cb_status::wait_checked` replaced 77 raw `wait_until_completed()`
-  calls.** A raw wait swallows GPU errors silently. There are ~121 checked
-  call sites now; new code must use the helper, and `cb_status/tests.rs`
-  enforces it by scanning the source tree.
+- **Every command-buffer wait refuses on failure.** A raw
+  `wait_until_completed()` returns for a failed or ignored buffer exactly
+  as for a finished one, with stale bytes in the outputs, so a step that
+  only waited would report garbage at full speed (#229). The rule is that
+  any number this crate contributes to a benchmark comes from an execution
+  that actually completed: `cb_status::wait_checked` hands the failure to
+  callers with an error channel (`GroupedError::CommandBufferFailed` on
+  the Kimi/MLA/KDA and grouped-expert paths, which refuse before any cache
+  advances), `cb_status::wait_or_abort` ends the step for callers without
+  one (a `None` there would be taken as "fall back to the CPU" and the
+  fallback's number reported as the GPU's), and tests `.expect` it.
+  `cb_status/tests.rs` scans the source tree for both a naked wait and a
+  discarded result. A real fault cannot be produced deterministically, so
+  the refusal paths are witnessed through `cb_status::inject_fault_at_for_test`.
 
 ## Operator controls
 

--- a/crates/larql-compute-metal/src/backend/mod.rs
+++ b/crates/larql-compute-metal/src/backend/mod.rs
@@ -234,10 +234,7 @@ impl MetalBackend {
     pub fn empty_roundtrip(&self) {
         let cmd = self.queue.new_command_buffer();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/backend/mod.rs:196",
-        );
+        crate::cb_status::wait_or_abort(cmd, "crates/larql-compute-metal/src/backend/mod.rs:196");
     }
 
     /// The same, with an empty compute encoder opened and closed, which
@@ -247,10 +244,7 @@ impl MetalBackend {
         let enc = cmd.new_compute_command_encoder();
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/backend/mod.rs:206",
-        );
+        crate::cb_status::wait_or_abort(cmd, "crates/larql-compute-metal/src/backend/mod.rs:206");
     }
 
     /// Create a Metal backend with default options derived from the

--- a/crates/larql-compute-metal/src/buffers/regions/tests.rs
+++ b/crates/larql-compute-metal/src/buffers/regions/tests.rs
@@ -110,10 +110,11 @@ fn sealing_is_a_no_op_under_the_implicit_arm() {
     let enc = cmd.new_compute_command_encoder();
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_checked(
         cmd,
         "crates/larql-compute-metal/src/buffers/regions/tests.rs:104",
-    );
+    )
+    .expect("command buffer completed");
 }
 
 /// Both explicit arms build, commit and attach a set over the registered
@@ -134,10 +135,11 @@ fn sealing_runs_both_explicit_arms_and_leaves_the_queue_usable() {
         let enc = cmd.new_compute_command_encoder();
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/buffers/regions/tests.rs:125",
-        );
+        )
+        .expect("command buffer completed");
     }
 }
 

--- a/crates/larql-compute-metal/src/buffers/residency/tests.rs
+++ b/crates/larql-compute-metal/src/buffers/residency/tests.rs
@@ -154,10 +154,11 @@ fn attaching_to_a_queue_reports_whether_it_took() {
         let enc = cmd.new_compute_command_encoder();
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/buffers/residency/tests.rs:157",
-        );
+        )
+        .expect("command buffer completed");
     }
 }
 

--- a/crates/larql-compute-metal/src/cb_status.rs
+++ b/crates/larql-compute-metal/src/cb_status.rs
@@ -11,33 +11,103 @@
 //! on main and predates seqpar": impossible ~0.5 ms/token decode steps,
 //! token ids past the vocabulary, EOS at token 1.
 //!
-//! This module names the condition. It does not yet change control flow —
-//! that is the fix, and it needs the evidence this produces first.
+//! This module names the condition and refuses on it. The rule for every
+//! wait in this crate: any number LARQL reports must come from an
+//! execution that actually succeeded, so a failed buffer never becomes a
+//! result. [`wait_checked`] hands the failure to callers that have an
+//! error channel; [`wait_or_abort`] stops the step for callers that do
+//! not (a `Vec<f32>`-returning stage, or an `Option`-returning trait
+//! method whose `None` would be taken as "fall back to the CPU" and
+//! report the fallback's number as the GPU's). `cb_status::tests` pins
+//! that no production site waits without one of the two, and that none
+//! discards the result.
+//!
+//! A real fault cannot be produced deterministically — an out-of-bounds
+//! kernel may be tolerated, or may poison the queue for the rest of the
+//! process — so the refusal paths are witnessed through
+//! [`inject_fault_at_for_test`] instead.
 
 use metal::foreign_types::ForeignTypeRef;
 use metal::{CommandBufferRef, MTLCommandBufferStatus};
 use objc::runtime::Object;
 use objc::{msg_send, sel, sel_impl};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
 
 /// Buffers observed in a non-`Completed` state since process start.
 static NON_COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
+/// A fault a test asked for: the next [`check_completed`] whose `site`
+/// contains this fragment reports a failure instead of reading the
+/// buffer. Consumed on first match.
+static INJECTED_FAULT: Mutex<Option<String>> = Mutex::new(None);
+
 /// How many command buffers this process has seen finish in any state other
-/// than `Completed`. Zero on a healthy process.
+/// than `Completed`. Zero on a healthy process. Injected test faults are
+/// not counted: this number reports what the GPU actually did.
 pub fn non_completed_count() -> usize {
     NON_COMPLETED.load(Ordering::Relaxed)
+}
+
+/// Make the next wait whose site name contains `site_fragment` report a
+/// failure, without any GPU fault. Tests use this to witness that a
+/// refusal path refuses: no readback, no cache advance, no result.
+#[doc(hidden)]
+pub fn inject_fault_at_for_test(site_fragment: &str) {
+    *INJECTED_FAULT.lock().unwrap_or_else(|p| p.into_inner()) = Some(site_fragment.to_string());
+}
+
+/// Whether an injected fault is armed and has not yet been consumed. A
+/// test that arms one asserts this is `false` afterwards, so a fault
+/// that never fired cannot leak into the next test.
+#[doc(hidden)]
+pub fn injected_fault_pending() -> bool {
+    INJECTED_FAULT
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .is_some()
+}
+
+fn take_injected_fault(site: &str) -> bool {
+    let mut slot = INJECTED_FAULT.lock().unwrap_or_else(|p| p.into_inner());
+    match slot.as_deref() {
+        Some(fragment) if site.contains(fragment) => {
+            *slot = None;
+            true
+        }
+        _ => false,
+    }
 }
 
 /// Wait for `cmd`, then inspect it. This is the only sanctioned way to
 /// wait on a command buffer in this crate: `wait_until_completed` alone
 /// cannot distinguish a finished buffer from a failed or ignored one, and
 /// a test pins that no production site calls it directly. Callers with a
-/// result channel propagate the `Err`; callers without one at least leave
-/// the line in the log.
+/// result channel propagate the `Err`; callers without one use
+/// [`wait_or_abort`]. Discarding the result is not an option — a test
+/// pins that too.
+#[must_use = "a failed command buffer must refuse the step, not be logged past"]
 pub fn wait_checked(cmd: &CommandBufferRef, site: &'static str) -> Result<(), String> {
     cmd.wait_until_completed();
     check_completed(cmd, site)
+}
+
+/// Wait for `cmd` and abort the step if it did not complete. For sites
+/// whose enclosing function has no error channel to its caller. A fault
+/// surfacing as a CPU fallback would report the fallback's number as the
+/// GPU's, and a fault surfacing as a stale output would report garbage;
+/// neither is a result, so the step ends here.
+pub fn wait_or_abort(cmd: &CommandBufferRef, site: &'static str) {
+    cmd.wait_until_completed();
+    require_completed(cmd, site);
+}
+
+/// [`check_completed`] for a buffer the caller has already waited on by
+/// other means (a spin loop on `status()`), aborting the step on failure.
+pub fn require_completed(cmd: &CommandBufferRef, site: &'static str) {
+    if let Err(msg) = check_completed(cmd, site) {
+        panic!("[metal] refusing to continue past a failed command buffer: {msg}");
+    }
 }
 
 /// Inspect `cmd` after `wait_until_completed`. Returns `Ok(())` for
@@ -45,6 +115,12 @@ pub fn wait_checked(cmd: &CommandBufferRef, site: &'static str) -> Result<(), St
 /// site, the status and Metal's own error description, and returns that
 /// description so a caller can decide what to do with a poisoned step.
 pub fn check_completed(cmd: &CommandBufferRef, site: &'static str) -> Result<(), String> {
+    if take_injected_fault(site) {
+        let msg =
+            format!("command buffer at {site} finished with status <injected fault, test hook>");
+        eprintln!("[metal] {msg}");
+        return Err(msg);
+    }
     let status = cmd.status();
     if status == MTLCommandBufferStatus::Completed {
         return Ok(());
@@ -57,6 +133,10 @@ pub fn check_completed(cmd: &CommandBufferRef, site: &'static str) -> Result<(),
 }
 
 /// UTF-8 contents of an `NSString*`, or `None` for nil.
+///
+/// # Safety
+/// `ns` must be nil or a live `NSString*`; the returned bytes are copied
+/// before the autorelease pool can reclaim it.
 unsafe fn ns_string(ns: *mut Object) -> Option<String> {
     if ns.is_null() {
         return None;

--- a/crates/larql-compute-metal/src/cb_status/tests.rs
+++ b/crates/larql-compute-metal/src/cb_status/tests.rs
@@ -104,3 +104,103 @@ fn ns_string_reads_an_nsstring() {
     };
     assert_eq!(got.as_deref(), Some("command buffer text"));
 }
+
+/// The second containment rule: every wait either propagates its result
+/// or aborts. A `let _ =` on `wait_checked` is the "log and continue"
+/// this module exists to end — the step would carry on with whatever the
+/// output buffers held before the fault and report it as a result.
+#[test]
+fn no_discarded_wait_checked_outside_cb_status() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rust_sources(&src, &mut files);
+
+    let mut offenders = Vec::new();
+    for path in files {
+        if path.ends_with("cb_status.rs") || path.ends_with("cb_status/tests.rs") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).expect("source readable");
+        for (i, line) in text.lines().enumerate() {
+            let code = line.split("//").next().unwrap_or("");
+            if code.contains("let _ =") && code.contains(concat!("wait_", "checked")) {
+                offenders.push(format!("{}:{}", path.display(), i + 1));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "discarded wait_checked — propagate with `?` or use cb_status::wait_or_abort:\n{}",
+        offenders.join("\n")
+    );
+}
+
+/// The injection hook fires once, only at the named site, and is not
+/// counted as a GPU observation.
+#[cfg(target_os = "macos")]
+#[test]
+fn an_injected_fault_is_reported_once_at_its_site_and_then_cleared() {
+    let Some(device) = metal::Device::system_default() else {
+        return;
+    };
+    let queue = device.new_command_queue();
+    let cmd = queue.new_command_buffer();
+    cmd.commit();
+
+    inject_fault_at_for_test("cb_status injection witness");
+    assert!(injected_fault_pending());
+    // A wait at some other site neither fires nor consumes it.
+    assert!(wait_checked(cmd, "cb_status somewhere else").is_ok());
+    assert!(injected_fault_pending());
+
+    let before = non_completed_count();
+    let err = wait_checked(cmd, "cb_status injection witness").expect_err("armed fault must fire");
+    assert!(err.contains("injected fault"), "{err}");
+    assert!(err.contains("cb_status injection witness"), "{err}");
+    assert_eq!(
+        non_completed_count(),
+        before,
+        "an injected fault is not a GPU observation"
+    );
+    assert!(!injected_fault_pending(), "consumed on first match");
+    assert!(
+        wait_checked(cmd, "cb_status injection witness").is_ok(),
+        "fires exactly once"
+    );
+}
+
+/// `wait_or_abort` is the refusal for a site with no error channel: the
+/// step ends, so no result can be reported from a failed buffer.
+#[cfg(target_os = "macos")]
+#[test]
+#[should_panic(expected = "refusing to continue past a failed command buffer")]
+fn wait_or_abort_stops_the_step_on_an_injected_fault() {
+    let Some(device) = metal::Device::system_default() else {
+        panic!("refusing to continue past a failed command buffer: no Metal device on this host");
+    };
+    let queue = device.new_command_queue();
+    let cmd = queue.new_command_buffer();
+    cmd.commit();
+    inject_fault_at_for_test("cb_status abort witness");
+    wait_or_abort(cmd, "cb_status abort witness");
+}
+
+/// A production site with no error channel: `MatMul::matmul` returns a
+/// plain `Array2<f32>`, so a faulted buffer there ends the step rather
+/// than handing back the previous contents of the output buffer as a
+/// product.
+#[cfg(target_os = "macos")]
+#[test]
+#[should_panic(expected = "refusing to continue past a failed command buffer")]
+fn a_faulted_matmul_aborts_instead_of_returning_a_result() {
+    let Some(m) = crate::MetalBackend::new() else {
+        panic!("refusing to continue past a failed command buffer: no Metal device on this host");
+    };
+    // Below the FLOP threshold `matmul` computes on the CPU; force the
+    // GPU path so the wait site under test is the one that runs.
+    m.set_flop_threshold(1);
+    let a = ndarray::Array2::<f32>::from_elem((128, 128), 1.0);
+    let b = ndarray::Array2::<f32>::from_elem((128, 128), 1.0);
+    inject_fault_at_for_test("f32_ops.rs:40");
+    let _ = larql_compute::MatMul::matmul(&m, a.view(), b.view());
+}

--- a/crates/larql-compute-metal/src/decode/encode_post_ffn.rs
+++ b/crates/larql-compute-metal/src/decode/encode_post_ffn.rs
@@ -278,10 +278,11 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/decode/encode_post_ffn.rs:281",
-        );
+        )
+        .expect("command buffer completed");
 
         let out = crate::buffers::read_buffer_f32(&new_h, hidden);
         assert_eq!(out.len(), hidden);

--- a/crates/larql-compute-metal/src/decode/gpu_timing.rs
+++ b/crates/larql-compute-metal/src/decode/gpu_timing.rs
@@ -394,10 +394,11 @@ mod tests {
         };
         let cmd = m.queue.new_command_buffer();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/decode/gpu_timing.rs:397",
-        );
+        )
+        .expect("command buffer completed");
 
         let mut t = TokenGpuTime::default();
         // gpu_elapsed_ms returns 0.0 for an empty cmd buffer (no GPU

--- a/crates/larql-compute-metal/src/decode/head/tests.rs
+++ b/crates/larql-compute-metal/src/decode/head/tests.rs
@@ -85,10 +85,11 @@ fn run_head(
     let out = metal.encode_decode_head(enc, &h_buf, HIDDEN, plan);
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_checked(
         cmd,
         "crates/larql-compute-metal/src/decode/head/tests.rs:88",
-    );
+    )
+    .expect("command buffer completed");
     out.map(|b| b.reduce_and_recycle(&metal.bufs))
 }
 

--- a/crates/larql-compute-metal/src/decode/moe_interleave.rs
+++ b/crates/larql-compute-metal/src/decode/moe_interleave.rs
@@ -244,8 +244,15 @@ impl MetalBackend {
             {
                 std::hint::spin_loop();
             }
+            // The spin only knows the buffer stopped; whether it
+            // completed is a separate question, answered the same way
+            // as on the blocking arm.
+            crate::cb_status::require_completed(
+                state.cmd,
+                "crates/larql-compute-metal/src/decode/moe_interleave.rs:spin",
+            );
         } else {
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 state.cmd,
                 "crates/larql-compute-metal/src/decode/moe_interleave.rs:248",
             );
@@ -256,7 +263,7 @@ impl MetalBackend {
             for _ in 0..extra {
                 let cb = self.queue.new_command_buffer();
                 cb.commit();
-                let _ = crate::cb_status::wait_checked(
+                crate::cb_status::wait_or_abort(
                     cb,
                     "crates/larql-compute-metal/src/decode/moe_interleave.rs:256",
                 );
@@ -360,7 +367,7 @@ impl MetalBackend {
                 .as_deref_mut()
                 .expect("split_mode implies moe_collect_fn");
             let result = collect(ctx.layer_idx);
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 state.cmd,
                 "crates/larql-compute-metal/src/decode/moe_interleave.rs:357",
             );

--- a/crates/larql-compute-metal/src/decode/moe_interleave/tests.rs
+++ b/crates/larql-compute-metal/src/decode/moe_interleave/tests.rs
@@ -210,10 +210,11 @@ fn try_inline_zero_copy_moe_encodes_experts_and_combine_on_registered_region() {
     // that was never `end_encoding()`'d.
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_checked(
         &cmd,
         "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:213",
-    );
+    )
+    .expect("command buffer completed");
     let took_zero_copy_path = m.try_inline_zero_copy_moe(
         &layer,
         &ctx,
@@ -232,10 +233,11 @@ fn try_inline_zero_copy_moe_encodes_experts_and_combine_on_registered_region() {
 
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_checked(
         &cmd,
         "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:232",
-    );
+    )
+    .expect("command buffer completed");
 
     let out = unsafe { std::slice::from_raw_parts(new_h_buf.contents() as *const f32, hidden) };
     assert!(
@@ -391,10 +393,11 @@ fn try_inline_zero_copy_moe_uses_non_grouped_dispatch_across_separate_regions() 
     let mut encoder_ended = true;
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_checked(
         &cmd,
         "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:388",
-    );
+    )
+    .expect("command buffer completed");
     let took_zero_copy_path = m.try_inline_zero_copy_moe(
         &layer,
         &ctx,
@@ -413,10 +416,11 @@ fn try_inline_zero_copy_moe_uses_non_grouped_dispatch_across_separate_regions() 
 
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_checked(
         &cmd,
         "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:407",
-    );
+    )
+    .expect("command buffer completed");
 
     let out = unsafe { std::slice::from_raw_parts(new_h_buf.contents() as *const f32, hidden) };
     assert!(
@@ -573,10 +577,11 @@ fn try_inline_zero_copy_moe_uses_q6k_grouped_dispatch() {
     let mut encoder_ended = true;
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_checked(
         &cmd,
         "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:564",
-    );
+    )
+    .expect("command buffer completed");
     let took_zero_copy_path = m.try_inline_zero_copy_moe(
         &layer,
         &ctx,
@@ -595,10 +600,11 @@ fn try_inline_zero_copy_moe_uses_q6k_grouped_dispatch() {
 
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_checked(
         &cmd,
         "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:583",
-    );
+    )
+    .expect("command buffer completed");
 
     let out = unsafe { std::slice::from_raw_parts(new_h_buf.contents() as *const f32, hidden) };
     assert!(
@@ -666,10 +672,11 @@ fn try_inline_zero_copy_moe_returns_false_without_moe_layer() {
     // that was never `end_encoding()`'d.
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_checked(
         &cmd,
         "crates/larql-compute-metal/src/decode/moe_interleave/tests.rs:651",
-    );
+    )
+    .expect("command buffer completed");
     let took_zero_copy_path = m.try_inline_zero_copy_moe(
         &layer,
         &ctx,

--- a/crates/larql-compute-metal/src/decode/token.rs
+++ b/crates/larql-compute-metal/src/decode/token.rs
@@ -356,7 +356,7 @@ impl MetalBackend {
             if stage_timing_split {
                 enc.end_encoding();
                 cmd.commit();
-                let _ = crate::cb_status::wait_checked(
+                crate::cb_status::wait_or_abort(
                     &cmd,
                     "crates/larql-compute-metal/src/decode/token.rs:359",
                 );
@@ -416,7 +416,7 @@ impl MetalBackend {
                     self.encode_ffn_gate_up_phase(&enc, layer, &ffn_bufs, ffn_dims);
                     enc.end_encoding();
                     cmd.commit();
-                    let _ = crate::cb_status::wait_checked(
+                    crate::cb_status::wait_or_abort(
                         &cmd,
                         "crates/larql-compute-metal/src/decode/token.rs:416",
                     );
@@ -435,7 +435,7 @@ impl MetalBackend {
                     );
                     enc.end_encoding();
                     cmd.commit();
-                    let _ = crate::cb_status::wait_checked(
+                    crate::cb_status::wait_or_abort(
                         &cmd,
                         "crates/larql-compute-metal/src/decode/token.rs:432",
                     );
@@ -524,7 +524,7 @@ impl MetalBackend {
                     enc.end_encoding();
                 }
                 cmd.commit();
-                let _ = crate::cb_status::wait_checked(
+                crate::cb_status::wait_or_abort(
                     &cmd,
                     "crates/larql-compute-metal/src/decode/token.rs:518",
                 );
@@ -636,7 +636,7 @@ impl MetalBackend {
                     if !encoder_ended {
                         enc.end_encoding();
                         cmd.commit();
-                        let _ = crate::cb_status::wait_checked(
+                        crate::cb_status::wait_or_abort(
                             &cmd,
                             "crates/larql-compute-metal/src/decode/token.rs:627",
                         );
@@ -675,7 +675,7 @@ impl MetalBackend {
                 if !encoder_ended {
                     enc.end_encoding();
                     cmd.commit();
-                    let _ = crate::cb_status::wait_checked(
+                    crate::cb_status::wait_or_abort(
                         &cmd,
                         "crates/larql-compute-metal/src/decode/token.rs:663",
                     );
@@ -731,7 +731,7 @@ impl MetalBackend {
                 if !encoder_ended {
                     enc.end_encoding();
                     cmd.commit();
-                    let _ = crate::cb_status::wait_checked(
+                    crate::cb_status::wait_or_abort(
                         &cmd,
                         "crates/larql-compute-metal/src/decode/token.rs:716",
                     );
@@ -779,7 +779,7 @@ impl MetalBackend {
         if !encoder_ended {
             enc.end_encoding();
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 &cmd,
                 "crates/larql-compute-metal/src/decode/token.rs:761",
             );

--- a/crates/larql-compute-metal/src/decode_hybrid.rs
+++ b/crates/larql-compute-metal/src/decode_hybrid.rs
@@ -559,10 +559,7 @@ impl MetalBackend {
         enc_c.end_encoding();
 
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/decode_hybrid.rs:562",
-        );
+        crate::cb_status::wait_or_abort(cmd, "crates/larql-compute-metal/src/decode_hybrid.rs:562");
 
         super::buffers::read_buffer_f32(&h_post_attn, hidden)
     }

--- a/crates/larql-compute-metal/src/diag/kernel_profile/all.rs
+++ b/crates/larql-compute-metal/src/diag/kernel_profile/all.rs
@@ -42,7 +42,7 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
             let enc = cmd.new_compute_command_encoder();
             enc.end_encoding();
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 cmd,
                 "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:45",
             );
@@ -132,7 +132,7 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
                 }
                 enc.end_encoding();
                 cmd.commit();
-                let _ = crate::cb_status::wait_checked(
+                crate::cb_status::wait_or_abort(
                     cmd,
                     "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:132",
                 );
@@ -213,7 +213,7 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
             dispatch(enc);
             enc.end_encoding();
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 cmd,
                 "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:210",
             );
@@ -284,7 +284,7 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
                 }
                 enc.end_encoding();
                 cmd.commit();
-                let _ = crate::cb_status::wait_checked(
+                crate::cb_status::wait_or_abort(
                     cmd,
                     "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:278",
                 );
@@ -441,7 +441,7 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
             dispatch(enc);
             enc.end_encoding();
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 cmd,
                 "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:432",
             );
@@ -540,7 +540,7 @@ pub fn profile_all(n_layers: usize, warmup: usize, iters: usize) -> Vec<KernelRe
             dispatch(enc);
             enc.end_encoding();
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 cmd,
                 "crates/larql-compute-metal/src/diag/kernel_profile/all.rs:528",
             );

--- a/crates/larql-compute-metal/src/diag/kernel_profile/census.rs
+++ b/crates/larql-compute-metal/src/diag/kernel_profile/census.rs
@@ -120,7 +120,7 @@ pub fn profile_shape_census(n_layers: usize, warmup: usize, iters: usize) -> Vec
                 }
                 enc.end_encoding();
                 cmd.commit();
-                let _ = crate::cb_status::wait_checked(
+                crate::cb_status::wait_or_abort(
                     cmd,
                     "crates/larql-compute-metal/src/diag/kernel_profile/census.rs:123",
                 );

--- a/crates/larql-compute-metal/src/diag/kernel_profile/grouped.rs
+++ b/crates/larql-compute-metal/src/diag/kernel_profile/grouped.rs
@@ -81,7 +81,7 @@ pub fn profile_grouped_experts(
             }
             enc.end_encoding();
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 cmd,
                 "crates/larql-compute-metal/src/diag/kernel_profile/grouped.rs:84",
             );
@@ -116,7 +116,7 @@ pub fn profile_grouped_experts(
             }
             enc.end_encoding();
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 cmd,
                 "crates/larql-compute-metal/src/diag/kernel_profile/grouped.rs:116",
             );

--- a/crates/larql-compute-metal/src/diag/kernel_profile/measure.rs
+++ b/crates/larql-compute-metal/src/diag/kernel_profile/measure.rs
@@ -95,7 +95,7 @@ pub(super) fn measure_single_cmdbuf_batched(
         }
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/diag/kernel_profile/measure.rs:98",
         );

--- a/crates/larql-compute-metal/src/diag/mxfp4_layout.rs
+++ b/crates/larql-compute-metal/src/diag/mxfp4_layout.rs
@@ -377,7 +377,7 @@ pub fn race(
             }
             enc.end_encoding();
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 cmd,
                 "crates/larql-compute-metal/src/diag/mxfp4_layout.rs:380",
             );

--- a/crates/larql-compute-metal/src/diag/nvfp4_call_profile/mod.rs
+++ b/crates/larql-compute-metal/src/diag/nvfp4_call_profile/mod.rs
@@ -118,7 +118,7 @@ impl MetalBackend {
         p.commit = t.elapsed().as_secs_f64() * 1e6;
 
         let t = Instant::now();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/diag/nvfp4_call_profile.rs:121",
         );
@@ -209,7 +209,7 @@ impl MetalBackend {
             last = Some(cmd);
         }
         if let Some(cmd) = last {
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 &cmd,
                 "crates/larql-compute-metal/src/diag/nvfp4_call_profile.rs:209",
             );

--- a/crates/larql-compute-metal/src/diag/shader_bench/measure.rs
+++ b/crates/larql-compute-metal/src/diag/shader_bench/measure.rs
@@ -61,7 +61,7 @@ pub(crate) fn measure_isolated(
         encode(enc);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/diag/shader_bench/measure.rs:64",
         );
@@ -89,7 +89,7 @@ pub(crate) fn measure_batched(
         }
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/diag/shader_bench/measure.rs:89",
         );

--- a/crates/larql-compute-metal/src/f32_ops.rs
+++ b/crates/larql-compute-metal/src/f32_ops.rs
@@ -37,7 +37,7 @@ impl F32Ops {
         Self::encode_static(&self.sgemm_pipeline, enc, &buf_a, &buf_b, &buf_c, m, n, k);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/f32_ops.rs:40");
+        crate::cb_status::wait_or_abort(cmd, "crates/larql-compute-metal/src/f32_ops.rs:40");
 
         super::buffers::read_buffer_f32(&buf_c, m * n)
     }
@@ -63,7 +63,7 @@ impl F32Ops {
         Self::encode_static(&self.transb_pipeline, enc, &buf_a, &buf_b, &buf_c, m, n, k);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/f32_ops.rs:66");
+        crate::cb_status::wait_or_abort(cmd, "crates/larql-compute-metal/src/f32_ops.rs:66");
 
         super::buffers::read_buffer_f32(&buf_c, m * n)
     }

--- a/crates/larql-compute-metal/src/moe_descriptor.rs
+++ b/crates/larql-compute-metal/src/moe_descriptor.rs
@@ -379,7 +379,7 @@ impl MetalBackend {
         let out = self.encode_descriptor_gather(enc, table, &ids_buf, n_slots, gate_half_bytes);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/moe_descriptor.rs:382",
         );
@@ -443,7 +443,7 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/moe_descriptor.rs:443",
         );

--- a/crates/larql-compute-metal/src/moe_dispatch/dense.rs
+++ b/crates/larql-compute-metal/src/moe_dispatch/dense.rs
@@ -106,7 +106,7 @@ impl MetalBackend {
 
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/moe_dispatch/dense.rs:109",
         );

--- a/crates/larql-compute-metal/src/moe_dispatch/dispatch.rs
+++ b/crates/larql-compute-metal/src/moe_dispatch/dispatch.rs
@@ -327,7 +327,7 @@ impl MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/moe_dispatch/dispatch.rs:330",
         );

--- a/crates/larql-compute-metal/src/moe_dispatch/experts.rs
+++ b/crates/larql-compute-metal/src/moe_dispatch/experts.rs
@@ -137,7 +137,7 @@ impl MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/moe_dispatch/experts.rs:140",
         );
@@ -349,7 +349,7 @@ impl MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/moe_dispatch/experts.rs:349",
         );

--- a/crates/larql-compute-metal/src/moe_gpu_route/encode/tests.rs
+++ b/crates/larql-compute-metal/src/moe_gpu_route/encode/tests.rs
@@ -385,10 +385,11 @@ fn run_gpu_route(metal: &MetalBackend, moe: &MoeLayerWeights<'_>, x: &[f32]) -> 
     metal.encode_moe_layer_gpu_route(enc, moe, &s, &table, &h_post_attn, &new_h, 1e-6);
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_checked(
         cmd,
         "crates/larql-compute-metal/src/moe_gpu_route/encode/tests.rs:388",
-    );
+    )
+    .expect("command buffer completed");
     crate::buffers::read_buffer_f32(&new_h, HIDDEN)
 }
 

--- a/crates/larql-compute-metal/src/moe_gpu_route/forward.rs
+++ b/crates/larql-compute-metal/src/moe_gpu_route/forward.rs
@@ -43,7 +43,7 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/moe_gpu_route/forward.rs:46",
         );
@@ -156,7 +156,7 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/moe_gpu_route/forward.rs:156",
         );
@@ -280,7 +280,7 @@ impl MetalBackend {
             }
             enc.end_encoding();
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 cmd,
                 "crates/larql-compute-metal/src/moe_gpu_route/forward.rs:278",
             );
@@ -298,7 +298,7 @@ impl MetalBackend {
                 encode_layer(enc, &prev, out);
                 enc.end_encoding();
                 cmd.commit();
-                let _ = crate::cb_status::wait_checked(
+                crate::cb_status::wait_or_abort(
                     cmd,
                     "crates/larql-compute-metal/src/moe_gpu_route/forward.rs:293",
                 );

--- a/crates/larql-compute-metal/src/moe_zero_copy.rs
+++ b/crates/larql-compute-metal/src/moe_zero_copy.rs
@@ -511,10 +511,7 @@ impl MetalBackend {
         self.encode_experts_zero_copy(enc, expert_input, moe, scratch, resolved);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/moe_zero_copy.rs:514",
-        );
+        crate::cb_status::wait_or_abort(cmd, "crates/larql-compute-metal/src/moe_zero_copy.rs:514");
         let t_gpu = t_start.elapsed();
 
         // ── Readback: down bias joins each expert's output BEFORE the

--- a/crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs
+++ b/crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs
@@ -462,7 +462,7 @@ pub fn dispatch_full_pipeline(
         if let Some(iv) = intervention {
             if l == iv.target_layer {
                 cmd.commit();
-                let _ = crate::cb_status::wait_checked(
+                crate::cb_status::wait_or_abort(
                     &cmd,
                     "crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs:465",
                 );
@@ -532,7 +532,7 @@ pub fn dispatch_full_pipeline(
         if let Some(iv) = intervention {
             if l == iv.target_layer {
                 cmd.commit();
-                let _ = crate::cb_status::wait_checked(
+                crate::cb_status::wait_or_abort(
                     &cmd,
                     "crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs:532",
                 );
@@ -748,7 +748,7 @@ pub fn dispatch_full_pipeline(
         // restart the command buffer for the next layer.
         if needs_per_layer_commit {
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_or_abort(
                 &cmd,
                 "crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs:745",
             );
@@ -779,7 +779,7 @@ pub fn dispatch_full_pipeline(
 
     if !needs_per_layer_commit {
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             &cmd,
             "crates/larql-compute-metal/src/ops/full_pipeline/dispatch.rs:773",
         );

--- a/crates/larql-compute-metal/src/ops/full_pipeline/dump.rs
+++ b/crates/larql-compute-metal/src/ops/full_pipeline/dump.rs
@@ -67,7 +67,7 @@ pub(super) fn dump_layer0_q_after_stage(
         return cmd;
     }
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_or_abort(
         &cmd,
         "crates/larql-compute-metal/src/ops/full_pipeline/dump.rs:70",
     );
@@ -96,7 +96,7 @@ pub(super) fn dump_layer_snapshots(
         return cmd;
     };
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_or_abort(
         &cmd,
         "crates/larql-compute-metal/src/ops/full_pipeline/dump.rs:96",
     );

--- a/crates/larql-compute-metal/src/ops/kv_cache.rs
+++ b/crates/larql-compute-metal/src/ops/kv_cache.rs
@@ -823,7 +823,8 @@ mod tests {
         }));
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(cmd, "kv_cache refuse test");
+        crate::cb_status::wait_checked(cmd, "kv_cache refuse test")
+            .expect("command buffer completed");
         let msg = match refused {
             Err(payload) => payload
                 .downcast_ref::<String>()
@@ -866,10 +867,8 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/ops/kv_cache.rs:1042",
-        );
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/ops/kv_cache.rs:1042")
+            .expect("command buffer completed");
 
         // The callsite is responsible for bumping `current_len`; the
         // encoder itself only writes the buffer.  Mirror the legacy
@@ -911,10 +910,8 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/ops/kv_cache.rs:1084",
-        );
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/ops/kv_cache.rs:1084")
+            .expect("command buffer completed");
 
         let out = crate::buffers::read_buffer_f32(&out_buf, num_kv * head_dim);
         assert!(out.iter().all(|v| v.is_finite()));
@@ -961,10 +958,8 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/ops/kv_cache.rs:1131",
-        );
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/ops/kv_cache.rs:1131")
+            .expect("command buffer completed");
 
         // Output buffer length matches the requested shape (a weak but
         // valid post-condition: a panicked kernel never gets here, and
@@ -1009,10 +1004,8 @@ mod tests {
             (head_dim as f32).sqrt().recip(),
         );
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/ops/kv_cache.rs:1176",
-        );
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/ops/kv_cache.rs:1176")
+            .expect("command buffer completed");
 
         assert_eq!(
             layer.current_len, 1,

--- a/crates/larql-compute-metal/src/ops/moe_router.rs
+++ b/crates/larql-compute-metal/src/ops/moe_router.rs
@@ -95,10 +95,7 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/ops/moe_router.rs:98",
-        );
+        crate::cb_status::wait_or_abort(cmd, "crates/larql-compute-metal/src/ops/moe_router.rs:98");
 
         crate::buffers::try_read_buffer_f32(&out_buf, num_experts)
     }
@@ -218,7 +215,7 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/ops/moe_router.rs:218",
         );

--- a/crates/larql-compute-metal/src/ops/q4_f32_matvec.rs
+++ b/crates/larql-compute-metal/src/ops/q4_f32_matvec.rs
@@ -45,7 +45,7 @@ pub fn dispatch(
     enc.dispatch_threads(threads, tg);
     enc.end_encoding();
     cmd.commit();
-    let _ = crate::cb_status::wait_checked(
+    crate::cb_status::wait_or_abort(
         cmd,
         "crates/larql-compute-metal/src/ops/q4_f32_matvec.rs:48",
     );

--- a/crates/larql-compute-metal/src/stages/layer_scalar.rs
+++ b/crates/larql-compute-metal/src/stages/layer_scalar.rs
@@ -91,7 +91,7 @@ mod tests {
         encode(enc, &pipeline, &h_buf, seq_len, hidden, scalar);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/stages/layer_scalar.rs:94",
         );
@@ -139,7 +139,7 @@ mod tests {
         encode(enc, &pipeline, &h_buf, 1, hidden, 0.0);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/stages/layer_scalar.rs:139",
         );

--- a/crates/larql-compute-metal/src/stages/qk_norm.rs
+++ b/crates/larql-compute-metal/src/stages/qk_norm.rs
@@ -194,10 +194,8 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/stages/qk_norm.rs:194",
-        );
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/stages/qk_norm.rs:194")
+            .expect("command buffer completed");
 
         let q_out = crate::buffers::read_buffer_f32(&q_buf, num_q_heads * head_dim);
         let k_out = crate::buffers::read_buffer_f32(&k_buf, num_kv_heads * head_dim);
@@ -246,10 +244,8 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/stages/qk_norm.rs:243",
-        );
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/stages/qk_norm.rs:243")
+            .expect("command buffer completed");
 
         let v_out = crate::buffers::read_buffer_f32(&v_buf, num_kv_heads * head_dim);
         assert!(

--- a/crates/larql-compute-metal/src/stages/qkv_proj.rs
+++ b/crates/larql-compute-metal/src/stages/qkv_proj.rs
@@ -566,10 +566,11 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/stages/qkv_proj.rs:569",
-        );
+        )
+        .expect("command buffer completed");
 
         let q = crate::buffers::read_buffer_f32(&q_out, q_rows);
         let k = crate::buffers::read_buffer_f32(&k_out, kv_rows);

--- a/crates/larql-compute-metal/src/stages/quant_matvec.rs
+++ b/crates/larql-compute-metal/src/stages/quant_matvec.rs
@@ -355,10 +355,11 @@ mod tests {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/stages/quant_matvec.rs:358",
-        );
+        )
+        .expect("command buffer completed");
     }
 
     /// Q4_KF format dispatches the dedicated Q4_KF shader when the
@@ -461,10 +462,11 @@ mod tests {
         }));
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/stages/quant_matvec.rs:461",
-        );
+        )
+        .expect("command buffer completed");
         if let Err(payload) = result {
             std::panic::resume_unwind(payload);
         }
@@ -509,10 +511,11 @@ mod tests {
             }));
             enc.end_encoding();
             cmd.commit();
-            let _ = crate::cb_status::wait_checked(
+            crate::cb_status::wait_checked(
                 cmd,
                 "crates/larql-compute-metal/src/stages/quant_matvec.rs:506",
-            );
+            )
+            .expect("command buffer completed");
             let payload = result.expect_err("float formats must refuse, not no-op");
             let msg = payload
                 .downcast_ref::<String>()

--- a/crates/larql-compute-metal/src/trait_impl/bf16_gemv.rs
+++ b/crates/larql-compute-metal/src/trait_impl/bf16_gemv.rs
@@ -67,7 +67,7 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/bf16_gemv.rs:71",
         );
@@ -143,7 +143,7 @@ impl MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/bf16_gemv.rs:multi",
         );

--- a/crates/larql-compute-metal/src/trait_impl/bf16_grouped.rs
+++ b/crates/larql-compute-metal/src/trait_impl/bf16_grouped.rs
@@ -188,10 +188,14 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/bf16_grouped.rs:at",
-        );
+        )
+        .map_err(|detail| GroupedError::CommandBufferFailed {
+            site: "crates/larql-compute-metal/src/trait_impl/bf16_grouped.rs:at",
+            detail,
+        })?;
         Ok(crate::buffers::read_buffer_f32(&buf_out, offsets.len() * n))
     }
 
@@ -236,10 +240,14 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/bf16_grouped.rs:dispatch",
-        );
+        )
+        .map_err(|detail| GroupedError::CommandBufferFailed {
+            site: "crates/larql-compute-metal/src/trait_impl/bf16_grouped.rs:dispatch",
+            detail,
+        })?;
 
         let gpu_ms = crate::decode::gpu_timing::gpu_elapsed_ms(cmd);
         Ok((

--- a/crates/larql-compute-metal/src/trait_impl/bf16_moe_block/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/bf16_moe_block/mod.rs
@@ -378,10 +378,14 @@ impl MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/bf16_moe_block/mod.rs:blocks",
-        );
+        )
+        .map_err(|detail| GroupedError::CommandBufferFailed {
+            site: "crates/larql-compute-metal/src/trait_impl/bf16_moe_block/mod.rs:blocks",
+            detail,
+        })?;
 
         let gpu_ms = crate::decode::gpu_timing::gpu_elapsed_ms(cmd);
         let results: Vec<Vec<f32>> = outs

--- a/crates/larql-compute-metal/src/trait_impl/grouped_experts.rs
+++ b/crates/larql-compute-metal/src/trait_impl/grouped_experts.rs
@@ -73,6 +73,14 @@ pub enum GroupedError {
     /// layer index: `slot` already means the projection a host-side
     /// bounds check failed on, and a caller that read one as the other
     /// would blame the wrong thing. A control did exactly that.
+    /// The command buffer carrying this call finished in a state other
+    /// than `Completed`: the GPU faulted, or Metal dropped the buffer
+    /// after an earlier fault. Its outputs are whatever the scratch held
+    /// before, so nothing is read back and no cache advances.
+    CommandBufferFailed {
+        site: &'static str,
+        detail: String,
+    },
     LayerRouteNotResident {
         layer: usize,
         refusals: u32,
@@ -97,6 +105,9 @@ pub enum GroupedError {
 impl std::fmt::Display for GroupedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::CommandBufferFailed { site, detail } => {
+                write!(f, "command buffer at {site} did not complete: {detail}")
+            }
             Self::KNotSuperblockAligned { k } => {
                 write!(f, "grouped experts: K={k} is not a multiple of 256")
             }
@@ -316,10 +327,14 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/grouped_experts.rs:kquant_grouped",
-        );
+        )
+        .map_err(|detail| GroupedError::CommandBufferFailed {
+            site: "crates/larql-compute-metal/src/trait_impl/grouped_experts.rs:kquant_grouped",
+            detail,
+        })?;
         let gpu_ms = crate::decode::gpu_timing::gpu_elapsed_ms(cmd);
         Ok((
             crate::buffers::read_buffer_f32(&buf_out, offsets.len() * n),

--- a/crates/larql-compute-metal/src/trait_impl/kda/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kda/mod.rs
@@ -350,10 +350,14 @@ impl MetalBackend {
         self.encode_kda_attention(enc, w, shape, state, &buf_x, &s);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/kda/mod.rs:step",
-        );
+        )
+        .map_err(|detail| GroupedError::CommandBufferFailed {
+            site: "crates/larql-compute-metal/src/trait_impl/kda/mod.rs:step",
+            detail,
+        })?;
         Ok((s, crate::decode::gpu_timing::gpu_elapsed_ms(cmd)))
     }
 

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/ffn.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/ffn.rs
@@ -380,10 +380,14 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/kimi_layer/ffn.rs:encoded",
-        );
+        )
+        .map_err(|detail| GroupedError::CommandBufferFailed {
+            site: "crates/larql-compute-metal/src/trait_impl/kimi_layer/ffn.rs:encoded",
+            detail,
+        })?;
         Ok(crate::buffers::read_buffer_f32(
             &buf_out,
             offsets.len() * shape.n,

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/head.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/head.rs
@@ -83,10 +83,14 @@ impl MetalBackend {
         let held = self.encode_kimi_head(enc, head, &buf_x, &s, x.len());
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/kimi_layer/head.rs:kimi_head",
-        );
+        )
+        .map_err(|detail| GroupedError::CommandBufferFailed {
+            site: "crates/larql-compute-metal/src/trait_impl/kimi_layer/head.rs:kimi_head",
+            detail,
+        })?;
         let gpu_ms = crate::decode::gpu_timing::gpu_elapsed_ms(cmd);
         drop(held);
         let logits = crate::buffers::read_buffer_f32(&s.logits, head.vocab);

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/mod.rs
@@ -525,10 +525,20 @@ impl MetalBackend {
         let encode_ms = encode_clock.elapsed().as_secs_f64() * 1000.0;
         let wait_clock = std::time::Instant::now();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/trait_impl/kimi_layer/mod.rs:layers",
-        );
+        // A buffer that did not complete leaves every scratch holding
+        // whatever it held before, and nothing here may read it or
+        // advance a cache on it: refuse before the MLA positions move,
+        // and hand the scratch back to the pool untouched.
+        const WAIT_SITE: &str =
+            "crates/larql-compute-metal/src/trait_impl/kimi_layer/mod.rs:layers";
+        if let Err(detail) = crate::cb_status::wait_checked(cmd, WAIT_SITE) {
+            drop(held);
+            self.recycle_chain(scratch, kda_scratch);
+            return Err(GroupedError::CommandBufferFailed {
+                site: WAIT_SITE,
+                detail,
+            });
+        }
         let wait_ms = wait_clock.elapsed().as_secs_f64() * 1000.0;
         let gpu_ms = crate::decode::gpu_timing::gpu_elapsed_ms(cmd);
         // Encode-vs-wait, because they have different fixes: encode is

--- a/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/kimi_layer/tests/mod.rs
@@ -709,6 +709,72 @@ fn a_kda_layer_and_an_mla_layer_share_one_command_buffer() {
     );
 }
 
+/// **A failed command buffer refuses the whole chain and advances nothing.**
+///
+/// The fault is injected at the chain's own wait site, so it fires after
+/// the (valid) buffer ran; what is under test is the host's response: a
+/// typed refusal naming the site, no readback, the MLA cache still at its
+/// pre-call length, and a backend that serves the next call normally.
+/// This is the path the Kimi MLA/KDA trajectory evidence runs through.
+#[test]
+fn a_failed_command_buffer_refuses_the_chain_and_advances_nothing() {
+    let m = backend();
+    let f = fixture();
+    let bits = mla_bits();
+    let kda_state = KdaDeviceState::zeros(&m, shape());
+    let mla_state = MlaDeviceState::with_capacity(&m, mla_shape(), 8);
+
+    let mut second = f.layer(&kda_state);
+    second.attention = AttentionSpec::Mla {
+        weights: bits.device(),
+        shape: mla_shape(),
+        state: &mla_state,
+    };
+    let chain = [
+        KimiLayerCall {
+            weights: f.layer(&kda_state),
+        },
+        KimiLayerCall { weights: second },
+    ];
+
+    crate::cb_status::inject_fault_at_for_test("kimi_layer/mod.rs:layers");
+    let faults_before = crate::cb_status::non_completed_count();
+    let err = m
+        .kimi_decoder_layers(&chain, &f.x, None)
+        .expect_err("a failed command buffer must refuse the chain");
+    assert!(
+        matches!(&err, GroupedError::CommandBufferFailed { site, .. }
+            if site.ends_with("kimi_layer/mod.rs:layers")),
+        "refusal must name the chain's wait site: {err}"
+    );
+    assert_eq!(
+        mla_state.len(),
+        0,
+        "the MLA cache must not advance past a failed buffer"
+    );
+    assert!(
+        !crate::cb_status::injected_fault_pending(),
+        "the fault fired at the chain's own wait, not at an earlier one"
+    );
+    assert_eq!(
+        crate::cb_status::non_completed_count(),
+        faults_before,
+        "an injected fault is not a GPU observation"
+    );
+
+    // The refusal left the backend usable: the same chain now runs and
+    // advances the cache exactly once.
+    let (out, _) = m
+        .kimi_decoder_layers(&chain, &f.x, None)
+        .expect("a healthy chain after a refused one");
+    assert_eq!(out.len(), f.x.len());
+    assert_eq!(
+        mla_state.len(),
+        1,
+        "the healthy call advanced the cache once"
+    );
+}
+
 mod addressing;
 mod dense;
 mod encoding;

--- a/crates/larql-compute-metal/src/trait_impl/matmul.rs
+++ b/crates/larql-compute-metal/src/trait_impl/matmul.rs
@@ -159,7 +159,7 @@ impl MatMul for MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:125",
         );
@@ -218,7 +218,7 @@ impl MatMul for MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:181",
         );
@@ -309,7 +309,7 @@ impl MatMul for MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:269",
         );
@@ -397,7 +397,7 @@ impl MatMul for MetalBackend {
         }
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:354",
         );
@@ -484,7 +484,7 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:140",
         );
@@ -541,7 +541,7 @@ impl MetalBackend {
         let (partial_vals, partial_idxs, n_partials) = self.encode_argmax_partial(enc, &scores, n);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:194",
         );
@@ -588,7 +588,7 @@ impl MetalBackend {
         let (partial_vals, partial_idxs, n_partials) = self.encode_argmax_partial(enc, &scores, n);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:238",
         );
@@ -803,7 +803,7 @@ impl MetalBackend {
         let (partial_vals, partial_idxs, num_tgs) = self.encode_topk_partial(enc, &scores, n);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:450",
         );
@@ -854,7 +854,7 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:498",
         );
@@ -899,7 +899,7 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:530",
         );
@@ -1011,10 +1011,11 @@ mod tests {
         let (vals, idxs, num_tgs) = metal.encode_topk_partial(enc, &scores_buf, n);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:570",
-        );
+        )
+        .expect("command buffer completed");
 
         let hits = MetalBackend::reduce_topk_partial(&vals, &idxs, num_tgs, 5);
         assert_eq!(hits.len(), 5);
@@ -1044,10 +1045,11 @@ mod tests {
         let (vals, idxs, num_tgs) = metal.encode_topk_partial(enc, &scores_buf, n);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/matmul.rs:600",
-        );
+        )
+        .expect("command buffer completed");
         let hits = MetalBackend::reduce_topk_partial(&vals, &idxs, num_tgs, 2);
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].0, 42);

--- a/crates/larql-compute-metal/src/trait_impl/mla/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/mla/mod.rs
@@ -243,10 +243,14 @@ impl MetalBackend {
         self.encode_mla_attention_into(enc, w, shape, state, &buf_x, &s, visible);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/mla/mod.rs:step",
-        );
+        )
+        .map_err(|detail| GroupedError::CommandBufferFailed {
+            site: "crates/larql-compute-metal/src/trait_impl/mla/mod.rs:step",
+            detail,
+        })?;
         state.positions.set(visible);
         Ok((s, visible, crate::decode::gpu_timing::gpu_elapsed_ms(cmd)))
     }

--- a/crates/larql-compute-metal/src/trait_impl/mod.rs
+++ b/crates/larql-compute-metal/src/trait_impl/mod.rs
@@ -297,9 +297,7 @@ mod tests {
         let enc = cmd.new_compute_command_encoder();
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
-            cmd,
-            "crates/larql-compute-metal/src/trait_impl/mod.rs:294",
-        );
+        crate::cb_status::wait_checked(cmd, "crates/larql-compute-metal/src/trait_impl/mod.rs:294")
+            .expect("command buffer completed");
     }
 }

--- a/crates/larql-compute-metal/src/trait_impl/mxfp4.rs
+++ b/crates/larql-compute-metal/src/trait_impl/mxfp4.rs
@@ -45,6 +45,9 @@ pub enum Mxfp4Error {
         got: usize,
         need: usize,
     },
+    /// The command buffer carrying this call finished in a state other
+    /// than `Completed`; its output is not read back.
+    CommandBufferFailed { site: &'static str, detail: String },
     /// A ladder rung that does not exist yet.
     Unimplemented(&'static str),
 }
@@ -52,6 +55,9 @@ pub enum Mxfp4Error {
 impl std::fmt::Display for Mxfp4Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::CommandBufferFailed { site, detail } => {
+                write!(f, "command buffer at {site} did not complete: {detail}")
+            }
             Self::KNotGroupAligned { k } => {
                 write!(f, "MXFP4: K={k} is not a multiple of the 32-element group")
             }
@@ -159,10 +165,14 @@ impl MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_checked(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/mxfp4.rs:162",
-        );
+        )
+        .map_err(|detail| Mxfp4Error::CommandBufferFailed {
+            site: "crates/larql-compute-metal/src/trait_impl/mxfp4.rs:162",
+            detail,
+        })?;
 
         Ok(crate::buffers::read_buffer_f32(&buf_out, m))
     }

--- a/crates/larql-compute-metal/src/trait_impl/quant_matvec.rs
+++ b/crates/larql-compute-metal/src/trait_impl/quant_matvec.rs
@@ -56,7 +56,7 @@ impl QuantMatVec for MetalBackend {
             self.encode_argmax_partial(enc, &scores, num_rows);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:59",
         );
@@ -103,7 +103,7 @@ impl QuantMatVec for MetalBackend {
             self.encode_topk_partial(enc, &scores, num_rows);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:103",
         );
@@ -187,7 +187,7 @@ impl QuantMatVec for MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:184",
         );
@@ -240,7 +240,7 @@ impl QuantMatVec for MetalBackend {
             self.encode_topk_partial(enc, &buf_out, num_rows);
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:234",
         );
@@ -300,7 +300,7 @@ impl QuantMatVec for MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:291",
         );
@@ -348,7 +348,7 @@ impl QuantMatVec for MetalBackend {
         );
         enc.end_encoding();
         cmd.commit();
-        let _ = crate::cb_status::wait_checked(
+        crate::cb_status::wait_or_abort(
             cmd,
             "crates/larql-compute-metal/src/trait_impl/quant_matvec.rs:336",
         );

--- a/crates/larql-compute/benches/q4k_q8k_matvec.rs
+++ b/crates/larql-compute/benches/q4k_q8k_matvec.rs
@@ -111,7 +111,8 @@ fn bench_q4k_q8k(c: &mut Criterion) {
         #[cfg(target_arch = "aarch64")]
         group.bench_with_input(BenchmarkId::new("neon", name), &(), |b, _| {
             b.iter(|| {
-                q4k_q8k_matvec_neon(&mut out, &q8, &w_q4, rows, cols);
+                q4k_q8k_matvec_neon(&mut out, &q8, &w_q4, rows, cols)
+                    .expect("bench shapes are valid");
                 std::hint::black_box(out[0]);
             });
         });
@@ -120,7 +121,8 @@ fn bench_q4k_q8k(c: &mut Criterion) {
         #[cfg(target_arch = "aarch64")]
         group.bench_with_input(BenchmarkId::new("asm", name), &(), |b, _| {
             b.iter(|| {
-                q4k_q8k_matvec_asm(&mut out, &q8, &w_q4, rows, cols);
+                q4k_q8k_matvec_asm(&mut out, &q8, &w_q4, rows, cols)
+                    .expect("bench shapes are valid");
                 std::hint::black_box(out[0]);
             });
         });
@@ -130,7 +132,8 @@ fn bench_q4k_q8k(c: &mut Criterion) {
         if rows * cols <= 2560 * 2560 {
             group.bench_with_input(BenchmarkId::new("scalar", name), &(), |b, _| {
                 b.iter(|| {
-                    q4k_q8k_matvec_scalar(&mut out, &q8, &w_q4, rows, cols);
+                    q4k_q8k_matvec_scalar(&mut out, &q8, &w_q4, rows, cols)
+                        .expect("bench shapes are valid");
                     std::hint::black_box(out[0]);
                 });
             });
@@ -159,13 +162,15 @@ fn bench_q4k_q8k(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(2 * weight_bytes(rows, cols)));
         group.bench_with_input(BenchmarkId::new("neon", "ffn_gate_up"), &(), |b, _| {
             b.iter(|| {
-                q4k_q8k_gate_up_neon(&mut g_out, &mut u_out, &q8, &g_q4, &u_q4, rows, cols);
+                q4k_q8k_gate_up_neon(&mut g_out, &mut u_out, &q8, &g_q4, &u_q4, rows, cols)
+                    .expect("bench shapes are valid");
                 std::hint::black_box(g_out[0] + u_out[0]);
             });
         });
         group.bench_with_input(BenchmarkId::new("asm", "ffn_gate_up"), &(), |b, _| {
             b.iter(|| {
-                q4k_q8k_gate_up_asm(&mut g_out, &mut u_out, &q8, &g_q4, &u_q4, rows, cols);
+                q4k_q8k_gate_up_asm(&mut g_out, &mut u_out, &q8, &g_q4, &u_q4, rows, cols)
+                    .expect("bench shapes are valid");
                 std::hint::black_box(g_out[0] + u_out[0]);
             });
         });
@@ -190,13 +195,15 @@ fn bench_q4k_q8k(c: &mut Criterion) {
         ));
         group.bench_with_input(BenchmarkId::new("neon", "ffn_down"), &(), |b, _| {
             b.iter(|| {
-                q6k_q8k_matvec_neon(&mut out, &q8, &w_q6, rows, cols);
+                q6k_q8k_matvec_neon(&mut out, &q8, &w_q6, rows, cols)
+                    .expect("bench shapes are valid");
                 std::hint::black_box(out[0]);
             });
         });
         group.bench_with_input(BenchmarkId::new("asm", "ffn_down"), &(), |b, _| {
             b.iter(|| {
-                q6k_q8k_matvec_asm(&mut out, &q8, &w_q6, rows, cols);
+                q6k_q8k_matvec_asm(&mut out, &q8, &w_q6, rows, cols)
+                    .expect("bench shapes are valid");
                 std::hint::black_box(out[0]);
             });
         });
@@ -304,7 +311,7 @@ fn bench_sb_decomposition(c: &mut Criterion) {
     group.bench_function("full_matvec", |b| {
         let mut out = vec![0.0f32; rows];
         b.iter(|| {
-            q4k_q8k_matvec_asm(&mut out, &q8, &w_q4, rows, cols);
+            q4k_q8k_matvec_asm(&mut out, &q8, &w_q4, rows, cols).expect("bench shapes are valid");
             std::hint::black_box(out[0]);
         });
     });
@@ -313,7 +320,8 @@ fn bench_sb_decomposition(c: &mut Criterion) {
         use larql_compute::cpu::ops::q4k_q8k_dot::q4k_q8k_matvec_asm_v2;
         let mut out = vec![0.0f32; rows];
         b.iter(|| {
-            q4k_q8k_matvec_asm_v2(&mut out, &q8, &w_q4, rows, cols);
+            q4k_q8k_matvec_asm_v2(&mut out, &q8, &w_q4, rows, cols)
+                .expect("bench shapes are valid");
             std::hint::black_box(out[0]);
         });
     });
@@ -322,7 +330,8 @@ fn bench_sb_decomposition(c: &mut Criterion) {
         use larql_compute::cpu::ops::q4k_q8k_dot::q4k_q8k_matvec_asm_v3;
         let mut out = vec![0.0f32; rows];
         b.iter(|| {
-            q4k_q8k_matvec_asm_v3(&mut out, &q8, &w_q4, rows, cols);
+            q4k_q8k_matvec_asm_v3(&mut out, &q8, &w_q4, rows, cols)
+                .expect("bench shapes are valid");
             std::hint::black_box(out[0]);
         });
     });
@@ -374,7 +383,8 @@ fn bench_mt_shapes(c: &mut Criterion) {
                         return;
                     }
                     let w = &w_q4[row_start * bytes_per_row..(row_start + n) * bytes_per_row];
-                    q4k_q8k_matvec_asm_v3(&mut chunk[..n], &q8, w, n, cols);
+                    q4k_q8k_matvec_asm_v3(&mut chunk[..n], &q8, w, n, cols)
+                        .expect("bench shapes are valid");
                 });
                 std::hint::black_box(out[0]);
             });
@@ -408,8 +418,10 @@ fn bench_mt_shapes(c: &mut Criterion) {
                     .map(|_| {
                         let mut gu_out = vec![0.0f32; gu_rows];
                         let mut dn_out = vec![0.0f32; hidden];
-                        q4k_q8k_matvec_asm_v3(&mut gu_out, &q8, &per_expert_gu, gu_rows, hidden);
-                        q4k_q8k_matvec_asm_v3(&mut dn_out, &q8_act, &per_expert_dn, hidden, 768);
+                        q4k_q8k_matvec_asm_v3(&mut gu_out, &q8, &per_expert_gu, gu_rows, hidden)
+                            .expect("bench shapes are valid");
+                        q4k_q8k_matvec_asm_v3(&mut dn_out, &q8_act, &per_expert_dn, hidden, 768)
+                            .expect("bench shapes are valid");
                         gu_out[0] + dn_out[0]
                     })
                     .sum();
@@ -467,7 +479,8 @@ fn bench_mt_production(c: &mut Criterion) {
         group.throughput(Throughput::Bytes((rows * bytes_per_row) as u64));
         group.bench_function(label, |b| {
             b.iter(|| {
-                q4k_q8k_matvec_parallel(&mut out, &q8, &w_q4, rows, cols, "Q4_K");
+                q4k_q8k_matvec_parallel(&mut out, &q8, &w_q4, rows, cols, "Q4_K")
+                    .expect("bench shapes are valid");
                 std::hint::black_box(out[0]);
             });
         });

--- a/crates/larql-compute/src/attention/decode/q4k_direct.rs
+++ b/crates/larql-compute/src/attention/decode/q4k_direct.rs
@@ -45,15 +45,18 @@ pub(super) fn q8k_direct_proj(
             return;
         }
         let w_chunk = &qw.data[row_start * bytes_per_row..(row_start + chunk_len) * bytes_per_row];
-        match qw.format() {
+        let run = match qw.format() {
             crate::QuantFormat::Q4_K => {
                 q4k_q8k_matvec_into(&mut chunk[..chunk_len], x_q8k, w_chunk, chunk_len, in_dim)
             }
             crate::QuantFormat::Q6_K => {
                 q6k_q8k_matvec_into(&mut chunk[..chunk_len], x_q8k, w_chunk, chunk_len, in_dim)
             }
-            _ => {}
-        }
+            _ => Ok(()),
+        };
+        // Every chunk is a sub-slice of the pre-flight-checked whole;
+        // a refusal here is a defect in the chunking, not in the input.
+        run.unwrap_or_else(|e| panic!("q8k_direct_proj: chunk {chunk_idx} refused: {e}"));
     });
     Array2::from_shape_vec((1, num_rows), out).ok()
 }

--- a/crates/larql-compute/src/attention/decode/tests.rs
+++ b/crates/larql-compute/src/attention/decode/tests.rs
@@ -37,6 +37,7 @@ fn q8k_direct_proj_chunking_is_bit_exact() {
             }
             _ => q6k_q8k_matvec_into(&mut whole, &q8, &bytes, num_rows, in_dim),
         }
+        .expect("whole-matrix matvec on a valid shape");
         for (r, (&c, &w)) in chunked.iter().zip(whole.iter()).enumerate() {
             assert_eq!(
                 c.to_bits(),

--- a/crates/larql-compute/src/cpu/mod.rs
+++ b/crates/larql-compute/src/cpu/mod.rs
@@ -102,7 +102,9 @@ impl QuantMatVec for CpuBackend {
         // Parallelised across rows with rayon for the matvec shapes
         // a decode step pulls (2560–8192 rows).
         let mut out = vec![0.0f32; num_rows];
-        ops::q4_common::q4k_matvec_into(&mut out, x, q4k_data, num_rows, hidden);
+        // Shape errors surface as `None`, the trait's contract for a
+        // backend that cannot compute the request.
+        ops::q4_common::q4k_matvec_into(&mut out, x, q4k_data, num_rows, hidden).ok()?;
         Some(out)
     }
 
@@ -145,7 +147,8 @@ impl QuantMatVec for CpuBackend {
         let mut out_b = vec![0.0f32; num_rows];
         ops::q4_common::q4k_dual_matvec_into(
             &mut out_a, &mut out_b, x, q4k_a, q4k_b, num_rows, hidden,
-        );
+        )
+        .ok()?;
         Some((out_a, out_b))
     }
 

--- a/crates/larql-compute/src/cpu/ops/kernel_shape.rs
+++ b/crates/larql-compute/src/cpu/ops/kernel_shape.rs
@@ -1,0 +1,149 @@
+//! Typed refusal for the CPU quantised kernels' operand shapes.
+//!
+//! Every Q*K matvec kernel used to zero-fill its output and return when a
+//! caller handed it inconsistent slices: an output shorter than `rows`, an
+//! activation that was not `cols` long, a column count that was not a
+//! whole number of super-blocks, or a weight slab too short for the
+//! geometry. Those guards exist because the hand-asm kernels take
+//! `q8k_x.qs.as_ptr()` as a bare pointer with no bound of its own, so a
+//! caller-side mismatch is a real out-of-bounds read, not a debug-only
+//! assertion. But a zero vector is a plausible logit vector — the
+//! wrong-but-plausible failure class dec-readiness §1 names — so the
+//! kernels now refuse by name and leave `out` untouched instead.
+//!
+//! Zero dimensions are not a refusal: a matvec over no rows or no columns
+//! is the empty product, and the kernels still write zeros for it.
+
+use std::fmt;
+
+/// Why a quantised kernel refused its operands. Every field is the value
+/// the kernel saw, so the message names the mismatch rather than the rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KernelShapeError {
+    /// The refusing kernel.
+    pub kernel: &'static str,
+    /// `out.len()` as handed in; must equal `rows`.
+    pub out_len: usize,
+    /// Output rows the caller asked for.
+    pub rows: usize,
+    /// Activation length (`q8k_x.qs.len()` or `x.len()`); must equal `cols`.
+    pub x_len: usize,
+    /// Weight columns the caller asked for; must be a whole number of
+    /// super-blocks.
+    pub cols: usize,
+    /// Packed weight bytes handed in.
+    pub weight_bytes: usize,
+    /// Packed weight bytes `rows × cols` needs at this block layout.
+    pub needed_bytes: usize,
+}
+
+impl KernelShapeError {
+    /// Validate a `rows × cols` matvec over packed super-blocks of
+    /// `block_bytes` per `block_elems` columns. `Ok` means every slice is
+    /// exactly what the kernel will index: `out.len() == rows`,
+    /// `x_len == cols`, `cols` a multiple of `block_elems`, and at least
+    /// `rows` packed rows of weight bytes.
+    #[allow(clippy::too_many_arguments)]
+    pub fn check(
+        kernel: &'static str,
+        out_len: usize,
+        rows: usize,
+        x_len: usize,
+        cols: usize,
+        weight_bytes: usize,
+        block_elems: usize,
+        block_bytes: usize,
+    ) -> Result<(), Self> {
+        let needed_bytes = (cols / block_elems) * block_bytes * rows;
+        let ok = out_len == rows
+            && x_len == cols
+            && cols.is_multiple_of(block_elems)
+            && weight_bytes >= needed_bytes;
+        if ok {
+            Ok(())
+        } else {
+            Err(Self {
+                kernel,
+                out_len,
+                rows,
+                x_len,
+                cols,
+                weight_bytes,
+                needed_bytes,
+            })
+        }
+    }
+}
+
+impl fmt::Display for KernelShapeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}: refused operands: out.len() {} for {} rows, activation length {} for {} cols \
+             (cols must be a whole number of super-blocks), {} weight bytes where {} are needed",
+            self.kernel,
+            self.out_len,
+            self.rows,
+            self.x_len,
+            self.cols,
+            self.weight_bytes,
+            self.needed_bytes
+        )
+    }
+}
+
+impl std::error::Error for KernelShapeError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ELEMS: usize = 256;
+    const BYTES: usize = 144;
+
+    #[test]
+    fn a_consistent_shape_passes() {
+        assert_eq!(
+            KernelShapeError::check("k", 3, 3, 512, 512, 3 * 2 * BYTES, ELEMS, BYTES),
+            Ok(())
+        );
+        // Zero dimensions are the empty product, not a refusal.
+        assert_eq!(
+            KernelShapeError::check("k", 0, 0, 0, 0, 0, ELEMS, BYTES),
+            Ok(())
+        );
+        assert_eq!(
+            KernelShapeError::check("k", 4, 4, 0, 0, 0, ELEMS, BYTES),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn every_mismatch_is_refused_by_name() {
+        let cases: [(usize, usize, usize, usize, usize); 4] = [
+            (2, 3, 512, 512, 3 * 2 * BYTES),     // out shorter than rows
+            (3, 3, 511, 512, 3 * 2 * BYTES),     // activation not cols long
+            (3, 3, 500, 500, 3 * 2 * BYTES),     // cols not a super-block multiple
+            (3, 3, 512, 512, 3 * 2 * BYTES - 1), // weight slab short
+        ];
+        for (out_len, rows, x_len, cols, wb) in cases {
+            let err =
+                KernelShapeError::check("q4k_test", out_len, rows, x_len, cols, wb, ELEMS, BYTES)
+                    .expect_err("must refuse");
+            assert_eq!(err.kernel, "q4k_test");
+            assert_eq!(
+                (err.out_len, err.rows, err.x_len, err.cols, err.weight_bytes),
+                (out_len, rows, x_len, cols, wb)
+            );
+            let text = err.to_string();
+            assert!(text.starts_with("q4k_test: refused operands"), "{text}");
+            assert!(text.contains(&format!("{wb} weight bytes")), "{text}");
+        }
+    }
+
+    #[test]
+    fn needed_bytes_follows_the_block_layout() {
+        let err = KernelShapeError::check("k", 5, 5, 768, 768, 0, ELEMS, 210).expect_err("short");
+        assert_eq!(err.needed_bytes, 3 * 210 * 5);
+    }
+}

--- a/crates/larql-compute/src/cpu/ops/mod.rs
+++ b/crates/larql-compute/src/cpu/ops/mod.rs
@@ -6,6 +6,7 @@
 pub mod attention;
 pub mod f32_matmul;
 pub mod geglu;
+pub mod kernel_shape;
 pub mod linalg;
 pub mod moe;
 pub mod outer_combine;
@@ -18,3 +19,5 @@ pub mod q6k_matvec;
 pub mod q8_matvec;
 pub mod ternary_matvec;
 pub mod vector;
+
+pub use kernel_shape::KernelShapeError;

--- a/crates/larql-compute/src/cpu/ops/moe/expert/f32.rs
+++ b/crates/larql-compute/src/cpu/ops/moe/expert/f32.rs
@@ -230,12 +230,14 @@ pub fn run_single_expert_into<'s>(
         let half = inter * row_block_bytes;
         let gate_bytes = &gate_up_bytes[..half];
         let up_bytes = &gate_up_bytes[half..2 * half];
-        q4k_matvec_into(&mut scratch.gate_out, &h_w, gate_bytes, inter, weight_cols);
+        q4k_matvec_into(&mut scratch.gate_out, &h_w, gate_bytes, inter, weight_cols)
+            .unwrap_or_else(|e| panic!("run_single_expert_into: {e}"));
         let t_gate = if timing { Some(t.elapsed()) } else { None };
         if timing {
             t = std::time::Instant::now();
         }
-        q4k_matvec_into(&mut scratch.up_out, &h_w, up_bytes, inter, weight_cols);
+        q4k_matvec_into(&mut scratch.up_out, &h_w, up_bytes, inter, weight_cols)
+            .unwrap_or_else(|e| panic!("run_single_expert_into: {e}"));
         let t_up = if timing { Some(t.elapsed()) } else { None };
         if timing {
             t = std::time::Instant::now();
@@ -255,7 +257,8 @@ pub fn run_single_expert_into<'s>(
             down_bytes,
             hidden,
             inter_padded,
-        );
+        )
+        .unwrap_or_else(|e| panic!("run_single_expert_into: {e}"));
         mlp.add_down_bias(&mut scratch.out);
         let t_down = if timing { Some(t.elapsed()) } else { None };
         if timing {

--- a/crates/larql-compute/src/cpu/ops/moe/expert/q4k.rs
+++ b/crates/larql-compute/src/cpu/ops/moe/expert/q4k.rs
@@ -3,6 +3,7 @@ use crate::cpu::ops::q4k_q8k_dot::{
     q4k_q8k_matvec_into, q6k_q8k_matvec_into, quantize_x_to_q8k, quantize_x_to_q8k_into,
     Q8KActivation,
 };
+use crate::cpu::ops::KernelShapeError;
 use crate::options;
 
 /// One integer matvec, dispatched by the store's weight format. The two
@@ -17,11 +18,41 @@ fn kq_q8k_matvec_into(
     rows: usize,
     cols: usize,
     format: crate::QuantFormat,
-) {
+) -> Result<(), KernelShapeError> {
     match format {
         crate::QuantFormat::Q6_K => q6k_q8k_matvec_into(out, q8k_x, w, rows, cols),
         _ => q4k_q8k_matvec_into(out, q8k_x, w, rows, cols),
     }
+}
+
+/// The expert paths below return a borrowed scratch slice and have no
+/// error channel; a refused operand shape is a defect in the caller's
+/// slab arithmetic, and the step ends here rather than with zeros.
+fn refuse(kernel: &'static str, e: KernelShapeError) -> ! {
+    panic!("{kernel}: {e}")
+}
+
+/// A gate+up slab shorter than two `inter`-row halves: refused by name,
+/// with the same fields the kernels report.
+fn short_gate_up_slab(
+    kernel: &'static str,
+    have: usize,
+    need: usize,
+    inter: usize,
+    cols: usize,
+) -> ! {
+    panic!(
+        "{}",
+        KernelShapeError {
+            kernel,
+            out_len: inter,
+            rows: inter,
+            x_len: cols,
+            cols,
+            weight_bytes: have,
+            needed_bytes: need,
+        }
+    )
 }
 
 /// Bytes per weight row at `cols` elements under `format`. `cols` must be
@@ -72,10 +103,13 @@ pub fn run_single_expert_kq_q8k_parallel_into<'s>(
     let inter_padded = inter.div_ceil(block) * block;
     let half = inter * row_block_bytes(cols, format);
     if gate_up_bytes.len() < 2 * half {
-        for v in scratch.out.iter_mut() {
-            *v = 0.0;
-        }
-        return &scratch.out;
+        short_gate_up_slab(
+            "run_single_expert_kq_q8k_parallel_into",
+            gate_up_bytes.len(),
+            2 * half,
+            inter,
+            cols,
+        );
     }
     let tag = format.registry_tag();
     q4k_q8k_matvec_parallel(
@@ -85,7 +119,8 @@ pub fn run_single_expert_kq_q8k_parallel_into<'s>(
         inter,
         cols,
         tag,
-    );
+    )
+    .unwrap_or_else(|e| refuse("run_single_expert_kq_q8k_parallel_into", e));
     q4k_q8k_matvec_parallel(
         &mut scratch.up_out,
         h_norm_q8k,
@@ -93,7 +128,8 @@ pub fn run_single_expert_kq_q8k_parallel_into<'s>(
         inter,
         cols,
         tag,
-    );
+    )
+    .unwrap_or_else(|e| refuse("run_single_expert_kq_q8k_parallel_into", e));
     for j in 0..inter {
         let g = scratch.gate_out[j] + mlp.gate_bias(j);
         let u = scratch.up_out[j] + mlp.up_bias(j);
@@ -108,7 +144,8 @@ pub fn run_single_expert_kq_q8k_parallel_into<'s>(
         hidden_out,
         inter_padded,
         tag,
-    );
+    )
+    .unwrap_or_else(|e| refuse("run_single_expert_kq_q8k_parallel_into", e));
     mlp.add_down_bias(&mut scratch.out);
     &scratch.out
 }
@@ -207,10 +244,13 @@ pub fn run_single_expert_kq_q8k_into<'s>(
     let inter_padded = inter.div_ceil(block) * block;
     let half = inter * row_block_bytes(cols, format);
     if gate_up_bytes.len() < 2 * half {
-        for v in scratch.out.iter_mut() {
-            *v = 0.0;
-        }
-        return &scratch.out;
+        short_gate_up_slab(
+            "run_single_expert_kq_q8k_into",
+            gate_up_bytes.len(),
+            2 * half,
+            inter,
+            cols,
+        );
     }
     let gate_bytes = &gate_up_bytes[..half];
     let up_bytes = &gate_up_bytes[half..2 * half];
@@ -231,7 +271,8 @@ pub fn run_single_expert_kq_q8k_into<'s>(
         inter,
         cols,
         format,
-    );
+    )
+    .unwrap_or_else(|e| refuse("run_single_expert_kq_q8k_into", e));
     let t_gate = if timing { Some(t.elapsed()) } else { None };
     if timing {
         t = std::time::Instant::now();
@@ -244,7 +285,8 @@ pub fn run_single_expert_kq_q8k_into<'s>(
         inter,
         cols,
         format,
-    );
+    )
+    .unwrap_or_else(|e| refuse("run_single_expert_kq_q8k_into", e));
     let t_up = if timing { Some(t.elapsed()) } else { None };
     if timing {
         t = std::time::Instant::now();
@@ -288,7 +330,8 @@ pub fn run_single_expert_kq_q8k_into<'s>(
         hidden_out,
         inter_padded,
         format,
-    );
+    )
+    .unwrap_or_else(|e| refuse("run_single_expert_kq_q8k_into", e));
     mlp.add_down_bias(&mut scratch.out);
     let t_down = if timing { Some(t.elapsed()) } else { None };
 

--- a/crates/larql-compute/src/cpu/ops/moe/expert/tests/bias.rs
+++ b/crates/larql-compute/src/cpu/ops/moe/expert/tests/bias.rs
@@ -286,10 +286,33 @@ fn parallel_expert_variant_matches_serial_exactly() {
     .to_vec();
     assert_eq!(serial, parallel, "schedules must not change the numbers");
     assert!(serial.iter().any(|v| v.abs() > 1e-4));
+}
 
-    // Degenerate guards return zeroed output on both variants.
+/// The parallel variant refuses a short gate+up slab by name, like the
+/// serial one; it used to hand back a zeroed expert output.
+#[test]
+#[should_panic(expected = "run_single_expert_kq_q8k_parallel_into: refused operands")]
+fn parallel_expert_variant_refuses_a_short_slab() {
+    use super::super::super::{
+        quantize_h_norm_for_q4k, run_single_expert_kq_q8k_parallel_into, ExpertScratch,
+    };
+    use crate::cpu::ops::q4_common::quantize_q6_k;
+
+    const H: usize = 256;
+    const I: usize = 256;
+    let gu_q = quantize_q6_k(&vec![0.25f32; 2 * I * H]);
+    let dn_q = quantize_q6_k(&vec![0.25f32; H * I]);
+    let q8k = quantize_h_norm_for_q4k(&vec![1.0f32; H]).expect("block-multiple width");
+    let mlp = ExpertMlp {
+        rule: MoeGateRule::ClampedGlu {
+            limit: 7.0,
+            alpha: 1.702,
+        },
+        gate_up_bias: &[],
+        down_bias: &[],
+    };
     let mut s3 = ExpertScratch::new(H, I, I);
-    let short = run_single_expert_kq_q8k_parallel_into(
+    let _ = run_single_expert_kq_q8k_parallel_into(
         &mut s3,
         &q8k,
         &gu_q[..10],
@@ -298,5 +321,4 @@ fn parallel_expert_variant_matches_serial_exactly() {
         crate::QuantFormat::Q6_K,
         mlp,
     );
-    assert!(short.iter().all(|v| *v == 0.0));
 }

--- a/crates/larql-compute/src/cpu/ops/moe/expert/tests/mod.rs
+++ b/crates/larql-compute/src/cpu/ops/moe/expert/tests/mod.rs
@@ -153,15 +153,18 @@ fn quantize_h_norm_for_q4k_rejects_empty_or_misaligned_input() {
     assert_eq!(q8.qs.len(), 256);
 }
 
+/// An empty gate+up slab is the same refusal at the smallest shape, and
+/// the pre-filled output is never overwritten with zeros first.
 #[test]
-fn run_single_expert_q4k_q8k_into_zeroes_output_for_short_gate_up() {
+#[should_panic(expected = "288 are needed")]
+fn run_single_expert_q4k_q8k_into_refuses_an_empty_gate_up() {
     let hidden = 256;
     let inter = 1;
     let mut scratch = ExpertScratch::new(hidden, inter, 256);
     scratch.out.fill(7.0);
     let h_q8 = quantize_h_norm_for_q4k(&vec![1.0f32; hidden]).unwrap();
 
-    let out = run_single_expert_q4k_q8k_into(
+    let _ = run_single_expert_q4k_q8k_into(
         &mut scratch,
         &h_q8,
         &[],
@@ -169,8 +172,6 @@ fn run_single_expert_q4k_q8k_into_zeroes_output_for_short_gate_up() {
         inter,
         crate::ExpertMlp::gated(Activation::Silu),
     );
-
-    assert!(out.iter().all(|v| *v == 0.0));
 }
 
 #[test]
@@ -588,10 +589,13 @@ fn run_single_expert_q4k_q8k_into_zero_inter_returns_zeroed() {
     assert_eq!(out, &[0.0f32; 256]);
 }
 
-/// `gate_up_bytes` too short for the claimed (hidden, inter) shape
-/// returns zeroed output instead of panicking.
+/// `gate_up_bytes` too short for the claimed (hidden, inter) shape is
+/// refused by name. This path returns a borrowed scratch slice and has no
+/// error channel, so the refusal ends the step; it used to hand back a
+/// zeroed expert output that a combine would add as if it were computed.
 #[test]
-fn run_single_expert_q4k_q8k_into_short_bytes_returns_zeroed() {
+#[should_panic(expected = "run_single_expert_kq_q8k_into: refused operands")]
+fn run_single_expert_q4k_q8k_into_short_bytes_are_refused() {
     let hidden = 256usize;
     let inter = 256usize;
     let mut scratch = ExpertScratch::new(hidden, inter, inter);
@@ -599,7 +603,7 @@ fn run_single_expert_q4k_q8k_into_short_bytes_returns_zeroed() {
     let h_q8k = quantize_x_to_q8k(&h);
     // Only 100 bytes — far less than 2 * inter * (hidden/256) * 144.
     let short_gate_up = vec![0u8; 100];
-    let out = run_single_expert_q4k_q8k_into(
+    let _ = run_single_expert_q4k_q8k_into(
         &mut scratch,
         &h_q8k,
         &short_gate_up,
@@ -607,7 +611,6 @@ fn run_single_expert_q4k_q8k_into_short_bytes_returns_zeroed() {
         inter,
         crate::ExpertMlp::gated(Activation::Silu),
     );
-    assert_eq!(out, &[0.0f32; 256]);
 }
 
 /// GeluTanh activation branch in `run_single_expert_q4k_q8k_into`.

--- a/crates/larql-compute/src/cpu/ops/q4_common/dual.rs
+++ b/crates/larql-compute/src/cpu/ops/q4_common/dual.rs
@@ -1,4 +1,5 @@
 use super::f16_to_f32;
+use crate::cpu::ops::KernelShapeError;
 
 /// Fused two-weight Q4_K matvec sharing one input vector.
 ///
@@ -26,41 +27,36 @@ pub fn q4k_dual_matvec_into(
     w_b: &[u8],
     rows: usize,
     cols: usize,
-) {
-    debug_assert_eq!(out_a.len(), rows);
-    debug_assert_eq!(out_b.len(), rows);
-    debug_assert_eq!(x.len(), cols);
-    if rows == 0 || cols == 0 {
-        for v in out_a.iter_mut() {
-            *v = 0.0;
-        }
-        for v in out_b.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
+) -> Result<(), KernelShapeError> {
     const BLOCK_BYTES: usize = 144;
     const ELEMS_PER_BLOCK: usize = 256;
-    if !cols.is_multiple_of(ELEMS_PER_BLOCK) {
-        for v in out_a.iter_mut() {
-            *v = 0.0;
-        }
-        for v in out_b.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+    KernelShapeError::check(
+        "q4k_dual_matvec_into (a)",
+        out_a.len(),
+        rows,
+        x.len(),
+        cols,
+        w_a.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    KernelShapeError::check(
+        "q4k_dual_matvec_into (b)",
+        out_b.len(),
+        rows,
+        x.len(),
+        cols,
+        w_b.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        out_a.fill(0.0);
+        out_b.fill(0.0);
+        return Ok(());
     }
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * BLOCK_BYTES;
-    if w_a.len() < rows * row_bytes || w_b.len() < rows * row_bytes {
-        for v in out_a.iter_mut() {
-            *v = 0.0;
-        }
-        for v in out_b.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
 
     // Precompute sum_x once.
     let n_subblocks = n_blocks * 8;
@@ -167,6 +163,7 @@ pub fn q4k_dual_matvec_into(
             }
         },
     );
+    Ok(())
 }
 
 /// 32-element dual nibble dot product: returns

--- a/crates/larql-compute/src/cpu/ops/q4_common/matvec_f32.rs
+++ b/crates/larql-compute/src/cpu/ops/q4_common/matvec_f32.rs
@@ -1,5 +1,6 @@
 use super::dual::q4_dual_dot_32;
 use super::f16_to_f32;
+use crate::cpu::ops::KernelShapeError;
 
 /// Direct Q4_K matrix-vector product: `out = W · x` where `W` is the raw
 /// Q4_K byte stream (`rows × cols` weights, 144 bytes per 256 elements).
@@ -28,37 +29,36 @@ use super::f16_to_f32;
 /// sum is row-invariant.  Computing it once outside the row loop saves
 /// `rows × 8 · n_blocks` redundant sums.
 ///
-/// Returns silently on shape mismatch (debug-asserted) and on Q4_K layout
-/// errors (input too short, or `cols` not a multiple of 256).
+/// Refuses a shape mismatch or a Q4_K layout error (input too short, or
+/// `cols` not a multiple of 256) with a [`KernelShapeError`] naming the
+/// operands, leaving `out` untouched.
 ///
 /// Caller layout: `w.len() == rows * (cols / 256) * 144` bytes.
-pub fn q4k_matvec_into(out: &mut [f32], x: &[f32], w: &[u8], rows: usize, cols: usize) {
-    debug_assert_eq!(out.len(), rows);
-    debug_assert_eq!(x.len(), cols);
-    if rows == 0 || cols == 0 {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
+pub fn q4k_matvec_into(
+    out: &mut [f32],
+    x: &[f32],
+    w: &[u8],
+    rows: usize,
+    cols: usize,
+) -> Result<(), KernelShapeError> {
     const BLOCK_BYTES: usize = 144;
     const ELEMS_PER_BLOCK: usize = 256;
-    if !cols.is_multiple_of(ELEMS_PER_BLOCK) {
-        // Caller pads; falling back to zero output makes the failure visible
-        // without panicking (the existing dequant path returns Vec::new()).
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+    KernelShapeError::check(
+        "q4k_matvec_into",
+        out.len(),
+        rows,
+        x.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        out.fill(0.0);
+        return Ok(());
     }
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * BLOCK_BYTES;
-    if w.len() < rows * row_bytes {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
 
     // Precompute per-sub-block sum_x (one f32 per 32-element chunk of x).
     // 2-byte stride per (sb, subblk) pair lets us index by `sb * 8 + subblk`.
@@ -102,6 +102,7 @@ pub fn q4k_matvec_into(out: &mut [f32], x: &[f32], w: &[u8], rows: usize, cols: 
             *out_slot = acc;
         }
     });
+    Ok(())
 }
 
 /// Per-super-block dot contribution for a Q4_K row. Returned scalar

--- a/crates/larql-compute/src/cpu/ops/q4_common/neon_tests.rs
+++ b/crates/larql-compute/src/cpu/ops/q4_common/neon_tests.rs
@@ -89,12 +89,13 @@ fn q4k_dual_matvec_into_matches_two_sequential_calls() {
 
     let mut sep_a = vec![0.0f32; rows];
     let mut sep_b = vec![0.0f32; rows];
-    q4k_matvec_into(&mut sep_a, &x, &q4k_a, rows, cols);
-    q4k_matvec_into(&mut sep_b, &x, &q4k_b, rows, cols);
+    q4k_matvec_into(&mut sep_a, &x, &q4k_a, rows, cols).expect("valid shape");
+    q4k_matvec_into(&mut sep_b, &x, &q4k_b, rows, cols).expect("valid shape");
 
     let mut fused_a = vec![0.0f32; rows];
     let mut fused_b = vec![0.0f32; rows];
-    q4k_dual_matvec_into(&mut fused_a, &mut fused_b, &x, &q4k_a, &q4k_b, rows, cols);
+    q4k_dual_matvec_into(&mut fused_a, &mut fused_b, &x, &q4k_a, &q4k_b, rows, cols)
+        .expect("valid shape");
 
     for r in 0..rows {
         let rel_a = (sep_a[r] - fused_a[r]).abs() / sep_a[r].abs().max(1e-6);
@@ -118,20 +119,23 @@ fn q4k_dual_matvec_into_matches_two_sequential_calls() {
 fn q4k_dual_matvec_into_zero_dims_zero_output() {
     let mut out_a = vec![1.0f32; 4];
     let mut out_b = vec![1.0f32; 4];
-    q4k_dual_matvec_into(&mut out_a, &mut out_b, &[], &[], &[], 4, 0);
+    q4k_dual_matvec_into(&mut out_a, &mut out_b, &[], &[], &[], 4, 0).expect("valid shape");
     assert!(out_a.iter().all(|&v| v == 0.0));
     assert!(out_b.iter().all(|&v| v == 0.0));
 }
 
 #[test]
-fn q4k_dual_matvec_into_non_multiple_cols_zeros_output() {
-    // cols = 100 is not a multiple of 256 → must zero output, not
-    // panic. Matches the single-matvec contract.
+fn q4k_dual_matvec_into_non_multiple_cols_is_refused_untouched() {
+    // cols = 100 is not a multiple of 256: refused by name, both
+    // outputs left as handed in. Matches the single-matvec contract.
     let mut out_a = vec![1.0f32; 2];
     let mut out_b = vec![2.0f32; 2];
     let x = vec![1.0f32; 100];
     let w = vec![0u8; 2 * 144];
-    q4k_dual_matvec_into(&mut out_a, &mut out_b, &x, &w, &w, 2, 100);
-    assert!(out_a.iter().all(|&v| v == 0.0));
-    assert!(out_b.iter().all(|&v| v == 0.0));
+    let err = q4k_dual_matvec_into(&mut out_a, &mut out_b, &x, &w, &w, 2, 100)
+        .expect_err("cols off a super-block must be refused");
+    assert_eq!(out_a, vec![1.0f32; 2]);
+    assert_eq!(out_b, vec![2.0f32; 2]);
+    assert_eq!(err.kernel, "q4k_dual_matvec_into (a)");
+    assert_eq!(err.cols, 100);
 }

--- a/crates/larql-compute/src/cpu/ops/q4_common/tests.rs
+++ b/crates/larql-compute/src/cpu/ops/q4_common/tests.rs
@@ -200,7 +200,7 @@ fn q6k_int8_matvec_matches_models_reference_incl_tiny_scales() {
         let mut x_q8k = Q8KActivation::with_capacity(cols);
         quantize_x_to_q8k_into(&mut x_q8k, &x);
         let mut out = vec![0.0f32; rows];
-        q6k_q8k_matvec_into(&mut out, &x_q8k, &bytes, rows, cols);
+        q6k_q8k_matvec_into(&mut out, &x_q8k, &bytes, rows, cols).expect("valid shape");
         for (r, (got, want)) in out.iter().zip(expected.iter()).enumerate() {
             assert!(
                 (got - want).abs() <= 2e-2 * denom,
@@ -240,7 +240,7 @@ fn q4k_matvecs_match_dequant_dot_incl_subnormal_scales() {
 
         // f32-activation kernel: decode-identical, tight tolerance.
         let mut out_f32 = vec![0.0f32; rows];
-        q4k_matvec_into(&mut out_f32, &x, &bytes, rows, cols);
+        q4k_matvec_into(&mut out_f32, &x, &bytes, rows, cols).expect("valid shape");
         for (r, (got, want)) in out_f32.iter().zip(expected.iter()).enumerate() {
             assert!(
                 (got - want).abs() <= 1e-4 * denom,
@@ -252,7 +252,7 @@ fn q4k_matvecs_match_dequant_dot_incl_subnormal_scales() {
         let mut x_q8k = Q8KActivation::with_capacity(cols);
         quantize_x_to_q8k_into(&mut x_q8k, &x);
         let mut out_i8 = vec![0.0f32; rows];
-        q4k_q8k_matvec_into(&mut out_i8, &x_q8k, &bytes, rows, cols);
+        q4k_q8k_matvec_into(&mut out_i8, &x_q8k, &bytes, rows, cols).expect("valid shape");
         for (r, (got, want)) in out_i8.iter().zip(expected.iter()).enumerate() {
             assert!(
                 (got - want).abs() <= 2e-2 * denom,
@@ -374,7 +374,7 @@ fn q4k_matvec_matches_dequant_then_matmul() {
     }
 
     let mut got = vec![0.0f32; rows];
-    q4k_matvec_into(&mut got, &x, &q4k, rows, cols);
+    q4k_matvec_into(&mut got, &x, &q4k, rows, cols).expect("valid shape");
 
     let max_diff: f32 = reference
         .iter()
@@ -416,7 +416,7 @@ fn q4k_matvec_multi_block_matches_dequant() {
         }
     }
     let mut got = vec![0.0f32; rows];
-    q4k_matvec_into(&mut got, &x, &q4k, rows, cols);
+    q4k_matvec_into(&mut got, &x, &q4k, rows, cols).expect("valid shape");
     let max_diff: f32 = reference
         .iter()
         .zip(got.iter())
@@ -500,7 +500,8 @@ fn q4k_matmul_rows_match_q4k_matvec() {
             &q4k,
             rows,
             hidden,
-        );
+        )
+        .expect("valid shape");
         for r in 0..rows {
             let diff = (mm[s * rows + r] - mv[r]).abs();
             assert!(
@@ -619,29 +620,48 @@ fn q6k_matmul_matches_dequant_then_matmul() {
     assert!(max < 5e-3, "q6k_matmul diverged: {max}");
 }
 
-/// Defensive: caller passes a malformed `cols` (not multiple of 256).
-/// We zero the output rather than reading past the buffer, mirroring
-/// `dequantize_q4_k`'s `Vec::new()` shape-error contract.
+/// A malformed `cols` (not a multiple of 256) is refused by name rather
+/// than read past the buffer, and the output is left exactly as handed
+/// in — the old contract zeroed it, which a caller could mistake for a
+/// computed result.
 #[test]
 fn q4k_matvec_rejects_non_multiple_of_256() {
-    let mut out = vec![1.0f32; 4]; // pre-fill to detect zeroing
+    let mut out = vec![1.0f32; 4]; // pre-fill to detect any write
     let x = vec![0.5f32; 100];
     let w = vec![0u8; 4 * 144];
-    q4k_matvec_into(&mut out, &x, &w, 4, 100);
-    assert_eq!(out, vec![0.0f32; 4]);
+    let err = q4k_matvec_into(&mut out, &x, &w, 4, 100).expect_err("cols off a super-block");
+    assert_eq!(out, vec![1.0f32; 4], "refusal must not touch the output");
+    assert_eq!(err.cols, 100);
+    assert!(
+        err.to_string().contains("whole number of super-blocks"),
+        "{err}"
+    );
 }
 
+/// `q4k_matvec_into`: zero dims are the empty product, and a short weight
+/// slab is refused by name with the output untouched.
 #[test]
-fn q4k_matvec_zero_dims_and_short_weights_zero_output() {
+fn q4k_matvec_zero_dims_are_empty_and_short_weights_are_refused() {
     let mut out = vec![1.0f32; 3];
-    q4k_matvec_into(&mut out, &[], &[], 3, 0);
+    q4k_matvec_into(&mut out, &[], &[], 3, 0).expect("zero dims are the empty product");
     assert_eq!(out, vec![0.0f32; 3]);
 
     let mut out = vec![1.0f32; 2];
     let x = vec![0.5f32; 256];
     let short_w = vec![0u8; 144];
-    q4k_matvec_into(&mut out, &x, &short_w, 2, 256);
-    assert_eq!(out, vec![0.0f32; 2]);
+    let err =
+        q4k_matvec_into(&mut out, &x, &short_w, 2, 256).expect_err("short slab must be refused");
+    assert_eq!(out, vec![1.0f32; 2], "refusal must not touch the output");
+    assert_eq!(err.kernel, "q4k_matvec_into");
+    assert_eq!((err.weight_bytes, err.needed_bytes), (144, 288));
+
+    // The dual kernel refuses the same way, naming the half that is short.
+    let (mut a, mut b) = (vec![1.0f32; 2], vec![1.0f32; 2]);
+    let full = vec![0u8; 288];
+    let err = q4k_dual_matvec_into(&mut a, &mut b, &x, &full, &short_w, 2, 256)
+        .expect_err("short b slab must be refused");
+    assert_eq!((a, b), (vec![1.0f32; 2], vec![1.0f32; 2]));
+    assert_eq!(err.kernel, "q4k_dual_matvec_into (b)");
 }
 
 #[test]

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/common.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/common.rs
@@ -12,24 +12,12 @@ pub(super) const SUBBLOCKS_PER_BLOCK: usize = 8;
 /// Sub-block size (matches Q4_K's per-32 nibble groups).
 pub(super) const SUBBLOCK_SIZE: usize = 32;
 
-/// Runtime-checked replacement for the `out.len()==rows` / `q8k_x.qs.len()==cols`
-/// / `cols % ELEMS_PER_BLOCK==0` shape invariants every matvec kernel below
-/// used to rely on `debug_assert_eq!` alone for. Those compile to nothing in
-/// this workspace's release profile (`[profile.release]` never sets
-/// `debug-assertions`), so a caller-side length mismatch on `q8k_x.qs` fell
-/// straight through the NEON/scalar kernels' own bounds-checked slicing is
-/// fine on its own, but the hand-asm kernels (`q4k_q8k_matvec_asm*`,
-/// `q4k_q8k_gate_up_asm`, `q6k_q8k_matvec_asm`) take `q8k_x.qs.as_ptr()` as a
-/// bare pointer with no length of its own and no per-iteration bound in the
-/// `asm!` block - a real unguarded OOB read, not a debug-only guard.
-/// Callers zero-fill and return early when this is `false`, matching the
-/// `w.len() < rows * row_bytes` early-return already present in every one of
-/// these kernels.
-#[inline]
-pub(super) fn q8k_shape_ok(out_len: usize, rows: usize, q8k_qs_len: usize, cols: usize) -> bool {
-    out_len == rows && q8k_qs_len == cols && cols.is_multiple_of(ELEMS_PER_BLOCK)
-}
-
+/// Operand validation for every kernel in this module is
+/// [`crate::cpu::ops::KernelShapeError::check`]: the hand-asm kernels take
+/// `q8k_x.qs.as_ptr()` as a bare pointer with no length of its own and no
+/// per-iteration bound in the `asm!` block, so a caller-side mismatch is a
+/// real unguarded OOB read. The kernels used to zero-fill and return on a
+/// mismatch; they now refuse by name and leave `out` untouched.
 /// One-line summary of which SIMD kernel class each Q4_K/Q6_K×Q8_K matvec
 /// kernel selects **on this machine, right now** — not what the doc
 /// comments claim.

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/dispatch.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/dispatch.rs
@@ -6,6 +6,7 @@ use super::q4k_avx2::q4k_q8k_matvec_avx2;
 use super::q4k_neon::q4k_q8k_matvec_neon;
 use super::q4k_scalar::q4k_q8k_matvec_scalar;
 use super::q8k_activation::Q8KActivation;
+use crate::cpu::ops::KernelShapeError;
 
 /// Public entry point: dispatches to NEON on aarch64, scalar elsewhere.
 /// Caller pre-quantises `x` once via `quantize_x_to_q8k` (cost is amortised
@@ -17,7 +18,7 @@ pub fn q4k_q8k_matvec_into(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
+) -> Result<(), KernelShapeError> {
     #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     {
         // 2-row variant tried 2026-05-01 — bit-exact (`q8k_matvec_2row_matches_single_row_bit_exact`)
@@ -34,21 +35,19 @@ pub fn q4k_q8k_matvec_into(
         // Rust glue into the asm block (vectorised scale/min unpack, sum2,
         // hardware fcvt + epilogue) — the decomposition bench measured the
         // glue at 19.2 cyc/SB vs the asm block's 16.3.
-        if use_asm_kernel() {
-            q4k_q8k_matvec_asm_v3(out, q8k_x, w, rows, cols);
+        return if use_asm_kernel() {
+            q4k_q8k_matvec_asm_v3(out, q8k_x, w, rows, cols)
         } else {
-            q4k_q8k_matvec_neon(out, q8k_x, w, rows, cols);
-        }
-        return;
+            q4k_q8k_matvec_neon(out, q8k_x, w, rows, cols)
+        };
     }
     #[cfg(target_arch = "x86_64")]
     if is_x86_feature_detected!("avx2") {
         // SAFETY: runtime check guarantees AVX2 availability.
-        unsafe { q4k_q8k_matvec_avx2(out, q8k_x, w, rows, cols) };
-        return;
+        return unsafe { q4k_q8k_matvec_avx2(out, q8k_x, w, rows, cols) };
     }
     #[allow(unreachable_code)]
-    q4k_q8k_matvec_scalar(out, q8k_x, w, rows, cols);
+    q4k_q8k_matvec_scalar(out, q8k_x, w, rows, cols)
 }
 
 /// Row-chunked **parallel** Q4_K / Q6_K × Q8_K matvec — the single source for
@@ -66,6 +65,13 @@ pub fn q4k_q8k_matvec_into(
 /// (larql-compute `cached.rs`, larql-inference `cached.rs`, and the two lm_head
 /// blocks in larql-inference `dense.rs`) — the "consolidation hazard" twins.
 /// `out.len()` must be `>= rows`; rows beyond `rows` are left untouched.
+///
+/// Shape refusal: an output shorter than `rows`, an activation that is not
+/// `cols` long, a `cols` that is not a whole number of super-blocks, or a
+/// weight slab too short for `rows × cols` returns [`KernelShapeError`]
+/// naming every operand, with `out` untouched. A zero vector is a
+/// plausible logit vector and was the dec-readiness §1 failure class;
+/// the refusal is typed so a caller with a channel can carry it up.
 pub fn q4k_q8k_matvec_parallel(
     out: &mut [f32],
     q8k_x: &Q8KActivation,
@@ -73,7 +79,7 @@ pub fn q4k_q8k_matvec_parallel(
     rows: usize,
     cols: usize,
     format: &str,
-) {
+) -> Result<(), KernelShapeError> {
     // Format dispatch goes through the `FormatRoute` registry: the tag
     // resolves to its per-row kernel and its packed super-block geometry
     // (no local `(cols/256)*144`/`*210` re-spelling). The truncating
@@ -96,14 +102,35 @@ pub fn q4k_q8k_matvec_parallel(
         .packed_block_layout()
         .expect("q8k-matvec formats always have a packed block layout");
     let bytes_per_row = (cols / block_elems) * block_bytes;
-    if rows == 0 || cols == 0 {
-        return;
+    // Whole-shape validation once, up front, against the rows this call
+    // will write. The per-chunk kernels re-check their own slices, but by
+    // then every chunk is a sub-slice of an already-validated whole.
+    let out_len = out.len();
+    if out_len < rows {
+        return Err(KernelShapeError {
+            kernel: "q4k_q8k_matvec_parallel",
+            out_len,
+            rows,
+            x_len: q8k_x.qs.len(),
+            cols,
+            weight_bytes: bytes.len(),
+            needed_bytes: rows * bytes_per_row,
+        });
     }
-    assert!(
-        bytes.len() >= rows * bytes_per_row,
-        "q4k_q8k_matvec_parallel: {format} weight slab too short: {} bytes < {rows} rows × {bytes_per_row} bytes/row",
+    KernelShapeError::check(
+        "q4k_q8k_matvec_parallel",
+        rows,
+        rows,
+        q8k_x.qs.len(),
+        cols,
         bytes.len(),
-    );
+        block_elems,
+        block_bytes,
+    )?;
+    if rows == 0 || cols == 0 {
+        out[..rows].fill(0.0);
+        return Ok(());
+    }
     const CHUNK_ROWS: usize = 32;
     crate::cpu::spin_pool::par_chunks_mut(&mut out[..rows], CHUNK_ROWS, |chunk_idx, chunk| {
         let row_start = chunk_idx * CHUNK_ROWS;
@@ -112,6 +139,9 @@ pub fn q4k_q8k_matvec_parallel(
             return;
         }
         let w_chunk = &bytes[row_start * bytes_per_row..(row_start + chunk_len) * bytes_per_row];
-        kernel(&mut chunk[..chunk_len], q8k_x, w_chunk, chunk_len, cols);
+        kernel(&mut chunk[..chunk_len], q8k_x, w_chunk, chunk_len, cols).unwrap_or_else(|e| {
+            panic!("q4k_q8k_matvec_parallel: chunk {chunk_idx} refused after whole-shape validation: {e}")
+        });
     });
+    Ok(())
 }

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/gate_up.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/gate_up.rs
@@ -1,7 +1,6 @@
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use super::common::{
-    q8k_shape_ok, unpack_scales_mins, BLOCK_BYTES, ELEMS_PER_BLOCK, SUBBLOCKS_PER_BLOCK,
-    SUBBLOCK_SIZE,
+    unpack_scales_mins, BLOCK_BYTES, ELEMS_PER_BLOCK, SUBBLOCKS_PER_BLOCK, SUBBLOCK_SIZE,
 };
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use super::q4k_asm::use_asm_kernel;
@@ -11,6 +10,7 @@ use super::q4k_scalar::q4k_q8k_matvec_scalar;
 use super::q8k_activation::Q8KActivation;
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use crate::cpu::ops::q4_common::f16_to_f32;
+use crate::cpu::ops::KernelShapeError;
 
 /// Fused gate+up matvec: produce two output vectors from two weight matrices
 /// against the SAME pre-quantised Q8_K activation in one pass.  Each
@@ -35,24 +35,23 @@ pub fn q4k_q8k_gate_up_into(
     up_w: &[u8],
     rows: usize,
     cols: usize,
-) {
+) -> Result<(), KernelShapeError> {
     #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     {
         // C12: same opt-in as `q4k_q8k_matvec_into` — `LARQL_Q4K_ASM=1`
         // routes the fused kernel through the hand-asm form. Bit-exact
         // (`q8k_gate_up_asm_matches_scalar_bit_exact`); default off.
-        if use_asm_kernel() {
-            q4k_q8k_gate_up_asm(gate_out, up_out, q8k_x, gate_w, up_w, rows, cols);
+        return if use_asm_kernel() {
+            q4k_q8k_gate_up_asm(gate_out, up_out, q8k_x, gate_w, up_w, rows, cols)
         } else {
-            q4k_q8k_gate_up_neon(gate_out, up_out, q8k_x, gate_w, up_w, rows, cols);
-        }
-        return;
+            q4k_q8k_gate_up_neon(gate_out, up_out, q8k_x, gate_w, up_w, rows, cols)
+        };
     }
     #[allow(unreachable_code)]
     {
         // Scalar fallback: just call the existing single-matvec path twice.
-        q4k_q8k_matvec_scalar(gate_out, q8k_x, gate_w, rows, cols);
-        q4k_q8k_matvec_scalar(up_out, q8k_x, up_w, rows, cols);
+        q4k_q8k_matvec_scalar(gate_out, q8k_x, gate_w, rows, cols)?;
+        q4k_q8k_matvec_scalar(up_out, q8k_x, up_w, rows, cols)
     }
 }
 
@@ -65,31 +64,36 @@ pub fn q4k_q8k_gate_up_neon(
     up_w: &[u8],
     rows: usize,
     cols: usize,
-) {
+) -> Result<(), KernelShapeError> {
     use std::arch::aarch64::*;
 
-    let shapes_ok =
-        q8k_shape_ok(gate_out.len(), rows, q8k_x.qs.len(), cols) && up_out.len() == rows;
-    if !shapes_ok || rows == 0 || cols == 0 {
-        for v in gate_out.iter_mut() {
-            *v = 0.0;
-        }
-        for v in up_out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+    KernelShapeError::check(
+        "q4k_q8k_gate_up_neon (gate)",
+        gate_out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        gate_w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    KernelShapeError::check(
+        "q4k_q8k_gate_up_neon (up)",
+        up_out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        up_w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        gate_out.fill(0.0);
+        up_out.fill(0.0);
+        return Ok(());
     }
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * BLOCK_BYTES;
-    if gate_w.len() < rows * row_bytes || up_w.len() < rows * row_bytes {
-        for v in gate_out.iter_mut() {
-            *v = 0.0;
-        }
-        for v in up_out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
 
     let mask_lo = unsafe { vdupq_n_u8(0x0F) };
 
@@ -180,6 +184,7 @@ pub fn q4k_q8k_gate_up_neon(
         gate_out[r] = acc_g;
         up_out[r] = acc_u;
     }
+    Ok(())
 }
 
 /// Fused gate+up twin of [`q4k_sb_sum1_asm`] (C12): one super-block's integer
@@ -314,29 +319,34 @@ pub fn q4k_q8k_gate_up_asm(
     up_w: &[u8],
     rows: usize,
     cols: usize,
-) {
-    let shapes_ok =
-        q8k_shape_ok(gate_out.len(), rows, q8k_x.qs.len(), cols) && up_out.len() == rows;
-    if !shapes_ok || rows == 0 || cols == 0 {
-        for v in gate_out.iter_mut() {
-            *v = 0.0;
-        }
-        for v in up_out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+) -> Result<(), KernelShapeError> {
+    KernelShapeError::check(
+        "q4k_q8k_gate_up_asm (gate)",
+        gate_out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        gate_w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    KernelShapeError::check(
+        "q4k_q8k_gate_up_asm (up)",
+        up_out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        up_w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        gate_out.fill(0.0);
+        up_out.fill(0.0);
+        return Ok(());
     }
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * BLOCK_BYTES;
-    if gate_w.len() < rows * row_bytes || up_w.len() < rows * row_bytes {
-        for v in gate_out.iter_mut() {
-            *v = 0.0;
-        }
-        for v in up_out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
 
     for r in 0..rows {
         let row_base = r * row_bytes;
@@ -406,4 +416,5 @@ pub fn q4k_q8k_gate_up_asm(
         gate_out[r] = acc_g;
         up_out[r] = acc_u;
     }
+    Ok(())
 }

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/gemm.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/gemm.rs
@@ -81,7 +81,13 @@ pub fn q4k_q8k_gemm_into(
                 w,
                 rows,
                 cols,
-            );
+            )
+            .unwrap_or_else(|e| {
+                panic!(
+                    "q4k_q8k_gemm_into: row {} refused after the asserts above: {e}",
+                    seq_base + local
+                )
+            });
         }
     });
 }
@@ -126,7 +132,8 @@ mod tests {
         for (s, x) in xs.iter().enumerate() {
             let q8 = quantize_x_to_q8k(x);
             let mut row_out = vec![0.0f32; ROWS];
-            q4k_q8k_matvec_parallel(&mut row_out, &q8, &w, ROWS, COLS, "Q4_K");
+            q4k_q8k_matvec_parallel(&mut row_out, &q8, &w, ROWS, COLS, "Q4_K")
+                .expect("valid shape");
             assert_eq!(
                 &gemm_out[s * ROWS..(s + 1) * ROWS],
                 row_out.as_slice(),

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/q4k_asm.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/q4k_asm.rs
@@ -1,8 +1,7 @@
-use super::common::{
-    q8k_shape_ok, unpack_scales_mins, BLOCK_BYTES, ELEMS_PER_BLOCK, SUBBLOCKS_PER_BLOCK,
-};
+use super::common::{unpack_scales_mins, BLOCK_BYTES, ELEMS_PER_BLOCK, SUBBLOCKS_PER_BLOCK};
 use super::q8k_activation::Q8KActivation;
 use crate::cpu::ops::q4_common::f16_to_f32;
+use crate::cpu::ops::KernelShapeError;
 
 /// Hand-asm inner loop (C12 Phase 1): the per-super-block scaled integer dot
 /// `sum1 = Σ_sb scale[sb] · Σ_i nibble[sb][i]·y[sb][i]`, computed in one
@@ -109,21 +108,23 @@ pub fn q4k_q8k_matvec_asm(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
-    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+) -> Result<(), KernelShapeError> {
+    KernelShapeError::check(
+        "q4k_q8k_matvec_asm",
+        out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        out.fill(0.0);
+        return Ok(());
     }
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * BLOCK_BYTES;
-    if w.len() < rows * row_bytes {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
 
     for (r, out_slot) in out.iter_mut().enumerate().take(rows) {
         let row_base = r * row_bytes;
@@ -166,6 +167,7 @@ pub fn q4k_q8k_matvec_asm(
         }
         *out_slot = acc;
     }
+    Ok(())
 }
 
 /// TBL index tables for the v2 super-block kernel's vectorised scale/min
@@ -330,21 +332,23 @@ pub fn q4k_q8k_matvec_asm_v2(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
-    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+) -> Result<(), KernelShapeError> {
+    KernelShapeError::check(
+        "q4k_q8k_matvec_asm_v2",
+        out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        out.fill(0.0);
+        return Ok(());
     }
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * BLOCK_BYTES;
-    if w.len() < rows * row_bytes {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
 
     for (r, out_slot) in out.iter_mut().enumerate().take(rows) {
         let row_base = r * row_bytes;
@@ -367,6 +371,7 @@ pub fn q4k_q8k_matvec_asm_v2(
         }
         *out_slot = acc;
     }
+    Ok(())
 }
 
 /// v3 (C12): one `asm!` block per ROW — the super-block loop lives inside
@@ -510,21 +515,23 @@ pub fn q4k_q8k_matvec_asm_v3(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
-    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+) -> Result<(), KernelShapeError> {
+    KernelShapeError::check(
+        "q4k_q8k_matvec_asm_v3",
+        out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        out.fill(0.0);
+        return Ok(());
     }
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * BLOCK_BYTES;
-    if w.len() < rows * row_bytes {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
 
     for (r, out_slot) in out.iter_mut().enumerate().take(rows) {
         // SAFETY: the row spans n_blocks × 144 bytes (checked above); the
@@ -539,6 +546,7 @@ pub fn q4k_q8k_matvec_asm_v3(
             )
         };
     }
+    Ok(())
 }
 
 /// C12: route Q4_K × Q8_K matvecs through the hand-asm kernel

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/q4k_avx2.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/q4k_avx2.rs
@@ -3,6 +3,7 @@ use super::common::{
 };
 use super::q8k_activation::Q8KActivation;
 use crate::cpu::ops::q4_common::f16_to_f32;
+use crate::cpu::ops::KernelShapeError;
 
 /// AVX2 Q4_K × Q8_K matvec for x86_64.
 ///
@@ -19,14 +20,22 @@ pub(super) unsafe fn q4k_q8k_matvec_avx2(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
+) -> Result<(), KernelShapeError> {
     use std::arch::x86_64::*;
 
-    if rows == 0 || cols == 0 || w.len() < rows * (cols / ELEMS_PER_BLOCK) * BLOCK_BYTES {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+    KernelShapeError::check(
+        "q4k_q8k_matvec_avx2",
+        out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        out.fill(0.0);
+        return Ok(());
     }
 
     let n_blocks = cols / ELEMS_PER_BLOCK;
@@ -88,6 +97,7 @@ pub(super) unsafe fn q4k_q8k_matvec_avx2(
         }
         *out_slot = acc;
     }
+    Ok(())
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/q4k_neon.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/q4k_neon.rs
@@ -1,12 +1,12 @@
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use super::common::{
-    q8k_shape_ok, unpack_scales_mins, BLOCK_BYTES, ELEMS_PER_BLOCK, SUBBLOCKS_PER_BLOCK,
-    SUBBLOCK_SIZE,
+    unpack_scales_mins, BLOCK_BYTES, ELEMS_PER_BLOCK, SUBBLOCKS_PER_BLOCK, SUBBLOCK_SIZE,
 };
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use super::q8k_activation::Q8KActivation;
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use crate::cpu::ops::q4_common::f16_to_f32;
+use crate::cpu::ops::KernelShapeError;
 
 /// SDOT (signed 8-bit dot-product, accumulate-into-i32x4) wrapper.
 ///
@@ -73,23 +73,25 @@ pub fn q4k_q8k_matvec_neon(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
+) -> Result<(), KernelShapeError> {
     use std::arch::aarch64::*;
 
-    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+    KernelShapeError::check(
+        "q4k_q8k_matvec_neon",
+        out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        out.fill(0.0);
+        return Ok(());
     }
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * BLOCK_BYTES;
-    if w.len() < rows * row_bytes {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
 
     // Mask vector for low-nibble extraction (broadcast 0x0F across 16 lanes).
     let mask_lo = unsafe { vdupq_n_u8(0x0F) };
@@ -192,6 +194,7 @@ pub fn q4k_q8k_matvec_neon(
         }
         *out_slot = acc;
     }
+    Ok(())
 }
 
 /// Two-row variant of `q4k_q8k_matvec_neon`: processes a pair of output rows
@@ -219,23 +222,25 @@ pub fn q4k_q8k_matvec_neon_2row(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
+) -> Result<(), KernelShapeError> {
     use std::arch::aarch64::*;
 
-    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+    KernelShapeError::check(
+        "q4k_q8k_matvec_neon_2row",
+        out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        out.fill(0.0);
+        return Ok(());
     }
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * BLOCK_BYTES;
-    if w.len() < rows * row_bytes {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
 
     let mask_lo = unsafe { vdupq_n_u8(0x0F) };
 
@@ -340,7 +345,8 @@ pub fn q4k_q8k_matvec_neon_2row(
         let r = rows - 1;
         let mut tail_out = [0.0f32; 1];
         let row_w = &w[r * row_bytes..(r + 1) * row_bytes];
-        q4k_q8k_matvec_neon(&mut tail_out, q8k_x, row_w, 1, cols);
+        q4k_q8k_matvec_neon(&mut tail_out, q8k_x, row_w, 1, cols)?;
         out[r] = tail_out[0];
     }
+    Ok(())
 }

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/q4k_scalar.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/q4k_scalar.rs
@@ -1,9 +1,9 @@
 use super::common::{
-    q8k_shape_ok, unpack_scales_mins, BLOCK_BYTES, ELEMS_PER_BLOCK, SUBBLOCKS_PER_BLOCK,
-    SUBBLOCK_SIZE,
+    unpack_scales_mins, BLOCK_BYTES, ELEMS_PER_BLOCK, SUBBLOCKS_PER_BLOCK, SUBBLOCK_SIZE,
 };
 use super::q8k_activation::Q8KActivation;
 use crate::cpu::ops::q4_common::f16_to_f32;
+use crate::cpu::ops::KernelShapeError;
 
 /// Scalar reference: `out = W · x` where `W` is `rows × cols` Q4_K and `x`
 /// has been pre-quantised to Q8_K.  Mathematically equivalent (within Q8
@@ -17,21 +17,23 @@ pub fn q4k_q8k_matvec_scalar(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
-    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
+) -> Result<(), KernelShapeError> {
+    KernelShapeError::check(
+        "q4k_q8k_matvec_scalar",
+        out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        BLOCK_BYTES,
+    )?;
+    if rows == 0 || cols == 0 {
+        out.fill(0.0);
+        return Ok(());
     }
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * BLOCK_BYTES;
-    if w.len() < rows * row_bytes {
-        for v in out.iter_mut() {
-            *v = 0.0;
-        }
-        return;
-    }
 
     for (r, out_slot) in out.iter_mut().enumerate().take(rows) {
         let row_base = r * row_bytes;
@@ -78,4 +80,5 @@ pub fn q4k_q8k_matvec_scalar(
         }
         *out_slot = acc;
     }
+    Ok(())
 }

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/q6k.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/q6k.rs
@@ -7,6 +7,7 @@ use super::common::ELEMS_PER_BLOCK;
 use super::q4k_neon::sdot_acc;
 use super::q8k_activation::Q8KActivation;
 use crate::cpu::ops::q4_common::f16_to_f32;
+use crate::cpu::ops::KernelShapeError;
 
 // ── Q6_K × Q8_K matvec ───────────────────────────────────────────────────────
 //
@@ -40,20 +41,22 @@ pub fn q6k_q8k_matvec_scalar(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
+) -> Result<(), KernelShapeError> {
+    KernelShapeError::check(
+        "q6k_q8k_matvec_scalar",
+        out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        Q6K_BLOCK_BYTES,
+    )?;
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * Q6K_BLOCK_BYTES;
-    for v in out.iter_mut() {
-        *v = 0.0;
-    }
-    if rows == 0
-        || cols == 0
-        || !cols.is_multiple_of(ELEMS_PER_BLOCK)
-        || out.len() != rows
-        || q8k_x.qs.len() != cols
-        || w.len() < rows * row_bytes
-    {
-        return;
+    out.fill(0.0);
+    if rows == 0 || cols == 0 {
+        return Ok(());
     }
     for (r, out_r) in out.iter_mut().enumerate().take(rows) {
         let row_base = r * row_bytes;
@@ -85,6 +88,7 @@ pub fn q6k_q8k_matvec_scalar(
         }
         *out_r = acc;
     }
+    Ok(())
 }
 
 /// NEON-accelerated Q6_K × Q8_K matvec for `aarch64`.
@@ -112,22 +116,24 @@ pub fn q6k_q8k_matvec_neon(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
+) -> Result<(), KernelShapeError> {
     use std::arch::aarch64::*;
 
+    KernelShapeError::check(
+        "q6k_q8k_matvec_neon",
+        out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        Q6K_BLOCK_BYTES,
+    )?;
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * Q6K_BLOCK_BYTES;
-    for v in out.iter_mut() {
-        *v = 0.0;
-    }
-    if rows == 0
-        || cols == 0
-        || !cols.is_multiple_of(ELEMS_PER_BLOCK)
-        || out.len() != rows
-        || q8k_x.qs.len() != cols
-        || w.len() < rows * row_bytes
-    {
-        return;
+    out.fill(0.0);
+    if rows == 0 || cols == 0 {
+        return Ok(());
     }
 
     let mask_0f = unsafe { vdupq_n_u8(0x0F) };
@@ -201,6 +207,7 @@ pub fn q6k_q8k_matvec_neon(
         }
         *out_r = acc;
     }
+    Ok(())
 }
 
 /// TBL index table for the Q6_K hi2 replicate: group `j` (of 4 within one
@@ -330,20 +337,22 @@ pub fn q6k_q8k_matvec_asm(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
+) -> Result<(), KernelShapeError> {
+    KernelShapeError::check(
+        "q6k_q8k_matvec_asm",
+        out.len(),
+        rows,
+        q8k_x.qs.len(),
+        cols,
+        w.len(),
+        ELEMS_PER_BLOCK,
+        Q6K_BLOCK_BYTES,
+    )?;
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * Q6K_BLOCK_BYTES;
-    for v in out.iter_mut() {
-        *v = 0.0;
-    }
-    if rows == 0
-        || cols == 0
-        || !cols.is_multiple_of(ELEMS_PER_BLOCK)
-        || out.len() != rows
-        || q8k_x.qs.len() != cols
-        || w.len() < rows * row_bytes
-    {
-        return;
+    out.fill(0.0);
+    if rows == 0 || cols == 0 {
+        return Ok(());
     }
 
     for (r, out_r) in out.iter_mut().enumerate().take(rows) {
@@ -373,6 +382,7 @@ pub fn q6k_q8k_matvec_asm(
         }
         *out_r = acc;
     }
+    Ok(())
 }
 
 /// Public entry point: dispatches to NEON on aarch64, scalar elsewhere.
@@ -384,16 +394,15 @@ pub fn q6k_q8k_matvec_into(
     w: &[u8],
     rows: usize,
     cols: usize,
-) {
+) -> Result<(), KernelShapeError> {
     #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     {
         // TODO(q6k-planar): the `LARQL_Q4K_ASM=1` hand-asm form still decodes
         // the pre-fix interleaved layout, so unlike the Q4_K kernels there is
         // no asm opt-in here yet. The NEON intrinsic form is ggml-planar and
         // bit-exact with the scalar reference.
-        q6k_q8k_matvec_neon(out, q8k_x, w, rows, cols);
-        return;
+        return q6k_q8k_matvec_neon(out, q8k_x, w, rows, cols);
     }
     #[allow(unreachable_code)]
-    q6k_q8k_matvec_scalar(out, q8k_x, w, rows, cols);
+    q6k_q8k_matvec_scalar(out, q8k_x, w, rows, cols)
 }

--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/tests.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot/tests.rs
@@ -74,11 +74,11 @@ fn q8k_matvec_matches_f32_cached_within_q8_noise() {
     assert_eq!(w_q4.len(), rows * 144);
 
     let mut out_f32 = vec![0.0f32; rows];
-    q4k_matvec_into(&mut out_f32, &x, &w_q4, rows, cols);
+    q4k_matvec_into(&mut out_f32, &x, &w_q4, rows, cols).expect("valid shape");
 
     let q8 = quantize_x_to_q8k(&x);
     let mut out_q8 = vec![0.0f32; rows];
-    q4k_q8k_matvec_scalar(&mut out_q8, &q8, &w_q4, rows, cols);
+    q4k_q8k_matvec_scalar(&mut out_q8, &q8, &w_q4, rows, cols).expect("valid shape");
 
     // Q8 quantisation step on x is amax/127; downstream noise per
     // output element is ~‖w_row‖₁ · step.  For typical sin-ramp inputs
@@ -108,11 +108,11 @@ fn q8k_matvec_multi_block_within_noise() {
     let w_q4 = quantize_q4_k(&w_f32);
 
     let mut out_f32 = vec![0.0f32; rows];
-    q4k_matvec_into(&mut out_f32, &x, &w_q4, rows, cols);
+    q4k_matvec_into(&mut out_f32, &x, &w_q4, rows, cols).expect("valid shape");
 
     let q8 = quantize_x_to_q8k(&x);
     let mut out_q8 = vec![0.0f32; rows];
-    q4k_q8k_matvec_scalar(&mut out_q8, &q8, &w_q4, rows, cols);
+    q4k_q8k_matvec_scalar(&mut out_q8, &q8, &w_q4, rows, cols).expect("valid shape");
 
     for r in 0..rows {
         let diff = (out_f32[r] - out_q8[r]).abs();
@@ -153,8 +153,8 @@ fn q8k_matvec_neon_matches_scalar_bit_exact() {
 
     let mut out_scalar = vec![0.0f32; rows];
     let mut out_neon = vec![0.0f32; rows];
-    q4k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q4, rows, cols);
-    q4k_q8k_matvec_neon(&mut out_neon, &q8, &w_q4, rows, cols);
+    q4k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q4, rows, cols).expect("valid shape");
+    q4k_q8k_matvec_neon(&mut out_neon, &q8, &w_q4, rows, cols).expect("valid shape");
 
     for r in 0..rows {
         assert_eq!(
@@ -195,8 +195,8 @@ fn q8k_matvec_asm_matches_scalar_bit_exact() {
 
         let mut out_scalar = vec![0.0f32; rows];
         let mut out_asm = vec![0.0f32; rows];
-        q4k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q4, rows, cols);
-        q4k_q8k_matvec_asm(&mut out_asm, &q8, &w_q4, rows, cols);
+        q4k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q4, rows, cols).expect("valid shape");
+        q4k_q8k_matvec_asm(&mut out_asm, &q8, &w_q4, rows, cols).expect("valid shape");
 
         for r in 0..rows {
             assert_eq!(
@@ -211,31 +211,37 @@ fn q8k_matvec_asm_matches_scalar_bit_exact() {
     }
 }
 
-/// Asm kernel's early-return guards (zero dims, short weight buffer)
-/// must zero the output, same as the scalar/neon paths.
+/// `q4k_q8k_matvec_asm`: zero dims are the empty product (zeros written), and a
+/// weight slab shorter than `rows` packed rows is refused by name with the
+/// output left exactly as handed in — never silently zeroed.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[test]
-fn q8k_matvec_asm_zero_dims_and_short_weights_zero_output() {
-    // cols == 0 → early return.
+fn q8k_matvec_asm_zero_dims_are_empty_and_short_weights_are_refused() {
     let empty = Q8KActivation {
         qs: vec![],
         d: vec![],
         sums: vec![],
     };
     let mut out = vec![1.0f32; 4];
-    q4k_q8k_matvec_asm(&mut out, &empty, &[], 4, 0);
+    q4k_q8k_matvec_asm(&mut out, &empty, &[], 4, 0).expect("zero dims are the empty product");
     assert!(out.iter().all(|&v| v == 0.0), "zero-dims must zero output");
 
-    // w shorter than rows * row_bytes → early return.
     let cols = 256;
     let rows = 2;
     let q = quantize_x_to_q8k(&vec![0.5f32; cols]);
     let w = vec![0u8; BLOCK_BYTES]; // one row's worth, but rows == 2
     let mut out = vec![1.0f32; rows];
-    q4k_q8k_matvec_asm(&mut out, &q, &w, rows, cols);
-    assert!(
-        out.iter().all(|&v| v == 0.0),
-        "short buffer must zero output"
+    let err = q4k_q8k_matvec_asm(&mut out, &q, &w, rows, cols)
+        .expect_err("a short weight slab must be refused");
+    assert_eq!(out, vec![1.0f32; rows], "refusal must not touch the output");
+    assert_eq!(err.kernel, "q4k_q8k_matvec_asm");
+    assert_eq!(
+        (err.weight_bytes, err.needed_bytes),
+        (BLOCK_BYTES, 2 * BLOCK_BYTES)
+    );
+    assert_eq!(
+        (err.out_len, err.rows, err.x_len, err.cols),
+        (rows, rows, cols, cols)
     );
 }
 
@@ -271,12 +277,13 @@ fn q8k_gate_up_asm_matches_scalar_bit_exact() {
 
         let mut g_scalar = vec![0.0f32; rows];
         let mut u_scalar = vec![0.0f32; rows];
-        q4k_q8k_matvec_scalar(&mut g_scalar, &q8, &g_q4, rows, cols);
-        q4k_q8k_matvec_scalar(&mut u_scalar, &q8, &u_q4, rows, cols);
+        q4k_q8k_matvec_scalar(&mut g_scalar, &q8, &g_q4, rows, cols).expect("valid shape");
+        q4k_q8k_matvec_scalar(&mut u_scalar, &q8, &u_q4, rows, cols).expect("valid shape");
 
         let mut g_asm = vec![0.0f32; rows];
         let mut u_asm = vec![0.0f32; rows];
-        q4k_q8k_gate_up_asm(&mut g_asm, &mut u_asm, &q8, &g_q4, &u_q4, rows, cols);
+        q4k_q8k_gate_up_asm(&mut g_asm, &mut u_asm, &q8, &g_q4, &u_q4, rows, cols)
+            .expect("valid shape");
 
         for r in 0..rows {
             assert_eq!(
@@ -297,11 +304,11 @@ fn q8k_gate_up_asm_matches_scalar_bit_exact() {
     }
 }
 
-/// Fused gate+up asm early-return guards: zero dims and short weight
-/// buffers must zero BOTH outputs (same contract as the neon form).
+/// `q4k_q8k_gate_up_asm`: zero dims zero BOTH outputs, and a short gate slab is
+/// refused naming the gate half, with both outputs left untouched.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[test]
-fn q8k_gate_up_asm_zero_dims_and_short_weights_zero_output() {
+fn q8k_gate_up_asm_zero_dims_are_empty_and_short_weights_are_refused() {
     let empty = Q8KActivation {
         qs: vec![],
         d: vec![],
@@ -309,7 +316,8 @@ fn q8k_gate_up_asm_zero_dims_and_short_weights_zero_output() {
     };
     let mut g = vec![1.0f32; 4];
     let mut u = vec![1.0f32; 4];
-    q4k_q8k_gate_up_asm(&mut g, &mut u, &empty, &[], &[], 4, 0);
+    q4k_q8k_gate_up_asm(&mut g, &mut u, &empty, &[], &[], 4, 0)
+        .expect("zero dims are the empty product");
     assert!(g.iter().chain(u.iter()).all(|&v| v == 0.0));
 
     let cols = 256;
@@ -319,8 +327,25 @@ fn q8k_gate_up_asm_zero_dims_and_short_weights_zero_output() {
     let w_full = vec![0u8; 2 * BLOCK_BYTES];
     let mut g = vec![1.0f32; rows];
     let mut u = vec![1.0f32; rows];
-    q4k_q8k_gate_up_asm(&mut g, &mut u, &q, &w_short, &w_full, rows, cols);
-    assert!(g.iter().chain(u.iter()).all(|&v| v == 0.0));
+    let err = q4k_q8k_gate_up_asm(&mut g, &mut u, &q, &w_short, &w_full, rows, cols)
+        .expect_err("a short gate slab must be refused");
+    assert_eq!(
+        (g, u),
+        (vec![1.0f32; rows], vec![1.0f32; rows]),
+        "refusal must not touch either output"
+    );
+    assert_eq!(err.kernel, "q4k_q8k_gate_up_asm (gate)");
+    assert_eq!(
+        (err.weight_bytes, err.needed_bytes),
+        (BLOCK_BYTES, 2 * BLOCK_BYTES)
+    );
+
+    // The up half is checked independently: a short UP slab names it.
+    let mut g = vec![1.0f32; rows];
+    let mut u = vec![1.0f32; rows];
+    let err = q4k_q8k_gate_up_asm(&mut g, &mut u, &q, &w_full, &w_short, rows, cols)
+        .expect_err("a short up slab must be refused");
+    assert_eq!(err.kernel, "q4k_q8k_gate_up_asm (up)");
 }
 
 /// The v2 (all-glue-in-asm) kernel must be bit-exact with the scalar
@@ -348,8 +373,8 @@ fn q8k_matvec_asm_v2_matches_scalar_bit_exact() {
 
         let mut out_scalar = vec![0.0f32; rows];
         let mut out_v2 = vec![0.0f32; rows];
-        q4k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q4, rows, cols);
-        q4k_q8k_matvec_asm_v2(&mut out_v2, &q8, &w_q4, rows, cols);
+        q4k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q4, rows, cols).expect("valid shape");
+        q4k_q8k_matvec_asm_v2(&mut out_v2, &q8, &w_q4, rows, cols).expect("valid shape");
 
         for r in 0..rows {
             assert_eq!(
@@ -388,8 +413,8 @@ fn q8k_matvec_asm_v3_matches_scalar_bit_exact() {
 
         let mut out_scalar = vec![0.0f32; rows];
         let mut out_v3 = vec![0.0f32; rows];
-        q4k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q4, rows, cols);
-        q4k_q8k_matvec_asm_v3(&mut out_v3, &q8, &w_q4, rows, cols);
+        q4k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q4, rows, cols).expect("valid shape");
+        q4k_q8k_matvec_asm_v3(&mut out_v3, &q8, &w_q4, rows, cols).expect("valid shape");
 
         for r in 0..rows {
             assert_eq!(
@@ -433,8 +458,8 @@ fn q6k_matvec_asm_matches_scalar_bit_exact() {
 
         let mut out_scalar = vec![0.0f32; rows];
         let mut out_asm = vec![0.0f32; rows];
-        q6k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q6, rows, cols);
-        q6k_q8k_matvec_asm(&mut out_asm, &q8, &w_q6, rows, cols);
+        q6k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q6, rows, cols).expect("valid shape");
+        q6k_q8k_matvec_asm(&mut out_asm, &q8, &w_q6, rows, cols).expect("valid shape");
 
         for r in 0..rows {
             assert_eq!(
@@ -449,26 +474,38 @@ fn q6k_matvec_asm_matches_scalar_bit_exact() {
     }
 }
 
-/// Q6_K asm early-return guards: zero dims / short weights zero output.
+/// `q6k_q8k_matvec_asm`: zero dims are the empty product (zeros written), and a
+/// weight slab shorter than `rows` packed rows is refused by name with the
+/// output left exactly as handed in — never silently zeroed.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[test]
-fn q6k_matvec_asm_zero_dims_and_short_weights_zero_output() {
+fn q6k_matvec_asm_zero_dims_are_empty_and_short_weights_are_refused() {
     let empty = Q8KActivation {
         qs: vec![],
         d: vec![],
         sums: vec![],
     };
     let mut out = vec![1.0f32; 4];
-    q6k_q8k_matvec_asm(&mut out, &empty, &[], 4, 0);
-    assert!(out.iter().all(|&v| v == 0.0));
+    q6k_q8k_matvec_asm(&mut out, &empty, &[], 4, 0).expect("zero dims are the empty product");
+    assert!(out.iter().all(|&v| v == 0.0), "zero-dims must zero output");
 
     let cols = 256;
     let rows = 2;
     let q = quantize_x_to_q8k(&vec![0.5f32; cols]);
-    let w = vec![0u8; Q6K_BLOCK_BYTES]; // one row's worth, rows == 2
+    let w = vec![0u8; Q6K_BLOCK_BYTES]; // one row's worth, but rows == 2
     let mut out = vec![1.0f32; rows];
-    q6k_q8k_matvec_asm(&mut out, &q, &w, rows, cols);
-    assert!(out.iter().all(|&v| v == 0.0));
+    let err = q6k_q8k_matvec_asm(&mut out, &q, &w, rows, cols)
+        .expect_err("a short weight slab must be refused");
+    assert_eq!(out, vec![1.0f32; rows], "refusal must not touch the output");
+    assert_eq!(err.kernel, "q6k_q8k_matvec_asm");
+    assert_eq!(
+        (err.weight_bytes, err.needed_bytes),
+        (Q6K_BLOCK_BYTES, 2 * Q6K_BLOCK_BYTES)
+    );
+    assert_eq!(
+        (err.out_len, err.rows, err.x_len, err.cols),
+        (rows, rows, cols, cols)
+    );
 }
 
 /// `quantize_x_to_q8k_into` must produce the same `qs`, `d`, `sums` as
@@ -518,8 +555,8 @@ fn q8k_matvec_2row_matches_single_row_bit_exact() {
 
         let mut out_single = vec![0.0f32; rows];
         let mut out_2row = vec![0.0f32; rows];
-        q4k_q8k_matvec_neon(&mut out_single, &q8, &w_q4, rows, cols);
-        q4k_q8k_matvec_neon_2row(&mut out_2row, &q8, &w_q4, rows, cols);
+        q4k_q8k_matvec_neon(&mut out_single, &q8, &w_q4, rows, cols).expect("valid shape");
+        q4k_q8k_matvec_neon_2row(&mut out_2row, &q8, &w_q4, rows, cols).expect("valid shape");
 
         for r in 0..rows {
             assert_eq!(
@@ -556,12 +593,13 @@ fn q8k_gate_up_fused_matches_separate_matvecs() {
 
     let mut g_sep = vec![0.0f32; rows];
     let mut u_sep = vec![0.0f32; rows];
-    q4k_q8k_matvec_into(&mut g_sep, &q8, &g_w, rows, cols);
-    q4k_q8k_matvec_into(&mut u_sep, &q8, &u_w, rows, cols);
+    q4k_q8k_matvec_into(&mut g_sep, &q8, &g_w, rows, cols).expect("valid shape");
+    q4k_q8k_matvec_into(&mut u_sep, &q8, &u_w, rows, cols).expect("valid shape");
 
     let mut g_fused = vec![0.0f32; rows];
     let mut u_fused = vec![0.0f32; rows];
-    q4k_q8k_gate_up_into(&mut g_fused, &mut u_fused, &q8, &g_w, &u_w, rows, cols);
+    q4k_q8k_gate_up_into(&mut g_fused, &mut u_fused, &q8, &g_w, &u_w, rows, cols)
+        .expect("valid shape");
 
     for r in 0..rows {
         assert_eq!(
@@ -590,22 +628,30 @@ fn q8k_matvec_zero_dims_returns_zero() {
         sums: vec![],
     };
     let mut out = vec![1.0f32; 4];
-    q4k_q8k_matvec_scalar(&mut out, &q, &[], 4, 0);
+    q4k_q8k_matvec_scalar(&mut out, &q, &[], 4, 0).expect("valid shape");
     assert!(out.iter().all(|&v| v == 0.0));
 }
 
-/// Misaligned col count (not a multiple of 256) should fail safely
-/// (leave caller-visible zeros, like the scalar `q4k_matvec_into`).
+/// A weight slab shorter than `rows` packed rows is refused by name, and
+/// the output is left exactly as the caller handed it in — never zeros,
+/// which a sampler would accept as logits.
 #[test]
-fn q8k_matvec_short_weight_buffer_returns_zero() {
+fn q8k_matvec_short_weight_buffer_is_refused_untouched() {
     let cols = 256;
     let rows = 2;
     let x = vec![0.5f32; cols];
     let q = quantize_x_to_q8k(&x);
     let w = vec![0u8; 144]; // only enough for 1 row, but rows=2
     let mut out = vec![1.0f32; rows];
-    q4k_q8k_matvec_scalar(&mut out, &q, &w, rows, cols);
-    assert!(out.iter().all(|&v| v == 0.0));
+    let err = q4k_q8k_matvec_scalar(&mut out, &q, &w, rows, cols)
+        .expect_err("a short weight slab must be refused");
+    assert_eq!(out, vec![1.0f32; rows], "refusal must not touch the output");
+    assert_eq!(err.kernel, "q4k_q8k_matvec_scalar");
+    assert_eq!((err.weight_bytes, err.needed_bytes), (144, 288));
+    assert_eq!(
+        (err.out_len, err.rows, err.x_len, err.cols),
+        (rows, rows, cols, cols)
+    );
 }
 
 #[test]
@@ -621,7 +667,7 @@ fn q6k_q8k_matvec_matches_q6k_f32_dispatch_within_noise() {
     let f32_path = crate::cpu::ops::q6k_matvec::dispatch(&w_q6, &x, rows, cols);
     let q8 = quantize_x_to_q8k(&x);
     let mut q8_path = vec![0.0f32; rows];
-    q6k_q8k_matvec_scalar(&mut q8_path, &q8, &w_q6, rows, cols);
+    q6k_q8k_matvec_scalar(&mut q8_path, &q8, &w_q6, rows, cols).expect("valid shape");
 
     for r in 0..rows {
         let diff = (f32_path[r] - q8_path[r]).abs();
@@ -647,26 +693,45 @@ fn q6k_q8k_public_entrypoint_matches_scalar() {
     let mut scalar = vec![0.0f32; rows];
     let mut dispatched = vec![0.0f32; rows];
 
-    q6k_q8k_matvec_scalar(&mut scalar, &q8, &w_q6, rows, cols);
-    q6k_q8k_matvec_into(&mut dispatched, &q8, &w_q6, rows, cols);
+    q6k_q8k_matvec_scalar(&mut scalar, &q8, &w_q6, rows, cols).expect("valid shape");
+    q6k_q8k_matvec_into(&mut dispatched, &q8, &w_q6, rows, cols).expect("valid shape");
 
     for (a, b) in scalar.iter().zip(dispatched.iter()) {
         assert_eq!(a.to_bits(), b.to_bits());
     }
 }
 
+/// `q6k_q8k_matvec_scalar`: zero dims are the empty product (zeros written), and a
+/// weight slab shorter than `rows` packed rows is refused by name with the
+/// output left exactly as handed in — never silently zeroed.
 #[test]
-fn q6k_q8k_zero_dims_and_short_weights_zero_output() {
-    let q = Q8KActivation::with_capacity(0);
+fn q6k_q8k_zero_dims_are_empty_and_short_weights_are_refused() {
+    let empty = Q8KActivation {
+        qs: vec![],
+        d: vec![],
+        sums: vec![],
+    };
     let mut out = vec![1.0f32; 4];
-    q6k_q8k_matvec_scalar(&mut out, &q, &[], 4, 0);
-    assert_eq!(out, vec![0.0f32; 4]);
+    q6k_q8k_matvec_scalar(&mut out, &empty, &[], 4, 0).expect("zero dims are the empty product");
+    assert!(out.iter().all(|&v| v == 0.0), "zero-dims must zero output");
 
-    let x = vec![1.0f32; 256];
-    let q = quantize_x_to_q8k(&x);
-    let mut out = vec![1.0f32; 2];
-    q6k_q8k_matvec_scalar(&mut out, &q, &vec![0u8; 210], 2, 256);
-    assert_eq!(out, vec![0.0f32; 2]);
+    let cols = 256;
+    let rows = 2;
+    let q = quantize_x_to_q8k(&vec![0.5f32; cols]);
+    let w = vec![0u8; Q6K_BLOCK_BYTES]; // one row's worth, but rows == 2
+    let mut out = vec![1.0f32; rows];
+    let err = q6k_q8k_matvec_scalar(&mut out, &q, &w, rows, cols)
+        .expect_err("a short weight slab must be refused");
+    assert_eq!(out, vec![1.0f32; rows], "refusal must not touch the output");
+    assert_eq!(err.kernel, "q6k_q8k_matvec_scalar");
+    assert_eq!(
+        (err.weight_bytes, err.needed_bytes),
+        (Q6K_BLOCK_BYTES, 2 * Q6K_BLOCK_BYTES)
+    );
+    assert_eq!(
+        (err.out_len, err.rows, err.x_len, err.cols),
+        (rows, rows, cols, cols)
+    );
 }
 
 /// AVX2 must produce bit-identical output to the scalar reference.
@@ -695,7 +760,7 @@ fn q8k_matvec_avx2_matches_scalar() {
 
     let mut out_scalar = vec![0.0f32; rows];
     let mut out_avx2 = vec![0.0f32; rows];
-    q4k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q4, rows, cols);
+    q4k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q4, rows, cols).expect("valid shape");
     unsafe { q4k_q8k_matvec_avx2(&mut out_avx2, &q8, &w_q4, rows, cols) };
 
     for r in 0..rows {
@@ -721,7 +786,7 @@ fn matvec_parallel_panics_on_unknown_format_tag_instead_of_zero_filling() {
     let q8k_x = quantize_x_to_q8k(&x);
     let bytes = quantize_q4_k(&x);
     let mut out = vec![0.0f32; 1];
-    q4k_q8k_matvec_parallel(&mut out, &q8k_x, &bytes, 1, 256, "MXFP9");
+    q4k_q8k_matvec_parallel(&mut out, &q8k_x, &bytes, 1, 256, "MXFP9").expect("valid shape");
 }
 
 /// Same contract for a format that parses but has no Q8K matvec kernel.
@@ -733,19 +798,7 @@ fn matvec_parallel_panics_on_format_without_q8k_kernel() {
     let mut out = vec![0.0f32; 1];
     // BF16 parses via `from_registry_tag` but has no block-stream kernel.
     let bytes = vec![0u8; 512];
-    q4k_q8k_matvec_parallel(&mut out, &q8k_x, &bytes, 1, 256, "BF16");
-}
-
-/// Same contract for a weight slab shorter than `rows × bytes_per_row` —
-/// previously a silent early-return that left the output zeroed.
-#[test]
-#[should_panic(expected = "weight slab too short")]
-fn matvec_parallel_panics_on_short_weight_slab() {
-    let x: Vec<f32> = (0..256).map(|i| i as f32 * 0.01).collect();
-    let q8k_x = quantize_x_to_q8k(&x);
-    let bytes = quantize_q4_k(&x); // one row's worth
-    let mut out = vec![0.0f32; 2];
-    q4k_q8k_matvec_parallel(&mut out, &q8k_x, &bytes, 2, 256, "Q4_K");
+    q4k_q8k_matvec_parallel(&mut out, &q8k_x, &bytes, 1, 256, "BF16").expect("valid shape");
 }
 
 /// The NEON-intrinsic fused gate+up kernel must be bit-exact with two
@@ -780,12 +833,13 @@ fn q8k_gate_up_neon_matches_scalar_bit_exact() {
 
         let mut g_scalar = vec![0.0f32; rows];
         let mut u_scalar = vec![0.0f32; rows];
-        q4k_q8k_matvec_scalar(&mut g_scalar, &q8, &g_q4, rows, cols);
-        q4k_q8k_matvec_scalar(&mut u_scalar, &q8, &u_q4, rows, cols);
+        q4k_q8k_matvec_scalar(&mut g_scalar, &q8, &g_q4, rows, cols).expect("valid shape");
+        q4k_q8k_matvec_scalar(&mut u_scalar, &q8, &u_q4, rows, cols).expect("valid shape");
 
         let mut g_neon = vec![0.0f32; rows];
         let mut u_neon = vec![0.0f32; rows];
-        q4k_q8k_gate_up_neon(&mut g_neon, &mut u_neon, &q8, &g_q4, &u_q4, rows, cols);
+        q4k_q8k_gate_up_neon(&mut g_neon, &mut u_neon, &q8, &g_q4, &u_q4, rows, cols)
+            .expect("valid shape");
 
         for r in 0..rows {
             assert_eq!(
@@ -806,11 +860,11 @@ fn q8k_gate_up_neon_matches_scalar_bit_exact() {
     }
 }
 
-/// Fused gate+up NEON early-return guards: zero dims and short weight
-/// buffers must zero BOTH outputs (same contract as the asm form).
+/// `q4k_q8k_gate_up_neon`: zero dims zero BOTH outputs, and a short gate slab is
+/// refused naming the gate half, with both outputs left untouched.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[test]
-fn q8k_gate_up_neon_zero_dims_and_short_weights_zero_output() {
+fn q8k_gate_up_neon_zero_dims_are_empty_and_short_weights_are_refused() {
     let empty = Q8KActivation {
         qs: vec![],
         d: vec![],
@@ -818,7 +872,8 @@ fn q8k_gate_up_neon_zero_dims_and_short_weights_zero_output() {
     };
     let mut g = vec![1.0f32; 4];
     let mut u = vec![1.0f32; 4];
-    q4k_q8k_gate_up_neon(&mut g, &mut u, &empty, &[], &[], 4, 0);
+    q4k_q8k_gate_up_neon(&mut g, &mut u, &empty, &[], &[], 4, 0)
+        .expect("zero dims are the empty product");
     assert!(g.iter().chain(u.iter()).all(|&v| v == 0.0));
 
     let cols = 256;
@@ -828,8 +883,25 @@ fn q8k_gate_up_neon_zero_dims_and_short_weights_zero_output() {
     let w_full = vec![0u8; 2 * BLOCK_BYTES];
     let mut g = vec![1.0f32; rows];
     let mut u = vec![1.0f32; rows];
-    q4k_q8k_gate_up_neon(&mut g, &mut u, &q, &w_short, &w_full, rows, cols);
-    assert!(g.iter().chain(u.iter()).all(|&v| v == 0.0));
+    let err = q4k_q8k_gate_up_neon(&mut g, &mut u, &q, &w_short, &w_full, rows, cols)
+        .expect_err("a short gate slab must be refused");
+    assert_eq!(
+        (g, u),
+        (vec![1.0f32; rows], vec![1.0f32; rows]),
+        "refusal must not touch either output"
+    );
+    assert_eq!(err.kernel, "q4k_q8k_gate_up_neon (gate)");
+    assert_eq!(
+        (err.weight_bytes, err.needed_bytes),
+        (BLOCK_BYTES, 2 * BLOCK_BYTES)
+    );
+
+    // The up half is checked independently: a short UP slab names it.
+    let mut g = vec![1.0f32; rows];
+    let mut u = vec![1.0f32; rows];
+    let err = q4k_q8k_gate_up_neon(&mut g, &mut u, &q, &w_full, &w_short, rows, cols)
+        .expect_err("a short up slab must be refused");
+    assert_eq!(err.kernel, "q4k_q8k_gate_up_neon (up)");
 }
 
 /// The Q6_K NEON-intrinsic kernel must be bit-exact with the scalar
@@ -856,8 +928,8 @@ fn q6k_matvec_neon_matches_scalar_bit_exact() {
 
         let mut out_scalar = vec![0.0f32; rows];
         let mut out_neon = vec![0.0f32; rows];
-        q6k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q6, rows, cols);
-        q6k_q8k_matvec_neon(&mut out_neon, &q8, &w_q6, rows, cols);
+        q6k_q8k_matvec_scalar(&mut out_scalar, &q8, &w_q6, rows, cols).expect("valid shape");
+        q6k_q8k_matvec_neon(&mut out_neon, &q8, &w_q6, rows, cols).expect("valid shape");
 
         for r in 0..rows {
             assert_eq!(
@@ -871,50 +943,72 @@ fn q6k_matvec_neon_matches_scalar_bit_exact() {
     }
 }
 
-/// Q6_K NEON early-return guards: zero dims / short weights zero output.
+/// `q6k_q8k_matvec_neon`: zero dims are the empty product (zeros written), and a
+/// weight slab shorter than `rows` packed rows is refused by name with the
+/// output left exactly as handed in — never silently zeroed.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[test]
-fn q6k_matvec_neon_zero_dims_and_short_weights_zero_output() {
+fn q6k_matvec_neon_zero_dims_are_empty_and_short_weights_are_refused() {
     let empty = Q8KActivation {
         qs: vec![],
         d: vec![],
         sums: vec![],
     };
     let mut out = vec![1.0f32; 4];
-    q6k_q8k_matvec_neon(&mut out, &empty, &[], 4, 0);
-    assert!(out.iter().all(|&v| v == 0.0));
+    q6k_q8k_matvec_neon(&mut out, &empty, &[], 4, 0).expect("zero dims are the empty product");
+    assert!(out.iter().all(|&v| v == 0.0), "zero-dims must zero output");
 
     let cols = 256;
     let rows = 2;
     let q = quantize_x_to_q8k(&vec![0.5f32; cols]);
-    let w = vec![0u8; Q6K_BLOCK_BYTES]; // one row's worth, rows == 2
+    let w = vec![0u8; Q6K_BLOCK_BYTES]; // one row's worth, but rows == 2
     let mut out = vec![1.0f32; rows];
-    q6k_q8k_matvec_neon(&mut out, &q, &w, rows, cols);
-    assert!(out.iter().all(|&v| v == 0.0));
+    let err = q6k_q8k_matvec_neon(&mut out, &q, &w, rows, cols)
+        .expect_err("a short weight slab must be refused");
+    assert_eq!(out, vec![1.0f32; rows], "refusal must not touch the output");
+    assert_eq!(err.kernel, "q6k_q8k_matvec_neon");
+    assert_eq!(
+        (err.weight_bytes, err.needed_bytes),
+        (Q6K_BLOCK_BYTES, 2 * Q6K_BLOCK_BYTES)
+    );
+    assert_eq!(
+        (err.out_len, err.rows, err.x_len, err.cols),
+        (rows, rows, cols, cols)
+    );
 }
 
-/// Q4_K NEON single-row kernel guards: zero dims / short weights zero
-/// output (the asm form already has this; the intrinsic form's guards
-/// were only reachable through the dispatch before).
+/// `q4k_q8k_matvec_neon`: zero dims are the empty product (zeros written), and a
+/// weight slab shorter than `rows` packed rows is refused by name with the
+/// output left exactly as handed in — never silently zeroed.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[test]
-fn q4k_matvec_neon_zero_dims_and_short_weights_zero_output() {
+fn q4k_matvec_neon_zero_dims_are_empty_and_short_weights_are_refused() {
     let empty = Q8KActivation {
         qs: vec![],
         d: vec![],
         sums: vec![],
     };
     let mut out = vec![1.0f32; 4];
-    q4k_q8k_matvec_neon(&mut out, &empty, &[], 4, 0);
-    assert!(out.iter().all(|&v| v == 0.0));
+    q4k_q8k_matvec_neon(&mut out, &empty, &[], 4, 0).expect("zero dims are the empty product");
+    assert!(out.iter().all(|&v| v == 0.0), "zero-dims must zero output");
 
     let cols = 256;
     let rows = 2;
     let q = quantize_x_to_q8k(&vec![0.5f32; cols]);
-    let w_short = vec![0u8; BLOCK_BYTES]; // one row's worth, rows == 2
+    let w = vec![0u8; BLOCK_BYTES]; // one row's worth, but rows == 2
     let mut out = vec![1.0f32; rows];
-    q4k_q8k_matvec_neon(&mut out, &q, &w_short, rows, cols);
-    assert!(out.iter().all(|&v| v == 0.0));
+    let err = q4k_q8k_matvec_neon(&mut out, &q, &w, rows, cols)
+        .expect_err("a short weight slab must be refused");
+    assert_eq!(out, vec![1.0f32; rows], "refusal must not touch the output");
+    assert_eq!(err.kernel, "q4k_q8k_matvec_neon");
+    assert_eq!(
+        (err.weight_bytes, err.needed_bytes),
+        (BLOCK_BYTES, 2 * BLOCK_BYTES)
+    );
+    assert_eq!(
+        (err.out_len, err.rows, err.x_len, err.cols),
+        (rows, rows, cols, cols)
+    );
 }
 
 /// Q4_K NEON 2-row kernel: guards zero the output, and an ODD row count
@@ -928,7 +1022,7 @@ fn q4k_matvec_neon_2row_guards_and_odd_row_tail() {
         sums: vec![],
     };
     let mut out = vec![1.0f32; 4];
-    q4k_q8k_matvec_neon_2row(&mut out, &empty, &[], 4, 0);
+    q4k_q8k_matvec_neon_2row(&mut out, &empty, &[], 4, 0).expect("valid shape");
     assert!(out.iter().all(|&v| v == 0.0));
 
     let cols = 512;
@@ -943,15 +1037,18 @@ fn q4k_matvec_neon_2row_guards_and_odd_row_tail() {
         .collect();
     let w = quantize_q4_k(&w_f32);
 
-    // short-weight guard: one row's bytes for rows == 3
+    // short-weight guard: one row's bytes for rows == 3 is refused,
+    // output untouched.
     let mut out = vec![1.0f32; rows];
-    q4k_q8k_matvec_neon_2row(&mut out, &q8, &w[..2 * BLOCK_BYTES], rows, cols);
-    assert!(out.iter().all(|&v| v == 0.0));
+    let err = q4k_q8k_matvec_neon_2row(&mut out, &q8, &w[..2 * BLOCK_BYTES], rows, cols)
+        .expect_err("a short weight slab must be refused");
+    assert_eq!(out, vec![1.0f32; rows]);
+    assert_eq!(err.kernel, "q4k_q8k_matvec_neon_2row");
 
     let mut out_single = vec![0.0f32; rows];
     let mut out_2row = vec![0.0f32; rows];
-    q4k_q8k_matvec_neon(&mut out_single, &q8, &w, rows, cols);
-    q4k_q8k_matvec_neon_2row(&mut out_2row, &q8, &w, rows, cols);
+    q4k_q8k_matvec_neon(&mut out_single, &q8, &w, rows, cols).expect("valid shape");
+    q4k_q8k_matvec_neon_2row(&mut out_2row, &q8, &w, rows, cols).expect("valid shape");
     for r in 0..rows {
         assert_eq!(
             out_single[r].to_bits(),
@@ -961,4 +1058,111 @@ fn q4k_matvec_neon_2row_guards_and_odd_row_tail() {
             out_2row[r],
         );
     }
+}
+
+// ── Public execution path: `q4k_q8k_matvec_parallel` ─────────────────────
+//
+// The parallel entry is the single source for every quantised projection
+// on the decode path. One fixture serves the refusal cases and the parity
+// case beside them, so the same weights prove both halves of the change:
+// an invalid shape refuses with the output untouched, and the unchanged
+// valid shape still computes exactly what the scalar reference computes.
+
+/// `(packed Q4_K weights, Q8_K activation, rows, cols)` for the public-path
+/// tests. Five rows keeps a partial final chunk out of the picture; two
+/// super-blocks per row keeps the scale/min unpack exercised twice.
+fn public_path_fixture() -> (Vec<u8>, Q8KActivation, usize, usize) {
+    let rows = 5;
+    let cols = 512;
+    let x: Vec<f32> = (0..cols).map(|i| (i as f32 * 0.013).sin() * 1.7).collect();
+    let w_f32: Vec<f32> = (0..rows * cols)
+        .map(|i| (i as f32 * 0.007).cos() * 0.6)
+        .collect();
+    (quantize_q4_k(&w_f32), quantize_x_to_q8k(&x), rows, cols)
+}
+
+/// Valid shape, unchanged numerics: the parallel entry is bit-identical to
+/// the scalar reference on the fixture the refusal tests below reuse.
+#[test]
+fn q8k_matvec_parallel_computes_exactly_the_scalar_reference_on_the_fixture() {
+    let (w, q, rows, cols) = public_path_fixture();
+    let mut reference = vec![0.0f32; rows];
+    q4k_q8k_matvec_scalar(&mut reference, &q, &w, rows, cols).expect("valid shape");
+    let mut out = vec![7.0f32; rows];
+    q4k_q8k_matvec_parallel(&mut out, &q, &w, rows, cols, "Q4_K").expect("valid shape");
+    assert!(
+        reference.iter().any(|&v| v != 0.0),
+        "control: the fixture must not be all zeros"
+    );
+    for r in 0..rows {
+        assert_eq!(
+            out[r].to_bits(),
+            reference[r].to_bits(),
+            "row {r}: parallel={} scalar={}",
+            out[r],
+            reference[r]
+        );
+    }
+}
+
+/// An activation that is not `cols` long is refused by name — the hand-asm
+/// kernels read `qs` through a bare pointer, so this used to be an OOB
+/// read hidden behind a zero-filled output.
+#[test]
+fn q8k_matvec_parallel_refuses_an_activation_of_the_wrong_length() {
+    let (w, _, rows, cols) = public_path_fixture();
+    let wrong = quantize_x_to_q8k(&vec![0.5f32; cols + 256]);
+    let mut out = vec![7.0f32; rows];
+    let err = q4k_q8k_matvec_parallel(&mut out, &wrong, &w, rows, cols, "Q4_K")
+        .expect_err("activation length must match cols");
+    assert_eq!(out, vec![7.0f32; rows], "refusal must not touch the output");
+    assert_eq!(err.kernel, "q4k_q8k_matvec_parallel");
+    assert_eq!((err.x_len, err.cols), (cols + 256, cols));
+    assert!(
+        err.to_string()
+            .contains("activation length 768 for 512 cols"),
+        "{err}"
+    );
+}
+
+/// An output shorter than `rows` is refused before any row is written.
+#[test]
+fn q8k_matvec_parallel_refuses_an_output_shorter_than_rows() {
+    let (w, q, rows, cols) = public_path_fixture();
+    let mut out = vec![7.0f32; rows - 1];
+    let err = q4k_q8k_matvec_parallel(&mut out, &q, &w, rows, cols, "Q4_K")
+        .expect_err("output must hold rows");
+    assert_eq!(out, vec![7.0f32; rows - 1]);
+    assert_eq!((err.out_len, err.rows), (rows - 1, rows));
+}
+
+/// A weight slab shorter than `rows` packed rows is refused by name. This
+/// case used to panic at the entry point; it is now the same typed
+/// refusal the per-row kernels return, so a caller with a channel can
+/// carry it up.
+#[test]
+fn q8k_matvec_parallel_refuses_a_short_weight_slab() {
+    let (w, q, rows, cols) = public_path_fixture();
+    let short = &w[..w.len() - BLOCK_BYTES];
+    let mut out = vec![7.0f32; rows];
+    let err = q4k_q8k_matvec_parallel(&mut out, &q, short, rows, cols, "Q4_K")
+        .expect_err("short slab must be refused");
+    assert_eq!(out, vec![7.0f32; rows]);
+    assert_eq!(
+        (err.weight_bytes, err.needed_bytes),
+        (w.len() - BLOCK_BYTES, w.len())
+    );
+}
+
+/// The refusal reaches the `FormatRoute` registry's kernel pointer too:
+/// the Q6_K route returns the same typed error.
+#[test]
+fn q8k_matvec_parallel_refuses_through_the_q6k_route_as_well() {
+    let (_, q, rows, cols) = public_path_fixture();
+    let short = vec![0u8; Q6K_BLOCK_BYTES];
+    let mut out = vec![7.0f32; rows];
+    let err = q4k_q8k_matvec_parallel(&mut out, &q, &short, rows, cols, "Q6_K")
+        .expect_err("short Q6_K slab must be refused");
+    assert_eq!(out, vec![7.0f32; rows]);
+    assert_eq!(err.needed_bytes, rows * 2 * Q6K_BLOCK_BYTES);
 }

--- a/crates/larql-compute/src/ffn/q4k_weight.rs
+++ b/crates/larql-compute/src/ffn/q4k_weight.rs
@@ -128,7 +128,8 @@ impl FfnBackend for Q4kFfn {
                 l.intermediate,
                 l.hidden,
                 Q4K_FORMAT_TAG,
-            );
+            )
+            .unwrap_or_else(|e| panic!("Q4kFfn::forward layer {layer}: {e}"));
             q4k_q8k_matvec_parallel(
                 up.row_mut(row).as_slice_mut().expect("contiguous"),
                 &q8,
@@ -136,7 +137,8 @@ impl FfnBackend for Q4kFfn {
                 l.intermediate,
                 l.hidden,
                 Q4K_FORMAT_TAG,
-            );
+            )
+            .unwrap_or_else(|e| panic!("Q4kFfn::forward layer {layer}: {e}"));
         }
         let activation = silu_gate_up(&gate, &up);
         let mut out = Array2::<f32>::zeros((rows, l.hidden));
@@ -150,7 +152,8 @@ impl FfnBackend for Q4kFfn {
                 l.hidden,
                 l.intermediate,
                 Q4K_FORMAT_TAG,
-            );
+            )
+            .unwrap_or_else(|e| panic!("Q4kFfn::forward layer {layer}: {e}"));
         }
         out
     }

--- a/crates/larql-compute/src/kquant_forward/cached/predict.rs
+++ b/crates/larql-compute/src/kquant_forward/cached/predict.rs
@@ -257,7 +257,8 @@ pub(crate) fn matvec_q4k_or_q6k_q8k(
     let mut out = vec![0.0f32; rows];
     crate::cpu::ops::q4k_q8k_dot::q4k_q8k_matvec_parallel(
         &mut out, x_q8k, bytes, rows, cols, format,
-    );
+    )
+    .unwrap_or_else(|e| panic!("matvec_q4k_or_q6k_q8k: refused after pre-flight checks: {e}"));
     Some(out)
 }
 

--- a/crates/larql-compute/src/kquant_forward/walk_ffn.rs
+++ b/crates/larql-compute/src/kquant_forward/walk_ffn.rs
@@ -116,7 +116,8 @@ pub fn kquant_ffn_forward_layer_q8k(
         ffn[1].0, // up Q4K bytes
         intermediate,
         hidden,
-    );
+    )
+    .unwrap_or_else(|e| panic!("kquant_ffn_forward_layer_q8k layer {layer}: {e}"));
 
     // Wrap into Array2 for the shared activation + down path.
     let gate = Array2::from_shape_vec((1, intermediate), gate_flat).expect("gate shape");
@@ -141,7 +142,8 @@ pub fn kquant_ffn_forward_layer_q8k(
         let activation_flat = activation.as_slice().expect("activation contiguous");
         let act_q8k = quantize_x_to_q8k(activation_flat);
         let mut out = vec![0.0f32; hidden];
-        q4k_q8k_matvec_into(&mut out, &act_q8k, ffn[2].0, hidden, intermediate);
+        q4k_q8k_matvec_into(&mut out, &act_q8k, ffn[2].0, hidden, intermediate)
+            .unwrap_or_else(|e| panic!("kquant_ffn_forward_layer_q8k layer {layer}: {e}"));
         Array2::from_shape_vec((1, hidden), out).expect("down output shape")
     } else {
         // Fallback: OnceLock cache + ndarray dot; consults `ffn[2].1` via

--- a/crates/larql-compute/src/lib.rs
+++ b/crates/larql-compute/src/lib.rs
@@ -147,6 +147,7 @@ pub use cpu::ops::linalg::{cholesky, cholesky_inverse, cholesky_solve, ridge_dec
 pub use cpu::ops::moe::{quantize_x_to_q8k, Q8KActivation};
 pub use cpu::ops::q4k_matvec::f16_to_f32;
 pub use cpu::ops::vector::{cosine, dot, norm};
+pub use cpu::ops::KernelShapeError;
 pub use cpu::CpuBackend;
 pub use packed_attn_index::PackedAttnIndex;
 

--- a/crates/larql-compute/src/quant_route.rs
+++ b/crates/larql-compute/src/quant_route.rs
@@ -31,6 +31,7 @@
 
 use crate::cpu::ops::q4_common::{q4k_matmul_into, q6k_matmul_into};
 use crate::cpu::ops::q4k_q8k_dot::{q4k_q8k_matvec_into, q6k_q8k_matvec_into, Q8KActivation};
+use crate::cpu::ops::KernelShapeError;
 use crate::QuantFormat;
 
 /// Dequantise exactly `padded_elems` (a block-multiple) values from a
@@ -40,7 +41,8 @@ pub type DequantPaddedFn = fn(&[u8], usize) -> Result<Vec<f32>, String>;
 /// Multi-row matvec `(out, q8k_x, weight_bytes, rows, cols)` against a
 /// pre-quantised Q8K activation. Single-threaded per call; row-chunk
 /// parallelism lives in `q4k_q8k_matvec_parallel`.
-pub type Q8kMatvecFn = fn(&mut [f32], &Q8KActivation, &[u8], usize, usize);
+pub type Q8kMatvecFn =
+    fn(&mut [f32], &Q8KActivation, &[u8], usize, usize) -> Result<(), KernelShapeError>;
 
 /// Amortised matmul `(out, x, weight_bytes, rows, cols, seq)` reading
 /// the packed bytes once for all `seq` positions.

--- a/crates/larql-inference/src/forward/predict/dense.rs
+++ b/crates/larql-inference/src/forward/predict/dense.rs
@@ -181,7 +181,8 @@ pub fn logits_to_predictions_q4_lm_head(
         let mut h_q8k = Q8KActivation::with_capacity(hidden);
         quantize_x_to_q8k_into(&mut h_q8k, last_row);
         let mut out = vec![0.0f32; vocab];
-        q4k_q8k_matvec_parallel(&mut out, &h_q8k, q4_lm_head, vocab, hidden, "Q4_K");
+        q4k_q8k_matvec_parallel(&mut out, &h_q8k, q4_lm_head, vocab, hidden, "Q4_K")
+            .unwrap_or_else(|e| panic!("Q4_K lm_head: {e}"));
         out
     };
     let _ = backend;
@@ -235,7 +236,8 @@ pub fn q4_lm_head_argmax(
         let mut h_q8k = Q8KActivation::with_capacity(hidden);
         quantize_x_to_q8k_into(&mut h_q8k, last_row);
         let mut out = vec![0.0f32; vocab];
-        q4k_q8k_matvec_parallel(&mut out, &h_q8k, q4_lm_head, vocab, hidden, "Q4_K");
+        q4k_q8k_matvec_parallel(&mut out, &h_q8k, q4_lm_head, vocab, hidden, "Q4_K")
+            .unwrap_or_else(|e| panic!("Q4_K lm_head: {e}"));
         out
     };
 

--- a/crates/larql-inference/src/vindex/kquant_forward/walk_ffn.rs
+++ b/crates/larql-inference/src/vindex/kquant_forward/walk_ffn.rs
@@ -111,7 +111,8 @@ pub fn kquant_ffn_forward_layer_q8k(
         ffn[1].0, // up Q4K bytes
         intermediate,
         hidden,
-    );
+    )
+    .unwrap_or_else(|e| panic!("kquant_ffn_forward_layer_q8k layer {layer}: {e}"));
 
     // Wrap into Array2 for the shared activation + down path.
     let gate = Array2::from_shape_vec((1, intermediate), gate_flat).expect("gate shape");
@@ -136,7 +137,8 @@ pub fn kquant_ffn_forward_layer_q8k(
         let activation_flat = activation.as_slice().expect("activation contiguous");
         let act_q8k = quantize_x_to_q8k(activation_flat);
         let mut out = vec![0.0f32; hidden];
-        q4k_q8k_matvec_into(&mut out, &act_q8k, ffn[2].0, hidden, intermediate);
+        q4k_q8k_matvec_into(&mut out, &act_q8k, ffn[2].0, hidden, intermediate)
+            .unwrap_or_else(|e| panic!("kquant_ffn_forward_layer_q8k layer {layer}: {e}"));
         Array2::from_shape_vec((1, hidden), out).expect("down output shape")
     } else {
         // Fallback: OnceLock cache + ndarray dot; consults `ffn[2].1` via

--- a/crates/larql-kv/tests/moss_prefill_bench.rs
+++ b/crates/larql-kv/tests/moss_prefill_bench.rs
@@ -130,7 +130,8 @@ fn q4_prefill_prediction() {
                     op.rows,
                     op.cols,
                     Q4K_FORMAT_TAG,
-                );
+                )
+                .expect("bench shapes are valid");
                 sink += out_row[0];
             }
         }

--- a/crates/larql-kv/tests/moss_q4_frame_bench.rs
+++ b/crates/larql-kv/tests/moss_q4_frame_bench.rs
@@ -186,7 +186,8 @@ fn q4_frame_prediction() {
             let q8k = quantize_x_to_q8k(&x);
             let mut out = vec![0.0f32; *rows];
             for _ in 0..*uses {
-                q4k_q8k_matvec_into(&mut out, &q8k, blob, *rows, *cols);
+                q4k_q8k_matvec_into(&mut out, &q8k, blob, *rows, *cols)
+                    .expect("bench shapes are valid");
                 sink += out[0];
             }
         }
@@ -201,7 +202,8 @@ fn q4_frame_prediction() {
             let q8k = quantize_x_to_q8k(&x);
             let mut out = vec![0.0f32; *rows];
             for _ in 0..*uses {
-                q4k_q8k_matvec_parallel(&mut out, &q8k, blob, *rows, *cols, "Q4_K");
+                q4k_q8k_matvec_parallel(&mut out, &q8k, blob, *rows, *cols, "Q4_K")
+                    .expect("bench shapes are valid");
                 sink += out[0];
             }
         }


### PR DESCRIPTION
**Invariant:** a benchmark result cannot be emitted from a failed Metal command buffer or an invalid CPU kernel shape.

Four changes, one invariant. Branch `measurement-guards`, rebased on `origin/main` 8238b53c.

### 1. Metal: a failed command buffer never becomes a result

`cb_status::wait_checked` returned `Result` and all 109 production and test call sites discarded it with `let _ =`. A faulted buffer, or one Metal dropped after an earlier fault, returned from its wait with stale bytes in every output and the step carried on (#229 class).

- **Typed refusal where a channel exists.** `GroupedError::CommandBufferFailed { site, detail }` and `Mxfp4Error::CommandBufferFailed` on the Kimi KDA/MLA chain, the standalone KDA and MLA encoders, the grouped-expert and bf16 MoE block paths, and the MXFP4 matmul. In `kimi_layer::encode_layer_chain` the refusal happens **before** `state.advance_to`, and the scratch goes back to the pool untouched, so a fault cannot advance the MLA cache.
- **Abort where none exists.** `cb_status::wait_or_abort` for `Vec<f32>`-returning decode stages and the `Option`-returning `MatMul`/`QuantMatVec`/`bf16_gemv`/router methods. A `None` from those is taken by callers as "fall back to the CPU", which would report the fallback's number as the GPU's.
- **`expect` in tests.** 28 sites.
- The `LARQL_SPIN_WAIT=1` arm in `moe_interleave.rs` now runs `require_completed` after the spin; it previously bypassed the only refusal on that path.
- The three naked `wait_until_completed()` calls in `larql-cli`'s metal-lowered step (the `vindex3 exec --backend metal-lowered` instrument) go through `cb_status` too; the step's wait propagates as `VindexError`.
- `wait_checked` is `#[must_use]`, and `cb_status/tests.rs` now scans the tree for a discarded result as well as a naked wait.
- **Witnesses**, via `cb_status::inject_fault_at_for_test(site_fragment)` (a real fault cannot be produced deterministically; injected faults are not counted as GPU observations):
  - `kimi_layer::tests::a_failed_command_buffer_refuses_the_chain_and_advances_nothing` — KDA+MLA chain, fault at the chain's own wait: `Err(CommandBufferFailed)` naming the site, no readback, `mla_state.len() == 0`, and the same chain then runs and advances once.
  - `cb_status::tests::a_faulted_matmul_aborts_instead_of_returning_a_result` — production `MatMul::matmul` on the GPU path, `should_panic`.
  - `cb_status::tests::wait_or_abort_stops_the_step_on_an_injected_fault`, `an_injected_fault_is_reported_once_at_its_site_and_then_cleared`.

### 2. CPU: kernels refuse malformed geometry instead of zero-filling

Every Q4_K/Q6_K × Q8_K kernel (scalar, NEON, NEON 2-row, three hand-asm variants, AVX2, the fused gate+up pair, the Q6_K trio) and the Q4_K f32 twins (`q4k_matvec_into`, `q4k_dual_matvec_into`) zero-filled `out` and returned on a shape mismatch or a short weight slab. A zero vector is a plausible logit vector.

- New `larql_compute::KernelShapeError { kernel, out_len, rows, x_len, cols, weight_bytes, needed_bytes }`; every kernel and the public `q4k_q8k_matvec_parallel` return `Result<(), KernelShapeError>` and leave `out` untouched on refusal. Zero dimensions remain the empty product (zeros written, `Ok`).
- `FormatRoute::q8k_matvec` carries the new signature, so the registry's kernel pointers refuse the same way.
- Callers with a channel propagate (`CpuBackend::q4k_matvec` / `q4k_dual_matvec` → `None`, the trait's documented contract for a shape error). Callers without one refuse by name (`unwrap_or_else(panic)` with the typed message) instead of returning zeros: the MoE expert paths' own short-slab guards, `Q4kFfn::forward`, the Q4_K lm_head, the direct attention projection, walk-FFN Q8K.
- **Tests, through the public path**, in `q4k_q8k_dot/tests.rs`: one fixture serves `q8k_matvec_parallel_computes_exactly_the_scalar_reference_on_the_fixture` (bit-identical to the scalar reference; control asserts the fixture is not all zeros) and, beside it, refusals for a wrong-length activation, an output shorter than `rows`, a short weight slab (previously a panic, now typed), and the same through the Q6_K route. The nine per-kernel zero-fill tests became `*_zero_dims_are_empty_and_short_weights_are_refused`, asserting `out` untouched and the error's fields.

### 3. wasmtime 36.0.13 → 36.0.14

`cargo update -p wasmtime`: lockfile only, the wasmtime/cranelift/pulley/winch family at 36.0.14 and nothing else. Clears RUSTSEC-2026-0269 (the reason main's `quality` workflow has been red).

### 4. The MSRV gate runs the compiler it claims

`rust-toolchain.toml` pins the development toolchain and rustup honours it over what `dtolnay/rust-toolchain` installed, so since 2026-08-22 the MSRV job checked at 1.98 while claiming 1.88. The check step now runs under `RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}`, preceded by a step that prints `rustc --version` and fails if it is not the declared version.

Making the gate real exposed that the declared MSRV was false: the NEON dot-product intrinsics (`stdarch_neon_dotprod`) used by the VINDEX3 CPU integer path (`opplan/exec/cpu/{integer,stationary}.rs`) and the `cpu7_probe` example are unstable through 1.97 (bisected locally: 1.88, 1.89, 1.90, 1.91, 1.97 fail on exactly that error; 1.98 passes). `rust-version` is now `1.98`, with the reason recorded beside it and in AGENTS.md. The gate was previously hollow; making it execute the declared compiler proved the declaration was false; 1.98 is the first verified toolchain that supports the existing VINDEX3 CPU integer path. Rewriting that path as inline asm would turn a measurement-integrity PR into execution-path surgery, so it stays.

### Not in this PR

Activation default, V3 EOS, the W10 gate. Real, but a different thesis.
