### PR TITLE
Explorer contract steps 3+4: a server says what it will do, and plans a source without encoding it

### DIFF
--- a/crates/larql-cli/src/commands/primary/mod.rs
+++ b/crates/larql-cli/src/commands/primary/mod.rs
@@ -26,6 +26,7 @@ pub mod run_cmd_image;
 pub mod run_cmd_speak;
 pub mod run_cmd_vindex3;
 pub mod serve_resolve;
+pub mod server_capabilities_cmd;
 pub mod shannon_cmd;
 pub mod shannon_trace;
 pub mod show_cmd;

--- a/crates/larql-cli/src/commands/primary/server_capabilities_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/server_capabilities_cmd.rs
@@ -1,0 +1,282 @@
+//! `larql server-capabilities <URL>` — ask a running LARQL server
+//! what it will and will not do.
+//!
+//! Deliberately *not* folded into `larql capabilities`, which answers
+//! a different question about a different object: what architectures
+//! **this release** recognises, a build-time fact. This asks a
+//! specific running process about its own route surface. Same English
+//! word, two objects — so two verbs.
+//!
+//! The client half of the Explorer contract's step 3. The rule it
+//! exists to enforce is that nobody infers a server's powers from its
+//! address: this prints what the server says, and refuses a report
+//! whose schema it does not recognise rather than reading the keys it
+//! happens to know.
+
+use std::time::Duration;
+
+use clap::Args;
+
+/// The report schema this client understands. A server speaking a
+/// different one is refused, not partially read — the same discipline
+/// `SystemPlan::parse` applies to plan schema 4.
+const SUPPORTED_SCHEMA: u64 = 1;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Args, Debug)]
+pub struct ServerCapabilitiesArgs {
+    /// Base URL of a running LARQL server, e.g. `http://localhost:8080`.
+    #[arg(value_name = "SERVER_URL")]
+    pub url: String,
+
+    /// Print the server's report verbatim instead of a summary.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Also list every route the server reports mounting.
+    #[arg(long)]
+    pub routes: bool,
+}
+
+pub fn run(args: ServerCapabilitiesArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let base = args.url.trim_end_matches('/');
+    let endpoint = format!("{base}/v1/capabilities");
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()?;
+    let response = client.get(&endpoint).send()?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(format!(
+            "{endpoint} → 404. This server does not serve the capabilities contract: either it \
+             predates it, or {base} is not a LARQL server. Nothing can be inferred about what it \
+             supports from the fact that it answered."
+        )
+        .into());
+    }
+    if !response.status().is_success() {
+        return Err(format!("{endpoint} → {}", response.status()).into());
+    }
+
+    let report: serde_json::Value = response.json()?;
+    check_schema(&report, &endpoint)?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    print!("{}", render_summary(base, &report, args.routes));
+    Ok(())
+}
+
+/// Refuse a report this client cannot read, rather than picking out
+/// the keys it recognises and hoping the rest meant what it expects.
+fn check_schema(
+    report: &serde_json::Value,
+    endpoint: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = report["schema"].as_u64().ok_or_else(|| {
+        format!("{endpoint} answered without a schema — refusing to read it as capabilities")
+    })?;
+    if schema != SUPPORTED_SCHEMA {
+        return Err(format!(
+            "{endpoint} speaks capabilities schema {schema}; this build understands \
+             {SUPPORTED_SCHEMA}. Refusing to read a document whose shape it does not know — \
+             upgrade the client, or read it with --json."
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// The human summary. Returns a `String` rather than printing so the
+/// rendering is testable without a running server — the transport
+/// above is the only part that needs one.
+fn render_summary(base: &str, report: &serde_json::Value, list_routes: bool) -> String {
+    use std::fmt::Write as _;
+    const UNKNOWN: &str = "unknown";
+    let mut out = String::new();
+
+    let _ = writeln!(out, "{base}");
+    let _ = writeln!(
+        out,
+        "  server     {} {}",
+        report["server"]["name"].as_str().unwrap_or(UNKNOWN),
+        report["server"]["version"].as_str().unwrap_or(UNKNOWN),
+    );
+    let _ = writeln!(
+        out,
+        "  profile    {}",
+        report["profile"].as_str().unwrap_or(UNKNOWN)
+    );
+
+    let _ = writeln!(out, "\nSOURCES         LOCAL   HF");
+    for verb in ["load", "plan", "encode"] {
+        let _ = writeln!(
+            out,
+            "  {verb:<16}{:<8}{}",
+            mark(&report["sources"][verb]["local"]),
+            mark(&report["sources"][verb]["hf"]),
+        );
+    }
+    // The distinction the server draws, restated where someone reading
+    // "load: hf yes" might otherwise hand it a raw checkpoint.
+    let _ = writeln!(
+        out,
+        "  load takes an encoded container; plan and encode take a checkpoint."
+    );
+
+    render_block(&mut out, "EXPLORER", &report["explorer"]);
+    render_block(&mut out, "RUNTIME", &report["runtime"]);
+
+    if let Some(backends) = report["runtime"]["backends"].as_array() {
+        let names: Vec<&str> = backends.iter().filter_map(|b| b.as_str()).collect();
+        let _ = writeln!(out, "  {:<16}{}", "backends", names.join(", "));
+    }
+
+    if list_routes {
+        let _ = writeln!(out, "\nROUTES");
+        for route in report["routes"].as_array().into_iter().flatten() {
+            let _ = writeln!(out, "  {}", route.as_str().unwrap_or(UNKNOWN));
+        }
+    }
+    out
+}
+
+/// Render every boolean in `block`, sorted by key. Driven by what the
+/// server sent rather than by a list of keys this client expects — a
+/// server that gains a capability shows it here with no client
+/// release, and one that drops a key simply stops printing it.
+fn render_block(out: &mut String, title: &str, block: &serde_json::Value) {
+    use std::fmt::Write as _;
+    let Some(map) = block.as_object() else { return };
+    let _ = writeln!(out, "\n{title}");
+    for (key, value) in map {
+        if value.is_boolean() {
+            let _ = writeln!(out, "  {key:<16}{}", mark(value));
+        }
+    }
+}
+
+fn mark(value: &serde_json::Value) -> &'static str {
+    match value.as_bool() {
+        Some(true) => "yes",
+        Some(false) => "no",
+        None => "-",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(schema: u64) -> serde_json::Value {
+        serde_json::json!({
+            "object": "capabilities",
+            "schema": schema,
+            "profile": "single_model",
+            "server": { "name": "larql-server", "version": "0.2.0" },
+            "sources": {
+                "load": { "local": true, "hf": true },
+                "plan": { "local": false, "hf": false },
+                "encode": { "local": false, "hf": false },
+            },
+            "explorer": { "components": false, "walk": true },
+            "runtime": { "execute": true, "backends": ["cpu"] },
+            "routes": ["/v1/capabilities", "/v1/walk"],
+        })
+    }
+
+    #[test]
+    fn accepts_the_schema_it_understands() {
+        assert!(check_schema(&report(SUPPORTED_SCHEMA), "u").is_ok());
+    }
+
+    #[test]
+    fn refuses_a_schema_it_does_not_understand() {
+        let err = check_schema(&report(SUPPORTED_SCHEMA + 1), "u")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("schema 2"), "{err}");
+        assert!(err.contains("Refusing"), "{err}");
+    }
+
+    #[test]
+    fn refuses_a_document_with_no_schema_at_all() {
+        let err = check_schema(&serde_json::json!({"profile": "x"}), "u")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("without a schema"), "{err}");
+    }
+
+    #[test]
+    fn summary_names_the_server_and_its_profile() {
+        let out = render_summary("http://localhost:8080", &report(1), false);
+        assert!(out.contains("http://localhost:8080"), "{out}");
+        assert!(out.contains("larql-server 0.2.0"), "{out}");
+        assert!(out.contains("single_model"), "{out}");
+    }
+
+    #[test]
+    fn summary_separates_what_load_takes_from_what_encode_takes() {
+        let out = render_summary("u", &report(1), false);
+        let load = out.lines().find(|l| l.contains("load ")).unwrap();
+        let encode = out.lines().find(|l| l.contains("encode")).unwrap();
+        assert!(load.contains("yes"), "{load}");
+        assert!(!encode.contains("yes"), "{encode}");
+        assert!(
+            out.contains("load takes an encoded container"),
+            "the container/checkpoint distinction must survive into the summary: {out}"
+        );
+    }
+
+    /// The renderer prints whatever booleans the server sent. A server
+    /// that gains a capability shows it without a client release —
+    /// this is what stops the CLI becoming a second, staler list of
+    /// what servers can do.
+    #[test]
+    fn summary_renders_capabilities_this_build_has_never_heard_of() {
+        let mut r = report(1);
+        r["explorer"]["time_travel"] = serde_json::json!(true);
+        let out = render_summary("u", &r, false);
+        assert!(out.contains("time_travel"), "{out}");
+    }
+
+    #[test]
+    fn backends_are_named() {
+        let out = render_summary("u", &report(1), false);
+        assert!(out.contains("backends"), "{out}");
+        assert!(out.contains("cpu"), "{out}");
+    }
+
+    #[test]
+    fn routes_are_listed_only_when_asked() {
+        assert!(!render_summary("u", &report(1), false).contains("/v1/walk"));
+        let listed = render_summary("u", &report(1), true);
+        assert!(listed.contains("ROUTES"), "{listed}");
+        assert!(listed.contains("/v1/walk"), "{listed}");
+    }
+
+    #[test]
+    fn a_non_object_block_renders_nothing() {
+        let mut out = String::new();
+        render_block(&mut out, "EXPLORER", &serde_json::json!("not an object"));
+        assert!(out.is_empty(), "{out}");
+    }
+
+    #[test]
+    fn marks_cover_true_false_and_absent() {
+        assert_eq!(mark(&serde_json::json!(true)), "yes");
+        assert_eq!(mark(&serde_json::json!(false)), "no");
+        assert_eq!(mark(&serde_json::Value::Null), "-");
+    }
+
+    #[test]
+    fn missing_identity_fields_render_as_unknown_rather_than_panicking() {
+        let out = render_summary("u", &serde_json::json!({"schema": 1}), true);
+        assert!(out.contains("unknown"), "{out}");
+    }
+}

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use clap::{Args, Subcommand};
 
 use larql_models::inventory::{build_inventory, ArchitectureInventory};
-use larql_vindex::format::vindex3::plan::{plan_system_with_sources, ArtifactSource};
+use larql_vindex::format::vindex3::plan::plan_resolved;
 
 /// Extension distinguishing a saved inventory JSON from a checkpoint dir.
 const INVENTORY_EXT: &str = "json";
@@ -964,23 +964,7 @@ fn run_plan(args: PlanArgs) -> Result<(), Box<dyn std::error::Error>> {
     for entry in &resolved {
         report_staging(entry);
     }
-    // The verdict names its subject: the argument as given and, for a
-    // repo, the commit the facts were read at.
-    let sources: Vec<ArtifactSource> = args
-        .artifacts
-        .iter()
-        .zip(&resolved)
-        .map(|(spec, a)| ArtifactSource {
-            path: spec.display().to_string(),
-            revision: a.commit().map(str::to_string),
-            unpinned_revision: a.unpinned_revision().map(str::to_string),
-        })
-        .collect();
-    let named: Vec<(String, ArchitectureInventory)> = resolved
-        .into_iter()
-        .map(|a| (a.name, a.inventory))
-        .collect();
-    let plan = plan_system_with_sources(&named, &sources)?;
+    let plan = plan_resolved(&args.artifacts, resolved)?;
     let json = serde_json::to_string_pretty(&plan)?;
     match &args.output {
         Some(path) => {

--- a/crates/larql-cli/src/main.rs
+++ b/crates/larql-cli/src/main.rs
@@ -121,6 +121,13 @@ enum Commands {
     /// Serve a vindex over HTTP + gRPC.
     Serve(ServeArgs),
 
+    #[command(next_help_heading = "Server")]
+    /// Ask a running LARQL server what it will and will not do
+    /// (`GET /v1/capabilities`). Distinct from `capabilities`, which
+    /// reports what this release recognises rather than what one
+    /// server offers.
+    ServerCapabilities(server_capabilities_cmd::ServerCapabilitiesArgs),
+
     // ── LQL ─────────────────────────────────────────────────────────
     #[command(next_help_heading = "LQL")]
     /// Launch the LQL interactive REPL.
@@ -661,6 +668,7 @@ fn real_main() -> i32 {
         // ── Factory ──
         Commands::Recipe(cmd) => recipe_cmd::run(cmd),
         Commands::Capabilities => capabilities_cmd::run(),
+        Commands::ServerCapabilities(args) => server_capabilities_cmd::run(args),
         Commands::InspectHf(args) => inspect_hf_cmd::run(args),
         Commands::Vindex3(cmd) => vindex3_cmd::run(cmd),
         Commands::Card(cmd) => card_cmd::run(cmd),

--- a/crates/larql-server/src/bootstrap/load.rs
+++ b/crates/larql-server/src/bootstrap/load.rs
@@ -199,14 +199,77 @@ fn resolve_artifact_path_with(
     path_str: &str,
     registry: &larql_vindex::registry::RegistryManifest,
 ) -> Result<PathBuf, BoxError> {
+    match classify_with(path_str, registry)? {
+        SourceResolution::Registry(resolved) => Ok(resolved),
+        SourceResolution::Hf => Ok(larql_vindex::resolve_hf_vindex(path_str)?),
+        SourceResolution::Local => Ok(PathBuf::from(path_str)),
+    }
+}
+
+/// Which branch a reference takes, carrying whatever that branch
+/// already resolved. Split out of [`resolve_artifact_path_with`] so
+/// that `/v1/capabilities` can report the reference forms this server
+/// accepts by *asking the resolver* ([`classify_source`]) rather than
+/// restating its branches in a second list that can drift.
+///
+/// The registry arm carries its resolved path because
+/// `resolve_claimed` has already done the work — classifying and then
+/// re-resolving would run it twice on the load path.
+enum SourceResolution {
+    /// A registry-claimed name, resolved by the registry.
+    Registry(PathBuf),
+    /// An `hf://` reference to a *published container*. Not fetched
+    /// yet: classification is free, resolution is a download.
+    Hf,
+    /// A literal filesystem path.
+    Local,
+}
+
+fn classify_with(
+    path_str: &str,
+    registry: &larql_vindex::registry::RegistryManifest,
+) -> Result<SourceResolution, BoxError> {
     if let Some(resolved) = larql_vindex::registry::resolve_claimed(path_str, registry)? {
-        return Ok(resolved);
+        return Ok(SourceResolution::Registry(resolved));
     }
     if larql_vindex::is_hf_path(path_str) {
-        Ok(larql_vindex::resolve_hf_vindex(path_str)?)
+        Ok(SourceResolution::Hf)
     } else {
-        Ok(PathBuf::from(path_str))
+        Ok(SourceResolution::Local)
     }
+}
+
+/// How `load_artifact` will interpret `reference`.
+///
+/// Reported by `GET /v1/capabilities` as the source forms this
+/// server's load verb accepts. Note what an `Hf` answer does and does
+/// not promise: `resolve_hf_vindex` fetches an **already-encoded
+/// VINDEX container** (it looks for `index.json`), so `hf://` here
+/// means "a published container", never "a raw checkpoint". Encoding
+/// a checkpoint is `vindex encode`, a capability this server does not
+/// have — which is why the capability table keeps `load` and `encode`
+/// as separate verbs over separate objects.
+pub fn classify_source(reference: &str) -> SourceKind {
+    match classify_with(reference, &larql_vindex::registry::production_registry()) {
+        // A refusal from the registry is still the registry
+        // answering: the name was claimed, and failed. Reporting it
+        // as `Local` would say a claimed-but-broken name is a
+        // filesystem path.
+        Ok(SourceResolution::Registry(_)) | Err(_) => SourceKind::Registry,
+        Ok(SourceResolution::Hf) => SourceKind::Hf,
+        Ok(SourceResolution::Local) => SourceKind::Local,
+    }
+}
+
+/// The reference forms [`classify_source`] distinguishes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceKind {
+    /// A name the VINDEX3 registry has claimed.
+    Registry,
+    /// An `hf://owner/repo` reference to a published container.
+    Hf,
+    /// A literal filesystem path.
+    Local,
 }
 
 pub fn load_single_vindex(

--- a/crates/larql-server/src/bootstrap/mod.rs
+++ b/crates/larql-server/src/bootstrap/mod.rs
@@ -25,8 +25,8 @@ pub use cli::{
     DEFAULT_PORT, DEFAULT_SESSION_TTL_SECS,
 };
 pub use load::{
-    discover_vindexes, load_artifact, load_single_vindex, parse_unit_manifest, LoadVindexOptions,
-    LoadedArtifact, UnitManifest,
+    classify_source, discover_vindexes, load_artifact, load_single_vindex, parse_unit_manifest,
+    LoadVindexOptions, LoadedArtifact, SourceKind, UnitManifest,
 };
 
 use std::sync::Arc;

--- a/crates/larql-server/src/capabilities.rs
+++ b/crates/larql-server/src/capabilities.rs
@@ -45,6 +45,11 @@ use crate::routes::paths;
 /// to plan schema 4: an unattributed answer is refused, not guessed.
 pub const CAPABILITIES_SCHEMA: u32 = 1;
 
+/// The plan-document schema this build's `/v1/plan` emits, re-exported
+/// from the planner so a test asserting the wire shape reads the
+/// planner's own number rather than a copy of it.
+pub const PLAN_SCHEMA_EXPECTED: u32 = larql_vindex::format::vindex3::plan::PLAN_SCHEMA;
+
 /// The execution backends this server can actually bind a VINDEX3
 /// container to.
 ///
@@ -136,10 +141,44 @@ pub struct RouteCapability {
     /// The route whose presence **is** this capability. Reported
     /// `true` iff `routes::mod` mounted exactly this path.
     pub route: &'static str,
-    /// An extra conjunct for source-taking verbs: the resolver must
-    /// also accept this reference form. `None` for capabilities that
-    /// are purely a question of the route existing.
-    pub source: Option<SourceScheme>,
+    /// An extra conjunct for source-taking verbs. `None` for
+    /// capabilities that are purely a question of the route existing.
+    pub source: Option<SourceGate>,
+}
+
+/// The second half of a source-taking capability: what, besides the
+/// route existing, has to be true for the server to accept this
+/// reference form.
+///
+/// Each variant names the authority that decides it, and the handler
+/// for that verb asks the *same* authority — so what the report
+/// advertises and what the endpoint does are one decision read twice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceGate {
+    /// `load` — `bootstrap::classify_source` must recognise the form.
+    Resolver(SourceScheme),
+    /// `plan` — this profile must be willing to plan that form.
+    /// `routes::plan` refuses through [`plans_source`].
+    PlanPolicy(SourceScheme),
+}
+
+/// Whether `profile` will plan a source of this form.
+///
+/// The public surface plans `hf://` references and nothing else. A
+/// local path accepted from an internet caller is a filesystem probe:
+/// even when it plans nothing, the refusals distinguish "no such
+/// directory" from "not a checkpoint", and that difference maps the
+/// host. A localhost server has no such caller and plans either.
+///
+/// `POST /v1/plan` refuses through this function, and
+/// `sources.plan.{local,hf}` is advertised through it — one decision,
+/// two readings, checked against each other in
+/// `tests/test_plan_route.rs`.
+pub const fn plans_source(profile: ServerProfile, scheme: SourceScheme) -> bool {
+    !matches!(
+        (profile, scheme),
+        (ServerProfile::PublicExplorer, SourceScheme::Local)
+    )
 }
 
 /// Every capability this server advertises. The report's whole
@@ -156,32 +195,35 @@ pub const ROUTE_CAPABILITIES: &[RouteCapability] = &[
     RouteCapability {
         key: "/sources/load/local",
         route: paths::RUNTIME_MODEL,
-        source: Some(SourceScheme::Local),
+        source: Some(SourceGate::Resolver(SourceScheme::Local)),
     },
     RouteCapability {
         key: "/sources/load/hf",
         route: paths::RUNTIME_MODEL,
-        source: Some(SourceScheme::Hf),
+        source: Some(SourceGate::Resolver(SourceScheme::Hf)),
     },
     RouteCapability {
         key: "/sources/plan/local",
         route: paths::PLAN,
-        source: Some(SourceScheme::Local),
+        source: Some(SourceGate::PlanPolicy(SourceScheme::Local)),
     },
     RouteCapability {
         key: "/sources/plan/hf",
         route: paths::PLAN,
-        source: Some(SourceScheme::Hf),
+        source: Some(SourceGate::PlanPolicy(SourceScheme::Hf)),
     },
     RouteCapability {
         key: "/sources/encode/local",
         route: paths::ENCODE,
-        source: Some(SourceScheme::Local),
+        // No gate: encode-by-source has no policy yet, and the route is
+        // mounted by nobody, so this is `false` on the route alone. The
+        // rung that mounts it brings its own `SourceGate`.
+        source: None,
     },
     RouteCapability {
         key: "/sources/encode/hf",
         route: paths::ENCODE,
-        source: Some(SourceScheme::Hf),
+        source: None,
     },
     // ── explorer: the read surface over a bound container ──
     RouteCapability {
@@ -303,7 +345,12 @@ impl Capabilities {
     /// Whether `cap` is offered: its route was mounted, and — for a
     /// source-taking verb — the resolver accepts that reference form.
     pub fn advertises(&self, cap: &RouteCapability) -> bool {
-        self.mounted.contains(cap.route) && cap.source.is_none_or(SourceScheme::accepted)
+        self.mounted.contains(cap.route)
+            && match cap.source {
+                None => true,
+                Some(SourceGate::Resolver(scheme)) => scheme.accepted(),
+                Some(SourceGate::PlanPolicy(scheme)) => plans_source(self.profile, scheme),
+            }
     }
 
     /// The report. The `sources` / `explorer` / `runtime` blocks are

--- a/crates/larql-server/src/capabilities.rs
+++ b/crates/larql-server/src/capabilities.rs
@@ -1,0 +1,350 @@
+//! What this server will and will not do, answered by the server.
+//!
+//! The Explorer contract's premise (`docs/runtime-lifecycle-design.md`
+//! and the Explorer programme's step 3) is that a client must never
+//! infer a server's powers from its hostname — "localhost means I may
+//! encode, https means read-only" is a guess, and a guess that is
+//! wrong in the permissive direction offers a button that fails. So
+//! the server says.
+//!
+//! The risk in saying it is that the answer becomes a second,
+//! hand-maintained list beside the router: a table that claims
+//! `components: true` while `/v1/components` was never mounted moves
+//! the guess from the client into the server rather than removing it.
+//!
+//! So no boolean here is written down. Every route-backed capability
+//! is derived from [`MountedRoutes`] — the ledger `routes::mod`
+//! records *while it builds the router* — through the one table
+//! [`ROUTE_CAPABILITIES`], which names, for each advertised key, the
+//! route whose presence **is** that capability. Consequences worth
+//! stating:
+//!
+//! - A capability cannot be advertised without the route existing.
+//! - A route this server does not mount reports `false` on every
+//!   profile, with no "unsupported" list to maintain.
+//! - The rung that mounts `/v1/plan` flips `sources.plan.*` to `true`
+//!   without editing this file.
+//! - `tests/test_capabilities.rs` re-reads the same question through
+//!   axum's own matcher (a method-mismatch probe: 405 means the path
+//!   is mounted, 404 means it is not) and asserts the two readings
+//!   agree, per profile. The ledger is checked, not trusted.
+//!
+//! Two facts here are *not* route-derived, and are marked as such:
+//! the accepted source reference forms (read from the resolver's own
+//! classifier, [`crate::bootstrap::classify_source`]) and the
+//! execution backends ([`V3_BACKENDS`]).
+
+use std::collections::BTreeSet;
+
+use crate::bootstrap::SourceKind;
+use crate::routes::paths;
+
+/// The shape of this report. A client that does not recognise the
+/// schema must refuse the document rather than read the keys it
+/// happens to know — the same discipline `SystemPlan::parse` applies
+/// to plan schema 4: an unattributed answer is refused, not guessed.
+pub const CAPABILITIES_SCHEMA: u32 = 1;
+
+/// The execution backends this server can actually bind a VINDEX3
+/// container to.
+///
+/// `crate::vindex3::load_v3_model` opens every V3 container with
+/// `ProductionBackend` — the CPU executor — so this is `["cpu"]` even
+/// on a binary built with `metal-experts`. That feature drives
+/// VINDEX2 MoE expert dispatch; it is not on the V3 execution path,
+/// and reporting it here would tell the Explorer it can offer a GPU
+/// run this server has no way to perform. `larql run --metal` is a
+/// CLI capability, not a server one. When the server gains a Metal V3
+/// binding, this list grows with it — and
+/// `capabilities_backends_match_the_v3_binding` fails until it does.
+pub const V3_BACKENDS: &[&str] = &["cpu"];
+
+/// Which router `bootstrap::serve` built. Distinct from
+/// [`crate::state::RouterTopology`], which answers a narrower
+/// question (may the bound model count mutate?) and deliberately
+/// cannot see the public surface: `--public-explorer` freezes
+/// `SingleModel` topology while building an entirely different route
+/// table. Conflating them would report a public deployment as an
+/// ordinary single-model server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerProfile {
+    /// `routes::public_explorer_router` — the read surface plus
+    /// `POST /v1/query`. No inference, no lifecycle, no mutation.
+    PublicExplorer,
+    /// `routes::single_model_router`.
+    SingleModel,
+    /// `routes::multi_model_router`.
+    MultiModel,
+}
+
+impl ServerProfile {
+    /// The wire name. Stable: a client keys behaviour off it.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ServerProfile::PublicExplorer => "public_explorer",
+            ServerProfile::SingleModel => "single_model",
+            ServerProfile::MultiModel => "multi_model",
+        }
+    }
+}
+
+/// A reference form a client can hand to a source-taking verb.
+/// Reported separately from the verb's route because the two can fail
+/// independently: `/v1/runtime/model` being mounted says the *verb*
+/// exists, and the resolver's classifier says which *reference forms*
+/// it understands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceScheme {
+    /// A filesystem path.
+    Local,
+    /// An `hf://owner/repo` reference.
+    Hf,
+}
+
+impl SourceScheme {
+    /// A reference of this form, used to ask the resolver's own
+    /// classifier whether it recognises the form — rather than
+    /// restating the resolver's branches here.
+    const fn exemplar(self) -> &'static str {
+        match self {
+            SourceScheme::Local => "/var/lib/larql/example.vindex3",
+            SourceScheme::Hf => "hf://owner/repo",
+        }
+    }
+
+    const fn expected_kind(self) -> SourceKind {
+        match self {
+            SourceScheme::Local => SourceKind::Local,
+            SourceScheme::Hf => SourceKind::Hf,
+        }
+    }
+
+    /// Whether `load_artifact`'s resolver actually classifies this
+    /// form as itself. Positive evidence: if `is_hf_path` stopped
+    /// recognising `hf://`, the exemplar would classify as `Local`
+    /// and `sources.load.hf` would go false on its own.
+    fn accepted(self) -> bool {
+        crate::bootstrap::classify_source(self.exemplar()) == self.expected_kind()
+    }
+}
+
+/// One advertised capability, and the route whose presence is it.
+pub struct RouteCapability {
+    /// Where this lands in the report, as a JSON pointer. Also what
+    /// the conformance test reads back.
+    pub key: &'static str,
+    /// The route whose presence **is** this capability. Reported
+    /// `true` iff `routes::mod` mounted exactly this path.
+    pub route: &'static str,
+    /// An extra conjunct for source-taking verbs: the resolver must
+    /// also accept this reference form. `None` for capabilities that
+    /// are purely a question of the route existing.
+    pub source: Option<SourceScheme>,
+}
+
+/// Every capability this server advertises. The report's whole
+/// route-backed content is generated from this table plus the
+/// mounted-route ledger — see the module doc.
+pub const ROUTE_CAPABILITIES: &[RouteCapability] = &[
+    // ── sources: what a client may hand this server, and as what ──
+    // `load` binds an ALREADY-ENCODED container. `plan` and `encode`
+    // take a raw checkpoint. Keeping them apart matters: the server
+    // resolves `hf://` today, but only as a published *container*
+    // (`resolve_hf_vindex` fetches `index.json`). Reporting one
+    // "hf: true" would let the Explorer offer `hf://Qwen/Qwen3-0.6B`
+    // — a raw checkpoint — to a verb that can only take a container.
+    RouteCapability {
+        key: "/sources/load/local",
+        route: paths::RUNTIME_MODEL,
+        source: Some(SourceScheme::Local),
+    },
+    RouteCapability {
+        key: "/sources/load/hf",
+        route: paths::RUNTIME_MODEL,
+        source: Some(SourceScheme::Hf),
+    },
+    RouteCapability {
+        key: "/sources/plan/local",
+        route: paths::PLAN,
+        source: Some(SourceScheme::Local),
+    },
+    RouteCapability {
+        key: "/sources/plan/hf",
+        route: paths::PLAN,
+        source: Some(SourceScheme::Hf),
+    },
+    RouteCapability {
+        key: "/sources/encode/local",
+        route: paths::ENCODE,
+        source: Some(SourceScheme::Local),
+    },
+    RouteCapability {
+        key: "/sources/encode/hf",
+        route: paths::ENCODE,
+        source: Some(SourceScheme::Hf),
+    },
+    // ── explorer: the read surface over a bound container ──
+    RouteCapability {
+        key: "/explorer/models",
+        route: paths::MODELS,
+        source: None,
+    },
+    RouteCapability {
+        key: "/explorer/describe",
+        route: paths::DESCRIBE,
+        source: None,
+    },
+    RouteCapability {
+        key: "/explorer/walk",
+        route: paths::WALK,
+        source: None,
+    },
+    RouteCapability {
+        key: "/explorer/relations",
+        route: paths::RELATIONS,
+        source: None,
+    },
+    RouteCapability {
+        key: "/explorer/stats",
+        route: paths::STATS,
+        source: None,
+    },
+    RouteCapability {
+        key: "/explorer/components",
+        route: paths::COMPONENTS,
+        source: None,
+    },
+    RouteCapability {
+        key: "/explorer/representations",
+        route: paths::REPRESENTATIONS,
+        source: None,
+    },
+    RouteCapability {
+        key: "/explorer/provenance",
+        route: paths::PROVENANCE,
+        source: None,
+    },
+    RouteCapability {
+        key: "/explorer/authority",
+        route: paths::AUTHORITY,
+        source: None,
+    },
+    RouteCapability {
+        key: "/explorer/query",
+        route: paths::QUERY,
+        source: None,
+    },
+    RouteCapability {
+        key: "/explorer/residency",
+        route: paths::RESIDENCY,
+        source: None,
+    },
+    // ── runtime: what this process will do with the bound model ──
+    RouteCapability {
+        key: "/runtime/introspect",
+        route: paths::RUNTIME,
+        source: None,
+    },
+    RouteCapability {
+        key: "/runtime/execute",
+        route: paths::INFER,
+        source: None,
+    },
+    RouteCapability {
+        key: "/runtime/lifecycle",
+        route: paths::RUNTIME_MODEL,
+        source: None,
+    },
+];
+
+/// The paths `routes::mod` actually handed to axum, recorded as it
+/// built the router. The only thing that decides a route-backed
+/// capability.
+#[derive(Debug, Default, Clone)]
+pub struct MountedRoutes(BTreeSet<&'static str>);
+
+impl MountedRoutes {
+    /// Record a mount. Returns whether the path was new — a
+    /// double-mount is a router bug (axum silently keeps the last
+    /// one), and the caller asserts on it.
+    pub fn record(&mut self, path: &'static str) -> bool {
+        self.0.insert(path)
+    }
+
+    pub fn contains(&self, path: &str) -> bool {
+        self.0.contains(path)
+    }
+
+    /// Every mounted path, sorted. Reported verbatim so a client can
+    /// see the surface it is talking to without probing for it.
+    pub fn paths(&self) -> impl Iterator<Item = &&'static str> {
+        self.0.iter()
+    }
+}
+
+/// The answer to `GET /v1/capabilities`, computed once at router
+/// build time — the route table cannot change afterwards, so neither
+/// can this.
+#[derive(Debug, Clone)]
+pub struct Capabilities {
+    profile: ServerProfile,
+    mounted: MountedRoutes,
+}
+
+impl Capabilities {
+    pub fn derive(profile: ServerProfile, mounted: MountedRoutes) -> Self {
+        Self { profile, mounted }
+    }
+
+    pub fn profile(&self) -> ServerProfile {
+        self.profile
+    }
+
+    /// Whether `cap` is offered: its route was mounted, and — for a
+    /// source-taking verb — the resolver accepts that reference form.
+    pub fn advertises(&self, cap: &RouteCapability) -> bool {
+        self.mounted.contains(cap.route) && cap.source.is_none_or(SourceScheme::accepted)
+    }
+
+    /// The report. The `sources` / `explorer` / `runtime` blocks are
+    /// generated from [`ROUTE_CAPABILITIES`]; nothing else writes a
+    /// boolean into them.
+    pub fn to_json(&self) -> serde_json::Value {
+        let mut report = serde_json::json!({
+            "object": "capabilities",
+            "schema": CAPABILITIES_SCHEMA,
+            "profile": self.profile.as_str(),
+            "server": {
+                "name": env!("CARGO_PKG_NAME"),
+                "version": env!("CARGO_PKG_VERSION"),
+            },
+            "runtime": { "backends": V3_BACKENDS },
+            "routes": self.mounted.paths().collect::<Vec<_>>(),
+        });
+
+        for cap in ROUTE_CAPABILITIES {
+            insert_at(&mut report, cap.key, self.advertises(cap).into());
+        }
+        report
+    }
+}
+
+/// Insert `value` at a `/`-separated JSON pointer, creating the
+/// intermediate objects. Small and local on purpose: `serde_json`'s
+/// `pointer_mut` will not vivify a missing branch, and the alternative
+/// — hand-building the nested literal — is the second list this
+/// module exists to avoid.
+fn insert_at(root: &mut serde_json::Value, pointer: &str, value: serde_json::Value) {
+    let mut node = root;
+    let mut segments = pointer.trim_start_matches('/').split('/').peekable();
+    while let Some(segment) = segments.next() {
+        if segments.peek().is_none() {
+            node[segment] = value;
+            return;
+        }
+        if !node[segment].is_object() {
+            node[segment] = serde_json::json!({});
+        }
+        node = &mut node[segment];
+    }
+}

--- a/crates/larql-server/src/error.rs
+++ b/crates/larql-server/src/error.rs
@@ -56,6 +56,16 @@ pub enum ServerError {
     /// Implemented` with the generation named, never a 404.
     #[error("not supported: {0}")]
     Unsupported(String),
+
+    /// The request is well-formed and this build can do it, but the
+    /// profile this server is serving under will not do it for this
+    /// caller — `POST /v1/plan` given a local path on the public
+    /// surface. Distinct from `Unsupported`: the capability exists and
+    /// the same request succeeds on a localhost server, so `403`, not
+    /// `501`, and `GET /v1/capabilities` says so in advance rather
+    /// than leaving the client to discover it by being refused.
+    #[error("refused: {0}")]
+    Refused(String),
 }
 
 impl ServerError {
@@ -69,7 +79,8 @@ impl ServerError {
             | ServerError::InferenceUnavailable(m)
             | ServerError::Internal(m)
             | ServerError::Timeout(m)
-            | ServerError::Unsupported(m) => m,
+            | ServerError::Unsupported(m)
+            | ServerError::Refused(m) => m,
         }
     }
 }
@@ -86,6 +97,7 @@ impl IntoResponse for ServerError {
             ServerError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
             ServerError::Timeout(msg) => (StatusCode::GATEWAY_TIMEOUT, msg.clone()),
             ServerError::Unsupported(msg) => (StatusCode::NOT_IMPLEMENTED, msg.clone()),
+            ServerError::Refused(msg) => (StatusCode::FORBIDDEN, msg.clone()),
         };
 
         (status, axum::Json(ErrorBody { error: message })).into_response()
@@ -105,6 +117,7 @@ mod tests {
             ServerError::Internal("in".into()),
             ServerError::Timeout("to".into()),
             ServerError::Unsupported("un".into()),
+            ServerError::Refused("rf".into()),
         ]
     }
 

--- a/crates/larql-server/src/lib.rs
+++ b/crates/larql-server/src/lib.rs
@@ -9,6 +9,7 @@ pub mod auth;
 pub mod band_utils;
 pub mod bootstrap;
 pub mod cache;
+pub mod capabilities;
 pub mod embed_store;
 pub mod env_flags;
 pub mod error;

--- a/crates/larql-server/src/lib.rs
+++ b/crates/larql-server/src/lib.rs
@@ -23,6 +23,7 @@ pub mod maintenance;
 pub mod memcheck;
 pub mod metrics;
 pub mod openapi;
+pub mod plan_service;
 pub mod ratelimit;
 pub mod response_kv;
 pub mod response_store;

--- a/crates/larql-server/src/openapi.rs
+++ b/crates/larql-server/src/openapi.rs
@@ -339,6 +339,30 @@ pub mod schemas {
 
     // ---- admin -------------------------------------------------------
 
+    /// `GET /v1/capabilities`. The `sources` / `explorer` /
+    /// `runtime` blocks are generated from
+    /// `crate::capabilities::ROUTE_CAPABILITIES` and the mounted-route
+    /// ledger, so this schema documents the *shape*; the authority for
+    /// which keys appear is that table, not this struct.
+    #[derive(Serialize, ToSchema)]
+    pub struct CapabilitiesResponse {
+        /// Always `"capabilities"`.
+        pub object: String,
+        /// Report schema version. A client that does not recognise it
+        /// must refuse the document rather than read the keys it knows.
+        pub schema: u32,
+        /// `"public_explorer"` | `"single_model"` | `"multi_model"`.
+        pub profile: String,
+        /// Which source reference forms each source-taking verb accepts.
+        pub sources: serde_json::Value,
+        /// The read surface over a bound container.
+        pub explorer: serde_json::Value,
+        /// What this process will do with the bound model, and on what.
+        pub runtime: serde_json::Value,
+        /// Every path this server mounted, sorted.
+        pub routes: Vec<String>,
+    }
+
     #[derive(Serialize, ToSchema)]
     pub struct HealthResponse {
         pub status: String,
@@ -665,6 +689,7 @@ pub mod schemas {
         crate::routes::patches::handle_remove_patch,
         // admin
         crate::routes::health::handle_health,
+        crate::routes::capabilities::handle_capabilities,
         crate::routes::runtime::handle_runtime,
         crate::routes::runtime_lifecycle::handle_load_model,
         crate::routes::runtime_lifecycle::handle_unload_model,
@@ -722,6 +747,7 @@ pub mod schemas {
         schemas::RelationsResponse,
         schemas::LayerBands,
         schemas::LoadedCapabilities,
+        schemas::CapabilitiesResponse,
         schemas::StatsResponse,
         schemas::ModelEntry,
         schemas::ModelsListResponse,

--- a/crates/larql-server/src/openapi.rs
+++ b/crates/larql-server/src/openapi.rs
@@ -690,6 +690,7 @@ pub mod schemas {
         // admin
         crate::routes::health::handle_health,
         crate::routes::capabilities::handle_capabilities,
+        crate::routes::plan::handle_plan,
         crate::routes::runtime::handle_runtime,
         crate::routes::runtime_lifecycle::handle_load_model,
         crate::routes::runtime_lifecycle::handle_unload_model,
@@ -748,6 +749,7 @@ pub mod schemas {
         schemas::LayerBands,
         schemas::LoadedCapabilities,
         schemas::CapabilitiesResponse,
+        crate::routes::plan::PlanRequest,
         schemas::StatsResponse,
         schemas::ModelEntry,
         schemas::ModelsListResponse,

--- a/crates/larql-server/src/plan_service.rs
+++ b/crates/larql-server/src/plan_service.rs
@@ -227,7 +227,10 @@ struct Planned {
 fn plan_specs(specs: &[PathBuf]) -> Result<Planned, ServerError> {
     let resolved = artifact::resolve_all(specs)
         .map_err(|e| ServerError::BadRequest(format!("cannot read this source: {e}")))?;
-    let staging: Vec<Value> = resolved.iter().filter_map(artifact::staging_json).collect();
+    let staging: Vec<Value> = resolved
+        .iter()
+        .filter_map(artifact::ResolvedArtifact::staging_json)
+        .collect();
 
     let plan = plan_resolved(specs, resolved)
         .map_err(|e| ServerError::BadRequest(format!("cannot plan this source: {e}")))?;

--- a/crates/larql-server/src/plan_service.rs
+++ b/crates/larql-server/src/plan_service.rs
@@ -1,0 +1,361 @@
+//! `POST /v1/plan` — what VINDEX understands about a source, before
+//! anything has been encoded.
+//!
+//! The Explorer's "enter a model" path: a visitor types
+//! `hf://Qwen/Qwen3-4B` and gets an architecture-support verdict —
+//! identity, resolved commit, operators, findings, admissibility —
+//! without a checkpoint being downloaded or a container being built.
+//! Answering costs headers, not weights.
+//!
+//! Three things this module owns, and one it deliberately does not:
+//!
+//! - **Policy.** Which source forms this profile will plan, asked
+//!   through [`crate::capabilities::plans_source`] — the same function
+//!   `GET /v1/capabilities` advertises through, so a client is never
+//!   refused for something the report said was available.
+//! - **Cost.** A plan is a network fetch (~11 MB of headers for a
+//!   0.6B model, ~39 MB for a 328 GB one) and a public endpoint that
+//!   performs one per request on demand is trivially abusable. Plans
+//!   are bounded in flight and refused, not queued, past the bound.
+//! - **Cache.** Keyed on [`VerdictCacheKey`] — every artifact's
+//!   immutable commit plus the planner's semantics version — and
+//!   therefore only for plans where every artifact is pinned. An
+//!   unpinned verdict is served and never stored: caching it would
+//!   answer tomorrow's question with today's facts.
+//!
+//! What it does not own is the verdict. That is
+//! `larql_vindex::format::vindex3::plan::plan_resolved`, the same
+//! function behind `vindex plan` and `larql vindex3 plan` — so the
+//! answer cannot depend on which front door asked.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use larql_vindex::format::vindex3::artifact;
+use larql_vindex::format::vindex3::plan::{plan_resolved, VerdictCacheKey};
+use serde_json::Value;
+use tokio::sync::Semaphore;
+use tracing::info;
+
+use crate::capabilities::{plans_source, ServerProfile, SourceScheme};
+use crate::error::ServerError;
+
+/// A system plan spans artifacts, but a request that names dozens is
+/// asking this server to make dozens of round trips on its behalf.
+pub const MAX_SOURCES_PER_PLAN: usize = 8;
+
+/// Distinct pinned verdicts retained. Small on purpose: this is a
+/// courtesy for repeated views of the same model, not a store.
+const CACHE_CAPACITY: usize = 256;
+
+/// Plans in flight at once. Two, because each one is bounded by a
+/// remote's response time rather than by this machine, and a queue of
+/// them is the cheapest denial of service against a public endpoint.
+pub const MAX_CONCURRENT_PLANS: usize = 2;
+
+/// The planning surface for one server.
+pub struct PlanService {
+    profile: ServerProfile,
+    cache: Mutex<HashMap<VerdictCacheKey, Value>>,
+    cache_capacity: usize,
+    permits: Semaphore,
+}
+
+impl PlanService {
+    pub fn new(profile: ServerProfile) -> Self {
+        Self::with_limits(profile, MAX_CONCURRENT_PLANS, CACHE_CAPACITY)
+    }
+
+    /// [`Self::new`] with the bounds stated, so a test can drive the
+    /// refusal path deterministically (`max_concurrent = 0` refuses
+    /// every plan) instead of racing two real fetches and hoping.
+    pub fn with_limits(
+        profile: ServerProfile,
+        max_concurrent: usize,
+        cache_capacity: usize,
+    ) -> Self {
+        Self {
+            profile,
+            cache: Mutex::new(HashMap::new()),
+            cache_capacity,
+            permits: Semaphore::new(max_concurrent),
+        }
+    }
+
+    /// How this server would classify `spec` — the *plan* resolver's
+    /// own branch ([`artifact::is_remote_spec`]), not the load
+    /// resolver's. The two verbs take different objects (a checkpoint
+    /// versus an encoded container), so they must not share a
+    /// classifier just because both understand the string `hf://`.
+    pub fn scheme_of(spec: &std::path::Path) -> SourceScheme {
+        if artifact::is_remote_spec(spec) {
+            SourceScheme::Hf
+        } else {
+            SourceScheme::Local
+        }
+    }
+
+    /// Refuse the source forms this profile will not plan, naming the
+    /// profile — a client that reads `/v1/capabilities` first should
+    /// never see this, and one that does see it should know why.
+    fn admit(&self, specs: &[PathBuf]) -> Result<(), ServerError> {
+        for spec in specs {
+            let scheme = Self::scheme_of(spec);
+            if !plans_source(self.profile, scheme) {
+                return Err(ServerError::Refused(format!(
+                    "this server serves the {} profile, which plans hf:// sources only — \
+                     a local path is not planned here. GET /v1/capabilities reports this \
+                     as sources.plan.local = false.",
+                    self.profile.as_str()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate(&self, sources: &[String]) -> Result<Vec<PathBuf>, ServerError> {
+        if sources.is_empty() {
+            return Err(ServerError::BadRequest(
+                "sources must name at least one artifact".into(),
+            ));
+        }
+        if sources.len() > MAX_SOURCES_PER_PLAN {
+            return Err(ServerError::BadRequest(format!(
+                "{} sources requested; this server plans at most {MAX_SOURCES_PER_PLAN} \
+                 artifacts in one system plan",
+                sources.len()
+            )));
+        }
+        let specs: Vec<PathBuf> = sources.iter().map(PathBuf::from).collect();
+        self.admit(&specs)?;
+        Ok(specs)
+    }
+
+    fn cached(&self, key: &VerdictCacheKey) -> Option<Value> {
+        self.cache
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .get(key)
+            .cloned()
+    }
+
+    fn store(&self, key: VerdictCacheKey, value: Value) {
+        let mut cache = self.cache.lock().unwrap_or_else(|p| p.into_inner());
+        // At capacity, keep what is there rather than evicting: this
+        // is a courtesy cache, and a wrong eviction policy is worse
+        // than a cold one.
+        if cache.len() < self.cache_capacity {
+            cache.insert(key, value);
+        }
+    }
+
+    /// Serve a verdict: a held pinned one from cache, otherwise store
+    /// this one and serve it.
+    ///
+    /// Split out of [`Self::plan`] because the branch that matters —
+    /// a pinned verdict coming back from cache instead of being
+    /// recomputed — can only be reached with an immutable commit, and
+    /// every source that has one is a network fetch. As its own
+    /// method it is reachable from a unit test, so the cache rule is
+    /// checked rather than assumed.
+    fn serve(&self, document: Value, cache_key: Option<&VerdictCacheKey>) -> (Value, bool) {
+        let Some(key) = cache_key else {
+            // Unpinned: served, never stored. A cache that held this
+            // would answer tomorrow's question with today's facts.
+            return (document, false);
+        };
+        match self.cached(key) {
+            Some(hit) => (hit, true),
+            None => {
+                self.store(key.clone(), document.clone());
+                (document, false)
+            }
+        }
+    }
+
+    /// Plan `sources`, serving a pinned verdict from cache when one is
+    /// held.
+    ///
+    /// The returned document is the plan exactly as `vindex plan
+    /// --json` writes it, plus `staging` and a `serving` block — so a
+    /// client can read a server's answer and a CLI's answer with the
+    /// same parser.
+    pub async fn plan(&self, sources: Vec<String>) -> Result<Value, ServerError> {
+        let specs = self.validate(&sources)?;
+
+        // Bound the work before doing any of it. `try_acquire` rather
+        // than `acquire`: a caller waiting behind a slow remote fetch
+        // learns nothing useful, and a queue is the thing being
+        // defended against.
+        let _permit = self.permits.try_acquire().map_err(|_| {
+            ServerError::Conflict(format!(
+                "{MAX_CONCURRENT_PLANS} plans already in flight — planning reads a remote \
+                 checkpoint's headers, so this server runs a bounded number at once. Retry."
+            ))
+        })?;
+
+        let planned = tokio::task::spawn_blocking(move || plan_specs(&specs))
+            .await
+            .map_err(|e| ServerError::Internal(format!("plan task failed: {e}")))??;
+
+        let Planned {
+            document,
+            cache_key,
+        } = planned;
+
+        let (mut document, served_from_cache) = self.serve(document, cache_key.as_ref());
+
+        document["serving"] = serde_json::json!({
+            "cached": served_from_cache,
+            // Says why a verdict was not stored without making the
+            // client infer it from the absence of a commit.
+            "cacheable": cache_key.is_some(),
+            "profile": self.profile.as_str(),
+        });
+        Ok(document)
+    }
+}
+
+struct Planned {
+    document: Value,
+    cache_key: Option<VerdictCacheKey>,
+}
+
+/// Resolve and plan, on a blocking thread. Everything that touches the
+/// network lives here.
+fn plan_specs(specs: &[PathBuf]) -> Result<Planned, ServerError> {
+    let resolved = artifact::resolve_all(specs)
+        .map_err(|e| ServerError::BadRequest(format!("cannot read this source: {e}")))?;
+    let staging: Vec<Value> = resolved.iter().filter_map(artifact::staging_json).collect();
+
+    let plan = plan_resolved(specs, resolved)
+        .map_err(|e| ServerError::BadRequest(format!("cannot plan this source: {e}")))?;
+    let cache_key = plan.cache_key();
+    info!(
+        artifacts = plan.artifacts.len(),
+        blocking = plan.summary.blocking,
+        admissible = plan.admissible,
+        cacheable = cache_key.is_some(),
+        "planned",
+    );
+
+    let mut document = serde_json::to_value(&plan)
+        .map_err(|e| ServerError::Internal(format!("plan is not serialisable: {e}")))?;
+    if !staging.is_empty() {
+        document["staging"] = Value::Array(staging);
+    }
+    Ok(Planned {
+        document,
+        cache_key,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(revisions: &[&str]) -> VerdictCacheKey {
+        VerdictCacheKey {
+            revisions: revisions.iter().map(|r| r.to_string()).collect(),
+            semantics_version: 1,
+        }
+    }
+
+    #[test]
+    fn a_stored_verdict_comes_back_under_its_own_key() {
+        let s = PlanService::new(ServerProfile::SingleModel);
+        s.store(key(&["abc"]), serde_json::json!({"schema": 4}));
+        assert_eq!(
+            s.cached(&key(&["abc"])),
+            Some(serde_json::json!({"schema": 4}))
+        );
+        assert_eq!(s.cached(&key(&["def"])), None);
+    }
+
+    /// Two artifacts at the same commits but a different semantics
+    /// version are different verdicts — the planner changed its mind,
+    /// not the model.
+    #[test]
+    fn semantics_version_is_part_of_the_identity() {
+        let s = PlanService::new(ServerProfile::SingleModel);
+        s.store(key(&["abc"]), serde_json::json!({"v": 1}));
+        let newer = VerdictCacheKey {
+            revisions: vec!["abc".into()],
+            semantics_version: 2,
+        };
+        assert_eq!(s.cached(&newer), None);
+    }
+
+    #[test]
+    fn a_full_cache_keeps_what_it_has() {
+        let s = PlanService::with_limits(ServerProfile::SingleModel, 1, 1);
+        s.store(key(&["first"]), serde_json::json!(1));
+        s.store(key(&["second"]), serde_json::json!(2));
+        assert_eq!(s.cached(&key(&["first"])), Some(serde_json::json!(1)));
+        assert_eq!(s.cached(&key(&["second"])), None);
+    }
+
+    #[test]
+    fn the_plan_resolvers_own_classifier_decides_the_scheme() {
+        assert_eq!(
+            PlanService::scheme_of(std::path::Path::new("hf://owner/repo")),
+            SourceScheme::Hf
+        );
+        assert_eq!(
+            PlanService::scheme_of(std::path::Path::new("/var/lib/checkpoint")),
+            SourceScheme::Local
+        );
+    }
+
+    #[test]
+    fn an_unpinned_verdict_is_served_and_never_stored() {
+        let s = PlanService::new(ServerProfile::SingleModel);
+        let (doc, cached) = s.serve(serde_json::json!({"v": 1}), None);
+        assert_eq!(doc, serde_json::json!({"v": 1}));
+        assert!(!cached);
+        assert!(s.cache.lock().unwrap().is_empty(), "nothing may be stored");
+    }
+
+    #[test]
+    fn a_pinned_verdict_is_stored_on_the_first_ask_and_served_on_the_second() {
+        let s = PlanService::new(ServerProfile::SingleModel);
+        let k = key(&["abc"]);
+
+        let (first, cached) = s.serve(serde_json::json!({"v": 1}), Some(&k));
+        assert_eq!(first, serde_json::json!({"v": 1}));
+        assert!(!cached, "the first ask computed it");
+
+        // A second, DIFFERENT document under the same key must lose to
+        // the stored one — that is what "cached" has to mean.
+        let (second, cached) = s.serve(serde_json::json!({"v": 2}), Some(&k));
+        assert_eq!(second, serde_json::json!({"v": 1}));
+        assert!(cached);
+    }
+
+    #[tokio::test]
+    async fn planning_is_refused_when_every_permit_is_taken() {
+        let s = PlanService::with_limits(ServerProfile::SingleModel, 0, 8);
+        let err = s.plan(vec!["/nonexistent".into()]).await.unwrap_err();
+        assert!(
+            matches!(err, ServerError::Conflict(_)),
+            "a bounded service must refuse rather than queue: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_or_oversized_request_is_refused_before_any_fetch() {
+        let s = PlanService::new(ServerProfile::SingleModel);
+        assert!(matches!(
+            s.plan(Vec::new()).await.unwrap_err(),
+            ServerError::BadRequest(_)
+        ));
+        let many: Vec<String> = (0..MAX_SOURCES_PER_PLAN + 1)
+            .map(|i| format!("hf://owner/repo{i}"))
+            .collect();
+        assert!(matches!(
+            s.plan(many).await.unwrap_err(),
+            ServerError::BadRequest(_)
+        ));
+    }
+}

--- a/crates/larql-server/src/routes/capabilities.rs
+++ b/crates/larql-server/src/routes/capabilities.rs
@@ -1,0 +1,32 @@
+//! `GET /v1/capabilities` — the Explorer contract's front door.
+//!
+//! Thin by design. Every judgement lives in
+//! [`crate::capabilities`], which derived this answer from the route
+//! ledger at router-build time; the handler only serves it. There is
+//! nothing to recompute per request — the route table is frozen once
+//! axum has it, so a capability that changed between requests would
+//! be a lie in one of them.
+//!
+//! Unauthenticated and mounted on every profile: a client has to be
+//! able to ask what a server does *before* it knows whether it can
+//! talk to it, and the answer discloses no model, no data and no
+//! path — only which of this server's own routes exist.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::Json;
+
+use crate::capabilities::Capabilities;
+
+#[utoipa::path(
+    get,
+    path = "/v1/capabilities",
+    tag = "admin",
+    responses(
+        (status = 200, description = "What this server will and will not do", body = crate::openapi::schemas::CapabilitiesResponse),
+    ),
+)]
+pub async fn handle_capabilities(State(caps): State<Arc<Capabilities>>) -> Json<serde_json::Value> {
+    Json(caps.to_json())
+}

--- a/crates/larql-server/src/routes/mod.rs
+++ b/crates/larql-server/src/routes/mod.rs
@@ -13,6 +13,7 @@ pub mod models;
 pub mod openai;
 pub mod patches;
 pub(crate) mod paths;
+pub mod plan;
 pub mod query;
 pub mod relations;
 pub mod runtime;
@@ -96,12 +97,27 @@ impl Mount {
             mounted.record(CAPABILITIES),
             "capabilities mounted twice: {CAPABILITIES}"
         );
+        // Planning is served on every profile — it reads a source's
+        // headers and builds nothing, so it is safe to offer publicly.
+        // WHICH sources a profile will plan is the policy question, and
+        // it lives in one place that both the handler and the
+        // capability report ask (`capabilities::plans_source`).
+        assert!(mounted.record(PLAN), "plan mounted twice: {PLAN}");
+
         let caps = Arc::new(Capabilities::derive(profile, mounted));
-        let mut app = router.with_state(state).merge(
-            Router::new()
-                .route(CAPABILITIES, get(capabilities::handle_capabilities))
-                .with_state(caps),
-        );
+        let planning = Arc::new(crate::plan_service::PlanService::new(profile));
+        let mut app = router
+            .with_state(state)
+            .merge(
+                Router::new()
+                    .route(CAPABILITIES, get(capabilities::handle_capabilities))
+                    .with_state(caps),
+            )
+            .merge(
+                Router::new()
+                    .route(PLAN, post(plan::handle_plan))
+                    .with_state(planning),
+            );
         for graft in grafts {
             app = app.merge(graft);
         }

--- a/crates/larql-server/src/routes/mod.rs
+++ b/crates/larql-server/src/routes/mod.rs
@@ -1,5 +1,6 @@
 //! Router setup — maps URL paths to handlers.
 
+pub mod capabilities;
 pub mod container_facts;
 pub mod describe;
 pub mod embed;
@@ -11,6 +12,7 @@ pub mod insert;
 pub mod models;
 pub mod openai;
 pub mod patches;
+pub(crate) mod paths;
 pub mod query;
 pub mod relations;
 pub mod runtime;
@@ -28,7 +30,7 @@ pub mod warmup;
 use std::sync::Arc;
 
 use axum::extract::DefaultBodyLimit;
-use axum::routing::{delete, get, post};
+use axum::routing::{delete, get, post, MethodRouter};
 use axum::Router;
 
 // Expert batch payloads can be large when the client batches all sequence
@@ -36,73 +38,76 @@ use axum::Router;
 // JSON). 64 MB covers: 512 positions × 8 experts × 2816 floats × ~7 bytes/float.
 const EXPERT_BATCH_BODY_LIMIT: usize = crate::http::REQUEST_BODY_LIMIT_BYTES;
 
+use crate::capabilities::{Capabilities, MountedRoutes, ServerProfile};
 use crate::state::AppState;
+use paths::*;
 
-const HEALTH: &str = "/v1/health";
-const RUNTIME: &str = "/v1/runtime";
-const RUNTIME_MODEL: &str = "/v1/runtime/model";
-const MODELS: &str = "/v1/models";
-const DESCRIBE: &str = "/v1/describe";
-const WALK: &str = "/v1/walk";
-const SELECT: &str = "/v1/select";
-const RELATIONS: &str = "/v1/relations";
-const STATS: &str = "/v1/stats";
-const INFER: &str = "/v1/infer";
-const SESSIONS: &str = "/v1/sessions";
-const SESSION_BY_ID: &str = "/v1/sessions/{session_id}";
-const PATCHES_APPLY: &str = "/v1/patches/apply";
-const PATCHES: &str = "/v1/patches";
-const PATCH_BY_NAME: &str = "/v1/patches/{name}";
-const WALK_FFN: &str = "/v1/walk-ffn";
-const WALK_FFN_Q8K: &str = "/v1/walk-ffn-q8k";
-const EXPERT_TOPOLOGY: &str = "/v1/expert/topology";
-const EXPERT_BATCH: &str = "/v1/expert/batch";
-const EXPERTS_LAYER_BATCH: &str = "/v1/experts/layer-batch";
-const EXPERTS_LAYER_BATCH_F16: &str = "/v1/experts/layer-batch-f16";
-const EXPERTS_MULTI_LAYER_BATCH: &str = "/v1/experts/multi-layer-batch";
-const EXPERTS_MULTI_LAYER_BATCH_Q8K: &str = "/v1/experts/multi-layer-batch-q8k";
-const EXPERT: &str = "/v1/expert/{layer}/{expert_id}";
-const EXPLAIN_INFER: &str = "/v1/explain-infer";
-const INSERT: &str = "/v1/insert";
-const STREAM: &str = "/v1/stream";
-const WARMUP: &str = "/v1/warmup";
-const EMBED: &str = "/v1/embed";
-const EMBED_TOKEN: &str = "/v1/embed/{token_id}";
-const LOGITS: &str = "/v1/logits";
-const TOKEN_ENCODE: &str = "/v1/token/encode";
-const TOKEN_DECODE: &str = "/v1/token/decode";
-// Mode B shard handoff: donor streams its on-disk vindex as a tar so a
-// freshly-assigned spare server can mirror the shard locally.
-const SHARD: &str = "/v1/shard/{model_id}/{range}";
-const QUERY: &str = "/v1/query";
-const COMPONENTS: &str = "/v1/components";
-const REPRESENTATIONS: &str = "/v1/representations";
-const PROVENANCE: &str = "/v1/provenance";
-const AUTHORITY: &str = "/v1/authority";
+/// Builds a router while recording every path it mounts.
+///
+/// `GET /v1/capabilities` answers from this ledger, so the surface a
+/// server advertises and the surface axum actually serves are two
+/// readings of one act — not two lists that agree by discipline. A
+/// route added below is advertised automatically; a route deleted
+/// stops being advertised automatically. See [`crate::capabilities`].
+struct Mount {
+    router: Router<Arc<AppState>>,
+    /// Sub-routers with their own state (the LQL bridge), merged in
+    /// `finish`. Their paths go in the same ledger — where the state
+    /// comes from is not the client's question.
+    grafts: Vec<Router>,
+    mounted: MountedRoutes,
+}
 
-const OPENAI_EMBEDDINGS: &str = "/v1/embeddings";
-const OPENAI_COMPLETIONS: &str = "/v1/completions";
-const OPENAI_CHAT_COMPLETIONS: &str = "/v1/chat/completions";
-const OPENAI_RESPONSES: &str = "/v1/responses";
-const OPENAI_RESPONSE_BY_ID: &str = "/v1/responses/{response_id}";
-const MODEL_BY_ID: &str = "/v1/models/{model}";
+impl Mount {
+    fn new() -> Self {
+        Self {
+            router: Router::new(),
+            grafts: Vec::new(),
+            mounted: MountedRoutes::default(),
+        }
+    }
 
-const M_DESCRIBE: &str = "/v1/{model_id}/describe";
-const M_WALK: &str = "/v1/{model_id}/walk";
-const M_SELECT: &str = "/v1/{model_id}/select";
-const M_RELATIONS: &str = "/v1/{model_id}/relations";
-const M_STATS: &str = "/v1/{model_id}/stats";
-const M_INFER: &str = "/v1/{model_id}/infer";
-const M_PATCHES_APPLY: &str = "/v1/{model_id}/patches/apply";
-const M_PATCHES: &str = "/v1/{model_id}/patches";
-const M_PATCH_BY_NAME: &str = "/v1/{model_id}/patches/{name}";
-const M_EXPLAIN_INFER: &str = "/v1/{model_id}/explain-infer";
-const M_INSERT: &str = "/v1/{model_id}/insert";
-const M_EMBED: &str = "/v1/{model_id}/embed";
-const M_EMBED_TOKEN: &str = "/v1/{model_id}/embed/{token_id}";
-const M_LOGITS: &str = "/v1/{model_id}/logits";
-const M_TOKEN_ENCODE: &str = "/v1/{model_id}/token/encode";
-const M_TOKEN_DECODE: &str = "/v1/{model_id}/token/decode";
+    fn at(mut self, path: &'static str, method: MethodRouter<Arc<AppState>>) -> Self {
+        // axum keeps the last registration for a duplicated path, so a
+        // double-mount silently drops handlers. The ledger would still
+        // be right; the router would not.
+        assert!(self.mounted.record(path), "route mounted twice: {path}");
+        self.router = self.router.route(path, method);
+        self
+    }
+
+    /// Record and merge a sub-router that carries its own state.
+    fn graft(mut self, path: &'static str, sub: Router) -> Self {
+        assert!(self.mounted.record(path), "route mounted twice: {path}");
+        self.grafts.push(sub);
+        self
+    }
+
+    /// Close the ledger and serve it. `/v1/capabilities` is recorded
+    /// like any other route — a server that reports its surface should
+    /// appear in the surface it reports.
+    fn finish(self, profile: ServerProfile, state: Arc<AppState>) -> Router {
+        let Mount {
+            router,
+            grafts,
+            mut mounted,
+        } = self;
+        assert!(
+            mounted.record(CAPABILITIES),
+            "capabilities mounted twice: {CAPABILITIES}"
+        );
+        let caps = Arc::new(Capabilities::derive(profile, mounted));
+        let mut app = router.with_state(state).merge(
+            Router::new()
+                .route(CAPABILITIES, get(capabilities::handle_capabilities))
+                .with_state(caps),
+        );
+        for graft in grafts {
+            app = app.merge(graft);
+        }
+        app
+    }
+}
 
 /// Build the router for the PUBLIC_EXPLORER profile: the read routes
 /// plus `POST /v1/query`. Mutating and lifecycle routes are not
@@ -113,153 +118,154 @@ pub fn public_explorer_router(
     state: Arc<AppState>,
     bridge: Arc<crate::lql_bridge::LqlBridge>,
 ) -> Router {
-    Router::new()
-        .route(HEALTH, get(health::handle_health))
-        .route(MODELS, get(models::handle_models))
-        .route(MODEL_BY_ID, get(models::handle_model_retrieve))
-        .route(DESCRIBE, get(describe::handle_describe))
-        .route(WALK, get(walk::handle_walk))
-        .route(RELATIONS, get(relations::handle_relations))
-        .route(STATS, get(stats::handle_stats))
-        .route(COMPONENTS, get(container_facts::handle_components))
-        .route(
+    Mount::new()
+        .at(HEALTH, get(health::handle_health))
+        .at(MODELS, get(models::handle_models))
+        .at(MODEL_BY_ID, get(models::handle_model_retrieve))
+        .at(DESCRIBE, get(describe::handle_describe))
+        .at(WALK, get(walk::handle_walk))
+        .at(RELATIONS, get(relations::handle_relations))
+        .at(STATS, get(stats::handle_stats))
+        .at(COMPONENTS, get(container_facts::handle_components))
+        .at(
             REPRESENTATIONS,
             get(container_facts::handle_representations),
         )
-        .route(PROVENANCE, get(container_facts::handle_provenance))
-        .route(AUTHORITY, get(container_facts::handle_authority))
-        .with_state(state)
-        .merge(
+        .at(PROVENANCE, get(container_facts::handle_provenance))
+        .at(AUTHORITY, get(container_facts::handle_authority))
+        .graft(
+            QUERY,
             Router::new()
                 .route(QUERY, post(query::handle_query))
                 .with_state(bridge),
         )
+        .finish(ServerProfile::PublicExplorer, state)
 }
 
 /// Build the router for single-model serving.
 pub fn single_model_router(state: Arc<AppState>) -> Router {
-    Router::new()
-        .route(DESCRIBE, get(describe::handle_describe))
-        .route(WALK, get(walk::handle_walk))
-        .route(SELECT, post(select::handle_select))
-        .route(RELATIONS, get(relations::handle_relations))
-        .route(STATS, get(stats::handle_stats))
-        .route(INFER, post(infer::handle_infer))
-        .route(SESSIONS, get(sessions::handle_list_sessions))
-        .route(
+    Mount::new()
+        .at(DESCRIBE, get(describe::handle_describe))
+        .at(WALK, get(walk::handle_walk))
+        .at(SELECT, post(select::handle_select))
+        .at(RELATIONS, get(relations::handle_relations))
+        .at(STATS, get(stats::handle_stats))
+        .at(INFER, post(infer::handle_infer))
+        .at(SESSIONS, get(sessions::handle_list_sessions))
+        .at(
             SESSION_BY_ID,
             get(sessions::handle_get_session).delete(sessions::handle_delete_session),
         )
-        .route(PATCHES_APPLY, post(patches::handle_apply_patch))
-        .route(PATCHES, get(patches::handle_list_patches))
-        .route(PATCH_BY_NAME, delete(patches::handle_remove_patch))
-        .route(WALK_FFN, post(walk_ffn::handle_walk_ffn))
-        .route(WALK_FFN_Q8K, post(walk_ffn::handle_walk_ffn_q8k))
-        .route(EXPERT_TOPOLOGY, get(topology::handle_topology))
-        .route(
+        .at(PATCHES_APPLY, post(patches::handle_apply_patch))
+        .at(PATCHES, get(patches::handle_list_patches))
+        .at(PATCH_BY_NAME, delete(patches::handle_remove_patch))
+        .at(WALK_FFN, post(walk_ffn::handle_walk_ffn))
+        .at(WALK_FFN_Q8K, post(walk_ffn::handle_walk_ffn_q8k))
+        .at(EXPERT_TOPOLOGY, get(topology::handle_topology))
+        .at(
             EXPERT_BATCH,
             post(expert::handle_expert_batch).layer(DefaultBodyLimit::max(EXPERT_BATCH_BODY_LIMIT)),
         )
-        .route(
+        .at(
             EXPERTS_LAYER_BATCH,
             post(expert::handle_experts_layer_batch)
                 .layer(DefaultBodyLimit::max(EXPERT_BATCH_BODY_LIMIT)),
         )
-        .route(
+        .at(
             EXPERTS_LAYER_BATCH_F16,
             post(expert::handle_experts_layer_batch_f16)
                 .layer(DefaultBodyLimit::max(EXPERT_BATCH_BODY_LIMIT)),
         )
-        .route(
+        .at(
             EXPERTS_MULTI_LAYER_BATCH,
             post(expert::handle_experts_multi_layer_batch)
                 .layer(DefaultBodyLimit::max(EXPERT_BATCH_BODY_LIMIT)),
         )
-        .route(
+        .at(
             EXPERTS_MULTI_LAYER_BATCH_Q8K,
             post(expert::handle_experts_multi_layer_batch_q8k)
                 .layer(DefaultBodyLimit::max(EXPERT_BATCH_BODY_LIMIT)),
         )
-        .route(EXPERT, post(expert::handle_expert))
-        .route(EXPLAIN_INFER, post(explain::handle_explain))
-        .route(INSERT, post(insert::handle_insert))
-        .route(STREAM, get(stream::handle_stream))
-        .route(HEALTH, get(health::handle_health))
-        .route(RUNTIME, get(runtime::handle_runtime))
+        .at(EXPERT, post(expert::handle_expert))
+        .at(EXPLAIN_INFER, post(explain::handle_explain))
+        .at(INSERT, post(insert::handle_insert))
+        .at(STREAM, get(stream::handle_stream))
+        .at(HEALTH, get(health::handle_health))
+        .at(RUNTIME, get(runtime::handle_runtime))
         // Dynamic model lifecycle — single-model topology only (0↔1
         // invariant, `docs/runtime-lifecycle-design.md` §7). Not present
         // on `multi_model_router`: that route table is sized for a
         // fixed boot-time model count with no slot for this to mutate.
-        .route(
+        .at(
             RUNTIME_MODEL,
             post(runtime_lifecycle::handle_load_model)
                 .delete(runtime_lifecycle::handle_unload_model),
         )
-        .route(MODELS, get(models::handle_models))
-        .route(WARMUP, post(warmup::handle_warmup))
+        .at(MODELS, get(models::handle_models))
+        .at(WARMUP, post(warmup::handle_warmup))
         // Embed server endpoints (always available, required for --embed-only mode)
-        .route(EMBED, post(embed::handle_embed))
-        .route(EMBED_TOKEN, get(embed::handle_embed_single))
-        .route(LOGITS, post(embed::handle_logits))
-        .route(TOKEN_ENCODE, get(embed::handle_token_encode))
-        .route(TOKEN_DECODE, get(embed::handle_token_decode))
-        .route(SHARD, get(shard::handle_shard))
-        .route(OPENAI_EMBEDDINGS, post(openai::handle_embeddings))
-        .route(OPENAI_COMPLETIONS, post(openai::handle_completions))
-        .route(
+        .at(EMBED, post(embed::handle_embed))
+        .at(EMBED_TOKEN, get(embed::handle_embed_single))
+        .at(LOGITS, post(embed::handle_logits))
+        .at(TOKEN_ENCODE, get(embed::handle_token_encode))
+        .at(TOKEN_DECODE, get(embed::handle_token_decode))
+        .at(SHARD, get(shard::handle_shard))
+        .at(OPENAI_EMBEDDINGS, post(openai::handle_embeddings))
+        .at(OPENAI_COMPLETIONS, post(openai::handle_completions))
+        .at(
             OPENAI_CHAT_COMPLETIONS,
             post(openai::handle_chat_completions),
         )
-        .route(OPENAI_RESPONSES, post(openai::handle_responses))
-        .route(
+        .at(OPENAI_RESPONSES, post(openai::handle_responses))
+        .at(
             OPENAI_RESPONSE_BY_ID,
             get(openai::handle_get_response).delete(openai::handle_delete_response),
         )
-        .route(MODEL_BY_ID, get(models::handle_model_retrieve))
-        .with_state(state)
+        .at(MODEL_BY_ID, get(models::handle_model_retrieve))
+        .finish(ServerProfile::SingleModel, state)
 }
 
 /// Build the router for multi-model serving.
 pub fn multi_model_router(state: Arc<AppState>) -> Router {
-    Router::new()
-        .route(HEALTH, get(health::handle_health))
-        .route(RUNTIME, get(runtime::handle_runtime))
-        .route(MODELS, get(models::handle_models))
-        .route(M_DESCRIBE, get(describe::handle_describe_multi))
-        .route(M_WALK, get(walk::handle_walk_multi))
-        .route(M_SELECT, post(select::handle_select_multi))
-        .route(M_RELATIONS, get(relations::handle_relations_multi))
-        .route(M_STATS, get(stats::handle_stats_multi))
-        .route(M_INFER, post(infer::handle_infer_multi))
-        .route(SESSIONS, get(sessions::handle_list_sessions))
-        .route(
+    Mount::new()
+        .at(HEALTH, get(health::handle_health))
+        .at(RUNTIME, get(runtime::handle_runtime))
+        .at(MODELS, get(models::handle_models))
+        .at(M_DESCRIBE, get(describe::handle_describe_multi))
+        .at(M_WALK, get(walk::handle_walk_multi))
+        .at(M_SELECT, post(select::handle_select_multi))
+        .at(M_RELATIONS, get(relations::handle_relations_multi))
+        .at(M_STATS, get(stats::handle_stats_multi))
+        .at(M_INFER, post(infer::handle_infer_multi))
+        .at(SESSIONS, get(sessions::handle_list_sessions))
+        .at(
             SESSION_BY_ID,
             get(sessions::handle_get_session).delete(sessions::handle_delete_session),
         )
-        .route(M_PATCHES_APPLY, post(patches::handle_apply_patch_multi))
-        .route(M_PATCHES, get(patches::handle_list_patches_multi))
-        .route(M_PATCH_BY_NAME, delete(patches::handle_remove_patch_multi))
-        .route(M_EXPLAIN_INFER, post(explain::handle_explain_multi))
-        .route(M_INSERT, post(insert::handle_insert_multi))
+        .at(M_PATCHES_APPLY, post(patches::handle_apply_patch_multi))
+        .at(M_PATCHES, get(patches::handle_list_patches_multi))
+        .at(M_PATCH_BY_NAME, delete(patches::handle_remove_patch_multi))
+        .at(M_EXPLAIN_INFER, post(explain::handle_explain_multi))
+        .at(M_INSERT, post(insert::handle_insert_multi))
         // Embed server endpoints for multi-model mode
-        .route(M_EMBED, post(embed::handle_embed_multi))
-        .route(M_EMBED_TOKEN, get(embed::handle_embed_single_multi))
-        .route(M_LOGITS, post(embed::handle_logits_multi))
-        .route(M_TOKEN_ENCODE, get(embed::handle_token_encode_multi))
-        .route(M_TOKEN_DECODE, get(embed::handle_token_decode_multi))
-        .route(SHARD, get(shard::handle_shard))
+        .at(M_EMBED, post(embed::handle_embed_multi))
+        .at(M_EMBED_TOKEN, get(embed::handle_embed_single_multi))
+        .at(M_LOGITS, post(embed::handle_logits_multi))
+        .at(M_TOKEN_ENCODE, get(embed::handle_token_encode_multi))
+        .at(M_TOKEN_DECODE, get(embed::handle_token_decode_multi))
+        .at(SHARD, get(shard::handle_shard))
         // OpenAI-compat endpoints (multi-model: client passes `model` in body).
-        .route(OPENAI_EMBEDDINGS, post(openai::handle_embeddings))
-        .route(OPENAI_COMPLETIONS, post(openai::handle_completions))
-        .route(
+        .at(OPENAI_EMBEDDINGS, post(openai::handle_embeddings))
+        .at(OPENAI_COMPLETIONS, post(openai::handle_completions))
+        .at(
             OPENAI_CHAT_COMPLETIONS,
             post(openai::handle_chat_completions),
         )
-        .route(OPENAI_RESPONSES, post(openai::handle_responses))
-        .route(
+        .at(OPENAI_RESPONSES, post(openai::handle_responses))
+        .at(
             OPENAI_RESPONSE_BY_ID,
             get(openai::handle_get_response).delete(openai::handle_delete_response),
         )
-        .route(MODEL_BY_ID, get(models::handle_model_retrieve))
-        .with_state(state)
+        .at(MODEL_BY_ID, get(models::handle_model_retrieve))
+        .finish(ServerProfile::MultiModel, state)
 }

--- a/crates/larql-server/src/routes/openai/error.rs
+++ b/crates/larql-server/src/routes/openai/error.rs
@@ -135,6 +135,19 @@ impl OpenAIError {
             code: None,
         }
     }
+
+    /// The serving profile will not do this for this caller. Kept
+    /// distinct from `not_implemented`: the capability exists, and the
+    /// same request succeeds on a server serving a different profile.
+    pub fn permission_denied(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            message: message.into(),
+            error_type: "permission_error",
+            param: None,
+            code: None,
+        }
+    }
 }
 
 impl From<ServerError> for OpenAIError {
@@ -147,6 +160,7 @@ impl From<ServerError> for OpenAIError {
             ServerError::Timeout(m) => OpenAIError::timeout(m),
             ServerError::Conflict(m) => OpenAIError::conflict(m),
             ServerError::Unsupported(m) => OpenAIError::not_implemented(m),
+            ServerError::Refused(m) => OpenAIError::permission_denied(m),
         }
     }
 }

--- a/crates/larql-server/src/routes/paths.rs
+++ b/crates/larql-server/src/routes/paths.rs
@@ -1,0 +1,107 @@
+//! Every URL path this server can mount, in one place.
+//!
+//! Extracted from `routes/mod.rs` so that
+//! [`crate::capabilities`] and the router build from the *same*
+//! strings. A capability is advertised by naming the route that
+//! serves it, and a route is mounted by naming the same constant —
+//! two readings of one fact rather than two facts that agree by
+//! discipline.
+//!
+//! Some paths here are declared but mounted by nobody yet
+//! ([`PLAN`], [`ENCODE`], [`RESIDENCY`]). That is deliberate and is
+//! not a stub: `/v1/capabilities` reports a capability as present iff
+//! its route was actually mounted, so an unmounted path reports
+//! `false` on every profile today, and the rung that mounts it flips
+//! the advertised flag without editing the capability table at all.
+
+pub(crate) const HEALTH: &str = "/v1/health";
+pub(crate) const RUNTIME: &str = "/v1/runtime";
+pub(crate) const RUNTIME_MODEL: &str = "/v1/runtime/model";
+pub(crate) const MODELS: &str = "/v1/models";
+pub(crate) const DESCRIBE: &str = "/v1/describe";
+pub(crate) const WALK: &str = "/v1/walk";
+pub(crate) const SELECT: &str = "/v1/select";
+pub(crate) const RELATIONS: &str = "/v1/relations";
+pub(crate) const STATS: &str = "/v1/stats";
+pub(crate) const INFER: &str = "/v1/infer";
+pub(crate) const SESSIONS: &str = "/v1/sessions";
+pub(crate) const SESSION_BY_ID: &str = "/v1/sessions/{session_id}";
+pub(crate) const PATCHES_APPLY: &str = "/v1/patches/apply";
+pub(crate) const PATCHES: &str = "/v1/patches";
+pub(crate) const PATCH_BY_NAME: &str = "/v1/patches/{name}";
+pub(crate) const WALK_FFN: &str = "/v1/walk-ffn";
+pub(crate) const WALK_FFN_Q8K: &str = "/v1/walk-ffn-q8k";
+pub(crate) const EXPERT_TOPOLOGY: &str = "/v1/expert/topology";
+pub(crate) const EXPERT_BATCH: &str = "/v1/expert/batch";
+pub(crate) const EXPERTS_LAYER_BATCH: &str = "/v1/experts/layer-batch";
+pub(crate) const EXPERTS_LAYER_BATCH_F16: &str = "/v1/experts/layer-batch-f16";
+pub(crate) const EXPERTS_MULTI_LAYER_BATCH: &str = "/v1/experts/multi-layer-batch";
+pub(crate) const EXPERTS_MULTI_LAYER_BATCH_Q8K: &str = "/v1/experts/multi-layer-batch-q8k";
+pub(crate) const EXPERT: &str = "/v1/expert/{layer}/{expert_id}";
+pub(crate) const EXPLAIN_INFER: &str = "/v1/explain-infer";
+pub(crate) const INSERT: &str = "/v1/insert";
+pub(crate) const STREAM: &str = "/v1/stream";
+pub(crate) const WARMUP: &str = "/v1/warmup";
+pub(crate) const EMBED: &str = "/v1/embed";
+pub(crate) const EMBED_TOKEN: &str = "/v1/embed/{token_id}";
+pub(crate) const LOGITS: &str = "/v1/logits";
+pub(crate) const TOKEN_ENCODE: &str = "/v1/token/encode";
+pub(crate) const TOKEN_DECODE: &str = "/v1/token/decode";
+// Mode B shard handoff: donor streams its on-disk vindex as a tar so a
+// freshly-assigned spare server can mirror the shard locally.
+pub(crate) const SHARD: &str = "/v1/shard/{model_id}/{range}";
+pub(crate) const QUERY: &str = "/v1/query";
+pub(crate) const COMPONENTS: &str = "/v1/components";
+pub(crate) const REPRESENTATIONS: &str = "/v1/representations";
+pub(crate) const PROVENANCE: &str = "/v1/provenance";
+pub(crate) const AUTHORITY: &str = "/v1/authority";
+
+pub(crate) const OPENAI_EMBEDDINGS: &str = "/v1/embeddings";
+pub(crate) const OPENAI_COMPLETIONS: &str = "/v1/completions";
+pub(crate) const OPENAI_CHAT_COMPLETIONS: &str = "/v1/chat/completions";
+pub(crate) const OPENAI_RESPONSES: &str = "/v1/responses";
+pub(crate) const OPENAI_RESPONSE_BY_ID: &str = "/v1/responses/{response_id}";
+pub(crate) const MODEL_BY_ID: &str = "/v1/models/{model}";
+
+pub(crate) const M_DESCRIBE: &str = "/v1/{model_id}/describe";
+pub(crate) const M_WALK: &str = "/v1/{model_id}/walk";
+pub(crate) const M_SELECT: &str = "/v1/{model_id}/select";
+pub(crate) const M_RELATIONS: &str = "/v1/{model_id}/relations";
+pub(crate) const M_STATS: &str = "/v1/{model_id}/stats";
+pub(crate) const M_INFER: &str = "/v1/{model_id}/infer";
+pub(crate) const M_PATCHES_APPLY: &str = "/v1/{model_id}/patches/apply";
+pub(crate) const M_PATCHES: &str = "/v1/{model_id}/patches";
+pub(crate) const M_PATCH_BY_NAME: &str = "/v1/{model_id}/patches/{name}";
+pub(crate) const M_EXPLAIN_INFER: &str = "/v1/{model_id}/explain-infer";
+pub(crate) const M_INSERT: &str = "/v1/{model_id}/insert";
+pub(crate) const M_EMBED: &str = "/v1/{model_id}/embed";
+pub(crate) const M_EMBED_TOKEN: &str = "/v1/{model_id}/embed/{token_id}";
+pub(crate) const M_LOGITS: &str = "/v1/{model_id}/logits";
+pub(crate) const M_TOKEN_ENCODE: &str = "/v1/{model_id}/token/encode";
+pub(crate) const M_TOKEN_DECODE: &str = "/v1/{model_id}/token/decode";
+
+// ── Declared, not yet mounted ────────────────────────────────────────
+// The Explorer contract's remaining verbs. See the module doc: these
+// exist so the capability table can name a route for a capability the
+// server does not have yet, and answer `false` from the ledger rather
+// than from a hand-maintained "not supported" list.
+
+/// `POST /v1/plan` — judge a *source* (a raw checkpoint) for
+/// architecture support from its headers, without encoding it.
+/// Explorer contract step 4.
+pub(crate) const PLAN: &str = "/v1/plan";
+
+/// `POST /v1/encode` — compile a source checkpoint into a VINDEX3
+/// container. No profile mounts this; on a public deployment it never
+/// should.
+pub(crate) const ENCODE: &str = "/v1/encode";
+
+/// `GET /v1/residency` — the described/resident/remote ledger per
+/// object, read from the same ledger execution uses. Explorer
+/// contract step 7.
+pub(crate) const RESIDENCY: &str = "/v1/residency";
+
+/// `GET /v1/capabilities` — this contract's own front door: what this
+/// server will and will not do, enforced here rather than guessed by
+/// the client from a hostname.
+pub(crate) const CAPABILITIES: &str = "/v1/capabilities";

--- a/crates/larql-server/src/routes/plan.rs
+++ b/crates/larql-server/src/routes/plan.rs
@@ -1,0 +1,48 @@
+//! `POST /v1/plan` — plan a source without encoding it.
+//!
+//! Thin: the policy, the cost bound and the cache live in
+//! [`crate::plan_service`], and the verdict itself comes from
+//! `larql-vindex`. This handler is the HTTP shape and nothing else.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::Json;
+use serde::Deserialize;
+use utoipa::ToSchema;
+
+use crate::error::ServerError;
+use crate::plan_service::PlanService;
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PlanRequest {
+    /// The artifacts to plan, as `hf://owner/repo[@revision]` or —
+    /// where the profile permits it — local checkpoint paths.
+    ///
+    /// A list, not a string, because a VINDEX3 plan is a *system*
+    /// plan: several artifacts can compose into one model, and their
+    /// interfaces are part of the verdict. One source is the ordinary
+    /// case and is written `["hf://owner/repo"]`. There is deliberately
+    /// no singular `source` alias — two spellings of one request is a
+    /// second thing to keep in agreement.
+    pub sources: Vec<String>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/plan",
+    tag = "admin",
+    request_body = PlanRequest,
+    responses(
+        (status = 200, description = "The architecture-support verdict, plus what staging read to reach it", body = serde_json::Value),
+        (status = 400, body = crate::error::ErrorBody, description = "No sources, too many, or a source that cannot be read or planned"),
+        (status = 403, body = crate::error::ErrorBody, description = "This serving profile will not plan that source form — see GET /v1/capabilities"),
+        (status = 409, body = crate::error::ErrorBody, description = "Too many plans already in flight"),
+    ),
+)]
+pub async fn handle_plan(
+    State(service): State<Arc<PlanService>>,
+    Json(req): Json<PlanRequest>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    service.plan(req.sources).await.map(Json)
+}

--- a/crates/larql-server/tests/test_capabilities.rs
+++ b/crates/larql-server/tests/test_capabilities.rs
@@ -1,0 +1,358 @@
+//! `GET /v1/capabilities` — and the invariant that makes it worth
+//! trusting.
+//!
+//! The endpoint exists so a client (the vindex3.org Explorer) never
+//! infers a server's powers from its hostname. That only helps if the
+//! report cannot over-claim, so the load-bearing test here is
+//! `advertised_capabilities_match_the_mounted_router`: for every
+//! capability, on every profile, it reads the answer twice —
+//!
+//! 1. from the report the server generated off its mounted-route
+//!    ledger, and
+//! 2. from axum's own matcher, by sending a method the route does not
+//!    accept: **405 means the path is mounted, 404 means it is not**.
+//!    The probe never reaches a handler, so it needs no model and has
+//!    no side effects, and it cannot be fooled by a handler that
+//!    returns 404 for its own reasons.
+//!
+//! — and asserts they agree. Two independent readings of one fact.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use larql_inference::test_utils::synthetic_tokenizer_json;
+use larql_server::bootstrap::{classify_source, SourceKind};
+use larql_server::capabilities::{CAPABILITIES_SCHEMA, ROUTE_CAPABILITIES, V3_BACKENDS};
+use larql_vindex::format::vindex3::fixtures::{
+    encode_fixture_container, miniature_glimmer, G_VOCAB,
+};
+use tower::ServiceExt;
+
+/// A method no route in this server accepts, used to ask axum whether
+/// a path exists without invoking anything behind it.
+const PROBE_METHOD: &str = "PATCH";
+
+fn v3_container() -> tempfile::TempDir {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(
+        miniature_glimmer,
+        checkpoint.path(),
+        container.path(),
+        "capabilities-fixture",
+    );
+    std::fs::write(
+        container.path().join("tokenizer.json"),
+        synthetic_tokenizer_json(G_VOCAB),
+    )
+    .unwrap();
+    container
+}
+
+fn public_app(container: &std::path::Path) -> axum::Router {
+    let artifact = larql_server::bootstrap::load_artifact(
+        &container.to_string_lossy(),
+        larql_server::bootstrap::LoadVindexOptions::default(),
+    )
+    .unwrap();
+    let v3 = match artifact {
+        larql_server::bootstrap::LoadedArtifact::V3(m) => Arc::new(*m),
+        larql_server::bootstrap::LoadedArtifact::V2(_) => panic!("fixture must bind as V3"),
+    };
+    let state = common::state(Vec::new());
+    state.model_set.write().unwrap().v3_models = vec![v3];
+    let bridge = Arc::new(
+        larql_server::lql_bridge::spawn(container, std::time::Duration::from_secs(60)).unwrap(),
+    );
+    larql_server::routes::public_explorer_router(state, bridge)
+}
+
+async fn get_json(app: &axum::Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null),
+    )
+}
+
+/// Ask axum whether `path` is mounted, without reaching a handler.
+async fn is_mounted(app: &axum::Router, path: &str) -> bool {
+    let req = Request::builder()
+        .method(PROBE_METHOD)
+        .uri(path)
+        .body(Body::empty())
+        .unwrap();
+    let status = app.clone().oneshot(req).await.unwrap().status();
+    match status {
+        StatusCode::METHOD_NOT_ALLOWED => true,
+        StatusCode::NOT_FOUND => false,
+        other => panic!(
+            "probe of {path} answered {other} — the {PROBE_METHOD} probe only distinguishes \
+             mounted (405) from absent (404); some route now accepts {PROBE_METHOD} and the \
+             probe needs a different method"
+        ),
+    }
+}
+
+async fn capabilities_of(app: &axum::Router) -> serde_json::Value {
+    let (status, body) = get_json(app, "/v1/capabilities").await;
+    assert_eq!(status, StatusCode::OK, "capabilities must answer: {body}");
+    body
+}
+
+/// The three profiles, each as a live router.
+async fn all_profiles(container: &std::path::Path) -> Vec<(&'static str, axum::Router)> {
+    vec![
+        ("public_explorer", public_app(container)),
+        (
+            "single_model",
+            larql_server::routes::single_model_router(common::state(Vec::new())),
+        ),
+        (
+            "multi_model",
+            larql_server::routes::multi_model_router(common::state(Vec::new())),
+        ),
+    ]
+}
+
+// ── the invariant ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn advertised_capabilities_match_the_mounted_router() {
+    let container = v3_container();
+    for (name, app) in all_profiles(container.path()).await {
+        let report = capabilities_of(&app).await;
+        assert_eq!(report["profile"], name, "profile must name its own router");
+
+        for cap in ROUTE_CAPABILITIES {
+            let advertised = report
+                .pointer(cap.key)
+                .unwrap_or_else(|| panic!("{name}: {} missing from the report", cap.key))
+                .as_bool()
+                .unwrap_or_else(|| panic!("{name}: {} is not a boolean", cap.key));
+            let mounted = is_mounted(&app, cap.route).await;
+
+            if advertised {
+                assert!(
+                    mounted,
+                    "{name} advertises {} but never mounted {} — the report over-claims, \
+                     which is exactly the failure this endpoint exists to prevent",
+                    cap.key, cap.route
+                );
+            } else if cap.source.is_none() {
+                // With no source conjunct, "not advertised" can only
+                // mean "route absent" — so the two readings must agree
+                // in both directions, not just the dangerous one.
+                assert!(
+                    !mounted,
+                    "{name} mounted {} but does not advertise {} — the report under-claims",
+                    cap.route, cap.key
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn capabilities_lists_itself_and_is_mounted_on_every_profile() {
+    let container = v3_container();
+    for (name, app) in all_profiles(container.path()).await {
+        let report = capabilities_of(&app).await;
+        let routes: Vec<&str> = report["routes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r.as_str().unwrap())
+            .collect();
+        assert!(
+            routes.contains(&"/v1/capabilities"),
+            "{name}: a server reporting its surface must appear in it: {routes:?}"
+        );
+        assert_eq!(report["schema"], CAPABILITIES_SCHEMA);
+        assert_eq!(report["object"], "capabilities");
+        assert_eq!(report["server"]["name"], "larql-server");
+    }
+}
+
+/// The reported route list is the ledger, so it must agree with axum
+/// route for route — not just on the paths the capability table
+/// happens to name.
+#[tokio::test]
+async fn every_reported_route_is_really_mounted() {
+    let container = v3_container();
+    for (name, app) in all_profiles(container.path()).await {
+        let report = capabilities_of(&app).await;
+        for route in report["routes"].as_array().unwrap() {
+            let path = route.as_str().unwrap();
+            // Paths with parameters need a concrete value to probe.
+            if path.contains('{') {
+                continue;
+            }
+            assert!(
+                is_mounted(&app, path).await,
+                "{name} reports {path} as mounted, but axum does not serve it"
+            );
+        }
+    }
+}
+
+// ── what today's server actually offers ─────────────────────────────
+
+#[tokio::test]
+async fn public_explorer_offers_the_read_surface_and_refuses_the_rest() {
+    let container = v3_container();
+    let app = public_app(container.path());
+    let report = capabilities_of(&app).await;
+
+    for key in [
+        "/explorer/models",
+        "/explorer/components",
+        "/explorer/representations",
+        "/explorer/provenance",
+        "/explorer/authority",
+        "/explorer/query",
+    ] {
+        assert_eq!(
+            report.pointer(key).unwrap(),
+            &serde_json::json!(true),
+            "{key}"
+        );
+    }
+    // The public surface executes nothing and binds nothing.
+    for key in [
+        "/runtime/execute",
+        "/runtime/lifecycle",
+        "/runtime/introspect",
+        "/sources/load/local",
+        "/sources/load/hf",
+    ] {
+        assert_eq!(
+            report.pointer(key).unwrap(),
+            &serde_json::json!(false),
+            "{key}"
+        );
+    }
+}
+
+/// The container-facts routes are mounted **only** on the public
+/// explorer today. A localhost server therefore cannot answer them,
+/// and the Explorer must be told so rather than discovering it with a
+/// 404 — this test pins the asymmetry so it is a decision, not a
+/// surprise.
+#[tokio::test]
+async fn a_local_single_model_server_does_not_yet_serve_container_facts() {
+    let app = larql_server::routes::single_model_router(common::state(Vec::new()));
+    let report = capabilities_of(&app).await;
+    for key in [
+        "/explorer/components",
+        "/explorer/representations",
+        "/explorer/provenance",
+        "/explorer/authority",
+        "/explorer/query",
+    ] {
+        assert_eq!(
+            report.pointer(key).unwrap(),
+            &serde_json::json!(false),
+            "{key} — if this flipped, the facts routes gained a second mount and the \
+             Explorer's server tab can now offer them"
+        );
+    }
+    // What it does offer instead: binding and running a model.
+    assert_eq!(
+        report.pointer("/runtime/execute").unwrap(),
+        &serde_json::json!(true)
+    );
+    assert_eq!(
+        report.pointer("/runtime/lifecycle").unwrap(),
+        &serde_json::json!(true)
+    );
+    assert_eq!(
+        report.pointer("/sources/load/local").unwrap(),
+        &serde_json::json!(true)
+    );
+    assert_eq!(
+        report.pointer("/sources/load/hf").unwrap(),
+        &serde_json::json!(true)
+    );
+}
+
+/// No profile plans or encodes a checkpoint. This is the honest
+/// answer for step 3, and the test that will *fail loudly* when the
+/// rung that mounts `/v1/plan` lands — at which point the expectation
+/// flips here and nowhere else, because no capability table was
+/// hand-edited.
+#[tokio::test]
+async fn no_profile_claims_to_plan_encode_or_report_residency() {
+    let container = v3_container();
+    for (name, app) in all_profiles(container.path()).await {
+        let report = capabilities_of(&app).await;
+        for key in [
+            "/sources/plan/local",
+            "/sources/plan/hf",
+            "/sources/encode/local",
+            "/sources/encode/hf",
+            "/explorer/residency",
+        ] {
+            assert_eq!(
+                report.pointer(key).unwrap(),
+                &serde_json::json!(false),
+                "{name}: {key}"
+            );
+        }
+    }
+}
+
+// ── the two facts that are not route-derived ────────────────────────
+
+/// `sources.load.hf` is true because the resolver classifies `hf://`
+/// as an HF reference — not because a table says so. If `is_hf_path`
+/// stopped recognising the scheme, the capability would go false on
+/// its own.
+#[test]
+fn source_kinds_come_from_the_resolver() {
+    assert_eq!(classify_source("hf://owner/repo"), SourceKind::Hf);
+    assert_eq!(
+        classify_source("/var/lib/larql/example.vindex3"),
+        SourceKind::Local
+    );
+    assert_eq!(classify_source("./relative.vindex3"), SourceKind::Local);
+}
+
+/// The server binds every V3 container on the CPU executor, so
+/// `runtime.backends` is `["cpu"]`. `metal-experts` is a VINDEX2 MoE
+/// dispatch feature and must not widen this list: advertising Metal
+/// would tell the Explorer it can offer a GPU run this server cannot
+/// perform. When a real Metal V3 binding lands, this test fails and
+/// `V3_BACKENDS` grows with it.
+#[test]
+fn backends_match_the_v3_binding() {
+    let binding = include_str!("../src/vindex3.rs");
+    assert!(
+        binding.contains("ProductionBackend"),
+        "the V3 loader no longer names ProductionBackend — re-derive V3_BACKENDS"
+    );
+    let metal_bound = binding.contains("MetalBackend");
+    assert_eq!(
+        metal_bound,
+        V3_BACKENDS.contains(&"metal"),
+        "V3_BACKENDS says {V3_BACKENDS:?} while the V3 loader {} a Metal backend",
+        if metal_bound {
+            "binds"
+        } else {
+            "does not bind"
+        }
+    );
+    assert_eq!(V3_BACKENDS, &["cpu"]);
+}

--- a/crates/larql-server/tests/test_capabilities.rs
+++ b/crates/larql-server/tests/test_capabilities.rs
@@ -288,19 +288,21 @@ async fn a_local_single_model_server_does_not_yet_serve_container_facts() {
     );
 }
 
-/// No profile plans or encodes a checkpoint. This is the honest
-/// answer for step 3, and the test that will *fail loudly* when the
-/// rung that mounts `/v1/plan` lands — at which point the expectation
-/// flips here and nowhere else, because no capability table was
-/// hand-edited.
+/// Step 4 mounted `/v1/plan`, and this is the whole point of deriving
+/// the report from the route ledger: the capability flipped because the
+/// route appeared, with no edit to `ROUTE_CAPABILITIES`. Encode and
+/// residency are still mounted by nobody and still report false.
 #[tokio::test]
-async fn no_profile_claims_to_plan_encode_or_report_residency() {
+async fn planning_is_offered_but_encoding_and_residency_are_not() {
     let container = v3_container();
     for (name, app) in all_profiles(container.path()).await {
         let report = capabilities_of(&app).await;
+        assert_eq!(
+            report.pointer("/sources/plan/hf").unwrap(),
+            &serde_json::json!(true),
+            "{name}: every profile plans an hf:// source"
+        );
         for key in [
-            "/sources/plan/local",
-            "/sources/plan/hf",
             "/sources/encode/local",
             "/sources/encode/hf",
             "/explorer/residency",
@@ -312,6 +314,31 @@ async fn no_profile_claims_to_plan_encode_or_report_residency() {
             );
         }
     }
+}
+
+/// The one capability that differs by profile rather than by route.
+/// A public server plans `hf://` and refuses a local path; a localhost
+/// server plans either. `tests/test_plan_route.rs` checks that the
+/// endpoint actually behaves this way — here we only pin what is
+/// advertised.
+#[tokio::test]
+async fn only_a_local_server_advertises_planning_a_local_path() {
+    let container = v3_container();
+    let public = capabilities_of(&public_app(container.path())).await;
+    assert_eq!(
+        public.pointer("/sources/plan/local").unwrap(),
+        &serde_json::json!(false),
+        "the public surface must not offer to plan a filesystem path"
+    );
+
+    let local = capabilities_of(&larql_server::routes::single_model_router(common::state(
+        Vec::new(),
+    )))
+    .await;
+    assert_eq!(
+        local.pointer("/sources/plan/local").unwrap(),
+        &serde_json::json!(true)
+    );
 }
 
 // ── the two facts that are not route-derived ────────────────────────

--- a/crates/larql-server/tests/test_plan_route.rs
+++ b/crates/larql-server/tests/test_plan_route.rs
@@ -1,0 +1,251 @@
+//! `POST /v1/plan` — planning a source before anything is encoded.
+//!
+//! The load-bearing test is `advertised_plan_sources_match_what_the_
+//! endpoint_does`. `GET /v1/capabilities` tells a client which source
+//! forms this server will plan; that promise is only worth making if
+//! the endpoint keeps it, so the test reads the promise from the
+//! report and then checks it against the endpoint's actual answer, per
+//! profile. One policy, two readings — the same discipline the
+//! capability ledger uses against axum's router.
+//!
+//! No test here reaches the network. The `hf://` probes are
+//! deliberately malformed (`hf://` with no repo), which the spec parser
+//! refuses before a client is ever constructed — so an HF source can be
+//! taken all the way through the policy gate and stopped at the first
+//! step that would cost anything.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use larql_inference::test_utils::synthetic_tokenizer_json;
+use larql_server::capabilities::PLAN_SCHEMA_EXPECTED;
+use larql_vindex::format::vindex3::fixtures::{
+    encode_fixture_container, miniature_glimmer, G_VOCAB,
+};
+use tower::ServiceExt;
+
+/// An `hf://` reference that is classified as remote and then refused
+/// by the parser — reaching the policy gate without reaching the hub.
+const UNREACHABLE_HF: &str = "hf://";
+
+fn v3_container() -> tempfile::TempDir {
+    let checkpoint = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(
+        miniature_glimmer,
+        checkpoint.path(),
+        container.path(),
+        "plan-fixture",
+    );
+    std::fs::write(
+        container.path().join("tokenizer.json"),
+        synthetic_tokenizer_json(G_VOCAB),
+    )
+    .unwrap();
+    container
+}
+
+/// A real checkpoint on disk — the thing `plan` actually takes.
+fn checkpoint() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_glimmer(dir.path());
+    dir
+}
+
+fn public_app(container: &std::path::Path) -> axum::Router {
+    let artifact = larql_server::bootstrap::load_artifact(
+        &container.to_string_lossy(),
+        larql_server::bootstrap::LoadVindexOptions::default(),
+    )
+    .unwrap();
+    let v3 = match artifact {
+        larql_server::bootstrap::LoadedArtifact::V3(m) => Arc::new(*m),
+        larql_server::bootstrap::LoadedArtifact::V2(_) => panic!("fixture must bind as V3"),
+    };
+    let state = common::state(Vec::new());
+    state.model_set.write().unwrap().v3_models = vec![v3];
+    let bridge = Arc::new(
+        larql_server::lql_bridge::spawn(container, std::time::Duration::from_secs(60)).unwrap(),
+    );
+    larql_server::routes::public_explorer_router(state, bridge)
+}
+
+fn local_app() -> axum::Router {
+    larql_server::routes::single_model_router(common::state(Vec::new()))
+}
+
+async fn post_plan(app: &axum::Router, sources: &[&str]) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/plan")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::json!({ "sources": sources }).to_string(),
+        ))
+        .unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null),
+    )
+}
+
+async fn capabilities(app: &axum::Router) -> serde_json::Value {
+    let req = Request::builder()
+        .uri("/v1/capabilities")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+// ── the invariant ───────────────────────────────────────────────────
+
+/// What the report promises about `sources.plan.*` is what the endpoint
+/// does. A refusal for policy is 403; anything else (including a 400
+/// for a source that cannot be read) means the policy admitted it.
+#[tokio::test]
+async fn advertised_plan_sources_match_what_the_endpoint_does() {
+    let container = v3_container();
+    let local_path = checkpoint();
+    let local_spec = local_path.path().to_string_lossy().into_owned();
+
+    for (name, app) in [
+        ("public_explorer", public_app(container.path())),
+        ("single_model", local_app()),
+    ] {
+        let report = capabilities(&app).await;
+        for (key, source) in [
+            ("/sources/plan/local", local_spec.as_str()),
+            ("/sources/plan/hf", UNREACHABLE_HF),
+        ] {
+            let advertised = report.pointer(key).unwrap().as_bool().unwrap();
+            let (status, body) = post_plan(&app, &[source]).await;
+            let refused = status == StatusCode::FORBIDDEN;
+            assert_eq!(
+                advertised, !refused,
+                "{name}: {key} advertises {advertised} but POST /v1/plan answered \
+                 {status} for {source} — a client that read the report first would be \
+                 surprised by the endpoint. Body: {body}"
+            );
+        }
+    }
+}
+
+/// The public surface names what it refuses and why, and points at the
+/// report — a refusal that leaves the caller guessing is the failure
+/// this whole contract exists to remove.
+#[tokio::test]
+async fn the_public_refusal_names_the_profile_and_the_capability() {
+    let container = v3_container();
+    let local = checkpoint();
+    let (status, body) = post_plan(
+        &public_app(container.path()),
+        &[&local.path().to_string_lossy()],
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    let msg = body["error"].as_str().unwrap();
+    assert!(msg.contains("public_explorer"), "{msg}");
+    assert!(msg.contains("sources.plan.local"), "{msg}");
+}
+
+// ── the verdict ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_local_server_plans_a_real_checkpoint() {
+    let dir = checkpoint();
+    let (status, body) = post_plan(&local_app(), &[&dir.path().to_string_lossy()]).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    // The document is the plan, at the same keys `vindex plan --json`
+    // writes it — not a server-shaped wrapper around one.
+    assert_eq!(body["schema"], PLAN_SCHEMA_EXPECTED);
+    assert!(
+        body["planner"].is_object(),
+        "the verdict names its judge: {body}"
+    );
+    assert!(body["artifacts"].is_array());
+    assert!(body["admissible"].is_boolean());
+
+    // The verdict names its subject as the caller wrote it.
+    assert_eq!(
+        body["artifacts"][0]["source"]["path"],
+        serde_json::json!(dir.path().to_string_lossy())
+    );
+}
+
+/// A local checkpoint has no immutable commit, so its verdict is served
+/// and never stored. This is the cache rule that matters: a partially
+/// immutable verdict is not an immutable verdict.
+#[tokio::test]
+async fn a_local_verdict_is_served_but_never_cached() {
+    let dir = checkpoint();
+    let (status, body) = post_plan(&local_app(), &[&dir.path().to_string_lossy()]).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["serving"]["cacheable"], serde_json::json!(false));
+    assert_eq!(body["serving"]["cached"], serde_json::json!(false));
+    assert_eq!(
+        body["serving"]["profile"],
+        serde_json::json!("single_model")
+    );
+
+    // Asking twice must not turn an uncacheable verdict into a hit.
+    let (_, again) = post_plan(&local_app(), &[&dir.path().to_string_lossy()]).await;
+    assert_eq!(again["serving"]["cached"], serde_json::json!(false));
+}
+
+/// Planning reads headers, so a local checkpoint reports no staging —
+/// nothing was staged to answer.
+#[tokio::test]
+async fn a_local_plan_reports_no_staging() {
+    let dir = checkpoint();
+    let (_, body) = post_plan(&local_app(), &[&dir.path().to_string_lossy()]).await;
+    assert!(
+        body.get("staging").is_none(),
+        "a local artifact stages nothing: {body}"
+    );
+}
+
+// ── refusals that are not policy ────────────────────────────────────
+
+#[tokio::test]
+async fn an_unreadable_source_is_a_bad_request_not_a_server_error() {
+    let (status, body) = post_plan(&local_app(), &["/no/such/checkpoint"]).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(
+        body["error"].as_str().unwrap().contains("cannot read"),
+        "{body}"
+    );
+}
+
+#[tokio::test]
+async fn a_malformed_hf_reference_is_refused_before_the_network() {
+    let (status, body) = post_plan(&local_app(), &[UNREACHABLE_HF]).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+}
+
+#[tokio::test]
+async fn an_empty_source_list_is_refused() {
+    let (status, _) = post_plan(&local_app(), &[]).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn plan_is_mounted_on_every_profile() {
+    let container = v3_container();
+    for app in [public_app(container.path()), local_app()] {
+        let (status, _) = post_plan(&app, &[UNREACHABLE_HF]).await;
+        assert_ne!(status, StatusCode::NOT_FOUND, "every profile plans");
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/artifact/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/artifact/mod.rs
@@ -42,7 +42,7 @@ pub use resolve::{
     is_remote_spec, resolve, resolve_all, ArtifactPayloads, ResolvedArtifact, INVENTORY_EXT,
 };
 pub use size::size;
-pub use staging::{staging_json, StagingReport};
+pub use staging::StagingReport;
 
 #[cfg(test)]
 mod tests;

--- a/crates/larql-vindex/src/format/vindex3/artifact/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/artifact/mod.rs
@@ -42,7 +42,7 @@ pub use resolve::{
     is_remote_spec, resolve, resolve_all, ArtifactPayloads, ResolvedArtifact, INVENTORY_EXT,
 };
 pub use size::size;
-pub use staging::StagingReport;
+pub use staging::{staging_json, StagingReport};
 
 #[cfg(test)]
 mod tests;

--- a/crates/larql-vindex/src/format/vindex3/artifact/resolve.rs
+++ b/crates/larql-vindex/src/format/vindex3/artifact/resolve.rs
@@ -91,6 +91,19 @@ impl ResolvedArtifact {
 
     /// What staging cost, for a repo artifact. `None` for a local one,
     /// which staged nothing.
+    /// What staging read to answer a question about this artifact, as
+    /// JSON — or `None` for a local artifact, which staged nothing.
+    /// Not an empty report: that would read as "staged, and it cost
+    /// zero". The object's shape is
+    /// [`super::staging::staging_report_json`].
+    pub fn staging_json(&self) -> Option<serde_json::Value> {
+        Some(super::staging::staging_report_json(
+            &self.name,
+            self.commit(),
+            &self.staging()?,
+        ))
+    }
+
     pub fn staging(&self) -> Option<StagingReport> {
         let Origin::Remote(remote) = &self.origin else {
             return None;

--- a/crates/larql-vindex/src/format/vindex3/artifact/staging.rs
+++ b/crates/larql-vindex/src/format/vindex3/artifact/staging.rs
@@ -51,3 +51,31 @@ impl StagingReport {
             .map(|declared| declared.abs_diff(payload))
     }
 }
+
+/// What staging read to answer a question about `artifact`, as JSON —
+/// or `None` for a local artifact, which staged nothing.
+///
+/// Lives here rather than in a caller because two front doors report it
+/// (`vindex plan --json` and `POST /v1/plan`) and the server's response
+/// body is defined as the CLI's document plus one serving field. Two
+/// hand-written copies of this object would make that parity a
+/// coincidence rather than a property.
+pub fn staging_json(artifact: &super::ResolvedArtifact) -> Option<serde_json::Value> {
+    let report = artifact.staging()?;
+    Some(serde_json::json!({
+        "artifact": artifact.name,
+        "commit": artifact.commit(),
+        "shards": report.shards,
+        "staged": super::size(report.staged_bytes()),
+        "headers": super::size(report.header_bytes),
+        "metadata": super::size(report.metadata_bytes),
+        "stands_in_for": report.payload_bytes.as_ref().ok().map(|b| super::size(*b)),
+        // Stated only when the index disagrees with its own headers, so
+        // the difference reads as a fact about the checkpoint rather than
+        // a units bug in the report.
+        "index_declares": report
+            .declared_total
+            .filter(|d| report.payload_bytes.as_ref().is_ok_and(|p| d != p))
+            .map(super::size),
+    }))
+}

--- a/crates/larql-vindex/src/format/vindex3/artifact/staging.rs
+++ b/crates/larql-vindex/src/format/vindex3/artifact/staging.rs
@@ -52,19 +52,27 @@ impl StagingReport {
     }
 }
 
-/// What staging read to answer a question about `artifact`, as JSON —
-/// or `None` for a local artifact, which staged nothing.
+/// What a staging pass cost and what it stands in for, as JSON.
 ///
-/// Lives here rather than in a caller because two front doors report it
-/// (`vindex plan --json` and `POST /v1/plan`) and the server's response
-/// body is defined as the CLI's document plus one serving field. Two
-/// hand-written copies of this object would make that parity a
+/// The one place this object's shape is written. Two front doors print
+/// it — `vindex plan --json` and `POST /v1/plan` — and the server's
+/// response body is defined as the CLI's document plus one serving
+/// field, so two hand-written copies would make that parity a
 /// coincidence rather than a property.
-pub fn staging_json(artifact: &super::ResolvedArtifact) -> Option<serde_json::Value> {
-    let report = artifact.staging()?;
-    Some(serde_json::json!({
-        "artifact": artifact.name,
-        "commit": artifact.commit(),
+///
+/// A pure function of the report rather than a method on
+/// `ResolvedArtifact`, because an artifact with a remote origin can
+/// only be built by staging a real repo: through that door the shape
+/// could only ever be checked over the network, which is to say never.
+/// `ResolvedArtifact::staging_json` is the two-line adapter.
+pub(super) fn staging_report_json(
+    name: &str,
+    commit: Option<&str>,
+    report: &StagingReport,
+) -> serde_json::Value {
+    serde_json::json!({
+        "artifact": name,
+        "commit": commit,
         "shards": report.shards,
         "staged": super::size(report.staged_bytes()),
         "headers": super::size(report.header_bytes),
@@ -77,5 +85,5 @@ pub fn staging_json(artifact: &super::ResolvedArtifact) -> Option<serde_json::Va
             .declared_total
             .filter(|d| report.payload_bytes.as_ref().is_ok_and(|p| d != p))
             .map(super::size),
-    }))
+    })
 }

--- a/crates/larql-vindex/src/format/vindex3/artifact/tests/staging.rs
+++ b/crates/larql-vindex/src/format/vindex3/artifact/tests/staging.rs
@@ -56,3 +56,78 @@ fn nothing_to_compare_against_is_not_a_disagreement() {
         "a failed census cannot be compared against anything"
     );
 }
+
+// ── the JSON two front doors both print ──────────────────────────────
+
+use super::super::staging::staging_report_json as render;
+
+#[test]
+fn the_rendered_figures_separate_what_was_read_from_what_it_stands_in_for() {
+    let v = render(
+        "GLM-5.3-Flash",
+        Some("abc123"),
+        &report(Ok(328_330_000_000), None),
+    );
+    assert_eq!(v["artifact"], "GLM-5.3-Flash");
+    assert_eq!(v["commit"], "abc123");
+    assert_eq!(v["shards"], 62);
+    // Headers alone would understate the pass fourfold, so `staged` is
+    // the total and `headers` stays visible beside it.
+    assert_eq!(v["staged"], "39.39 MB");
+    assert_eq!(v["headers"], "10.68 MB");
+    assert_eq!(v["metadata"], "28.71 MB");
+    assert_eq!(v["stands_in_for"], "328.33 GB (305.78 GiB)");
+}
+
+#[test]
+fn a_local_artifact_has_no_commit_to_report() {
+    let v = render("checkpoint", None, &report(Ok(1_000), None));
+    assert!(v["commit"].is_null(), "{v}");
+}
+
+/// The index figure appears only when it contradicts the headers —
+/// printing it when the two agree would read as a units bug rather than
+/// as a fact about the checkpoint.
+#[test]
+fn an_agreeing_index_is_not_restated() {
+    let agree = render(
+        "granite",
+        None,
+        &report(Ok(7_319_475_200), Some(7_319_475_200)),
+    );
+    assert!(agree["index_declares"].is_null(), "{agree}");
+
+    let disagree = render(
+        "granite",
+        None,
+        &report(Ok(7_319_475_200), Some(6_805_672_960)),
+    );
+    assert!(!disagree["index_declares"].is_null(), "{disagree}");
+}
+
+/// A census that failed carries no payload figure, and the rendering
+/// says nothing rather than inventing a zero.
+#[test]
+fn a_failed_census_reports_no_payload_and_no_index_claim() {
+    let v = render(
+        "broken",
+        None,
+        &report(Err(VindexError::Parse("no headers".into())), Some(123)),
+    );
+    assert!(v["stands_in_for"].is_null(), "{v}");
+    assert!(v["index_declares"].is_null(), "{v}");
+}
+
+/// The wrapper's only other answer: a local checkpoint staged nothing,
+/// so there is nothing to report — not an empty report, which would
+/// read as "staged, and it cost zero".
+#[test]
+fn a_local_artifact_reports_no_staging_at_all() {
+    let dir = tempfile::tempdir().unwrap();
+    crate::format::vindex3::fixtures::miniature_glimmer(dir.path());
+    let resolved = crate::format::vindex3::artifact::resolve(dir.path()).unwrap();
+    assert!(
+        resolved.staging_json().is_none(),
+        "a local artifact has no staging pass to describe"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/plan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/mod.rs
@@ -722,3 +722,50 @@ fn unresolved_interface_findings(artifact: &str, built: &BuiltGraph) -> Vec<Find
         })
         .collect()
 }
+
+// ── The plan-by-source sequence, in one place ────────────────────────
+
+/// Plan artifacts the caller has already resolved.
+///
+/// `specs[i]` is the argument the caller was given for `resolved[i]` —
+/// the string the user typed, which is what the verdict should name, not
+/// the local directory an `hf://` reference happened to stage into.
+///
+/// This exists because three front doors were carrying their own copy of
+/// the same fifteen lines (`vindex plan`, `larql vindex3 plan`, and
+/// `POST /v1/plan`): resolve, name each artifact's source with the commit
+/// its facts were read at, then plan. A verdict that differs by which
+/// door asked for it is not a verdict, so the sequence is one function
+/// and the doors differ only in how they report it.
+///
+/// Resolution stays with the caller: it is the step that can be slow and
+/// can fail, and each door reports staging differently — the CLIs to
+/// stderr as it happens, the server as a field in its response.
+pub fn plan_resolved(
+    specs: &[std::path::PathBuf],
+    resolved: Vec<super::artifact::ResolvedArtifact>,
+) -> Result<SystemPlan, crate::error::VindexError> {
+    if specs.len() != resolved.len() {
+        return Err(crate::error::VindexError::Parse(format!(
+            "{} spec(s) but {} resolved artifact(s): every artifact needs exactly one spec",
+            specs.len(),
+            resolved.len()
+        )));
+    }
+    // The verdict names its subject: the argument as given and, for a
+    // repo, the commit the facts were read at.
+    let sources: Vec<ArtifactSource> = specs
+        .iter()
+        .zip(&resolved)
+        .map(|(spec, a)| ArtifactSource {
+            path: spec.display().to_string(),
+            revision: a.commit().map(str::to_string),
+            unpinned_revision: a.unpinned_revision().map(str::to_string),
+        })
+        .collect();
+    let named: Vec<(String, ArchitectureInventory)> = resolved
+        .into_iter()
+        .map(|a| (a.name, a.inventory))
+        .collect();
+    plan_system_with_sources(&named, &sources)
+}

--- a/crates/vindex-cli/src/lib.rs
+++ b/crates/vindex-cli/src/lib.rs
@@ -27,7 +27,7 @@ use larql_vindex::format::vindex3::opplan::{
     plan_component_ops, ComponentOpPlan, LayerFfn, OperandRef,
 };
 use larql_vindex::format::vindex3::plan::capability::Capability;
-use larql_vindex::format::vindex3::plan::{plan_system_with_sources, ArtifactSource};
+use larql_vindex::format::vindex3::plan::plan_resolved;
 use larql_vindex::format::vindex3::represent::nvfp4_pack::{split, PackLayout, DTYPE_NVFP4};
 use larql_vindex::format::vindex3::represent::{compile_representation, RepresentSpec};
 
@@ -1047,23 +1047,8 @@ pub fn represent_facts(src: &Path, out: &Path, encoding: &str) -> Facts {
 /// staging against a 328 GB checkpoint.
 pub fn plan_facts(artifacts: &[PathBuf]) -> Facts {
     let resolved = artifact::resolve_all(artifacts).map_err(|e| e.to_string())?;
-    let staging: Vec<Value> = resolved.iter().filter_map(staging_value).collect();
-    // The verdict names its subject: the argument as given and, for a
-    // repo, the commit the facts were read at.
-    let sources: Vec<ArtifactSource> = artifacts
-        .iter()
-        .zip(&resolved)
-        .map(|(spec, a)| ArtifactSource {
-            path: spec.display().to_string(),
-            revision: a.commit().map(str::to_string),
-            unpinned_revision: a.unpinned_revision().map(str::to_string),
-        })
-        .collect();
-    let named: Vec<_> = resolved
-        .into_iter()
-        .map(|a| (a.name, a.inventory))
-        .collect();
-    let plan = plan_system_with_sources(&named, &sources).map_err(|e| e.to_string())?;
+    let staging: Vec<Value> = resolved.iter().filter_map(artifact::staging_json).collect();
+    let plan = plan_resolved(artifacts, resolved).map_err(|e| e.to_string())?;
     let mut value = serde_json::to_value(&plan).map_err(|e| e.to_string())?;
     if !staging.is_empty() {
         value["staging"] = Value::Array(staging);
@@ -1077,7 +1062,7 @@ pub fn plan_facts(artifacts: &[PathBuf]) -> Facts {
 /// never needs to exist as a complete local file.
 pub fn encode_facts(artifacts: &[PathBuf], output: &Path, text_only: bool) -> Facts {
     let resolved = artifact::resolve_all(artifacts).map_err(|e| e.to_string())?;
-    let staging: Vec<Value> = resolved.iter().filter_map(staging_value).collect();
+    let staging: Vec<Value> = resolved.iter().filter_map(artifact::staging_json).collect();
     let pinned: Vec<Value> = resolved
         .iter()
         .filter_map(|a| {
@@ -1121,26 +1106,5 @@ pub fn encode_facts(artifacts: &[PathBuf], output: &Path, text_only: bool) -> Fa
             // checkpoint holds.
             "fraction": if t.declared == 0 { 0.0 } else { t.fetched as f64 / t.declared as f64 },
         })).collect::<Vec<_>>(),
-    }))
-}
-
-/// One artifact's staging figures, when it was staged from a repo.
-fn staging_value(a: &artifact::ResolvedArtifact) -> Option<Value> {
-    let report = a.staging()?;
-    Some(json!({
-        "artifact": a.name,
-        "commit": a.commit(),
-        "shards": report.shards,
-        "staged": artifact::size(report.staged_bytes()),
-        "headers": artifact::size(report.header_bytes),
-        "metadata": artifact::size(report.metadata_bytes),
-        "stands_in_for": report.payload_bytes.as_ref().ok().map(|b| artifact::size(*b)),
-        // Stated only when the index disagrees with its own headers, so
-        // the difference reads as a fact about the checkpoint rather than
-        // a units bug in the report.
-        "index_declares": report
-            .declared_total
-            .filter(|d| report.payload_bytes.as_ref().is_ok_and(|p| d != p))
-            .map(artifact::size),
     }))
 }

--- a/crates/vindex-cli/src/lib.rs
+++ b/crates/vindex-cli/src/lib.rs
@@ -1047,7 +1047,10 @@ pub fn represent_facts(src: &Path, out: &Path, encoding: &str) -> Facts {
 /// staging against a 328 GB checkpoint.
 pub fn plan_facts(artifacts: &[PathBuf]) -> Facts {
     let resolved = artifact::resolve_all(artifacts).map_err(|e| e.to_string())?;
-    let staging: Vec<Value> = resolved.iter().filter_map(artifact::staging_json).collect();
+    let staging: Vec<Value> = resolved
+        .iter()
+        .filter_map(artifact::ResolvedArtifact::staging_json)
+        .collect();
     let plan = plan_resolved(artifacts, resolved).map_err(|e| e.to_string())?;
     let mut value = serde_json::to_value(&plan).map_err(|e| e.to_string())?;
     if !staging.is_empty() {
@@ -1062,7 +1065,10 @@ pub fn plan_facts(artifacts: &[PathBuf]) -> Facts {
 /// never needs to exist as a complete local file.
 pub fn encode_facts(artifacts: &[PathBuf], output: &Path, text_only: bool) -> Facts {
     let resolved = artifact::resolve_all(artifacts).map_err(|e| e.to_string())?;
-    let staging: Vec<Value> = resolved.iter().filter_map(artifact::staging_json).collect();
+    let staging: Vec<Value> = resolved
+        .iter()
+        .filter_map(artifact::ResolvedArtifact::staging_json)
+        .collect();
     let pinned: Vec<Value> = resolved
         .iter()
         .filter_map(|a| {

--- a/deploy/fly-explorer/verify.sh
+++ b/deploy/fly-explorer/verify.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Post-deploy gate for the public explorer endpoint.
+#
+# The capability contract is only worth anything if the deployed server
+# keeps it, so this checks the promise against the behaviour rather than
+# checking that the endpoint merely answers:
+#
+#   1. the report is readable    — schema this client knows, profile named
+#   2. it promises hf:// planning and refuses local-path planning
+#   3. planning a real repo works, is pinned, and is cacheable
+#   4. asking again is served from cache
+#   5. a local path is refused 403 — the promise in (2), kept
+#
+# Step 3 reaches Hugging Face and reads ~11 MB of headers. It downloads
+# no weights.
+#
+#   ./deploy/fly-explorer/verify.sh [BASE_URL]
+
+set -euo pipefail
+
+BASE="${1:-https://vindex3-explorer.fly.dev}"
+MODEL="${VERIFY_MODEL:-hf://Qwen/Qwen3-0.6B}"
+# Never a path that exists: this must be refused by POLICY, before the
+# server ever looks at the filesystem.
+LOCAL_PROBE="/tmp/not-a-checkpoint-$$"
+
+pass() { printf '  ok    %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1" >&2; exit 1; }
+
+say() { printf '\n%s\n' "$1"; }
+
+# Read one JSON path out of stdin, or "-" when absent or unreadable.
+# A server that predates this contract answers 404 with no body, and
+# that must read as "does not promise it", not as a crash.
+jget() { python3 -c "
+import json,sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print('-'); sys.exit()
+for k in sys.argv[1].split('.'):
+    d = d.get(k) if isinstance(d, dict) else None
+    if d is None: print('-'); sys.exit()
+print(json.dumps(d) if isinstance(d,(dict,list)) else d)
+" "$1"; }
+
+say "== $BASE =="
+
+# ── 1-2. the report ─────────────────────────────────────────────────
+CAPS="$(curl -sS --max-time 60 "$BASE/v1/capabilities")"
+SCHEMA="$(printf '%s' "$CAPS" | jget schema)"
+[ "$SCHEMA" = "-" ] \
+  && fail "$BASE/v1/capabilities did not answer with a report — this server predates the capability contract, so the Explorer's PLAN control will stay hidden. Deploy first."
+[ "$SCHEMA" = "1" ] \
+  || fail "capabilities schema is $SCHEMA; this script reads schema 1 only"
+pass "capabilities schema 1"
+
+PROFILE="$(printf '%s' "$CAPS" | jget profile)"
+[ "$PROFILE" = "public_explorer" ] \
+  || fail "profile is '$PROFILE', expected public_explorer"
+pass "profile public_explorer"
+
+[ "$(printf '%s' "$CAPS" | jget sources.plan.hf)" = "true" ] \
+  || fail "sources.plan.hf is not true — the Explorer's PLAN control will stay hidden"
+pass "promises: sources.plan.hf = true"
+
+[ "$(printf '%s' "$CAPS" | jget sources.plan.local)" = "false" ] \
+  || fail "sources.plan.local is true on a PUBLIC server — a local path would be a filesystem probe"
+pass "promises: sources.plan.local = false"
+
+for forbidden in runtime.execute runtime.lifecycle sources.encode.hf; do
+  [ "$(printf '%s' "$CAPS" | jget "$forbidden")" = "false" ] \
+    || fail "$forbidden is true on the public surface"
+done
+pass "public surface executes, binds and encodes nothing"
+
+# ── 3. a real verdict ───────────────────────────────────────────────
+say "planning $MODEL (headers only; no weights are downloaded)"
+PLAN="$(curl -sS --max-time 180 -X POST "$BASE/v1/plan" \
+  -H 'content-type: application/json' \
+  -d "{\"sources\":[\"$MODEL\"]}")"
+
+[ "$(printf '%s' "$PLAN" | jget schema)" = "4" ] \
+  || fail "plan schema is not 4: $(printf '%s' "$PLAN" | head -c 200)"
+pass "plan schema 4"
+
+REV="$(printf '%s' "$PLAN" | jget artifacts)"
+printf '%s' "$PLAN" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+a=d['artifacts'][0]
+assert a['source'].get('revision'), 'verdict is not pinned to a commit'
+print('  ok    pinned at', a['source']['revision'][:12] + '...', '(' + a['name'] + ')')
+print('  ok    judged by', d['planner']['package'], d['planner']['package_version'],
+      '· semantics', d['planner']['semantics_version'])
+s=d['staging'][0]
+print('  ok    read', s['staged'], 'standing in for', s['stands_in_for'])
+" || fail "the verdict did not name its subject"
+
+[ "$(printf '%s' "$PLAN" | jget serving.cacheable)" = "true" ] \
+  || fail "a pinned verdict reports cacheable=false"
+pass "verdict is cacheable (every artifact pinned)"
+
+# ── 4. the cache ────────────────────────────────────────────────────
+AGAIN="$(curl -sS --max-time 180 -X POST "$BASE/v1/plan" \
+  -H 'content-type: application/json' -d "{\"sources\":[\"$MODEL\"]}")"
+[ "$(printf '%s' "$AGAIN" | jget serving.cached)" = "true" ] \
+  || fail "the second ask was not served from cache"
+pass "second ask served from the verdict cache"
+
+# ── 5. the promise, kept ────────────────────────────────────────────
+CODE="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 60 \
+  -X POST "$BASE/v1/plan" -H 'content-type: application/json' \
+  -d "{\"sources\":[\"$LOCAL_PROBE\"]}")"
+[ "$CODE" = "403" ] \
+  || fail "a local path answered $CODE, expected 403 — the report promised it would be refused"
+pass "local-path planning refused 403, as advertised"
+
+say "PASS — the deployed server keeps what its capability report promises."


### PR DESCRIPTION
Steps 3 and 4 of the Explorer programme, plus the convergence step 4 needed first.

The Explorer is meant to be a universal VINDEX client, which means it has to know what a
server will do **before** it offers a control. Inferring that from the address — localhost
means I may encode, https means read-only — is a guess that fails permissively: it renders a
button that 404s. So the server answers, and the answer is derived rather than asserted.

## What lands

| | |
|---|---|
| `GET /v1/capabilities` | every profile; sources × verbs, explorer surface, runtime + backends |
| `POST /v1/plan` | every profile; an architecture-support verdict from headers alone |
| `larql server-capabilities <URL>` | the client half |
| `plan_resolved` | one planning authority for both CLIs and the server |
| `deploy/fly-explorer/verify.sh` | post-deploy gate: the promise, checked against the behaviour |

## The design point

No advertised boolean is written down. `routes::mod` builds through a `Mount` builder that
records each path as it mounts it, and the report is generated from that ledger through one
table naming, per capability, the route whose presence **is** that capability. So a
capability cannot be advertised without its route existing, and mounting `/v1/plan` in commit
3 flipped `sources.plan.*` with **no edit to the capability table** — the step-3 test
asserting "no profile plans" failed exactly as its own comment predicted.

The ledger is checked, not trusted. `advertised_capabilities_match_the_mounted_router`
re-reads the same question through axum's own matcher with a method the routes do not accept
— 405 means mounted, 404 means absent — so it never reaches a handler and a handler's own 404
cannot fool it. Both directions fail the gate.

The same shape guards planning: `plans_source` decides policy once, the handler refuses
through it and the report advertises through it, and a test reads the promise out of
`/v1/capabilities` and checks it against the endpoint per profile.

## Witnessed against the live hub

```
vindex plan hf://Qwen/Qwen3-0.6B --json  ==  POST /v1/plan response - serving
```

Byte-for-byte. Pinned at `c1899de2…`, 11.47 MB read standing in for 1.50 GB, nothing
downloaded. Second request returned `cached: true`. A local path on the public profile
returns 403; on a localhost server it does not. CORS preflight for `POST /v1/plan` from
`https://vindex3.org` answers 200.

## Two judgement calls worth review

- **`403 Refused` is not `501 Unsupported`.** The capability exists and the same request
  succeeds on a localhost server, so this is a profile declining, not a build unable.
- **The plan scheme classifier is the plan resolver's own**, not the load resolver's. Those
  verbs take different objects — a raw checkpoint against an encoded container — and sharing
  a classifier because both understand `hf://` is how a UI comes to offer a checkpoint to a
  verb that cannot take one.

## Cost control

Planning is bounded at two in flight and refuses rather than queues; the public box is a
512 MB `shared-cpu-1x`, and an endpoint performing a remote fetch per request is otherwise
trivially abusable.

## Gates

larql-server 1,271 · larql-vindex 3,991 · larql-cli 831 · vindex-cli 28, all passing.
fmt + clippy clean on all four crates including `--no-default-features`.
Coverage: `plan_service.rs` 94.13%, `routes/plan.rs` 100%, `capabilities.rs` 97.17%,
`routes/mod.rs` 100%; crate total 83.20% against a 65 floor.

## After merge

The endpoint deploy is **manual** — `fly deploy --app vindex3-explorer --config
deploy/fly-explorer/fly.toml --remote-only`; no workflow in this repo does it. Until that
runs, the site's PLAN control stays correctly hidden, because it is gated on the capability
report rather than on a release flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLjrZXbjKjaTCjE151aDKL
