### PR TITLE
fix(deploy): the gate reads the plan schema this checkout declares

### DIFF
--- a/deploy/fly-explorer/verify.sh
+++ b/deploy/fly-explorer/verify.sh
@@ -110,9 +110,26 @@ PLAN="$(curl -sS --max-time 180 -X POST "$BASE/v1/plan" \
   -H 'content-type: application/json' \
   -d "{\"sources\":[\"$MODEL\"]}")"
 
-[ "$(printf '%s' "$PLAN" | jget schema)" = "4" ] \
-  || fail "plan schema is not 4: $(printf '%s' "$PLAN" | head -c 200)"
-pass "plan schema 4"
+# The expected schema is read from THIS checkout's source, never
+# hardcoded. It has already moved 4 -> 6 while this gate said 4, and a
+# gate that fails because the format advanced is a gate people learn to
+# ignore. Now that the revision assertion above pins the live server to
+# this commit, the constant here IS the constant it was built from.
+SCHEMA_SRC=crates/larql-vindex/src/format/vindex3/plan/report.rs
+WANT_SCHEMA="$(sed -n 's/^pub const PLAN_SCHEMA: u32 = \([0-9]*\);.*/\1/p' "$SCHEMA_SRC" 2>/dev/null | head -1)"
+GOT_SCHEMA="$(printf '%s' "$PLAN" | jget schema)"
+if [ -n "$WANT_SCHEMA" ]; then
+  [ "$GOT_SCHEMA" = "$WANT_SCHEMA" ] \
+    || fail "plan schema is $GOT_SCHEMA, this checkout declares $WANT_SCHEMA"
+  pass "plan schema $GOT_SCHEMA, as this checkout declares"
+else
+  # Run from outside a checkout: still refuse an unattributed document,
+  # but say that the number itself went unchecked.
+  case "$GOT_SCHEMA" in
+    ''|*[!0-9]*) fail "plan carries no schema: $(printf '%s' "$PLAN" | head -c 160)" ;;
+    *) pass "plan schema $GOT_SCHEMA (source not readable here — number unverified)" ;;
+  esac
+fi
 
 REV="$(printf '%s' "$PLAN" | jget artifacts)"
 printf '%s' "$PLAN" | python3 -c "


### PR DESCRIPTION
The first categorical deploy witness failed — on a hardcoded number, not on the deployment.

The gate asserted `plan schema 4`. `PLAN_SCHEMA` is now **6**, moved by the
architecture-conformance work. A gate that goes red because the format advanced is a gate
people learn to ignore.

The expected value now comes from `PLAN_SCHEMA` in this checkout's source. That is sound
*because* of the revision assertion added in #401: the gate has already confirmed the live
server **is** this commit, so the constant here is the constant it was built from.

Same mistake the cache tests made with `PLANNER_SEMANTICS_VERSION` one rung earlier —
hardcoding a value the code derives asserts today's number rather than the agreement between
the two.

Run from outside a checkout, the number can't be read; the gate still refuses a document
carrying no schema but says the number went unverified rather than passing as though checked.

## The witness, now complete

```
== https://vindex3-explorer.fly.dev ==
  ok    capabilities schema 1
  ok    live server IS 3cd1207aedab7a815d2890803efb946964eb9e06
  ok    profile public_explorer
  ok    promises: sources.plan.hf = true
  ok    promises: sources.plan.local = false
  ok    public surface executes, binds and encodes nothing
  ok    plan schema 6, as this checkout declares
  ok    pinned at c1899de289a0... (Qwen3-0.6B)
  ok    judged by larql-vindex 0.2.0 · semantics 6
  ok    read 11.47 MB standing in for 1.50 GB (1.40 GiB)
  ok    verdict is cacheable (every artifact pinned)
  ok    second ask served from the verdict cache
  ok    a hit costs 0.18s of server work (0.27s minus a 0.10s network floor), under 0.5s
  ok    local-path planning refused 403, as advertised

PASS
```

Every link asserted rather than inferred: which code is live, what it judged, how it judged
it, and that the important path still behaves.
