### PR TITLE
VINDEX3 front door: execute as declared or refuse truthfully

### DIFF
--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/consequence.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/consequence.rs
@@ -37,7 +37,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use clap::Args;
-use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_inference::vindex3::{open_component, OpenPolicy, OpenedComponent};
 use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
 use larql_vindex::format::vindex3::opplan::OperandRef;
 use larql_vindex::format::vindex3::represent::policy::{classify_in, Role};
@@ -179,7 +179,21 @@ pub fn run(args: ConsequenceArgs) -> Result<(), Box<dyn std::error::Error>> {
         .into());
     }
 
-    let inspection = inspect_container(&args.container, false)?;
+    // The opener is the one authority on inspect → plan → open; the
+    // provenance checks below read the inspection it judged.
+    let OpenedComponent {
+        inspection,
+        store,
+        plan,
+        ..
+    } = open_component(
+        &args.container,
+        "target",
+        OpenPolicy {
+            want: None,
+            source: RepresentationSource::Transient,
+        },
+    )?;
     if inspection.index.model != moments.container.model {
         return Err(format!(
             "REFUSED: container is not the one the moments were captured from.\n  \
@@ -216,18 +230,6 @@ pub fn run(args: ConsequenceArgs) -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // ---- the operands --------------------------------------------------
-    let store = OperandStore::open_for(
-        &args.container,
-        &inspection,
-        None,
-        RepresentationSource::Transient,
-    )?;
-    let outcome = larql_vindex::format::vindex3::opplan::plan_component_ops(
-        &inspection,
-        &args.container,
-        "target",
-    )?;
-    let plan = outcome.plan.ok_or("component produced no plan")?;
     let activation = ffn_activation(&plan)?;
     println!("ffn activation {activation:?}  (from the plan the executor runs)");
 

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/sensitivity.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/sensitivity.rs
@@ -31,8 +31,8 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use larql_vindex::format::vindex3::inspect::inspect_container;
-use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
+use larql_inference::vindex3::{open_component, OpenPolicy, OpenedComponent};
+use larql_vindex::format::vindex3::opplan::exec::operands::RepresentationSource;
 use larql_vindex::format::vindex3::opplan::OperandRef;
 use larql_vindex::format::vindex3::represent::policy::{classify_in, Role};
 
@@ -88,14 +88,18 @@ pub fn run(args: SensitivityArgs) -> Result<(), Box<dyn std::error::Error>> {
     use larql_models::quant::nvfp4::{round_trip, NVFP4_GROUP_ELEMS};
     use larql_vindex::format::vindex3::represent::nvfp4_pack::PackLayout;
 
-    let inspection = inspect_container(&args.container, false)?;
     // Canonical bytes: the screen scores what quantisation would do to the
-    // source, so it must read the source.
-    let store = OperandStore::open_for(
+    // source, so it must read the source. The opener is the one authority
+    // on inspect → plan → open, and refuses an unclosed program.
+    let OpenedComponent {
+        inspection, store, ..
+    } = open_component(
         &args.container,
-        &inspection,
-        None,
-        RepresentationSource::Transient,
+        "target",
+        OpenPolicy {
+            want: None,
+            source: RepresentationSource::Transient,
+        },
     )?;
 
     let text: std::collections::BTreeSet<&str> = inspection
@@ -347,20 +351,22 @@ fn capture_moments(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use larql_vindex::format::vindex3::opplan::exec::decode::DecodeSession;
     use larql_vindex::format::vindex3::opplan::exec::kv::RowKvState;
-    use larql_vindex::format::vindex3::opplan::plan_component_ops;
-
     let out = args
         .moments
         .clone()
         .ok_or("--calibration requires --moments")?;
-    let inspection = inspect_container(&args.container, false)?;
-    let outcome = plan_component_ops(&inspection, &args.container, "target")?;
-    let plan = outcome.plan.ok_or("component produced no plan")?;
-    let store = OperandStore::open_for(
+    let OpenedComponent {
+        inspection,
+        plan,
+        store,
+        ..
+    } = open_component(
         &args.container,
-        &inspection,
-        None,
-        RepresentationSource::Transient,
+        "target",
+        OpenPolicy {
+            want: None,
+            source: RepresentationSource::Transient,
+        },
     )?;
 
     let text = std::fs::read_to_string(calibration)?;

--- a/crates/larql-inference/src/vindex3/runtime.rs
+++ b/crates/larql-inference/src/vindex3/runtime.rs
@@ -11,7 +11,7 @@
 
 use std::path::Path;
 
-use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::inspect::{inspect_container, SystemInspection};
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
 use larql_vindex::format::vindex3::opplan::exec::kv::KvState;
 use larql_vindex::format::vindex3::opplan::exec::operands::{
@@ -47,6 +47,11 @@ pub struct OpenPolicy {
 /// store, the two identities the container declares about itself, and
 /// the encoding the store was asked for.
 pub struct OpenedComponent {
+    /// The inspection the plan and store were built from — the
+    /// container's own directory, graph and index facts — so a caller
+    /// that needs them (provenance checks, representation listings)
+    /// reads the same inspection the opener judged, not a second one.
+    pub inspection: SystemInspection,
     pub plan: ComponentOpPlan,
     pub store: OperandStore,
     /// The container's self-declared model name (`index.model`) — the
@@ -97,6 +102,7 @@ pub fn open_component(
         model_name: inspection.index.model.clone(),
         family: inspection.index.family.clone(),
         want: policy.want,
+        inspection,
     })
 }
 
@@ -155,6 +161,7 @@ impl<B: PlanBackend> Vindex3Runtime<B> {
             model_name,
             family,
             want: _,
+            inspection: _,
         } = open_component(container, component, policy)?;
         Ok(Self {
             plan,

--- a/crates/larql-server/src/error.rs
+++ b/crates/larql-server/src/error.rs
@@ -47,6 +47,31 @@ pub enum ServerError {
     /// no longer holds up the HTTP handler or the next request.
     #[error("inference timed out: {0}")]
     Timeout(String),
+
+    /// The request names a model that IS bound, but the capability
+    /// behind this route is not served for that model's generation —
+    /// today, a VINDEX2-only route asked to act on a VINDEX3
+    /// container. Distinct from `NotFound`: a loaded-but-unsupported
+    /// model must never masquerade as absent, so this is `501 Not
+    /// Implemented` with the generation named, never a 404.
+    #[error("not supported: {0}")]
+    Unsupported(String),
+}
+
+impl ServerError {
+    /// The message without the variant prefix — for surfaces that carry
+    /// their own status vocabulary (WebSocket error frames, gRPC).
+    pub fn message(&self) -> &str {
+        match self {
+            ServerError::NotFound(m)
+            | ServerError::BadRequest(m)
+            | ServerError::Conflict(m)
+            | ServerError::InferenceUnavailable(m)
+            | ServerError::Internal(m)
+            | ServerError::Timeout(m)
+            | ServerError::Unsupported(m) => m,
+        }
+    }
 }
 
 impl IntoResponse for ServerError {
@@ -60,8 +85,57 @@ impl IntoResponse for ServerError {
             }
             ServerError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
             ServerError::Timeout(msg) => (StatusCode::GATEWAY_TIMEOUT, msg.clone()),
+            ServerError::Unsupported(msg) => (StatusCode::NOT_IMPLEMENTED, msg.clone()),
         };
 
         (status, axum::Json(ErrorBody { error: message })).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn every_variant() -> Vec<ServerError> {
+        vec![
+            ServerError::NotFound("nf".into()),
+            ServerError::BadRequest("br".into()),
+            ServerError::Conflict("cf".into()),
+            ServerError::InferenceUnavailable("iu".into()),
+            ServerError::Internal("in".into()),
+            ServerError::Timeout("to".into()),
+            ServerError::Unsupported("un".into()),
+        ]
+    }
+
+    /// `message()` is the bare text every variant carries, for the
+    /// surfaces that speak their own status vocabulary.
+    #[test]
+    fn message_is_the_inner_text_of_every_variant() {
+        let expected = ["nf", "br", "cf", "iu", "in", "to", "un"];
+        for (err, want) in every_variant().into_iter().zip(expected) {
+            assert_eq!(err.message(), want, "{err}");
+            assert!(err.to_string().ends_with(want), "{err}");
+        }
+    }
+
+    /// Each variant maps to exactly one status; `Unsupported` is 501, the
+    /// code that says "bound, but not this operation" — never 404.
+    #[test]
+    fn each_variant_maps_to_its_status() {
+        let expected = [
+            StatusCode::NOT_FOUND,
+            StatusCode::BAD_REQUEST,
+            StatusCode::CONFLICT,
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::GATEWAY_TIMEOUT,
+            StatusCode::NOT_IMPLEMENTED,
+        ];
+        for (err, want) in every_variant().into_iter().zip(expected) {
+            let text = err.message().to_string();
+            let response = err.into_response();
+            assert_eq!(response.status(), want, "{text}");
+        }
     }
 }

--- a/crates/larql-server/src/grpc.rs
+++ b/crates/larql-server/src/grpc.rs
@@ -21,6 +21,19 @@ pub struct VindexGrpcService {
     pub state: Arc<AppState>,
 }
 
+impl VindexGrpcService {
+    /// The bound VINDEX2 model, in gRPC's vocabulary: nothing bound is
+    /// `NotFound`, a VINDEX3 container is `Unimplemented` naming the
+    /// generation — never `NotFound`, which would present a bound model
+    /// as absent.
+    fn v2_model(&self) -> Result<Arc<crate::state::LoadedModel>, Status> {
+        self.state.v2_or_unsupported(None).map_err(|e| match e {
+            crate::error::ServerError::Unsupported(msg) => Status::unimplemented(msg),
+            other => Status::not_found(other.message().to_string()),
+        })
+    }
+}
+
 #[tonic::async_trait]
 impl VindexService for VindexGrpcService {
     async fn health(
@@ -45,10 +58,7 @@ impl VindexService for VindexGrpcService {
         _request: Request<StatsRequest>,
     ) -> Result<Response<StatsResponse>, Status> {
         self.state.bump_requests();
-        let model = self
-            .state
-            .model(None)
-            .ok_or_else(|| Status::not_found("no model loaded"))?;
+        let model = self.v2_model()?;
 
         let config = &model.config;
         let total_features: usize = config.layers.iter().map(|l| l.num_features).sum();
@@ -88,10 +98,7 @@ impl VindexService for VindexGrpcService {
     ) -> Result<Response<DescribeResponse>, Status> {
         self.state.bump_requests();
         let req = request.into_inner();
-        let model = self
-            .state
-            .model(None)
-            .ok_or_else(|| Status::not_found("no model loaded"))?;
+        let model = self.v2_model()?;
 
         let result = tokio::task::spawn_blocking(move || grpc_describe(&model, &req))
             .await
@@ -103,10 +110,7 @@ impl VindexService for VindexGrpcService {
     async fn walk(&self, request: Request<WalkRequest>) -> Result<Response<WalkResponse>, Status> {
         self.state.bump_requests();
         let req = request.into_inner();
-        let model = self
-            .state
-            .model(None)
-            .ok_or_else(|| Status::not_found("no model loaded"))?;
+        let model = self.v2_model()?;
 
         let result = tokio::task::spawn_blocking(move || grpc_walk(&model, &req))
             .await
@@ -121,10 +125,7 @@ impl VindexService for VindexGrpcService {
     ) -> Result<Response<SelectResponse>, Status> {
         self.state.bump_requests();
         let req = request.into_inner();
-        let model = self
-            .state
-            .model(None)
-            .ok_or_else(|| Status::not_found("no model loaded"))?;
+        let model = self.v2_model()?;
 
         let result = tokio::task::spawn_blocking(move || grpc_select(&model, &req))
             .await
@@ -139,10 +140,7 @@ impl VindexService for VindexGrpcService {
     ) -> Result<Response<InferResponse>, Status> {
         self.state.bump_requests();
         let req = request.into_inner();
-        let model = self
-            .state
-            .model(None)
-            .ok_or_else(|| Status::not_found("no model loaded"))?;
+        let model = self.v2_model()?;
 
         if model.infer_disabled {
             return Err(Status::unavailable("inference disabled (--no-infer)"));
@@ -160,10 +158,7 @@ impl VindexService for VindexGrpcService {
         _request: Request<RelationsRequest>,
     ) -> Result<Response<RelationsResponse>, Status> {
         self.state.bump_requests();
-        let model = self
-            .state
-            .model(None)
-            .ok_or_else(|| Status::not_found("no model loaded"))?;
+        let model = self.v2_model()?;
 
         let result = tokio::task::spawn_blocking(move || grpc_relations(&model))
             .await
@@ -178,10 +173,7 @@ impl VindexService for VindexGrpcService {
     ) -> Result<Response<WalkFfnResponse>, Status> {
         self.state.bump_requests();
         let req = request.into_inner();
-        let model = self
-            .state
-            .model(None)
-            .ok_or_else(|| Status::not_found("no model loaded"))?;
+        let model = self.v2_model()?;
 
         let result = tokio::task::spawn_blocking(move || grpc_walk_ffn(&model, &req))
             .await
@@ -198,10 +190,7 @@ impl VindexService for VindexGrpcService {
     ) -> Result<Response<Self::StreamDescribeStream>, Status> {
         self.state.bump_requests();
         let req = request.into_inner();
-        let model = self
-            .state
-            .model(None)
-            .ok_or_else(|| Status::not_found("no model loaded"))?;
+        let model = self.v2_model()?;
 
         let (tx, rx) = tokio::sync::mpsc::channel(64);
 

--- a/crates/larql-server/src/routes/embed.rs
+++ b/crates/larql-server/src/routes/embed.rs
@@ -247,11 +247,9 @@ async fn handle_embed_inner(
     body: Body,
 ) -> Response {
     state.bump_requests();
-    let model = match state.model(model_id) {
-        Some(m) => m,
-        None => {
-            return error_response(ServerError::NotFound("model not found".into()));
-        }
+    let model = match state.v2_or_unsupported(model_id) {
+        Ok(m) => m,
+        Err(e) => return error_response(e),
     };
 
     let is_binary = crate::wire::has_content_type(&headers, BINARY_FFN_CONTENT_TYPE);
@@ -372,9 +370,9 @@ async fn handle_logits_inner(
     body: Body,
 ) -> Response {
     state.bump_requests();
-    let model = match state.model(model_id) {
-        Some(m) => m,
-        None => return error_response(ServerError::NotFound("model not found".into())),
+    let model = match state.v2_or_unsupported(model_id) {
+        Ok(m) => m,
+        Err(e) => return error_response(e),
     };
 
     let is_binary = crate::wire::has_content_type(&headers, BINARY_FFN_CONTENT_TYPE);
@@ -653,9 +651,9 @@ fn handle_embed_single_inner(
     headers: axum::http::HeaderMap,
 ) -> Response {
     state.bump_requests();
-    let model = match state.model(model_id) {
-        Some(m) => m,
-        None => return error_response(ServerError::NotFound("model not found".into())),
+    let model = match state.v2_or_unsupported(model_id) {
+        Ok(m) => m,
+        Err(e) => return error_response(e),
     };
 
     let row: Vec<f32> = if let Some(ref store) = model.embed_store {

--- a/crates/larql-server/src/routes/openai/chat/v3.rs
+++ b/crates/larql-server/src/routes/openai/chat/v3.rs
@@ -33,9 +33,9 @@ use crate::routes::openai::prompt::{render, ASSISTANT_ROLE};
 use crate::routes::openai::schema::Schema;
 use crate::routes::openai::token_tap::{EmitFailure, TokenTap};
 use crate::routes::openai::util::{
-    build_sampling_eos, contains_any, error_chunk, join_generation, new_id_suffix, trim_at_stop,
-    unix_now, SamplingParams, FINISH_REASON_LENGTH, FINISH_REASON_STOP, SSE_CHANNEL_DEPTH,
-    SSE_DONE,
+    build_sampling_eos_from, contains_any, error_chunk, join_generation, new_id_suffix,
+    trim_at_stop, unix_now, SamplingParams, FINISH_REASON_LENGTH, FINISH_REASON_STOP,
+    SSE_CHANNEL_DEPTH, SSE_DONE,
 };
 use crate::routes::openai::OpenAIError;
 use crate::vindex3::{generate_v3, generate_v3_constrained, V3Generation, V3Model};
@@ -181,7 +181,7 @@ fn run_v3_chat(
     tally: &mut crate::runtime_stats::GenerationTally,
 ) -> Result<BufferedChat, ServerError> {
     let prompt_ids = encode_chat_prompt(model, messages)?;
-    let (sampling, eos) = build_sampling_eos(sampling_params, stop_strings);
+    let (sampling, eos) = build_sampling_eos_from(model.eos.clone(), sampling_params, stop_strings);
     let generation = generate_maybe_masked(
         model,
         &prompt_ids,
@@ -287,7 +287,8 @@ fn stream_v3_chat(
             return;
         }
 
-        let (sampling, eos) = build_sampling_eos(sampling_params, &stop_strings);
+        let (sampling, eos) =
+            build_sampling_eos_from(model.eos.clone(), sampling_params, &stop_strings);
         // Tools buffer (the tool_calls delta shape only makes sense
         // once the full JSON has parsed); content streams per token.
         let mut tap = if tools_active {

--- a/crates/larql-server/src/routes/openai/error.rs
+++ b/crates/larql-server/src/routes/openai/error.rs
@@ -113,6 +113,19 @@ impl OpenAIError {
         }
     }
 
+    /// A bound model whose generation this route does not serve
+    /// (a VINDEX3 container on a VINDEX2-only capability): `501`, so
+    /// a loaded-but-unsupported model never reads as absent.
+    pub fn not_implemented(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::NOT_IMPLEMENTED,
+            message: message.into(),
+            error_type: "not_implemented_error",
+            param: None,
+            code: None,
+        }
+    }
+
     pub fn conflict(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::CONFLICT,
@@ -133,6 +146,7 @@ impl From<ServerError> for OpenAIError {
             ServerError::Internal(m) => OpenAIError::server_error(m),
             ServerError::Timeout(m) => OpenAIError::timeout(m),
             ServerError::Conflict(m) => OpenAIError::conflict(m),
+            ServerError::Unsupported(m) => OpenAIError::not_implemented(m),
         }
     }
 }

--- a/crates/larql-server/src/routes/openai/responses/engine.rs
+++ b/crates/larql-server/src/routes/openai/responses/engine.rs
@@ -22,7 +22,9 @@ use super::super::chat::ChatMessage;
 use super::super::prompt::{pick_template, render};
 use super::super::schema::Schema;
 use super::super::token_tap::{EmitFailure, TokenTap};
-use super::super::util::{build_sampling_eos, contains_any, trim_at_stop, SamplingParams};
+use super::super::util::{
+    build_sampling_eos, build_sampling_eos_from, contains_any, trim_at_stop, SamplingParams,
+};
 
 /// The resolved runtime binding for one request, cloned out of
 /// `AppState` so generation can move onto a blocking thread.
@@ -213,7 +215,7 @@ fn generate_on_v3(
     let prompt = render(template, messages);
     let prompt_ids = encode(&model.tokenizer, &prompt)?;
 
-    let (sampling, eos) = build_sampling_eos(params, stop_strings);
+    let (sampling, eos) = build_sampling_eos_from(model.eos.clone(), params, stop_strings);
     let mut tap = TokenTap::new(stop_strings, EmitFailure::StopEmitting);
     // The mask pipeline is V2's `build_constrained_mask` verbatim —
     // one grammar implementation, two runtimes.

--- a/crates/larql-server/src/routes/openai/util.rs
+++ b/crates/larql-server/src/routes/openai/util.rs
@@ -164,6 +164,22 @@ pub fn build_sampling_eos(
     params: SamplingParams,
     stop_strings: &[String],
 ) -> (larql_inference::SamplingConfig, larql_inference::EosConfig) {
+    build_sampling_eos_from(larql_inference::EosConfig::builtin(), params, stop_strings)
+}
+
+/// [`build_sampling_eos`] on top of a model's own EOS declaration.
+///
+/// The V2 decode loop re-decodes special tokens and matches their
+/// surface form against the built-in stop strings, so starting from
+/// [`EosConfig::builtin`](larql_inference::EosConfig::builtin) is enough
+/// there. The V3 driver judges EOS on ids only: a V3 route must start
+/// from the ids the container declares ([`V3Model::eos`](crate::vindex3::V3Model::eos))
+/// or every generation runs to `max_tokens`.
+pub fn build_sampling_eos_from(
+    base: larql_inference::EosConfig,
+    params: SamplingParams,
+    stop_strings: &[String],
+) -> (larql_inference::SamplingConfig, larql_inference::EosConfig) {
     let temp = params.temperature.unwrap_or(0.0).max(0.0);
     let mut sampling = if temp > 0.0 {
         larql_inference::SamplingConfig::temperature(temp)
@@ -185,7 +201,7 @@ pub fn build_sampling_eos(
     if let Some(p) = params.presence_penalty {
         sampling = sampling.with_presence_penalty(p.clamp(-2.0, 2.0));
     }
-    let mut eos = larql_inference::EosConfig::builtin();
+    let mut eos = base;
     for s in stop_strings {
         if !s.is_empty() {
             eos = eos.with_stop_string(s.clone());

--- a/crates/larql-server/src/routes/openai/v3_completions.rs
+++ b/crates/larql-server/src/routes/openai/v3_completions.rs
@@ -32,7 +32,7 @@ use super::completions::{
 };
 use super::error::OpenAIError;
 use super::util::{
-    build_sampling_eos, contains_any, error_chunk, join_generation, new_id_suffix, unix_now,
+    build_sampling_eos_from, contains_any, error_chunk, join_generation, new_id_suffix, unix_now,
     FINISH_REASON_LENGTH, FINISH_REASON_STOP, SSE_CHANNEL_DEPTH, SSE_DONE,
 };
 
@@ -119,7 +119,8 @@ fn run_v3_completions_loop(
     let mut completion_tokens_sum = 0;
     for (index, prompt) in prompts.iter().enumerate() {
         let prompt_ids = encode_prompt(model, prompt)?;
-        let (sampling, eos) = build_sampling_eos(sampling_params, stop_strings);
+        let (sampling, eos) =
+            build_sampling_eos_from(model.eos.clone(), sampling_params, stop_strings);
         let generation = generate_v3(model, &prompt_ids, max_tokens, sampling, &eos, |_, _| {})?;
         tally.add_v3(
             generation.prompt_tokens,
@@ -176,7 +177,8 @@ fn stream_v3_completions(
                 return;
             }
         };
-        let (sampling, eos) = build_sampling_eos(sampling_params, &stop_strings);
+        let (sampling, eos) =
+            build_sampling_eos_from(model.eos.clone(), sampling_params, &stop_strings);
 
         let cmpl_id_cb = cmpl_id.clone();
         let model_id_cb = model_id.clone();

--- a/crates/larql-server/src/routes/patches.rs
+++ b/crates/larql-server/src/routes/patches.rs
@@ -234,7 +234,7 @@ async fn list_patches_for_model(
         })));
     }
 
-    let model = state.model(model_id).unwrap();
+    let model = state.v2_or_unsupported(model_id)?;
     let patched = model.patched.read().await;
     let patches: Vec<serde_json::Value> = patched
         .patches

--- a/crates/larql-server/src/routes/shard.rs
+++ b/crates/larql-server/src/routes/shard.rs
@@ -66,9 +66,12 @@ pub async fn handle_shard(
             .into_response();
     }
 
-    let model = match state.model(Some(&model_id)) {
-        Some(m) => m.clone(),
-        None => {
+    let model = match state.v2_or_unsupported(Some(&model_id)) {
+        Ok(m) => m,
+        Err(crate::error::ServerError::Unsupported(msg)) => {
+            return (StatusCode::NOT_IMPLEMENTED, msg).into_response();
+        }
+        Err(_) => {
             return (
                 StatusCode::NOT_FOUND,
                 format!("model '{model_id}' not loaded on this server"),

--- a/crates/larql-server/src/routes/stream.rs
+++ b/crates/larql-server/src/routes/stream.rs
@@ -196,9 +196,9 @@ async fn stream_describe_messages(
         None => return vec![ws_error("missing entity")],
     };
 
-    let model = match state.model(None) {
-        Some(m) => m,
-        None => return vec![ws_error("no model loaded")],
+    let model = match state.v2_or_unsupported(None) {
+        Ok(m) => m,
+        Err(e) => return vec![ws_error(e.message())],
     };
 
     let band = request["band"].as_str().unwrap_or("all");
@@ -300,10 +300,10 @@ async fn handle_stream_infer(
         }
     };
 
-    let model = match state.model(None) {
-        Some(m) => m,
-        None => {
-            send_error(socket, "no model loaded").await;
+    let model = match state.v2_or_unsupported(None) {
+        Ok(m) => m,
+        Err(e) => {
+            send_error(socket, e.message()).await;
             return;
         }
     };
@@ -407,10 +407,10 @@ async fn handle_stream_generate(
         .as_u64()
         .unwrap_or(DEFAULT_STREAM_MAX_TOKENS) as usize;
 
-    let model = match state.model(None) {
-        Some(m) => m,
-        None => {
-            send_error(socket, "no model loaded").await;
+    let model = match state.v2_or_unsupported(None) {
+        Ok(m) => m,
+        Err(e) => {
+            send_error(socket, e.message()).await;
             return;
         }
     };

--- a/crates/larql-server/src/routes/walk_ffn/dispatch.rs
+++ b/crates/larql-server/src/routes/walk_ffn/dispatch.rs
@@ -77,9 +77,7 @@ pub(crate) fn run_walk_ffn(
     state: &AppState,
     req: &WalkFfnRequest,
 ) -> Result<serde_json::Value, ServerError> {
-    let model = state
-        .model(None)
-        .ok_or_else(|| ServerError::NotFound("no model loaded".into()))?;
+    let model = state.v2_or_unsupported(None)?;
 
     let hidden = model.config.hidden_size;
     validate_residual(req, hidden)?;

--- a/crates/larql-server/src/routes/walk_ffn/handler.rs
+++ b/crates/larql-server/src/routes/walk_ffn/handler.rs
@@ -80,9 +80,7 @@ pub async fn handle_walk_ffn(
         let resp_ct = crate::wire::preferred_response_ct(accept.as_deref()).to_owned();
 
         let result = tokio::task::spawn_blocking(move || {
-            let model = state
-                .model(None)
-                .ok_or_else(|| ServerError::NotFound("no model loaded".into()))?;
+            let model = state.v2_or_unsupported(None)?;
             validate_residual(&req, model.config.hidden_size)?;
             let scan_layers = collect_scan_layers(&req)?;
             validate_owned(&model, &scan_layers)?;

--- a/crates/larql-server/src/routes/walk_ffn/q8k.rs
+++ b/crates/larql-server/src/routes/walk_ffn/q8k.rs
@@ -92,9 +92,7 @@ pub async fn handle_walk_ffn_q8k(
         };
         use larql_inference::vindex::{kquant_ffn_forward_layer, kquant_ffn_forward_layer_q8k};
 
-        let model = state
-            .model(None)
-            .ok_or_else(|| crate::error::ServerError::NotFound("no model loaded".into()))?;
+        let model = state.v2_or_unsupported(None)?;
 
         // Require interleaved Q4K to serve this endpoint.
         let has_q4k = {

--- a/crates/larql-server/src/state/model_set.rs
+++ b/crates/larql-server/src/state/model_set.rs
@@ -187,13 +187,33 @@ impl AppState {
         &self,
         id: Option<&str>,
     ) -> Result<Arc<LoadedModel>, crate::error::ServerError> {
-        self.model(id).ok_or_else(|| {
-            let msg = match id {
-                Some(mid) => format!("model '{}' not found", mid),
-                None => "no model loaded".into(),
-            };
-            crate::error::ServerError::NotFound(msg)
-        })
+        self.v2_or_unsupported(id)
+    }
+
+    /// Resolve a request's model for a route that serves VINDEX2 only.
+    ///
+    /// Three answers, and the distinction is the point: nothing bound
+    /// is `NotFound` (404); a VINDEX2 model is the model; a VINDEX3
+    /// container is `Unsupported` (501) naming the generation. The
+    /// third used to fall into the first — `model()` looked only at the
+    /// V2 registry — so a server with one V3 container bound answered
+    /// "no model loaded" on every V2-only route while `GET /v1/models`
+    /// listed it. A loaded-but-unsupported model never masquerades as
+    /// absent. This refuses; it does not make the route serve V3.
+    pub fn v2_or_unsupported(
+        &self,
+        id: Option<&str>,
+    ) -> Result<Arc<LoadedModel>, crate::error::ServerError> {
+        match self.served_or_err(id)? {
+            ServedModel::V2(model) => Ok(model),
+            ServedModel::V3(model) => Err(crate::error::ServerError::Unsupported(format!(
+                "model '{}' is a VINDEX3 container; this operation is served for VINDEX2 \
+                 models only (VINDEX3 is served on /v1/models, /v1/runtime, /v1/stats, \
+                 /v1/completions, /v1/chat/completions, /v1/responses and the \
+                 container-facts routes)",
+                model.id
+            ))),
+        }
     }
 }
 

--- a/crates/larql-server/src/vindex3.rs
+++ b/crates/larql-server/src/vindex3.rs
@@ -66,6 +66,15 @@ pub struct V3Model {
     /// directory basename, so id-substring matching answers "plain" for
     /// any container whose folder is not named after its family.
     pub family: String,
+    /// The end-of-turn tokens the container declares
+    /// (`generation_config.json::eos_token_id`), resolved once at load
+    /// through the same authority the CLI's V3 arm uses. The V3 driver
+    /// judges EOS on ids alone — it has no tokenizer to re-decode a
+    /// special token's surface form the way the V2 loop does — so a
+    /// route that starts from the empty built-in set runs every
+    /// generation to `max_tokens`. Every V3 route builds its request
+    /// EOS on top of this.
+    pub eos: EosConfig,
     /// Count of in-flight generations on this container — the V3
     /// counterpart of `LoadedModel.requests_in_flight`, which V3 had
     /// none of before this (no walk-ffn/grid participation to have
@@ -147,6 +156,7 @@ pub fn load_v3_model(path: &Path) -> Result<V3Model, Box<dyn std::error::Error +
         runtime,
         tokenizer,
         family,
+        eos: EosConfig::from_vindex_dir(path),
         requests_in_flight: Arc::new(AtomicU32::new(0)),
     };
     if matches!(

--- a/crates/larql-server/tests/test_vindex3_serve.rs
+++ b/crates/larql-server/tests/test_vindex3_serve.rs
@@ -624,3 +624,295 @@ fn v3_generation_in_flight_counter_reflects_genuine_concurrency() {
         "the guard must decrement back to 0 once generation returns"
     );
 }
+
+/// Ids named by `[N]` tokens in a synthetic-tokenizer surface string, in
+/// order — the chat route returns text, and on this fixture the text IS
+/// the id sequence.
+fn ids_in_surface(text: &str) -> Vec<u32> {
+    text.split('[')
+        .filter_map(|piece| piece.split(']').next())
+        .filter_map(|n| n.parse().ok())
+        .collect()
+}
+
+/// Encode the fixture and declare `eos_id` as its end-of-turn token in
+/// `generation_config.json`, the file the CLI's V3 arm already reads.
+fn v3_container_declaring_eos(eos_id: u32) -> tempfile::TempDir {
+    let container = v3_container();
+    std::fs::write(
+        container
+            .path()
+            .join(larql_vindex::format::filenames::GENERATION_CONFIG_JSON),
+        serde_json::json!({ "eos_token_id": eos_id }).to_string(),
+    )
+    .unwrap();
+    container
+}
+
+/// **A container's declared end-of-turn token stops served generation.**
+///
+/// The V3 driver judges EOS on ids alone, so the server must hand it the
+/// ids the container declares — an empty built-in set means every V3
+/// completion runs to `max_tokens`. The direct arm says what the fixture
+/// emits for PROMPT; its second id is declared as EOS; the same request
+/// then finishes with `stop` after exactly the tokens before that id,
+/// buffered and streamed, and a chat turn stops the same way. The
+/// identical container without the declaration runs to `length`, which
+/// is the control that the stop came from the declaration.
+#[tokio::test]
+async fn v3_generation_stops_on_the_containers_declared_eos_token() {
+    // Control: no declaration, the budget is filled.
+    let plain = v3_container();
+    let emitted = direct_arm(plain.path(), NEW_TOKENS);
+    let eos_id = emitted[1].0;
+    let expected_len = emitted
+        .iter()
+        .position(|(id, _)| *id == eos_id)
+        .expect("the declared id is one the fixture emits");
+    let expected_text: String = emitted[..expected_len]
+        .iter()
+        .map(|(_, t)| t.as_str())
+        .collect();
+    let plain_app = larql_server::routes::single_model_router(v3_state(plain.path()));
+    let resp = common::post_json(
+        plain_app.clone(),
+        "/v1/completions",
+        serde_json::json!({"prompt": PROMPT, "max_tokens": NEW_TOKENS}),
+    )
+    .await;
+    let json = common::body_json(resp.into_body()).await;
+    assert_eq!(
+        json["choices"][0]["finish_reason"], "length",
+        "control: {json}"
+    );
+    assert_eq!(
+        json["usage"]["completion_tokens"], NEW_TOKENS,
+        "control: {json}"
+    );
+    let plain_chat = common::post_json(
+        plain_app,
+        "/v1/chat/completions",
+        serde_json::json!({
+            "messages": [{"role": "user", "content": "[1]"}],
+            "max_tokens": NEW_TOKENS,
+        }),
+    )
+    .await;
+    let plain_chat = common::body_json(plain_chat.into_body()).await;
+    assert_eq!(
+        plain_chat["choices"][0]["finish_reason"], "length",
+        "control: {plain_chat}"
+    );
+    let chat_ids = ids_in_surface(
+        plain_chat["choices"][0]["message"]["content"]
+            .as_str()
+            .unwrap(),
+    );
+    assert!(
+        chat_ids.len() >= 2,
+        "control: the chat turn must emit ids: {plain_chat}"
+    );
+    let chat_eos_id = chat_ids[1];
+    let chat_expected_len = chat_ids.iter().position(|&id| id == chat_eos_id).unwrap();
+
+    // Declared: the same fixture with `generation_config.json`.
+    let container = v3_container_declaring_eos(eos_id);
+    let app = larql_server::routes::single_model_router(v3_state(container.path()));
+
+    let resp = common::post_json(
+        app.clone(),
+        "/v1/completions",
+        serde_json::json!({"prompt": PROMPT, "max_tokens": NEW_TOKENS}),
+    )
+    .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let json = common::body_json(resp.into_body()).await;
+    assert_eq!(
+        json["choices"][0]["finish_reason"], "stop",
+        "buffered: {json}"
+    );
+    assert_eq!(
+        json["usage"]["completion_tokens"], expected_len,
+        "buffered: {json}"
+    );
+    assert_eq!(
+        json["choices"][0]["text"],
+        expected_text.as_str(),
+        "buffered: {json}"
+    );
+
+    let resp = common::post_json(
+        app.clone(),
+        "/v1/completions",
+        serde_json::json!({"prompt": PROMPT, "max_tokens": NEW_TOKENS, "stream": true}),
+    )
+    .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let chunks = sse_chunks(core::str::from_utf8(&bytes).unwrap());
+    assert_eq!(
+        chunks.len(),
+        expected_len + 1,
+        "streamed: one chunk per kept token plus the stop"
+    );
+    assert_eq!(
+        chunks[expected_len]["choices"][0]["finish_reason"], "stop",
+        "streamed: {chunks:?}"
+    );
+
+    // Chat: its own prompt, its own sequence, the same stop.
+    let chat_container = v3_container_declaring_eos(chat_eos_id);
+    let chat_app = larql_server::routes::single_model_router(v3_state(chat_container.path()));
+    let resp = common::post_json(
+        chat_app,
+        "/v1/chat/completions",
+        serde_json::json!({
+            "messages": [{"role": "user", "content": "[1]"}],
+            "max_tokens": NEW_TOKENS,
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let json = common::body_json(resp.into_body()).await;
+    assert_eq!(json["choices"][0]["finish_reason"], "stop", "chat: {json}");
+    assert_eq!(
+        json["usage"]["completion_tokens"], chat_expected_len,
+        "chat: {json}"
+    );
+    assert_eq!(
+        ids_in_surface(json["choices"][0]["message"]["content"].as_str().unwrap()),
+        chat_ids[..chat_expected_len],
+        "chat: {json}"
+    );
+}
+
+/// An `AppState` with nothing bound: the control for "absent".
+fn empty_state() -> Arc<AppState> {
+    let state = v3_state(v3_container().path());
+    state
+        .model_set
+        .write()
+        .unwrap_or_else(|p| p.into_inner())
+        .v3_models
+        .clear();
+    state
+}
+
+/// **A loaded-but-unsupported model never masquerades as absent.**
+///
+/// The V2-only surfaces resolve a VINDEX2 model; on a server that has
+/// only a VINDEX3 container bound they used to answer 404 "no model
+/// loaded" while `/v1/models` listed the container. The rule is three-
+/// way: no model is 404, a V2 model takes the route, and a V3 model on
+/// a V2-only capability is 501 naming VINDEX3 — a truthful refusal, not
+/// V3 support, which those routes do not have.
+#[tokio::test]
+async fn v2_only_surfaces_refuse_a_v3_container_as_unsupported_not_absent() {
+    let container = v3_container();
+    let state = v3_state(container.path());
+    let app = larql_server::routes::single_model_router(state.clone());
+
+    let gets = [
+        "/v1/describe?entity=%5B1%5D",
+        "/v1/relations",
+        "/v1/patches",
+        "/v1/walk?prompt=%5B1%5D&top=1",
+    ];
+    for path in gets {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(path)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let json = common::body_json(resp.into_body()).await;
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{path}: {json}");
+        let error = json["error"].as_str().unwrap_or_default().to_string();
+        assert!(
+            error.contains("VINDEX3"),
+            "{path}: refusal must name VINDEX3: {json}"
+        );
+        assert!(
+            !error.contains("not found"),
+            "{path}: a bound model is not absent: {json}"
+        );
+    }
+    let resp = common::post_json(
+        app.clone(),
+        "/v1/infer",
+        serde_json::json!({"prompt": "[1]"}),
+    )
+    .await;
+    let status = resp.status();
+    let json = common::body_json(resp.into_body()).await;
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "/v1/infer: {json}");
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("VINDEX3"),
+        "{json}"
+    );
+
+    // An OpenAI-shaped V2-only route answers in the OpenAI envelope.
+    let resp = common::post_json(
+        app.clone(),
+        "/v1/embeddings",
+        serde_json::json!({"input": "[1]"}),
+    )
+    .await;
+    let status = resp.status();
+    let json = common::body_json(resp.into_body()).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_IMPLEMENTED,
+        "/v1/embeddings: {json}"
+    );
+    assert_eq!(json["error"]["type"], "not_implemented_error", "{json}");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("VINDEX3"),
+        "{json}"
+    );
+
+    // gRPC: the same rule, in gRPC's vocabulary.
+    use larql_server::grpc::proto::vindex_service_server::VindexService;
+    let svc = larql_server::grpc::VindexGrpcService {
+        state: state.clone(),
+    };
+    let err = svc
+        .get_stats(tonic::Request::new(
+            larql_server::grpc::proto::StatsRequest {},
+        ))
+        .await
+        .expect_err("a V3-only server refuses the V2 gRPC surface");
+    assert_eq!(err.code(), tonic::Code::Unimplemented, "{err}");
+    assert!(err.message().contains("VINDEX3"), "{err}");
+
+    // Control: nothing bound is still "absent".
+    let empty = larql_server::routes::single_model_router(empty_state());
+    let resp = empty
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/describe?entity=%5B1%5D")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let json = common::body_json(resp.into_body()).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "control: {json}");
+    assert_eq!(json["error"], "no model loaded", "control: {json}");
+}

--- a/crates/larql-vindex/src/format/vindex3/inspect.rs
+++ b/crates/larql-vindex/src/format/vindex3/inspect.rs
@@ -17,6 +17,7 @@ use super::graph::{SystemGraph, GRAPH_SCHEMA};
 use super::index::Vindex3Index;
 use crate::error::VindexError;
 use crate::format::filenames::INDEX_JSON;
+use crate::format::generation::{detect_generation, ContainerGeneration};
 
 /// A structural problem found while inspecting a container.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -103,6 +104,22 @@ pub fn inspect_container(
     root: &Path,
     verify_payloads: bool,
 ) -> Result<SystemInspection, VindexError> {
+    // The generation before any other byte. `index.json`'s `version` is
+    // the sole schema discriminator, and this is the opening step for
+    // every graph-path consumer (`vindex3 exec`, the runtime opener,
+    // represent, compile, the download validator), so an old VINDEX2
+    // directory, a future schema this build does not read, or an index
+    // with no version at all must be refused here by name — not parsed
+    // as if it were current and reported as a defect in something else.
+    match detect_generation(root)? {
+        ContainerGeneration::V3 => {}
+        ContainerGeneration::V2 => {
+            return Err(VindexError::WrongContainerGeneration {
+                found: "VINDEX2",
+                required: "VINDEX3",
+            })
+        }
+    }
     let index: Vindex3Index = serde_json::from_str(
         &std::fs::read_to_string(root.join(INDEX_JSON))
             .map_err(|e| VindexError::Parse(format!("read {INDEX_JSON}: {e}")))?,
@@ -251,3 +268,6 @@ fn verify_segment_hash(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/inspect/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/inspect/tests.rs
@@ -1,0 +1,89 @@
+//! The generation gate on the inspect path.
+//!
+//! `inspect_container` is the opening step for every graph-path consumer,
+//! so it must refuse by name before reading any other byte: a VINDEX2
+//! directory, a schema this build does not read, and an index with no
+//! version at all are three different refusals, and none of them may be
+//! reported as a parse error in something else.
+
+use super::*;
+use crate::format::generation::{V2_CURRENT_SCHEMA, V3_CURRENT_SCHEMA};
+use crate::format::vindex3::fixtures::{encode_fixture_container, miniature_glimmer};
+
+fn fixture() -> tempfile::TempDir {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(
+        miniature_glimmer,
+        checkpoint.path(),
+        container.path(),
+        "inspect-fixture",
+    );
+    container
+}
+
+fn rewrite_version(root: &Path, version: Option<u64>) {
+    let path = root.join(INDEX_JSON);
+    let mut index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    match version {
+        Some(v) => {
+            index["version"] = serde_json::json!(v);
+        }
+        None => {
+            index.as_object_mut().unwrap().remove("version");
+        }
+    }
+    std::fs::write(&path, serde_json::to_string_pretty(&index).unwrap()).unwrap();
+}
+
+#[test]
+fn the_current_schema_inspects() {
+    let container = fixture();
+    let inspection = inspect_container(container.path(), false).expect("current schema inspects");
+    assert!(inspection.defects.is_empty(), "{:?}", inspection.defects);
+}
+
+#[test]
+fn a_future_schema_is_refused_by_version_before_anything_else_is_read() {
+    let container = fixture();
+    let future = u64::from(V3_CURRENT_SCHEMA) + 1;
+    rewrite_version(container.path(), Some(future));
+    let err = inspect_container(container.path(), false).expect_err("a future schema must refuse");
+    assert!(
+        matches!(&err, VindexError::UnknownContainerGeneration { found, .. } if u64::from(*found) == future),
+        "refusal must name the version it found: {err}"
+    );
+    assert!(err.to_string().contains(&future.to_string()), "{err}");
+}
+
+#[test]
+fn a_vindex2_index_is_refused_as_the_wrong_generation() {
+    let container = fixture();
+    rewrite_version(container.path(), Some(u64::from(V2_CURRENT_SCHEMA)));
+    let err = inspect_container(container.path(), false).expect_err("a VINDEX2 index must refuse");
+    assert!(
+        matches!(
+            &err,
+            VindexError::WrongContainerGeneration {
+                found: "VINDEX2",
+                required: "VINDEX3"
+            }
+        ),
+        "{err}"
+    );
+}
+
+#[test]
+fn an_index_with_no_version_is_refused_not_assumed_current() {
+    let container = fixture();
+    rewrite_version(container.path(), None);
+    let err = inspect_container(container.path(), false).expect_err("no version, no inspection");
+    assert!(
+        matches!(
+            &err,
+            VindexError::UnknownContainerGeneration { found: 0, .. }
+        ),
+        "{err}"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/build.rs
@@ -29,10 +29,10 @@ use super::super::graph::surface::MoeSurface;
 use super::super::graph::{LogicalObject, NormPlacement, ObjectKind, OperandRole};
 use super::super::inspect::SystemInspection;
 use super::{
-    AttentionOp, ClosureDefect, ComponentOpPlan, EmbeddingOp, ExpertBank, FfnOp, GateOp,
-    GatedDeltaOp, HybridFfnOp, KdaOp, LayerAttention, LayerFfn, LayerPlan, Mamba2Op, MlaOp, NormOp,
-    OpPlanOutcome, OperandRef, OutputOp, PackedProjection, QkNormOp, RoutedFfnOp, SharedExpertOp,
-    SinkOp,
+    AttentionOp, ClosureDefect, ComponentOpPlan, EmbeddingOp, ExpertBank, FfnIdentity, FfnOp,
+    GateOp, GatedDeltaOp, HybridFfnOp, KdaOp, LayerAttention, LayerFfn, LayerPlan, Mamba2Op, MlaOp,
+    NormOp, OpPlanOutcome, OperandRef, OutputOp, PackedProjection, QkNormOp, RoutedFfnOp,
+    SharedExpertOp, SinkOp,
 };
 use crate::error::VindexError;
 use larql_models::config::ExpertFormat;
@@ -50,6 +50,15 @@ const GATE_UP_LAYOUT_FACT: &str = "gate_up branch layout";
 /// Build the operation plan for `component_id` from a container's
 /// inspection plus its segment tables. I/O failures are hard errors;
 /// every semantic shortfall is a [`ClosureDefect`].
+/// Whether the surface declares `layer` routed: `None` when the surface
+/// carries no MoE judgment at all, `Some(false)` inside the dense prefix
+/// the surface names (`dense_prefix_layers`), `Some(true)` otherwise.
+/// The one derivation both the closure pass and the plan construction
+/// read, so they cannot disagree about which layers are routed.
+fn declared_routed(moe: Option<&MoeSurface>, layer: usize) -> Option<bool> {
+    moe.map(|m| m.dense_prefix_layers.is_none_or(|prefix| layer >= prefix))
+}
+
 pub fn plan_component_ops(
     inspection: &SystemInspection,
     root: &Path,
@@ -302,13 +311,41 @@ pub fn plan_component_ops(
             let geometry = layer_geometry(layer);
             let present = by_layer.get(&layer);
             let bank = bank_by_layer.get(&layer);
-            // A layer is routed by operand evidence — it has an expert
-            // bank or a router — under the surface's judgment; the
-            // judgment alone routes nothing, the evidence alone is a
-            // stray operand (`absent_op` names it).
-            let routed = ffn_moe.is_some()
-                && (bank.is_some()
-                    || present.is_some_and(|s| s.contains_key(&OperandRole::MoeRouterWeight)));
+            // Which layers are routed is DECLARED by the surface: every
+            // layer of a MoE surface, less the dense prefix it names
+            // (`dense_prefix_layers`, Kimi's 1, GLM-5.3-Flash's 3). The
+            // expert bank and router operands are evidence that the
+            // declaration is honoured. They never decide: a routed layer
+            // whose bank is missing is a defect, not a dense layer, and a
+            // dense-prefix layer carrying routed operands is the same
+            // disagreement the other way. A surface with no MoE judgment
+            // routes nothing; its stray operands are `absent_op`'s to
+            // name.
+            let evidence_routed = bank.is_some()
+                || present.is_some_and(|s| s.contains_key(&OperandRole::MoeRouterWeight));
+            let routed = match declared_routed(ffn_moe.as_ref(), layer) {
+                Some(true) => {
+                    if !evidence_routed {
+                        defects.push(ClosureDefect::FfnIdentityMismatch {
+                            layer,
+                            declared: FfnIdentity::Routed,
+                            evidence: FfnIdentity::Dense,
+                        });
+                    }
+                    true
+                }
+                Some(false) => {
+                    if evidence_routed {
+                        defects.push(ClosureDefect::FfnIdentityMismatch {
+                            layer,
+                            declared: FfnIdentity::Dense,
+                            evidence: FfnIdentity::Routed,
+                        });
+                    }
+                    false
+                }
+                None => false,
+            };
             // A hybrid layer is routed AND dense: the judgment says the
             // family runs both, and the evidence is the routed evidence.
             let hybrid = routed && ffn_moe.is_some_and(|m| m.hybrid);
@@ -642,7 +679,11 @@ pub fn plan_component_ops(
             down: operand(&stack_id, get(OperandRole::FfnDown)),
         };
         let ffn = match (ffn_moe, bank_slot) {
-            (Some(moe), Some(bank)) => {
+            // A declared-dense prefix layer plans dense even if stray bank
+            // tensors exist (the mismatch defect above already refuses
+            // the plan); a declared-routed layer with no bank plans dense
+            // only as a placeholder behind its own defect.
+            (Some(moe), Some(bank)) if declared_routed(ffn_moe.as_ref(), layer) == Some(true) => {
                 let bank_operand = |role: OperandRole| operand(&bank_id, &bank[&role]);
                 let optional = |role: OperandRole| bank.get(&role).map(|t| operand(&bank_id, t));
                 let gemma4_router = moe.router_kind == MoeRouterKind::Gemma4Hybrid;

--- a/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
@@ -586,6 +586,25 @@ pub struct ComponentOpPlan {
     pub output: Option<OutputOp>,
 }
 
+/// Which FFN a layer runs, as a declaration or as operand evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum FfnIdentity {
+    /// A dense MLP.
+    Dense,
+    /// A routed expert block (routed alone, or routed-plus-dense hybrid).
+    Routed,
+}
+
+impl FfnIdentity {
+    /// Lower-case name for messages.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Dense => "dense",
+            Self::Routed => "routed",
+        }
+    }
+}
+
 /// Why a plan could not be built — each variant names the exact operand
 /// or fact, so a refusal is a work item, not a mystery.
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -612,6 +631,20 @@ pub enum ClosureDefect {
     },
     /// An op the surface/placement implies has no operand.
     MissingOperand { layer: usize, role: OperandRole },
+    /// The declared FFN schedule and the operand evidence disagree for a
+    /// layer. The surface declares which layers are routed
+    /// (`dense_prefix_layers`, else every layer of a MoE surface); the
+    /// expert bank and router operands are evidence that the declaration
+    /// is honoured, never the authority. A routed layer whose bank is
+    /// absent used to plan as dense with no defect — a missing expert
+    /// bank must not quietly turn a MoE layer into an MLP — and a
+    /// declared-dense prefix layer with routed operands is the same
+    /// disagreement the other way round.
+    FfnIdentityMismatch {
+        layer: usize,
+        declared: FfnIdentity,
+        evidence: FfnIdentity,
+    },
     /// Two tensors classified into the same role of the same layer.
     DuplicateOperand { layer: usize, role: OperandRole },
     /// An operand's stored shape contradicts the surface's geometry.
@@ -650,6 +683,18 @@ impl std::fmt::Display for ClosureDefect {
             Self::UnclassifiedOperand { object, tensor } => {
                 write!(f, "unclassified executable operand: {object}/{tensor}")
             }
+            Self::FfnIdentityMismatch {
+                layer,
+                declared,
+                evidence,
+            } => write!(
+                f,
+                "layer {layer}: the surface declares a {} FFN but the operands are those of a {} \
+                 one — a missing expert bank does not make a routed layer dense, and stray \
+                 routed operands do not make a dense-prefix layer routed",
+                declared.name(),
+                evidence.name()
+            ),
             Self::MisplacedOperand {
                 object,
                 tensor,

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/kimi_moe_closure.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/kimi_moe_closure.rs
@@ -13,7 +13,7 @@ use crate::format::vindex3::encode::encode_system_unenforced as encode_system;
 use crate::format::vindex3::graph::{ObjectKind, OperandRole};
 use crate::format::vindex3::inspect::inspect_container;
 use crate::format::vindex3::opplan::{
-    plan_component_ops, ClosureDefect, ExpertBank, LayerFfn, OpPlanOutcome,
+    plan_component_ops, ClosureDefect, ExpertBank, FfnIdentity, LayerFfn, OpPlanOutcome,
 };
 use crate::format::vindex3::plan::tests_support::custom_artifact;
 
@@ -138,6 +138,15 @@ fn kimi_tensors() -> Vec<(String, Vec<usize>)> {
 
 /// Encode a Kimi-shaped variant and plan its target component.
 fn plan_variant(mutate: impl FnOnce(&mut Vec<(String, Vec<usize>)>)) -> OpPlanOutcome {
+    plan_variant_with(kimi_config(), mutate)
+}
+
+/// [`plan_variant`] under a different declaration — the dense-prefix
+/// tests change what the config SAYS, not only what the estate holds.
+fn plan_variant_with(
+    config: serde_json::Value,
+    mutate: impl FnOnce(&mut Vec<(String, Vec<usize>)>),
+) -> OpPlanOutcome {
     let dir = tempfile::tempdir().unwrap();
     let mut tensors = kimi_tensors();
     mutate(&mut tensors);
@@ -145,7 +154,7 @@ fn plan_variant(mutate: impl FnOnce(&mut Vec<(String, Vec<usize>)>)) -> OpPlanOu
         .iter()
         .map(|(name, shape)| (name.as_str(), shape.as_slice()))
         .collect();
-    let inventory = custom_artifact(dir.path(), &kimi_config(), &borrowed);
+    let inventory = custom_artifact(dir.path(), &config, &borrowed);
     let named = vec![("kimi-artifact".to_string(), inventory)];
     let out = tempfile::tempdir().unwrap();
     encode_system(&named, out.path()).unwrap();
@@ -388,4 +397,134 @@ fn carving_places_every_expert_tensor_in_the_bank_object_and_nothing_else() {
             binding.tensor_prefix
         );
     }
+}
+
+// ── The dense prefix is declared, not inferred ────────────────────────
+//
+// `first_k_dense_replace` is the surface's schedule (`dense_prefix_layers`).
+// Closure used to route a layer by operand evidence alone, so a routed
+// layer whose expert bank was missing quietly planned as dense. The
+// declaration is now the authority and the operands are evidence that it
+// is honoured; disagreement in either direction is a defect, not a
+// different plan.
+
+/// Kimi's own config with a one-layer dense prefix.
+fn dense_prefix_config(prefix: usize) -> serde_json::Value {
+    let mut config = kimi_config();
+    config["first_k_dense_replace"] = serde_json::json!(prefix);
+    config
+}
+
+/// Replace layer 0's routed block with the dense MLP a Kimi dense-prefix
+/// layer carries.
+fn make_layer_0_dense(tensors: &mut Vec<(String, Vec<usize>)>) {
+    tensors.retain(|(name, _)| {
+        !(name.starts_with("model.layers.0.") && name.contains("block_sparse_moe"))
+    });
+    let inter = HIDDEN * 4;
+    tensors.push((
+        "model.layers.0.mlp.gate_proj.weight".to_string(),
+        vec![inter, HIDDEN],
+    ));
+    tensors.push((
+        "model.layers.0.mlp.up_proj.weight".to_string(),
+        vec![inter, HIDDEN],
+    ));
+    tensors.push((
+        "model.layers.0.mlp.down_proj.weight".to_string(),
+        vec![HIDDEN, inter],
+    ));
+}
+
+fn identity_defect(layer: usize, declared: FfnIdentity, evidence: FfnIdentity) -> ClosureDefect {
+    ClosureDefect::FfnIdentityMismatch {
+        layer,
+        declared,
+        evidence,
+    }
+}
+
+/// A declared dense-prefix layer plans dense, and the layers after it
+/// keep their routed plan: the declaration is valid as dense when the
+/// estate agrees with it.
+///
+/// Three layers, not the fixture's two: with a single routed layer the
+/// encoder names the bank's tensors relative to that one layer's prefix
+/// and the layer segment vanishes from the name (`0.w1.weight`), which
+/// closure then cannot place — an encoder naming artefact of a one-layer
+/// bank, not a closure fact, and outside this test's claim.
+#[test]
+fn a_declared_dense_prefix_layer_plans_dense_and_the_rest_routed() {
+    const THREE: usize = 3;
+    let mut config = dense_prefix_config(1);
+    config["num_hidden_layers"] = serde_json::json!(THREE);
+    config["linear_attn_config"]["full_attn_layers"] =
+        serde_json::json!((1..=THREE).collect::<Vec<_>>());
+    let outcome = plan_variant_with(config, |tensors| {
+        tensors.extend(kimi_layer_tensors(2));
+        make_layer_0_dense(tensors);
+    });
+    assert!(outcome.closed(), "{:?}", outcome.defects);
+    let plan = outcome.plan.unwrap();
+    assert_eq!(plan.layers.len(), THREE);
+    assert!(
+        matches!(plan.layers[0].ffn, Some(LayerFfn::Dense(_))),
+        "layer 0 is the declared dense prefix"
+    );
+    for layer in &plan.layers[1..] {
+        assert!(
+            matches!(layer.ffn, Some(LayerFfn::Routed(_))),
+            "layer {} is routed by declaration and by its bank",
+            layer.layer
+        );
+    }
+}
+
+/// A routed layer whose expert bank and router are missing is refused by
+/// name. It used to plan as dense with no defect — the silent identity
+/// change a missing bank must never cause.
+#[test]
+fn a_routed_layer_with_no_expert_bank_is_refused_not_planned_dense() {
+    let outcome = plan_variant(|tensors| {
+        tensors.retain(|(name, _)| {
+            !(name.starts_with("model.layers.1.") && name.contains("block_sparse_moe"))
+        })
+    });
+    assert!(!outcome.closed(), "a bank-less routed layer must not close");
+    let mismatch = identity_defect(1, FfnIdentity::Routed, FfnIdentity::Dense);
+    assert!(outcome.defects.contains(&mismatch), "{:?}", outcome.defects);
+    let text = mismatch.to_string();
+    assert!(
+        text.starts_with(
+            "layer 1: the surface declares a routed FFN but the operands are those of a dense"
+        ),
+        "{text}"
+    );
+    assert!(
+        !outcome
+            .defects
+            .iter()
+            .any(|d| matches!(d, ClosureDefect::FfnIdentityMismatch { layer: 0, .. })),
+        "layer 0 still agrees with its declaration: {:?}",
+        outcome.defects
+    );
+}
+
+/// The other direction: a declared-dense prefix layer that still carries
+/// routed operands is the same disagreement, refused the same way rather
+/// than routed on the strength of the stray operands.
+#[test]
+fn a_dense_prefix_layer_carrying_routed_operands_is_refused() {
+    let outcome = plan_variant_with(dense_prefix_config(1), |_| {});
+    assert!(
+        !outcome.closed(),
+        "routed operands on a declared-dense layer must not close"
+    );
+    assert!(
+        outcome
+            .defects
+            .contains(&identity_defect(0, FfnIdentity::Dense, FfnIdentity::Routed)),
+        "{:?}",
+        outcome.defects
+    );
 }


### PR DESCRIPTION
**Invariant:** a VINDEX3 container entering through a supported product surface either executes according to its declared semantics or receives an explicit, truthful refusal.

Five changes, one invariant. Branch `v3-front-door` off `origin/main` e783d824 (after #378, #382, #383, which had already landed `larql run <vindex3>` and the `open_component` authority).

### 1. Served V3 generation stops on the container's declared end-of-turn token

The V3 driver judges EOS on ids alone, and every server route started from `EosConfig::builtin()`, whose id set is empty, so every V3 completion ran to `max_tokens`. `V3Model` now resolves `generation_config.json` once at load through the same authority the CLI's V3 arm uses, and the five V3 routes (buffered and streamed completions, buffered and streamed chat, the responses engine's V3 arm) build their request EOS on top of it via `build_sampling_eos_from`. The V2 routes are unchanged: their loop re-decodes special tokens and needed no declaration.

Test (`test_vindex3_serve.rs`): the direct arm says what the fixture emits; its second id is declared as EOS; the same request finishes with `stop` after exactly the tokens before it, buffered and streamed, and a chat turn stops the same way on its own sequence. The identical container without the declaration runs to `length` — the control that the stop came from the declaration.

### 2. A loaded-but-unsupported model never masquerades as absent

Twenty route files, all three gRPC services and the WebSocket stream resolved V2 models only, so a server with one V3 container bound answered 404 "no model loaded" while `/v1/models` listed it. `AppState::v2_or_unsupported` is the three-way rule — nothing bound is 404, a V2 model is the model, a V3 container is `ServerError::Unsupported` (501) naming VINDEX3 — and `model_or_err` delegates to it, so the consolidated call sites get it for free. The raw sites (embed ×3, shard, walk-ffn ×3, patches, WebSocket ×3) moved onto it; gRPC maps it to `Unimplemented` through one helper; the OpenAI envelope gained `not_implemented_error`. This refuses; it does not make those routes serve V3.

Test: five V2-only HTTP routes answer 501 naming VINDEX3 and never "not found"; `/v1/embeddings` answers in the OpenAI envelope; gRPC `GetStats` is `Unimplemented`; an empty server still answers 404 "no model loaded".

### 3. The inspect path checks the generation before any other byte

`inspect_container` is the opening step for every graph-path consumer and never read `index.json.version`. It now applies the same `detect_generation` gate `Vindex3Container::open` applies: a VINDEX2 directory is `WrongContainerGeneration`, a future schema is `UnknownContainerGeneration` naming the version it found, and an index with no version is refused rather than assumed current. Four tests, one per case plus the baseline.

### 4. The declared MoE schedule is the authority in closure

Closure routed a layer by operand evidence — bank or router present — so a routed layer whose expert bank was missing planned as dense with no defect, while `dense_prefix_layers` sat unread outside a test fixture. One derivation (`declared_routed`) now decides for both the closure pass and plan construction: every layer of a MoE surface is routed except the declared dense prefix; the operands are evidence the declaration is honoured. Disagreement either way is `ClosureDefect::FfnIdentityMismatch { layer, declared, evidence }`, and an unclosed plan is refused by the opener as before. The executor already honoured the declaration; closure now agrees with it.

Tests on the Kimi MoE fixture: a declared dense prefix plans dense and the layers after it routed; a routed layer with its bank removed is refused by name, not planned dense; a dense-prefix layer still carrying routed operands is refused the other way.

Follow-up, outside this PR: with a single routed layer the encoder names the bank's tensors relative to that one layer's prefix and the layer segment vanishes (`0.w1.weight`); the positive test uses three layers to stay clear of it.

### 5. Opener stragglers

`OpenedComponent` now carries the inspection it judged. `sensitivity` (both arms) and `consequence` open through `open_component` instead of re-implementing inspect, plan, open. `ops` and `inspect` stop at planning and are inspection tools by design, so they stay on `inspect_container`, which is now gated.

### Not in this PR

`larql bench` on V3 (`vindex3 exec --profile` is the instrument), V3 support on the twenty V2-only routes, the single-routed-layer bank naming.
