### PR TITLE
ci: the attribution guard reads the pull-request body too

### DIFF
--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -68,7 +68,16 @@ jobs:
             }
             inspect(
               `PR #${pullNumber} title`,
-              context.payload.pull_request.title,
+              context.payload.pull_request.title ?? "",
+            );
+            // The body is where the generator attribution actually
+            // landed historically — a trailing "Generated with [Claude
+            // Code]" line plus a session URL. Checking only the title
+            // would have let through every case this guard exists for.
+            // Null when a pull request has no description at all.
+            inspect(
+              `PR #${pullNumber} body`,
+              context.payload.pull_request.body ?? "",
             );
 
             for (const finding of findings) {


### PR DESCRIPTION
The guard inspects every commit message and the pull-request title, but not the body — which
is where the tool attribution actually landed: a trailing attribution line and a session URL,
both in the description rather than the title. Every case this check exists to catch would
have gone straight through it.

Both markers are already in the forbidden list, so this is only a matter of handing them the
text. The body is null when a pull request has no description, hence the coalesce; the title
gets the same treatment since it costs nothing and removes a second way to throw on absent
metadata.

## Verified

Ran the four patterns against a real historical description and a clean one:

```
CAUGHT  historical body: generator attribution, session URL
clean   description without them
clean   null body -> empty string
```

## The guard caught me writing this

The first draft of the commit message quoted the forbidden marker verbatim in order to explain
it, and tripped the check. A message about the rule has to describe the string rather than
reproduce it — which is a small piece of evidence that the check does what it says.
