### PR TITLE
feat(vindex): a plan names who judged it and what it judged (plan schema 4)

### DIFF
--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use clap::{Args, Subcommand};
 
 use larql_models::inventory::{build_inventory, ArchitectureInventory};
-use larql_vindex::format::vindex3::plan::plan_system;
+use larql_vindex::format::vindex3::plan::{plan_system_with_sources, ArtifactSource};
 
 /// Extension distinguishing a saved inventory JSON from a checkpoint dir.
 const INVENTORY_EXT: &str = "json";
@@ -964,11 +964,23 @@ fn run_plan(args: PlanArgs) -> Result<(), Box<dyn std::error::Error>> {
     for entry in &resolved {
         report_staging(entry);
     }
+    // The verdict names its subject: the argument as given and, for a
+    // repo, the commit the facts were read at.
+    let sources: Vec<ArtifactSource> = args
+        .artifacts
+        .iter()
+        .zip(&resolved)
+        .map(|(spec, a)| ArtifactSource {
+            path: spec.display().to_string(),
+            revision: a.commit().map(str::to_string),
+            unpinned_revision: a.unpinned_revision().map(str::to_string),
+        })
+        .collect();
     let named: Vec<(String, ArchitectureInventory)> = resolved
         .into_iter()
         .map(|a| (a.name, a.inventory))
         .collect();
-    let plan = plan_system(&named);
+    let plan = plan_system_with_sources(&named, &sources)?;
     let json = serde_json::to_string_pretty(&plan)?;
     match &args.output {
         Some(path) => {

--- a/crates/larql-vindex/src/format/vindex3/plan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/mod.rs
@@ -47,20 +47,54 @@ use larql_models::inventory::{ArchitectureInventory, KeyStatus};
 use super::graph::{build_from_inventories, BuiltGraph, Component, ComponentRole};
 
 pub use report::{
-    ArtifactPlan, Finding, FindingCategory, InterfacePlan, PlanSummary, SemanticClass, SystemPlan,
+    ArtifactPlan, ArtifactSource, Finding, FindingCategory, InterfacePlan, PlanSummary,
+    PlannerIdentity, SemanticClass, SystemPlan, VerdictCacheKey, PLANNER_SEMANTICS_VERSION,
     PLAN_SCHEMA,
 };
 
 /// Build the system plan over one or more inventories.
 ///
 /// `named` pairs one display name per inventory (the CLI passes directory
-/// stems).
+/// stems). Each artifact's source is the path its inventory recorded, with
+/// no revision — the local-checkpoint case. A caller that knows more
+/// (a repo commit) uses [`plan_system_with_sources`].
 pub fn plan_system(named: &[(String, ArchitectureInventory)]) -> SystemPlan {
+    let sources: Vec<ArtifactSource> = named
+        .iter()
+        .map(|(_, inventory)| ArtifactSource::local(inventory.path.clone()))
+        .collect();
+    plan_sourced(named, &sources)
+}
+
+/// [`plan_system`] with each artifact's source stated by the caller —
+/// `sources[i]` describes `named[i]`. Refuses mismatched lengths rather
+/// than pairing verdicts with the wrong subjects.
+pub fn plan_system_with_sources(
+    named: &[(String, ArchitectureInventory)],
+    sources: &[ArtifactSource],
+) -> Result<SystemPlan, crate::error::VindexError> {
+    if named.len() != sources.len() {
+        return Err(crate::error::VindexError::Parse(format!(
+            "{} artifact(s) but {} source(s): every artifact needs exactly one source",
+            named.len(),
+            sources.len()
+        )));
+    }
+    Ok(plan_sourced(named, sources))
+}
+
+/// The planner proper. `sources` is exactly as long as `named`; both
+/// public entry points guarantee it.
+fn plan_sourced(
+    named: &[(String, ArchitectureInventory)],
+    sources: &[ArtifactSource],
+) -> SystemPlan {
     let built = build_from_inventories(named);
 
     let artifacts: Vec<ArtifactPlan> = named
         .iter()
-        .map(|(name, inventory)| plan_artifact(name, inventory, &built))
+        .zip(sources)
+        .map(|((name, inventory), source)| plan_artifact(name, inventory, source, &built))
         .collect();
 
     let interfaces: Vec<InterfacePlan> = built
@@ -103,6 +137,7 @@ pub fn plan_system(named: &[(String, ArchitectureInventory)]) -> SystemPlan {
 
     SystemPlan {
         schema: PLAN_SCHEMA,
+        planner: PlannerIdentity::current(),
         artifacts,
         interfaces,
         admissible,
@@ -117,6 +152,7 @@ pub fn plan_system(named: &[(String, ArchitectureInventory)]) -> SystemPlan {
 fn plan_artifact(
     name: &str,
     inventory: &ArchitectureInventory,
+    source: &ArtifactSource,
     built: &BuiltGraph,
 ) -> ArtifactPlan {
     let mut findings = compare::compare(inventory);
@@ -129,6 +165,7 @@ fn plan_artifact(
     findings.extend(unresolved_interface_findings(name, built));
     ArtifactPlan {
         name: name.to_string(),
+        source: source.clone(),
         model_type: inventory.identity.model_type.clone(),
         findings,
     }

--- a/crates/larql-vindex/src/format/vindex3/plan/report.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/report.rs
@@ -19,6 +19,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::carriage::Carriage;
+use crate::error::VindexError;
 use crate::format::vindex3::graph::SystemGraph;
 
 /// Current plan schema. Bump on any breaking change to these types.
@@ -32,13 +33,114 @@ use crate::format::vindex3::graph::SystemGraph;
 /// ones — so `unrepresented: N` is a count against a stated denominator
 /// instead of a lower bound. Adds the `training_only` and `alias`
 /// semantic classes.
-pub const PLAN_SCHEMA: u32 = 3;
+///
+/// v4: the plan names who judged it and what it judged. `planner` carries
+/// the planner's package version and its *semantics* version; every
+/// artifact carries its `source` — the argument as given and, for a repo,
+/// the immutable commit the facts were read at. A verdict without these
+/// is not attributable, and a plan of an earlier schema is refused by
+/// [`SystemPlan::parse`] rather than read as unattributed.
+pub const PLAN_SCHEMA: u32 = 4;
+
+/// The planner's semantics version.
+///
+/// Bumped **only** when a verdict can change: a new or corrected rule that
+/// makes a checkpoint admissible or blocked where it was not before (the
+/// sliding-window normalisation flipped six Qwen3 sizes from three
+/// blockers to zero — that is a bump). A fix to the CLI, the report's
+/// wording or the JSON layout is not. The package version says which
+/// build ran; this says whether its answers are comparable with another
+/// build's. Anything caching verdicts keys on (source revision, this).
+///
+/// `plan/tests/identity.rs` pins fixture verdicts against this value, so
+/// a change that flips one fails there until the version is bumped.
+pub const PLANNER_SEMANTICS_VERSION: u32 = 1;
+
+/// Who judged a plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlannerIdentity {
+    /// The crate that implements the planner.
+    pub package: String,
+    /// That crate's package version — which build ran.
+    pub package_version: String,
+    /// [`PLANNER_SEMANTICS_VERSION`] at the time — whether two verdicts
+    /// are comparable.
+    pub semantics_version: u32,
+}
+
+impl PlannerIdentity {
+    /// This build's identity.
+    pub fn current() -> Self {
+        Self {
+            package: env!("CARGO_PKG_NAME").to_string(),
+            package_version: env!("CARGO_PKG_VERSION").to_string(),
+            semantics_version: PLANNER_SEMANTICS_VERSION,
+        }
+    }
+}
+
+/// What an artifact's facts were read from, so the verdict names its
+/// subject.
+///
+/// **Cache authority is pinned-only.** A persisted verdict cache requires
+/// an immutable source revision — [`revision`](Self::revision), a commit.
+/// [`unpinned_revision`](Self::unpinned_revision) is provenance, not a
+/// cache identity: `main` on Monday and `main` on Tuesday can name
+/// different facts, so a verdict over it may be shown, visibly marked
+/// unpinned, and must never be stored as authority.
+/// [`SystemPlan::cache_key`] enforces this for the whole plan.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactSource {
+    /// The artifact as the caller gave it: a checkpoint directory, a saved
+    /// inventory, or an `hf://org/name[@revision]` spec.
+    pub path: String,
+    /// The immutable revision the facts were read at, when the source has
+    /// one — a repo's commit. A verdict is re-usable exactly as far as
+    /// this and the planner's semantics version are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+    /// A revision *name* the source fell back to because the hub named no
+    /// commit — provenance that can move, and worth saying so. Never a
+    /// cache identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unpinned_revision: Option<String>,
+}
+
+impl ArtifactSource {
+    /// A local source: the path the inventory recorded, no revision.
+    pub fn local(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            revision: None,
+            unpinned_revision: None,
+        }
+    }
+
+    /// The immutable revision a cache may key on, if this source has one.
+    /// `None` for a local path and for an unpinned revision name.
+    pub fn pinned_revision(&self) -> Option<&str> {
+        self.revision.as_deref()
+    }
+}
+
+/// The identity under which a plan's verdict may be persisted: every
+/// artifact's immutable revision, in artifact order, and the semantics
+/// version that judged them. Exists only when every artifact is pinned.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct VerdictCacheKey {
+    pub revisions: Vec<String>,
+    pub semantics_version: u32,
+}
 
 /// The whole-system plan over every artifact given.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SystemPlan {
     /// Always [`PLAN_SCHEMA`].
     pub schema: u32,
+    /// Who judged this plan. Not defaulted on deserialisation: a plan
+    /// without it is an earlier schema and is refused, not read as
+    /// unattributed.
+    pub planner: PlannerIdentity,
     /// One entry per inspected artifact, in input order.
     pub artifacts: Vec<ArtifactPlan>,
     /// Cross-component interfaces resolved into graph edges.
@@ -83,8 +185,63 @@ pub struct PlanSummary {
 pub struct ArtifactPlan {
     /// Artifact name (the inspected directory's stem).
     pub name: String,
+    /// What this artifact's facts were read from.
+    pub source: ArtifactSource,
     pub model_type: String,
     pub findings: Vec<Finding>,
+}
+
+impl SystemPlan {
+    /// The identity under which this verdict may be cached, or `None`.
+    ///
+    /// A verdict is cacheable only when every artifact carries an
+    /// immutable revision and the planner's semantics version is known —
+    /// the same facts under the same rules. One local path or one
+    /// unpinned revision name among the artifacts makes the whole plan
+    /// uncacheable: it may still be shown, marked as such, but a cache
+    /// that stored it would answer tomorrow's question with today's
+    /// facts.
+    pub fn cache_key(&self) -> Option<VerdictCacheKey> {
+        let revisions = self
+            .artifacts
+            .iter()
+            .map(|a| a.source.pinned_revision().map(str::to_string))
+            .collect::<Option<Vec<String>>>()?;
+        Some(VerdictCacheKey {
+            revisions,
+            semantics_version: self.planner.semantics_version,
+        })
+    }
+
+    /// Read a plan back, refusing one written by another schema by name.
+    ///
+    /// The schema is checked before the body is parsed, so an older plan
+    /// fails as "schema 3, this build reads 4" rather than as a missing
+    /// field several lines in — and a plan that predates planner identity
+    /// can never be read as a verdict nobody attributed.
+    pub fn parse(json: &str) -> Result<Self, VindexError> {
+        #[derive(Deserialize)]
+        struct SchemaProbe {
+            schema: Option<u32>,
+        }
+        let probe: SchemaProbe = serde_json::from_str(json)
+            .map_err(|e| VindexError::Parse(format!("plan is not a JSON object: {e}")))?;
+        match probe.schema {
+            Some(found) if found == PLAN_SCHEMA => {}
+            Some(found) => {
+                return Err(VindexError::Parse(format!(
+                    "plan schema {found}; this build reads plan schema {PLAN_SCHEMA} — \
+                     re-run `vindex plan` so the verdict is attributed"
+                )))
+            }
+            None => {
+                return Err(VindexError::Parse(format!(
+                    "plan declares no schema; this build reads plan schema {PLAN_SCHEMA}"
+                )))
+            }
+        }
+        serde_json::from_str(json).map_err(|e| VindexError::Parse(format!("parse plan: {e}")))
+    }
 }
 
 /// One statement about one subject.

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/identity.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/identity.rs
@@ -1,0 +1,179 @@
+//! Plan schema 4: who judged, what was judged, and whether two verdicts
+//! are comparable.
+
+use larql_models::inventory::ArchitectureInventory;
+
+use super::support::{glimmer_shaped_target, glimmer_shaped_target_with};
+use crate::format::vindex3::plan::{
+    plan_system, plan_system_with_sources, ArtifactSource, PlannerIdentity, SystemPlan,
+    VerdictCacheKey, PLANNER_SEMANTICS_VERSION, PLAN_SCHEMA,
+};
+
+const ARTIFACT: &str = "target-artifact";
+
+fn one_glimmer(dir: &std::path::Path) -> Vec<(String, ArchitectureInventory)> {
+    vec![(ARTIFACT.to_string(), glimmer_shaped_target(dir))]
+}
+
+#[test]
+fn a_plan_names_the_build_that_judged_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_system(&one_glimmer(dir.path()));
+    assert_eq!(plan.schema, PLAN_SCHEMA);
+    assert_eq!(plan.planner, PlannerIdentity::current());
+    assert_eq!(plan.planner.package, env!("CARGO_PKG_NAME"));
+    assert_eq!(plan.planner.package_version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(plan.planner.semantics_version, PLANNER_SEMANTICS_VERSION);
+}
+
+#[test]
+fn a_local_artifacts_source_is_the_path_its_inventory_recorded() {
+    let dir = tempfile::tempdir().unwrap();
+    let named = one_glimmer(dir.path());
+    let plan = plan_system(&named);
+    assert_eq!(
+        plan.artifacts[0].source,
+        ArtifactSource::local(named[0].1.path.clone())
+    );
+    assert!(plan.artifacts[0].source.revision.is_none());
+}
+
+#[test]
+fn a_stated_source_carries_its_revision_and_changes_no_verdict() {
+    let dir = tempfile::tempdir().unwrap();
+    let named = one_glimmer(dir.path());
+    let sources = [ArtifactSource {
+        path: "hf://org/model@abc123".to_string(),
+        revision: Some("abc123".to_string()),
+        unpinned_revision: None,
+    }];
+    let plan = plan_system_with_sources(&named, &sources).unwrap();
+    assert_eq!(plan.artifacts[0].source, sources[0]);
+    assert_eq!(plan.summary, plan_system(&named).summary);
+}
+
+#[test]
+fn sources_must_pair_one_to_one_with_artifacts() {
+    let dir = tempfile::tempdir().unwrap();
+    let named = one_glimmer(dir.path());
+    let err = plan_system_with_sources(
+        &named,
+        &[ArtifactSource::local("a"), ArtifactSource::local("b")],
+    )
+    .err()
+    .map(|e| e.to_string())
+    .expect("two sources for one artifact must be refused");
+    assert!(err.contains("1 artifact(s) but 2 source(s)"), "{err}");
+}
+
+#[test]
+fn identity_survives_a_round_trip_and_parse_refuses_other_schemas_by_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_system(&one_glimmer(dir.path()));
+    let json = serde_json::to_string_pretty(&plan).unwrap();
+    let back = SystemPlan::parse(&json).unwrap();
+    assert_eq!(back.planner, plan.planner);
+    assert_eq!(back.artifacts[0].source, plan.artifacts[0].source);
+
+    // A plan written by the previous schema: no planner, schema 3.
+    let mut old: serde_json::Value = serde_json::from_str(&json).unwrap();
+    old["schema"] = serde_json::json!(3);
+    old.as_object_mut().unwrap().remove("planner");
+    let err = SystemPlan::parse(&old.to_string()).unwrap_err().to_string();
+    assert!(err.contains("plan schema 3"), "{err}");
+    assert!(
+        err.contains(&format!("reads plan schema {PLAN_SCHEMA}")),
+        "{err}"
+    );
+
+    old.as_object_mut().unwrap().remove("schema");
+    let err = SystemPlan::parse(&old.to_string()).unwrap_err().to_string();
+    assert!(err.contains("declares no schema"), "{err}");
+
+    let err = SystemPlan::parse("not json").unwrap_err().to_string();
+    assert!(err.contains("not a JSON object"), "{err}");
+}
+
+/// The semantics version is a promise about verdicts. This pins two
+/// verdicts the fixtures are known to give — an admissible one and a
+/// blocked one — beside the version, so a rule change that flips either
+/// fails here until `PLANNER_SEMANTICS_VERSION` is bumped and this
+/// witness is re-recorded.
+#[test]
+fn the_semantics_version_is_pinned_to_known_verdicts() {
+    assert_eq!(PLANNER_SEMANTICS_VERSION, 1);
+
+    let dir = tempfile::tempdir().unwrap();
+    let admissible = plan_system(&one_glimmer(dir.path()));
+    assert!(admissible.admissible, "{:?}", admissible.summary);
+    assert_eq!(admissible.summary.blocking, 0);
+
+    let dir = tempfile::tempdir().unwrap();
+    let inventory = glimmer_shaped_target_with(dir.path(), |config| {
+        config["text_config"]["some_future_field_nobody_reviewed"] = serde_json::json!(1.5);
+    });
+    let blocked = plan_system(&[(ARTIFACT.to_string(), inventory)]);
+    assert!(!blocked.admissible, "{:?}", blocked.summary);
+    assert!(blocked.summary.blocking > 0);
+}
+
+fn pinned(commit: &str) -> ArtifactSource {
+    ArtifactSource {
+        path: format!("hf://org/model@{commit}"),
+        revision: Some(commit.to_string()),
+        unpinned_revision: None,
+    }
+}
+
+fn unpinned(name: &str) -> ArtifactSource {
+    ArtifactSource {
+        path: format!("hf://org/model@{name}"),
+        revision: None,
+        unpinned_revision: Some(name.to_string()),
+    }
+}
+
+#[test]
+fn a_pinned_source_yields_a_cache_key_of_its_commit_and_the_semantics_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let plan = plan_system_with_sources(&one_glimmer(dir.path()), &[pinned("abc123")]).unwrap();
+    assert_eq!(
+        plan.cache_key(),
+        Some(VerdictCacheKey {
+            revisions: vec!["abc123".to_string()],
+            semantics_version: PLANNER_SEMANTICS_VERSION,
+        })
+    );
+}
+
+#[test]
+fn an_unpinned_or_local_source_is_provenance_not_cache_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let named = one_glimmer(dir.path());
+    // A revision NAME can point at different facts tomorrow.
+    let plan = plan_system_with_sources(&named, &[unpinned("main")]).unwrap();
+    assert_eq!(
+        plan.artifacts[0].source.unpinned_revision.as_deref(),
+        Some("main")
+    );
+    assert_eq!(plan.cache_key(), None);
+    // A local path has no revision at all.
+    assert_eq!(plan_system(&named).cache_key(), None);
+}
+
+#[test]
+fn one_unpinned_artifact_makes_the_whole_plan_uncacheable() {
+    let dir_a = tempfile::tempdir().unwrap();
+    let dir_b = tempfile::tempdir().unwrap();
+    let named = vec![
+        ("a".to_string(), glimmer_shaped_target(dir_a.path())),
+        ("b".to_string(), glimmer_shaped_target(dir_b.path())),
+    ];
+    let both = plan_system_with_sources(&named, &[pinned("aaa"), pinned("bbb")]).unwrap();
+    assert_eq!(
+        both.cache_key().map(|k| k.revisions),
+        Some(vec!["aaa".to_string(), "bbb".to_string()])
+    );
+    let mixed = plan_system_with_sources(&named, &[pinned("aaa"), unpinned("main")]).unwrap();
+    assert_eq!(mixed.cache_key(), None);
+}

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/mod.rs
@@ -5,6 +5,7 @@ mod carriage;
 mod compare;
 mod gemma4;
 mod hybrid_linear_attention;
+mod identity;
 mod mla_nope;
 mod moe_spellings;
 mod qw35d_admission;

--- a/crates/vindex-cli/src/lib.rs
+++ b/crates/vindex-cli/src/lib.rs
@@ -27,7 +27,7 @@ use larql_vindex::format::vindex3::opplan::{
     plan_component_ops, ComponentOpPlan, LayerFfn, OperandRef,
 };
 use larql_vindex::format::vindex3::plan::capability::Capability;
-use larql_vindex::format::vindex3::plan::plan_system;
+use larql_vindex::format::vindex3::plan::{plan_system_with_sources, ArtifactSource};
 use larql_vindex::format::vindex3::represent::nvfp4_pack::{split, PackLayout, DTYPE_NVFP4};
 use larql_vindex::format::vindex3::represent::{compile_representation, RepresentSpec};
 
@@ -1048,11 +1048,22 @@ pub fn represent_facts(src: &Path, out: &Path, encoding: &str) -> Facts {
 pub fn plan_facts(artifacts: &[PathBuf]) -> Facts {
     let resolved = artifact::resolve_all(artifacts).map_err(|e| e.to_string())?;
     let staging: Vec<Value> = resolved.iter().filter_map(staging_value).collect();
+    // The verdict names its subject: the argument as given and, for a
+    // repo, the commit the facts were read at.
+    let sources: Vec<ArtifactSource> = artifacts
+        .iter()
+        .zip(&resolved)
+        .map(|(spec, a)| ArtifactSource {
+            path: spec.display().to_string(),
+            revision: a.commit().map(str::to_string),
+            unpinned_revision: a.unpinned_revision().map(str::to_string),
+        })
+        .collect();
     let named: Vec<_> = resolved
         .into_iter()
         .map(|a| (a.name, a.inventory))
         .collect();
-    let plan = plan_system(&named);
+    let plan = plan_system_with_sources(&named, &sources).map_err(|e| e.to_string())?;
     let mut value = serde_json::to_value(&plan).map_err(|e| e.to_string())?;
     if !staging.is_empty() {
         value["staging"] = Value::Array(staging);

--- a/docs/vindex3-format.md
+++ b/docs/vindex3-format.md
@@ -151,9 +151,26 @@ type exists to remove.
 ## 4. G1/G2 — the representability plan
 
 `larql vindex3 plan <artifact>…` → `SystemPlan`
-(`larql-vindex/src/format/vindex3/plan/`), schema `PLAN_SCHEMA = 2`.
-Artifacts are checkpoint dirs and/or saved inventory JSONs, treated as one
-model system. Exit is non-zero when the plan is inadmissible.
+(`larql-vindex/src/format/vindex3/plan/`), schema `PLAN_SCHEMA = 4`.
+Artifacts are checkpoint dirs, saved inventory JSONs and/or `hf://` specs,
+treated as one model system. Exit is non-zero when the plan is
+inadmissible.
+
+Since schema 4 a plan names who judged it and what it judged. `planner`
+carries the planner crate's package version and its *semantics version*
+(`PLANNER_SEMANTICS_VERSION`), which is bumped only when a rule change can
+flip a verdict — a CLI or layout fix never bumps it — so two verdicts are
+comparable exactly when their semantics versions agree. Each artifact
+carries its `source`: the argument as given and, for a repo, the
+immutable commit the facts were read at (`revision`), or the revision
+*name* it fell back to when the hub named no commit (`unpinned_revision`).
+A persisted verdict cache requires an immutable source revision:
+`SystemPlan::cache_key` yields (commits, semantics version) only when every
+artifact carries a commit, and nothing for a local path or an unpinned
+revision — such a verdict may be shown, marked unpinned, and is never
+stored as authority, because a revision name can point at different facts
+tomorrow. `SystemPlan::parse` refuses a plan of another schema by name
+rather than reading it as an unattributed verdict.
 
 Findings are typed twice:
 


### PR DESCRIPTION
## What

Step 2 of the Explorer roadmap: **planner identity**. Plan schema 3 → 4.

- `SystemPlan.planner: PlannerIdentity { package, package_version, semantics_version }` — who judged.
- `ArtifactPlan.source: ArtifactSource { path, revision?, unpinned_revision? }` — what was judged: the argument as given and, for `hf://`, the immutable commit the facts were read at, or the revision *name* it fell back to when the hub named none.
- `PLANNER_SEMANTICS_VERSION` (= 1): bumped **only** when a rule change can flip a verdict (the sliding-window normalisation would have been one); a CLI, wording or layout fix never bumps it. Two verdicts are comparable exactly when it agrees.
- **Cache authority is pinned-only.** A persisted verdict cache requires an immutable source revision: `SystemPlan::cache_key()` is `Some((commits…, semantics_version))` only when *every* artifact carries a commit, and `None` for a local path or an `unpinned_revision`. An unpinned verdict (`hf://org/model@main` when the hub named no commit) may be shown, visibly marked unpinned, and must never be stored as authority — `main` on Monday and `main` on Tuesday can name different facts.
- `plan_system` keeps its signature (local source = the inventory's recorded path); `plan_system_with_sources` states sources and refuses a mismatched pairing. `larql vindex3 plan` and `vindex plan` both pass the resolved commit through.
- `SystemPlan::parse` reads a plan back and refuses another schema **by name** ("plan schema 3; this build reads plan schema 4"), so a pre-identity plan can never be read as an unattributed verdict. `planner` and `source` are deliberately not serde-defaulted.

## Why now

The server's plan-by-source endpoint (step 4) and the Explorer's cache both need to say *which planner* judged *which commit*; a verdict without that is incomplete, and the same planner has already changed a verdict once (6 Qwen3 sizes, 3 → 0 blocking).

## Gates

`plan/tests/identity.rs` (nine): identity equals this build's; a local source is the inventory's path; a stated source carries its revision and changes no verdict; sources pair one-to-one or are refused; round-trip + `parse` refusals by name (schema 3, no schema, not JSON); cache key present for a pinned source, absent for an unpinned one, absent for a local one, absent when any one artifact of several is unpinned; **semantics witness** — an admissible and a blocked fixture verdict pinned beside `PLANNER_SEMANTICS_VERSION`.

Local: fmt; clippy `-D warnings` for larql-vindex (`--all-targets`), vindex-cli, larql-cli (both feature shapes); larql-vindex check in three shapes, full suite + e0 + benches, coverage policy; larql-cli tests both shapes + registry checks; vindex-cli tests + `--locked`; doc gates.

## Witness — `larql vindex3 plan hf://Qwen/Qwen3-0.6B` and `vindex plan --json hf://Qwen/Qwen3-0.6B`

Both front doors, release builds, 11.47 MB staged for a 1.50 GB checkpoint that never touched disk. The identity fragment they wrote, **byte-identical between the two CLIs**:

```text
schema: 4

planner:
  package:           larql-vindex
  package_version:   0.2.0
  semantics_version: 1

artifacts[0].source:
  path:     hf://Qwen/Qwen3-0.6B
  revision: c1899de289a04d12100db370d81485cdf75e47ca

admissible: true   blocking: 0   (40 representable)
capabilities: text_generation: executable, image_conditioned: executable, audio_conditioned: executable, drafting: executable
cache_key: Some(([c1899de289a0…], 1))
```

## Docs

`docs/vindex3-format.md` §4 now describes schema 4 and the semantics-version promise (it still said `PLAN_SCHEMA = 2`).
