### PR TITLE
fix(vindex): lint the gpu-gated sources, and keep NaN reaching the dump

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/artifact/tests/resolve.rs
+++ b/crates/larql-vindex/src/format/vindex3/artifact/tests/resolve.rs
@@ -211,11 +211,9 @@ fn a_relative_local_path_is_not_mistaken_for_a_repo() {
 fn commits_are_reported_per_artifact_in_order() {
     let a = tempfile::tempdir().unwrap();
     let b = tempfile::tempdir().unwrap();
-    let got = super::super::resolve_pinned_commits(&[
-        a.path().to_path_buf(),
-        b.path().to_path_buf(),
-    ])
-    .unwrap();
+    let got =
+        super::super::resolve_pinned_commits(&[a.path().to_path_buf(), b.path().to_path_buf()])
+            .unwrap();
     assert_eq!(got, vec![None, None]);
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_moe_metal/grouped/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_moe_metal/grouped/represent/mod.rs
@@ -149,6 +149,11 @@ impl Format {
     /// bandwidth question is asked in: wall time at these durations is
     /// dominated by a fixed ~0.2 ms of submission, so a GB/s taken from
     /// it prices the stack rather than the kernel.
+    /// The argument list is the backend's grouped-dispatch signature,
+    /// not this shim's: every parameter is forwarded verbatim to
+    /// `*_grouped_experts*` below. A params struct would be unpacked
+    /// again at that single call site.
+    #[allow(clippy::too_many_arguments)]
     fn dispatch_profiled(
         self,
         metal: &MetalBackend,
@@ -169,6 +174,11 @@ impl Format {
         r.unwrap_or_else(|e| panic!("{} grouped dispatch refused: {e}", self.label()))
     }
 
+    /// The argument list is the backend's grouped-dispatch signature,
+    /// not this shim's: every parameter is forwarded verbatim to
+    /// `*_grouped_experts*` below. A params struct would be unpacked
+    /// again at that single call site.
+    #[allow(clippy::too_many_arguments)]
     fn dispatch(
         self,
         metal: &MetalBackend,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_moe_metal/grouped/represent/screen.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_moe_metal/grouped/represent/screen.rs
@@ -24,8 +24,8 @@ fn report_expert_bank_representation_screen() {
         fx.inter
     );
     eprintln!(
-        "[q1a] {:<6} {:>7} {:>9} {:>11} {:>11} {:>8}  {}",
-        "format", "bpw", "MiB/bank", "rel_rms", "max/scale", "x floor", "dispatch"
+        "[q1a] {:<6} {:>7} {:>9} {:>11} {:>11} {:>8}  dispatch",
+        "format", "bpw", "MiB/bank", "rel_rms", "max/scale", "x floor"
     );
     for (a, out) in arms.iter().zip(&outputs) {
         let rms = rel_rms(out, &oracle);
@@ -323,7 +323,12 @@ fn the_k_quant_grouped_dispatch_is_correct_across_slots_and_layouts() {
             f.label(),
             stage.label()
         );
-        if !(overall < 1e-3) {
+        // Not `overall >= 1e-3`: the point of the guard is that a
+        // NON-FINITE overall reaches the per-slot dump, and `>=` is
+        // false for NaN. `partial_cmp` says the same thing as the
+        // original negation without hiding that the values may be
+        // incomparable.
+        if !matches!(overall.partial_cmp(&1e-3), Some(std::cmp::Ordering::Less)) {
             for s in 0..slots {
                 eprintln!(
                     "[q1a-grouped]   slot {s}: vs own {:.3e}, vs slot0 {:.3e}",


### PR DESCRIPTION
CI compiles the gpu feature but never lints it:

```
check job    cargo check  -p larql-vindex --features gpu --all-targets
clippy job   cargo clippy -p larql-vindex --all-targets -- -D warnings
```

Every `cfg(all(feature = "gpu", target_os = "macos"))` source is therefore built and then skipped by `-D warnings`. Four errors had accumulated behind that gap. They matter now because the rung-5 search runs on exactly those paths, and "CI green, research path dirty" is the failure mode this repo already pinned its toolchain to avoid.

## The one that was not a lint rewrite

The screen's per-slot diagnostic guard was:

```rust
if !(overall < 1e-3) {
```

clippy flags the negated comparison on a partially ordered type. **The lint is right about the expression and the expression was right about the behaviour**: the negation is `true` for NaN, so a non-finite `overall` reaches the per-slot dump — precisely when a reader needs it.

The obvious fix, `overall >= 1e-3`, is `false` for NaN and would have silently stopped dumping in the one case the dump exists for. It now asks `partial_cmp` and treats an incomparable result the way the original negation did.

| `overall` | `!(overall < 1e-3)` | `overall >= 1e-3` | this PR |
|---|---|---|---|
| `< 1e-3` | skip | skip | skip |
| `>= 1e-3` | dump | dump | dump |
| `NaN` | **dump** | **skip** ✗ | **dump** ✓ |

## The other three

`dispatch` and `dispatch_profiled` take eight arguments because that is the backend's grouped-dispatch signature, forwarded verbatim to `*_grouped_experts*`. A params struct would be unpacked again at the single call site, so the arity is allowed with that reason recorded rather than wrapped. The header row's trailing literal moves into its format string.

## Unrelated, and included only because it blocks everything

`cargo fmt -p larql-vindex -- --check` has been failing on main since `77fc1fab`: one call in the artifact resolve tests fits on a line at the pinned 1.98.0 rustfmt. Every larql-vindex branch is red until it lands. Called out separately because it is not lint work.

## Gates

```
cargo fmt -p larql-vindex -- --check                        0
cargo check  -p larql-vindex --features gpu --all-targets   0
cargo clippy -p larql-vindex --features gpu --all-targets -- -D warnings   0   <- new
cargo clippy -p larql-vindex --all-targets -- -D warnings   0
cargo test   -p larql-vindex                                0
```

The third is the gate this PR makes passable, and it becomes a standing local gate for rung 5.

## Follow-up, not in this PR

CI should gain a `--features gpu` clippy job. It needs no Metal hardware — cfg-gated Rust errors surface at compile time — so it is a matrix entry, not an infrastructure change.
