### PR TITLE
feat(server): a server says which build is answering

### DIFF
--- a/crates/larql-server/src/capabilities.rs
+++ b/crates/larql-server/src/capabilities.rs
@@ -361,10 +361,7 @@ impl Capabilities {
             "object": "capabilities",
             "schema": CAPABILITIES_SCHEMA,
             "profile": self.profile.as_str(),
-            "server": {
-                "name": env!("CARGO_PKG_NAME"),
-                "version": env!("CARGO_PKG_VERSION"),
-            },
+            "server": server_identity(BUILD_REVISION),
             "runtime": { "backends": V3_BACKENDS },
             "routes": self.mounted.paths().collect::<Vec<_>>(),
         });
@@ -374,6 +371,41 @@ impl Capabilities {
         }
         report
     }
+}
+
+/// The commit this binary was built from, or `None`.
+///
+/// `option_env!`, so it is resolved at COMPILE time and baked into the
+/// binary. A build that was not told its revision produces `None` here
+/// and the field is then absent from the report — never `"unknown"`,
+/// and never derived at runtime.
+///
+/// That last part is the point. A revision read from the working
+/// directory, or from a `.git` beside the executable, describes the
+/// machine the process happens to be running on rather than the code
+/// it is running, and would let a stale binary in a fresh checkout
+/// claim the checkout's commit. The only honest source is the build.
+pub const BUILD_REVISION: Option<&str> = option_env!("LARQL_SERVER_REVISION");
+
+/// The `server` block: what is answering, and which build of it.
+///
+/// `revision` is omitted rather than nulled when the build did not say,
+/// so a client can distinguish "this server does not report a
+/// revision" from "this server reports it does not know" — the same
+/// discipline the site's build record uses, where an identifier that
+/// does not exist is absent rather than guessed.
+fn server_identity(revision: Option<&str>) -> serde_json::Value {
+    let mut block = serde_json::json!({
+        "name": env!("CARGO_PKG_NAME"),
+        "version": env!("CARGO_PKG_VERSION"),
+    });
+    if let Some(revision) = revision {
+        // Verbatim. Not shortened, not validated as a sha: the build
+        // said this, and the deploy gate compares it to what it
+        // expected to publish.
+        block["revision"] = serde_json::Value::String(revision.to_string());
+    }
+    block
 }
 
 /// Insert `value` at a `/`-separated JSON pointer, creating the
@@ -393,5 +425,67 @@ fn insert_at(root: &mut serde_json::Value, pointer: &str, value: serde_json::Val
             node[segment] = serde_json::json!({});
         }
         node = &mut node[segment];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A build that was told its commit reports it verbatim — not
+    /// shortened, not reformatted. The deploy gate compares this string
+    /// to the SHA it expected to publish, so any tidying here would
+    /// break the comparison it exists for.
+    #[test]
+    fn a_stated_revision_is_reported_verbatim() {
+        let block = server_identity(Some("481fa87cdeadbeef"));
+        assert_eq!(block["revision"], "481fa87cdeadbeef");
+        assert_eq!(block["name"], "larql-server");
+    }
+
+    /// A build that was told nothing omits the field. Not `null`, not
+    /// `"unknown"`: a client must be able to tell "this server does not
+    /// report a revision" from "this server claims not to know", and a
+    /// manufactured placeholder would make a gate comparing against it
+    /// silently unfalsifiable.
+    #[test]
+    fn an_unstated_revision_is_absent_rather_than_invented() {
+        let block = server_identity(None);
+        assert!(
+            block.get("revision").is_none(),
+            "revision must be absent, got {block}"
+        );
+        assert!(
+            block.get("name").is_some(),
+            "the rest of the block still stands"
+        );
+    }
+
+    /// The revision can only come from the build. This pins the
+    /// mechanism, because the failure it guards against — deriving the
+    /// commit at runtime from a `.git` next to the process — would let
+    /// a stale binary in a fresh checkout report the checkout's commit
+    /// and pass a deploy gate it should fail.
+    #[test]
+    fn the_revision_is_a_compile_time_fact() {
+        // Only the non-test half: this module's own assertions quote the
+        // very strings being searched for, so scanning the whole file
+        // would have it match itself and fail regardless of the code.
+        let whole = include_str!("capabilities.rs");
+        let source = &whole[..whole.find("#[cfg(test)]").unwrap_or(whole.len())];
+        assert!(
+            source.contains("option_env!(\"LARQL_SERVER_REVISION\")"),
+            "the revision must be baked in by the build"
+        );
+        for runtime_source in [
+            "std::env::var",
+            "Command::new(\"git\")",
+            "read_to_string(\".git",
+        ] {
+            assert!(
+                !source.contains(runtime_source),
+                "the revision must not be derived at runtime: found {runtime_source}"
+            );
+        }
     }
 }

--- a/deploy/fly-explorer/Dockerfile
+++ b/deploy/fly-explorer/Dockerfile
@@ -4,6 +4,18 @@
 FROM rust:1-slim AS builder
 WORKDIR /build
 
+# The commit this image is built from, surfaced by the server as
+# `server.revision` in GET /v1/capabilities so a deploy can be asserted
+# rather than inferred from behaviour. Passed by the deploy:
+#
+#   fly deploy --build-arg LARQL_SERVER_REVISION=$(git rev-parse HEAD) ...
+#
+# Unset is a legitimate state: `option_env!` then yields None and the
+# field is absent from the report. Never defaulted to a placeholder —
+# a build that does not know its commit must not claim one.
+ARG LARQL_SERVER_REVISION
+ENV LARQL_SERVER_REVISION=${LARQL_SERVER_REVISION}
+
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
 # larql-vindex embeds registry model records via include_str! at compile

