### PR TITLE
feat(models): read partial_rotary_factor from inside rope_parameters (semantics 7)

### DIFF
--- a/crates/larql-models/src/detect/parser.rs
+++ b/crates/larql-models/src/detect/parser.rs
@@ -450,12 +450,31 @@ pub(super) fn parse_model_config(config: &serde_json::Value) -> ModelConfig {
     let num_global_kv_heads = text_config["num_global_key_value_heads"]
         .as_u64()
         .map(|v| v as usize);
-    // Partial rotary factor: check rope_parameters.full_attention first (Gemma 4),
-    // then top-level partial_rotary_factor.
-    let partial_rotary_factor = rope_params
-        .and_then(|rp| rp.get("full_attention"))
-        .and_then(|fa| fa["partial_rotary_factor"].as_f64())
-        .or_else(|| text_config["partial_rotary_factor"].as_f64());
+    // Partial rotary factor, in the reference's precedence
+    // (`PreTrainedConfig::standardize_rope_params`, transformers 5.x):
+    //  1. partial_rotary_factor at the top level — the legacy flat form.
+    //     The reference copies it INTO `rope_parameters`, overwriting
+    //     whatever the block declared, so when both are present this one
+    //     is the fraction the model runs with;
+    //  2. rope_parameters.full_attention.partial_rotary_factor — Gemma 4's
+    //     per-layer-type form;
+    //  3. rope_parameters.partial_rotary_factor — the 5.x flat form, and
+    //     the ONLY spelling every Qwen3.5 checkpoint uses.
+    //
+    // Form 3 was not read until wave 8 of the conformance sweep. Qwen3.8
+    // writes forms 1 and 3 together, so it resolved; Qwen3.5 writes form 3
+    // alone, lost the fraction, and would have rotated all 256 head dims
+    // where the checkpoint asks for 64 — the same fallthrough shape as
+    // `rope_theta` form 2 above, on the next key. VINDEX3 refused those
+    // checkpoints outright; the engine path did not.
+    let partial_rotary_factor = text_config["partial_rotary_factor"]
+        .as_f64()
+        .or_else(|| {
+            rope_params
+                .and_then(|rp| rp.get("full_attention"))
+                .and_then(|fa| fa["partial_rotary_factor"].as_f64())
+        })
+        .or_else(|| rope_params.and_then(|rp| rp["partial_rotary_factor"].as_f64()));
     // Sliding window pattern: explicit sliding_window_pattern field, or infer later.
     let sliding_window_pattern = text_config["sliding_window_pattern"]
         .as_u64()

--- a/crates/larql-models/src/detect/tests/qwen35_hybrid.rs
+++ b/crates/larql-models/src/detect/tests/qwen35_hybrid.rs
@@ -96,14 +96,49 @@ fn qwen35_uses_the_qwen_prefix_route() {
     assert_eq!(arch.family(), "qwen3_5_text");
 }
 
-/// `partial_rotary_factor` is read from both the flat `text_config` spot
-/// and the nested `rope_parameters` spot the real checkpoint declares it
-/// under — the flat form wins when `rope_parameters.full_attention` is
-/// absent (Gemma 4's structured nesting is a different shape).
+/// `partial_rotary_factor` is read when the checkpoint declares it at
+/// both the flat `text_config` spot and under `rope_parameters` — the
+/// Qwen3.8 shape, which this fixture mirrors.
 #[test]
 fn partial_rotary_factor_is_read_from_the_declared_spot() {
     let arch = detect_from_json(&qwen35_shaped_config());
     assert_eq!(arch.config().partial_rotary_factor, Some(0.25));
+}
+
+/// **The real Qwen3.5 shape declares the fraction under `rope_parameters`
+/// only.** Every Qwen3.5 checkpoint on the Hub (0.8B through 397B-A17B)
+/// omits the flat key; Qwen3.8 happens to write both, which is the only
+/// reason the test above ever passed — it pinned a coincidence of the
+/// fixture, not the parser. transformers 5.5.0 reads the fraction from
+/// `rope_parameters` (`modeling_rope_utils.py`, every `_compute_*`
+/// function: `rope_parameters_dict.get("partial_rotary_factor", 1.0)`),
+/// so a parser that only reads the flat spelling rotates all 256 head
+/// dims of a Qwen3.5 layer where the checkpoint asks for 64.
+#[test]
+fn the_nested_only_partial_rotary_spelling_is_read() {
+    let mut config = qwen35_shaped_config();
+    config["text_config"]
+        .as_object_mut()
+        .unwrap()
+        .remove("partial_rotary_factor");
+    assert!(config["text_config"]["rope_parameters"]["partial_rotary_factor"].is_number());
+    let arch = detect_from_json(&config);
+    assert_eq!(arch.config().partial_rotary_factor, Some(0.25));
+}
+
+/// When both spellings are present the flat one wins, because that is
+/// what the reference does: `PreTrainedConfig::standardize_rope_params`
+/// copies a top-level `partial_rotary_factor` INTO `rope_parameters`,
+/// overwriting whatever the block declared. VINDEX3 blocks the
+/// disagreement separately (`two_disagreeing_partial_rotary_spellings_block`);
+/// this pins which value the engine path resolves so that the two doors
+/// agree on what "the declared fraction" is.
+#[test]
+fn the_flat_partial_rotary_spelling_overrides_the_nested_one() {
+    let mut config = qwen35_shaped_config();
+    config["text_config"]["partial_rotary_factor"] = serde_json::json!(0.5);
+    let arch = detect_from_json(&config);
+    assert_eq!(arch.config().partial_rotary_factor, Some(0.5));
 }
 
 /// An absent hybrid block (an ordinary dense Qwen3 config) leaves every

--- a/crates/larql-vindex/src/format/vindex3/plan/report.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/report.rs
@@ -57,6 +57,17 @@ pub const PLAN_SCHEMA: u32 = 6;
 /// `plan/tests/identity.rs` pins fixture verdicts against this value, so
 /// a change that flips one fails there until the version is bumped.
 ///
+/// **7** — `partial_rotary_factor` is read from inside `rope_parameters`,
+/// the transformers-5.x flat form and the only spelling every Qwen3.5
+/// checkpoint uses. The parser read the legacy top-level key and Gemma 4's
+/// per-layer-type block, so Qwen3.8 (which writes both) resolved while
+/// Qwen3.5 lost its fraction: no layer carried one, the partial and
+/// multi-axis rotary probes answered nothing, and three leaves refused a
+/// family whose text path this build executes. Precedence now mirrors
+/// `standardize_rope_params`: top level, then per-type block, then flat
+/// block. Forecast before the code: three Qwen3.5 dense rows admissible,
+/// three Qwen3.5 MoE rows from six blockers to three, nothing else moves.
+///
 /// **6** — a declaration a companion switch turns off is inert. Qwen2.5
 /// ships `sliding_window: 32768` beside `use_sliding_window: false`; the
 /// graph carries no window, which agrees with the checkpoint, and the
@@ -94,7 +105,7 @@ pub const PLAN_SCHEMA: u32 = 6;
 /// architectures, now block instead of passing silently into
 /// `GenericArch`'s Llama-shaped defaults. Measured on the conformance
 /// corpus: 15 of 42 declared `model_type` strings, across 30 checkpoints.
-pub const PLANNER_SEMANTICS_VERSION: u32 = 6;
+pub const PLANNER_SEMANTICS_VERSION: u32 = 7;
 
 /// Who judged a plan.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/hybrid_linear_attention.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/hybrid_linear_attention.rs
@@ -477,6 +477,58 @@ fn the_rotary_facts_are_carried_into_the_position_policy() {
     }
 }
 
