### PR TITLE
fix(deploy): the post-deploy gate was reading Python's True, not JSON's true

### DIFF
--- a/deploy/fly-explorer/verify.sh
+++ b/deploy/fly-explorer/verify.sh
@@ -41,7 +41,13 @@ except Exception:
 for k in sys.argv[1].split('.'):
     d = d.get(k) if isinstance(d, dict) else None
     if d is None: print('-'); sys.exit()
-print(json.dumps(d) if isinstance(d,(dict,list)) else d)
+# JSON spelling, not Python's, so a boolean prints lowercase
+# true and never capital-True: the comparisons below are against
+# JSON literals and matched neither, which made this gate report a
+# capability the server was in fact advertising.
+# (No backticks in here - this block is inside a double-quoted
+# shell string, where bash would run them as commands.)
+print(d if isinstance(d, str) else json.dumps(d))
 " "$1"; }
 
 say "== $BASE =="


### PR DESCRIPTION
Found by running the gate against the real deployment of #389.

It reported `sources.plan.hf is not true` while the server was advertising exactly that. The
JSON reader printed non-container values with Python's `repr`, so a boolean arrived as
capital-`True` and matched none of the JSON literals the checks compare against.

False failure rather than false pass — the safer direction, but only by luck. The same bug
misreads `false` too, so a check written the other way round would have passed on nothing.

**Why it shipped:** the gate had been run once, against the *old* deployment, where it
correctly stopped at the first check with "this server predates the contract". That is
precisely why the rest of it had never executed. A verification whose success path has never
run is not a verification.

Also removes backticks from the comment inside that reader — the block is a double-quoted
shell string, so bash was running `json.dumps` and `True` as commands on every call.

## Verified against the live endpoint

```
== https://vindex3-explorer.fly.dev ==
  ok    capabilities schema 1
  ok    profile public_explorer
  ok    promises: sources.plan.hf = true
  ok    promises: sources.plan.local = false
  ok    public surface executes, binds and encodes nothing
  ok    plan schema 4
  ok    pinned at c1899de289a0... (Qwen3-0.6B)
  ok    judged by larql-vindex 0.2.0 · semantics 1
  ok    read 11.47 MB standing in for 1.50 GB (1.40 GiB)
  ok    verdict is cacheable (every artifact pinned)
  ok    second ask served from the verdict cache
  ok    local-path planning refused 403, as advertised

PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLjrZXbjKjaTCjE151aDKL
