### PR TITLE
ci: the deploy gate measures what a cache hit still costs

### DIFF
--- a/deploy/fly-explorer/verify.sh
+++ b/deploy/fly-explorer/verify.sh
@@ -114,7 +114,41 @@ AGAIN="$(curl -sS --max-time 180 -X POST "$BASE/v1/plan" \
   || fail "the second ask was not served from cache"
 pass "second ask served from the verdict cache"
 
-# ── 5. the promise, kept ────────────────────────────────────────────
+# ── 5. a hit must not redo the work ─────────────────────────────────
+# Latency alone cannot show this: before the cache moved ahead of the
+# work, a hit was already fast because hf-hub's disk cache had removed
+# the network, while the 39 MB header parse still ran. So measure the
+# round trip to a route that does nothing (/v1/health) and subtract it.
+# What remains is server-side time.
+#
+#   pre-fix hit    0.76-1.81 s of work (reparse from local disk)
+#   post-fix hit   ~0.25 s             (one ranged GET for the commit)
+#
+# measured 2026-09-03 on this box. The threshold sits between them with
+# room either side; it is a deployment signature, not a perf budget.
+MAX_HIT_WORK_S=0.50
+
+floor="$(for _ in 1 2 3; do
+  curl -s -o /dev/null -w '%{time_total}\n' --max-time 60 "$BASE/v1/health"
+done | sort -n | head -1)"
+hit="$(curl -s -o /dev/null --max-time 180 -w '%{time_total}' \
+  -X POST "$BASE/v1/plan" -H 'content-type: application/json' \
+  -d "{\"sources\":[\"$MODEL\"]}")"
+
+python3 - "$floor" "$hit" "$MAX_HIT_WORK_S" <<'PYEOF' || fail "a cache hit is still doing the work it should have skipped"
+import sys
+floor, hit, limit = (float(x) for x in sys.argv[1:])
+work = hit - floor
+print(f"  ok    a hit costs {work:.2f}s of server work "
+      f"({hit:.2f}s minus a {floor:.2f}s network floor), under {limit}s"
+      if work < limit else
+      f"  FAIL  a hit costs {work:.2f}s of server work "
+      f"({hit:.2f}s minus a {floor:.2f}s floor) — at or above the {limit}s "
+      f"ceiling, which is where a full header reparse lands")
+raise SystemExit(0 if work < limit else 1)
+PYEOF
+
+# ── 6. the promise, kept ────────────────────────────────────────────
 CODE="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 60 \
   -X POST "$BASE/v1/plan" -H 'content-type: application/json' \
   -d "{\"sources\":[\"$LOCAL_PROBE\"]}")"


### PR DESCRIPTION
Follow-through on the cache-before-work fix (#392): turn the observed separation into a gate.

A hit being *fast* never showed the cache was working. Before the lookup moved ahead of the
work, a repeat already answered in 0.85–1.90s because hf-hub's disk cache had removed the
network while the 39 MB header parse still ran. Any wall-clock assertion would have passed on
the broken path.

So the gate measures the round trip to a route that does nothing (`/v1/health`) and subtracts
it. What remains is server-side time:

| | total | minus floor |
|---|---|---|
| `/v1/health` | 0.083–0.101s | — |
| hit, post-fix (GLM-5.3-Flash) | 0.322–0.389s | **~0.25s** |
| hit, post-fix (Qwen3-0.6B) | 0.26s | **0.15s** |
| hit, pre-fix | 0.85–1.90s | 0.76–1.81s |

Ceiling at 0.50s, between them with margin either side.

## Control

The same logic against real timings from both paths:

```
pre-fix warm, slow      work=1.71s  FAIL
pre-fix warm, fast      work=0.86s  FAIL
post-fix, GLM           work=0.25s  PASS
post-fix, Qwen3-0.6B    work=0.15s  PASS
```

## What it is and is not

A deployment signature, not a performance budget. The semantics are proven in CI by
`a_cache_hit_stages_nothing_and_plans_nothing`, which counts commit probes, staging passes and
planner invocations directly and fails when the old order is restored. This only answers
whether the binary serving traffic is the one that does that — which `VmHWM` cannot, since it
is cumulative and a retained arena can absorb a reparse without moving the high-water mark.

Verified against the live deployment: the full gate passes end to end.
