### PR TITLE
ci: never restore compiled workspace artefacts across source revisions

### DIFF
--- a/.github/workflows/bench-regress.yml
+++ b/.github/workflows/bench-regress.yml
@@ -75,10 +75,21 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-bench-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-bench-
+            ${{ runner.os }}-cargo-reg2-bench-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       # Criterion baselines: write-through on main, read-only on PRs.
       # Keyed by the run number so each main push refreshes the cache.

--- a/.github/workflows/larql-boundary.yml
+++ b/.github/workflows/larql-boundary.yml
@@ -53,16 +53,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-boundary-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-boundary-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-boundary-
+            ${{ runner.os }}-cargo-reg2-boundary-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-boundary -- --check

--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -82,16 +82,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-cli-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-cli-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-cli-
+            ${{ runner.os }}-cargo-reg2-cli-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-cli -- --check

--- a/.github/workflows/larql-compute-metal.yml
+++ b/.github/workflows/larql-compute-metal.yml
@@ -53,16 +53,27 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: macOS-cargo-compute-metal-${{ hashFiles('**/Cargo.lock') }}
+          key: macOS-cargo-reg2-compute-metal-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            macOS-cargo-compute-metal-
+            macOS-cargo-reg2-compute-metal-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-compute-metal -- --check

--- a/.github/workflows/larql-compute.yml
+++ b/.github/workflows/larql-compute.yml
@@ -81,16 +81,27 @@ jobs:
           "VCPKG_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "$root\installed\x64-windows\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-compute-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-compute-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-compute-
+            ${{ runner.os }}-cargo-reg2-compute-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-compute -- --check

--- a/.github/workflows/larql-core.yml
+++ b/.github/workflows/larql-core.yml
@@ -53,16 +53,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-core-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-core-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-core-
+            ${{ runner.os }}-cargo-reg2-core-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-core -- --check

--- a/.github/workflows/larql-demos.yml
+++ b/.github/workflows/larql-demos.yml
@@ -54,16 +54,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-demos-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-demos-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-demos-
+            ${{ runner.os }}-cargo-reg2-demos-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-demos -- --check

--- a/.github/workflows/larql-factory.yml
+++ b/.github/workflows/larql-factory.yml
@@ -50,16 +50,27 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-factory-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-factory-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-factory-
+            ${{ runner.os }}-cargo-reg2-factory-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-factory -- --check

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -80,16 +80,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-inference-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-inference-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-inference-
+            ${{ runner.os }}-cargo-reg2-inference-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-inference -- --check

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -93,16 +93,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-kv-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-kv-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-kv-
+            ${{ runner.os }}-cargo-reg2-kv-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-kv -- --check

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -76,16 +76,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-lql-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-lql-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-lql-
+            ${{ runner.os }}-cargo-reg2-lql-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-lql -- --check

