### PR TITLE
fix(server): consult the verdict cache before doing the work it would produce

### DIFF
--- a/crates/larql-server/src/plan_service.rs
+++ b/crates/larql-server/src/plan_service.rs
@@ -30,10 +30,13 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use larql_vindex::format::vindex3::artifact;
-use larql_vindex::format::vindex3::plan::{plan_resolved, VerdictCacheKey};
+use larql_vindex::format::vindex3::plan::{
+    plan_resolved, VerdictCacheKey, PLANNER_SEMANTICS_VERSION,
+};
 use serde_json::Value;
 use tokio::sync::Semaphore;
 use tracing::info;
@@ -55,11 +58,57 @@ const CACHE_CAPACITY: usize = 256;
 pub const MAX_CONCURRENT_PLANS: usize = 2;
 
 /// The planning surface for one server.
+/// How this service learns an artifact's immutable commit.
+///
+/// Injectable because the real one is a network call, and the
+/// invariant that matters here — a cache hit performs no staging and
+/// no planning — is a statement about work not happening, which can
+/// only be asserted by driving both paths deterministically.
+pub type CommitResolver = Arc<
+    dyn Fn(&[PathBuf]) -> Result<Vec<Option<String>>, larql_vindex::error::VindexError>
+        + Send
+        + Sync,
+>;
+
 pub struct PlanService {
     profile: ServerProfile,
+    resolver: CommitResolver,
     cache: Mutex<HashMap<VerdictCacheKey, Value>>,
     cache_capacity: usize,
     permits: Semaphore,
+    work: Arc<PlanWork>,
+}
+
+/// What this service has actually done, as counts.
+///
+/// Exists because "the cache is consulted before the work" is a claim
+/// about work NOT happening, and the only honest way to assert that is
+/// to count the work. A structural check — the lookup appears earlier
+/// in the function — would still pass if some staging leaked in ahead
+/// of it. Production measurement made the point: before this, a hit
+/// answered in 0.9 s and still moved the process high-water mark,
+/// because it had already staged and planned.
+#[derive(Debug, Default)]
+pub struct PlanWork {
+    /// Commit probes: one ranged request per artifact, no staging.
+    pub commits_resolved: AtomicU64,
+    /// Header staging passes — the expensive half.
+    pub staged: AtomicU64,
+    /// Planner invocations.
+    pub planned: AtomicU64,
+}
+
+impl PlanWork {
+    /// `(commit probes, staging passes, planner invocations)`, for a
+    /// caller that wants to assert what this service did — or, more
+    /// usefully, what it did not do.
+    pub fn snapshot(&self) -> (u64, u64, u64) {
+        (
+            self.commits_resolved.load(Ordering::Relaxed),
+            self.staged.load(Ordering::Relaxed),
+            self.planned.load(Ordering::Relaxed),
+        )
+    }
 }
 
 impl PlanService {
@@ -75,11 +124,29 @@ impl PlanService {
         max_concurrent: usize,
         cache_capacity: usize,
     ) -> Self {
+        Self::with_resolver(
+            profile,
+            max_concurrent,
+            cache_capacity,
+            Arc::new(artifact::resolve_pinned_commits),
+        )
+    }
+
+    /// [`Self::with_limits`] with the commit probe stated, so a test
+    /// can drive cache hit and cache miss without a hub.
+    pub fn with_resolver(
+        profile: ServerProfile,
+        max_concurrent: usize,
+        cache_capacity: usize,
+        resolver: CommitResolver,
+    ) -> Self {
         Self {
             profile,
+            resolver,
             cache: Mutex::new(HashMap::new()),
             cache_capacity,
             permits: Semaphore::new(max_concurrent),
+            work: Arc::new(PlanWork::default()),
         }
     }
 
@@ -150,37 +217,58 @@ impl PlanService {
         }
     }
 
