### PR TITLE
fix(server): the cache tests read the planner's semantics version

### DIFF
--- a/crates/larql-server/src/plan_service.rs
+++ b/crates/larql-server/src/plan_service.rs
@@ -378,10 +378,15 @@ fn plan_specs(specs: &[PathBuf], work: &PlanWork) -> Result<Planned, ServerError
 mod tests {
     use super::*;
 
+    /// A key as the SERVICE would build it — reading the planner's own
+    /// constant, not a copy of today's value. Hardcoding `1` here made
+    /// every one of these tests fail the moment the planner's semantics
+    /// version moved to 5, for a reason that had nothing to do with the
+    /// cache.
     fn key(revisions: &[&str]) -> VerdictCacheKey {
         VerdictCacheKey {
             revisions: revisions.iter().map(|r| r.to_string()).collect(),
-            semantics_version: 1,
+            semantics_version: PLANNER_SEMANTICS_VERSION,
         }
     }
 
@@ -403,9 +408,12 @@ mod tests {
     fn semantics_version_is_part_of_the_identity() {
         let s = PlanService::new(ServerProfile::SingleModel);
         s.store(key(&["abc"]), serde_json::json!({"v": 1}));
+        // Whatever the planner says today, plus one: the point is that a
+        // DIFFERENT semantics version is a different verdict, not that
+        // any particular number is.
         let newer = VerdictCacheKey {
             revisions: vec!["abc".into()],
-            semantics_version: 2,
+            semantics_version: PLANNER_SEMANTICS_VERSION + 1,
         };
         assert_eq!(s.cached(&newer), None);
     }


### PR DESCRIPTION
**Main is broken by #392 and its checks are still queued**, so this lands before they report.

The plan cache is keyed on every artifact's commit plus the planner's semantics version, and
the service builds that key from `PLANNER_SEMANTICS_VERSION`. The tests built theirs from a
literal `1`.

That held for exactly as long as the constant did. Your arch-conformance work moved it to `5`,
so the service looks up version 5 while the test stored version 1, every lookup misses, and
four tests fail for a reason unrelated to the cache they exercise:

```
assertion `left == right` failed: the STORED verdict is served
  left: Null
 right: Bool(true)
```

The fix is what the tests should have done from the start — read the same constant the service
reads. A test hardcoding a value the code derives asserts today's number rather than the
relationship.

The one test that deliberately uses a *different* version — proving the semantics version is
part of the verdict's identity — now says `PLANNER_SEMANTICS_VERSION + 1`, so it keeps meaning
"different" rather than meaning "2".

## How it got in

#392 merged with zero CI signal while the queue was backed up. This is precisely the class of
thing that gap admits: the change was correct against the main it was written on, and stale
against the main it landed on. Found by branching off newer main for the next rung, not by
review.

Verified: `cargo test -p larql-server` fully green locally, 11/11 in `plan_service`.
