### PR TITLE
feat(represent): structural invariance is not ordering evidence

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/represent/decision.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/decision.rs
@@ -55,6 +55,7 @@ use serde::{Deserialize, Serialize};
 
 use super::diagnostic::DiagnosticVector;
 use super::measurement::TailSupportPolicy;
+use super::participation::ParticipationDeclaration;
 use super::promotion::{PromotionCandidate, PromotionReadiness};
 use super::quality::Statistic;
 use super::search_evidence::SearchCalibrationRegistry;
@@ -66,6 +67,12 @@ pub struct SearchCandidate {
     pub id: String,
     pub promotion: PromotionCandidate,
     pub diagnostic: DiagnosticVector,
+    /// What this candidate's action can and cannot causally affect.
+    ///
+    /// R4-F10: a statistic the action cannot move must not rank it
+    /// against one that can. Defaults to all-affected, so a candidate
+    /// that declares nothing is compared on everything.
+    pub participation: ParticipationDeclaration,
 }
 
 impl SearchCandidate {
@@ -84,6 +91,12 @@ impl SearchCandidate {
             .filter(|r| {
                 r.observed.is_some()
                     && r.evidence(registry, policy).orders()
+                    // R4-F10. A dimension either side is structurally
+                    // invariant on cannot rank this PAIR: an unchanged
+                    // value that the action could not have changed is
+                    // not evidence that it fared well.
+                    && self.participation.of(r.statistic).participates()
+                    && other.participation.of(r.statistic).participates()
                     && other.diagnostic.reading(r.statistic).is_some_and(|o| {
                         o.observed.is_some() && o.evidence(registry, policy).orders()
                     })
@@ -112,12 +125,26 @@ impl SearchCandidate {
             .assessment
             .marginal
             .unpriceable_costs()
-            .filter(|c| !c.orders() && self.promotion.proxy_for(c.what).is_none())
+            .filter(|c| {
+                !c.orders()
+                    && self.promotion.proxy_for(c.what).is_none()
+                    // Exact zero spend is knowledge, not an open risk.
+                    && !self.participation.of(c.what).is_structurally_invariant()
+            })
             .map(|c| c.what)
             .collect();
         out.sort_by_key(|s| s.label());
         out.dedup();
         out
+    }
+
+    /// Authority dimensions this candidate provably cannot spend.
+    ///
+    /// The complement of [`Self::unresolved_dimensions`]: those are what
+    /// the diagnostic scale could not speak to, these are what it can
+    /// speak to with certainty (R4-F10).
+    pub fn known_zero_spend(&self) -> Vec<Statistic> {
+        self.participation.known_zero_spend()
     }
 
     /// **`self` proxy-dominates `other`**: no worse on every comparable
@@ -187,6 +214,12 @@ pub struct PromotionEvidence {
     /// exactly the criteria on which this candidate might still be
     /// refused, and a trace that omitted them would read as confidence.
     pub unresolved: Vec<Statistic>,
+    /// **Dimensions this action provably cannot spend** (R4-F10).
+    ///
+    /// Recorded beside `unresolved` because the two are opposite kinds
+    /// of statement and a reader must not have to guess which a missing
+    /// dimension was.
+    pub known_zero_spend: Vec<Statistic>,
 }
 
 /// The outcome of one search round.
@@ -330,11 +363,26 @@ pub fn decide_promotion(
         // but a trace that differs between runs of the same round is not
         // reproducible, and identity is allowed to order a record.
         dominated.sort();
-        let deciding = pool
+        // Every proxy on which the winner was strictly better than
+        // something it beat.
+        //
+        // This once read the comparable set of whichever candidate came
+        // FIRST, which was invisible while every pair shared one set.
+        // R4-F10 makes the comparable set pair-dependent, so that
+        // shortcut made the RECORD depend on input order even though the
+        // decision did not — the same defect as R4-F1, one layer out.
+        let mut deciding: Vec<Statistic> = pool
             .iter()
-            .find(|o| !std::ptr::eq(**o, winner))
-            .map(|o| winner.comparable(o, registry, policy))
-            .unwrap_or_default();
+            .filter(|o| !std::ptr::eq(**o, winner))
+            .flat_map(|o| {
+                winner
+                    .comparable(o, registry, policy)
+                    .into_iter()
+                    .filter(|s| winner.order_on(o, *s) == Some(Ordering::Less))
+            })
+            .collect();
+        deciding.sort_by_key(|s| s.label());
+        deciding.dedup();
         return PromotionDecision::SelectForAuthority {
             candidate: winner.id.clone(),
             evidence: PromotionEvidence {
@@ -343,6 +391,7 @@ pub fn decide_promotion(
                 readiness: winner.promotion.readiness(),
                 decided_by_physical_gain: false,
                 unresolved: winner.unresolved_dimensions(),
+                known_zero_spend: winner.known_zero_spend(),
             },
         };
     }
@@ -404,6 +453,7 @@ pub fn decide_promotion(
                 readiness: by_gain[0].promotion.readiness(),
                 decided_by_physical_gain: true,
                 unresolved: by_gain[0].unresolved_dimensions(),
+                known_zero_spend: by_gain[0].known_zero_spend(),
             },
         };
     }

--- a/crates/larql-vindex/src/format/vindex3/represent/decision_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/decision_tests.rs
@@ -7,6 +7,7 @@ use super::super::constraint::ConstraintVector;
 use super::super::diagnostic::{DiagnosticPolicy, DiagnosticVector};
 use super::super::execution_cost::{m3max_metal_001, ExecutionCostModel};
 use super::super::measurement::EvidenceScale;
+use super::super::participation::ParticipationDeclaration;
 use super::super::promotion::PromotionCandidate;
 use super::super::quality::{kimi_logit_balanced_v1, QualityBank};
 use super::*;
@@ -36,6 +37,23 @@ fn ledger(name: &str, bytes: u64) -> ByteLedger {
 
 /// A candidate whose diagnostic bank says `kl`/`flips`, removing `bytes`.
 fn candidate(id: &str, kl: f64, flips: u64, bytes: u64) -> SearchCandidate {
+    declaring(
+        id,
+        kl,
+        flips,
+        bytes,
+        ParticipationDeclaration::all_affected(),
+    )
+}
+
+/// The same, with an explicit participation declaration (R4-F10).
+fn declaring(
+    id: &str,
+    kl: f64,
+    flips: u64,
+    bytes: u64,
+    participation: ParticipationDeclaration,
+) -> SearchCandidate {
     let b = bank(kl, flips);
     let gate = kimi_logit_balanced_v1();
     let parent = bank(2.4762e-3, 46);
@@ -52,6 +70,7 @@ fn candidate(id: &str, kl: f64, flips: u64, bytes: u64) -> SearchCandidate {
         id: id.into(),
         promotion: PromotionCandidate::new(a, vec![]),
         diagnostic: DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &b),
+        participation,
     }
 }
 
@@ -269,5 +288,115 @@ fn uninformed_may_be_selected_for_authority_and_names_what_it_cannot_see() {
             }
         }
         other => panic!("Uninformed must be eligible to measure: {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// R4-F10 — structural invariance is not ordering evidence.
+// ---------------------------------------------------------------------
+
+/// The head's causal ground, as proven in rung-4 iteration 4.
+const HEAD: &str = "lm_head is applied after every routing decision";
+
+/// Iteration 4's real four, against the M26 parent (kl 2.5707e-3,
+/// flips 43). `H` cannot move routing; the other three did.
+fn iteration4(head_declares_invariance: bool) -> Vec<SearchCandidate> {
+    let head = if head_declares_invariance {
+        ParticipationDeclaration::all_affected()
+            .structurally_invariant(Statistic::RouteFlipRate, HEAD)
+    } else {
+        ParticipationDeclaration::all_affected()
+    };
+    vec![
+        declaring("H", 4.4171e-3, 43, 13_040_000_000, head),
+        candidate("M23", 5.7311e-3, 53, 13_040_000_000),
+        candidate("K25", 2.5262e-3, 50, 13_040_000_000),
+        candidate("K24", 5.3580e-3, 51, 13_040_000_000),
+    ]
+}
+
+#[test]
+fn undeclared_invariance_manufactures_the_conflict_that_blocked_iteration_4() {
+    // The DEFECT, pinned. H's unchanged flip rate reads as a win.
+    let set = iteration4(false);
+    match decide_promotion(&set, &reg(), &pol()) {
+        PromotionDecision::Ambiguous { candidates, reason } => {
+            assert_eq!(candidates, vec!["H".to_string(), "K25".to_string()]);
+            assert_eq!(reason, AmbiguityReason::ConflictingOrderingProxies);
+        }
+        other => panic!("expected the historical refusal, got {other:?}"),
+    }
+}
+
+#[test]
+fn declaring_the_invariance_lets_the_applicable_evidence_decide() {
+    let set = iteration4(true);
+    match decide_promotion(&set, &reg(), &pol()) {
+        PromotionDecision::SelectForAuthority {
+            candidate,
+            evidence,
+        } => {
+            assert_eq!(candidate, "K25");
+            assert_eq!(evidence.dominated, vec!["H", "K24", "M23"]);
+            // It won on evidence that APPLIES, not on bytes.
+            assert!(!evidence.decided_by_physical_gain);
+        }
+        other => panic!("expected K25, got {other:?}"),
+    }
+}
+
+#[test]
+fn the_corrected_decision_is_permutation_invariant() {
+    let mut set = iteration4(true);
+    let forward = decide_promotion(&set, &reg(), &pol());
+    set.reverse();
+    assert_eq!(forward, decide_promotion(&set, &reg(), &pol()));
+}
+
+#[test]
+fn an_invariant_dimension_is_dropped_from_the_pair_not_from_the_candidate() {
+    let set = iteration4(true);
+    let h = &set[0];
+    let k25 = &set[2];
+    // The pair loses the route dimension...
+    assert_eq!(h.comparable(k25, &reg(), &pol()), vec![Statistic::KlP99]);
+    // ...while two participants keep it.
+    let k24 = &set[3];
+    assert!(k25
+        .comparable(k24, &reg(), &pol())
+        .contains(&Statistic::RouteFlipRate));
+}
+
+#[test]
+fn invariance_is_recorded_as_known_zero_spend_not_as_unresolved() {
+    let set = iteration4(true);
+    let h = &set[0];
+    assert_eq!(h.known_zero_spend(), vec![Statistic::RouteFlipRate]);
+    assert!(
+        !h.unresolved_dimensions()
+            .contains(&Statistic::RouteFlipRate),
+        "a proven zero is knowledge, not an open risk"
+    );
+}
+
+#[test]
+fn physical_gain_still_cannot_rescue_a_dominated_candidate() {
+    // H saves 10x the bytes of K25 and is still refused, because the
+    // comparison it loses is on evidence that applies to both.
+    let head = ParticipationDeclaration::all_affected()
+        .structurally_invariant(Statistic::RouteFlipRate, HEAD);
+    let set = vec![
+        declaring("H", 4.4171e-3, 43, 12_000_000_000, head),
+        candidate("K25", 2.5262e-3, 50, 13_040_000_000),
+    ];
+    match decide_promotion(&set, &reg(), &pol()) {
+        PromotionDecision::SelectForAuthority {
+            candidate,
+            evidence,
+        } => {
+            assert_eq!(candidate, "K25");
+            assert!(!evidence.decided_by_physical_gain);
+        }
+        other => panic!("expected K25, got {other:?}"),
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -61,6 +61,7 @@ pub mod kda_candidate;
 pub mod map;
 pub mod measurement;
 pub mod nvfp4_pack;
+pub mod participation;
 pub mod physical;
 pub mod plan_roles;
 #[cfg(test)]

--- a/crates/larql-vindex/src/format/vindex3/represent/participation.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/participation.rs
@@ -1,0 +1,215 @@
+//! **R4-F10 — structural invariance is not ordering evidence.**
+//!
+//! Rung-4 iteration 4 ranked four one-step moves against the M26 parent
+//! and REFUSED to promote: the frontier was `{H, K25}` and the proxies
+//! conflicted. K25 was better on kl; H was better on route flip rate.
+//!
+//! H is `lm_head Q8_0 -> Q6_K`. The head is applied to the final hidden
+//! state and feeds no router, so H cannot change a routing decision at
+//! all — and it did not. Its whole routing block was BIT-IDENTICAL to
+//! the parent's, `route_margin.p50` included, to 17 significant figures
+//! over 256 positions. Its flip rate was the PARENT's value carried
+//! through a causal path H cannot touch.
+//!
+//! [`proxy_dominates`] could not tell those apart:
+//!
+//! ```text
+//! candidate improved the route proxy
+//! candidate CANNOT INFLUENCE the route proxy
+//! ```
+//!
+//! Both present as "no worse", so an unchanged value entered a dominance
+//! test as though it had been won, and blocked a round that had a clean
+//! answer on the evidence that actually applied.
+//!
+//! # The rule
+//!
+//! > A diagnostic statistic that a candidate cannot causally affect must
+//! > not enter proxy dominance as though its unchanged value were
+//! > favourable evidence. Structural invariance instead licenses an
+//! > exact ZERO SPEND on the corresponding authority dimension, where
+//! > that causal relationship is proven.
+//!
+//! Two questions, kept apart:
+//!
+//! ```text
+//! SEARCH                which candidate should authority MEASURE?
+//!                       compare only statistics candidates can affect
+//! CONSTRAINT ACCOUNTING what can this action CONSUME?
+//!                       structural invariance means exact zero spend
+//! ```
+//!
+//! # Why this is not `Direct`
+//!
+//! An invariant statistic is not a superior measurement. It is a
+//! statement that the candidate cannot generate a measurement-relevant
+//! effect at all. Calling it `Direct` would say the opposite — that its
+//! zero is an unusually trustworthy number — and would put it straight
+//! back into pricing, which is the failure BS2-F2 already was.
+//!
+//! # DECLARED, never inferred
+//!
+//! Participation comes from the ACTION's position in the computation
+//! graph, never from noticing a zero delta. A zero delta is what a
+//! structural invariant looks like, not evidence that one exists: K25's
+//! flips could coincide with the parent's on some other bank and would
+//! still be a real routing participant. Inferring invariance from an
+//! observation would let a coincidence silently delete a dimension from
+//! the comparison — the [`Statistic`] equivalent of the adjacency
+//! reasoning that `UnsupportedComponent` is forbidden to use.
+//!
+//! The default is [`StatisticParticipation::Affected`]: an undeclared
+//! statistic PARTICIPATES. Exclusion must be asked for.
+//!
+//! # And then CHECKED
+//!
+//! A declaration that is never checked is an assumption wearing a type.
+//! [`ParticipationDeclaration::verify`] requires every statistic
+//! declared invariant to be BIT-IDENTICAL between parent and candidate,
+//! and refuses otherwise — a declaration that would have hidden a real
+//! effect is a hard error, not a warning.
+//!
+//! [`proxy_dominates`]: super::decision::SearchCandidate::proxy_dominates
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::diagnostic::DiagnosticVector;
+use super::statistic::Statistic;
+
+/// How a candidate's action relates CAUSALLY to one statistic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum StatisticParticipation {
+    /// The action can causally affect this statistic. The default, and
+    /// the conservative reading: a participant's evidence counts.
+    Affected,
+    /// The action provably CANNOT affect this statistic, because of
+    /// where it sits in the computation graph.
+    ///
+    /// Excluded from candidate-vs-candidate ordinal dominance. Still
+    /// exact knowledge for accounting: zero spend on this dimension.
+    StructurallyInvariant {
+        /// The causal ground, for the trace. This never joins on
+        /// anything — it explains, and [`ParticipationDeclaration::verify`]
+        /// is what actually checks the claim.
+        because: String,
+    },
+}
+
+impl StatisticParticipation {
+    /// May this statistic rank the candidate against another?
+    pub fn participates(&self) -> bool {
+        matches!(self, Self::Affected)
+    }
+
+    /// Is the candidate's spend on this dimension known to be exactly
+    /// zero, rather than merely unmeasured?
+    pub fn is_structurally_invariant(&self) -> bool {
+        matches!(self, Self::StructurallyInvariant { .. })
+    }
+}
+
+/// What a candidate's action declares it can and cannot affect.
+///
+/// Absent means [`StatisticParticipation::Affected`] — the checked
+/// default. Only invariance is recorded, because only invariance
+/// removes evidence from a comparison.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ParticipationDeclaration {
+    invariant: BTreeMap<Statistic, String>,
+}
+
+/// A declared structural invariant that the measurement CONTRADICTS.
+///
+/// The candidate moved a statistic it declared it could not move, so the
+/// declaration would have deleted a real effect from the comparison.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParticipationViolation {
+    pub statistic: Statistic,
+    pub because: String,
+    pub parent: Option<f64>,
+    pub candidate: Option<f64>,
+}
+
+impl std::fmt::Display for ParticipationViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} was declared structurally invariant ({}) but moved: parent {:?} -> candidate {:?}",
+            self.statistic, self.because, self.parent, self.candidate
+        )
+    }
+}
+
+impl std::error::Error for ParticipationViolation {}
+
+impl ParticipationDeclaration {
+    /// Everything participates. What an action declares when it sits
+    /// upstream of every statistic the search reads.
+    pub fn all_affected() -> Self {
+        Self::default()
+    }
+
+    /// Declare that this action cannot affect `statistic`, and why.
+    pub fn structurally_invariant(mut self, statistic: Statistic, because: &str) -> Self {
+        self.invariant.insert(statistic, because.to_string());
+        self
+    }
+
+    /// How this action relates to `statistic`.
+    pub fn of(&self, statistic: Statistic) -> StatisticParticipation {
+        match self.invariant.get(&statistic) {
+            Some(because) => StatisticParticipation::StructurallyInvariant {
+                because: because.clone(),
+            },
+            None => StatisticParticipation::Affected,
+        }
+    }
+
+    /// The dimensions on which this action's spend is exactly zero.
+    ///
+    /// **Not "unresolved".** These are the one class of authority
+    /// dimension a diagnostic round can speak to with certainty, and a
+    /// trace that filed them under uncertainty would understate what the
+    /// search knows.
+    pub fn known_zero_spend(&self) -> Vec<Statistic> {
+        self.invariant.keys().copied().collect()
+    }
+
+    /// Every declared invariant must be BIT-IDENTICAL between parent and
+    /// candidate.
+    ///
+    /// Bit equality, not tolerance: a structural invariant is the same
+    /// number arriving by the same path, and anything else is a
+    /// different claim. NaN compares equal to NaN here for the same
+    /// reason — identical bits are identical evidence.
+    pub fn verify(
+        &self,
+        parent: &DiagnosticVector,
+        candidate: &DiagnosticVector,
+    ) -> Result<(), ParticipationViolation> {
+        for (&statistic, because) in &self.invariant {
+            let before = parent.reading(statistic).and_then(|r| r.observed);
+            let after = candidate.reading(statistic).and_then(|r| r.observed);
+            let identical = match (before, after) {
+                (None, None) => true,
+                (Some(a), Some(b)) => a.to_bits() == b.to_bits(),
+                _ => false,
+            };
+            if !identical {
+                return Err(ParticipationViolation {
+                    statistic,
+                    because: because.clone(),
+                    parent: before,
+                    candidate: after,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "participation_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/participation_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/participation_tests.rs
@@ -1,0 +1,144 @@
+//! R4-F10. The declaration is checked, never trusted, and never inferred.
+
+use super::super::diagnostic::{DiagnosticPolicy, DiagnosticVector};
+use super::super::quality::{Distribution, QualityBank};
+use super::*;
+
+fn bank(kl: f64, flips: u64) -> QualityBank {
+    let mut b = super::super::diagnostic::tests::guard_256();
+    b.logits.kl_p99 = kl;
+    b.routing.route_flips = flips;
+    b
+}
+
+fn vector(kl: f64, flips: u64) -> DiagnosticVector {
+    DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &bank(kl, flips))
+}
+
+/// The head's ground, as measured in iteration 4.
+const HEAD: &str = "lm_head is applied after every routing decision";
+
+#[test]
+fn undeclared_statistics_participate() {
+    let d = ParticipationDeclaration::all_affected();
+    assert_eq!(
+        d.of(Statistic::RouteFlipRate),
+        StatisticParticipation::Affected
+    );
+    assert!(d.of(Statistic::KlP99).participates());
+    assert!(!d.of(Statistic::KlP99).is_structurally_invariant());
+    assert!(d.known_zero_spend().is_empty());
+}
+
+#[test]
+fn a_declared_invariant_does_not_participate_but_is_known() {
+    let d = ParticipationDeclaration::all_affected()
+        .structurally_invariant(Statistic::RouteFlipRate, HEAD);
+    let p = d.of(Statistic::RouteFlipRate);
+    assert!(!p.participates(), "an invariant may not rank the pair");
+    assert!(p.is_structurally_invariant());
+    assert_eq!(d.known_zero_spend(), vec![Statistic::RouteFlipRate]);
+    // Declaring one dimension must not touch any other.
+    assert!(d.of(Statistic::KlP99).participates());
+}
+
+#[test]
+fn the_ground_is_carried_for_the_trace() {
+    let d = ParticipationDeclaration::all_affected()
+        .structurally_invariant(Statistic::RouteFlips, HEAD);
+    match d.of(Statistic::RouteFlips) {
+        StatisticParticipation::StructurallyInvariant { because } => assert_eq!(because, HEAD),
+        other => panic!("expected an invariant, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_unchanged_statistic_verifies() {
+    let parent = vector(2.5707e-3, 43);
+    // H: kl moved a long way, routing did not move at all.
+    let candidate = vector(4.4171e-3, 43);
+    let d = ParticipationDeclaration::all_affected()
+        .structurally_invariant(Statistic::RouteFlipRate, HEAD)
+        .structurally_invariant(Statistic::RouteFlips, HEAD);
+    assert_eq!(d.verify(&parent, &candidate), Ok(()));
+}
+
+#[test]
+fn a_moved_statistic_is_a_violation_not_a_warning() {
+    let parent = vector(2.5707e-3, 43);
+    // K25 moved routing. Declaring it invariant would DELETE that.
+    let candidate = vector(2.5262e-3, 50);
+    let d = ParticipationDeclaration::all_affected()
+        .structurally_invariant(Statistic::RouteFlipRate, HEAD);
+    let err = d.verify(&parent, &candidate).expect_err("must refuse");
+    assert_eq!(err.statistic, Statistic::RouteFlipRate);
+    assert_eq!(err.parent, Some(43.0 / 256.0));
+    assert_eq!(err.candidate, Some(50.0 / 256.0));
+    assert!(err.to_string().contains("declared structurally invariant"));
+}
+
+#[test]
+fn verification_is_bit_exact_not_approximate() {
+    let parent = vector(2.5707e-3, 43);
+    let mut b = bank(2.5707e-3, 43);
+    // One ulp. A structural invariant is the SAME number by the same
+    // path; "nearly the same" is a different claim.
+    b.logits.kl_p99 = f64::from_bits(b.logits.kl_p99.to_bits() + 1);
+    let candidate = DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &b);
+    let d = ParticipationDeclaration::all_affected()
+        .structurally_invariant(Statistic::KlP99, "hypothetical");
+    assert!(d.verify(&parent, &candidate).is_err(), "one ulp is a move");
+}
+
+#[test]
+fn a_statistic_neither_side_observed_is_vacuously_conformant() {
+    // route mixture mass is absent from guard_256 on both sides.
+    let parent = vector(2.5707e-3, 43);
+    let candidate = vector(4.4171e-3, 43);
+    assert!(parent
+        .reading(Statistic::RouteMixtureMassP99)
+        .is_none_or(|r| r.observed.is_none()));
+    let d = ParticipationDeclaration::all_affected()
+        .structurally_invariant(Statistic::RouteMixtureMassP99, HEAD);
+    assert_eq!(d.verify(&parent, &candidate), Ok(()));
+}
+
+#[test]
+fn appearing_on_only_one_side_is_a_violation() {
+    // Observed on the parent, absent on the candidate. Not "identical",
+    // and emphatically not a proven zero.
+    let mut pb = bank(2.5707e-3, 43);
+    pb.top1_mass_displaced = Some(Distribution {
+        count: 4,
+        min: 0.01,
+        p50: 0.02,
+        p95: 0.05,
+        p99: 0.058,
+        max: 0.0583,
+    });
+    let parent = DiagnosticVector::of(&DiagnosticPolicy::bs2_kimi_v1(), &pb);
+    let candidate = vector(2.5707e-3, 43);
+    assert!(parent
+        .reading(Statistic::Top1MassDisplaced)
+        .is_some_and(|r| r.observed.is_some()));
+    let d = ParticipationDeclaration::all_affected()
+        .structurally_invariant(Statistic::Top1MassDisplaced, "hypothetical");
+    let err = d
+        .verify(&parent, &candidate)
+        .expect_err("one-sided is not identical");
+    assert_eq!(err.statistic, Statistic::Top1MassDisplaced);
+    assert_eq!(err.parent, Some(0.0583));
+    assert!(err.candidate.is_none());
+}
+
+#[test]
+fn redeclaring_replaces_rather_than_duplicates() {
+    let d = ParticipationDeclaration::all_affected()
+        .structurally_invariant(Statistic::RouteFlips, "first")
+        .structurally_invariant(Statistic::RouteFlips, "second");
+    assert_eq!(d.known_zero_spend(), vec![Statistic::RouteFlips]);
+    match d.of(Statistic::RouteFlips) {
+        StatisticParticipation::StructurallyInvariant { because } => assert_eq!(because, "second"),
+        other => panic!("expected an invariant, got {other:?}"),
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/statistic.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/statistic.rs
@@ -29,7 +29,7 @@ use super::quality::QualityBank;
 /// calibrated as ordering-only, which is the failure the whole evidence
 /// ladder exists to prevent. Two of the three keys matched, so the
 /// mechanism looked like it worked. A typed key cannot drift.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Statistic {
     KlP99,
     Top1Flips,


### PR DESCRIPTION
Rung-4 iteration 4 refused to promote: the frontier was `{H, K25}` and the proxies conflicted — K25 better on kl, H better on route flip rate. H is the lm_head, which feeds no router, so it cannot change a routing decision at all, and it did not: its whole routing block was bit-identical to the parent's, `route_margin.p50` included, to 17 significant figures over 256 positions. `proxy_dominates` could not tell "improved this statistic" from "cannot influence this statistic" — both present as no worse — so an unchanged value entered a dominance test as though it had been won, and blocked a round that had a clean answer on the evidence that applied.

## The rule

> A diagnostic statistic that a candidate cannot causally affect must not enter proxy dominance as though its unchanged value were favourable evidence. Structural invariance instead licenses an exact zero spend on the corresponding authority dimension, where that causal relationship is proven.

`StatisticParticipation::{Affected, StructurallyInvariant}` names the difference, and `comparable()` drops such a statistic for the **pair** — it is the comparison, not the candidate, that is meaningless there.

Deliberately **not** `Direct`: an invariant is the absence of a measurable effect, not a superior measurement, and `Direct` would route it back into pricing, which is what BS2-F2 was. The invariance is kept as exact knowledge instead — `unresolved_dimensions` no longer files a proven zero under uncertainty, and `PromotionEvidence` gains `known_zero_spend`.

```
SEARCH                 which candidate should authority MEASURE?
                       compare only statistics candidates can affect
CONSTRAINT ACCOUNTING  what can this action CONSUME?
                       structural invariance means exact zero spend
```

## Declared, never inferred, then checked

Participation comes from the action's position in the computation graph, never from an observed zero delta — a zero delta is what an invariant looks like, not evidence one exists, and inferring it would let a coincidence delete a dimension from the comparison. `verify()` then requires every declared invariant to be bit-identical between parent and candidate and refuses otherwise, so a declaration that would have hidden a real effect cannot pass.

## Also fixed: `PromotionEvidence::deciding` was input-order dependent

It read the comparable set of whichever candidate appeared first in the pool. Invisible while every pair shared one set; making comparable sets pair-dependent exposed it as `[kl p99]` forward and `[kl p99, route flip rate]` reversed from the same round — same winner, unreproducible record. R4-F1's defect displaced from the decision into its justification. It is now every proxy on which the winner beat something, sorted, as `dominated` already was.

## Result

Replaying iteration 4 on the unchanged measurements promotes K25 over H, K24 and M23, permutation-invariantly and not by physical gain — H saves ten times the bytes and is still refused, because gain separates only candidates the proxies call equal, never merely incomparable. K25 subsequently passed both authority banks with `failures: []`.

## Gates

```
fmt              clean
clippy           --all-targets -D warnings    0 warnings
lib tests        3663 passed, 0 failed
coverage         crate 93.50% (floor 71), policy script PASSED
                 participation.rs  100.00%
                 decision.rs        96.69%
                 statistic.rs      100.00%
```