-    /// Serve a verdict: a held pinned one from cache, otherwise store
-    /// this one and serve it.
-    ///
-    /// Split out of [`Self::plan`] because the branch that matters —
-    /// a pinned verdict coming back from cache instead of being
-    /// recomputed — can only be reached with an immutable commit, and
-    /// every source that has one is a network fetch. As its own
-    /// method it is reachable from a unit test, so the cache rule is
-    /// checked rather than assumed.
-    fn serve(&self, document: Value, cache_key: Option<&VerdictCacheKey>) -> (Value, bool) {
-        let Some(key) = cache_key else {
-            // Unpinned: served, never stored. A cache that held this
-            // would answer tomorrow's question with today's facts.
-            return (document, false);
-        };
-        match self.cached(key) {
-            Some(hit) => (hit, true),
-            None => {
-                self.store(key.clone(), document.clone());
-                (document, false)
-            }
-        }
+    /// Counts of what this service has actually done. Test surface for
+    /// the invariant that a cache hit performs no staging and no
+    /// planning.
+    pub fn work(&self) -> &PlanWork {
+        &self.work
     }
 
-    /// Plan `sources`, serving a pinned verdict from cache when one is
-    /// held.
+    /// The identity a cached verdict would be filed under, learned
+    /// **without staging anything**.
+    ///
+    /// `None` means "do not consult the cache": a local path, an
+    /// unpinned revision name among the artifacts, or a probe that
+    /// failed. The last is deliberately not an error — the probe is an
+    /// optimisation, and a repo that cannot be reached will fail again
+    /// in the planning path below with a better message than a bare
+    /// commit lookup can give.
+    async fn lookup_key(&self, specs: &[PathBuf]) -> Option<VerdictCacheKey> {
+        let owned = specs.to_vec();
+        let work = Arc::clone(&self.work);
+        let resolver = Arc::clone(&self.resolver);
+        let commits = tokio::task::spawn_blocking(move || {
+            work.commits_resolved
+                .fetch_add(owned.len() as u64, Ordering::Relaxed);
+            resolver(&owned)
+        })
+        .await
+        .ok()?
+        .ok()?;
+        // Every artifact pinned, or no key at all. One unpinned source
+        // poisons the whole verdict — a partially immutable verdict is
+        // not an immutable verdict.
+        let revisions: Vec<String> = commits.into_iter().collect::<Option<Vec<_>>>()?;
+        Some(VerdictCacheKey {
+            revisions,
+            semantics_version: PLANNER_SEMANTICS_VERSION,
+        })
+    }
+
+    /// Plan `sources`, answering from cache before doing the work that
+    /// would produce the answer.
+    ///
+    /// The order is the point. Keying on the resolved commit means the
+    /// identity is only knowable after asking the hub — but asking for
+    /// the commit is one ranged request, while producing the verdict is
+    /// tens of megabytes of headers and a planner pass. Consulting the
+    /// cache after the second step, as this did originally, makes a hit
+    /// fast (the hub's bytes are locally cached) while still costing
+    /// the full parse and allocation. Measured on the public box: a hit
+    /// answered in 0.9 s and still pushed peak RSS up 23 MB.
     ///
     /// The returned document is the plan exactly as `vindex plan
-    /// --json` writes it, plus `staging` and a `serving` block — so a
-    /// client can read a server's answer and a CLI's answer with the
-    /// same parser.
+    /// --json` writes it, plus `staging` and a `serving` block.
     pub async fn plan(&self, sources: Vec<String>) -> Result<Value, ServerError> {
         let specs = self.validate(&sources)?;
 
@@ -195,26 +283,56 @@ impl PlanService {
             ))
         })?;
 
-        let planned = tokio::task::spawn_blocking(move || plan_specs(&specs))
+        // ── the cheap half ──
+        let probe_key = self.lookup_key(&specs).await;
+        if let Some(key) = &probe_key {
+            if let Some(hit) = self.cached(key) {
+                return Ok(with_serving(hit, true, true, self.profile));
+            }
+        }
+
+        // ── the expensive half, only on a miss ──
+        let work = Arc::clone(&self.work);
+        let owned = specs.clone();
+        let planned = tokio::task::spawn_blocking(move || plan_specs(&owned, &work))
             .await
             .map_err(|e| ServerError::Internal(format!("plan task failed: {e}")))??;
-
         let Planned {
             document,
             cache_key,
         } = planned;
 