+/// **The real Qwen3.5 shape: the fraction is declared under
+/// `rope_parameters` only, and it must still lower — with its mrope.**
+///
+/// `hybrid_findings` mirrors Qwen3.8, which writes the fraction at both
+/// spots. Every Qwen3.5 checkpoint (0.8B through 397B-A17B) writes only
+/// the nested one, and until wave 8 the parser read only the flat one:
+/// no layer carried a rotary fraction, `probe_partial_rotary_factor` and
+/// `mrope_of` both answered `None`, and three leaves refused a family
+/// whose text path this build executes. The reference reads the nested
+/// spelling (`rope_parameters_dict.get("partial_rotary_factor", 1.0)`),
+/// so this is a carriage gap on the parser side of the boundary, not a
+/// new position policy.
+#[test]
+fn the_nested_only_partial_rotary_spelling_lowers_with_its_mrope() {
+    let dir = tempfile::tempdir().unwrap();
+    let inventory = glimmer_shaped_target_with(dir.path(), |config| {
+        declare_hybrid_cadence(config);
+        declare_gated_delta_geometry(config);
+        config["text_config"]["attn_output_gate"] = serde_json::json!(true);
+        config["text_config"]["output_gate_type"] = serde_json::json!("swish");
+        // Same closing geometry as `hybrid_findings`, nested spelling only.
+        config["text_config"]["rope_parameters"]["partial_rotary_factor"] = serde_json::json!(0.5);
+        config["text_config"]["rope_parameters"]["mrope_interleaved"] = serde_json::json!(true);
+        config["text_config"]["rope_parameters"]["mrope_section"] = serde_json::json!([1, 1, 0]);
+    });
+    let findings: Vec<PlannedFinding> = plan_system(&[("target-artifact".to_string(), inventory)])
+        .artifacts
+        .into_iter()
+        .flat_map(|a| a.findings)
+        .collect();
+    assert!(
+        !findings
+            .iter()
+            .any(|f| f.subject == "text_config.partial_rotary_factor"),
+        "the fixture must not declare the flat spelling, or it proves nothing"
+    );
+    for subject in [
+        "text_config.rope_parameters.partial_rotary_factor",
+        "text_config.rope_parameters.mrope_section",
+        "text_config.rope_parameters.mrope_interleaved",
+    ] {
+        let finding = finding_for(&findings, subject);
+        assert_eq!(
+            finding.category,
+            FindingCategory::Representable,
+            "{subject}: {}",
+            finding.detail
+        );
+        assert!(!finding.blocks(), "{subject}");
+    }
+}
+
 /// **The value-sensitive half.** Two spellings of the partial rotary that
 /// DISAGREE must block, even though both parse.
 ///

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/identity.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/identity.rs
@@ -101,7 +101,7 @@ fn identity_survives_a_round_trip_and_parse_refuses_other_schemas_by_name() {
 /// witness is re-recorded.
 #[test]
 fn the_semantics_version_is_pinned_to_known_verdicts() {
-    assert_eq!(PLANNER_SEMANTICS_VERSION, 6);
+    assert_eq!(PLANNER_SEMANTICS_VERSION, 7);
 
     let dir = tempfile::tempdir().unwrap();
     let admissible = plan_system(&one_glimmer(dir.path()));

--- a/docs/arch-conformance/README.md
+++ b/docs/arch-conformance/README.md
@@ -46,16 +46,16 @@ The sweep is the regression instrument for the conformance programme. Every
 semantic change is measured against the same 88-row corpus, and the two
 invariants are the ones that matter most:
 
-| Metric | Baseline | Waves 1+3 | rope | moe | sliding window | frontier census† |
-|---|---:|---:|---:|---:|---:|---:|
-| semantics version | 1 | 3 | 4 | 5 | **6** | 6 (held) |
-| GREEN | 17 | 18 | 21 | 26 | **28** | 28 |
-| AMBER | 6 | 6 | 6 | 6 | 6 | 7 |
-| RED | 65 | 64 | 61 | 56 | **54** | 74 |
-| **BUG** | **0** | **0** | **0** | **0** | **0** | **0** |
-| **silent drops** | **0** | **0** | **0** | **0** | **0** | **0** |
-| text-closure blockers | 886 | 776 | 756 | 671 | **668** | 1109 |
-| K3 clusters remaining | 7 | 7 | 7 | 7 | **7** | 7 |
+| Metric | Baseline | Waves 1+3 | rope | moe | sliding window | frontier census† | partial rotary |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| semantics version | 1 | 3 | 4 | 5 | 6 | 6 (held) | **7** |
+| GREEN | 17 | 18 | 21 | 26 | 28 | 28 | **31** |
+| AMBER | 6 | 6 | 6 | 6 | 6 | 7 | 7 |
+| RED | 65 | 64 | 61 | 56 | 54 | 74 | **71** |
+| **BUG** | **0** | **0** | **0** | **0** | **0** | **0** | **0** |
+| **silent drops** | **0** | **0** | **0** | **0** | **0** | **0** | **0** |
+| text-closure blockers | 886 | 776 | 756 | 671 | 668 | 1109 | **1091** |
+| K3 clusters remaining | 7 | 7 | 7 | 7 | 7 | 7 | **7** |
 
 † Wave 7 widened the corpus from 88 to 109 scored rows. The 88 rows every
 earlier column was measured on are unchanged — same verdicts, same 668
@@ -252,6 +252,39 @@ against 45 layers, the three multi-token-prediction layers included, so no
 layer aligns. The cluster reads as "attention schedule"; the fix is a length
 rule.
 
+**Wave 8 — `partial_rotary_factor` inside `rope_parameters` (semantics 7).**
+The first fix chosen from the 109-row corpus, and the cheapest kind there is:
+a key read from the wrong spot. The parser read the legacy top-level
+`partial_rotary_factor` and Gemma 4's per-layer-type block, never
+`rope_parameters.partial_rotary_factor` — the transformers-5.x flat form, the
+spelling the reference reads
+(`rope_parameters_dict.get("partial_rotary_factor", 1.0)`), and the only one
+every Qwen3.5 checkpoint uses. Qwen3.8 writes both and was GREEN; Qwen3.5
+wrote one and lost the fraction, so no layer carried one, the partial and
+multi-axis rotary probes answered nothing, and three leaves refused a family
+this build executes. Precedence now mirrors `standardize_rope_params`: top
+level (the reference copies it *into* the block, overwriting), then the
+per-type block, then the flat block.
+
+Frozen before the code in
+[`forecasts/wave8-partial-rotary-factor-in-rope-parameters.json`](forecasts/wave8-partial-rotary-factor-in-rope-parameters.json):
+three Qwen3.5 dense rows green, three Qwen3.5 MoE rows from six blockers to
+three, and three rows that *declare* the key staying exactly where they were
+(Qwen3.8-Flash-Next, Nemotron 3, GLM-4.7-Flash). **Every arm held**: GREEN 31,
+RED 71, blockers 1091, six rows changed and no others. Both new tests were run
+before the parser change and failed with the corpus's own message, then
+passed after it.
+
+Two things worth keeping. The earlier parser test
+`partial_rotary_factor_is_read_from_the_declared_spot` passed only because
+its fixture mirrored Qwen3.8 and declared both spellings — it pinned a
+coincidence of the fixture, not the parser; the nested-only test now sits
+beside it. And outside VINDEX3 this was a fail-open wrong answer: the engine
+path would have rotated all 256 head dims of a Qwen3.5 attention layer where
+the checkpoint asks for 64. VINDEX3 refused those checkpoints; the engine
+did not. The fix lands in the shared parser, so both doors now read the
+reference's spelling.
+
 **What did not happen, and why it is worth recording.** The inert clusters
 reach 34 checkpoints, which looked like a large GREEN wave. It was one row
 (Yi-1.5-6B). Cluster *reach* counts checkpoints a fix touches; only a
@@ -270,11 +303,11 @@ Scored against the **text-generation closure**, which the plan computes
 itself — a checkpoint whose only blockers sit in a vision tower is not
 evidence about its language model.
 
-| outcome | baseline (88) | after wave 7 (109) | share now |
+| outcome | baseline (88) | after wave 8 (109) | share now |
 |---|---:|---:|---:|
-| GREEN — representable | 17 | 28 | 26% |
+| GREEN — representable | 17 | 31 | 28% |
 | AMBER — identified, no implementation | 6 | 7 | 6% |
-| RED — semantic gap | 65 | 74 | 68% |
+| RED — semantic gap | 65 | 71 | 65% |
 | BUG — should work, doesn't | 0 | 0 | 0% |
 | *unreachable (gated/absent/no config)* | *6* | *8* | *not evidence* |
 
@@ -309,12 +342,11 @@ the table; the verdict columns are the sweep's, not the table's.
 | Fine-grained MoE | command-a, exaone-moe, glm, gpt-oss, hunyuan, minimax-m2, step | 12 | 11 | 2 | 0 | 10 |
 | MLA + MoE | deepseek-mla, kimi-moe | 7 | 7 | 0 | 0 | 7 |
 | Sparse-indexed / DSA + MLA + MoE | deepseek-mla, deepseek-v4, glm-5, hunyuan | 7 | 5 | 0 | 7 | 0 |
-| Linear-attention hybrid | qwen-3.8, qwen-dense, qwen-moe | 9 | 4 | 1 | 0 | 8 |
+| Linear-attention hybrid | qwen-3.8, qwen-dense, qwen-moe | 9 | 4 | 4 | 0 | 5 |
 | KDA + MLA | kimi-k3, kimi-linear | 2 | 2 | 1 | 0 | 1 |
 | SSM + attention | falcon-hybrid, granite-hybrid, jamba, nemotron-hybrid | 6 | 4 | 0 | 0 | 6 |
 | SSM + attention + latent MoE + MTP | nemotron-hybrid | 4 | 4 | 0 | 0 | 4 |
 | Conv + attention hybrid | lfm2, lfm2-moe | 4 | 3 | 0 | 0 | 4 |
-
 Read across: the sparse-indexed frontier is **seven for seven AMBER** — every
 DeepSeek V3.2/V4, GLM-5.x and Hy4 row names its indexer and is refused, none
 is approximated — and the three recurrent envelopes (SSM, latent-MoE
@@ -417,18 +449,17 @@ cause. Each is a whole family-generation:
 | 2 | phi-4 | `architecture_family`, `original_max_position_embeddings` — `phi3` is unregistered (fused `qkv_proj` / `gate_up_proj`) — a family entry, not an alias |
 | 3 | GLM-4.5-Air, GLM-4.6 | `architecture_family`, `num_nextn_predict_layers`, `use_qk_norm` |
 | 3 | Phi-3-mini-4k-instruct | `architecture_family`, `original_max_position_embeddings`, `sliding_window` |
-| 3 | Qwen3.5-0.8B, Qwen3.5-27B, Qwen3.5-9B | `mrope_interleaved`, `mrope_section`, `partial_rotary_factor` — the rule already claims `PositionPolicy::MRope`; no built component answers the probe. One lowering, one family-generation |
-| 3 | Qwen3.8-2.4T-A95B | `hidden_act`, `num_experts_per_tok`, `shared_expert_intermediate_size` — the MoE keys the `qwen3_5_moe` parser does not carry; the dense sibling carries them |
+| 3 | Qwen3.5-35B-A3B, 122B-A10B, 397B-A17B, Qwen3.8-2.4T-A95B | `hidden_act`, `num_experts_per_tok`, `shared_expert_intermediate_size` — the MoE keys the `qwen3_5_moe` parser does not carry; the dense sibling carries them. The three Qwen3.5 MoE rows arrived here from six in wave 8 |
 | 3 | bitnet-b1.58-2B-4T-bf16 | `hidden_act`, `linear_class`, `quantization_mode` — BitNet's ternary representation |
 | 3 | gemma-4-E4B-it | `hidden_size_per_layer_input`, `num_kv_shared_layers`, `per_layer_model_projection` — per-layer input embeddings and KV sharing — execution semantics, not spelling |
 | 4 | EXAONE-4.0-1.2B | `architecture_family`, `execution_surface`, `hidden_act`, `rms_norm_eps` — all four follow from the unregistered `exaone4` family |
 | 4 | gemma-3-1b-it | `rope_local_base_freq`, `rope_theta`, `sliding_window_pattern` — `gemma3_text` at the ROOT: `rope_theta` is *mismatched* ("resolution does not honour the declared value") where the same keys under `text_config` lower on the 4B and 27B. A flat-layout parse, and the one mismatch in the frontier |
 
-Five of the twelve entries are the recurring *kinds* the census predicted — two
-vestigial keys, a gated variant of a component that already lowers, a
-lowering the rule already names, and a flat-layout parse of a family that is
-green when nested. Together they clear seven rows across five
-family-generations without a new kernel. `attention_schedule`, at reach 23,
+Four of the eleven entries are the recurring *kinds* the census predicted — two
+vestigial keys, a gated variant of a component that already lowers, and a
+flat-layout parse of a family that is green when nested (wave 8 was the
+fifth, a key read from the wrong spot, and cleared its three). Together they
+clear four more rows across four family-generations without a new kernel. `attention_schedule`, at reach 23,
 clears **none** alone: its `layer_types` blockers are missing mixer vocabulary
 (`conv`, `mamba`, sparse spans) or Step's length rule, and every carrier has
 three to ten other clusters. Reach ranks; the cover predicts.

--- a/docs/arch-conformance/forecasts/wave8-partial-rotary-factor-in-rope-parameters.json
+++ b/docs/arch-conformance/forecasts/wave8-partial-rotary-factor-in-rope-parameters.json
@@ -35,5 +35,39 @@
   "any Qwen3.5 dense row staying red \u2014 would mean the mrope identity does not close on this head geometry",
   "BUG > 0"
  ],
- "engine_note": "Outside VINDEX3 this is a fail-open wrong answer: the engine path would rotate all 256 head dims of a Qwen3.5 layer instead of 64. VINDEX3 refuses; the engine does not. The fix lands in the shared parser so both doors read the reference's spelling."
+ "engine_note": "Outside VINDEX3 this is a fail-open wrong answer: the engine path would rotate all 256 head dims of a Qwen3.5 layer instead of 64. VINDEX3 refuses; the engine does not. The fix lands in the shared parser so both doors read the reference's spelling.",
+ "result": {
+  "scored_on": "2026-09-03",
+  "outcome_semantics_version": 7,
+  "predicted_clears": 3,
+  "actual_clears": 3,
+  "hit": [
+   "Qwen/Qwen3.5-0.8B",
+   "Qwen/Qwen3.5-9B",
+   "Qwen/Qwen3.5-27B"
+  ],
+  "missed": [],
+  "unpredicted": [],
+  "regressions": [],
+  "rows_whose_blocker_count_changed": {
+   "Qwen/Qwen3.5-0.8B": "3 -> 0",
+   "Qwen/Qwen3.5-9B": "3 -> 0",
+   "Qwen/Qwen3.5-27B": "3 -> 0",
+   "Qwen/Qwen3.5-35B-A3B": "6 -> 3",
+   "Qwen/Qwen3.5-122B-A10B": "6 -> 3",
+   "Qwen/Qwen3.5-397B-A17B": "6 -> 3"
+  },
+  "after": {
+   "GREEN": 31,
+   "AMBER": 7,
+   "RED": 71,
+   "BUG": 0,
+   "silent_drops": 0,
+   "text_closure_blockers": 1091
+  },
+  "predicted_after_matched": true,
+  "verdict": "EXACT \u2014 every arm, including the three rows predicted to stay red at exactly 3 and the three declared-but-unmoved rows (Flash-Next, Nemotron, GLM-4.7).",
+  "controls": "Both new tests (larql-models nested-only parse; larql-vindex nested-only lowering) were run BEFORE the parser change and failed with the corpus's own message: `rule claims lowered ... but no built component answered the probe`. After the change both pass. Full sweep re-planned all 117 rows on the semantics-7 binary in 43 s.",
+  "fix_as_landed": "detect/parser.rs: precedence top level -> rope_parameters.full_attention -> rope_parameters, mirroring standardize_rope_params (the reference copies the top-level key INTO the block, overwriting). Pinned by `the_flat_partial_rotary_spelling_overrides_the_nested_one`."
+ }
 }


### PR DESCRIPTION
Wave 8 of the conformance programme — the first fix chosen from the 109-row corpus, and the cheapest kind: a key read from the wrong spot. Semantics version 6 → 7.

| Metric | wave 7 | wave 8 |
|---|---:|---:|
| GREEN | 28 | **31** |
| AMBER | 7 | 7 |
| RED | 74 | **71** |
| **BUG** | **0** | **0** |
| **silent drops** | **0** | **0** |
| text-closure blockers | 1109 | **1091** |
| rows changed | | 6, as forecast |
| K3 clusters | 7 | 7 |

**The fix.** `detect/parser.rs` read `partial_rotary_factor` from the legacy top level and from Gemma 4's per-layer-type block, never from `rope_parameters.partial_rotary_factor` — the transformers-5.x flat form, the spelling the reference reads (`rope_parameters_dict.get("partial_rotary_factor", 1.0)`), and the only one every Qwen3.5 checkpoint uses. Qwen3.8 writes both and was GREEN; Qwen3.5 wrote one, lost its fraction, no layer carried one, and the partial and multi-axis rotary probes answered nothing. Precedence now mirrors `standardize_rope_params`: top level (the reference copies it *into* the block, overwriting), then the per-type block, then the flat block.

**Forecast** (`forecasts/wave8-partial-rotary-factor-in-rope-parameters.json`, frozen before the code): Qwen3.5 0.8B / 9B / 27B green (3 → 0), Qwen3.5 35B-A3B / 122B-A10B / 397B-A17B from 6 blockers to 3, and the three rows that declare the key at the top level (Qwen3.8-Flash-Next, Nemotron 3, GLM-4.7-Flash) unmoved. Every arm held on a full 117-row re-plan.

**Controls.** Both new tests — the nested-only parse in `larql-models` and the nested-only lowering in `larql-vindex` — were run before the parser change and failed with the corpus's own message (`rule claims lowered … but no built component answered the probe`), then passed after it. The earlier test `partial_rotary_factor_is_read_from_the_declared_spot` had passed only because its fixture mirrored Qwen3.8 and declared both spellings; the override order is now pinned too.

Outside VINDEX3 this was a fail-open wrong answer (all 256 head dims rotated where the checkpoint asks for 64); the fix lands in the shared parser so both doors read the reference's spelling.

Gates: `precommit_check.sh larql-models larql-vindex larql-server larql-cli` green; doc links and references pass. Stacked on #403.