--- a/deploy/fly-explorer/README.md
+++ b/deploy/fly-explorer/README.md
@@ -29,8 +29,17 @@ keeping: wipe the machine and it rebuilds identically.
 
 ```bash
 fly apps create vindex3-explorer
-fly deploy --app vindex3-explorer --config deploy/fly-explorer/fly.toml --remote-only
+fly deploy --app vindex3-explorer --config deploy/fly-explorer/fly.toml --remote-only \
+  --build-arg LARQL_SERVER_REVISION=$(git rev-parse HEAD)
 ```
+
+Run the deploy from a checkout of the commit you intend to publish, not
+from a feature branch: `--build-arg` states which commit the image is
+built from, and `GET /v1/capabilities` reports it back as
+`server.revision`. `verify.sh --revision <sha>` then asserts the live
+server *is* that commit, rather than inferring it from behaviour.
+Omitting the arg is allowed — the field is simply absent, and the gate
+says so instead of passing quietly.
 
 Hardening is layered: fly's connection limits → per-IP rate limit
 (`RATE_LIMIT`, default 120/min, trusting `X-Forwarded-For` from fly's

--- a/deploy/fly-explorer/verify.sh
+++ b/deploy/fly-explorer/verify.sh
@@ -18,6 +18,15 @@
 
 set -euo pipefail
 
+# --revision <sha>: assert the live server IS this commit. Without it
+# the gate can only show the server BEHAVES like the build it expects,
+# which is circumstantial — a signature, not an identity.
+EXPECT_REVISION=""
+if [ "${1:-}" = "--revision" ]; then
+  EXPECT_REVISION="${2:?--revision needs a commit sha}"
+  shift 2
+fi
+
 BASE="${1:-https://vindex3-explorer.fly.dev}"
 MODEL="${VERIFY_MODEL:-hf://Qwen/Qwen3-0.6B}"
 # Never a path that exists: this must be refused by POLICY, before the
@@ -60,6 +69,21 @@ SCHEMA="$(printf '%s' "$CAPS" | jget schema)"
 [ "$SCHEMA" = "1" ] \
   || fail "capabilities schema is $SCHEMA; this script reads schema 1 only"
 pass "capabilities schema 1"
+
+REVISION="$(printf '%s' "$CAPS" | jget server.revision)"
+if [ -n "$EXPECT_REVISION" ]; then
+  [ "$REVISION" = "-" ] \
+    && fail "the server reports no build revision, so this gate cannot confirm which code is live. Deploy with --build-arg LARQL_SERVER_REVISION=\$(git rev-parse HEAD)."
+  [ "$REVISION" = "$EXPECT_REVISION" ] \
+    || fail "live server is $REVISION, expected $EXPECT_REVISION — a different build is serving traffic"
+  pass "live server IS $EXPECT_REVISION"
+elif [ "$REVISION" != "-" ]; then
+  pass "build revision $REVISION (pass --revision <sha> to assert it)"
+else
+  # Not a failure: a build may legitimately not know its commit. But say
+  # so, because everything below is then a behavioural signature only.
+  pass "build revision not reported — identity unasserted, signature only"
+fi
 
 PROFILE="$(printf '%s' "$CAPS" | jget profile)"
 [ "$PROFILE" = "public_explorer" ] \


### PR DESCRIPTION
The deploy gate could show the endpoint *behaves* like the build it expected — a cache hit
costing one probe rather than a reparse — but not that it **is** that build.
`/v1/capabilities` identified the crate version and nothing else, so "the merged commit is
live" was inferred from behaviour.

```text
build   LARQL_SERVER_REVISION=<git sha>
              ↓
        server startup
              ↓
        GET /v1/capabilities

        server:
          name:     larql-server
          version:  0.2.0
          revision: 67afdea7...
```

## The rules, and why each one

| build says | report says | why |
|---|---|---|
| a revision | it, verbatim | the gate compares strings; tidying breaks the comparison it exists for |
| nothing | **field absent** | not `null`, not `"unknown"` — a placeholder makes a gate comparing against it unfalsifiable |
| — | never derived at runtime | a commit read from a `.git` beside the process describes the machine, not the code, and lets a stale binary in a fresh checkout claim the checkout's commit |

`option_env!` resolves at compile time, so the value is baked into the binary and cannot be
spoofed by the environment it runs in. A test pins that mechanism — **controlled**: replacing
it with `std::env::var` fails the test.

## The gate becomes categorical

```bash
verify.sh --revision $(git rev-parse HEAD)
```

Verified against the currently-live server, which was built before this rung and reports no
revision — it **fails with exit 1** rather than passing quietly:

```
FAIL  the server reports no build revision, so this gate cannot confirm which
      code is live. Deploy with --build-arg LARQL_SERVER_REVISION=$(git rev-parse HEAD).
```

Without `--revision` it reports what it sees and says the run is a signature only.

## What it completes

The chain, rather than any one link: the source commit says *what* was judged, the semantics
version says *how*, the server revision says *which code* served the judgement, and the gate
asserts the expected one is live. Behaviour then confirms the path is right instead of
standing in for all of it.

## Gates

larql-server 1,277 tests, fmt and clippy clean, coverage policy passes with `capabilities.rs`
at 97.22%. Rebuilt on top of #398 so its repeat-cost gate is preserved — both features present
in `verify.sh`.