--- a/.github/workflows/larql-models.yml
+++ b/.github/workflows/larql-models.yml
@@ -44,16 +44,27 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-models-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-models-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-models-
+            ${{ runner.os }}-cargo-reg2-models-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-models -- --check

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -85,16 +85,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-server-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-server-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-server-
+            ${{ runner.os }}-cargo-reg2-server-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-server -- --check

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -83,16 +83,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-vindex-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-vindex-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-vindex-
+            ${{ runner.os }}-cargo-reg2-vindex-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Format check
         run: cargo fmt -p larql-vindex -- --check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -131,16 +131,27 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libopenblas-dev pkg-config
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-msrv-${{ steps.msrv.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-msrv-${{ steps.msrv.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-msrv-${{ steps.msrv.outputs.version }}-
+            ${{ runner.os }}-cargo-reg2-msrv-${{ steps.msrv.outputs.version }}-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       # This is `cargo check` at the pinned toolchain rather than
       # `cargo msrv verify`. cargo-msrv bisects across many toolchains to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,16 +73,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-release-
+            ${{ runner.os }}-cargo-reg2-release-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Build (release-dist profile)
         run: cargo build --profile release-dist --target ${{ matrix.target }} -p larql-cli -p larql-server ${{ matrix.features }}

--- a/.github/workflows/shannon-verify.yml
+++ b/.github/workflows/shannon-verify.yml
@@ -70,10 +70,21 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-shannon-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-shannon-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-shannon-
+            ${{ runner.os }}-cargo-reg2-shannon-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Cache HF model snapshot
         uses: actions/cache@v6

--- a/.github/workflows/vindex-release.yml
+++ b/.github/workflows/vindex-release.yml
@@ -76,16 +76,27 @@ jobs:
         shell: pwsh
         run: choco install protoc -y --no-progress
 
-      - name: Cache cargo registry + build artefacts
+      - name: Cache cargo registry (downloads only, never target/)
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-vindex-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-reg2-vindex-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-vindex-release-
+            ${{ runner.os }}-cargo-reg2-vindex-release-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
 
       - name: Version from the tag
         id: v


### PR DESCRIPTION
Every workflow cached `target/` under `${{ runner.os }}-cargo-<crate>-${{ hashFiles('**/Cargo.lock') }}` with a bare prefix restore-key. Most changes don't touch `Cargo.lock`, so CI restored a `target/` built from an earlier commit — and cargo's fingerprint is mtime-based, so after a restore the stale artefact can look newer than the source and be reused.

### What it did on #405

Wave 9 added `ffn_shape_from_hf_name`, `ffn_shape_hf_name`, `LLAMA_FAMILY`, `ModelConfig::ffn_shape_name` and `is_llama_config` to **larql-models**, consumed from larql-vindex's `plan/carriage.rs`. On the **same verified merge candidate** (`Merge 5077bf1a into aa19f119`):

| job | crates compiled | result |
| --- | --- | --- |
| ubuntu | larql-core, **larql-models**, larql-vindex | pass |
| windows | **larql-vindex only** | `E0425`/`E0609` symbols "not found" |

Windows linked the new `carriage.rs` against a pre-wave-9 larql-models rlib and reported missing symbols that are present in the tree. `larql-server` and `larql-cli` both failed this way; re-running with a cold cache rebuilt larql-models and both passed with zero failing tests. Intermittent — which is worse than reproducible.

### Why this is worth a correctness-first fix

That was the *lucky* form. Missing symbols are a compile error, so it failed loudly. The dangerous form is a stale rlib that still **compiles**: the tests pass, and the green is evidence about an artefact that is not in the commit. This cache sits underneath every other gate in the repo, so a green matrix could certify code that was never exercised.

### The change

- `target` removed from all 18 cargo cache paths. Downloads (`~/.cargo/registry`, `~/.cargo/git`) are still cached, and for those the `Cargo.lock` key is exactly correct — it is what they depend on.
- Key namespace moved to `cargo-reg2-`. **Load-bearing, not cosmetic:** archives saved under the old keys contain `target/`, and a restore-key prefix match would extract one.
- Each cargo cache step is now followed by a step that **fails the job if `target/` exists after the restore** (`shell: bash`, since the Windows default is pwsh). The invariant is machine-checked rather than asserted: if a key or path regresses, CI says so instead of silently building on another commit's artefacts.

Verified structurally by parsing every workflow rather than grepping: 20 workflows parse, 18 cargo caches, 18 guards immediately following, 0 caching `target`.

### The control (run, then removed)

The control commit has been **removed** — `git log` here is the workflow change alone. It ran as `7cff6a33` against candidate `00429a46`, and this is what it showed.

`larql_models::STALE_CACHE_PROBE` was added without touching `Cargo.toml` or `Cargo.lock`, so the cache key was unchanged and the restore path was exactly the one that broke on #405. larql-vindex and larql-server — the two crates whose Windows jobs failed there — each asserted it from an integration test, so a job linking an older larql-models would fail to **compile**, reproducing the #405 signature deliberately.

Result on the platform that failed:

| | larql-vindex / windows | larql-server / windows |
| --- | --- | --- |
| job conclusion | success | success |
| guard step (no `target/` restored) | success | success |
| candidate checked out | `00429a46` | `00429a46` |
| `Compiling larql-models` | 1 | 1 |
| `larql_models_is_built_from_this_commit` | ok | ok |

Jobs [100653042434](https://github.com/chrishayuk/larql/actions/runs/33756382866) and [100653036272](https://github.com/chrishayuk/larql/actions/runs/33756382736). Full matrix: 62/62 green.

That demonstrates the invariant end to end:

```
source changes, Cargo.lock unchanged
  -> the workspace crate is rebuilt
  -> tests and clippy consume the artefact from THIS commit
```

The guard proves the mechanism and stays. The probe proved the consequence and is gone.

### Trade-off

Build times rise, since nothing compiled is reused. That is the intended cost. If it becomes painful the answer is a source-aware mechanism such as `Swatinem/rust-cache`, not a hand-maintained `Cargo.lock` key over `target/`.