-        let (mut document, served_from_cache) = self.serve(document, cache_key.as_ref());
-
-        document["serving"] = serde_json::json!({
-            "cached": served_from_cache,
-            // Says why a verdict was not stored without making the
-            // client infer it from the absence of a commit.
-            "cacheable": cache_key.is_some(),
-            "profile": self.profile.as_str(),
-        });
-        Ok(document)
+        // Filed under the PLAN's key, never the probe's. If the repo
+        // moved between the probe and the staging, this verdict belongs
+        // to the commit that was actually read.
+        if let Some(key) = &cache_key {
+            self.store(key.clone(), document.clone());
+        }
+        Ok(with_serving(
+            document,
+            false,
+            cache_key.is_some(),
+            self.profile,
+        ))
     }
+}
+
+/// Attach the serving block. One place, so a cache hit and a fresh
+/// verdict cannot describe themselves differently.
+fn with_serving(
+    mut document: Value,
+    cached: bool,
+    cacheable: bool,
+    profile: ServerProfile,
+) -> Value {
+    document["serving"] = serde_json::json!({
+        "cached": cached,
+        // Says why a verdict was not stored without making the client
+        // infer it from the absence of a commit.
+        "cacheable": cacheable,
+        "profile": profile.as_str(),
+    });
+    document
 }
 
 struct Planned {
@@ -224,7 +342,8 @@ struct Planned {
 
 /// Resolve and plan, on a blocking thread. Everything that touches the
 /// network lives here.
-fn plan_specs(specs: &[PathBuf]) -> Result<Planned, ServerError> {
+fn plan_specs(specs: &[PathBuf], work: &PlanWork) -> Result<Planned, ServerError> {
+    work.staged.fetch_add(1, Ordering::Relaxed);
     let resolved = artifact::resolve_all(specs)
         .map_err(|e| ServerError::BadRequest(format!("cannot read this source: {e}")))?;
     let staging: Vec<Value> = resolved
@@ -232,6 +351,7 @@ fn plan_specs(specs: &[PathBuf]) -> Result<Planned, ServerError> {
         .filter_map(artifact::ResolvedArtifact::staging_json)
         .collect();
 
+    work.planned.fetch_add(1, Ordering::Relaxed);
     let plan = plan_resolved(specs, resolved)
         .map_err(|e| ServerError::BadRequest(format!("cannot plan this source: {e}")))?;
     let cache_key = plan.cache_key();
@@ -311,29 +431,137 @@ mod tests {
         );
     }
 
-    #[test]
-    fn an_unpinned_verdict_is_served_and_never_stored() {
-        let s = PlanService::new(ServerProfile::SingleModel);
-        let (doc, cached) = s.serve(serde_json::json!({"v": 1}), None);
-        assert_eq!(doc, serde_json::json!({"v": 1}));
-        assert!(!cached);
-        assert!(s.cache.lock().unwrap().is_empty(), "nothing may be stored");
+    // ── cache before work: the invariant, asserted as work NOT done ──
+
+    /// A real checkpoint on disk, so the miss path actually plans.
+    fn checkpoint() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        larql_vindex::format::vindex3::fixtures::miniature_glimmer(dir.path());
+        dir
     }
 
-    #[test]
-    fn a_pinned_verdict_is_stored_on_the_first_ask_and_served_on_the_second() {
-        let s = PlanService::new(ServerProfile::SingleModel);
-        let k = key(&["abc"]);
+    /// A commit probe that answers whatever the test says, without a hub.
+    fn resolver(answers: Vec<Option<&'static str>>) -> CommitResolver {
+        Arc::new(move |_: &[PathBuf]| {
+            Ok(answers
+                .iter()
+                .map(|a| a.map(str::to_string))
+                .collect::<Vec<_>>())
+        })
+    }
 
-        let (first, cached) = s.serve(serde_json::json!({"v": 1}), Some(&k));
-        assert_eq!(first, serde_json::json!({"v": 1}));
-        assert!(!cached, "the first ask computed it");
+    fn service(answers: Vec<Option<&'static str>>) -> PlanService {
+        PlanService::with_resolver(ServerProfile::SingleModel, 2, 8, resolver(answers))
+    }
 
-        // A second, DIFFERENT document under the same key must lose to
-        // the stored one — that is what "cached" has to mean.
-        let (second, cached) = s.serve(serde_json::json!({"v": 2}), Some(&k));
-        assert_eq!(second, serde_json::json!({"v": 1}));
-        assert!(cached);
+    /// The whole point of the rung. A hit must cost one commit probe
+    /// and nothing else — no header staging, no planner pass. Asserted
+    /// by counting, because "the lookup happens earlier in the
+    /// function" is a structural claim that would still hold if some
+    /// staging leaked in ahead of it.
+    #[tokio::test]
+    async fn a_cache_hit_stages_nothing_and_plans_nothing() {
+        let s = service(vec![Some("abc")]);
+        s.store(
+            key(&["abc"]),
+            serde_json::json!({"schema": 4, "stored": true}),
+        );
+        let dir = checkpoint();
+
+        let before = s.work().snapshot();
+        let out = s
+            .plan(vec![dir.path().to_string_lossy().into_owned()])
+            .await
+            .unwrap();
+        let after = s.work().snapshot();
+
+        assert_eq!(
+            out["stored"],
+            serde_json::json!(true),
+            "the STORED verdict is served"
+        );
+        assert_eq!(out["serving"]["cached"], serde_json::json!(true));
+        assert_eq!(after.0, before.0 + 1, "exactly one commit probe");
+        assert_eq!(after.1, before.1, "no header staging on a hit");
+        assert_eq!(after.2, before.2, "no planner invocation on a hit");
+    }
+
+    /// The invalidation control. Same request shape, a different
+    /// resolved commit: the stored verdict must not answer for it.
+    #[tokio::test]
+    async fn a_different_resolved_commit_is_a_miss() {
+        let s = service(vec![Some("def")]);
+        s.store(key(&["abc"]), serde_json::json!({"stored": true}));
+        let dir = checkpoint();
+
+        let before = s.work().snapshot();
+        let out = s
+            .plan(vec![dir.path().to_string_lossy().into_owned()])
+            .await
+            .unwrap();
+        let after = s.work().snapshot();
+
+        assert!(
+            out.get("stored").is_none(),
+            "a different commit must not reuse the verdict"
+        );
+        assert_eq!(out["serving"]["cached"], serde_json::json!(false));
+        assert_eq!(after.1, before.1 + 1, "a miss stages");
+        assert_eq!(after.2, before.2 + 1, "a miss plans");
+    }
+
+    /// A local path has no persistent identity, so it is planned
+    /// normally and its verdict is never filed.
+    #[tokio::test]
+    async fn a_local_source_is_planned_and_never_cached() {
+        let s = service(vec![None]);
+        let dir = checkpoint();
+        let out = s
+            .plan(vec![dir.path().to_string_lossy().into_owned()])
+            .await
+            .unwrap();
+        assert_eq!(out["serving"]["cached"], serde_json::json!(false));
+        assert_eq!(out["serving"]["cacheable"], serde_json::json!(false));
+        assert_eq!(s.work().snapshot().2, 1, "it really planned");
+        assert!(
+            s.cache.lock().unwrap().is_empty(),
+            "an unpinned verdict must never be stored"
+        );
+    }
+
+    /// One unpinned artifact poisons the whole key: a partially
+    /// immutable verdict is not an immutable verdict.
+    #[tokio::test]
+    async fn one_unpinned_artifact_makes_the_whole_plan_uncacheable() {
+        let s = service(vec![Some("abc"), None]);
+        assert!(
+            s.lookup_key(&[PathBuf::from("a"), PathBuf::from("b")])
+                .await
+                .is_none(),
+            "every artifact must be pinned, or there is no key at all"
+        );
+    }
+
+    /// A probe that fails is not an error — it means "do not consult
+    /// the cache", and the planning path below reports the real
+    /// problem with a better message.
+    #[tokio::test]
+    async fn a_failed_commit_probe_falls_through_to_planning() {
+        let failing: CommitResolver = Arc::new(|_: &[PathBuf]| {
+            Err(larql_vindex::error::VindexError::Parse(
+                "hub unreachable".into(),
+            ))
+        });
+        let s = PlanService::with_resolver(ServerProfile::SingleModel, 2, 8, failing);
+        assert!(s.lookup_key(&[PathBuf::from("hf://o/r")]).await.is_none());
+
+        let dir = checkpoint();
+        let out = s
+            .plan(vec![dir.path().to_string_lossy().into_owned()])
+            .await
+            .unwrap();
+        assert_eq!(out["serving"]["cached"], serde_json::json!(false));
+        assert_eq!(s.work().snapshot().2, 1, "it planned anyway");
     }
 
     #[tokio::test]

--- a/crates/larql-vindex/src/format/vindex3/artifact/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/artifact/mod.rs
@@ -39,7 +39,8 @@ mod staging;
 
 pub use ingest::{encode_from_specs, IngestOutcome, RemoteTransfer};
 pub use resolve::{
-    is_remote_spec, resolve, resolve_all, ArtifactPayloads, ResolvedArtifact, INVENTORY_EXT,
+    is_remote_spec, resolve, resolve_all, resolve_pinned_commit, resolve_pinned_commits,
+    ArtifactPayloads, ResolvedArtifact, INVENTORY_EXT,
 };
 pub use size::size;
 pub use staging::StagingReport;

--- a/crates/larql-vindex/src/format/vindex3/artifact/resolve.rs
+++ b/crates/larql-vindex/src/format/vindex3/artifact/resolve.rs
@@ -180,6 +180,43 @@ fn load_local(path: &Path) -> Result<ArchitectureInventory, VindexError> {
 /// payloads read at another would address a different checkpoint with the
 /// same offsets, which is the one failure this whole path could have that
 /// still produces plausible bytes.
+/// The immutable commit `spec` resolves to, **without staging it**.
+///
+/// One ranged request that reads the hub's commit header — the cheap
+/// half of what [`resolve`] does before it fetches anything. It exists
+/// so a caller holding a verdict cache can learn enough immutable
+/// identity to look up an answer *before* paying for the headers that
+/// would produce it. Measured on the public explorer, that is the
+/// difference between a repeat plan costing ~90 MB and a full header
+/// parse, and costing one HTTP round trip.
+///
+/// `None` — meaning "no persistent identity, do not cache" — for:
+/// - a local path, which has no commit at all; and
+/// - a repo the hub answers without a commit header, i.e. an unpinned
+///   revision name, which can move.
+///
+/// Goes through the same [`resolve_commit`] that [`resolve`] itself
+/// uses, so the commit a cache is keyed on and the commit a verdict
+/// records cannot disagree by construction rather than by discipline.
+pub fn resolve_pinned_commit(spec: &Path) -> Result<Option<String>, VindexError> {
+    let text = spec.to_string_lossy();
+    if !is_hf_spec(&text) {
+        return Ok(None);
+    }
+    let parsed = parse_spec(&text)?;
+    resolve_commit(&HfRangeClient::new(&parsed.repo, &parsed.revision)?)
+}
+
+/// [`resolve_pinned_commit`] for every spec, in order.
+///
+/// A caller may key a cache on the result only when **every** entry is
+/// `Some`: one local path or one unpinned revision among the artifacts
+/// makes the whole verdict uncacheable, the same rule
+/// `SystemPlan::cache_key` applies after the fact.
+pub fn resolve_pinned_commits(specs: &[PathBuf]) -> Result<Vec<Option<String>>, VindexError> {
+    specs.iter().map(|s| resolve_pinned_commit(s)).collect()
+}
+
 fn resolve_remote(spec: &str) -> Result<ResolvedArtifact, VindexError> {
     let parsed = parse_spec(spec)?;
     let named = HfRangeClient::new(&parsed.repo, &parsed.revision)?;

--- a/crates/larql-vindex/src/format/vindex3/artifact/tests/resolve.rs
+++ b/crates/larql-vindex/src/format/vindex3/artifact/tests/resolve.rs
@@ -177,3 +177,63 @@ fn a_path_with_no_stem_still_gets_a_name() {
         "root is not a checkpoint, and must fail rather than resolve namelessly"
     );
 }
+
+// ── the commit probe: identity without staging ───────────────────────
+//
+// `resolve_pinned_commit` exists so a caller holding a verdict cache can
+// look up an answer before paying for the headers that would produce it.
+// What matters here is that it says "no persistent identity" for exactly
+// the cases where a cached verdict would be wrong to reuse, and that it
+// does so without touching the network.
+
+#[test]
+fn a_local_path_has_no_commit_to_pin() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(
+        super::super::resolve_pinned_commit(dir.path()).unwrap(),
+        None,
+        "a local checkpoint has no persistent identity, so a verdict about it is never cacheable"
+    );
+}
+
+#[test]
+fn a_relative_local_path_is_not_mistaken_for_a_repo() {
+    assert_eq!(
+        super::super::resolve_pinned_commit(Path::new("./some/checkpoint")).unwrap(),
+        None
+    );
+}
+
+/// One unpinnable artifact among many is the case the caller must not
+/// get wrong, so the plural form reports per artifact rather than
+/// collapsing to a single answer.
+#[test]
+fn commits_are_reported_per_artifact_in_order() {
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    let got = super::super::resolve_pinned_commits(&[
+        a.path().to_path_buf(),
+        b.path().to_path_buf(),
+    ])
+    .unwrap();
+    assert_eq!(got, vec![None, None]);
+}
+
+#[test]
+fn no_specs_is_no_commits_rather_than_an_error() {
+    assert_eq!(
+        super::super::resolve_pinned_commits(&[]).unwrap(),
+        Vec::<Option<String>>::new()
+    );
+}
+
+/// A malformed reference is refused by the spec parser, before a client
+/// is built — so a bad argument costs nothing, and the probe cannot be
+/// used to make this process open connections on request.
+#[test]
+fn a_malformed_reference_is_refused_before_any_network() {
+    let err = super::super::resolve_pinned_commit(Path::new("hf://"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("malformed"), "{err}");
+}


### PR DESCRIPTION
Found by the production characterization of the 512 MB explorer box, not by review.

A plan whose verdict was already held answered in **0.9 s and still pushed peak RSS up
23 MB**. `PlanService::plan` staged the headers and ran the planner, then looked in the cache
and discarded what it had just computed. The cache was saving the hub transfer — hf-hub's
disk cache does that — and nothing else: not the parse, not the allocation, not the memory.

```text
parse source
    ↓
resolve immutable commit only          ← one ranged request
    ↓
candidate cache key
    ├── hit  → return cached SystemPlan   (no staging, no planner)
    └── miss → stage headers → plan → cache
```

## Why it was structural

The key comes from `SystemPlan::cache_key()`, which needs the resolved commit, which until now
only existed after staging. But `resolve_remote` already resolves the commit *before* fetching
anything, so `resolve_pinned_commit` exposes exactly that step — going through the same
`resolve_commit` the staging path uses, so the commit a cache is keyed on and the commit a
verdict records cannot disagree by construction rather than by discipline.

## The contract, unchanged

| source | behaviour |
|---|---|
| all HF artifacts pinned | cache lookup allowed |
| local path | no key, plan normally, never stored |
| any unpinned HF artifact | no lookup, no store, plan normally |
| same repo, different resolved commit | miss |

A verdict is filed under the **plan's** key, never the probe's — so a repo that moved between
the two belongs to the commit actually read. A failed probe is not an error; it means "do not
consult the cache", and the planning path reports the real problem with a better message.

## Gated behaviourally, not structurally

"The lookup happens earlier in the function" would still hold if some staging leaked in ahead
of it. `PlanWork` counts commit probes, staging passes and planner invocations:

```text
a_cache_hit_stages_nothing_and_plans_nothing
  exactly one commit probe
  no header staging on a hit
  no planner invocation on a hit
```

**Control:** restoring the old order fails it with `no header staging on a hit` (4 tests red).
Invalidation control included — same request, different resolved commit, miss.

The commit probe is injectable (`CommitResolver`) so both paths are driven deterministically
without a hub. No test here reaches the network.

## Gates

larql-server 1,274 · larql-vindex 3,996, all passing. fmt + clippy clean on both.
**Coverage policy run for both crates** — the gate missed on #389: server passes with
`plan_service.rs` at 97.46%; larql-vindex passes with `resolve.rs` back to 93.16% after
covering the probe's local, multi-artifact and malformed-reference branches.

Production witness to follow after deploy: a repeat plan should cost one round trip instead
of ~90 MB and a full parse.
