### PR TITLE
feat(represent): add the LARQL Physical Optimizer substrate

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -72,6 +72,7 @@ pub mod quality;
 pub mod search_evidence;
 pub mod selection;
 pub mod source_bank;
+pub mod state;
 pub mod statistic;
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/larql-vindex/src/format/vindex3/represent/policy.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/policy.rs
@@ -174,9 +174,20 @@ impl Serialize for Role {
 }
 
 impl<'de> Deserialize<'de> for Role {
+    /// Read through `Cow`, not `&str`.
+    ///
+    /// `&str` demands a BORROWED string and so only works for a
+    /// deserializer reading from a buffer it can borrow out of —
+    /// `from_str`, `from_slice`. It fails on every owning one:
+    /// `serde_json::from_value`, `from_reader`, and any binary format.
+    /// A role that could only survive one transport would put an
+    /// arbitrary limit on where a precision map may travel, and the
+    /// symptom is an unhelpful `invalid type: string, expected a
+    /// borrowed string` far from the cause. `Cow` still borrows where
+    /// borrowing is possible.
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let s = <&str as Deserialize>::deserialize(d)?;
-        Role::parse(s).ok_or_else(|| {
+        let s = <std::borrow::Cow<'de, str> as Deserialize>::deserialize(d)?;
+        Role::parse(&s).ok_or_else(|| {
             serde::de::Error::custom(format!(
                 "`{s}` is not a role; a precision map naming it cannot be resolved"
             ))

--- a/crates/larql-vindex/src/format/vindex3/represent/state.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state.rs
@@ -70,6 +70,8 @@
 //! generation (unprotecting is a move, un-refusing is not). Identity
 //! collapses them; explanation does not.
 
+pub mod action_space;
+pub mod candidate;
 pub mod evidence_bank;
 pub mod graph;
 pub mod identity;
@@ -82,6 +84,11 @@ pub mod snapshot;
 pub mod surface;
 pub mod transition;
 
+pub use action_space::{ActionVocabulary, MapEdit};
+pub use candidate::{
+    Candidate, CandidateDisposition, CandidateSet, Census, Footprint, Generator, MeasurementIntent,
+    PreMeasurementPrune,
+};
 pub use evidence_bank::{EvidenceBank, EvidenceBankId, EVIDENCE_BANK_ID_VERSION};
 pub use graph::{RepresentationStateGraph, StateNode, TransitionPolicy};
 pub use identity::{RepresentationState, RepresentationStateId, STATE_ID_VERSION};
@@ -97,6 +104,8 @@ pub use snapshot::{Adjudication, FrontierEntry, Objective, SearchSnapshot, SNAPS
 pub use surface::{SurfaceTensor, TensorSurface};
 pub use transition::{Action, Provenance, Transition};
 
+#[cfg(test)]
+mod candidate_tests;
 #[cfg(test)]
 mod graph_tests;
 #[cfg(test)]

--- a/crates/larql-vindex/src/format/vindex3/represent/state.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state.rs
@@ -107,7 +107,10 @@ pub use resolved::{
 };
 pub use search_policy::{BestFirst, MeasurementOpportunity, Selection};
 pub use semantics::{SearchSemantics, SearchSemanticsId, SEARCH_SEMANTICS_ID_VERSION};
-pub use snapshot::{Adjudication, FrontierEntry, Objective, SearchSnapshot, SNAPSHOT_SCHEMA};
+pub use snapshot::{
+    Adjudication, FrontierEntry, Objective, SearchConfig, SearchFacts, SearchSnapshot, SearchSpace,
+    SNAPSHOT_SCHEMA,
+};
 pub use surface::{SurfaceTensor, TensorSurface};
 pub use transition::{Action, Provenance, Transition};
 
@@ -117,6 +120,8 @@ mod candidate_tests;
 mod graph_tests;
 #[cfg(test)]
 mod key_tests;
+#[cfg(test)]
+mod replay_tests;
 #[cfg(test)]
 mod search_policy_tests;
 #[cfg(test)]

--- a/crates/larql-vindex/src/format/vindex3/represent/state.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state.rs
@@ -70,16 +70,24 @@
 //! generation (unprotecting is a move, un-refusing is not). Identity
 //! collapses them; explanation does not.
 
+pub mod graph;
 pub mod identity;
+pub mod realization;
 pub mod resolved;
 pub mod surface;
+pub mod transition;
 
+pub use graph::{RepresentationStateGraph, StateNode, TransitionPolicy};
 pub use identity::{RepresentationState, RepresentationStateId, STATE_ID_VERSION};
+pub use realization::{LogicalBytes, RealizationId, ResolvedState};
 pub use resolved::{
     resolve, LayoutAdmission, NoLayoutConstraint, PackLayoutAdmission, ResolvedDecision,
     ResolvedDecisionVector, ResolvedEncoding, SOURCE_PRECISION,
 };
 pub use surface::{SurfaceTensor, TensorSurface};
+pub use transition::{Action, Provenance, Transition};
 
+#[cfg(test)]
+mod graph_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/state.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state.rs
@@ -71,6 +71,7 @@
 //! collapses them; explanation does not.
 
 pub mod action_space;
+pub mod assess;
 pub mod candidate;
 pub mod evidence_bank;
 pub mod graph;
@@ -79,12 +80,17 @@ pub mod instrument;
 pub mod key;
 pub mod realization;
 pub mod resolved;
+pub mod search_policy;
 pub mod semantics;
 pub mod snapshot;
 pub mod surface;
 pub mod transition;
 
 pub use action_space::{ActionVocabulary, MapEdit};
+pub use assess::{
+    Assessment, NothingMeasured, ParentStanding, RankingRule, RankingSemantics, RankingSemanticsId,
+    Score, RANKING_SEMANTICS_ID_VERSION,
+};
 pub use candidate::{
     Candidate, CandidateDisposition, CandidateSet, Census, Footprint, Generator, MeasurementIntent,
     PreMeasurementPrune,
@@ -99,6 +105,7 @@ pub use resolved::{
     resolve, LayoutAdmission, NoLayoutConstraint, PackLayoutAdmission, ResolvedDecision,
     ResolvedDecisionVector, ResolvedEncoding, SOURCE_PRECISION,
 };
+pub use search_policy::{BestFirst, MeasurementOpportunity, Selection};
 pub use semantics::{SearchSemantics, SearchSemanticsId, SEARCH_SEMANTICS_ID_VERSION};
 pub use snapshot::{Adjudication, FrontierEntry, Objective, SearchSnapshot, SNAPSHOT_SCHEMA};
 pub use surface::{SurfaceTensor, TensorSurface};
@@ -110,6 +117,8 @@ mod candidate_tests;
 mod graph_tests;
 #[cfg(test)]
 mod key_tests;
+#[cfg(test)]
+mod search_policy_tests;
 #[cfg(test)]
 mod snapshot_tests;
 #[cfg(test)]

--- a/crates/larql-vindex/src/format/vindex3/represent/state.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state.rs
@@ -77,6 +77,8 @@ pub mod instrument;
 pub mod key;
 pub mod realization;
 pub mod resolved;
+pub mod semantics;
+pub mod snapshot;
 pub mod surface;
 pub mod transition;
 
@@ -90,6 +92,8 @@ pub use resolved::{
     resolve, LayoutAdmission, NoLayoutConstraint, PackLayoutAdmission, ResolvedDecision,
     ResolvedDecisionVector, ResolvedEncoding, SOURCE_PRECISION,
 };
+pub use semantics::{SearchSemantics, SearchSemanticsId, SEARCH_SEMANTICS_ID_VERSION};
+pub use snapshot::{Adjudication, FrontierEntry, Objective, SearchSnapshot, SNAPSHOT_SCHEMA};
 pub use surface::{SurfaceTensor, TensorSurface};
 pub use transition::{Action, Provenance, Transition};
 
@@ -97,5 +101,7 @@ pub use transition::{Action, Provenance, Transition};
 mod graph_tests;
 #[cfg(test)]
 mod key_tests;
+#[cfg(test)]
+mod snapshot_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/state.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state.rs
@@ -70,15 +70,21 @@
 //! generation (unprotecting is a move, un-refusing is not). Identity
 //! collapses them; explanation does not.
 
+pub mod evidence_bank;
 pub mod graph;
 pub mod identity;
+pub mod instrument;
+pub mod key;
 pub mod realization;
 pub mod resolved;
 pub mod surface;
 pub mod transition;
 
+pub use evidence_bank::{EvidenceBank, EvidenceBankId, EVIDENCE_BANK_ID_VERSION};
 pub use graph::{RepresentationStateGraph, StateNode, TransitionPolicy};
 pub use identity::{RepresentationState, RepresentationStateId, STATE_ID_VERSION};
+pub use instrument::{InstrumentSemantics, InstrumentSemanticsId, INSTRUMENT_SEMANTICS_ID_VERSION};
+pub use key::{MeasurementKey, MeasurementRegistry, MEASUREMENT_KEY_VERSION};
 pub use realization::{LogicalBytes, RealizationId, ResolvedState};
 pub use resolved::{
     resolve, LayoutAdmission, NoLayoutConstraint, PackLayoutAdmission, ResolvedDecision,
@@ -89,5 +95,7 @@ pub use transition::{Action, Provenance, Transition};
 
 #[cfg(test)]
 mod graph_tests;
+#[cfg(test)]
+mod key_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/state.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state.rs
@@ -1,0 +1,85 @@
+//! **The search state: what a representation IS, independent of how it
+//! was reached.**
+//!
+//! [`super::map::PrecisionMap`] is a *policy* — a default encoding, the
+//! roles it applies to, and ordered exceptions. That is the right shape
+//! for a program someone writes and a container carries, and it is the
+//! wrong shape for a search graph's identity, in both directions:
+//!
+//! ```text
+//! two different rule sets, identical resolved decisions   SAME state
+//! one rule set, two models                                DIFFERENT states
+//! ```
+//!
+//! A digest over the rule text gets both wrong. It splits a state that a
+//! redundant or shadowed exception wrote differently, and it merges two
+//! models that happen to share a policy. Splitting is the expensive
+//! failure: the search re-measures a state it has already refused, and
+//! every path that reaches a map by a different route looks novel. The
+//! exchange search already reached the same final map by different
+//! histories, which is what makes this the first thing to settle.
+//!
+//! # The invariant
+//!
+//! > **If two maps cause VINDEX3 to present exactly the same
+//! > representation decision for every tensor of the same model surface,
+//! > they are the same search state.**
+//!
+//! Everything in this module is in service of that sentence, and the
+//! boundaries follow from it:
+//!
+//! ```text
+//! IN   model identity          the same map on two models is two states
+//! IN   tensor surface          adding, removing or reshaping a tensor
+//!                              is a different model surface even when
+//!                              every surviving decision is unchanged
+//! IN   effective decisions     what the container will actually present
+//!
+//! OUT  rule syntax             ordering that changes no decision,
+//!                              shadowed exceptions, redundant defaults,
+//!                              the map's `name`, the recipe that built it
+//! OUT  evidence                a measurement DESCRIBES a state; it is
+//!                              not part of one
+//! OUT  search history          different paths to the same decisions
+//!                              converge to one node — that is the point
+//! OUT  the behavioural contract  a representation is the same
+//!                              representation when evaluated under
+//!                              another contract. Contract, bank and
+//!                              execution belong to the MEASUREMENT key,
+//!                              not to the state.
+//! ```
+//!
+//! That last exclusion is the one worth defending. Folding
+//! `balanced-v1` into the digest would identify an *experimental
+//! context* rather than a representation, and the same physical bytes
+//! measured under a second contract would arrive as an unrelated state
+//! with no shared physical accounting.
+//!
+//! # Effective, not declared
+//!
+//! A map may say "compile this" and the storage layout refuse it:
+//! NVFP4 stores 2-D matrices whose `k` is a multiple of 16, and
+//! `represent`'s compiler carries anything else verbatim whatever the
+//! policy said. So the resolved decision is what the layout will
+//! actually admit, not what the rules assert — see
+//! [`resolved::ResolvedEncoding`].
+//!
+//! A layout-refused tensor and a protected tensor present the same
+//! bytes, so they are the same *state*; they are different *facts*, and
+//! the decision vector keeps them apart for reports and for action
+//! generation (unprotecting is a move, un-refusing is not). Identity
+//! collapses them; explanation does not.
+
+pub mod identity;
+pub mod resolved;
+pub mod surface;
+
+pub use identity::{RepresentationState, RepresentationStateId, STATE_ID_VERSION};
+pub use resolved::{
+    resolve, LayoutAdmission, NoLayoutConstraint, PackLayoutAdmission, ResolvedDecision,
+    ResolvedDecisionVector, ResolvedEncoding, SOURCE_PRECISION,
+};
+pub use surface::{SurfaceTensor, TensorSurface};
+
+#[cfg(test)]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/state/action_space.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/action_space.rs
@@ -1,0 +1,132 @@
+//! **The vocabulary of moves, declared rather than inferred.**
+//!
+//! A search over precision maps needs a set of named, reusable edits —
+//! `E24`, `K25`, `M26` — and the question of *which* edits exist is not
+//! one this module may answer by guessing. R5-F6 is why: neighbourhood 1
+//! drew its in-moves from `{H, M23, K24}`, the candidates left
+//! unpromoted at iteration 4, and missed `{E20,E22,E23,E24,E25}`
+//! entirely. **In an exchange frame every never-admitted action is an
+//! in-move, whenever it was last considered.** Two moves worth ~430 MB
+//! each were invisible because the vocabulary had been mistaken for the
+//! last round's leftovers.
+//!
+//! So the vocabulary is an input. This module holds it, fixes its order,
+//! and turns an applied SET of edits into a map — nothing more.
+//!
+//! # Why a set, and how it becomes an ordered map
+//!
+//! [`super::super::map::PrecisionMap`] resolves exceptions in
+//! declaration order, first match deciding, so a map is not a set. But a
+//! *search state* is: `{E26, M26, K25}` names one map however the round
+//! that built it happened to order its edits. The vocabulary's own
+//! declaration order supplies the map order, so an applied set has
+//! exactly one map and two rounds that reach the same set reach the same
+//! bytes — which is what makes 1a's identity contract meaningful over
+//! search states rather than only over hand-written maps.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use super::super::map::{Exception, PrecisionMap};
+use crate::error::VindexError;
+
+/// One named, reusable change to a precision map.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MapEdit {
+    /// The programme's own name for it — `"E24"`, `"K25"`.
+    pub name: String,
+    /// What it puts into the map.
+    pub exception: Exception,
+}
+
+impl MapEdit {
+    pub fn new(name: impl Into<String>, exception: Exception) -> Self {
+        Self {
+            name: name.into(),
+            exception,
+        }
+    }
+}
+
+/// **Every move the search may make**, in the order that fixes map
+/// order.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ActionVocabulary {
+    edits: Vec<MapEdit>,
+}
+
+impl ActionVocabulary {
+    /// Build a vocabulary, refusing a repeated name.
+    ///
+    /// Two edits under one name would make an applied set ambiguous and
+    /// the map it produces dependent on which was found first.
+    pub fn new(edits: impl IntoIterator<Item = MapEdit>) -> Result<Self, VindexError> {
+        let edits: Vec<MapEdit> = edits.into_iter().collect();
+        let mut seen = BTreeSet::new();
+        for edit in &edits {
+            if !seen.insert(edit.name.as_str()) {
+                return Err(VindexError::Parse(format!(
+                    "action `{}` is declared twice — an applied set naming it would resolve to \
+                     whichever declaration was found first",
+                    edit.name
+                )));
+            }
+        }
+        Ok(Self { edits })
+    }
+
+    pub fn edits(&self) -> &[MapEdit] {
+        &self.edits
+    }
+
+    pub fn len(&self) -> usize {
+        self.edits.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.edits.is_empty()
+    }
+
+    pub fn contains(&self, name: &str) -> bool {
+        self.edits.iter().any(|e| e.name == name)
+    }
+
+    /// Every name, in declaration order.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.edits.iter().map(|e| e.name.as_str())
+    }
+
+    /// **The map an applied set produces.**
+    ///
+    /// Exceptions are emitted in vocabulary order and prepended to the
+    /// base map's own, so an applied edit always outranks a default the
+    /// base map declared. Unknown names are refused rather than skipped:
+    /// silently dropping one would hand back a map for a state that does
+    /// not exist.
+    pub fn map_for(
+        &self,
+        base: &PrecisionMap,
+        applied: &BTreeSet<String>,
+    ) -> Result<PrecisionMap, VindexError> {
+        if let Some(unknown) = applied.iter().find(|n| !self.contains(n)) {
+            return Err(VindexError::Parse(format!(
+                "action `{unknown}` is not in this vocabulary — a state cannot apply a move the \
+                 search does not have"
+            )));
+        }
+        let mut exceptions: Vec<Exception> = self
+            .edits
+            .iter()
+            .filter(|e| applied.contains(&e.name))
+            .map(|e| e.exception.clone())
+            .collect();
+        exceptions.extend(base.exceptions.iter().cloned());
+        Ok(PrecisionMap {
+            name: base.name.clone(),
+            encoding: base.encoding.clone(),
+            roles: base.roles.clone(),
+            exceptions,
+        })
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/assess.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/assess.rs
@@ -1,0 +1,243 @@
+//! **What can be derived about an eligible candidate from facts already
+//! held.**
+//!
+//! ```text
+//! EligibleCandidate → assess() → Assessment → SearchPolicy → ordered frontier
+//! ```
+//!
+//! [`Assessment`] carries ingredients and no scalar of record. That is
+//! deliberate and it is the lesson of 1d: `CandidateAssessment` holds a
+//! `ranking_score`, and a score is a CONCLUSION — persisting one is
+//! exactly why promotion could not be replayed from stored facts. A
+//! score here is computed on demand under a named rule
+//! ([`Assessment::score`]) and never stored.
+//!
+//! # Sign convention
+//!
+//! `physical_delta` keeps the sign it has everywhere else in this
+//! module: **negative removes bytes**. Ordering therefore prefers the
+//! most negative value, and no layer flips the sign on the way past —
+//! a sign flip between the accounting and the comparator is the shape
+//! of R4-F7's mistake at a different altitude.
+//!
+//! # What is deliberately not here
+//!
+//! No information-gain model. A 40 MB experiment that would resolve
+//! whether a whole family of moves is state-dependent may well deserve
+//! to run before a 600 MB candidate, and *experimental value* is a real
+//! quantity distinct from *physical value* — but nothing in this
+//! programme has measured it, and inventing it here would put a
+//! heuristic where the registered semantics belong. The types leave room
+//! for a second rule; they do not guess at one.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::compile::hash_bytes;
+use super::super::constraint::ConstraintVector;
+use super::candidate::Candidate;
+use super::identity::RepresentationStateId;
+use super::key::MeasurementKey;
+use super::realization::{LogicalBytes, RealizationId};
+use super::surface::{FIELD, SECTION};
+use super::transition::Action;
+
+/// The canonical-form version every ranking id is computed under.
+pub const RANKING_SEMANTICS_ID_VERSION: &str = "ranking-semantics-id/v1";
+
+/// **Which registered rule orders candidates.**
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct RankingSemanticsId(String);
+
+impl RankingSemanticsId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn short(&self) -> &str {
+        &self.0[..self.0.len().min(12)]
+    }
+}
+
+impl std::fmt::Display for RankingSemanticsId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The rules this programme has actually registered.
+///
+/// One variant, because one rule has actually been used. Rung 5 chose
+/// what to build and measure by physical prize — its neighbourhoods rank
+/// `−M26 +E24` at −431,777,920 B against `−M26 +K24` at −2,091,136 B and
+/// spend the run on the prize — and no other pre-measurement ordering
+/// has been registered. A second variant is a decision someone makes on
+/// purpose, not a gap to fill speculatively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RankingRule {
+    /// Order by the exact physical prize, most bytes removed first.
+    ///
+    /// The only quantity available before an experiment has been run
+    /// that is *exact*. Diagnostic evidence cannot order a candidate
+    /// that has not been measured, and R5-F4/R5-F9 forbid reading a
+    /// parent's diagnostic across to a child's authority.
+    PhysicalPrizeFirst,
+}
+
+impl RankingRule {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::PhysicalPrizeFirst => "physical-prize-first",
+        }
+    }
+}
+
+/// The ordering rule in force, and why.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RankingSemantics {
+    pub rule: RankingRule,
+    /// Where the rule comes from. Provenance — **excluded from the id**,
+    /// for the reason [`super::instrument`] states: a reworded
+    /// justification must not split a scientific record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<String>,
+}
+
+impl RankingSemantics {
+    pub fn new(rule: RankingRule) -> Self {
+        Self {
+            rule,
+            provenance: None,
+        }
+    }
+
+    pub fn because(mut self, provenance: impl Into<String>) -> Self {
+        self.provenance = Some(provenance.into());
+        self
+    }
+
+    /// **The complete order, stated once.**
+    ///
+    /// Every element after the first exists so that no answer can depend
+    /// on insertion order, map iteration order, thread completion order
+    /// or an accident of vocabulary traversal. Replay needs one answer,
+    /// not a usually-stable one.
+    pub fn tie_break_chain(&self) -> &'static [&'static str] {
+        &[
+            "registered rule",
+            "greater physical improvement",
+            "canonical child state id",
+            "canonical child realization id",
+            "canonical action identity",
+        ]
+    }
+
+    pub fn id(&self) -> RankingSemanticsId {
+        let input = format!(
+            "{RANKING_SEMANTICS_ID_VERSION}{SECTION}rule={}{FIELD}tie_breaks={}",
+            self.rule.name(),
+            self.tie_break_chain().join(",")
+        );
+        RankingSemanticsId(hash_bytes(input.as_bytes()))
+    }
+}
+
+/// A score, derived on demand and never stored.
+///
+/// Ordered so that **less is better**, matching `physical_delta`'s sign:
+/// the best candidate removes the most bytes and therefore has the most
+/// negative delta.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Score(i64);
+
+impl Score {
+    pub fn get(self) -> i64 {
+        self.0
+    }
+}
+
+/// What a state's standing against the contract is, where an
+/// observation of it exists.
+///
+/// A trait because deriving it needs the gate, which belongs to the
+/// snapshot rather than to a candidate — and because a policy that
+/// reached for a gate itself would be a second place the contract is
+/// applied.
+pub trait ParentStanding {
+    /// `None` where the state carries no reading. Absence is a fact.
+    fn of(&self, state: &RepresentationStateId) -> Option<ConstraintVector>;
+}
+
+/// Nothing has been measured. For a first round, and for tests about
+/// ordering rather than about evidence.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NothingMeasured;
+
+impl ParentStanding for NothingMeasured {
+    fn of(&self, _state: &RepresentationStateId) -> Option<ConstraintVector> {
+        None
+    }
+}
+
+/// **What is derivable about one eligible candidate.**
+///
+/// Ingredients only. Everything here is either an exact computation over
+/// stored facts or a `None` saying the fact is absent — there is no
+/// estimate, no prior and no judgement.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Assessment {
+    pub action: Action,
+    pub parent_state: RepresentationStateId,
+    pub child_state: RepresentationStateId,
+    pub child_realization: RealizationId,
+    /// Negative removes bytes. Computed by the generator from two
+    /// footprints; never asserted by an action.
+    pub physical_delta: i64,
+    pub child_bytes: LogicalBytes,
+    /// The experiment this candidate would run.
+    pub intended_key: MeasurementKey,
+    /// Readings already held of the child's PHYSICAL state, under other
+    /// banks, scales or instruments. An escalation is visible here.
+    pub prior_observations: Vec<MeasurementKey>,
+    /// The PARENT's standing against the contract, where an observation
+    /// of it exists. `None` means the parent is unmeasured — a fact, not
+    /// a zero.
+    ///
+    /// Kept whole rather than reduced to a number: the binding margin,
+    /// the headroom and which criterion is scarce are all questions a
+    /// reader may want, and a scalar would answer none of them.
+    pub parent_standing: Option<ConstraintVector>,
+}
+
+impl Assessment {
+    /// Assess a candidate against facts already held.
+    ///
+    /// `parent_standing` is supplied by the caller because deriving it
+    /// needs the gate, and the gate belongs to the snapshot rather than
+    /// to the candidate.
+    pub fn of(candidate: &Candidate, parent_standing: Option<ConstraintVector>) -> Self {
+        Self {
+            action: candidate.action.clone(),
+            parent_state: candidate.parent_state.clone(),
+            child_state: candidate.child.physical_id().clone(),
+            child_realization: candidate.child.realization_id().clone(),
+            physical_delta: candidate.physical_delta,
+            child_bytes: candidate.child.logical_bytes(),
+            intended_key: candidate.intended_key.clone(),
+            prior_observations: candidate.prior_observations.clone(),
+            parent_standing,
+        }
+    }
+
+    /// The score under a named rule. Computed here, stored nowhere.
+    pub fn score(&self, semantics: &RankingSemantics) -> Score {
+        match semantics.rule {
+            RankingRule::PhysicalPrizeFirst => Score(self.physical_delta),
+        }
+    }
+
+    /// Whether this candidate would escalate a state already observed
+    /// under some other experimental context.
+    pub fn is_escalation(&self) -> bool {
+        !self.prior_observations.is_empty()
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/candidate.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/candidate.rs
@@ -1,0 +1,433 @@
+//! **What experiments are legitimately available from this state?**
+//!
+//! That is the whole question. Not *which is promising*, not *which
+//! looks sensitive*, not *which the last round liked*. The generator
+//! enumerates, resolves, prices, and partitions — and every candidate
+//! that disappears carries one sanctioned mechanical reason for having
+//! disappeared.
+//!
+//! ```text
+//! realization
+//!     ↓ enumerate legal transformations
+//!     ↓ resolve the child realization
+//!     ↓ derive the physical state
+//!     ↓ price it, from the footprint oracle
+//!     ↓ apply ONLY registered pre-measurement pruning
+//! CandidateSet
+//! ```
+//!
+//! # The three prunes, and the fourth that is not held
+//!
+//! Ruling 1 states the complete list, and it is deliberately short:
+//!
+//! ```text
+//! 1  identical MeasurementKey observed            dedup
+//! 2  not physically better than an available map  physical dominance
+//! 3  structurally impossible map                  structural
+//! 4  a PROVED monotonicity theorem                NOT CURRENTLY HELD
+//! ```
+//!
+//! [`PreMeasurementPrune`] therefore has **three** variants. The fourth
+//! is absent by construction rather than present-and-unused, so adding
+//! it later is a visible schema change and not a quiet flag flip.
+//!
+//! **Behavioural-superset pruning is not on the list and must not slip
+//! onto it.** Ruling 1 is explicit: authority refusal attaches to the
+//! MEASURED MAP, is not upward-closed under action-set inclusion, and
+//! "more low precision" is not a behavioural partial order. The
+//! programme holds evidence against it at every level — R4-F7 on sign,
+//! R4-F2 on magnitude, R5-F4 on scale (N=3, both directions), R5-F9 on
+//! ordering, R5-F7's 2.47× between two states. The line to hold:
+//!
+//! ```text
+//! "this cannot produce a valid physical experiment"   → prune
+//! "this probably will not teach us anything"          → NOT a prune
+//! ```
+//!
+//! The second belongs to assessment and ranking, downstream, where it
+//! can be argued with. Here it would be indistinguishable from the
+//! first.
+//!
+//! # Nothing disappears silently
+//!
+//! [`CandidateSet::census`] counts every disposition and
+//! [`Census::conserves`] asserts the conservation law:
+//!
+//! ```text
+//! enumerated = eligible + already observed + dominated + structural
+//! ```
+//!
+//! That is what turns "no fifth prune" from a promise into something a
+//! test can check — and later, when an agent asks *why aren't we
+//! exploring E24*, the answer comes from this partition rather than from
+//! a language model reconstructing a rationale.
+//!
+//! # An action never asserts its own saving
+//!
+//! R5-F5 read a footprint column as a saving and overstated an expert
+//! revert by 3.39×. So no [`MapEdit`] carries a byte figure. The
+//! generator applies the edit, resolves the result, asks the
+//! [`Footprint`] oracle what the child costs, and computes the delta
+//! from two footprints it holds. Dominance then operates on that.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use super::super::compiler::SourceIdentity;
+use super::super::map::PrecisionMap;
+use super::super::measurement::EvidenceScale;
+use super::action_space::ActionVocabulary;
+use super::evidence_bank::EvidenceBankId;
+use super::graph::TransitionPolicy;
+use super::identity::{RepresentationState, RepresentationStateId};
+use super::instrument::InstrumentSemanticsId;
+use super::key::{MeasurementKey, MeasurementRegistry};
+use super::realization::{LogicalBytes, RealizationId, ResolvedState};
+use super::resolved::LayoutAdmission;
+use super::surface::TensorSurface;
+use super::transition::Action;
+use crate::error::VindexError;
+
+/// What a state's logical footprint is.
+///
+/// Supplied, never derived here. [`super::super::byte_ledger`] states
+/// why scopes are supplied rather than inferred from geometry, and
+/// inferring a footprint inside a candidate generator would be the same
+/// mistake with more leverage.
+pub trait Footprint {
+    fn logical_bytes(&self, state: &RepresentationState) -> LogicalBytes;
+}
+
+/// **The experiment a candidate would run.**
+///
+/// A state is not measured or unmeasured; it is measured *under a bank,
+/// at a scale, by an instrument*. 1c proved the distinction is load
+/// bearing — `diagnostic(child)` and `authority(child)` are two
+/// experiments on one physical state — so the generator asks about an
+/// intent and never about a state alone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MeasurementIntent {
+    pub bank: EvidenceBankId,
+    pub scale: EvidenceScale,
+    pub instrument: InstrumentSemanticsId,
+}
+
+impl MeasurementIntent {
+    pub fn new(
+        bank: EvidenceBankId,
+        scale: EvidenceScale,
+        instrument: InstrumentSemanticsId,
+    ) -> Self {
+        Self {
+            bank,
+            scale,
+            instrument,
+        }
+    }
+
+    pub fn key_for(&self, state: &RepresentationStateId) -> MeasurementKey {
+        MeasurementKey::new(state, &self.bank, self.scale, &self.instrument)
+    }
+}
+
+/// A move that may legitimately be measured.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Candidate {
+    /// The realization it departs from — not merely the physical state,
+    /// because the action space is a property of the decisions.
+    pub parent_realization: RealizationId,
+    pub parent_state: RepresentationStateId,
+    /// The applied-edit set this candidate would hold.
+    pub applied: BTreeSet<String>,
+    pub action: Action,
+    pub child: ResolvedState,
+    /// Computed from two footprints. Negative means bytes were removed.
+    pub physical_delta: i64,
+    /// The experiment this candidate would run.
+    pub intended_key: MeasurementKey,
+    /// Readings already held of this PHYSICAL state under other
+    /// contexts. Not a duplicate — an escalation, and the reason the
+    /// generator reports it rather than pruning on it.
+    pub prior_observations: Vec<MeasurementKey>,
+}
+
+/// The only reasons a candidate may vanish before it is measured.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PreMeasurementPrune {
+    /// Ruling 1 §1 — this exact experiment is already on the record.
+    AlreadyObserved { key: MeasurementKey },
+    /// Ruling 1 §2 — the transition policy refuses it on bytes.
+    PhysicallyDominated {
+        parent_bytes: LogicalBytes,
+        child_bytes: LogicalBytes,
+    },
+    /// Ruling 1 §3 — the move produces no distinct physical experiment,
+    /// or no map at all.
+    StructurallyInvalid { why: String },
+}
+
+impl PreMeasurementPrune {
+    /// The registered category, for the census and for reports.
+    pub fn category(&self) -> &'static str {
+        match self {
+            Self::AlreadyObserved { .. } => "already-observed",
+            Self::PhysicallyDominated { .. } => "physically-dominated",
+            Self::StructurallyInvalid { .. } => "structurally-invalid",
+        }
+    }
+}
+
+/// What became of one enumerated move.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CandidateDisposition {
+    Eligible(Box<Candidate>),
+    Pruned {
+        action: Action,
+        /// Absent when the move produced no map to identify.
+        child_state: Option<RepresentationStateId>,
+        reason: PreMeasurementPrune,
+    },
+}
+
+impl CandidateDisposition {
+    pub fn action(&self) -> &Action {
+        match self {
+            Self::Eligible(c) => &c.action,
+            Self::Pruned { action, .. } => action,
+        }
+    }
+}
+
+/// Counts, and the conservation law over them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Census {
+    pub enumerated: usize,
+    pub eligible: usize,
+    pub already_observed: usize,
+    pub physically_dominated: usize,
+    pub structurally_invalid: usize,
+}
+
+impl Census {
+    /// **Nothing disappears silently.**
+    pub fn conserves(&self) -> bool {
+        self.enumerated
+            == self.eligible
+                + self.already_observed
+                + self.physically_dominated
+                + self.structurally_invalid
+    }
+}
+
+impl std::fmt::Display for Census {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "generated {:>6}\nstructural invalid {:>6}\nphysical dominance {:>6}\n\
+             already measured {:>6}\neligible {:>6}",
+            self.enumerated,
+            self.structurally_invalid,
+            self.physically_dominated,
+            self.already_observed,
+            self.eligible
+        )
+    }
+}
+
+/// Every move available from one state, and what became of each.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct CandidateSet {
+    dispositions: Vec<CandidateDisposition>,
+}
+
+impl CandidateSet {
+    pub fn dispositions(&self) -> &[CandidateDisposition] {
+        &self.dispositions
+    }
+
+    pub fn eligible(&self) -> impl Iterator<Item = &Candidate> {
+        self.dispositions.iter().filter_map(|d| match d {
+            CandidateDisposition::Eligible(c) => Some(c.as_ref()),
+            CandidateDisposition::Pruned { .. } => None,
+        })
+    }
+
+    pub fn pruned(&self) -> impl Iterator<Item = (&Action, &PreMeasurementPrune)> {
+        self.dispositions.iter().filter_map(|d| match d {
+            CandidateDisposition::Pruned { action, reason, .. } => Some((action, reason)),
+            CandidateDisposition::Eligible(_) => None,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.dispositions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.dispositions.is_empty()
+    }
+
+    pub fn census(&self) -> Census {
+        let mut census = Census {
+            enumerated: self.dispositions.len(),
+            ..Census::default()
+        };
+        for disposition in &self.dispositions {
+            match disposition {
+                CandidateDisposition::Eligible(_) => census.eligible += 1,
+                CandidateDisposition::Pruned { reason, .. } => match reason {
+                    PreMeasurementPrune::AlreadyObserved { .. } => census.already_observed += 1,
+                    PreMeasurementPrune::PhysicallyDominated { .. } => {
+                        census.physically_dominated += 1
+                    }
+                    PreMeasurementPrune::StructurallyInvalid { .. } => {
+                        census.structurally_invalid += 1
+                    }
+                },
+            }
+        }
+        census
+    }
+}
+
+/// **The deterministic candidate generator.**
+///
+/// Holds only what enumeration and lawful pruning need. It has no
+/// ranking input on purpose: there is nothing here for a preference to
+/// attach to.
+pub struct Generator<'a> {
+    pub model: &'a SourceIdentity,
+    pub surface: &'a TensorSurface,
+    /// The map every applied set is layered onto.
+    pub base_map: &'a PrecisionMap,
+    pub vocabulary: &'a ActionVocabulary,
+    pub layout: &'a dyn LayoutAdmission,
+    pub footprint: &'a dyn Footprint,
+    pub policy: TransitionPolicy,
+    pub measurements: &'a MeasurementRegistry,
+}
+
+impl Generator<'_> {
+    /// Resolve one applied set into a priced realization.
+    pub fn realize(&self, applied: &BTreeSet<String>) -> Result<ResolvedState, VindexError> {
+        let map = self.vocabulary.map_for(self.base_map, applied)?;
+        let state = RepresentationState::resolve(self.model, self.surface, &map, self.layout);
+        let bytes = self.footprint.logical_bytes(&state);
+        Ok(ResolvedState::new(state, bytes))
+    }
+
+    /// **Every move available from `applied`, partitioned.**
+    ///
+    /// The universe is rung 5's frame: every unapplied edit as an
+    /// addition, and every (applied, unapplied) pair as a 1-out/1-in
+    /// exchange. Enumeration is over the whole vocabulary and never over
+    /// the last round's leftovers — R5-F6.
+    pub fn candidates(
+        &self,
+        applied: &BTreeSet<String>,
+        intent: &MeasurementIntent,
+    ) -> Result<CandidateSet, VindexError> {
+        let parent = self.realize(applied)?;
+        let unapplied: Vec<&str> = self
+            .vocabulary
+            .names()
+            .filter(|n| !applied.contains(*n))
+            .collect();
+
+        let mut moves: Vec<(Action, BTreeSet<String>)> = Vec::new();
+        for add in &unapplied {
+            let mut next = applied.clone();
+            next.insert((*add).to_string());
+            moves.push((Action::new(format!("+{add}")).adding([*add]), next));
+        }
+        for remove in applied {
+            for add in &unapplied {
+                let mut next = applied.clone();
+                next.remove(remove);
+                next.insert((*add).to_string());
+                moves.push((
+                    Action::new(format!("−{remove} +{add}"))
+                        .removing([remove.as_str()])
+                        .adding([*add]),
+                    next,
+                ));
+            }
+        }
+
+        let mut dispositions = Vec::with_capacity(moves.len());
+        for (action, next) in moves {
+            dispositions.push(self.dispose(&parent, action, next, intent)?);
+        }
+        Ok(CandidateSet { dispositions })
+    }
+
+    /// Resolve one move and decide its disposition.
+    fn dispose(
+        &self,
+        parent: &ResolvedState,
+        action: Action,
+        applied: BTreeSet<String>,
+        intent: &MeasurementIntent,
+    ) -> Result<CandidateDisposition, VindexError> {
+        let child = self.realize(&applied)?;
+        let child_state = child.physical_id().clone();
+
+        // §3 structural. A move that changes no decision at all produces
+        // no distinct experiment — there is nothing for an instrument to
+        // observe that the parent has not already shown.
+        if child.realization_id() == parent.realization_id() {
+            return Ok(CandidateDisposition::Pruned {
+                action,
+                child_state: Some(child_state),
+                reason: PreMeasurementPrune::StructurallyInvalid {
+                    why: "the move changes no resolved decision".into(),
+                },
+            });
+        }
+
+        // §2 physical dominance, delegated to the transition policy so
+        // the generator and the graph cannot disagree about what an
+        // admissible edge is.
+        let physical_delta = child.logical_bytes().delta_from(parent.logical_bytes());
+        if !self.policy.admits(physical_delta) {
+            return Ok(CandidateDisposition::Pruned {
+                action,
+                child_state: Some(child_state),
+                reason: PreMeasurementPrune::PhysicallyDominated {
+                    parent_bytes: parent.logical_bytes(),
+                    child_bytes: child.logical_bytes(),
+                },
+            });
+        }
+
+        // §1 dedup, on the INTENDED experiment and never on the state
+        // alone: escalating a measured state from diagnostic to
+        // authority is the ladder, not a repeat.
+        let intended_key = intent.key_for(&child_state);
+        if self.measurements.contains(&intended_key) {
+            return Ok(CandidateDisposition::Pruned {
+                action,
+                child_state: Some(child_state),
+                reason: PreMeasurementPrune::AlreadyObserved { key: intended_key },
+            });
+        }
+
+        let prior_observations: Vec<MeasurementKey> = self
+            .measurements
+            .of_state(&child_state)
+            .map(|(k, _)| k.clone())
+            .collect();
+
+        Ok(CandidateDisposition::Eligible(Box::new(Candidate {
+            parent_realization: parent.realization_id().clone(),
+            parent_state: parent.physical_id().clone(),
+            applied,
+            action,
+            child,
+            physical_delta,
+            intended_key,
+            prior_observations,
+        })))
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/candidate_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/candidate_tests.rs
@@ -1,0 +1,570 @@
+//! **2: what may legitimately be tried, and why everything else may
+//! not.**
+//!
+//! The property that matters is not "the expected candidate survived".
+//! It is:
+//!
+//! > Every enumerated move either survives or carries exactly one
+//! > sanctioned mechanical reason for not surviving.
+//!
+//! so that when an agent later asks *why aren't we exploring E24*, the
+//! answer comes from a deterministic partition and not from a language
+//! model reconstructing a rationale.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::super::compiler::SourceIdentity;
+use super::super::map::{Exception, PrecisionMap};
+use super::super::measurement::EvidenceScale;
+use super::super::nvfp4_pack::{PackLayout, DTYPE_NVFP4};
+use super::super::policy::Role;
+use super::super::quality::{Distribution, LogitEvidence, QualityBank, RoutingEvidence};
+use super::*;
+
+// ---------------------------------------------------------------- fixtures
+
+fn model() -> SourceIdentity {
+    SourceIdentity {
+        manifest_hash: "kimi-linear-48b".into(),
+        graph_hash: "aligned-vindex3".into(),
+        segments: BTreeMap::from([("target.decoder_stack".to_string(), "seg-dddd".to_string())]),
+    }
+}
+
+/// Four projections at one depth. `no_proj` is 1-D, so no layout can
+/// hold it — the structural case is a real property of the surface and
+/// not a flag.
+fn surface() -> TensorSurface {
+    let mut entries: Vec<SurfaceTensor> = ["e_proj", "k_proj", "m_proj"]
+        .into_iter()
+        .map(|p| {
+            SurfaceTensor::new(
+                "target.decoder_stack",
+                format!("0.self_attn.{p}.weight"),
+                Role::DecoderLinear,
+                vec![64, 64],
+            )
+        })
+        .collect();
+    entries.push(SurfaceTensor::new(
+        "target.decoder_stack",
+        "0.self_attn.no_proj.weight",
+        Role::DecoderLinear,
+        vec![64],
+    ));
+    TensorSurface::new(entries).expect("distinct tensors")
+}
+
+/// Compiles nothing by default; every edit is an explicit compile.
+fn base_map() -> PrecisionMap {
+    PrecisionMap {
+        name: "base".into(),
+        encoding: DTYPE_NVFP4.into(),
+        roles: vec!["decoder-linear".into()],
+        exceptions: vec![Exception {
+            projection: None,
+            layers: None,
+            encoding: None,
+        }],
+    }
+}
+
+fn compile(projection: &str) -> Exception {
+    Exception {
+        projection: Some(projection.into()),
+        layers: None,
+        encoding: Some(DTYPE_NVFP4.into()),
+    }
+}
+
+/// `E24`, `K25` and `M26` each compile one projection. `NO` compiles a
+/// tensor the NVFP4 layout refuses, so it changes a decision and saves
+/// nothing.
+fn vocabulary() -> ActionVocabulary {
+    ActionVocabulary::new([
+        MapEdit::new("E24", compile("e_proj")),
+        MapEdit::new("K25", compile("k_proj")),
+        MapEdit::new("M26", compile("m_proj")),
+        MapEdit::new("NO", compile("no_proj")),
+    ])
+    .expect("distinct names")
+}
+
+/// Prices a state from its resolved decisions and the surface's shapes:
+/// a compiled matrix costs what the NVFP4 pack stores, and anything at
+/// source precision costs BF16.
+struct ShapeFootprint {
+    surface: TensorSurface,
+}
+
+impl Footprint for ShapeFootprint {
+    fn logical_bytes(&self, state: &RepresentationState) -> LogicalBytes {
+        let total: u64 = state
+            .decisions()
+            .decisions()
+            .iter()
+            .map(|d| {
+                let tensor = self
+                    .surface
+                    .get(&d.object, &d.tensor)
+                    .expect("the state resolved against this surface");
+                let elements: usize = tensor.shape.iter().product();
+                match d.encoding.is_compiled() {
+                    true => {
+                        PackLayout::derive(&tensor.shape, &tensor.tensor)
+                            .expect("a compiled decision means the layout admitted it")
+                            .total_len as u64
+                    }
+                    false => elements as u64 * 2,
+                }
+            })
+            .sum();
+        LogicalBytes::new(total)
+    }
+}
+
+fn footprint() -> ShapeFootprint {
+    ShapeFootprint { surface: surface() }
+}
+
+fn bank() -> EvidenceBank {
+    EvidenceBank::new("kimi-teacher-forced/v1", "17d59a6b", ["seq-000"], 32)
+}
+
+fn instrument() -> InstrumentSemantics {
+    InstrumentSemantics::new("kl", "distribution", "teacher-forced", "q2a").truncated_to(2048)
+}
+
+fn intent(scale: EvidenceScale) -> MeasurementIntent {
+    MeasurementIntent::new(bank().id(), scale, instrument().id())
+}
+
+fn observation() -> QualityBank {
+    QualityBank {
+        positions: 8192,
+        logits: LogitEvidence {
+            kl_p50: 0.0,
+            kl_p95: 0.0,
+            kl_p99: 1.0e-3,
+            max_logit_delta: 0.0,
+            top1_flips: 0,
+            top10_changes: 0,
+        },
+        routing: RoutingEvidence {
+            route_flips: 0,
+            positions_with_route_change: 0,
+            layers_with_route_change: 0,
+            first_layer_with_route_change: None,
+            route_margin: None,
+            route_weight_mass_moved: Some(Distribution {
+                count: 1,
+                min: 0.0,
+                p50: 0.0,
+                p95: 0.0,
+                p99: 0.0,
+                max: 0.0,
+            }),
+        },
+        min_covered_mass: Some(0.63),
+        top10_margin: None,
+        top10_candidate_margin: None,
+        top10_mass_displaced: None,
+        top10_rank_displacement: None,
+        top1_margin: None,
+        top1_candidate_margin: None,
+        top1_mass_displaced: None,
+    }
+}
+
+fn applied(names: &[&str]) -> BTreeSet<String> {
+    names.iter().map(|n| (*n).to_string()).collect()
+}
+
+struct Rig {
+    vocabulary: ActionVocabulary,
+    base: PrecisionMap,
+    surface: TensorSurface,
+    footprint: ShapeFootprint,
+    measurements: MeasurementRegistry,
+    model: SourceIdentity,
+}
+
+impl Rig {
+    fn new() -> Self {
+        Self {
+            vocabulary: vocabulary(),
+            base: base_map(),
+            surface: surface(),
+            footprint: footprint(),
+            measurements: MeasurementRegistry::new(),
+            model: model(),
+        }
+    }
+
+    fn generator(&self) -> Generator<'_> {
+        Generator {
+            model: &self.model,
+            surface: &self.surface,
+            base_map: &self.base,
+            vocabulary: &self.vocabulary,
+            layout: &PackLayoutAdmission,
+            footprint: &self.footprint,
+            policy: TransitionPolicy::StrictlyImprovingPhysical,
+            measurements: &self.measurements,
+        }
+    }
+}
+
+// --------------------------------------------------- the conservation law
+
+#[test]
+fn every_enumerated_move_survives_or_carries_one_sanctioned_reason() {
+    let rig = Rig::new();
+    let g = rig.generator();
+    let set = g
+        .candidates(&applied(&["E24"]), &intent(EvidenceScale::Diagnostic))
+        .expect("generate");
+
+    // Universe from {E24} over a four-edit vocabulary: three additions,
+    // plus 1x3 exchanges.
+    let census = set.census();
+    assert_eq!(census.enumerated, 6);
+    assert_eq!(census.enumerated, set.len());
+    assert!(census.conserves(), "{census}");
+    assert_eq!(
+        census.eligible
+            + census.already_observed
+            + census.physically_dominated
+            + census.structurally_invalid,
+        6
+    );
+
+    // Every disposition names its move, and no move is named twice.
+    let labels: BTreeSet<&str> = set
+        .dispositions()
+        .iter()
+        .map(|d| d.action().label.as_str())
+        .collect();
+    assert_eq!(labels.len(), 6, "each move appears once");
+}
+
+#[test]
+fn the_census_reports_each_registered_category() {
+    // From {E24}: `+K25` and `+M26` save bytes and are eligible; `+NO`
+    // compiles a tensor the layout refuses, changing a decision while
+    // saving nothing, so the transition policy dominates it; the
+    // exchange `−E24 +NO` likewise. `−E24 +K25` and `−E24 +M26` swap one
+    // compiled 2-D matrix for another and save nothing either.
+    let rig = Rig::new();
+    let set = rig
+        .generator()
+        .candidates(&applied(&["E24"]), &intent(EvidenceScale::Diagnostic))
+        .expect("generate");
+    let census = set.census();
+
+    assert!(census.conserves(), "{census}");
+    assert_eq!(census.eligible, 2, "+K25 and +M26");
+    assert_eq!(census.physically_dominated, 4);
+    assert_eq!(census.already_observed, 0);
+
+    let eligible: BTreeSet<&str> = set.eligible().map(|c| c.action.label.as_str()).collect();
+    assert_eq!(eligible, BTreeSet::from(["+K25", "+M26"]));
+
+    for (action, reason) in set.pruned() {
+        assert_eq!(
+            reason.category(),
+            "physically-dominated",
+            "{}",
+            action.label
+        );
+    }
+}
+
+#[test]
+fn a_move_that_changes_no_decision_is_structurally_invalid() {
+    // Re-applying an edit the map already holds resolves identically.
+    // There is nothing for an instrument to observe that the parent has
+    // not already shown.
+    let rig = Rig::new();
+    let g = rig.generator();
+    let parent = applied(&["E24"]);
+
+    // Build the degenerate move directly: the vocabulary's enumeration
+    // never proposes `+E24` from `{E24}`, and the disposition must still
+    // be right if something else does.
+    let set = g
+        .candidates(&parent, &intent(EvidenceScale::Diagnostic))
+        .expect("generate");
+    assert!(
+        !set.dispositions()
+            .iter()
+            .any(|d| d.action().label == "+E24"),
+        "enumeration does not re-propose an applied edit"
+    );
+
+    // A vocabulary holding two names for the same exception does produce
+    // one: `+E24b` from `{E24}` changes no resolved decision.
+    let vocabulary = ActionVocabulary::new([
+        MapEdit::new("E24", compile("e_proj")),
+        MapEdit::new("E24b", compile("e_proj")),
+    ])
+    .expect("distinct names");
+    let rig2 = Rig {
+        vocabulary,
+        ..Rig::new()
+    };
+    let set = rig2
+        .generator()
+        .candidates(&applied(&["E24"]), &intent(EvidenceScale::Diagnostic))
+        .expect("generate");
+    // Both moves reachable from `{E24}` over that vocabulary resolve
+    // identically to the parent: adding the alias, and swapping the
+    // original for it.
+    let census = set.census();
+    assert!(census.conserves(), "{census}");
+    assert_eq!(census.enumerated, 2);
+    assert_eq!(census.structurally_invalid, 2);
+    let pruned: Vec<&str> = set.pruned().map(|(a, _)| a.label.as_str()).collect();
+    assert_eq!(pruned, vec!["+E24b", "−E24 +E24b"]);
+    assert!(set
+        .pruned()
+        .all(|(_, r)| matches!(r, PreMeasurementPrune::StructurallyInvalid { .. })));
+}
+
+// ------------------------------------------------- dedup needs the context
+
+#[test]
+fn dedup_is_on_the_intended_experiment_and_not_on_the_state() {
+    // The distinction 1c proved load-bearing: a diagnostic reading of a
+    // state does not make an authority reading of it a repeat.
+    let mut rig = Rig::new();
+    let child = rig
+        .generator()
+        .realize(&applied(&["E24", "K25"]))
+        .expect("realize");
+    rig.measurements
+        .record(
+            intent(EvidenceScale::Diagnostic).key_for(child.physical_id()),
+            observation(),
+        )
+        .expect("record");
+
+    let diagnostic = rig
+        .generator()
+        .candidates(&applied(&["E24"]), &intent(EvidenceScale::Diagnostic))
+        .expect("generate");
+    assert_eq!(diagnostic.census().already_observed, 1);
+    let (action, reason) = diagnostic
+        .pruned()
+        .find(|(_, r)| matches!(r, PreMeasurementPrune::AlreadyObserved { .. }))
+        .expect("the diagnostic is a repeat");
+    assert_eq!(action.label, "+K25");
+    assert!(matches!(
+        reason,
+        PreMeasurementPrune::AlreadyObserved { .. }
+    ));
+
+    // The same move at authority scale is a different experiment, and it
+    // arrives eligible — carrying the reading already held, so the
+    // escalation is visible rather than silent.
+    let authority = rig
+        .generator()
+        .candidates(&applied(&["E24"]), &intent(EvidenceScale::Authority))
+        .expect("generate");
+    assert_eq!(authority.census().already_observed, 0);
+    let escalation = authority
+        .eligible()
+        .find(|c| c.action.label == "+K25")
+        .expect("eligible at authority");
+    assert_eq!(escalation.prior_observations.len(), 1);
+    assert_eq!(
+        escalation.prior_observations[0].scale(),
+        EvidenceScale::Diagnostic
+    );
+    assert_eq!(escalation.intended_key.scale(), EvidenceScale::Authority);
+}
+
+#[test]
+fn an_authority_refused_action_is_still_offered_from_another_state() {
+    // **Ruling 1, the line that must not move.** `NO` — think E24 — is
+    // refused from one state. That refusal attaches to the MEASURED MAP
+    // and is not upward-closed under action-set inclusion, so the same
+    // action from a different parent is a different, unmeasured state
+    // and must still be enumerated. "More low precision" is not a
+    // behavioural partial order (R4-F7, R4-F2, R5-F4, R5-F9, R5-F7).
+    let mut rig = Rig::new();
+    let refused = rig
+        .generator()
+        .realize(&applied(&["E24", "M26"]))
+        .expect("realize");
+    rig.measurements
+        .record(
+            intent(EvidenceScale::Authority).key_for(refused.physical_id()),
+            observation(),
+        )
+        .expect("record");
+
+    // From {K25}, the move `+M26` reaches a DIFFERENT state, and nothing
+    // about the earlier refusal may remove it.
+    let set = rig
+        .generator()
+        .candidates(&applied(&["K25"]), &intent(EvidenceScale::Authority))
+        .expect("generate");
+    assert!(
+        set.eligible().any(|c| c.action.label == "+M26"),
+        "a refusal elsewhere does not prune this move"
+    );
+    assert!(set.census().conserves());
+}
+
+// ------------------------------------------------------- physics is derived
+
+#[test]
+fn an_action_never_asserts_its_own_saving() {
+    // R5-F5: a footprint column read as a saving overstated an expert
+    // revert 3.39x. No `MapEdit` carries bytes; the delta is computed
+    // from two footprints the generator resolved.
+    let rig = Rig::new();
+    let g = rig.generator();
+    let parent = g.realize(&applied(&["E24"])).expect("realize");
+    let set = g
+        .candidates(&applied(&["E24"]), &intent(EvidenceScale::Diagnostic))
+        .expect("generate");
+
+    for candidate in set.eligible() {
+        let expected = candidate
+            .child
+            .logical_bytes()
+            .delta_from(parent.logical_bytes());
+        assert_eq!(candidate.physical_delta, expected);
+        assert!(candidate.physical_delta < 0, "eligible means it saves");
+        assert_eq!(candidate.parent_state, *parent.physical_id());
+        assert_eq!(candidate.parent_realization, *parent.realization_id());
+    }
+
+    // A 64x64 BF16 matrix is 8192 B. NVFP4 stores four 16-element
+    // groups per row: 64 x 4 x 8 code bytes, plus 64 x 4 E4M3 group
+    // scales, plus one f32 tensor scale — 2308 B. So one compile saves
+    // 5884 B, and the generator says so without being told.
+    let k25 = set
+        .eligible()
+        .find(|c| c.action.label == "+K25")
+        .expect("+K25");
+    assert_eq!(k25.physical_delta, 2308 - 8192);
+}
+
+#[test]
+fn dominance_is_the_transition_policy_and_not_a_second_opinion() {
+    // A generator that offered candidates the graph would refuse, or
+    // pruned ones it would have taken, would be two answers to one
+    // question.
+    let rig = Rig { ..Rig::new() };
+    let mut g = rig.generator();
+    g.policy = TransitionPolicy::Unconstrained;
+    let set = g
+        .candidates(&applied(&["E24"]), &intent(EvidenceScale::Diagnostic))
+        .expect("generate");
+
+    let census = set.census();
+    assert!(census.conserves(), "{census}");
+    assert_eq!(
+        census.physically_dominated, 0,
+        "an unconstrained policy dominates nothing"
+    );
+    assert_eq!(census.eligible, 6);
+    assert!(set.eligible().any(|c| c.physical_delta == 0));
+}
+
+// ------------------------------------------------- the vocabulary is input
+
+#[test]
+fn enumeration_covers_the_vocabulary_not_the_last_rounds_leftovers() {
+    // R5-F6: neighbourhood 1 drew its in-moves from the candidates left
+    // unpromoted at iteration 4 and never listed E20/E22/E23/E24/E25.
+    // Two moves worth ~430 MB each were invisible. Enumeration is over
+    // the declared vocabulary, always.
+    let rig = Rig::new();
+    let set = rig
+        .generator()
+        .candidates(&applied(&["E24"]), &intent(EvidenceScale::Diagnostic))
+        .expect("generate");
+
+    let proposed: BTreeSet<String> = set
+        .dispositions()
+        .iter()
+        .flat_map(|d| d.action().added.iter().cloned())
+        .collect();
+    let expected: BTreeSet<String> = rig
+        .vocabulary
+        .names()
+        .filter(|n| *n != "E24")
+        .map(String::from)
+        .collect();
+    assert_eq!(proposed, expected, "every unapplied edit is an in-move");
+}
+
+#[test]
+fn a_vocabulary_refuses_a_repeated_name_and_a_state_refuses_an_unknown_move() {
+    let err = ActionVocabulary::new([
+        MapEdit::new("E24", compile("e_proj")),
+        MapEdit::new("E24", compile("k_proj")),
+    ])
+    .expect_err("one name, two edits");
+    assert!(format!("{err}").contains("declared twice"), "{err}");
+
+    let rig = Rig::new();
+    let err = rig
+        .generator()
+        .realize(&applied(&["E99"]))
+        .expect_err("not in the vocabulary");
+    assert!(format!("{err}").contains("not in this vocabulary"), "{err}");
+}
+
+#[test]
+fn an_applied_set_has_exactly_one_map_however_it_was_reached() {
+    // The vocabulary's declaration order supplies the map order, so two
+    // rounds that reach the same set reach the same bytes — which is
+    // what makes the identity contract meaningful over search states.
+    let rig = Rig::new();
+    let g = rig.generator();
+    let one = g.realize(&applied(&["E24", "M26"])).expect("realize");
+    let other = g.realize(&applied(&["M26", "E24"])).expect("realize");
+    assert_eq!(one.physical_id(), other.physical_id());
+    assert_eq!(one.realization_id(), other.realization_id());
+    assert_eq!(one.logical_bytes(), other.logical_bytes());
+
+    let empty = ActionVocabulary::default();
+    assert!(empty.is_empty());
+    assert_eq!(empty.len(), 0);
+    assert!(!empty.contains("E24"));
+    assert_eq!(rig.vocabulary.edits().len(), 4);
+}
+
+#[test]
+fn a_candidate_set_reports_what_it_holds() {
+    let rig = Rig::new();
+    let set = rig
+        .generator()
+        .candidates(&applied(&["E24"]), &intent(EvidenceScale::Diagnostic))
+        .expect("generate");
+    assert!(!set.is_empty());
+    assert_eq!(set.len(), set.dispositions().len());
+    assert_eq!(set.eligible().count() + set.pruned().count(), set.len());
+
+    let census = set.census();
+    let rendered = format!("{census}");
+    assert!(rendered.contains("generated"), "{rendered}");
+    assert!(rendered.contains("eligible"), "{rendered}");
+    assert!(Census::default().conserves(), "an empty round conserves");
+
+    // An eligible disposition names the same move as its candidate.
+    let first = set
+        .dispositions()
+        .iter()
+        .find(|d| matches!(d, CandidateDisposition::Eligible(_)))
+        .expect("one eligible");
+    assert!(set
+        .eligible()
+        .any(|c| c.action.label == first.action().label));
+    assert!(set.eligible().all(|c| c.applied.len() == 2));
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/evidence_bank.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/evidence_bank.rs
@@ -1,0 +1,148 @@
+//! **Which samples an observation was taken over.**
+//!
+//! Note what this is NOT. [`super::super::quality::QualityBank`] is
+//! *"one bank of measurements over a fixed token sequence"* — the
+//! OBSERVATION: measured KL, routing evidence, margin distributions. The
+//! programme's "evidence bank" is the CORPUS those were taken over — 256
+//! teacher-forced sequences of real prose, a directory with a
+//! `manifest.json`. One word, two things, and only the second can
+//! identify an experiment.
+//!
+//! Before this module the corpus had no type at all. Its identity was a
+//! `sha256` of `manifest.json` computed inline in the Q2a harness and
+//! written into the report as `bank_manifest_sha256` — which is the
+//! right instinct and not sufficient, because **the harness slices the
+//! corpus**. `LARQL_Q2A_SEQUENCES` takes 32 of 256, and a 32-sequence
+//! reading and a 256-sequence reading share a manifest digest while
+//! being different experiments. That slice is the difference between a
+//! diagnostic and an authority run.
+//!
+//! ```text
+//! IN   schema             the bank format the samples are in
+//! IN   manifest digest    the corpus's own content hash
+//! IN   ordered samples    WHICH sequences, in the order used
+//! IN   positions/sample   how many positions each contributes
+//!
+//! OUT  where it is stored  /tmp has proven ephemeral; a path is where a
+//!                          bank was last seen, not what it is
+//! OUT  when it was built
+//! OUT  what a human called it
+//! ```
+//!
+//! The rule, stated so it can be argued with:
+//!
+//! > **If changing it can legitimately change the measured result or its
+//! > comparability, it must change [`EvidenceBankId`]. If it cannot, it
+//! > must not.**
+//!
+//! The excluded-path rule is the same one
+//! [`super::super::compiler::SourceDependency`] already states for
+//! containers — *identified by CONTENT, not by path* — and it is here
+//! for the same reason: a bank that moved disk is the same bank, and a
+//! registry that thought otherwise would re-run twenty minutes of
+//! instrument time to learn what it already knew.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::compile::hash_bytes;
+use super::surface::{FIELD, RECORD, SECTION};
+
+/// The canonical-form version every bank id is computed under.
+pub const EVIDENCE_BANK_ID_VERSION: &str = "evidence-bank-id/v1";
+
+/// **What a corpus IS**, by the samples it presents.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct EvidenceBankId(String);
+
+impl EvidenceBankId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn short(&self) -> &str {
+        &self.0[..self.0.len().min(12)]
+    }
+}
+
+impl std::fmt::Display for EvidenceBankId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The corpus an observation was taken over.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceBank {
+    /// The bank format these samples are in. A reader that changed how
+    /// it interprets the files is measuring something else.
+    pub schema: String,
+    /// The corpus's own `manifest.json` digest, as the Q2a harness
+    /// already records it.
+    pub manifest_sha256: String,
+    /// **The samples actually used, in the order used.** Not a count: a
+    /// different 32 of the same 256 is a different experiment, and a
+    /// count cannot say which 32.
+    pub samples: Vec<String>,
+    /// Positions each sample contributes.
+    pub positions_per_sample: u32,
+    /// Where the bank was last seen. A hint for FINDING it, never part
+    /// of what it is.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locator_hint: Option<String>,
+    /// What a human called it. Provenance, never identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl EvidenceBank {
+    pub fn new(
+        schema: impl Into<String>,
+        manifest_sha256: impl Into<String>,
+        samples: impl IntoIterator<Item = impl Into<String>>,
+        positions_per_sample: u32,
+    ) -> Self {
+        Self {
+            schema: schema.into(),
+            manifest_sha256: manifest_sha256.into(),
+            samples: samples.into_iter().map(Into::into).collect(),
+            positions_per_sample,
+            locator_hint: None,
+            description: None,
+        }
+    }
+
+    pub fn found_at(mut self, locator: impl Into<String>) -> Self {
+        self.locator_hint = Some(locator.into());
+        self
+    }
+
+    pub fn described(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// **Positions, computed — never multiplied by hand.**
+    ///
+    /// `LARQL_Q2A_SEQUENCES=256` is SEQUENCES; the bank is 256 × 32 =
+    /// 8192 POSITIONS, and an acceptance check written against the wrong
+    /// one of those would have accepted a diagnostic run and rejected the
+    /// authority one. It nearly did.
+    pub fn positions(&self) -> u64 {
+        self.samples.len() as u64 * u64::from(self.positions_per_sample)
+    }
+
+    pub fn sample_count(&self) -> usize {
+        self.samples.len()
+    }
+
+    /// What this bank IS.
+    pub fn id(&self) -> EvidenceBankId {
+        let samples = self.samples.join(&RECORD.to_string());
+        let input = format!(
+            "{EVIDENCE_BANK_ID_VERSION}{SECTION}schema={}{FIELD}manifest={}{FIELD}\
+             positions_per_sample={}{SECTION}samples={samples}",
+            self.schema, self.manifest_sha256, self.positions_per_sample
+        );
+        EvidenceBankId(hash_bytes(input.as_bytes()))
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/graph.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/graph.rs
@@ -75,7 +75,13 @@ pub enum TransitionPolicy {
 
 impl TransitionPolicy {
     /// Whether an edge with this delta is admitted.
-    fn admits(self, physical_delta: i64) -> bool {
+    ///
+    /// Public because the candidate generator prunes on physical
+    /// dominance by asking THIS, rather than by reimplementing the
+    /// comparison — a generator that offered candidates the graph would
+    /// then refuse, or pruned ones it would have taken, would be two
+    /// answers to one question.
+    pub fn admits(self, physical_delta: i64) -> bool {
         match self {
             Self::StrictlyImprovingPhysical => physical_delta < 0,
             Self::Unconstrained => true,

--- a/crates/larql-vindex/src/format/vindex3/represent/state/graph.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/graph.rs
@@ -1,0 +1,354 @@
+//! **The state graph: physical nodes, realization facets, provenance on
+//! the edges.**
+//!
+//! ```text
+//! Physical identity        RepresentationStateId   → evidence, MeasurementKey
+//!         │
+//!         ▼
+//! Resolved realization     full decision facts     → the action generator
+//!         │
+//!         ▼
+//! State node               one per PHYSICAL state, holding its realizations
+//!         │
+//!  transformation edges    parent, child, action, delta, provenance
+//!         ▼
+//! State node
+//! ```
+//!
+//! # Why this is not called a DAG
+//!
+//! Acyclicity here is a **theorem under a policy**, not a property of
+//! the domain, and the distinction is worth a type rather than a
+//! comment.
+//!
+//! Under [`TransitionPolicy::StrictlyImprovingPhysical`] every admitted
+//! edge strictly decreases [`LogicalBytes`]. A cycle would require a
+//! strictly decreasing sequence of `u64` returning to its start, so
+//! there are no cycles: the structure is a DAG, and
+//! [`RepresentationStateGraph::is_acyclic`] can only ever confirm it.
+//! That policy is what rung 5 already enforces — its neighbourhoods
+//! pruned `−E26 + H` at +1.39 GB and `−K25 + M23` at +2,091,136 B for
+//! being physically worse, and Ruling 1 lists physical dominance as one
+//! of the four legitimate pre-measurement prunes.
+//!
+//! It is nonetheless a policy and not a law, and the programme's own
+//! roadmap says when it breaks: once residency joins the state and the
+//! objective becomes measured tok/s, a move that *adds* logical bytes
+//! while freeing unified memory for resident experts is exactly the kind
+//! of move the search must be able to make. At that point transitions
+//! stop being monotone in bytes, transpositions and cycles become
+//! reachable, and the canonical structure is a general graph with the
+//! DAG living in the search overlay instead.
+//!
+//! So the policy is recorded on the graph, checked on every insertion,
+//! and named in the serialised form — a graph built under one policy is
+//! recognisably not a graph built under the other.
+//!
+//! # One graph, one model
+//!
+//! A map's physical prize is a property of the model it is resolved
+//! against, so a graph that mixed models would hold nodes whose costs
+//! could not be compared. The root fixes the model and the tensor
+//! surface; every later state is checked against both.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use super::super::compiler::SourceIdentity;
+use super::identity::RepresentationStateId;
+use super::realization::{LogicalBytes, RealizationId, ResolvedState};
+use super::transition::{Action, Provenance, Transition};
+use crate::error::VindexError;
+
+/// What the graph will admit as an edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TransitionPolicy {
+    /// Every edge must strictly reduce logical bytes. Acyclicity
+    /// follows; the structure is a DAG.
+    StrictlyImprovingPhysical,
+    /// Any edge is admitted. Use when the objective is no longer bytes —
+    /// the structure is then a general graph and the caller owns
+    /// termination.
+    Unconstrained,
+}
+
+impl TransitionPolicy {
+    /// Whether an edge with this delta is admitted.
+    fn admits(self, physical_delta: i64) -> bool {
+        match self {
+            Self::StrictlyImprovingPhysical => physical_delta < 0,
+            Self::Unconstrained => true,
+        }
+    }
+
+    /// Whether acyclicity is guaranteed by construction under this
+    /// policy, rather than merely observed so far.
+    pub fn guarantees_acyclic(self) -> bool {
+        matches!(self, Self::StrictlyImprovingPhysical)
+    }
+}
+
+/// One physical state, and every realization of it seen so far.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateNode {
+    physical_id: RepresentationStateId,
+    logical_bytes: LogicalBytes,
+    realizations: BTreeMap<RealizationId, ResolvedState>,
+}
+
+impl StateNode {
+    pub fn physical_id(&self) -> &RepresentationStateId {
+        &self.physical_id
+    }
+
+    pub fn logical_bytes(&self) -> LogicalBytes {
+        self.logical_bytes
+    }
+
+    /// Every realization of this physical state, in id order.
+    ///
+    /// More than one is normal, not exceptional: a tensor held at source
+    /// precision by a protection and one held there by a layout refusal
+    /// present identical bytes and admit different moves.
+    pub fn realizations(&self) -> impl Iterator<Item = &ResolvedState> {
+        self.realizations.values()
+    }
+
+    pub fn realization(&self, id: &RealizationId) -> Option<&ResolvedState> {
+        self.realizations.get(id)
+    }
+
+    pub fn realization_count(&self) -> usize {
+        self.realizations.len()
+    }
+
+    /// Fold a realization in, refusing one that disagrees about bytes.
+    fn absorb(&mut self, state: ResolvedState) -> Result<(), VindexError> {
+        if state.logical_bytes() != self.logical_bytes {
+            return Err(VindexError::Parse(format!(
+                "state {} is already priced at {} but this realization reports {} — one \
+                 physical state presents one set of bytes, so one of the two footprints is \
+                 wrong",
+                self.physical_id.short(),
+                self.logical_bytes,
+                state.logical_bytes()
+            )));
+        }
+        self.realizations
+            .entry(state.realization_id().clone())
+            .or_insert(state);
+        Ok(())
+    }
+}
+
+/// **The search state graph.**
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepresentationStateGraph {
+    policy: TransitionPolicy,
+    model: SourceIdentity,
+    surface_identity: String,
+    root: RepresentationStateId,
+    nodes: BTreeMap<RepresentationStateId, StateNode>,
+    /// Keyed by [`Transition::identity`], so re-discovering an edge
+    /// merges into it rather than appending a duplicate.
+    edges: BTreeMap<String, Transition>,
+}
+
+impl RepresentationStateGraph {
+    /// Start a graph at `root`, which fixes the model and the surface.
+    pub fn new(policy: TransitionPolicy, root: ResolvedState) -> Self {
+        let physical_id = root.physical_id().clone();
+        let model = root.state().model().clone();
+        let surface_identity = root.state().surface_identity().to_string();
+        let node = StateNode {
+            physical_id: physical_id.clone(),
+            logical_bytes: root.logical_bytes(),
+            realizations: BTreeMap::from([(root.realization_id().clone(), root)]),
+        };
+        Self {
+            policy,
+            model,
+            surface_identity,
+            root: physical_id.clone(),
+            nodes: BTreeMap::from([(physical_id, node)]),
+            edges: BTreeMap::new(),
+        }
+    }
+
+    /// **Apply `action` at `parent`, arriving at `child`.**
+    ///
+    /// Returns the child's physical id. Every refusal names what it
+    /// checked rather than reporting a generic failure, because each one
+    /// is a different bug in the caller.
+    pub fn apply(
+        &mut self,
+        parent: &RepresentationStateId,
+        action: Action,
+        child: ResolvedState,
+        provenance: Provenance,
+    ) -> Result<RepresentationStateId, VindexError> {
+        let parent_node = self.nodes.get(parent).ok_or_else(|| {
+            VindexError::Parse(format!(
+                "no state {} in this graph — an edge cannot begin at a state the graph has \
+                 never held",
+                parent.short()
+            ))
+        })?;
+        self.check_same_model(&child)?;
+
+        let physical_delta = child
+            .logical_bytes()
+            .delta_from(parent_node.logical_bytes());
+        if !self.policy.admits(physical_delta) {
+            return Err(VindexError::Parse(format!(
+                "transition `{}` moves {} logical bytes and the graph's policy is {:?} — the \
+                 policy is what makes this structure acyclic, so admitting this edge would \
+                 silently change what the graph IS",
+                action.label, physical_delta, self.policy
+            )));
+        }
+
+        let child_id = child.physical_id().clone();
+        let realization_id = child.realization_id().clone();
+        match self.nodes.get_mut(&child_id) {
+            Some(existing) => existing.absorb(child)?,
+            None => {
+                self.nodes.insert(
+                    child_id.clone(),
+                    StateNode {
+                        physical_id: child_id.clone(),
+                        logical_bytes: child.logical_bytes(),
+                        realizations: BTreeMap::from([(realization_id.clone(), child)]),
+                    },
+                );
+            }
+        }
+
+        let edge = Transition::new(
+            parent.clone(),
+            child_id.clone(),
+            realization_id,
+            action,
+            physical_delta,
+            provenance.clone(),
+        );
+        match self.edges.get_mut(&edge.identity()) {
+            Some(existing) => existing.observe(provenance),
+            None => {
+                self.edges.insert(edge.identity(), edge);
+            }
+        }
+        Ok(child_id)
+    }
+
+    fn check_same_model(&self, child: &ResolvedState) -> Result<(), VindexError> {
+        if child.state().model() != &self.model {
+            return Err(VindexError::Parse(
+                "this state belongs to a different container — a map's physical prize is a \
+                 property of the model it resolves against, so one graph holds one model"
+                    .into(),
+            ));
+        }
+        if child.state().surface_identity() != self.surface_identity {
+            return Err(VindexError::Parse(format!(
+                "this state was resolved against surface {} but the graph's root used {} — \
+                 the same bytes under a different enumerated surface is a different search \
+                 problem",
+                &child.state().surface_identity()[..12],
+                &self.surface_identity[..12]
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn policy(&self) -> TransitionPolicy {
+        self.policy
+    }
+
+    pub fn model(&self) -> &SourceIdentity {
+        &self.model
+    }
+
+    pub fn surface_identity(&self) -> &str {
+        &self.surface_identity
+    }
+
+    pub fn root(&self) -> &RepresentationStateId {
+        &self.root
+    }
+
+    pub fn node(&self, id: &RepresentationStateId) -> Option<&StateNode> {
+        self.nodes.get(id)
+    }
+
+    pub fn nodes(&self) -> impl Iterator<Item = &StateNode> {
+        self.nodes.values()
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        // A graph always holds its root.
+        self.nodes.is_empty()
+    }
+
+    pub fn edges(&self) -> impl Iterator<Item = &Transition> {
+        self.edges.values()
+    }
+
+    pub fn edge_count(&self) -> usize {
+        self.edges.len()
+    }
+
+    /// Every edge that arrives at `id` — the several explanations of how
+    /// one state was reached.
+    pub fn incoming(&self, id: &RepresentationStateId) -> Vec<&Transition> {
+        self.edges.values().filter(|e| e.child() == id).collect()
+    }
+
+    pub fn outgoing(&self, id: &RepresentationStateId) -> Vec<&Transition> {
+        self.edges.values().filter(|e| e.parent() == id).collect()
+    }
+
+    /// Whether the graph contains no directed cycle.
+    ///
+    /// Under [`TransitionPolicy::StrictlyImprovingPhysical`] this can
+    /// only return `true` — it is the theorem, checked. It is a real
+    /// question only for an `Unconstrained` graph.
+    pub fn is_acyclic(&self) -> bool {
+        let mut done: BTreeSet<&RepresentationStateId> = BTreeSet::new();
+        let mut path: BTreeSet<&RepresentationStateId> = BTreeSet::new();
+        self.nodes
+            .keys()
+            .all(|id| Self::visit(self, id, &mut done, &mut path))
+    }
+
+    fn visit<'a>(
+        &'a self,
+        id: &'a RepresentationStateId,
+        done: &mut BTreeSet<&'a RepresentationStateId>,
+        path: &mut BTreeSet<&'a RepresentationStateId>,
+    ) -> bool {
+        if done.contains(id) {
+            return true;
+        }
+        if !path.insert(id) {
+            return false;
+        }
+        // Walk the edge's own child id rather than looking it up: `apply`
+        // inserts the child node before the edge, so a dangling child
+        // cannot exist, and a lookup here would need a `None` arm that no
+        // input can reach — an untestable branch guarding an impossible
+        // state.
+        let ok = self
+            .outgoing(id)
+            .into_iter()
+            .all(|e| self.visit(e.child(), done, path));
+        path.remove(id);
+        done.insert(id);
+        ok
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/graph_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/graph_tests.rs
@@ -1,0 +1,583 @@
+//! **1b: what the graph must never lose.**
+//!
+//! Stage 1a deliberately collapsed a protection and a layout refusal
+//! into one physical identity. That is right for evidence and wrong for
+//! actions, so the danger this file exists to catch is a *stage-1b
+//! information-loss bug*: a node keyed on the physical id quietly
+//! overwriting one realization with the other.
+
+use std::collections::BTreeMap;
+
+use super::super::compiler::SourceIdentity;
+use super::super::map::{Exception, PrecisionMap};
+use super::super::nvfp4_pack::DTYPE_NVFP4;
+use super::super::policy::Role;
+use super::*;
+
+// ---------------------------------------------------------------- fixtures
+
+fn model() -> SourceIdentity {
+    SourceIdentity {
+        manifest_hash: "manifest-aaaa".into(),
+        graph_hash: "graph-1111".into(),
+        segments: BTreeMap::from([("target.decoder_stack".to_string(), "seg-dddd".to_string())]),
+    }
+}
+
+fn tensor(projection: &str, shape: Vec<usize>) -> SurfaceTensor {
+    SurfaceTensor::new(
+        "target.decoder_stack",
+        format!("0.self_attn.{projection}.weight"),
+        Role::DecoderLinear,
+        shape,
+    )
+}
+
+/// q/k/v, all NVFP4-admissible.
+fn admissible_surface() -> TensorSurface {
+    TensorSurface::new(
+        ["q_proj", "k_proj", "v_proj"]
+            .into_iter()
+            .map(|p| tensor(p, vec![64, 64])),
+    )
+    .expect("distinct tensors")
+}
+
+/// q admissible, v refused by the layout — `k = 24` is not a multiple of
+/// the NVFP4 16-element group.
+fn mixed_surface() -> TensorSurface {
+    TensorSurface::new([
+        tensor("q_proj", vec![64, 64]),
+        tensor("v_proj", vec![64, 24]),
+    ])
+    .expect("distinct tensors")
+}
+
+fn map(roles: &[&str], exceptions: Vec<Exception>) -> PrecisionMap {
+    PrecisionMap {
+        name: "m".into(),
+        encoding: DTYPE_NVFP4.into(),
+        roles: roles.iter().map(|r| (*r).to_string()).collect(),
+        exceptions,
+    }
+}
+
+fn protect(projection: &str) -> Exception {
+    Exception {
+        projection: Some(projection.into()),
+        layers: None,
+        encoding: None,
+    }
+}
+
+fn compile(projection: &str) -> Exception {
+    Exception {
+        projection: Some(projection.into()),
+        layers: None,
+        encoding: Some(DTYPE_NVFP4.into()),
+    }
+}
+
+/// Resolve a map into a realization priced at `bytes`.
+fn st(m: &PrecisionMap, surface: &TensorSurface, bytes: u64) -> ResolvedState {
+    ResolvedState::new(
+        RepresentationState::resolve(&model(), surface, m, &PackLayoutAdmission),
+        LogicalBytes::new(bytes),
+    )
+}
+
+/// A map compiling nothing — the root of most of these graphs.
+fn nothing() -> PrecisionMap {
+    map(&[], vec![])
+}
+
+fn by(who: &str) -> Provenance {
+    Provenance::new(who)
+}
+
+fn dag(root: ResolvedState) -> RepresentationStateGraph {
+    RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, root)
+}
+
+// --------------------------------------------------- 1. two parents, one state
+
+#[test]
+fn two_parents_converge_on_one_state_and_both_provenances_survive() {
+    let s = admissible_surface();
+    let root = st(&nothing(), &s, 3000);
+    let mut g = dag(root.clone());
+
+    // Two different one-move states, each compiling a different
+    // projection, arriving at the same cost.
+    let p1 = st(
+        &map(
+            &["decoder-linear"],
+            vec![protect("k_proj"), protect("v_proj")],
+        ),
+        &s,
+        2000,
+    );
+    let p2 = st(
+        &map(
+            &["decoder-linear"],
+            vec![protect("q_proj"), protect("v_proj")],
+        ),
+        &s,
+        2000,
+    );
+    assert_ne!(p1.physical_id(), p2.physical_id(), "different maps");
+
+    let p1_id = g
+        .apply(root.physical_id(), Action::new("+q"), p1, by("rung4/i1"))
+        .expect("root -> p1");
+    let p2_id = g
+        .apply(root.physical_id(), Action::new("+k"), p2, by("rung4/i1"))
+        .expect("root -> p2");
+
+    // One child, reached from both, by different moves.
+    let child = st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 1000);
+    let from_p1 = g
+        .apply(&p1_id, Action::new("+k"), child.clone(), by("rung5/N1"))
+        .expect("p1 -> c");
+    let from_p2 = g
+        .apply(&p2_id, Action::new("+q"), child, by("rung5/N2"))
+        .expect("p2 -> c");
+
+    assert_eq!(from_p1, from_p2, "one physical state, two discoveries");
+    assert_eq!(g.len(), 4, "root, p1, p2, c");
+
+    let incoming = g.incoming(&from_p1);
+    assert_eq!(incoming.len(), 2);
+    let discoverers: Vec<&str> = {
+        let mut v: Vec<&str> = incoming
+            .iter()
+            .flat_map(|e| e.provenance())
+            .map(|p| p.by.as_str())
+            .collect();
+        v.sort_unstable();
+        v
+    };
+    assert_eq!(discoverers, vec!["rung5/N1", "rung5/N2"]);
+    assert!(g.is_acyclic());
+}
+
+// ------------------------------------- 2. different recipes, one physical state
+
+#[test]
+fn different_recipes_with_one_effective_representation_add_no_second_node() {
+    // R5-F3: `P - K25 + H` was a map already measured and rejected under
+    // another name. A graph keyed on recipes calls that novel.
+    let s = admissible_surface();
+    let root = st(&nothing(), &s, 3000);
+    let mut g = dag(root.clone());
+
+    let plain = st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 1000);
+    // Same decisions, written with a shadowed rule and a redundant one.
+    let ornate = st(
+        &map(
+            &["decoder-linear"],
+            vec![protect("v_proj"), compile("v_proj"), compile("q_proj")],
+        ),
+        &s,
+        1000,
+    );
+    assert_eq!(plain.physical_id(), ornate.physical_id());
+    assert_eq!(plain.realization_id(), ornate.realization_id());
+
+    let a = g
+        .apply(root.physical_id(), Action::new("direct"), plain, by("a"))
+        .expect("direct");
+    let b = g
+        .apply(root.physical_id(), Action::new("scenic"), ornate, by("b"))
+        .expect("scenic");
+
+    assert_eq!(a, b);
+    assert_eq!(g.len(), 2, "root and one child");
+    assert_eq!(
+        g.node(&a).expect("child").realization_count(),
+        1,
+        "identical facts are one realization"
+    );
+    assert_eq!(g.edge_count(), 2, "two moves, one destination");
+}
+
+// ------------------- 3. one physical state, two action-relevant realizations
+
+#[test]
+fn one_physical_state_keeps_both_realizations() {
+    // THE stage-1b hazard. Both maps present `v_proj` at source
+    // precision — one because a protection holds it there, one because
+    // the NVFP4 layout refuses `k = 24`. Same bytes, same evidence, and
+    // NOT the same action space: `unprotect v_proj` is a legal move from
+    // the first and no move whatever produces a compiled `v_proj` from
+    // the second.
+    let s = mixed_surface();
+    let root = st(&nothing(), &s, 3000);
+    let mut g = dag(root.clone());
+
+    let protected = st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 1000);
+    let refused = st(&map(&["decoder-linear"], vec![]), &s, 1000);
+
+    assert_eq!(
+        protected.physical_id(),
+        refused.physical_id(),
+        "1a collapses them, correctly"
+    );
+    assert_ne!(
+        protected.realization_id(),
+        refused.realization_id(),
+        "1b must not"
+    );
+
+    let id = g
+        .apply(
+            root.physical_id(),
+            Action::new("protect-v"),
+            protected.clone(),
+            by("a"),
+        )
+        .expect("protected");
+    g.apply(
+        root.physical_id(),
+        Action::new("compile-all"),
+        refused.clone(),
+        by("b"),
+    )
+    .expect("refused");
+
+    assert_eq!(g.len(), 2, "one physical child");
+    let node = g.node(&id).expect("child");
+    assert_eq!(node.realization_count(), 2, "neither overwrote the other");
+
+    let v = "0.self_attn.v_proj.weight";
+    assert_eq!(
+        node.realization(protected.realization_id())
+            .expect("protected realization")
+            .state()
+            .decisions()
+            .get("target.decoder_stack", v),
+        Some(&ResolvedEncoding::Source)
+    );
+    assert_eq!(
+        node.realization(refused.realization_id())
+            .expect("refused realization")
+            .state()
+            .decisions()
+            .get("target.decoder_stack", v),
+        Some(&ResolvedEncoding::LayoutRefused {
+            encoding: DTYPE_NVFP4.into()
+        })
+    );
+
+    // And the edges say which realization each move actually built.
+    let built: Vec<&RealizationId> = g
+        .incoming(&id)
+        .iter()
+        .map(|e| e.child_realization())
+        .collect();
+    assert_eq!(built.len(), 2);
+    assert!(built.contains(&protected.realization_id()));
+    assert!(built.contains(&refused.realization_id()));
+}
+
+// ------------------------------------------------------ 4. idempotent redisco
+
+#[test]
+fn rediscovering_an_edge_does_not_accumulate_duplicate_provenance() {
+    let s = admissible_surface();
+    let root = st(&nothing(), &s, 3000);
+    let mut g = dag(root.clone());
+    let child = st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 1000);
+
+    let apply = |g: &mut RepresentationStateGraph, who: &str| {
+        g.apply(
+            root.physical_id(),
+            Action::new("+qk").adding(["q", "k"]),
+            child.clone(),
+            by(who),
+        )
+        .expect("apply")
+    };
+
+    let id = apply(&mut g, "rung5/N1");
+    apply(&mut g, "rung5/N1");
+    apply(&mut g, "rung5/N1");
+    assert_eq!(g.edge_count(), 1, "one move is one edge");
+    assert_eq!(
+        g.incoming(&id)[0].provenance().len(),
+        1,
+        "a replayed round must not inflate the record"
+    );
+
+    // A genuinely different discoverer of the same edge is information.
+    apply(&mut g, "agent/session-7");
+    assert_eq!(g.edge_count(), 1);
+    assert_eq!(g.incoming(&id)[0].provenance().len(), 2);
+
+    // Order within an exchange is not identity: the same move written
+    // the other way round is the same edge.
+    g.apply(
+        root.physical_id(),
+        Action::new("+qk").adding(["k", "q"]),
+        child.clone(),
+        by("rung5/N1"),
+    )
+    .expect("apply");
+    assert_eq!(g.edge_count(), 1, "`+q +k` and `+k +q` are one move");
+}
+
+// ------------------------------------------------- 5. the monotone invariant
+
+#[test]
+fn a_transition_that_does_not_improve_physically_is_refused() {
+    let s = admissible_surface();
+    let root = st(&nothing(), &s, 3000);
+    let mut g = dag(root.clone());
+
+    let worse = st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 4000);
+    let err = g
+        .apply(root.physical_id(), Action::new("worse"), worse, by("a"))
+        .expect_err("+1000 bytes");
+    assert!(format!("{err}").contains("1000"), "{err}");
+
+    // Zero is refused too, and this is not a corner case: from a
+    // layout-refused realization, "unprotect" changes the facts and no
+    // bytes at all. Physical dominance already prunes it, and admitting
+    // it would put a zero-weight edge in the structure the strict
+    // decrease is what keeps acyclic.
+    let level = st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 3000);
+    g.apply(root.physical_id(), Action::new("level"), level, by("a"))
+        .expect_err("net zero");
+
+    assert_eq!(g.len(), 1, "neither refusal left a node behind");
+    assert_eq!(g.edge_count(), 0);
+}
+
+#[test]
+fn the_strict_policy_makes_the_graph_acyclic_and_the_loose_one_does_not() {
+    let s = admissible_surface();
+    let root = st(&nothing(), &s, 3000);
+    let a = st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 2000);
+
+    assert!(TransitionPolicy::StrictlyImprovingPhysical.guarantees_acyclic());
+    assert!(!TransitionPolicy::Unconstrained.guarantees_acyclic());
+
+    // Unconstrained admits a move back up, and a cycle with it.
+    let mut loose = RepresentationStateGraph::new(TransitionPolicy::Unconstrained, root.clone());
+    let a_id = loose
+        .apply(root.physical_id(), Action::new("down"), a, by("a"))
+        .expect("down");
+    loose
+        .apply(&a_id, Action::new("back up"), root.clone(), by("a"))
+        .expect("an unconstrained graph admits it");
+    assert!(
+        !loose.is_acyclic(),
+        "the objective is no longer bytes, so the structure is a graph"
+    );
+
+    // The same pair of moves under the strict policy cannot close.
+    let mut strict = dag(root.clone());
+    let a2 = st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 2000);
+    let a2_id = strict
+        .apply(root.physical_id(), Action::new("down"), a2, by("a"))
+        .expect("down");
+    strict
+        .apply(&a2_id, Action::new("back up"), root, by("a"))
+        .expect_err("a cycle needs a non-decreasing edge");
+    assert!(strict.is_acyclic());
+}
+
+// ------------------------------------------------------------ 6. round-trip
+
+#[test]
+fn a_graph_survives_serialization_with_identity_facts_and_edges_intact() {
+    let s = mixed_surface();
+    let root = st(&nothing(), &s, 3000);
+    let mut g = dag(root.clone());
+    let protected = st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 1000);
+    let refused = st(&map(&["decoder-linear"], vec![]), &s, 1000);
+    let id = g
+        .apply(
+            root.physical_id(),
+            Action::new("protect-v"),
+            protected.clone(),
+            by("a"),
+        )
+        .expect("protected");
+    g.apply(
+        root.physical_id(),
+        Action::new("compile-all"),
+        refused,
+        by("b"),
+    )
+    .expect("refused");
+
+    let json = serde_json::to_string(&g).expect("serialize");
+    let back: RepresentationStateGraph = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(back, g, "byte-for-byte the same graph");
+    assert_eq!(back.policy(), TransitionPolicy::StrictlyImprovingPhysical);
+    assert_eq!(back.root(), root.physical_id());
+    assert_eq!(back.model(), &model());
+    assert_eq!(back.surface_identity(), s.identity());
+
+    let node = back.node(&id).expect("child survived");
+    assert_eq!(node.realization_count(), 2, "both facts survived");
+    assert_eq!(node.logical_bytes(), LogicalBytes::new(1000));
+    assert_eq!(back.incoming(&id).len(), 2, "both edges survived");
+    assert!(node.realization(protected.realization_id()).is_some());
+}
+
+// ------------------------------------------------------- refusals that guard
+
+#[test]
+fn an_edge_cannot_begin_at_a_state_the_graph_never_held() {
+    let s = admissible_surface();
+    let root = st(&nothing(), &s, 3000);
+    let mut g = dag(root);
+    let stranger = st(&map(&["decoder-linear"], vec![protect("q_proj")]), &s, 2500);
+    let child = st(&map(&["decoder-linear"], vec![]), &s, 1000);
+
+    let err = g
+        .apply(stranger.physical_id(), Action::new("x"), child, by("a"))
+        .expect_err("unknown parent");
+    assert!(format!("{err}").contains("never held"), "{err}");
+}
+
+#[test]
+fn one_graph_holds_one_model_and_one_surface() {
+    // A map's physical prize is a property of the model it resolves
+    // against, so a graph that mixed models would hold costs that cannot
+    // be compared.
+    let s = admissible_surface();
+    let root = st(&nothing(), &s, 3000);
+    let mut g = dag(root.clone());
+
+    let other_model = SourceIdentity {
+        graph_hash: "graph-2222".into(),
+        ..model()
+    };
+    let elsewhere = ResolvedState::new(
+        RepresentationState::resolve(
+            &other_model,
+            &s,
+            &map(&["decoder-linear"], vec![]),
+            &PackLayoutAdmission,
+        ),
+        LogicalBytes::new(1000),
+    );
+    let err = g
+        .apply(root.physical_id(), Action::new("x"), elsewhere, by("a"))
+        .expect_err("different container");
+    assert!(format!("{err}").contains("different container"), "{err}");
+
+    // Same model, different enumerated surface.
+    let grown = TensorSurface::new(
+        s.entries()
+            .iter()
+            .cloned()
+            .chain([tensor("o_proj", vec![64, 64])]),
+    )
+    .expect("distinct");
+    let err = g
+        .apply(
+            root.physical_id(),
+            Action::new("x"),
+            st(&map(&["decoder-linear"], vec![]), &grown, 1000),
+            by("a"),
+        )
+        .expect_err("different surface");
+    assert!(
+        format!("{err}").contains("different search problem"),
+        "{err}"
+    );
+}
+
+#[test]
+fn one_physical_state_cannot_be_priced_two_ways() {
+    // Two realizations that present the same bytes must agree about how
+    // many. A disagreement is a bug in whoever read the ledger, and
+    // silently keeping the first would make every downstream delta wrong
+    // by the difference.
+    let s = mixed_surface();
+    let root = st(&nothing(), &s, 3000);
+    let mut g = dag(root.clone());
+
+    g.apply(
+        root.physical_id(),
+        Action::new("protect-v"),
+        st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 1000),
+        by("a"),
+    )
+    .expect("first");
+
+    let err = g
+        .apply(
+            root.physical_id(),
+            Action::new("compile-all"),
+            st(&map(&["decoder-linear"], vec![]), &s, 900),
+            by("b"),
+        )
+        .expect_err("same physical state, different footprint");
+    assert!(format!("{err}").contains("already priced"), "{err}");
+}
+
+#[test]
+fn a_realization_names_both_of_its_identities() {
+    let s = mixed_surface();
+    let r = st(&map(&["decoder-linear"], vec![]), &s, 1000);
+    assert_eq!(r.physical_id(), r.state().id());
+    assert_eq!(r.realization_id().as_str().len(), 64);
+    assert_eq!(r.realization_id().short().len(), 12);
+    assert_eq!(
+        format!("{}", r.realization_id()),
+        r.realization_id().as_str()
+    );
+    assert_eq!(r.logical_bytes().get(), 1000);
+    assert_eq!(format!("{}", r.logical_bytes()), "1000 B");
+    assert_eq!(
+        LogicalBytes::new(900).delta_from(LogicalBytes::new(1000)),
+        -100
+    );
+}
+
+#[test]
+fn an_edge_reports_the_move_and_what_it_cost() {
+    // The record a `MeasurementKey` and an `explain(state)` will read
+    // back: what was exchanged, how many bytes it bought, and every note
+    // anyone attached — with the note kept as text so that nothing can
+    // rank on it.
+    let s = admissible_surface();
+    let root = st(&nothing(), &s, 3000);
+    let mut g = dag(root.clone());
+
+    let exchange = Action::new("−M26 +E24").removing(["M26"]).adding(["E24"]);
+    let id = g
+        .apply(
+            root.physical_id(),
+            exchange,
+            st(&map(&["decoder-linear"], vec![protect("v_proj")]), &s, 1000),
+            by("rung5/N3").noting("candidate U1, ranked first, diagnostic 2.1720e-3"),
+        )
+        .expect("exchange");
+
+    let edge = g.incoming(&id)[0];
+    assert_eq!(edge.parent(), root.physical_id());
+    assert_eq!(edge.action().label, "−M26 +E24");
+    assert_eq!(edge.action().removed, ["M26"]);
+    assert_eq!(edge.action().added, ["E24"]);
+    assert_eq!(edge.physical_delta(), -2000);
+    assert_eq!(
+        edge.provenance()[0].note.as_deref(),
+        Some("candidate U1, ranked first, diagnostic 2.1720e-3")
+    );
+    assert_eq!(g.outgoing(root.physical_id()).len(), 1);
+
+    // And the graph's own inventory answers without a lookup.
+    assert!(!g.is_empty());
+    assert_eq!(g.nodes().count(), 2);
+    assert_eq!(g.edges().count(), 1);
+    let node = g.node(&id).expect("child");
+    assert_eq!(node.physical_id(), &id);
+    assert_eq!(node.realizations().count(), 1);
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/identity.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/identity.rs
@@ -1,0 +1,178 @@
+//! **`RepresentationStateId` — the dedup key the search graph is built
+//! on.**
+//!
+//! ```text
+//! RepresentationStateId = H( model_identity,
+//!                            tensor_surface_identity,
+//!                            effective_decision_vector )
+//! ```
+//!
+//! Three inputs, each answering a question the other two cannot:
+//!
+//! * **model identity** — [`SourceIdentity`], the container's own
+//!   three-level answer (index, semantic graph, payload segments). The
+//!   same map over two models is two states, and the graph level is
+//!   what catches byte-identical payloads under different semantics.
+//! * **surface identity** — a digest of every `(object, tensor, role,
+//!   shape)`. Adding, removing, renaming or reshaping a tensor is a
+//!   different surface even when every surviving decision is unchanged.
+//! * **effective decisions** — what is presented, per tensor, with
+//!   protected and layout-refused collapsed to source precision.
+//!
+//! The model identity already covers a great deal of what the surface
+//! covers, and both are kept: `SourceIdentity` hashes a container's
+//! files, while the surface is what REPRESENT *enumerated* from them
+//! under one classification. A change to role classification moves the
+//! surface without moving a single byte on disk, and that is a genuinely
+//! different search problem — the set of maps that would compile a
+//! tensor changed.
+//!
+//! # Versioned, because the canonical form is a promise
+//!
+//! Every digest input is prefixed with [`STATE_ID_VERSION`]. A stored
+//! DAG that outlives a change to the canonical form must be recognisably
+//! stale rather than silently colliding with new states, and the
+//! alternative — a bare hash whose meaning drifts — is how a persisted
+//! search state starts answering questions about a scheme it was not
+//! built under.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::compile::hash_bytes;
+use super::super::compiler::SourceIdentity;
+use super::super::map::PrecisionMap;
+use super::resolved::{resolve, LayoutAdmission, ResolvedDecisionVector};
+use super::surface::{TensorSurface, FIELD, RECORD, SECTION};
+
+/// The canonical-form version every state id is computed under.
+pub const STATE_ID_VERSION: &str = "represent-state-id/v1";
+
+/// **What a representation state IS.** Opaque by construction: it is a
+/// digest and there is nothing to read out of it, which is the point —
+/// a consumer that wants to know what a state decides asks the decision
+/// vector, not the key.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct RepresentationStateId(String);
+
+impl RepresentationStateId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// First twelve hex characters, for reports and log lines.
+    pub fn short(&self) -> &str {
+        &self.0[..self.0.len().min(12)]
+    }
+}
+
+impl std::fmt::Display for RepresentationStateId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// **A node's immutable truth.**
+///
+/// Deliberately carries no measurement, no contract, no visit count and
+/// no history. Evidence describes a state and mutable search statistics
+/// are the policy's business; both are keyed BY the id and neither is
+/// part of it. Keeping them out is what lets two paths that reach the
+/// same decisions converge on one node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepresentationState {
+    id: RepresentationStateId,
+    model: SourceIdentity,
+    surface_identity: String,
+    decisions: ResolvedDecisionVector,
+}
+
+impl RepresentationState {
+    /// Resolve `map` against `surface` and identify the result.
+    ///
+    /// The map itself is not retained. It is one witness rule set among
+    /// however many resolve identically, and keeping it on the node
+    /// would invite exactly the confusion this type exists to prevent —
+    /// a reader treating one arbitrary recipe as *the* recipe. The DAG's
+    /// incoming edges are where recipes belong.
+    pub fn resolve(
+        model: &SourceIdentity,
+        surface: &TensorSurface,
+        map: &PrecisionMap,
+        layout: &dyn LayoutAdmission,
+    ) -> Self {
+        Self::from_decisions(model, surface, resolve(map, surface, layout))
+    }
+
+    /// Identify an already-resolved decision vector.
+    ///
+    /// For a caller that read the decisions out of a built container
+    /// rather than resolving a map — the check that a compiled artifact
+    /// is the state the search believes it measured.
+    pub fn from_decisions(
+        model: &SourceIdentity,
+        surface: &TensorSurface,
+        decisions: ResolvedDecisionVector,
+    ) -> Self {
+        let surface_identity = surface.identity();
+        let id = RepresentationStateId(hash_bytes(
+            digest_input(model, &surface_identity, &decisions).as_bytes(),
+        ));
+        Self {
+            id,
+            model: model.clone(),
+            surface_identity,
+            decisions,
+        }
+    }
+
+    pub fn id(&self) -> &RepresentationStateId {
+        &self.id
+    }
+
+    pub fn model(&self) -> &SourceIdentity {
+        &self.model
+    }
+
+    pub fn surface_identity(&self) -> &str {
+        &self.surface_identity
+    }
+
+    pub fn decisions(&self) -> &ResolvedDecisionVector {
+        &self.decisions
+    }
+}
+
+/// The exact bytes the state digest is taken over.
+///
+/// Written out as one function so the canonical form is stated in a
+/// single place a reader can check against the doc comment, rather than
+/// implied by the order of calls at three call sites.
+fn digest_input(
+    model: &SourceIdentity,
+    surface_identity: &str,
+    decisions: &ResolvedDecisionVector,
+) -> String {
+    format!(
+        "{STATE_ID_VERSION}{SECTION}model={}{SECTION}surface={surface_identity}{SECTION}decisions={}",
+        model_canonical(model),
+        decisions.canonical()
+    )
+}
+
+/// A container's identity as one canonical string.
+///
+/// All three levels, because they can disagree independently and an
+/// overlay depends on all three: payload segments alone would miss a
+/// changed semantic graph over identical bytes.
+fn model_canonical(model: &SourceIdentity) -> String {
+    let segments = model
+        .segments
+        .iter()
+        .map(|(seg, hash)| format!("{seg}{FIELD}{hash}"))
+        .collect::<Vec<_>>()
+        .join(&RECORD.to_string());
+    format!(
+        "{}{FIELD}{}{RECORD}{segments}",
+        model.manifest_hash, model.graph_hash
+    )
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/instrument.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/instrument.rs
@@ -1,0 +1,134 @@
+//! **What the measurement MEANS, not which binary took it.**
+//!
+//! The tempting identity is a version string — `"diagnostic-kl-v1"` —
+//! and it fails in both directions. It moves when a refactor changes
+//! nothing observable, splitting a state's evidence for no reason; and
+//! it stays put when someone changes the truncation, silently making two
+//! incomparable readings look like a repeat.
+//!
+//! ```text
+//! implementation refactor, same semantics   →  SAME id
+//! different truncation                      →  different id
+//! different aggregation                     →  different id
+//! different token selection                 →  different id
+//! different metric definition               →  different id
+//! different procedure                       →  different id
+//! ```
+//!
+//! So the identity is a digest of *declared semantics*. Truncation is
+//! the concrete case this programme already paid for: the Q2a harness
+//! runs at `TOP_N = 2048`, and `QualityBank::min_covered_mass` exists
+//! because a KL over a truncation covering a third of the mass is a
+//! different measurement from one covering all of it — top-128 covered
+//! 0.307 of a first position, top-2048 covered 0.729. Two runs at
+//! different `top_n` are not repeats of each other and a key that could
+//! not tell them apart would say they were.
+//!
+//! # The limit, stated rather than papered over
+//!
+//! A declaration can lie. Change the runner's truncation without
+//! changing the [`InstrumentSemantics`] it reports and the id does not
+//! move, and nothing here can detect that. The mitigation is
+//! construction, not validation: build the declaration FROM the
+//! constants the runner uses rather than typing them twice. This module
+//! makes that possible and cannot make it mandatory, and a reader should
+//! know which of the two they are relying on.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::compile::hash_bytes;
+use super::surface::{FIELD, SECTION};
+
+/// The canonical-form version every instrument id is computed under.
+pub const INSTRUMENT_SEMANTICS_ID_VERSION: &str = "instrument-semantics-id/v1";
+
+/// **What an instrument MEANS**, as a digest of its declared semantics.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct InstrumentSemanticsId(String);
+
+impl InstrumentSemanticsId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn short(&self) -> &str {
+        &self.0[..self.0.len().min(12)]
+    }
+}
+
+impl std::fmt::Display for InstrumentSemanticsId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The measurement's meaning: every choice that changes what a reading
+/// is, and none that do not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstrumentSemantics {
+    /// What is computed, e.g. `"kl(baseline || candidate)"`.
+    pub metric: String,
+    /// Distribution truncation the metric was taken over. `None` is
+    /// untruncated and is NOT the same as a large `Some` — one is a
+    /// claim about the whole distribution, the other about a window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncation: Option<u32>,
+    /// How per-position readings become one number, e.g.
+    /// `"distribution{min,p50,p95,p99,max}"`.
+    pub aggregation: String,
+    /// Which positions contributed, e.g. `"teacher-forced, all
+    /// positions"`.
+    pub token_selection: String,
+    /// The two-arm procedure the reading was taken under, e.g.
+    /// `"q2a-teacher-forced/baseline-vs-overlay"`.
+    pub procedure: String,
+    /// Free text about the implementation — a commit, a binary, a
+    /// machine. **Excluded from the digest**: a refactor that changes
+    /// nothing observable must not split a state's evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub implementation_note: Option<String>,
+}
+
+impl InstrumentSemantics {
+    pub fn new(
+        metric: impl Into<String>,
+        aggregation: impl Into<String>,
+        token_selection: impl Into<String>,
+        procedure: impl Into<String>,
+    ) -> Self {
+        Self {
+            metric: metric.into(),
+            truncation: None,
+            aggregation: aggregation.into(),
+            token_selection: token_selection.into(),
+            procedure: procedure.into(),
+            implementation_note: None,
+        }
+    }
+
+    /// Declare the truncation. Pass the runner's own constant rather
+    /// than a literal, so the declaration cannot drift from the code.
+    pub fn truncated_to(mut self, top_n: u32) -> Self {
+        self.truncation = Some(top_n);
+        self
+    }
+
+    pub fn implemented_by(mut self, note: impl Into<String>) -> Self {
+        self.implementation_note = Some(note.into());
+        self
+    }
+
+    /// What this instrument MEANS.
+    pub fn id(&self) -> InstrumentSemanticsId {
+        let truncation = match self.truncation {
+            Some(n) => n.to_string(),
+            None => "untruncated".to_string(),
+        };
+        let input = format!(
+            "{INSTRUMENT_SEMANTICS_ID_VERSION}{SECTION}metric={}{FIELD}truncation={truncation}\
+             {FIELD}aggregation={}{FIELD}tokens={}{FIELD}procedure={}",
+            self.metric, self.aggregation, self.token_selection, self.procedure
+        );
+        InstrumentSemanticsId(hash_bytes(input.as_bytes()))
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/key.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/key.rs
@@ -40,14 +40,14 @@
 //!
 //! The key says *what experiment was performed against what state*; it
 //! does not say what the result meant. Classification stays downstream —
-//! [`Margin`] and [`Frontier`] price an observation against a gate, and
-//! [`decide_promotion`] rules on it — so that a later contract, or a
+//! [`Margin`] and [`ConstraintVector`] price an observation against a
+//! gate, and [`decide_promotion`] rules on it — so that a later contract, or a
 //! later promotion policy, reinterprets observations already held
 //! instead of making them disappear. A key carrying the verdict would
 //! turn every re-reading of old evidence into a re-measurement.
 //!
 //! [`Margin`]: super::super::constraint::Margin
-//! [`Frontier`]: super::super::constraint::Frontier
+//! [`ConstraintVector`]: super::super::constraint::ConstraintVector
 //! [`decide_promotion`]: super::super::decision::decide_promotion
 
 use std::collections::BTreeMap;

--- a/crates/larql-vindex/src/format/vindex3/represent/state/key.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/key.rs
@@ -1,0 +1,280 @@
+//! **`MeasurementKey` — have we already run THIS experiment against
+//! THIS physical state?**
+//!
+//! R5-F3 registered the shape and the correction that makes it work:
+//! dedup on a bare map hash would be wrong, because it would forbid the
+//! diagnostic → authority escalation the whole ladder depends on.
+//!
+//! ```text
+//! state_id    which physical representation was measured
+//! bank        which samples it was measured over
+//! scale       whether the reading may be priced against a contract
+//! instrument  what the measurement MEANS
+//! ```
+//!
+//! ```text
+//! recipes       are transactions
+//! states        are what exists
+//! measurements  are cached observations, keyed by state + query conditions
+//! ```
+//!
+//! # The join with 1a and 1b
+//!
+//! The key reads the PHYSICAL id, and that is the whole point of the two
+//! identities:
+//!
+//! ```text
+//! RealizationId differs, RepresentationStateId same
+//!     action search    → distinguish
+//!     measurement      → collapse, reuse the observation
+//! ```
+//!
+//! A protected tensor and a layout-refused one present identical bytes,
+//! so a measurement of one IS a measurement of the other, while the moves
+//! available from each still differ. Evidence deduplicates more
+//! aggressively than search does, and this is where that cashes out.
+//!
+//! # What is deliberately absent
+//!
+//! No PASS/FAIL. No promotion status. No contract.
+//!
+//! The key says *what experiment was performed against what state*; it
+//! does not say what the result meant. Classification stays downstream —
+//! [`Margin`] and [`Frontier`] price an observation against a gate, and
+//! [`decide_promotion`] rules on it — so that a later contract, or a
+//! later promotion policy, reinterprets observations already held
+//! instead of making them disappear. A key carrying the verdict would
+//! turn every re-reading of old evidence into a re-measurement.
+//!
+//! [`Margin`]: super::super::constraint::Margin
+//! [`Frontier`]: super::super::constraint::Frontier
+//! [`decide_promotion`]: super::super::decision::decide_promotion
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::super::compile::hash_bytes;
+use super::super::measurement::EvidenceScale;
+use super::super::quality::QualityBank;
+use super::evidence_bank::EvidenceBankId;
+use super::identity::RepresentationStateId;
+use super::instrument::InstrumentSemanticsId;
+use super::surface::{FIELD, SECTION};
+use crate::error::VindexError;
+
+/// The canonical-form version every key is computed under.
+pub const MEASUREMENT_KEY_VERSION: &str = "measurement-key/v1";
+
+/// **What makes two observations the same observation.**
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MeasurementKey {
+    state: RepresentationStateId,
+    bank: EvidenceBankId,
+    scale: EvidenceScale,
+    instrument: InstrumentSemanticsId,
+    /// The digest of the four above. Ordering is by this, so the key can
+    /// index a registry without [`EvidenceScale`] having to grow an
+    /// ordering it has no meaning for.
+    digest: String,
+}
+
+impl MeasurementKey {
+    pub fn new(
+        state: &RepresentationStateId,
+        bank: &EvidenceBankId,
+        scale: EvidenceScale,
+        instrument: &InstrumentSemanticsId,
+    ) -> Self {
+        let scale_name = match scale {
+            EvidenceScale::Diagnostic => "diagnostic",
+            EvidenceScale::Authority => "authority",
+        };
+        let input = format!(
+            "{MEASUREMENT_KEY_VERSION}{SECTION}state={state}{FIELD}bank={bank}{FIELD}\
+             scale={scale_name}{FIELD}instrument={instrument}"
+        );
+        Self {
+            state: state.clone(),
+            bank: bank.clone(),
+            scale,
+            instrument: instrument.clone(),
+            digest: hash_bytes(input.as_bytes()),
+        }
+    }
+
+    pub fn state(&self) -> &RepresentationStateId {
+        &self.state
+    }
+
+    pub fn bank(&self) -> &EvidenceBankId {
+        &self.bank
+    }
+
+    pub fn scale(&self) -> EvidenceScale {
+        self.scale
+    }
+
+    pub fn instrument(&self) -> &InstrumentSemanticsId {
+        &self.instrument
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.digest
+    }
+
+    pub fn short(&self) -> &str {
+        &self.digest[..self.digest.len().min(12)]
+    }
+}
+
+impl std::fmt::Display for MeasurementKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.digest)
+    }
+}
+
+impl PartialOrd for MeasurementKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for MeasurementKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.digest.cmp(&other.digest)
+    }
+}
+
+/// **Observations, keyed by what they observed.**
+///
+/// Holds [`QualityBank`]s — the readings — and nothing about what they
+/// meant. A registry that also stored verdicts would have to be
+/// invalidated whenever a contract moved; this one does not.
+///
+/// Serialises as a LIST of records rather than a map. A key is four
+/// identities, not a string, and flattening it to one so it could be a
+/// JSON object key would throw away the parts a reader needs to see why
+/// two observations are distinct.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(into = "RegistryRecords", try_from = "RegistryRecords")]
+pub struct MeasurementRegistry {
+    observations: BTreeMap<MeasurementKey, QualityBank>,
+}
+
+/// The persisted shape.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct RegistryRecords {
+    observations: Vec<RegistryRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RegistryRecord {
+    key: MeasurementKey,
+    observation: QualityBank,
+}
+
+impl From<MeasurementRegistry> for RegistryRecords {
+    fn from(registry: MeasurementRegistry) -> Self {
+        Self {
+            observations: registry
+                .observations
+                .into_iter()
+                .map(|(key, observation)| RegistryRecord { key, observation })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<RegistryRecords> for MeasurementRegistry {
+    type Error = VindexError;
+
+    /// Refuses a file that names one experiment twice.
+    ///
+    /// The in-memory registry cannot hold a duplicate, so a stored one
+    /// carrying two records under a single key was written by something
+    /// that bypassed [`MeasurementRegistry::record`] — and loading it
+    /// would silently keep whichever came last.
+    fn try_from(records: RegistryRecords) -> Result<Self, Self::Error> {
+        let mut observations = BTreeMap::new();
+        for record in records.observations {
+            let short = record.key.short().to_string();
+            if observations
+                .insert(record.key, record.observation)
+                .is_some()
+            {
+                return Err(VindexError::Parse(format!(
+                    "measurement {short} is recorded twice — a stored registry that names one \
+                     experiment twice was not written by `record`, and loading it would keep \
+                     whichever came last"
+                )));
+            }
+        }
+        Ok(Self { observations })
+    }
+}
+
+impl MeasurementRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether this exact experiment has already been run.
+    pub fn contains(&self, key: &MeasurementKey) -> bool {
+        self.observations.contains_key(key)
+    }
+
+    pub fn get(&self, key: &MeasurementKey) -> Option<&QualityBank> {
+        self.observations.get(key)
+    }
+
+    pub fn len(&self) -> usize {
+        self.observations.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.observations.is_empty()
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &MeasurementKey> {
+        self.observations.keys()
+    }
+
+    /// Every observation of one physical state, whatever bank, scale or
+    /// instrument produced it.
+    pub fn of_state<'a>(
+        &'a self,
+        state: &'a RepresentationStateId,
+    ) -> impl Iterator<Item = (&'a MeasurementKey, &'a QualityBank)> + 'a {
+        self.observations
+            .iter()
+            .filter(move |(k, _)| &k.state == state)
+    }
+
+    /// **Record an observation, refusing a contradiction.**
+    ///
+    /// Re-recording an identical reading is a no-op: that is a control
+    /// witness reproducing, which is exactly what a replayed round should
+    /// do. A DIFFERENT reading under the same key is not a duplicate — it
+    /// says the experiment is not reproducible, and quietly keeping
+    /// either one would hide that. The refusal is the finding.
+    pub fn record(
+        &mut self,
+        key: MeasurementKey,
+        observation: QualityBank,
+    ) -> Result<(), VindexError> {
+        match self.observations.get(&key) {
+            Some(held) if held == &observation => Ok(()),
+            Some(_) => Err(VindexError::Parse(format!(
+                "measurement {} is already held with a different reading — the same state, \
+                 bank, scale and instrument produced two different observations, so the \
+                 experiment is not reproducible and neither reading may silently win",
+                key.short()
+            ))),
+            None => {
+                self.observations.insert(key, observation);
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/key_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/key_tests.rs
@@ -1,0 +1,506 @@
+//! **1c: what counts as the same experiment.**
+//!
+//! The reason `MeasurementKey` exists is R5-F3 — the exchange search
+//! re-derived a map it had already measured and rejected, under another
+//! name — and the reason it is not keyed on a bare state id is the
+//! correction that came with it: a diagnostic reading and an authority
+//! reading of one state are two experiments, and a key that could not
+//! tell them apart would forbid the escalation the ladder is built on.
+
+use std::collections::BTreeMap;
+
+use super::super::compiler::SourceIdentity;
+use super::super::map::{Exception, PrecisionMap};
+use super::super::measurement::EvidenceScale;
+use super::super::nvfp4_pack::DTYPE_NVFP4;
+use super::super::policy::Role;
+use super::super::quality::{Distribution, LogitEvidence, QualityBank, RoutingEvidence};
+use super::*;
+
+// ---------------------------------------------------------------- fixtures
+
+fn model() -> SourceIdentity {
+    SourceIdentity {
+        manifest_hash: "manifest-aaaa".into(),
+        graph_hash: "graph-1111".into(),
+        segments: BTreeMap::from([("target.decoder_stack".to_string(), "seg-dddd".to_string())]),
+    }
+}
+
+fn tensor(projection: &str, shape: Vec<usize>) -> SurfaceTensor {
+    SurfaceTensor::new(
+        "target.decoder_stack",
+        format!("0.self_attn.{projection}.weight"),
+        Role::DecoderLinear,
+        shape,
+    )
+}
+
+/// q admissible, v refused by the layout — the surface that produces two
+/// realizations of one physical state.
+fn surface() -> TensorSurface {
+    TensorSurface::new([
+        tensor("q_proj", vec![64, 64]),
+        tensor("v_proj", vec![64, 24]),
+    ])
+    .expect("distinct tensors")
+}
+
+fn map(exceptions: Vec<Exception>) -> PrecisionMap {
+    PrecisionMap {
+        name: "m".into(),
+        encoding: DTYPE_NVFP4.into(),
+        roles: vec!["decoder-linear".into()],
+        exceptions,
+    }
+}
+
+fn state(m: &PrecisionMap) -> RepresentationState {
+    RepresentationState::resolve(&model(), &surface(), m, &PackLayoutAdmission)
+}
+
+/// The 256 × 32 selection bank, as the Q2a report records it.
+fn selection_bank() -> EvidenceBank {
+    EvidenceBank::new(
+        "kimi-teacher-forced/v1",
+        "17d59a6b",
+        (0..256).map(|i| format!("seq-{i:03}")),
+        32,
+    )
+    .found_at("/tmp/kimi_quality_bank")
+    .described("256 x 32-position teacher-forced sequences from real prose")
+}
+
+/// The 32-sequence slice the diagnostic runs over.
+fn diagnostic_slice() -> EvidenceBank {
+    EvidenceBank::new(
+        "kimi-teacher-forced/v1",
+        "17d59a6b",
+        (0..32).map(|i| format!("seq-{i:03}")),
+        32,
+    )
+}
+
+fn instrument() -> InstrumentSemantics {
+    InstrumentSemantics::new(
+        "kl(baseline || candidate)",
+        "distribution{min,p50,p95,p99,max}",
+        "teacher-forced, all positions",
+        "q2a-teacher-forced/baseline-vs-overlay",
+    )
+    .truncated_to(2048)
+}
+
+fn dist(p99: f64) -> Option<Distribution> {
+    Some(Distribution {
+        count: 1,
+        min: 0.0,
+        p50: 0.0,
+        p95: 0.0,
+        p99,
+        max: p99,
+    })
+}
+
+fn observation(kl_p99: f64) -> QualityBank {
+    QualityBank {
+        positions: 8192,
+        logits: LogitEvidence {
+            kl_p50: 0.0,
+            kl_p95: 0.0,
+            kl_p99,
+            max_logit_delta: 0.0,
+            top1_flips: 129,
+            top10_changes: 2527,
+        },
+        routing: RoutingEvidence {
+            route_flips: 1305,
+            positions_with_route_change: 0,
+            layers_with_route_change: 0,
+            first_layer_with_route_change: None,
+            route_margin: None,
+            route_weight_mass_moved: dist(0.1993),
+        },
+        min_covered_mass: Some(0.6315),
+        top10_margin: None,
+        top10_candidate_margin: None,
+        top10_mass_displaced: dist(0.0646),
+        top10_rank_displacement: None,
+        top1_margin: None,
+        top1_candidate_margin: None,
+        top1_mass_displaced: dist(0.0554),
+    }
+}
+
+fn key(
+    s: &RepresentationState,
+    bank: &EvidenceBank,
+    scale: EvidenceScale,
+    inst: &InstrumentSemantics,
+) -> MeasurementKey {
+    MeasurementKey::new(s.id(), &bank.id(), scale, &inst.id())
+}
+
+/// A registry holding one diagnostic reading of `s`.
+fn registry_with(s: &RepresentationState) -> (MeasurementRegistry, MeasurementKey) {
+    let k = key(
+        s,
+        &selection_bank(),
+        EvidenceScale::Diagnostic,
+        &instrument(),
+    );
+    let mut r = MeasurementRegistry::new();
+    r.record(k.clone(), observation(2.5262e-3)).expect("record");
+    (r, k)
+}
+
+// --------------------------------------------------- the five dedup cases
+
+#[test]
+fn the_same_experiment_on_the_same_state_is_reused() {
+    let s = state(&map(vec![]));
+    let (r, k) = registry_with(&s);
+
+    let again = key(
+        &s,
+        &selection_bank(),
+        EvidenceScale::Diagnostic,
+        &instrument(),
+    );
+    assert_eq!(again, k);
+    assert!(
+        r.contains(&again),
+        "already measured — do not spend it again"
+    );
+    assert_eq!(r.get(&again).expect("held").logits.kl_p99, 2.5262e-3);
+}
+
+#[test]
+fn authority_is_not_deduplicated_against_diagnostic() {
+    // The correction R5-F3 came with: dedup on the state alone would
+    // forbid the escalation the whole ladder depends on.
+    let s = state(&map(vec![]));
+    let (r, _) = registry_with(&s);
+
+    let authority = key(
+        &s,
+        &selection_bank(),
+        EvidenceScale::Authority,
+        &instrument(),
+    );
+    assert!(
+        !r.contains(&authority),
+        "a diagnostic reading is not an authority reading of the same state"
+    );
+}
+
+#[test]
+fn a_different_bank_is_not_deduplicated() {
+    let s = state(&map(vec![]));
+    let (r, _) = registry_with(&s);
+
+    // Same corpus, same manifest — a 32-of-256 SLICE. The manifest
+    // digest alone would have called this a repeat; it is the difference
+    // between a diagnostic and an authority run.
+    let sliced = diagnostic_slice();
+    assert_eq!(
+        sliced.manifest_sha256,
+        selection_bank().manifest_sha256,
+        "same corpus"
+    );
+    assert_ne!(sliced.id(), selection_bank().id(), "different samples");
+    assert!(!r.contains(&key(&s, &sliced, EvidenceScale::Diagnostic, &instrument())));
+
+    assert_eq!(selection_bank().positions(), 8192, "256 x 32");
+    assert_eq!(sliced.positions(), 1024);
+}
+
+#[test]
+fn different_instrument_semantics_are_not_deduplicated() {
+    let s = state(&map(vec![]));
+    let (r, _) = registry_with(&s);
+
+    // `min_covered_mass` exists because a KL over a truncation covering
+    // a third of the mass is a different measurement from one covering
+    // all of it — top-128 saw 0.307 of a first position, top-2048 0.729.
+    let narrower = instrument().truncated_to(128);
+    assert_ne!(narrower.id(), instrument().id());
+    assert!(!r.contains(&key(
+        &s,
+        &selection_bank(),
+        EvidenceScale::Diagnostic,
+        &narrower
+    )));
+}
+
+#[test]
+fn a_different_realization_of_one_physical_state_reuses_the_measurement() {
+    // **The case that joins 1a, 1b and 1c.** `v_proj` is held at source
+    // precision by a protection in one map and by a layout refusal in the
+    // other. Different realizations, one physical state:
+    //
+    //     action search   →  distinguish
+    //     measurement     →  collapse
+    let protected = state(&map(vec![Exception {
+        projection: Some("v_proj".into()),
+        layers: None,
+        encoding: None,
+    }]));
+    let refused = state(&map(vec![]));
+
+    let a = ResolvedState::new(protected.clone(), LogicalBytes::new(1000));
+    let b = ResolvedState::new(refused.clone(), LogicalBytes::new(1000));
+    assert_eq!(a.physical_id(), b.physical_id(), "one physical state");
+    assert_ne!(a.realization_id(), b.realization_id(), "two realizations");
+
+    let (r, _) = registry_with(&protected);
+    let from_the_other = key(
+        &refused,
+        &selection_bank(),
+        EvidenceScale::Diagnostic,
+        &instrument(),
+    );
+    assert!(
+        r.contains(&from_the_other),
+        "the same bytes were measured; the reading is the other one's too"
+    );
+}
+
+// ------------------------------------------- identity, not provenance
+
+#[test]
+fn a_bank_that_moved_disk_is_the_same_bank() {
+    // /tmp has proven ephemeral. A registry that treated a relocated
+    // bank as a new one would re-run twenty minutes of instrument time
+    // to learn what it already knew — and the same rule
+    // `SourceDependency` states for containers.
+    let here = selection_bank();
+    let moved = EvidenceBank::new(
+        here.schema.clone(),
+        here.manifest_sha256.clone(),
+        here.samples.clone(),
+        here.positions_per_sample,
+    )
+    .found_at("~/chris-models/qbanks/kimi-quality-bank-256x32")
+    .described("re-exported after the /tmp clear");
+
+    assert_ne!(here.locator_hint, moved.locator_hint);
+    assert_ne!(here.description, moved.description);
+    assert_eq!(here.id(), moved.id(), "content, not location");
+
+    let s = state(&map(vec![]));
+    let (r, _) = registry_with(&s);
+    assert!(r.contains(&key(&s, &moved, EvidenceScale::Diagnostic, &instrument())));
+}
+
+#[test]
+fn an_implementation_note_is_not_measurement_semantics() {
+    // A refactor that changes nothing observable must not split a
+    // state's evidence.
+    let refactored = instrument().implemented_by("rewritten in the new executor, 6bec0b43");
+    assert_ne!(
+        refactored.implementation_note,
+        instrument().implementation_note
+    );
+    assert_eq!(refactored.id(), instrument().id());
+
+    let s = state(&map(vec![]));
+    let (r, _) = registry_with(&s);
+    assert!(r.contains(&key(
+        &s,
+        &selection_bank(),
+        EvidenceScale::Diagnostic,
+        &refactored
+    )));
+}
+
+#[test]
+fn every_semantic_field_moves_the_instrument_id() {
+    // The other direction: each of these changes what a reading IS.
+    let base = instrument().id();
+    let variants = [
+        InstrumentSemantics::new("nll", "d", "t", "p"),
+        InstrumentSemantics::new("m", "p50-only", "t", "p"),
+        InstrumentSemantics::new("m", "d", "final position only", "p"),
+        InstrumentSemantics::new("m", "d", "t", "single-arm"),
+    ];
+    for v in &variants {
+        assert_ne!(v.id(), base);
+    }
+    // Untruncated is not a large truncation: one is a claim about the
+    // whole distribution, the other about a window.
+    let untruncated = InstrumentSemantics::new(
+        "kl(baseline || candidate)",
+        "distribution{min,p50,p95,p99,max}",
+        "teacher-forced, all positions",
+        "q2a-teacher-forced/baseline-vs-overlay",
+    );
+    assert!(untruncated.truncation.is_none());
+    assert_ne!(untruncated.id(), base);
+}
+
+#[test]
+fn a_bank_is_its_samples_in_order_not_a_count() {
+    // A different 32 of the same 256 is a different experiment, and a
+    // count cannot say which 32.
+    let a = EvidenceBank::new("s", "m", ["seq-000", "seq-001"], 32);
+    let b = EvidenceBank::new("s", "m", ["seq-000", "seq-002"], 32);
+    let reordered = EvidenceBank::new("s", "m", ["seq-001", "seq-000"], 32);
+    assert_eq!(a.sample_count(), b.sample_count());
+    assert_ne!(a.id(), b.id(), "different samples");
+    assert_ne!(a.id(), reordered.id(), "order is part of the bank");
+    assert_ne!(
+        a.id(),
+        EvidenceBank::new("s", "m", ["seq-000", "seq-001"], 16).id(),
+        "half the positions per sample is half the experiment"
+    );
+    assert_ne!(
+        a.id(),
+        EvidenceBank::new("other-schema", "m", ["seq-000", "seq-001"], 32).id()
+    );
+    assert_ne!(
+        a.id(),
+        EvidenceBank::new("s", "other-manifest", ["seq-000", "seq-001"], 32).id()
+    );
+}
+
+// ------------------------------------------------------------- registry
+
+#[test]
+fn re_recording_a_reproduced_reading_is_a_no_op_and_a_contradiction_is_refused() {
+    let s = state(&map(vec![]));
+    let (mut r, k) = registry_with(&s);
+    assert_eq!(r.len(), 1);
+
+    // A control witness reproducing is exactly what a replayed round
+    // should do.
+    r.record(k.clone(), observation(2.5262e-3))
+        .expect("a reproduced reading");
+    assert_eq!(r.len(), 1);
+
+    // A different reading under the same key says the experiment is not
+    // reproducible. Silently keeping either would hide that.
+    let err = r
+        .record(k.clone(), observation(3.3532e-3))
+        .expect_err("two readings, one key");
+    assert!(format!("{err}").contains("not reproducible"), "{err}");
+    assert_eq!(
+        r.get(&k).expect("held").logits.kl_p99,
+        2.5262e-3,
+        "the held reading is unchanged"
+    );
+}
+
+#[test]
+fn a_registry_answers_what_is_known_about_one_state() {
+    let s = state(&map(vec![]));
+    let (mut r, _) = registry_with(&s);
+    r.record(
+        key(
+            &s,
+            &selection_bank(),
+            EvidenceScale::Authority,
+            &instrument(),
+        ),
+        observation(3.3532e-3),
+    )
+    .expect("authority");
+    let other = state(&map(vec![Exception {
+        projection: Some("q_proj".into()),
+        layers: None,
+        encoding: None,
+    }]));
+    r.record(
+        key(
+            &other,
+            &selection_bank(),
+            EvidenceScale::Diagnostic,
+            &instrument(),
+        ),
+        observation(1.0e-3),
+    )
+    .expect("another state");
+
+    assert_eq!(r.len(), 3);
+    assert!(!r.is_empty());
+    assert_eq!(r.of_state(s.id()).count(), 2, "diagnostic and authority");
+    assert_eq!(r.of_state(other.id()).count(), 1);
+    assert_eq!(r.keys().count(), 3);
+
+    let scales: Vec<EvidenceScale> = r.of_state(s.id()).map(|(k, _)| k.scale()).collect();
+    assert!(scales.contains(&EvidenceScale::Diagnostic));
+    assert!(scales.contains(&EvidenceScale::Authority));
+}
+
+#[test]
+fn a_key_names_its_four_parts_and_orders_by_its_digest() {
+    let s = state(&map(vec![]));
+    let bank = selection_bank();
+    let inst = instrument();
+    let k = key(&s, &bank, EvidenceScale::Authority, &inst);
+
+    assert_eq!(k.state(), s.id());
+    assert_eq!(k.bank(), &bank.id());
+    assert_eq!(k.scale(), EvidenceScale::Authority);
+    assert_eq!(k.instrument(), &inst.id());
+    assert_eq!(k.as_str().len(), 64);
+    assert_eq!(k.short().len(), 12);
+    assert_eq!(format!("{k}"), k.as_str());
+
+    let diagnostic = key(&s, &bank, EvidenceScale::Diagnostic, &inst);
+    assert_ne!(k, diagnostic);
+    assert_eq!(k.cmp(&diagnostic), k.as_str().cmp(diagnostic.as_str()));
+    assert_eq!(k.partial_cmp(&diagnostic), Some(k.cmp(&diagnostic)));
+
+    assert!(MEASUREMENT_KEY_VERSION.starts_with("measurement-key/"));
+    assert!(EVIDENCE_BANK_ID_VERSION.starts_with("evidence-bank-id/"));
+    assert!(INSTRUMENT_SEMANTICS_ID_VERSION.starts_with("instrument-semantics-id/"));
+    assert_eq!(bank.id().short().len(), 12);
+    assert_eq!(format!("{}", bank.id()), bank.id().as_str());
+    assert_eq!(inst.id().short().len(), 12);
+    assert_eq!(format!("{}", inst.id()), inst.id().as_str());
+}
+
+#[test]
+fn a_registry_survives_serialization() {
+    let s = state(&map(vec![]));
+    let (r, k) = registry_with(&s);
+    let json = serde_json::to_string(&r).expect("serialize");
+    let back: MeasurementRegistry = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, r);
+    assert!(back.contains(&k));
+    assert_eq!(MeasurementRegistry::default().len(), 0);
+
+    // A list of records, not a map: a key is four identities, and
+    // flattening it to a JSON object key would throw away the parts a
+    // reader needs to see WHY two observations are distinct.
+    let doc: serde_json::Value = serde_json::from_str(&json).expect("json");
+    let record = &doc["observations"][0];
+    assert_eq!(record["key"]["state"], s.id().as_str());
+    assert_eq!(record["key"]["scale"], "Diagnostic");
+    assert_eq!(record["key"]["bank"], selection_bank().id().as_str());
+    assert!(record["observation"]["logits"]["kl_p99"].is_number());
+    assert!(
+        record["key"].get("verdict").is_none() && record["key"].get("contract").is_none(),
+        "a key says what was measured, never what it meant"
+    );
+}
+
+#[test]
+fn a_stored_registry_naming_one_experiment_twice_is_refused() {
+    // The in-memory registry cannot hold a duplicate, so a file with one
+    // was written by something that bypassed `record` — and loading it
+    // would silently keep whichever came last.
+    let s = state(&map(vec![]));
+    let (r, _) = registry_with(&s);
+    let mut doc: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&r).expect("serialize")).expect("json");
+    let first = doc["observations"][0].clone();
+    doc["observations"]
+        .as_array_mut()
+        .expect("array")
+        .push(first);
+
+    let err = serde_json::from_value::<MeasurementRegistry>(doc).expect_err("duplicate key");
+    assert!(format!("{err}").contains("recorded twice"), "{err}");
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/realization.rs
@@ -1,0 +1,162 @@
+//! **Physical identity is not search-context identity.**
+//!
+//! Stage 1a collapses a protected tensor and a layout-refused tensor
+//! into one [`RepresentationStateId`], and that is correct: they present
+//! the same bytes, so a measurement of one is a measurement of the
+//! other. It is also, on its own, an information-loss bug waiting to
+//! happen, because the two are not *action*-equivalent:
+//!
+//! ```text
+//!                  physical equivalence
+//!                          │
+//!                 RepresentationStateId
+//!                    ↑                ↑
+//!          realization A        realization B
+//!          X = Source           X = LayoutRefused
+//!                    │                │
+//!          "unprotect X" is    nothing can compile X;
+//!          a legal move        the layout refuses it
+//! ```
+//!
+//! So the graph holds two keys and keeps them straight:
+//!
+//! ```text
+//! RepresentationStateId   what is PRESENTED   → evidence, MeasurementKey
+//! RealizationId           what is DECIDED     → the action generator
+//! ```
+//!
+//! **Evidence may deduplicate more aggressively than search may.** A
+//! node is one physical state and may carry several realizations; a
+//! measurement belongs to the node, an action space belongs to a
+//! realization. Merging the second into the first would let an
+//! optimizer believe it can remove a structural refusal.
+//!
+//! The invariant tying them together — *same realization implies same
+//! physical state* — holds by construction, because
+//! [`ResolvedDecisionVector::canonical_full`] refines
+//! [`ResolvedDecisionVector::canonical`], and is tested rather than
+//! merely asserted here.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::compile::hash_bytes;
+use super::identity::{RepresentationState, RepresentationStateId, STATE_ID_VERSION};
+use super::surface::SECTION;
+
+/// **The whole-map logical footprint of one state.**
+///
+/// A newtype, and not a bare `u64`, because this programme has already
+/// paid for confusing three different byte quantities:
+///
+/// ```text
+/// logical footprint   what a MAP costs           this type
+/// per-token read      what a DECODER reads       ByteLedger
+/// saving              a DIFFERENCE of footprints Transition::physical_delta
+/// ```
+///
+/// R5-F5 read a footprint column as a saving and overstated an expert
+/// revert by 3.39×, in the direction that makes expert in-moves look
+/// prunable. A delta is therefore never supplied — it is computed, by
+/// [`Self::delta_from`], from two footprints the graph holds.
+///
+/// Supplied by the caller from the byte ledger, never derived here:
+/// [`super::super::byte_ledger`] states why scopes are supplied rather
+/// than inferred, and inferring a footprint from geometry would be the
+/// same mistake one level down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LogicalBytes(u64);
+
+impl LogicalBytes {
+    pub fn new(bytes: u64) -> Self {
+        Self(bytes)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    /// This footprint minus `parent`'s. Negative means bytes were
+    /// removed, which is the direction a search wants.
+    ///
+    /// `i64` is wide enough by three orders of magnitude for any model
+    /// that fits on a disk, so the cast cannot wrap in practice; it is
+    /// written as one expression so there is a single place to check.
+    pub fn delta_from(self, parent: LogicalBytes) -> i64 {
+        self.0 as i64 - parent.0 as i64
+    }
+}
+
+impl std::fmt::Display for LogicalBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} B", self.0)
+    }
+}
+
+/// **What a realization IS**: the full decision facts, not merely what
+/// they present.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct RealizationId(String);
+
+impl RealizationId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn short(&self) -> &str {
+        &self.0[..self.0.len().min(12)]
+    }
+}
+
+impl std::fmt::Display for RealizationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// One realization: a resolved state, its two identities, and what it
+/// costs.
+///
+/// The costs and the identities travel together deliberately. A node
+/// that held the id and looked its footprint up elsewhere could be
+/// asked about a state whose bytes nobody had priced, and would have to
+/// answer with a default.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedState {
+    realization_id: RealizationId,
+    state: RepresentationState,
+    logical_bytes: LogicalBytes,
+}
+
+impl ResolvedState {
+    /// Identify a resolved state as a realization.
+    pub fn new(state: RepresentationState, logical_bytes: LogicalBytes) -> Self {
+        let input = format!(
+            "{STATE_ID_VERSION}{SECTION}realization{SECTION}physical={}{SECTION}decisions={}",
+            state.id(),
+            state.decisions().canonical_full()
+        );
+        Self {
+            realization_id: RealizationId(hash_bytes(input.as_bytes())),
+            state,
+            logical_bytes,
+        }
+    }
+
+    /// What this state PRESENTS — the evidence and `MeasurementKey` key.
+    pub fn physical_id(&self) -> &RepresentationStateId {
+        self.state.id()
+    }
+
+    /// What this state DECIDES — the action generator's key.
+    pub fn realization_id(&self) -> &RealizationId {
+        &self.realization_id
+    }
+
+    pub fn state(&self) -> &RepresentationState {
+        &self.state
+    }
+
+    pub fn logical_bytes(&self) -> LogicalBytes {
+        self.logical_bytes
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/replay_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/replay_tests.rs
@@ -1,0 +1,574 @@
+//! **3b: the whole chain, from stored facts.**
+//!
+//! ```text
+//! snapshot facts
+//!     ↓ action space
+//!     ↓ assessment
+//!     ↓ ranking
+//!     ↓ promotion
+//! ```
+//!
+//! with none of the intermediates serialised. 1d closed the contract
+//! half of this — margins, binding constraint, admissibility, refusal —
+//! and left promotion open because `CandidateAssessment` carries a
+//! `ranking_score`, a conclusion, and persisting one to make the test
+//! pass would have been the exact cheat the stage forbids. The two
+//! FACTS it needed are now in the snapshot: a per-state [`ByteLedger`]
+//! and an [`ExecutionCostModel`].
+//!
+//! # What is real here and what is a fixture
+//!
+//! The recorded rung-5 numbers this replays against — kl p99, logical
+//! bytes, covered mass — are exercised in `snapshot_tests`. This file
+//! tests the DERIVATION CHAIN, and the per-token ledgers and the GPU
+//! cost observation are fixtures: the record holds no measured GPU time
+//! for P, T1 or S2, and inventing one and calling it recorded would be
+//! worse than saying so.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::super::byte_ledger::{ByteLedger, ScopeBytes};
+use super::super::compiler::SourceIdentity;
+use super::super::decision::{decide_promotion, NoPromotableCandidate, PromotionDecision};
+use super::super::diagnostic::DiagnosticPolicy;
+use super::super::execution_cost::{ExecutionCostModel, ExecutionCostObservation};
+use super::super::map::{Exception, PrecisionMap};
+use super::super::measurement::{EvidenceScale, TailSupportPolicy};
+use super::super::nvfp4_pack::{PackLayout, DTYPE_NVFP4};
+use super::super::policy::Role;
+use super::super::promotion::PromotionReadiness;
+use super::super::quality::{
+    kimi_logit_balanced_v1, Distribution, LogitEvidence, QualityBank, RoutingEvidence,
+};
+use super::super::search_evidence::SearchCalibrationRegistry;
+use super::*;
+
+const MODEL: &str = "kimi-linear-48b";
+
+// ---------------------------------------------------------------- fixtures
+
+fn model() -> SourceIdentity {
+    SourceIdentity {
+        manifest_hash: MODEL.into(),
+        graph_hash: "aligned-vindex3".into(),
+        segments: BTreeMap::from([("target.decoder_stack".to_string(), "seg-dddd".to_string())]),
+    }
+}
+
+fn surface() -> TensorSurface {
+    TensorSurface::new(
+        [("e_proj", 256usize), ("k_proj", 128), ("m_proj", 64)]
+            .into_iter()
+            .map(|(p, rows)| {
+                SurfaceTensor::new(
+                    "target.decoder_stack",
+                    format!("0.self_attn.{p}.weight"),
+                    Role::DecoderLinear,
+                    vec![rows, 64],
+                )
+            }),
+    )
+    .expect("distinct tensors")
+}
+
+fn compile(projection: &str) -> Exception {
+    Exception {
+        projection: Some(projection.into()),
+        layers: None,
+        encoding: Some(DTYPE_NVFP4.into()),
+    }
+}
+
+fn space() -> SearchSpace {
+    SearchSpace {
+        surface: surface(),
+        base_map: PrecisionMap {
+            name: "base".into(),
+            encoding: DTYPE_NVFP4.into(),
+            roles: vec!["decoder-linear".into()],
+            exceptions: vec![Exception {
+                projection: None,
+                layers: None,
+                encoding: None,
+            }],
+        },
+        vocabulary: ActionVocabulary::new([
+            MapEdit::new("E24", compile("e_proj")),
+            MapEdit::new("K25", compile("k_proj")),
+            MapEdit::new("M26", compile("m_proj")),
+        ])
+        .expect("distinct names"),
+    }
+}
+
+struct ShapeFootprint {
+    surface: TensorSurface,
+}
+
+impl Footprint for ShapeFootprint {
+    fn logical_bytes(&self, state: &RepresentationState) -> LogicalBytes {
+        let total: u64 = state
+            .decisions()
+            .decisions()
+            .iter()
+            .map(|d| {
+                let t = self
+                    .surface
+                    .get(&d.object, &d.tensor)
+                    .expect("resolved against this surface");
+                let elements: usize = t.shape.iter().product();
+                if d.encoding.is_compiled() {
+                    PackLayout::derive(&t.shape, &t.tensor)
+                        .expect("compiled means admitted")
+                        .total_len as u64
+                } else {
+                    elements as u64 * 2
+                }
+            })
+            .sum();
+        LogicalBytes::new(total)
+    }
+}
+
+/// A per-token ledger. **Not** `LogicalBytes`: these are the bytes the
+/// decoder READS per token, which is the quantity a throughput
+/// prediction is a function of.
+fn ledger(name: &str, e: u64, k: u64, m: u64) -> ByteLedger {
+    let scope = |scope: &str, family: &str, baseline, candidate| ScopeBytes {
+        scope: scope.into(),
+        family: family.into(),
+        baseline_bytes: baseline,
+        candidate_bytes: candidate,
+    };
+    ByteLedger {
+        model: MODEL.into(),
+        baseline_representation: "BF16".into(),
+        candidate_representation: name.into(),
+        scopes: vec![
+            scope("e", "attention", 16_384, e),
+            scope("k", "attention", 8_192, k),
+            scope("m", "attention", 4_096, m),
+        ],
+    }
+}
+
+/// One measured execution observation. A FIXTURE — the record holds no
+/// GPU timing for these maps — but shaped like a real one, carrying the
+/// machine, device, backend and commit that make a later reader able to
+/// tell whether it predates a kernel change.
+fn cost_model() -> ExecutionCostModel {
+    ExecutionCostModel::new(vec![ExecutionCostObservation {
+        id: "fixture-001".into(),
+        machine: "fixture".into(),
+        device: "fixture-gpu".into(),
+        backend: "metal".into(),
+        compiler_commit: "0000000".into(),
+        model_identity: MODEL.into(),
+        baseline_representation: "BF16".into(),
+        candidate_representation: "E24".into(),
+        families_changed: vec!["attention".into()],
+        scopes_changed: 1,
+        baseline_bytes_per_token: 28_672,
+        candidate_bytes_per_token: 20_480,
+        baseline_gpu_ms_per_token: 10.0,
+        candidate_gpu_ms_per_token: 8.0,
+        fixed_overhead_ms: 1.0,
+        benchmark_protocol: "fixture".into(),
+        evidence: vec![],
+    }])
+}
+
+fn bank() -> EvidenceBank {
+    EvidenceBank::new("kimi-teacher-forced/v1", "17d59a6b", ["seq-000"], 32)
+}
+
+fn instrument() -> InstrumentSemantics {
+    InstrumentSemantics::new("kl", "distribution", "teacher-forced", "q2a").truncated_to(2048)
+}
+
+fn intent(scale: EvidenceScale) -> MeasurementIntent {
+    MeasurementIntent::new(bank().id(), scale, instrument().id())
+}
+
+fn reading(kl_p99: f64) -> QualityBank {
+    let dist = |v: f64| {
+        Some(Distribution {
+            count: 8192,
+            min: 0.0,
+            p50: 0.0,
+            p95: 0.0,
+            p99: v,
+            max: v,
+        })
+    };
+    QualityBank {
+        positions: 8192,
+        logits: LogitEvidence {
+            kl_p50: 0.0,
+            kl_p95: 0.0,
+            kl_p99,
+            max_logit_delta: 0.0,
+            top1_flips: 0,
+            top10_changes: 0,
+        },
+        routing: RoutingEvidence {
+            route_flips: 0,
+            positions_with_route_change: 0,
+            layers_with_route_change: 0,
+            first_layer_with_route_change: None,
+            route_margin: None,
+            route_weight_mass_moved: dist(0.113),
+        },
+        min_covered_mass: Some(0.6315),
+        top10_margin: None,
+        top10_candidate_margin: None,
+        top10_mass_displaced: dist(0.065),
+        top10_rank_displacement: None,
+        top1_margin: None,
+        top1_candidate_margin: None,
+        top1_mass_displaced: dist(0.03),
+    }
+}
+
+fn applied(names: &[&str]) -> BTreeSet<String> {
+    names.iter().map(|n| (*n).to_string()).collect()
+}
+
+fn footprint() -> ShapeFootprint {
+    ShapeFootprint { surface: surface() }
+}
+
+fn realize(names: &[&str]) -> ResolvedState {
+    let space = space();
+    let map = space
+        .vocabulary
+        .map_for(&space.base_map, &applied(names))
+        .expect("known moves");
+    let state = RepresentationState::resolve(&model(), &surface(), &map, &PackLayoutAdmission);
+    let bytes = footprint().logical_bytes(&state);
+    ResolvedState::new(state, bytes)
+}
+
+/// The whole factual record: which states exist, how they were reached,
+/// what was observed, what each reads per token, and what execution has
+/// been measured to cost. No verdict, rank, frontier or promotion.
+fn recorded() -> SearchSnapshot {
+    let root = realize(&[]);
+    let e24 = realize(&["E24"]);
+
+    let mut graph =
+        RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, root.clone());
+    graph
+        .apply(
+            root.physical_id(),
+            Action::new("+E24").adding(["E24"]),
+            e24.clone(),
+            Provenance::new("rung5/N3"),
+        )
+        .expect("lighter");
+
+    let mut measurements = MeasurementRegistry::new();
+    measurements
+        .record(
+            intent(EvidenceScale::Authority).key_for(root.physical_id()),
+            reading(0.0),
+        )
+        .expect("record");
+    measurements
+        .record(
+            intent(EvidenceScale::Authority).key_for(e24.physical_id()),
+            reading(1.2e-3),
+        )
+        .expect("record");
+
+    SearchSnapshot::new(
+        space(),
+        SearchConfig {
+            objective: Objective::MinimiseLogicalBytes,
+            gate: kimi_logit_balanced_v1(),
+            tail_support: TailSupportPolicy::route_cal_1(),
+            calibrations: SearchCalibrationRegistry::route_cal_1(),
+            diagnostic_policy: DiagnosticPolicy::bs2_kimi_v1(),
+            semantics: SearchSemantics::new(
+                "exchange-1-out-1-in/v1",
+                "ruling-1-three-prunes/v1",
+                "search-evidence-ladder/v1",
+                "decide-promotion-ordinal/v1",
+                "physical-prize-first/v1",
+                "logical-bytes/v1",
+            ),
+            ranking: RankingSemantics::new(RankingRule::PhysicalPrizeFirst),
+        },
+        SearchFacts {
+            graph,
+            measurements,
+            byte_ledgers: BTreeMap::from([
+                (
+                    root.physical_id().clone(),
+                    ledger("BF16", 16_384, 8_192, 4_096),
+                ),
+                (
+                    e24.physical_id().clone(),
+                    ledger("E24", 4_096, 8_192, 4_096),
+                ),
+            ]),
+            execution_cost: cost_model(),
+        },
+    )
+}
+
+/// Store it, throw the live object away, read it back.
+fn reloaded() -> SearchSnapshot {
+    let json = serde_json::to_string(&recorded()).expect("serialize");
+    let back: SearchSnapshot = serde_json::from_str(&json).expect("deserialize");
+    back.check_schema().expect("schema");
+    back
+}
+
+// ------------------------------------------------------------ the chain
+
+#[test]
+fn the_action_space_is_derived_from_the_snapshot_alone() {
+    // 1d could not do this: the snapshot had no surface, base map or
+    // vocabulary, so nothing could build a `Generator` from it.
+    let snap = reloaded();
+    let set = snap
+        .generator(&PackLayoutAdmission, &footprint())
+        .candidates(&applied(&[]), &intent(EvidenceScale::Diagnostic))
+        .expect("generate");
+
+    let census = set.census();
+    assert_eq!(census.enumerated, 3, "+E24, +K25, +M26");
+    assert!(census.conserves(), "{census}");
+    assert_eq!(census.eligible, 3);
+}
+
+#[test]
+fn the_next_experiment_is_derived_end_to_end() {
+    let snap = reloaded();
+    let selection = snap
+        .next_experiment(
+            &applied(&[]),
+            &intent(EvidenceScale::Diagnostic),
+            &PackLayoutAdmission,
+            &footprint(),
+        )
+        .expect("derive");
+
+    match selection {
+        Selection::Ranked { chosen, considered } => {
+            assert_eq!(considered, 3);
+            assert_eq!(chosen.leading().action.label, "+E24", "the biggest prize");
+            assert_eq!(chosen.key.scale(), EvidenceScale::Diagnostic);
+        }
+        other => panic!("expected a ranked selection, got {other:?}"),
+    }
+}
+
+#[test]
+fn promotion_is_derived_from_stored_facts() {
+    // The gap 1d left open. `CandidateAssessment` is rebuilt here from
+    // the ledgers, the cost model and the two contract standings — never
+    // loaded — and `decide_promotion` is the crate's own, unmodified.
+    let snap = reloaded();
+    let candidates = snap
+        .promotion_candidates(EvidenceScale::Authority)
+        .expect("the cost model covers this model");
+
+    // The graph holds one edge, and both its ends carry a reading and a
+    // ledger. A move with either missing is skipped, not defaulted — a
+    // marginal quantity with one end absent is not a smaller number, it
+    // is no number.
+    assert_eq!(candidates.len(), 1);
+    let only = &candidates[0];
+    assert_eq!(only.id, "+E24");
+
+    let assessment = &only.promotion.assessment;
+    assert_eq!(assessment.scale, EvidenceScale::Authority);
+    assert_eq!(
+        assessment.bytes_removed_marginal, 12_288,
+        "16,384 -> 4,096 per token, computed from two ledgers"
+    );
+    assert!(assessment.binding_after().is_some());
+
+    let decision = decide_promotion(
+        &candidates,
+        &snap.config().calibrations,
+        snap.tail_support(),
+    );
+    // What matters is that a decision is REACHED from stored facts. Its
+    // content is `decide_promotion`'s to determine, and this test does
+    // not second-guess it.
+    assert!(
+        !matches!(
+            decision,
+            PromotionDecision::None {
+                reason: NoPromotableCandidate::EmptySet
+            }
+        ),
+        "the candidate set reached the comparator: {decision:?}"
+    );
+}
+
+#[test]
+fn a_move_with_one_end_unmeasured_is_skipped_rather_than_defaulted() {
+    // A second edge whose child nothing has measured. It is a real move
+    // in a real graph and it produces NO promotion candidate — not one
+    // carrying zeroes, because a marginal quantity with one end absent
+    // is no number at all.
+    let mut snap = recorded();
+    let root = realize(&[]);
+    let k25 = realize(&["K25"]);
+    let mut facts = snap.facts().clone();
+    facts
+        .graph
+        .apply(
+            root.physical_id(),
+            Action::new("+K25").adding(["K25"]),
+            k25.clone(),
+            Provenance::new("rung5/N3"),
+        )
+        .expect("lighter");
+    // It even has a ledger; what it lacks is a READING.
+    facts.byte_ledgers.insert(
+        k25.physical_id().clone(),
+        ledger("K25", 16_384, 2_048, 4_096),
+    );
+    snap = SearchSnapshot::new(snap.space().clone(), snap.config().clone(), facts);
+
+    assert_eq!(snap.graph().edge_count(), 2, "two moves were built");
+    let candidates = snap
+        .promotion_candidates(EvidenceScale::Authority)
+        .expect("no cost refusal");
+    assert_eq!(candidates.len(), 1, "only the measured move");
+    assert_eq!(candidates[0].id, "+E24");
+}
+
+#[test]
+fn readiness_and_diagnostic_come_from_the_stored_policy_and_bank() {
+    let snap = reloaded();
+    let candidates = snap
+        .promotion_candidates(EvidenceScale::Authority)
+        .expect("cost");
+    let only = &candidates[0];
+
+    // The diagnostic vector is read through the STORED policy, so a
+    // snapshot taken under one policy cannot be replayed under another
+    // without saying so.
+    assert_eq!(
+        only.diagnostic.policy_id,
+        DiagnosticPolicy::bs2_kimi_v1().id
+    );
+    assert!(!only.diagnostic.readings.is_empty());
+    assert!(matches!(
+        only.promotion.readiness(),
+        PromotionReadiness::Priceable
+            | PromotionReadiness::ProxySupported
+            | PromotionReadiness::Uninformed
+    ));
+
+    // No proxies were invented. A proxy is a registered finding about an
+    // instrument, and none exists for these statistics.
+    assert!(only.promotion.proxies.is_empty());
+}
+
+// ------------------------------------------------- still no conclusions
+
+#[test]
+fn the_widened_snapshot_still_stores_no_conclusion() {
+    // Six new fields went in. Every one is a fact or a rule, and the
+    // structural check still holds over the whole document.
+    let json = serde_json::to_value(recorded()).expect("serialize");
+
+    const FORBIDDEN: &[&str] = &[
+        "admissible",
+        "admitted",
+        "refused",
+        "binding",
+        "frontier",
+        "promotion",
+        "rank",
+        "chosen",
+        "best",
+        "recommendation",
+        "failures",
+        "passed",
+        "adjudication",
+        "ranking_score",
+        "selection",
+        "next_experiment",
+    ];
+
+    fn walk(value: &serde_json::Value, path: &str, found: &mut Vec<String>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                for (k, v) in map {
+                    // `config.calibrations[].verdict` is a REGISTERED
+                    // FINDING about an instrument — ROUTE-CAL-1 saying
+                    // how a statistic may be used — not a conclusion
+                    // about a candidate. Named, so the check stays blunt
+                    // everywhere else.
+                    let calibration = path.starts_with(".config.calibrations");
+                    if FORBIDDEN.contains(&k.as_str()) || (k == "verdict" && !calibration) {
+                        found.push(format!("{path}.{k}"));
+                    }
+                    walk(v, &format!("{path}.{k}"), found);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for (i, v) in items.iter().enumerate() {
+                    walk(v, &format!("{path}[{i}]"), found);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut found = Vec::new();
+    walk(&json, "", &mut found);
+    assert!(
+        found.is_empty(),
+        "conclusions in the stored form: {found:?}"
+    );
+
+    // And the new FACTS are all there, so the emptiness is not vacuous.
+    assert_eq!(
+        json["space"]["vocabulary"]["edits"]
+            .as_array()
+            .unwrap()
+            .len(),
+        3
+    );
+    assert!(json["space"]["surface"].is_object());
+    assert!(json["space"]["base_map"].is_object());
+    assert_eq!(json["facts"]["byte_ledgers"].as_object().unwrap().len(), 2);
+    assert_eq!(
+        json["facts"]["execution_cost"]["observations"][0]["machine"],
+        "fixture"
+    );
+    assert!(json["config"]["diagnostic_policy"]["id"].is_string());
+
+    // The cost itself is NOT stored — only the observations it is
+    // derived from, and the model's own honesty about its calibration.
+    assert!(json["facts"]["execution_cost"]
+        .get("gpu_ms_per_token")
+        .is_none());
+    assert!(json["facts"]["execution_cost"].get("status").is_none());
+}
+
+#[test]
+fn a_role_survives_an_owning_deserializer() {
+    // `TensorSurface` carries `Role`, whose `Deserialize` read `&str`
+    // and so demanded a BORROWED string: it worked for `from_str` and
+    // failed for `from_value`, `from_reader` and every binary format —
+    // with an `invalid type: string, expected a borrowed string` far
+    // from the cause. An MCP surface will go through `Value`.
+    let value = serde_json::to_value(recorded()).expect("serialize");
+    let back: SearchSnapshot = serde_json::from_value(value).expect("owning deserializer");
+    assert_eq!(back.space().surface, surface());
+
+    let bytes = serde_json::to_vec(&recorded()).expect("bytes");
+    let from_reader: SearchSnapshot =
+        serde_json::from_reader(bytes.as_slice()).expect("reader deserializer");
+    assert_eq!(from_reader.space().surface, surface());
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/resolved.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/resolved.rs
@@ -1,0 +1,229 @@
+//! **What the container will actually present, tensor by tensor.**
+//!
+//! [`PrecisionMap::resolve`] answers what the *rules* decide. That is
+//! not the same as what gets stored, because a storage layout can refuse
+//! a tensor the policy admits: NVFP4 holds 2-D matrices whose `k` is a
+//! multiple of the 16-element group, and `represent`'s compiler carries
+//! anything else verbatim whatever the map said. A search state built on
+//! the declared decision would believe it had compiled tensors that are
+//! still at source precision, and would price bytes it never saved.
+//!
+//! ```text
+//! map says          layout says       presented        counts as
+//! ────────────────────────────────────────────────────────────────
+//! compile NVFP4     can hold it       NVFP4            Compiled
+//! compile NVFP4     k not a multiple  source bytes     LayoutRefused
+//! source precision  —                 source bytes     Source
+//! ```
+//!
+//! `LayoutRefused` and `Source` present the same bytes, so they are the
+//! same *state* — [`ResolvedEncoding::effective`] is what the state
+//! digest reads. They are different *facts*, and the variants stay
+//! distinct because the action generator needs them apart: removing a
+//! protection is a legal move that changes the state, and "un-refusing"
+//! a layout is not a move at all.
+//!
+//! # Refusal takes positive evidence
+//!
+//! [`LayoutAdmission`] answers *does this layout refuse this tensor*, and
+//! an implementation that holds no rule for an encoding answers no. That
+//! is deliberate and it is the safe direction here: a refusal this
+//! module invents would silently mark a tensor as un-compilable and
+//! delete it from the action space forever, whereas an admission that
+//! the compiler later refuses shows up as a resolved-decision mismatch
+//! the moment anything is actually compiled. A constraint has to be
+//! stated by whoever owns the layout.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::map::{Precision, PrecisionMap};
+use super::super::nvfp4_pack::{PackLayout, DTYPE_NVFP4};
+use super::surface::{SurfaceTensor, TensorSurface, FIELD, RECORD};
+
+/// The canonical spelling of "whatever the checkpoint had".
+///
+/// A sentinel rather than an encoding name, because source precision is
+/// not one encoding — it is BF16 here and F32 there — and the state is
+/// the same state either way. What the source bytes actually are is
+/// already pinned by the model identity's per-segment hashes.
+pub const SOURCE_PRECISION: &str = "source";
+
+/// What one tensor ends up represented as.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResolvedEncoding {
+    /// The map compiles it and the layout can hold it.
+    Compiled(String),
+    /// The map holds it at source precision — an unnamed role, or an
+    /// exception that protects it.
+    Source,
+    /// The map compiles it and the layout cannot hold it, so the
+    /// container carries the source bytes.
+    LayoutRefused { encoding: String },
+}
+
+impl ResolvedEncoding {
+    /// **What is presented.** Identity reads this and only this: a
+    /// protected tensor and a layout-refused tensor are the same bytes.
+    pub fn effective(&self) -> &str {
+        match self {
+            Self::Compiled(enc) => enc,
+            Self::Source | Self::LayoutRefused { .. } => SOURCE_PRECISION,
+        }
+    }
+
+    pub fn is_compiled(&self) -> bool {
+        matches!(self, Self::Compiled(_))
+    }
+}
+
+/// Whether an encoding's storage layout can hold a tensor.
+///
+/// A trait rather than a call into [`PackLayout`] so that resolution
+/// does not become NVFP4-specific the moment a second encoding exists,
+/// and so tests can state a surface's admissibility directly instead of
+/// having to construct shapes that happen to trip a real layout.
+pub trait LayoutAdmission {
+    /// `false` only where the layout is known to refuse the tensor.
+    fn admits(&self, encoding: &str, tensor: &SurfaceTensor) -> bool;
+}
+
+/// Declares no constraint for any encoding.
+///
+/// For encodings whose layout rules live elsewhere, and for tests that
+/// are about map resolution rather than about layouts.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoLayoutConstraint;
+
+impl LayoutAdmission for NoLayoutConstraint {
+    fn admits(&self, _encoding: &str, _tensor: &SurfaceTensor) -> bool {
+        true
+    }
+}
+
+/// The constraint REPRESENT's own NVFP4 pack enforces.
+///
+/// Answers for `DTYPE_NVFP4` by asking [`PackLayout::derive`] — the same
+/// call the compiler makes, so the two cannot drift — and declares
+/// nothing about any other encoding.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PackLayoutAdmission;
+
+impl LayoutAdmission for PackLayoutAdmission {
+    fn admits(&self, encoding: &str, tensor: &SurfaceTensor) -> bool {
+        if encoding != DTYPE_NVFP4 {
+            return true;
+        }
+        PackLayout::derive(&tensor.shape, &tensor.tensor).is_ok()
+    }
+}
+
+/// One tensor's resolved decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedDecision {
+    pub object: String,
+    pub tensor: String,
+    pub encoding: ResolvedEncoding,
+}
+
+impl ResolvedDecision {
+    /// The canonical record identity reads: the pair, then what is
+    /// presented. The *fact* — protected versus refused — is
+    /// deliberately absent.
+    fn canonical(&self) -> String {
+        format!(
+            "{}{FIELD}{}{FIELD}{}",
+            self.object,
+            self.tensor,
+            self.encoding.effective()
+        )
+    }
+}
+
+/// **The resolved decision vector: one entry per surface tensor, in
+/// surface order.**
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ResolvedDecisionVector {
+    decisions: Vec<ResolvedDecision>,
+}
+
+impl ResolvedDecisionVector {
+    pub fn decisions(&self) -> &[ResolvedDecision] {
+        &self.decisions
+    }
+
+    pub fn len(&self) -> usize {
+        self.decisions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.decisions.is_empty()
+    }
+
+    pub fn get(&self, object: &str, tensor: &str) -> Option<&ResolvedEncoding> {
+        self.decisions
+            .iter()
+            .find(|d| d.object == object && d.tensor == tensor)
+            .map(|d| &d.encoding)
+    }
+
+    /// How many tensors this state actually compiles.
+    pub fn compiled(&self) -> usize {
+        self.decisions
+            .iter()
+            .filter(|d| d.encoding.is_compiled())
+            .count()
+    }
+
+    /// Tensors the map wanted and the layout would not take. Reported
+    /// rather than folded into "source", because "protected by policy"
+    /// and "refused by the layout" are different facts and a report that
+    /// cannot tell them apart is useless.
+    pub fn layout_refused(&self) -> Vec<&ResolvedDecision> {
+        self.decisions
+            .iter()
+            .filter(|d| matches!(d.encoding, ResolvedEncoding::LayoutRefused { .. }))
+            .collect()
+    }
+
+    /// The canonical form the state digest reads.
+    pub(crate) fn canonical(&self) -> String {
+        self.decisions
+            .iter()
+            .map(ResolvedDecision::canonical)
+            .collect::<Vec<_>>()
+            .join(&RECORD.to_string())
+    }
+}
+
+/// **Resolve a map against a surface.**
+///
+/// Role first, then exceptions, then the layout — the same order the
+/// compiler applies, because a state that resolved them in another order
+/// would describe a container nobody can build.
+pub fn resolve(
+    map: &PrecisionMap,
+    surface: &TensorSurface,
+    layout: &dyn LayoutAdmission,
+) -> ResolvedDecisionVector {
+    let decisions = surface
+        .entries()
+        .iter()
+        .map(|t| {
+            let encoding = match map.resolve(t.role, &t.tensor) {
+                Precision::Source => ResolvedEncoding::Source,
+                Precision::Compiled(enc) if layout.admits(enc, t) => {
+                    ResolvedEncoding::Compiled(enc.to_string())
+                }
+                Precision::Compiled(enc) => ResolvedEncoding::LayoutRefused {
+                    encoding: enc.to_string(),
+                },
+            };
+            ResolvedDecision {
+                object: t.object.clone(),
+                tensor: t.tensor.clone(),
+                encoding,
+            }
+        })
+        .collect();
+    ResolvedDecisionVector { decisions }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/resolved.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/resolved.rs
@@ -74,6 +74,22 @@ impl ResolvedEncoding {
     pub fn is_compiled(&self) -> bool {
         matches!(self, Self::Compiled(_))
     }
+
+    /// **Which fact produced this decision**, as distinct from what it
+    /// presents.
+    ///
+    /// `Source` and `LayoutRefused` present identical bytes and are one
+    /// physical state; they are not one *realization*, because the
+    /// actions available from them differ. Unprotecting a protected
+    /// tensor is a legal move; un-refusing a layout is not a move at
+    /// all. The search reads this; the physical digest does not.
+    pub fn fact(&self) -> &'static str {
+        match self {
+            Self::Compiled(_) => "compiled",
+            Self::Source => "source",
+            Self::LayoutRefused { .. } => "layout-refused",
+        }
+    }
 }
 
 /// Whether an encoding's storage layout can hold a tensor.
@@ -137,6 +153,18 @@ impl ResolvedDecision {
             self.encoding.effective()
         )
     }
+
+    /// The canonical record with the fact retained — what the search,
+    /// as opposed to the physical digest, is entitled to distinguish.
+    fn canonical_full(&self) -> String {
+        format!(
+            "{}{FIELD}{}{FIELD}{}{FIELD}{}",
+            self.object,
+            self.tensor,
+            self.encoding.effective(),
+            self.encoding.fact()
+        )
+    }
 }
 
 /// **The resolved decision vector: one entry per surface tensor, in
@@ -185,11 +213,27 @@ impl ResolvedDecisionVector {
             .collect()
     }
 
-    /// The canonical form the state digest reads.
+    /// The canonical form the PHYSICAL digest reads: what is presented,
+    /// with protection and layout refusal collapsed.
     pub(crate) fn canonical(&self) -> String {
         self.decisions
             .iter()
             .map(ResolvedDecision::canonical)
+            .collect::<Vec<_>>()
+            .join(&RECORD.to_string())
+    }
+
+    /// The canonical form the REALIZATION digest reads: every decision
+    /// with the fact that produced it, nothing collapsed.
+    ///
+    /// Two vectors can share [`Self::canonical`] and differ here. That
+    /// is not a defect of the physical digest — evidence may deduplicate
+    /// more aggressively than search may, and this is the form that
+    /// keeps the difference available to the action generator.
+    pub(crate) fn canonical_full(&self) -> String {
+        self.decisions
+            .iter()
+            .map(ResolvedDecision::canonical_full)
             .collect::<Vec<_>>()
             .join(&RECORD.to_string())
     }

--- a/crates/larql-vindex/src/format/vindex3/represent/state/search_policy.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/search_policy.rs
@@ -1,0 +1,221 @@
+//! **Which unresolved experiment has the highest priority?**
+//!
+//! That question, and not *which candidate can replace the incumbent* —
+//! those are different, and a candidate can rank first for measurement
+//! precisely because it is uncertain while being nowhere near
+//! promotable. So:
+//!
+//! ```text
+//! CandidateSet → Assessment → BestFirst        experiment selection
+//! Measurements → SearchEvidence → decide_promotion   admissibility
+//! ```
+//!
+//! `decide_promotion` stays downstream and unweakened. It already
+//! refuses to scalarise disagreeing proxies, and making ranking easier
+//! is not a reason to relax that.
+//!
+//! # Search orders states; measurement orders experiments
+//!
+//! Two realizations of one physical state have different future action
+//! spaces, so both belong on the frontier. Their *immediate experiment*
+//! can still be the same one:
+//!
+//! ```text
+//! A --action x--> C (realization r1) ┐
+//!                                    ├─ one MeasurementKey
+//! B --action y--> C (realization r2) ┘
+//!
+//! search:       r1 ≠ r2, both kept
+//! measurement:  one experiment, run once
+//! ```
+//!
+//! [`MeasurementOpportunity`] is that grouping, and it is the payoff of
+//! the whole 1a-1c identity model: when the observation lands, **both**
+//! realizations inherit it, because 1c keys evidence on the physical
+//! state while 1b keeps the realizations apart.
+//!
+//! # Ruling 3
+//!
+//! ```text
+//! 0 eligible  → EXHAUSTED
+//! 1 eligible  → SELECT it; the diagnostic is RECORDED and CANNOT VETO
+//! > 1         → the registered rule chooses which is measured FIRST
+//! ```
+//!
+//! The middle line is a ruling, not an optimisation: with one
+//! opportunity "what next?" is already answered, and an escalation rule
+//! that consulted a diagnostic there would be promoting the diagnostic
+//! into an admissibility screen — the accident that was withdrawn.
+//!
+//! # What this stage does not do
+//!
+//! It does not order the *authority escalation* of
+//! diagnostically-measured candidates, and it does not run promotion.
+//! Both go through `CandidateAssessment`, which needs two facts a
+//! snapshot does not yet hold — a per-state [`ByteLedger`] and an
+//! `ExecutionCostModel`. Those are inputs to add, not conclusions to
+//! invent, and until they exist this layer says so rather than
+//! approximating them.
+//!
+//! [`ByteLedger`]: super::super::byte_ledger::ByteLedger
+
+use std::collections::BTreeMap;
+
+use super::assess::{Assessment, ParentStanding, RankingSemantics};
+use super::candidate::CandidateSet;
+use super::identity::RepresentationStateId;
+use super::key::MeasurementKey;
+
+/// One experiment, and every eligible candidate that would run it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MeasurementOpportunity {
+    /// The experiment. One key, one run.
+    pub key: MeasurementKey,
+    pub state: RepresentationStateId,
+    /// Every route to it, in the policy's order. More than one is
+    /// normal: two realizations can reach one physical state.
+    pub candidates: Vec<Assessment>,
+}
+
+impl MeasurementOpportunity {
+    /// The best physical prize among the routes to this experiment.
+    ///
+    /// Most negative wins, matching the sign convention. The routes
+    /// differ in how they were reached and not in what the experiment
+    /// costs, so the opportunity takes the best of them.
+    pub fn physical_delta(&self) -> i64 {
+        self.candidates
+            .iter()
+            .map(|a| a.physical_delta)
+            .min()
+            .expect("an opportunity holds at least one candidate")
+    }
+
+    /// The route the policy ranked first.
+    pub fn leading(&self) -> &Assessment {
+        self.candidates
+            .first()
+            .expect("an opportunity holds at least one candidate")
+    }
+
+    pub fn routes(&self) -> usize {
+        self.candidates.len()
+    }
+}
+
+/// What the policy decided to do next.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Selection {
+    /// Nothing eligible. The neighbourhood is closed.
+    Exhausted,
+    /// Ruling 3's middle line: exactly one opportunity, so there is
+    /// nothing to rank and it is selected.
+    Sole(Box<MeasurementOpportunity>),
+    /// More than one, ordered by the registered rule.
+    Ranked {
+        chosen: Box<MeasurementOpportunity>,
+        considered: usize,
+    },
+}
+
+impl Selection {
+    pub fn opportunity(&self) -> Option<&MeasurementOpportunity> {
+        match self {
+            Self::Exhausted => None,
+            Self::Sole(o) => Some(o),
+            Self::Ranked { chosen, .. } => Some(chosen),
+        }
+    }
+
+    pub fn is_exhausted(&self) -> bool {
+        matches!(self, Self::Exhausted)
+    }
+}
+
+/// **The policy.** Deliberately small: identity, comparability,
+/// admissibility, deduplication and physical accounting were all settled
+/// beneath it, so what is left is an ordering.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BestFirst {
+    pub semantics: RankingSemantics,
+}
+
+impl BestFirst {
+    pub fn new(semantics: RankingSemantics) -> Self {
+        Self { semantics }
+    }
+
+    /// Assess every eligible candidate in `set`.
+    ///
+    /// `standing` answers what the parent's contract standing is, where
+    /// an observation of it exists; the policy does not reach for a gate
+    /// itself.
+    pub fn assess(&self, set: &CandidateSet, standing: &dyn ParentStanding) -> Vec<Assessment> {
+        set.eligible()
+            .map(|c| Assessment::of(c, standing.of(&c.parent_state)))
+            .collect()
+    }
+
+    /// **The total order, applied.**
+    ///
+    /// The chain is [`RankingSemantics::tie_break_chain`], and every
+    /// element after the first is there so no answer depends on the
+    /// order candidates arrived in.
+    pub fn order(&self, mut assessments: Vec<Assessment>) -> Vec<Assessment> {
+        assessments.sort_by(|a, b| self.compare(a, b));
+        assessments
+    }
+
+    /// How two candidates compare. `Less` means `a` is measured first.
+    pub fn compare(&self, a: &Assessment, b: &Assessment) -> std::cmp::Ordering {
+        a.score(&self.semantics)
+            .cmp(&b.score(&self.semantics))
+            .then_with(|| a.physical_delta.cmp(&b.physical_delta))
+            .then_with(|| a.child_state.as_str().cmp(b.child_state.as_str()))
+            .then_with(|| {
+                a.child_realization
+                    .as_str()
+                    .cmp(b.child_realization.as_str())
+            })
+            .then_with(|| a.action.identity().cmp(&b.action.identity()))
+    }
+
+    /// Group ordered candidates into experiments.
+    ///
+    /// One [`MeasurementKey`] is one opportunity however many routes
+    /// reach it, so an experiment is never scheduled twice in a round.
+    pub fn opportunities(&self, ordered: Vec<Assessment>) -> Vec<MeasurementOpportunity> {
+        let mut by_key: BTreeMap<MeasurementKey, MeasurementOpportunity> = BTreeMap::new();
+        for assessment in ordered {
+            by_key
+                .entry(assessment.intended_key.clone())
+                .or_insert_with(|| MeasurementOpportunity {
+                    key: assessment.intended_key.clone(),
+                    state: assessment.child_state.clone(),
+                    candidates: Vec::new(),
+                })
+                .candidates
+                .push(assessment);
+        }
+        let mut opportunities: Vec<MeasurementOpportunity> = by_key.into_values().collect();
+        // Grouping went through a map keyed by digest, so the order it
+        // yields is a property of the digests and not of the rule. Sort
+        // the opportunities by their leading route, which is.
+        opportunities.sort_by(|a, b| self.compare(a.leading(), b.leading()));
+        opportunities
+    }
+
+    /// **What to measure next**, from a candidate set.
+    pub fn select(&self, set: &CandidateSet, standing: &dyn ParentStanding) -> Selection {
+        let ordered = self.order(self.assess(set, standing));
+        let mut opportunities = self.opportunities(ordered);
+        match opportunities.len() {
+            0 => Selection::Exhausted,
+            1 => Selection::Sole(Box::new(opportunities.remove(0))),
+            considered => Selection::Ranked {
+                chosen: Box::new(opportunities.remove(0)),
+                considered,
+            },
+        }
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/search_policy_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/search_policy_tests.rs
@@ -8,6 +8,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::super::compiler::SourceIdentity;
+use super::super::diagnostic::DiagnosticPolicy;
+use super::super::execution_cost::ExecutionCostModel;
 use super::super::map::{Exception, PrecisionMap};
 use super::super::measurement::{EvidenceScale, TailSupportPolicy};
 use super::super::nvfp4_pack::{PackLayout, DTYPE_NVFP4};
@@ -15,6 +17,7 @@ use super::super::policy::Role;
 use super::super::quality::{
     kimi_logit_balanced_v1, Criterion, Distribution, LogitEvidence, QualityBank, RoutingEvidence,
 };
+use super::super::search_evidence::SearchCalibrationRegistry;
 use super::*;
 
 // ---------------------------------------------------------------- fixtures
@@ -164,6 +167,33 @@ impl Rig {
             .candidates(&applied(from), &intent(scale))
             .expect("generate")
     }
+}
+
+/// A snapshot over the given root and readings, with the same space and
+/// config every test here uses.
+fn snapshot(root: ResolvedState, measurements: MeasurementRegistry) -> SearchSnapshot {
+    SearchSnapshot::new(
+        SearchSpace {
+            surface: surface(),
+            base_map: base_map(),
+            vocabulary: vocabulary(),
+        },
+        SearchConfig {
+            objective: Objective::MinimiseLogicalBytes,
+            gate: kimi_logit_balanced_v1(),
+            tail_support: TailSupportPolicy::route_cal_1(),
+            calibrations: SearchCalibrationRegistry::default(),
+            diagnostic_policy: DiagnosticPolicy::bs2_kimi_v1(),
+            semantics: SearchSemantics::new("g/v1", "p/v1", "e/v1", "pr/v1", "rank/v1", "b/v1"),
+            ranking: semantics(),
+        },
+        SearchFacts {
+            graph: RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, root),
+            measurements,
+            byte_ledgers: BTreeMap::new(),
+            execution_cost: ExecutionCostModel::new(Vec::new()),
+        },
+    )
 }
 
 // ------------------------------------------------------- one answer, always
@@ -567,14 +597,7 @@ fn a_measured_parent_contributes_its_whole_standing_not_a_number() {
             observation(3.3532e-3),
         )
         .expect("record");
-    let snapshot = SearchSnapshot::new(
-        Objective::MinimiseLogicalBytes,
-        kimi_logit_balanced_v1(),
-        TailSupportPolicy::route_cal_1(),
-        SearchSemantics::new("g/v1", "p/v1", "e/v1", "pr/v1", "rank/v1", "b/v1"),
-        RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, parent.clone()),
-        measurements,
-    );
+    let snapshot = snapshot(parent.clone(), measurements);
 
     let set = rig.candidates(&[], EvidenceScale::Diagnostic);
     let assessed = policy.assess(&set, &snapshot);
@@ -606,14 +629,7 @@ fn a_diagnostic_reading_of_the_parent_is_not_its_standing() {
             observation(3.3532e-3),
         )
         .expect("record");
-    let snapshot = SearchSnapshot::new(
-        Objective::MinimiseLogicalBytes,
-        kimi_logit_balanced_v1(),
-        TailSupportPolicy::route_cal_1(),
-        SearchSemantics::new("g/v1", "p/v1", "e/v1", "pr/v1", "rank/v1", "b/v1"),
-        RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, parent),
-        measurements,
-    );
+    let snapshot = snapshot(parent, measurements);
 
     let assessed = policy.assess(&rig.candidates(&[], EvidenceScale::Diagnostic), &snapshot);
     assert!(

--- a/crates/larql-vindex/src/format/vindex3/represent/state/search_policy_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/search_policy_tests.rs
@@ -1,0 +1,684 @@
+//! **3: what should we try next — and one answer, always.**
+//!
+//! Best-first is where implementation accidents start contaminating
+//! replay, so the order is specified end to end and tested against
+//! permuted input. If two runs over the same facts can disagree, nothing
+//! above this layer is reproducible.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::super::compiler::SourceIdentity;
+use super::super::map::{Exception, PrecisionMap};
+use super::super::measurement::{EvidenceScale, TailSupportPolicy};
+use super::super::nvfp4_pack::{PackLayout, DTYPE_NVFP4};
+use super::super::policy::Role;
+use super::super::quality::{
+    kimi_logit_balanced_v1, Criterion, Distribution, LogitEvidence, QualityBank, RoutingEvidence,
+};
+use super::*;
+
+// ---------------------------------------------------------------- fixtures
+
+fn model() -> SourceIdentity {
+    SourceIdentity {
+        manifest_hash: "kimi-linear-48b".into(),
+        graph_hash: "aligned-vindex3".into(),
+        segments: BTreeMap::from([("target.decoder_stack".to_string(), "seg-dddd".to_string())]),
+    }
+}
+
+/// Three projections of increasing width, so the moves that compile them
+/// carry genuinely different physical prizes.
+fn surface() -> TensorSurface {
+    TensorSurface::new(
+        [("e_proj", 256usize), ("k_proj", 128), ("m_proj", 64)]
+            .into_iter()
+            .map(|(p, rows)| {
+                SurfaceTensor::new(
+                    "target.decoder_stack",
+                    format!("0.self_attn.{p}.weight"),
+                    Role::DecoderLinear,
+                    vec![rows, 64],
+                )
+            }),
+    )
+    .expect("distinct tensors")
+}
+
+fn base_map() -> PrecisionMap {
+    PrecisionMap {
+        name: "base".into(),
+        encoding: DTYPE_NVFP4.into(),
+        roles: vec!["decoder-linear".into()],
+        exceptions: vec![Exception {
+            projection: None,
+            layers: None,
+            encoding: None,
+        }],
+    }
+}
+
+fn compile(projection: &str) -> Exception {
+    Exception {
+        projection: Some(projection.into()),
+        layers: None,
+        encoding: Some(DTYPE_NVFP4.into()),
+    }
+}
+
+fn vocabulary() -> ActionVocabulary {
+    ActionVocabulary::new([
+        MapEdit::new("E24", compile("e_proj")),
+        MapEdit::new("K25", compile("k_proj")),
+        MapEdit::new("M26", compile("m_proj")),
+    ])
+    .expect("distinct names")
+}
+
+struct ShapeFootprint {
+    surface: TensorSurface,
+}
+
+impl Footprint for ShapeFootprint {
+    fn logical_bytes(&self, state: &RepresentationState) -> LogicalBytes {
+        let total: u64 = state
+            .decisions()
+            .decisions()
+            .iter()
+            .map(|d| {
+                let tensor = self
+                    .surface
+                    .get(&d.object, &d.tensor)
+                    .expect("resolved against this surface");
+                let elements: usize = tensor.shape.iter().product();
+                if d.encoding.is_compiled() {
+                    PackLayout::derive(&tensor.shape, &tensor.tensor)
+                        .expect("compiled means admitted")
+                        .total_len as u64
+                } else {
+                    elements as u64 * 2
+                }
+            })
+            .sum();
+        LogicalBytes::new(total)
+    }
+}
+
+fn bank() -> EvidenceBank {
+    EvidenceBank::new("kimi-teacher-forced/v1", "17d59a6b", ["seq-000"], 32)
+}
+
+fn instrument() -> InstrumentSemantics {
+    InstrumentSemantics::new("kl", "distribution", "teacher-forced", "q2a").truncated_to(2048)
+}
+
+fn intent(scale: EvidenceScale) -> MeasurementIntent {
+    MeasurementIntent::new(bank().id(), scale, instrument().id())
+}
+
+fn semantics() -> RankingSemantics {
+    RankingSemantics::new(RankingRule::PhysicalPrizeFirst)
+        .because("rung 5 spent the run on the prize: -431,777,920 B over -2,091,136 B")
+}
+
+fn applied(names: &[&str]) -> BTreeSet<String> {
+    names.iter().map(|n| (*n).to_string()).collect()
+}
+
+struct Rig {
+    vocabulary: ActionVocabulary,
+    base: PrecisionMap,
+    surface: TensorSurface,
+    footprint: ShapeFootprint,
+    measurements: MeasurementRegistry,
+    model: SourceIdentity,
+}
+
+impl Rig {
+    fn new() -> Self {
+        Self {
+            vocabulary: vocabulary(),
+            base: base_map(),
+            surface: surface(),
+            footprint: ShapeFootprint { surface: surface() },
+            measurements: MeasurementRegistry::new(),
+            model: model(),
+        }
+    }
+
+    fn generator(&self) -> Generator<'_> {
+        Generator {
+            model: &self.model,
+            surface: &self.surface,
+            base_map: &self.base,
+            vocabulary: &self.vocabulary,
+            layout: &PackLayoutAdmission,
+            footprint: &self.footprint,
+            policy: TransitionPolicy::StrictlyImprovingPhysical,
+            measurements: &self.measurements,
+        }
+    }
+
+    fn candidates(&self, from: &[&str], scale: EvidenceScale) -> CandidateSet {
+        self.generator()
+            .candidates(&applied(from), &intent(scale))
+            .expect("generate")
+    }
+}
+
+// ------------------------------------------------------- one answer, always
+
+#[test]
+fn the_order_is_total_and_independent_of_the_order_candidates_arrived_in() {
+    let rig = Rig::new();
+    let policy = BestFirst::new(semantics());
+    let set = rig.candidates(&[], EvidenceScale::Diagnostic);
+    let assessed = policy.assess(&set, &NothingMeasured);
+    assert_eq!(assessed.len(), 3, "+E24, +K25, +M26");
+
+    let forward = policy.order(assessed.clone());
+    let mut reversed = assessed.clone();
+    reversed.reverse();
+    let backward = policy.order(reversed);
+    let mut rotated = assessed;
+    rotated.rotate_left(1);
+    let rotated = policy.order(rotated);
+
+    let labels =
+        |v: &[Assessment]| -> Vec<String> { v.iter().map(|a| a.action.label.clone()).collect() };
+    assert_eq!(labels(&forward), labels(&backward));
+    assert_eq!(labels(&forward), labels(&rotated));
+
+    // The prize orders them: 256x64 removes most, 64x64 least.
+    assert_eq!(labels(&forward), vec!["+E24", "+K25", "+M26"]);
+    assert!(forward
+        .windows(2)
+        .all(|w| w[0].physical_delta <= w[1].physical_delta));
+}
+
+#[test]
+fn the_tie_break_chain_is_stated_and_reaches_identity_last() {
+    let s = semantics();
+    assert_eq!(
+        s.tie_break_chain(),
+        [
+            "registered rule",
+            "greater physical improvement",
+            "canonical child state id",
+            "canonical child realization id",
+            "canonical action identity",
+        ]
+    );
+    // The chain is part of what the rule IS: changing it changes which
+    // experiment runs first, so it must move the id.
+    assert!(s.id().as_str().len() == 64);
+    assert_eq!(s.rule.name(), "physical-prize-first");
+    assert_eq!(format!("{}", s.id()), s.id().as_str());
+    assert_eq!(s.id().short().len(), 12);
+
+    // Provenance is not semantics.
+    let reworded = RankingSemantics::new(RankingRule::PhysicalPrizeFirst).because("said otherwise");
+    assert_ne!(reworded.provenance, s.provenance);
+    assert_eq!(reworded.id(), s.id());
+    assert!(RANKING_SEMANTICS_ID_VERSION.starts_with("ranking-semantics-id/"));
+}
+
+#[test]
+fn candidates_that_tie_on_the_prize_still_have_exactly_one_order() {
+    // Two moves of identical width: the rule cannot separate them, so
+    // the chain must — and must do so the same way every run.
+    let surface = TensorSurface::new(["a_proj", "b_proj"].into_iter().map(|p| {
+        SurfaceTensor::new(
+            "target.decoder_stack",
+            format!("0.self_attn.{p}.weight"),
+            Role::DecoderLinear,
+            vec![64, 64],
+        )
+    }))
+    .expect("distinct");
+    let rig = Rig {
+        vocabulary: ActionVocabulary::new([
+            MapEdit::new("A", compile("a_proj")),
+            MapEdit::new("B", compile("b_proj")),
+        ])
+        .expect("distinct names"),
+        surface: surface.clone(),
+        footprint: ShapeFootprint { surface },
+        ..Rig::new()
+    };
+    let policy = BestFirst::new(semantics());
+    let set = rig.candidates(&[], EvidenceScale::Diagnostic);
+    let assessed = policy.assess(&set, &NothingMeasured);
+    assert_eq!(assessed.len(), 2);
+    assert_eq!(
+        assessed[0].physical_delta, assessed[1].physical_delta,
+        "a genuine tie on the rule"
+    );
+
+    let forward = policy.order(assessed.clone());
+    let mut reversed = assessed;
+    reversed.reverse();
+    let backward = policy.order(reversed);
+    assert_eq!(
+        forward[0].child_state, backward[0].child_state,
+        "the tie-break decides, not arrival order"
+    );
+    assert!(forward[0].child_state.as_str() < forward[1].child_state.as_str());
+}
+
+#[test]
+fn two_realizations_of_one_state_are_separated_by_the_realization_tie_break() {
+    // The chain's fourth element, reached only when two candidates agree
+    // on the rule, on the prize AND on the physical state. That happens
+    // exactly in 1b's case: `v_proj` held at source precision by a
+    // protection in one map and by a layout refusal in the other. Same
+    // bytes, same state, two realizations — and the order must still be
+    // decided by identity rather than by arrival.
+    let surface = TensorSurface::new([
+        SurfaceTensor::new(
+            "target.decoder_stack",
+            "0.self_attn.q_proj.weight",
+            Role::DecoderLinear,
+            vec![64, 64],
+        ),
+        SurfaceTensor::new(
+            "target.decoder_stack",
+            "0.self_attn.v_proj.weight",
+            Role::DecoderLinear,
+            vec![64, 24],
+        ),
+    ])
+    .expect("distinct");
+    let protecting = PrecisionMap {
+        name: "m".into(),
+        encoding: DTYPE_NVFP4.into(),
+        roles: vec!["decoder-linear".into()],
+        exceptions: vec![Exception {
+            projection: Some("v_proj".into()),
+            layers: None,
+            encoding: None,
+        }],
+    };
+    let refusing = PrecisionMap {
+        exceptions: vec![],
+        ..protecting.clone()
+    };
+    let resolve = |m: &PrecisionMap| {
+        ResolvedState::new(
+            RepresentationState::resolve(&model(), &surface, m, &PackLayoutAdmission),
+            LogicalBytes::new(4_000),
+        )
+    };
+    let (a, b) = (resolve(&protecting), resolve(&refusing));
+    assert_eq!(a.physical_id(), b.physical_id(), "one physical state");
+    assert_ne!(a.realization_id(), b.realization_id(), "two realizations");
+
+    let assessment = |r: &ResolvedState| Assessment {
+        action: Action::new("+V"),
+        parent_state: a.physical_id().clone(),
+        child_state: r.physical_id().clone(),
+        child_realization: r.realization_id().clone(),
+        physical_delta: -4_000,
+        child_bytes: r.logical_bytes(),
+        intended_key: intent(EvidenceScale::Diagnostic).key_for(r.physical_id()),
+        prior_observations: Vec::new(),
+        parent_standing: None,
+    };
+    let policy = BestFirst::new(semantics());
+    let forward = policy.order(vec![assessment(&a), assessment(&b)]);
+    let backward = policy.order(vec![assessment(&b), assessment(&a)]);
+    assert_eq!(forward[0].child_realization, backward[0].child_realization);
+    assert!(
+        forward[0].child_realization.as_str() < forward[1].child_realization.as_str(),
+        "ordered by canonical realization id"
+    );
+}
+
+// ------------------------------------- search orders states, measurement experiments
+
+#[test]
+fn two_routes_to_one_physical_state_are_one_experiment() {
+    // The payoff of the whole identity model. From {} the moves `+E24`
+    // and `+K25` reach different states; from {E24} the move `+K25` and
+    // from {K25} the move `+E24` reach the SAME physical state by
+    // different routes. Search keeps both; measurement runs one.
+    let rig = Rig::new();
+    let policy = BestFirst::new(semantics());
+
+    let from_e = rig.candidates(&["E24"], EvidenceScale::Diagnostic);
+    let from_k = rig.candidates(&["K25"], EvidenceScale::Diagnostic);
+    let route_a = policy
+        .assess(&from_e, &NothingMeasured)
+        .into_iter()
+        .find(|a| a.action.label == "+K25")
+        .expect("E24 then K25");
+    let route_b = policy
+        .assess(&from_k, &NothingMeasured)
+        .into_iter()
+        .find(|a| a.action.label == "+E24")
+        .expect("K25 then E24");
+
+    assert_eq!(route_a.child_state, route_b.child_state, "one state");
+    assert_eq!(route_a.intended_key, route_b.intended_key, "one experiment");
+    assert_ne!(route_a.parent_state, route_b.parent_state, "two routes");
+    assert_eq!(
+        route_a.child_realization, route_b.child_realization,
+        "here the routes also agree on the decisions; the stronger case is below"
+    );
+
+    let opportunities = policy.opportunities(policy.order(vec![route_a, route_b]));
+    assert_eq!(opportunities.len(), 1, "scheduled once, not twice");
+    assert_eq!(opportunities[0].routes(), 2);
+    assert_eq!(
+        opportunities[0].physical_delta(),
+        opportunities[0].leading().physical_delta
+    );
+}
+
+#[test]
+fn two_realizations_of_one_state_still_schedule_one_experiment() {
+    // **The strong form**, and the one the identity model exists for:
+    //
+    //     A --action x--> C (realization r1)
+    //     B --action y--> C (realization r2)
+    //     search:      r1 != r2, both kept
+    //     measurement: one MeasurementKey, run once
+    //
+    // `v_proj` is layout-refused, so `+V` changes the decisions and no
+    // bytes. From `{}` the move `+Q` reaches `{Q}` with v at Source;
+    // from `{V}` the same move reaches `{V,Q}` with v LayoutRefused.
+    // One physical state, two realizations, one experiment.
+    let surface = TensorSurface::new([
+        SurfaceTensor::new(
+            "target.decoder_stack",
+            "0.self_attn.q_proj.weight",
+            Role::DecoderLinear,
+            vec![64, 64],
+        ),
+        SurfaceTensor::new(
+            "target.decoder_stack",
+            "0.self_attn.v_proj.weight",
+            Role::DecoderLinear,
+            vec![64, 24],
+        ),
+    ])
+    .expect("distinct");
+    let rig = Rig {
+        vocabulary: ActionVocabulary::new([
+            MapEdit::new("Q", compile("q_proj")),
+            MapEdit::new("V", compile("v_proj")),
+        ])
+        .expect("distinct names"),
+        surface: surface.clone(),
+        footprint: ShapeFootprint { surface },
+        ..Rig::new()
+    };
+    let policy = BestFirst::new(semantics());
+
+    let pick = |from: &[&str]| {
+        policy
+            .assess(
+                &rig.candidates(from, EvidenceScale::Diagnostic),
+                &NothingMeasured,
+            )
+            .into_iter()
+            .find(|a| a.action.label == "+Q")
+            .expect("+Q is eligible from here")
+    };
+    let plain = pick(&[]);
+    let after_v = pick(&["V"]);
+
+    assert_eq!(plain.child_state, after_v.child_state, "one physical state");
+    assert_ne!(
+        plain.child_realization, after_v.child_realization,
+        "two realizations — the action spaces differ"
+    );
+    assert_eq!(plain.intended_key, after_v.intended_key, "one experiment");
+
+    let opportunities = policy.opportunities(policy.order(vec![plain, after_v]));
+    assert_eq!(
+        opportunities.len(),
+        1,
+        "grouping is by experiment, not by realization"
+    );
+    assert_eq!(opportunities[0].routes(), 2);
+    let realizations: BTreeSet<&str> = opportunities[0]
+        .candidates
+        .iter()
+        .map(|c| c.child_realization.as_str())
+        .collect();
+    assert_eq!(realizations.len(), 2, "both routes survive inside it");
+}
+
+#[test]
+fn an_observation_of_the_state_reaches_every_route_to_it() {
+    // Once the experiment lands, both search realizations inherit it —
+    // 1c keys evidence on the physical state while 1b keeps the
+    // realizations apart.
+    let mut rig = Rig::new();
+    let policy = BestFirst::new(semantics());
+    let shared = rig
+        .generator()
+        .realize(&applied(&["E24", "K25"]))
+        .expect("realize");
+    rig.measurements
+        .record(
+            intent(EvidenceScale::Diagnostic).key_for(shared.physical_id()),
+            observation(1.0e-3),
+        )
+        .expect("record");
+
+    // Both routes to it are now pruned as already observed, from either
+    // parent, with no second run scheduled.
+    for parent in [["E24"], ["K25"]] {
+        let set = rig.candidates(&parent, EvidenceScale::Diagnostic);
+        assert_eq!(set.census().already_observed, 1, "from {parent:?}");
+        assert!(policy
+            .select(&set, &NothingMeasured)
+            .opportunity()
+            .map(|o| o.state != *shared.physical_id())
+            .unwrap_or(true));
+    }
+}
+
+// --------------------------------------------------------------- Ruling 3
+
+#[test]
+fn ruling_three_exhausted_sole_and_ranked() {
+    let rig = Rig::new();
+    let policy = BestFirst::new(semantics());
+
+    // > 1 — the registered rule chooses which is measured FIRST.
+    let many = policy.select(
+        &rig.candidates(&[], EvidenceScale::Diagnostic),
+        &NothingMeasured,
+    );
+    match &many {
+        Selection::Ranked { chosen, considered } => {
+            assert_eq!(*considered, 3);
+            assert_eq!(chosen.leading().action.label, "+E24", "the biggest prize");
+        }
+        other => panic!("expected a ranked selection, got {other:?}"),
+    }
+    assert!(!many.is_exhausted());
+
+    // 1 — SELECT it. Nothing to rank, so nothing may veto.
+    let one_edit = Rig {
+        vocabulary: ActionVocabulary::new([MapEdit::new("M26", compile("m_proj"))])
+            .expect("one edit"),
+        ..Rig::new()
+    };
+    let sole = policy.select(
+        &one_edit.candidates(&[], EvidenceScale::Diagnostic),
+        &NothingMeasured,
+    );
+    assert!(matches!(sole, Selection::Sole(_)));
+    assert_eq!(sole.opportunity().expect("selected").routes(), 1);
+
+    // 0 — the neighbourhood is closed.
+    let exhausted = policy.select(
+        &Rig {
+            vocabulary: ActionVocabulary::default(),
+            ..Rig::new()
+        }
+        .candidates(&[], EvidenceScale::Diagnostic),
+        &NothingMeasured,
+    );
+    assert_eq!(exhausted, Selection::Exhausted);
+    assert!(exhausted.is_exhausted());
+    assert!(exhausted.opportunity().is_none());
+}
+
+// ----------------------------------------- assessment carries ingredients
+
+#[test]
+fn an_assessment_holds_ingredients_and_no_score_of_record() {
+    let rig = Rig::new();
+    let policy = BestFirst::new(semantics());
+    let set = rig.candidates(&[], EvidenceScale::Diagnostic);
+    let assessed = policy.order(policy.assess(&set, &NothingMeasured));
+    let first = &assessed[0];
+
+    // Exact, computed, and the sign convention is not flipped on the way
+    // to the comparator.
+    assert!(first.physical_delta < 0);
+    assert_eq!(first.score(&semantics()).get(), first.physical_delta);
+    assert!(first.child_bytes.get() > 0);
+    assert_eq!(first.intended_key.scale(), EvidenceScale::Diagnostic);
+    assert!(first.prior_observations.is_empty());
+    assert!(!first.is_escalation());
+
+    // The parent is unmeasured, and that is `None` rather than a zero.
+    assert!(first.parent_standing.is_none());
+}
+
+#[test]
+fn a_measured_parent_contributes_its_whole_standing_not_a_number() {
+    // The binding margin, the headroom and which criterion is scarce are
+    // all questions a reader may want; a scalar would answer none.
+    let rig = Rig::new();
+    let policy = BestFirst::new(semantics());
+    let parent = rig.generator().realize(&applied(&[])).expect("realize");
+
+    let mut measurements = MeasurementRegistry::new();
+    measurements
+        .record(
+            intent(EvidenceScale::Authority).key_for(parent.physical_id()),
+            observation(3.3532e-3),
+        )
+        .expect("record");
+    let snapshot = SearchSnapshot::new(
+        Objective::MinimiseLogicalBytes,
+        kimi_logit_balanced_v1(),
+        TailSupportPolicy::route_cal_1(),
+        SearchSemantics::new("g/v1", "p/v1", "e/v1", "pr/v1", "rank/v1", "b/v1"),
+        RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, parent.clone()),
+        measurements,
+    );
+
+    let set = rig.candidates(&[], EvidenceScale::Diagnostic);
+    let assessed = policy.assess(&set, &snapshot);
+    let standing = assessed[0]
+        .parent_standing
+        .as_ref()
+        .expect("the parent was measured at authority");
+    assert_eq!(standing.gate_id, "kimi-logit-balanced-v1");
+    assert_eq!(
+        standing.binding().expect("a ceiling scored").criterion,
+        Criterion::KlP99
+    );
+    assert!(standing.admissible());
+}
+
+#[test]
+fn a_diagnostic_reading_of_the_parent_is_not_its_standing() {
+    // Authority and not "whatever was measured": a diagnostic reading
+    // prices nothing against the contract, and handing one over as
+    // though it did is the inference R5-F4 and R5-F9 closed.
+    let rig = Rig::new();
+    let policy = BestFirst::new(semantics());
+    let parent = rig.generator().realize(&applied(&[])).expect("realize");
+
+    let mut measurements = MeasurementRegistry::new();
+    measurements
+        .record(
+            intent(EvidenceScale::Diagnostic).key_for(parent.physical_id()),
+            observation(3.3532e-3),
+        )
+        .expect("record");
+    let snapshot = SearchSnapshot::new(
+        Objective::MinimiseLogicalBytes,
+        kimi_logit_balanced_v1(),
+        TailSupportPolicy::route_cal_1(),
+        SearchSemantics::new("g/v1", "p/v1", "e/v1", "pr/v1", "rank/v1", "b/v1"),
+        RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, parent),
+        measurements,
+    );
+
+    let assessed = policy.assess(&rig.candidates(&[], EvidenceScale::Diagnostic), &snapshot);
+    assert!(
+        assessed[0].parent_standing.is_none(),
+        "a diagnostic reading is not a standing against the contract"
+    );
+}
+
+#[test]
+fn the_ranking_rule_is_named_in_the_search_semantics() {
+    // A snapshot must be able to distinguish the same observations under
+    // best-first-v1 from the same observations under v2: those can
+    // legitimately select different experiments without anything
+    // measured having changed.
+    let v1 = SearchSemantics::new("g/v1", "p/v1", "e/v1", "pr/v1", "rank/v1", "b/v1");
+    let v2 = SearchSemantics {
+        ranking_rule: "rank/v2".into(),
+        ..v1.clone()
+    };
+    assert_ne!(v1.id(), v2.id());
+    assert_eq!(v1.ranking_rule, "rank/v1");
+    assert_ne!(
+        v1.ranking_rule, v1.promotion_rule,
+        "priority and admissibility are different questions"
+    );
+}
+
+// ---------------------------------------------------------------- helper
+
+fn observation(kl_p99: f64) -> QualityBank {
+    let dist = |v: f64| {
+        Some(Distribution {
+            count: 8192,
+            min: 0.0,
+            p50: 0.0,
+            p95: 0.0,
+            p99: v,
+            max: v,
+        })
+    };
+    QualityBank {
+        positions: 8192,
+        logits: LogitEvidence {
+            kl_p50: 0.0,
+            kl_p95: 0.0,
+            kl_p99,
+            max_logit_delta: 0.0,
+            top1_flips: 0,
+            top10_changes: 0,
+        },
+        routing: RoutingEvidence {
+            route_flips: 0,
+            positions_with_route_change: 0,
+            layers_with_route_change: 0,
+            first_layer_with_route_change: None,
+            route_margin: None,
+            route_weight_mass_moved: dist(0.113),
+        },
+        min_covered_mass: Some(0.6315),
+        top10_margin: None,
+        top10_candidate_margin: None,
+        top10_mass_displaced: dist(0.065),
+        top10_rank_displacement: None,
+        top1_margin: None,
+        top1_candidate_margin: None,
+        top1_mass_displaced: dist(0.03),
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/semantics.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/semantics.rs
@@ -1,0 +1,119 @@
+//! **Which rules turned facts into conclusions.**
+//!
+//! 1c drew a line between an observation and its meaning so that a later
+//! contract could reinterpret evidence already held. Persistence forces
+//! the same line one level up, and it is easy to miss: six months from
+//! now `decide_promotion` legitimately changes, an old snapshot replays,
+//! and the answer differs while every stored measurement is intact.
+//!
+//! **That is not corruption. The decision procedure changed.** A replay
+//! that could not say which of the two had happened would make every
+//! improvement to the search look like a data problem.
+//!
+//! ```text
+//! observation replay          same facts, CURRENT rules
+//!                             → "what would we conclude today?"
+//!
+//! historical decision replay  same facts, the rules OF THE TIME
+//!                             → "what did we conclude, and why?"
+//! ```
+//!
+//! So a snapshot records the semantics its conclusions were originally
+//! drawn under, and a replay can compare.
+//!
+//! # Version identities, not source hashes
+//!
+//! Each field names a normative version — `"physical-dominance/v1"` —
+//! and not a commit or a binary digest. The reasoning is
+//! [`super::instrument`]'s, applied to decision procedures rather than
+//! to measurement: a refactor that changes no rule must not invalidate a
+//! scientific record, and a rule change must be visible even when the
+//! diff is one line. The same limit applies too — a declaration can lie,
+//! and only construction from the rule's own constant can close that.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::compile::hash_bytes;
+use super::surface::{FIELD, SECTION};
+
+/// The canonical-form version every semantics id is computed under.
+pub const SEARCH_SEMANTICS_ID_VERSION: &str = "search-semantics-id/v1";
+
+/// **What rules a conclusion was drawn under.**
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct SearchSemanticsId(String);
+
+impl SearchSemanticsId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn short(&self) -> &str {
+        &self.0[..self.0.len().min(12)]
+    }
+}
+
+impl std::fmt::Display for SearchSemanticsId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The five decision procedures between a fact and a conclusion.
+///
+/// Named separately because they change independently and for different
+/// reasons — Ruling 1 rewrote pruning without touching evidence
+/// interpretation, and R5-F4 rewrote evidence interpretation three times
+/// without touching pruning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchSemantics {
+    /// How candidate states are proposed.
+    pub candidate_generation: String,
+    /// What may be pruned before it is measured. Ruling 1's list of
+    /// four, and no fifth.
+    pub pre_measurement_pruning: String,
+    /// How a statistic may be used — the `SearchEvidence` ladder.
+    pub evidence_interpretation: String,
+    /// How candidates become admitted maps.
+    ///
+    /// Named `promotion_rule` and not `promotion` on purpose: the
+    /// structural check that a stored snapshot carries no CONCLUSION
+    /// looks for a key called `promotion`, and a rule identity must not
+    /// be mistaken for a decision. The name is the disambiguation, so
+    /// the check can stay blunt instead of growing an exemption.
+    pub promotion_rule: String,
+    /// How bytes are counted.
+    pub physical_accounting: String,
+}
+
+impl SearchSemantics {
+    pub fn new(
+        candidate_generation: impl Into<String>,
+        pre_measurement_pruning: impl Into<String>,
+        evidence_interpretation: impl Into<String>,
+        promotion: impl Into<String>,
+        physical_accounting: impl Into<String>,
+    ) -> Self {
+        Self {
+            candidate_generation: candidate_generation.into(),
+            pre_measurement_pruning: pre_measurement_pruning.into(),
+            evidence_interpretation: evidence_interpretation.into(),
+            promotion_rule: promotion.into(),
+            physical_accounting: physical_accounting.into(),
+        }
+    }
+
+    /// What these rules ARE.
+    pub fn id(&self) -> SearchSemanticsId {
+        let input = format!(
+            "{SEARCH_SEMANTICS_ID_VERSION}{SECTION}generation={}{FIELD}pruning={}{FIELD}\
+             evidence={}{FIELD}promotion={}{FIELD}physical={}",
+            self.candidate_generation,
+            self.pre_measurement_pruning,
+            self.evidence_interpretation,
+            self.promotion_rule,
+            self.physical_accounting
+        );
+        SearchSemanticsId(hash_bytes(input.as_bytes()))
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/semantics.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/semantics.rs
@@ -59,7 +59,7 @@ impl std::fmt::Display for SearchSemanticsId {
     }
 }
 
-/// The five decision procedures between a fact and a conclusion.
+/// The six decision procedures between a fact and a conclusion.
 ///
 /// Named separately because they change independently and for different
 /// reasons — Ruling 1 rewrote pruning without touching evidence
@@ -69,8 +69,8 @@ impl std::fmt::Display for SearchSemanticsId {
 pub struct SearchSemantics {
     /// How candidate states are proposed.
     pub candidate_generation: String,
-    /// What may be pruned before it is measured. Ruling 1's list of
-    /// four, and no fifth.
+    /// What may be pruned before it is measured. Ruling 1's three
+    /// usable categories, and no fourth.
     pub pre_measurement_pruning: String,
     /// How a statistic may be used — the `SearchEvidence` ladder.
     pub evidence_interpretation: String,
@@ -82,6 +82,11 @@ pub struct SearchSemantics {
     /// be mistaken for a decision. The name is the disambiguation, so
     /// the check can stay blunt instead of growing an exemption.
     pub promotion_rule: String,
+    /// How eligible candidates are ordered for measurement — the
+    /// `RankingSemanticsId` in force. Separate from `promotion_rule`
+    /// because the two answer different questions: which experiment has
+    /// priority, and which candidate may replace the incumbent.
+    pub ranking_rule: String,
     /// How bytes are counted.
     pub physical_accounting: String,
 }
@@ -92,6 +97,7 @@ impl SearchSemantics {
         pre_measurement_pruning: impl Into<String>,
         evidence_interpretation: impl Into<String>,
         promotion: impl Into<String>,
+        ranking: impl Into<String>,
         physical_accounting: impl Into<String>,
     ) -> Self {
         Self {
@@ -99,6 +105,7 @@ impl SearchSemantics {
             pre_measurement_pruning: pre_measurement_pruning.into(),
             evidence_interpretation: evidence_interpretation.into(),
             promotion_rule: promotion.into(),
+            ranking_rule: ranking.into(),
             physical_accounting: physical_accounting.into(),
         }
     }
@@ -107,11 +114,12 @@ impl SearchSemantics {
     pub fn id(&self) -> SearchSemanticsId {
         let input = format!(
             "{SEARCH_SEMANTICS_ID_VERSION}{SECTION}generation={}{FIELD}pruning={}{FIELD}\
-             evidence={}{FIELD}promotion={}{FIELD}physical={}",
+             evidence={}{FIELD}promotion={}{FIELD}ranking={}{FIELD}physical={}",
             self.candidate_generation,
             self.pre_measurement_pruning,
             self.evidence_interpretation,
             self.promotion_rule,
+            self.ranking_rule,
             self.physical_accounting
         );
         SearchSemanticsId(hash_bytes(input.as_bytes()))

--- a/crates/larql-vindex/src/format/vindex3/represent/state/snapshot.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/snapshot.rs
@@ -58,15 +58,32 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use std::collections::BTreeSet;
+
+use super::super::assessment::{CandidateAssessment, EvidenceContext};
+use super::super::byte_ledger::ByteLedger;
 use super::super::constraint::{ConstraintVector, Margin};
+use super::super::decision::SearchCandidate;
+use super::super::diagnostic::{DiagnosticPolicy, DiagnosticVector};
+use super::super::execution_cost::{CostRefusal, ExecutionCostModel};
+use super::super::map::PrecisionMap;
 use super::super::measurement::{EvidenceScale, TailSupportPolicy};
+use super::super::participation::ParticipationDeclaration;
+use super::super::promotion::PromotionCandidate;
+use super::super::quality::QualityBank;
 use super::super::quality::QualityGate;
-use super::assess::ParentStanding;
+use super::super::search_evidence::SearchCalibrationRegistry;
+use super::action_space::ActionVocabulary;
+use super::assess::{ParentStanding, RankingSemantics};
+use super::candidate::{Footprint, Generator, MeasurementIntent};
 use super::graph::RepresentationStateGraph;
 use super::identity::RepresentationStateId;
 use super::key::{MeasurementKey, MeasurementRegistry};
 use super::realization::LogicalBytes;
+use super::resolved::LayoutAdmission;
+use super::search_policy::{BestFirst, Selection};
 use super::semantics::{SearchSemantics, SearchSemanticsId};
+use super::surface::TensorSurface;
 use crate::error::VindexError;
 
 /// The snapshot format version.
@@ -176,39 +193,85 @@ impl FrontierEntry {
     }
 }
 
+/// **What the search is over**: the model's surface and the moves that
+/// exist at all.
+///
+/// The vocabulary belongs here and not in the policy: R5-F6 was a
+/// vocabulary failure, not a ranking failure, and no policy can recover
+/// a state whose move was never declared.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchSpace {
+    pub surface: TensorSurface,
+    /// The map every applied set is layered onto.
+    pub base_map: PrecisionMap,
+    pub vocabulary: ActionVocabulary,
+}
+
+/// **How facts become conclusions.** Every field is a rule or a
+/// threshold; none is an outcome.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchConfig {
+    pub objective: Objective,
+    /// The frozen behavioural contract conclusions are drawn against.
+    pub gate: QualityGate,
+    pub tail_support: TailSupportPolicy,
+    /// What this programme has learned about its own instruments — the
+    /// `SearchEvidence` ladder's registrations.
+    pub calibrations: SearchCalibrationRegistry,
+    /// Which statistics a diagnostic reads, and for what purpose.
+    pub diagnostic_policy: DiagnosticPolicy,
+    /// The rules the original conclusions were drawn under, so a later
+    /// replay can tell a changed procedure from changed data.
+    pub semantics: SearchSemantics,
+    pub ranking: RankingSemantics,
+}
+
+/// **What has been observed, and what it costs.**
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchFacts {
+    pub graph: RepresentationStateGraph,
+    pub measurements: MeasurementRegistry,
+    /// Per-token reads, per state. NOT [`LogicalBytes`], which is a
+    /// whole-map footprint — the two are different quantities and the
+    /// newtype exists to keep them apart.
+    pub byte_ledgers: BTreeMap<RepresentationStateId, ByteLedger>,
+    /// Measured execution observations, each carrying its machine,
+    /// device, backend and compiler commit. The COST is not stored:
+    /// `ExecutionCostModel::predict` derives it, and its `status()`
+    /// refuses to call the model calibrated until beta has been shown
+    /// across separated breadths.
+    pub execution_cost: ExecutionCostModel,
+}
+
 /// **The persisted scientific state of a search.**
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SearchSnapshot {
     schema: String,
-    objective: Objective,
-    /// The frozen behavioural contract conclusions are drawn against.
-    gate: QualityGate,
-    tail_support: TailSupportPolicy,
-    /// The rules the original conclusions were drawn under, so a later
-    /// replay can tell a changed procedure from changed data.
-    semantics: SearchSemantics,
-    graph: RepresentationStateGraph,
-    measurements: MeasurementRegistry,
+    space: SearchSpace,
+    config: SearchConfig,
+    facts: SearchFacts,
 }
 
 impl SearchSnapshot {
-    pub fn new(
-        objective: Objective,
-        gate: QualityGate,
-        tail_support: TailSupportPolicy,
-        semantics: SearchSemantics,
-        graph: RepresentationStateGraph,
-        measurements: MeasurementRegistry,
-    ) -> Self {
+    pub fn new(space: SearchSpace, config: SearchConfig, facts: SearchFacts) -> Self {
         Self {
             schema: SNAPSHOT_SCHEMA.into(),
-            objective,
-            gate,
-            tail_support,
-            semantics,
-            graph,
-            measurements,
+            space,
+            config,
+            facts,
         }
+    }
+
+    pub fn space(&self) -> &SearchSpace {
+        &self.space
+    }
+
+    pub fn config(&self) -> &SearchConfig {
+        &self.config
+    }
+
+    pub fn facts(&self) -> &SearchFacts {
+        &self.facts
     }
 
     /// Refuse a snapshot written under another schema.
@@ -229,34 +292,39 @@ impl SearchSnapshot {
     }
 
     pub fn objective(&self) -> Objective {
-        self.objective
+        self.config.objective
     }
 
     pub fn gate(&self) -> &QualityGate {
-        &self.gate
+        &self.config.gate
     }
 
     pub fn tail_support(&self) -> &TailSupportPolicy {
-        &self.tail_support
+        &self.config.tail_support
     }
 
     pub fn semantics(&self) -> &SearchSemantics {
-        &self.semantics
+        &self.config.semantics
     }
 
     /// The rules this snapshot's conclusions were originally drawn
     /// under. A replay whose own semantics differ is answering a
     /// different question, and this is what lets it say so.
     pub fn semantics_id(&self) -> SearchSemanticsId {
-        self.semantics.id()
+        self.config.semantics.id()
     }
 
     pub fn graph(&self) -> &RepresentationStateGraph {
-        &self.graph
+        &self.facts.graph
     }
 
     pub fn measurements(&self) -> &MeasurementRegistry {
-        &self.measurements
+        &self.facts.measurements
+    }
+
+    /// The per-token ledger for one state, where it is held.
+    pub fn ledger(&self, state: &RepresentationStateId) -> Option<&ByteLedger> {
+        self.facts.byte_ledgers.get(state)
     }
 
     // ---------------------------------------------------------- derived
@@ -265,10 +333,10 @@ impl SearchSnapshot {
     /// reading and the stored gate. `None` when no such experiment was
     /// run — a miss, which is a fact about the record and not a failure.
     pub fn adjudicate(&self, key: &MeasurementKey) -> Option<Adjudication> {
-        let observation = self.measurements.get(key)?;
+        let observation = self.facts.measurements.get(key)?;
         Some(Adjudication {
             key: key.clone(),
-            constraints: ConstraintVector::of(&self.gate, observation),
+            constraints: ConstraintVector::of(&self.config.gate, observation),
         })
     }
 
@@ -276,20 +344,21 @@ impl SearchSnapshot {
     /// holds, in state-id order — a stated order, never insertion order.
     pub fn frontier(&self) -> Vec<FrontierEntry> {
         let mut by_state: BTreeMap<&RepresentationStateId, Vec<Adjudication>> = BTreeMap::new();
-        for node in self.graph.nodes() {
+        for node in self.facts.graph.nodes() {
             by_state.entry(node.physical_id()).or_default();
         }
-        for (key, observation) in self
-            .measurements
-            .keys()
-            .filter_map(|k| self.measurements.get(k).map(|observation| (k, observation)))
-        {
+        for (key, observation) in self.facts.measurements.keys().filter_map(|k| {
+            self.facts
+                .measurements
+                .get(k)
+                .map(|observation| (k, observation))
+        }) {
             // A measurement of a state this graph does not hold belongs
             // to another search; it is not this frontier's business.
             if let Some(entry) = by_state.get_mut(key.state()) {
                 entry.push(Adjudication {
                     key: key.clone(),
-                    constraints: ConstraintVector::of(&self.gate, observation),
+                    constraints: ConstraintVector::of(&self.config.gate, observation),
                 });
             }
         }
@@ -298,6 +367,7 @@ impl SearchSnapshot {
             .map(|(state, adjudications)| FrontierEntry {
                 state: state.clone(),
                 logical_bytes: self
+                    .facts
                     .graph
                     .node(state)
                     .expect("every key came from the graph")
@@ -334,5 +404,129 @@ impl SearchSnapshot {
             .filter(|e| !e.measured_at(scale))
             .map(|e| e.state)
             .collect()
+    }
+
+    // ------------------------------------------------ the derivation chain
+
+    /// **The action space, from stored facts.**
+    ///
+    /// `layout` and `footprint` are supplied because they are CODE — a
+    /// layout rule and a pricing routine — not data. Everything the
+    /// generator reads that is a fact or a rule comes from the snapshot:
+    /// the model from the graph, the surface, base map and vocabulary
+    /// from the space, the transition policy from the graph, and the
+    /// measurement registry from the facts.
+    pub fn generator<'a>(
+        &'a self,
+        layout: &'a dyn LayoutAdmission,
+        footprint: &'a dyn Footprint,
+    ) -> Generator<'a> {
+        Generator {
+            model: self.facts.graph.model(),
+            surface: &self.space.surface,
+            base_map: &self.space.base_map,
+            vocabulary: &self.space.vocabulary,
+            layout,
+            footprint,
+            policy: self.facts.graph.policy(),
+            measurements: &self.facts.measurements,
+        }
+    }
+
+    /// The ordering policy this snapshot's conclusions are drawn under.
+    pub fn best_first(&self) -> BestFirst {
+        BestFirst::new(self.config.ranking.clone())
+    }
+
+    /// **What to measure next**, derived end to end from stored facts.
+    pub fn next_experiment(
+        &self,
+        applied: &BTreeSet<String>,
+        intent: &MeasurementIntent,
+        layout: &dyn LayoutAdmission,
+        footprint: &dyn Footprint,
+    ) -> Result<Selection, VindexError> {
+        let set = self
+            .generator(layout, footprint)
+            .candidates(applied, intent)?;
+        Ok(self.best_first().select(&set, self))
+    }
+
+    /// **Promotion, derived from stored facts.**
+    ///
+    /// Builds one [`SearchCandidate`] per measured move and hands the set
+    /// to [`decide_promotion`], which is not reimplemented here: it
+    /// already refuses to scalarise disagreeing proxies, and making this
+    /// convenient is not a reason to weaken it.
+    ///
+    /// **Promotion reads the graph's EDGES, not a candidate set.**
+    ///
+    /// A promotion candidate is a move that has been built and measured;
+    /// the generator prunes exactly those as `AlreadyObserved`, because
+    /// its question is what to try NEXT. Feeding it eligible candidates
+    /// would ask which unmeasured move should replace the incumbent,
+    /// which is not a question any evidence can answer.
+    ///
+    /// A move is only a promotion candidate when BOTH ends carry a
+    /// reading at `scale` and both carry a per-token ledger — the
+    /// marginal quantities are a difference between two predictions, and
+    /// a difference with one end missing is not a smaller number, it is
+    /// no number. Such a move is skipped, not defaulted.
+    pub fn promotion_candidates(
+        &self,
+        scale: EvidenceScale,
+    ) -> Result<Vec<SearchCandidate>, CostRefusal> {
+        let ctx = EvidenceContext {
+            scale,
+            registry: self.config.calibrations.clone(),
+            tail_policy: self.config.tail_support.clone(),
+        };
+        let mut candidates = Vec::new();
+        for edge in self.facts.graph.edges() {
+            let (Some(parent_bank), Some(child_bank)) = (
+                self.reading_of(edge.parent(), scale),
+                self.reading_of(edge.child(), scale),
+            ) else {
+                continue;
+            };
+            let (Some(parent_ledger), Some(child_ledger)) =
+                (self.ledger(edge.parent()), self.ledger(edge.child()))
+            else {
+                continue;
+            };
+            let assessment = CandidateAssessment::of(
+                &ctx,
+                &self.facts.execution_cost,
+                parent_ledger,
+                child_ledger,
+                ConstraintVector::of(&self.config.gate, parent_bank),
+                ConstraintVector::of(&self.config.gate, child_bank),
+            )?;
+            candidates.push(SearchCandidate {
+                id: edge.action().label.clone(),
+                // No proxies: a proxy observation is a registered
+                // finding about an instrument, and none has been
+                // recorded for these statistics. An invented one would
+                // be exactly the magnitude claim ROUTE-CAL-1 refused.
+                promotion: PromotionCandidate::new(assessment, Vec::new()),
+                diagnostic: DiagnosticVector::of(&self.config.diagnostic_policy, child_bank),
+                participation: ParticipationDeclaration::all_affected(),
+            });
+        }
+        Ok(candidates)
+    }
+
+    /// The reading held of one state at one scale, under any bank or
+    /// instrument this snapshot holds.
+    fn reading_of<'a>(
+        &'a self,
+        state: &'a RepresentationStateId,
+        scale: EvidenceScale,
+    ) -> Option<&'a QualityBank> {
+        self.facts
+            .measurements
+            .of_state(state)
+            .find(|(k, _)| k.scale() == scale)
+            .map(|(_, bank)| bank)
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/state/snapshot.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/snapshot.rs
@@ -1,0 +1,318 @@
+//! **The snapshot holds facts and configuration. Every conclusion is
+//! derived.**
+//!
+//! ```text
+//! STORED — facts and configuration
+//!     schema, objective, gate, tail-support policy, search semantics
+//!     the state graph      (which states exist, how they were reached)
+//!     the measurements     (what was observed of them)
+//!
+//! NEVER STORED — conclusions
+//!     admissible / refused        chosen candidate      candidate rank
+//!     binding constraint          the frontier          "best map"
+//!     promotion decision          an agent's recommendation
+//! ```
+//!
+//! The invariant, and the reason this stage exists:
+//!
+//! > **Delete every derived conclusion, deserialise the factual state,
+//! > run the deterministic optimiser, and recover the same conclusion.**
+//!
+//! That is what removes the experiment ledger — and an operator's
+//! memory — as the authority for a search. A snapshot that stored its
+//! own verdicts would prove serialisation and nothing else.
+//!
+//! # The frontier is a projection, not a record
+//!
+//! A stored frontier is a second authority that can drift from the graph
+//! and measurements it was computed from. [`SearchSnapshot::frontier`]
+//! recomputes it every time. Caching is a later optimisation; the replay
+//! gate must pass without one.
+//!
+//! Likewise `admissible`, `sound` and `binding`: all three are
+//! [`ConstraintVector`] questions about one observation and one gate, and
+//! all three are recomputed.
+//!
+//! # Semantic replay, not implementation replay
+//!
+//! What must reproduce is the eligible set and the conclusions, not the
+//! order a `BTreeMap` happened to yield. Swapping a container must not
+//! invalidate a scientific record. So the derived views return sets and
+//! adjudications keyed by identity, and where an order is exposed it is
+//! by a stated key — never by insertion.
+//!
+//! # What 1d does NOT replay, and why that is principled
+//!
+//! [`decide_promotion`] takes a `SearchCandidate`, which carries a
+//! `PromotionCandidate` holding an `assessment.ranking_score` — a
+//! CONCLUSION. Persisting one to make promotion replayable would be
+//! exactly the cheat this stage exists to forbid. Re-deriving it instead
+//! needs the assessment layer wired to the graph, which is the candidate
+//! generator's job at stage 2. Until then a snapshot replays the
+//! CONTRACT chain — margins, binding constraint, admissibility, refusal
+//! and its reasons — and does not claim to replay promotion ordering.
+//!
+//! [`decide_promotion`]: super::super::decision::decide_promotion
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::super::constraint::{ConstraintVector, Margin};
+use super::super::measurement::{EvidenceScale, TailSupportPolicy};
+use super::super::quality::QualityGate;
+use super::graph::RepresentationStateGraph;
+use super::identity::RepresentationStateId;
+use super::key::{MeasurementKey, MeasurementRegistry};
+use super::realization::LogicalBytes;
+use super::semantics::{SearchSemantics, SearchSemanticsId};
+use crate::error::VindexError;
+
+/// The snapshot format version.
+pub const SNAPSHOT_SCHEMA: &str = "represent-search-snapshot/v1";
+
+/// What the search is trying to do.
+///
+/// One variant, because one objective has actually been searched
+/// against. Measured throughput joins when residency enters the state
+/// and the transition policy stops being monotone in bytes; inventing
+/// the variant now would be inventing the accounting behind it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Objective {
+    /// Fewest logical bytes that still satisfies the contract.
+    MinimiseLogicalBytes,
+}
+
+/// **A derived verdict on one observation.** Never stored.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Adjudication {
+    key: MeasurementKey,
+    constraints: ConstraintVector,
+}
+
+impl Adjudication {
+    /// Which experiment this is a verdict on.
+    pub fn key(&self) -> &MeasurementKey {
+        &self.key
+    }
+
+    pub fn constraints(&self) -> &ConstraintVector {
+        &self.constraints
+    }
+
+    /// Whether every criterion — ceiling and floor — is met.
+    pub fn admissible(&self) -> bool {
+        self.constraints.admissible()
+    }
+
+    /// Whether the measurement itself is sound: every floor cleared. A
+    /// blind instrument passes every ceiling perfectly.
+    pub fn sound(&self) -> bool {
+        self.constraints.sound()
+    }
+
+    /// The scarce resource — the ceiling closest to its limit.
+    pub fn binding(&self) -> Option<&Margin> {
+        self.constraints.binding()
+    }
+
+    /// Every criterion this observation failed, in the gate's own order.
+    pub fn failures(&self) -> Vec<&Margin> {
+        self.constraints
+            .margins
+            .iter()
+            .filter(|m| !m.satisfied())
+            .collect()
+    }
+}
+
+/// One state's standing, derived.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FrontierEntry {
+    pub state: RepresentationStateId,
+    pub logical_bytes: LogicalBytes,
+    /// Every adjudication held for this state, one per observation.
+    pub adjudications: Vec<Adjudication>,
+}
+
+impl FrontierEntry {
+    /// Admitted only on an AUTHORITY reading. A diagnostic reading that
+    /// passes is not an admission — the whole ladder rests on that.
+    pub fn admitted(&self) -> bool {
+        self.adjudications
+            .iter()
+            .any(|a| a.key.scale() == EvidenceScale::Authority && a.admissible())
+    }
+
+    /// Refused where an authority reading failed the contract.
+    pub fn refused(&self) -> bool {
+        self.adjudications
+            .iter()
+            .any(|a| a.key.scale() == EvidenceScale::Authority && !a.admissible())
+    }
+
+    pub fn measured_at(&self, scale: EvidenceScale) -> bool {
+        self.adjudications.iter().any(|a| a.key.scale() == scale)
+    }
+}
+
+/// **The persisted scientific state of a search.**
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchSnapshot {
+    schema: String,
+    objective: Objective,
+    /// The frozen behavioural contract conclusions are drawn against.
+    gate: QualityGate,
+    tail_support: TailSupportPolicy,
+    /// The rules the original conclusions were drawn under, so a later
+    /// replay can tell a changed procedure from changed data.
+    semantics: SearchSemantics,
+    graph: RepresentationStateGraph,
+    measurements: MeasurementRegistry,
+}
+
+impl SearchSnapshot {
+    pub fn new(
+        objective: Objective,
+        gate: QualityGate,
+        tail_support: TailSupportPolicy,
+        semantics: SearchSemantics,
+        graph: RepresentationStateGraph,
+        measurements: MeasurementRegistry,
+    ) -> Self {
+        Self {
+            schema: SNAPSHOT_SCHEMA.into(),
+            objective,
+            gate,
+            tail_support,
+            semantics,
+            graph,
+            measurements,
+        }
+    }
+
+    /// Refuse a snapshot written under another schema.
+    pub fn check_schema(&self) -> Result<(), VindexError> {
+        if self.schema != SNAPSHOT_SCHEMA {
+            return Err(VindexError::Parse(format!(
+                "snapshot schema is `{}` but this build reads `{SNAPSHOT_SCHEMA}` — a stored \
+                 search state whose canonical forms have moved must be recognisably stale, \
+                 not silently reinterpreted",
+                self.schema
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    pub fn objective(&self) -> Objective {
+        self.objective
+    }
+
+    pub fn gate(&self) -> &QualityGate {
+        &self.gate
+    }
+
+    pub fn tail_support(&self) -> &TailSupportPolicy {
+        &self.tail_support
+    }
+
+    pub fn semantics(&self) -> &SearchSemantics {
+        &self.semantics
+    }
+
+    /// The rules this snapshot's conclusions were originally drawn
+    /// under. A replay whose own semantics differ is answering a
+    /// different question, and this is what lets it say so.
+    pub fn semantics_id(&self) -> SearchSemanticsId {
+        self.semantics.id()
+    }
+
+    pub fn graph(&self) -> &RepresentationStateGraph {
+        &self.graph
+    }
+
+    pub fn measurements(&self) -> &MeasurementRegistry {
+        &self.measurements
+    }
+
+    // ---------------------------------------------------------- derived
+
+    /// **The verdict on one observation**, computed from the stored
+    /// reading and the stored gate. `None` when no such experiment was
+    /// run — a miss, which is a fact about the record and not a failure.
+    pub fn adjudicate(&self, key: &MeasurementKey) -> Option<Adjudication> {
+        let observation = self.measurements.get(key)?;
+        Some(Adjudication {
+            key: key.clone(),
+            constraints: ConstraintVector::of(&self.gate, observation),
+        })
+    }
+
+    /// **The frontier, recomputed.** One entry per state the graph
+    /// holds, in state-id order — a stated order, never insertion order.
+    pub fn frontier(&self) -> Vec<FrontierEntry> {
+        let mut by_state: BTreeMap<&RepresentationStateId, Vec<Adjudication>> = BTreeMap::new();
+        for node in self.graph.nodes() {
+            by_state.entry(node.physical_id()).or_default();
+        }
+        for (key, observation) in self
+            .measurements
+            .keys()
+            .filter_map(|k| self.measurements.get(k).map(|observation| (k, observation)))
+        {
+            // A measurement of a state this graph does not hold belongs
+            // to another search; it is not this frontier's business.
+            if let Some(entry) = by_state.get_mut(key.state()) {
+                entry.push(Adjudication {
+                    key: key.clone(),
+                    constraints: ConstraintVector::of(&self.gate, observation),
+                });
+            }
+        }
+        by_state
+            .into_iter()
+            .map(|(state, adjudications)| FrontierEntry {
+                state: state.clone(),
+                logical_bytes: self
+                    .graph
+                    .node(state)
+                    .expect("every key came from the graph")
+                    .logical_bytes(),
+                adjudications,
+            })
+            .collect()
+    }
+
+    /// States with an authority reading that satisfies the contract,
+    /// **cheapest first** — the objective, applied.
+    pub fn admitted(&self) -> Vec<FrontierEntry> {
+        let mut admitted: Vec<FrontierEntry> = self
+            .frontier()
+            .into_iter()
+            .filter(|e| e.admitted())
+            .collect();
+        admitted.sort_by(|a, b| {
+            a.logical_bytes
+                .cmp(&b.logical_bytes)
+                .then_with(|| a.state.as_str().cmp(b.state.as_str()))
+        });
+        admitted
+    }
+
+    /// States the graph holds that carry no reading at `scale`.
+    ///
+    /// A fact query, deliberately unordered by desirability: WHICH of
+    /// these to spend an authority run on is a search policy's decision
+    /// and this stage has no policy.
+    pub fn unmeasured_at(&self, scale: EvidenceScale) -> Vec<RepresentationStateId> {
+        self.frontier()
+            .into_iter()
+            .filter(|e| !e.measured_at(scale))
+            .map(|e| e.state)
+            .collect()
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/snapshot.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/snapshot.rs
@@ -61,6 +61,7 @@ use serde::{Deserialize, Serialize};
 use super::super::constraint::{ConstraintVector, Margin};
 use super::super::measurement::{EvidenceScale, TailSupportPolicy};
 use super::super::quality::QualityGate;
+use super::assess::ParentStanding;
 use super::graph::RepresentationStateGraph;
 use super::identity::RepresentationStateId;
 use super::key::{MeasurementKey, MeasurementRegistry};
@@ -123,6 +124,25 @@ impl Adjudication {
             .iter()
             .filter(|m| !m.satisfied())
             .collect()
+    }
+}
+
+impl ParentStanding for SearchSnapshot {
+    /// A state's standing at AUTHORITY scale, where such a reading
+    /// exists.
+    ///
+    /// Authority and not "whatever was measured": a diagnostic reading
+    /// prices nothing against the contract, and a policy handed one as
+    /// though it did would be reading a diagnostic as authority — the
+    /// inference R5-F4 and R5-F9 closed.
+    fn of(&self, state: &RepresentationStateId) -> Option<ConstraintVector> {
+        self.frontier()
+            .into_iter()
+            .find(|e| &e.state == state)?
+            .adjudications
+            .into_iter()
+            .find(|a| a.key().scale() == EvidenceScale::Authority)
+            .map(|a| a.constraints().clone())
     }
 }
 

--- a/crates/larql-vindex/src/format/vindex3/represent/state/snapshot_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/snapshot_tests.rs
@@ -1,0 +1,572 @@
+//! **1d: the replay gate.**
+//!
+//! > Given a root realization, the search semantics, the contract and
+//! > the recorded measurements — and WITHOUT any recorded ranking,
+//! > pruning decision, promotion or frontier — the optimiser shall
+//! > reproduce the registered Rung 5 conclusion.
+//!
+//! The numbers below are the real ones. Rung 5's neighbourhoods 1 and 2,
+//! measured at 8192 positions on the selection bank and judged by the
+//! frozen `kimi-logit-balanced-v1`:
+//!
+//! ```text
+//! map   logical bytes      auth kl p99   recorded verdict
+//! P     13,684,764,800     3.3532e-03    admitted (K25 survives)
+//! T1    13,682,673,664     3.6480e-03    REFUSED  kl 3.648e-3 > 3.500e-3
+//! S2    13,602,484,352     4.0563e-03    REFUSED
+//! S1    13,600,393,216     —             never measured; dominated,
+//!                                        and the protocol spends ONE run
+//! ```
+//!
+//! Only `kl_p99`, `min_covered_mass` and the byte figures are recorded
+//! values. The other criteria are fixtures chosen to sit well inside
+//! their limits, so that what the replay turns on is the recorded
+//! evidence and not a number invented here — and so that `binding()`
+//! reproducing `KlP99` means something.
+
+use std::collections::BTreeMap;
+
+use super::super::compiler::SourceIdentity;
+use super::super::map::{Exception, PrecisionMap};
+use super::super::measurement::{EvidenceScale, TailSupportPolicy};
+use super::super::nvfp4_pack::DTYPE_NVFP4;
+use super::super::policy::Role;
+use super::super::quality::{
+    kimi_logit_balanced_v1, Criterion, Distribution, LogitEvidence, QualityBank, RoutingEvidence,
+};
+use super::*;
+
+// ---------------------------------------------------------------- fixtures
+
+fn model() -> SourceIdentity {
+    SourceIdentity {
+        manifest_hash: "kimi-linear-48b".into(),
+        graph_hash: "aligned-vindex3".into(),
+        segments: BTreeMap::from([("target.decoder_stack".to_string(), "seg-dddd".to_string())]),
+    }
+}
+
+fn surface() -> TensorSurface {
+    TensorSurface::new(
+        ["q_proj", "k_proj", "v_proj", "o_proj"]
+            .into_iter()
+            .map(|p| {
+                SurfaceTensor::new(
+                    "target.decoder_stack",
+                    format!("0.self_attn.{p}.weight"),
+                    Role::DecoderLinear,
+                    vec![64, 64],
+                )
+            }),
+    )
+    .expect("distinct tensors")
+}
+
+fn protect(projection: &str) -> Exception {
+    Exception {
+        projection: Some(projection.into()),
+        layers: None,
+        encoding: None,
+    }
+}
+
+fn map(exceptions: Vec<Exception>) -> PrecisionMap {
+    PrecisionMap {
+        name: "m".into(),
+        encoding: DTYPE_NVFP4.into(),
+        roles: vec!["decoder-linear".into()],
+        exceptions,
+    }
+}
+
+fn realization(exceptions: Vec<Exception>, bytes: u64) -> ResolvedState {
+    ResolvedState::new(
+        RepresentationState::resolve(&model(), &surface(), &map(exceptions), &PackLayoutAdmission),
+        LogicalBytes::new(bytes),
+    )
+}
+
+fn p() -> ResolvedState {
+    realization(vec![protect("v_proj"), protect("o_proj")], 13_684_764_800)
+}
+fn t1() -> ResolvedState {
+    realization(vec![protect("o_proj")], 13_682_673_664)
+}
+fn s2() -> ResolvedState {
+    realization(vec![protect("k_proj")], 13_602_484_352)
+}
+fn s1() -> ResolvedState {
+    realization(vec![], 13_600_393_216)
+}
+
+fn dist(p99: f64, max: f64) -> Option<Distribution> {
+    Some(Distribution {
+        count: 8192,
+        min: 0.0,
+        p50: 0.0,
+        p95: 0.0,
+        p99,
+        max,
+    })
+}
+
+/// An 8192-position authority reading. `kl_p99`, `route_flips` and
+/// `min_covered_mass` are the recorded values; the rest are fixtures
+/// sitting well inside their limits.
+fn authority_reading(kl_p99: f64, route_flips: u64) -> QualityBank {
+    QualityBank {
+        positions: 8192,
+        logits: LogitEvidence {
+            kl_p50: 0.0,
+            kl_p95: 0.0,
+            kl_p99,
+            max_logit_delta: 0.0,
+            top1_flips: 0,
+            top10_changes: 0,
+        },
+        routing: RoutingEvidence {
+            route_flips,
+            positions_with_route_change: 0,
+            layers_with_route_change: 0,
+            first_layer_with_route_change: None,
+            route_margin: None,
+            route_weight_mass_moved: dist(0.113, 0.19),
+        },
+        min_covered_mass: Some(0.6315),
+        top10_margin: None,
+        top10_candidate_margin: None,
+        top10_mass_displaced: dist(0.065, 0.065),
+        top10_rank_displacement: None,
+        top1_margin: None,
+        top1_candidate_margin: None,
+        top1_mass_displaced: dist(0.03, 0.03),
+    }
+}
+
+fn selection_bank() -> EvidenceBank {
+    EvidenceBank::new(
+        "kimi-teacher-forced/v1",
+        "17d59a6b",
+        (0..256).map(|i| format!("seq-{i:03}")),
+        32,
+    )
+}
+
+fn instrument() -> InstrumentSemantics {
+    InstrumentSemantics::new(
+        "kl(baseline || candidate)",
+        "distribution{min,p50,p95,p99,max}",
+        "teacher-forced, all positions",
+        "q2a-teacher-forced/baseline-vs-overlay",
+    )
+    .truncated_to(2048)
+}
+
+fn semantics() -> SearchSemantics {
+    SearchSemantics::new(
+        "exchange-1-out-1-in/v1",
+        "ruling-1-four-prunes/v1",
+        "search-evidence-ladder/v1",
+        "decide-promotion-ordinal/v1",
+        "logical-bytes/v1",
+    )
+}
+
+fn key_for(s: &ResolvedState, scale: EvidenceScale) -> MeasurementKey {
+    MeasurementKey::new(
+        s.physical_id(),
+        &selection_bank().id(),
+        scale,
+        &instrument().id(),
+    )
+}
+
+/// The Rung 5 record, as FACTS: which states exist, how they were
+/// reached, and what was observed of them. No verdicts.
+fn rung5_snapshot() -> SearchSnapshot {
+    let mut graph = RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, p());
+    for (child, action, who) in [
+        (
+            t1(),
+            Action::new("−M26 +K24").removing(["M26"]).adding(["K24"]),
+            "rung5/N2",
+        ),
+        (
+            s2(),
+            Action::new("−K25 +H").removing(["K25"]).adding(["H"]),
+            "rung5/N1",
+        ),
+        (
+            s1(),
+            Action::new("−M26 +H").removing(["M26"]).adding(["H"]),
+            "rung5/N1",
+        ),
+    ] {
+        graph
+            .apply(p().physical_id(), action, child, Provenance::new(who))
+            .expect("all three are physically lighter than the parent");
+    }
+
+    let mut measurements = MeasurementRegistry::new();
+    for (s, kl, flips) in [
+        (p(), 3.3532e-3, 1427),
+        (t1(), 3.6480e-3, 1570),
+        (s2(), 4.0563e-3, 1309),
+    ] {
+        measurements
+            .record(
+                key_for(&s, EvidenceScale::Authority),
+                authority_reading(kl, flips),
+            )
+            .expect("record");
+    }
+
+    SearchSnapshot::new(
+        Objective::MinimiseLogicalBytes,
+        kimi_logit_balanced_v1(),
+        TailSupportPolicy::route_cal_1(),
+        semantics(),
+        graph,
+        measurements,
+    )
+}
+
+/// Store it, throw the in-memory object away, and read it back. Every
+/// assertion below runs off the reloaded facts.
+fn reloaded() -> SearchSnapshot {
+    let json = serde_json::to_string(&rung5_snapshot()).expect("serialize");
+    let back: SearchSnapshot = serde_json::from_str(&json).expect("deserialize");
+    back.check_schema().expect("schema");
+    back
+}
+
+// -------------------------------------------------------- the replay gate
+
+#[test]
+fn the_rung5_conclusion_is_re_derived_from_stored_facts_alone() {
+    let snap = reloaded();
+
+    // P — admitted. The recorded reading clears every criterion.
+    let p_verdict = snap
+        .adjudicate(&key_for(&p(), EvidenceScale::Authority))
+        .expect("P was measured at authority");
+    assert!(p_verdict.admissible(), "K25 survives");
+    assert!(
+        p_verdict.sound(),
+        "the floors cleared, so the instrument saw"
+    );
+    assert!(p_verdict.failures().is_empty());
+
+    // T1 — refused, on kl alone, by 1.48e-4. The ledger's
+    // `balanced-v1 FAIL ['kl_p99: 3.648e-3 > 3.500e-3']`.
+    let t1_verdict = snap
+        .adjudicate(&key_for(&t1(), EvidenceScale::Authority))
+        .expect("T1 was measured");
+    assert!(!t1_verdict.admissible());
+    let failed: Vec<Criterion> = t1_verdict.failures().iter().map(|m| m.criterion).collect();
+    assert_eq!(failed, vec![Criterion::KlP99], "kl alone");
+    let over = t1_verdict.failures()[0];
+    assert!((over.observed.expect("observed") - 3.6480e-3).abs() < 1e-12);
+    assert!((over.limit - 3.5e-3).abs() < 1e-12);
+
+    // S2 — refused, and further out than T1.
+    let s2_verdict = snap
+        .adjudicate(&key_for(&s2(), EvidenceScale::Authority))
+        .expect("S2 was measured");
+    assert!(!s2_verdict.admissible());
+    assert!(
+        s2_verdict.constraints().utilisation_of(Criterion::KlP99)
+            > t1_verdict.constraints().utilisation_of(Criterion::KlP99),
+        "S2 blew through where T1 grazed"
+    );
+
+    // KL is the binding constraint on the admitted parent — the fact the
+    // whole exchange rung exists because of.
+    assert_eq!(
+        p_verdict.binding().expect("a ceiling was scored").criterion,
+        Criterion::KlP99
+    );
+
+    // S1 was never measured. Dominated, and the protocol spends ONE run:
+    // a MISS is a fact about the record, not a failure.
+    assert!(snap
+        .adjudicate(&key_for(&s1(), EvidenceScale::Authority))
+        .is_none());
+}
+
+#[test]
+fn the_admitted_set_and_the_frontier_are_re_derived_cheapest_first() {
+    let snap = reloaded();
+
+    let admitted = snap.admitted();
+    assert_eq!(admitted.len(), 1, "one map survives");
+    assert_eq!(&admitted[0].state, p().physical_id());
+    assert_eq!(admitted[0].logical_bytes, LogicalBytes::new(13_684_764_800));
+
+    let frontier = snap.frontier();
+    assert_eq!(frontier.len(), 4, "P, T1, S2, S1");
+    let refused: Vec<&FrontierEntry> = frontier.iter().filter(|e| e.refused()).collect();
+    assert_eq!(refused.len(), 2, "T1 and S2");
+    assert!(refused
+        .iter()
+        .all(|e| !e.admitted() && e.measured_at(EvidenceScale::Authority)));
+
+    // Nothing was measured diagnostically in this record, and the
+    // snapshot says so rather than guessing.
+    let mut unmeasured = snap.unmeasured_at(EvidenceScale::Diagnostic);
+    unmeasured.sort();
+    assert_eq!(unmeasured.len(), 4);
+    assert_eq!(
+        snap.unmeasured_at(EvidenceScale::Authority),
+        vec![s1().physical_id().clone()],
+        "only S1 lacks an authority reading"
+    );
+}
+
+#[test]
+fn the_objective_orders_the_admitted_set_and_ties_break_deterministically() {
+    // Two survivors: `MinimiseLogicalBytes` means the cheaper one leads.
+    // The tie-break is the state id and not insertion order, because a
+    // scientific record must not depend on which map was recorded first.
+    let mut graph = RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, p());
+    graph
+        .apply(
+            p().physical_id(),
+            Action::new("−M26 +H"),
+            s1(),
+            Provenance::new("rung5/N1"),
+        )
+        .expect("lighter");
+
+    let mut measurements = MeasurementRegistry::new();
+    for s in [p(), s1()] {
+        measurements
+            .record(
+                key_for(&s, EvidenceScale::Authority),
+                authority_reading(3.3532e-3, 1427),
+            )
+            .expect("record");
+    }
+    let snap = SearchSnapshot::new(
+        Objective::MinimiseLogicalBytes,
+        kimi_logit_balanced_v1(),
+        TailSupportPolicy::route_cal_1(),
+        semantics(),
+        graph,
+        measurements,
+    );
+
+    let admitted = snap.admitted();
+    assert_eq!(admitted.len(), 2);
+    assert_eq!(
+        admitted[0].logical_bytes,
+        LogicalBytes::new(13_600_393_216),
+        "cheapest first"
+    );
+    assert_eq!(&admitted[0].state, s1().physical_id());
+    assert_eq!(&admitted[1].state, p().physical_id());
+}
+
+#[test]
+fn an_authority_pass_admits_and_a_diagnostic_pass_does_not() {
+    // The ladder rests on this: a diagnostic reading that clears the
+    // contract is not an admission.
+    let mut measurements = MeasurementRegistry::new();
+    measurements
+        .record(
+            key_for(&p(), EvidenceScale::Diagnostic),
+            authority_reading(3.3532e-3, 1427),
+        )
+        .expect("record");
+    let snap = SearchSnapshot::new(
+        Objective::MinimiseLogicalBytes,
+        kimi_logit_balanced_v1(),
+        TailSupportPolicy::route_cal_1(),
+        semantics(),
+        RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, p()),
+        measurements,
+    );
+
+    let verdict = snap
+        .adjudicate(&key_for(&p(), EvidenceScale::Diagnostic))
+        .expect("measured");
+    assert!(verdict.admissible(), "it does clear the contract");
+    assert!(
+        snap.admitted().is_empty(),
+        "and it is still not an admission"
+    );
+}
+
+// ------------------------------------------------- no conclusion is stored
+
+#[test]
+fn the_stored_form_carries_no_conclusion() {
+    // The anti-cheat. If a verdict, a rank or a frontier were persisted,
+    // the replay above would prove serialisation rather than derivation.
+    let json = serde_json::to_value(rung5_snapshot()).expect("serialize");
+
+    const FORBIDDEN: &[&str] = &[
+        "admissible",
+        "admitted",
+        "refused",
+        "binding",
+        "frontier",
+        "verdict",
+        "promotion",
+        "rank",
+        "chosen",
+        "best",
+        "recommendation",
+        "failures",
+        "passed",
+        "adjudication",
+    ];
+
+    fn walk(value: &serde_json::Value, path: &str, found: &mut Vec<String>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                for (k, v) in map {
+                    if FORBIDDEN.contains(&k.as_str()) {
+                        found.push(format!("{path}.{k}"));
+                    }
+                    walk(v, &format!("{path}.{k}"), found);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for (i, v) in items.iter().enumerate() {
+                    walk(v, &format!("{path}[{i}]"), found);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut found = Vec::new();
+    walk(&json, "", &mut found);
+    assert!(
+        found.is_empty(),
+        "conclusions in the stored form: {found:?}"
+    );
+
+    // And the facts ARE there, so the emptiness above is not vacuous.
+    assert_eq!(json["schema"], SNAPSHOT_SCHEMA);
+    assert_eq!(json["objective"], "MinimiseLogicalBytes");
+    assert_eq!(json["gate"]["id"], "kimi-logit-balanced-v1");
+    assert_eq!(json["graph"]["policy"], "StrictlyImprovingPhysical");
+    assert_eq!(json["graph"]["nodes"].as_object().expect("nodes").len(), 4);
+    assert_eq!(
+        json["measurements"]["observations"]
+            .as_array()
+            .expect("observations")
+            .len(),
+        3
+    );
+    assert!(json["semantics"]["promotion_rule"].is_string());
+}
+
+// ------------------------------------------------- decision-procedure drift
+
+#[test]
+fn the_semantics_a_conclusion_was_drawn_under_travel_with_it() {
+    // Six months from now `decide_promotion` legitimately changes and an
+    // old snapshot replays differently. That is not corruption — the
+    // decision procedure changed — and a replay must be able to say so.
+    let snap = reloaded();
+    assert_eq!(snap.semantics_id(), semantics().id());
+
+    let new_promotion = SearchSemantics {
+        promotion_rule: "decide-promotion-ordinal/v2".into(),
+        ..semantics()
+    };
+    assert_ne!(
+        new_promotion.id(),
+        semantics().id(),
+        "a changed rule is visible"
+    );
+
+    // Every field is normative; none of them is a source hash.
+    for changed in [
+        SearchSemantics {
+            candidate_generation: "beam/v1".into(),
+            ..semantics()
+        },
+        SearchSemantics {
+            pre_measurement_pruning: "ruling-1-plus-monotonicity/v2".into(),
+            ..semantics()
+        },
+        SearchSemantics {
+            evidence_interpretation: "search-evidence-ladder/v2".into(),
+            ..semantics()
+        },
+        SearchSemantics {
+            physical_accounting: "bytes-per-token/v1".into(),
+            ..semantics()
+        },
+    ] {
+        assert_ne!(changed.id(), semantics().id());
+    }
+    assert!(SEARCH_SEMANTICS_ID_VERSION.starts_with("search-semantics-id/"));
+    assert_eq!(semantics().id().short().len(), 12);
+    assert_eq!(format!("{}", semantics().id()), semantics().id().as_str());
+}
+
+#[test]
+fn a_snapshot_written_under_another_schema_is_refused() {
+    let mut json = serde_json::to_value(rung5_snapshot()).expect("serialize");
+    json["schema"] = serde_json::Value::String("represent-search-snapshot/v0".into());
+    let stale: SearchSnapshot = serde_json::from_value(json).expect("still parses");
+    let err = stale.check_schema().expect_err("stale schema");
+    assert!(format!("{err}").contains("recognisably stale"), "{err}");
+    assert_eq!(stale.schema(), "represent-search-snapshot/v0");
+}
+
+#[test]
+fn a_snapshot_names_the_configuration_its_conclusions_depend_on() {
+    let snap = reloaded();
+    assert_eq!(snap.objective(), Objective::MinimiseLogicalBytes);
+    assert_eq!(snap.gate().id, "kimi-logit-balanced-v1");
+    assert_eq!(snap.gate().kl_p99_max, 3.5e-3);
+    assert_eq!(
+        snap.tail_support().min_tail_observations,
+        TailSupportPolicy::route_cal_1().min_tail_observations
+    );
+    assert_eq!(
+        snap.semantics().promotion_rule,
+        "decide-promotion-ordinal/v1"
+    );
+    assert_eq!(snap.graph().len(), 4);
+    assert_eq!(snap.measurements().len(), 3);
+    assert_eq!(snap.schema(), SNAPSHOT_SCHEMA);
+
+    // A verdict belongs to an EXPERIMENT, so an adjudication names the
+    // key it came from.
+    let k = key_for(&p(), EvidenceScale::Authority);
+    assert_eq!(snap.adjudicate(&k).expect("measured").key(), &k);
+}
+
+#[test]
+fn a_measurement_of_a_state_this_graph_does_not_hold_is_not_this_frontier() {
+    // Registries outlive graphs. An observation of a state some other
+    // search built must not appear here as an admitted map.
+    let mut measurements = MeasurementRegistry::new();
+    measurements
+        .record(
+            key_for(&s2(), EvidenceScale::Authority),
+            authority_reading(1.0e-3, 10),
+        )
+        .expect("record");
+    let snap = SearchSnapshot::new(
+        Objective::MinimiseLogicalBytes,
+        kimi_logit_balanced_v1(),
+        TailSupportPolicy::route_cal_1(),
+        semantics(),
+        RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, p()),
+        measurements,
+    );
+
+    assert_eq!(snap.frontier().len(), 1, "only the root is in the graph");
+    assert!(
+        snap.admitted().is_empty(),
+        "a passing reading of a foreign state admits nothing"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/snapshot_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/snapshot_tests.rs
@@ -165,9 +165,10 @@ fn instrument() -> InstrumentSemantics {
 fn semantics() -> SearchSemantics {
     SearchSemantics::new(
         "exchange-1-out-1-in/v1",
-        "ruling-1-four-prunes/v1",
+        "ruling-1-three-prunes/v1",
         "search-evidence-ladder/v1",
         "decide-promotion-ordinal/v1",
+        "physical-prize-first/v1",
         "logical-bytes/v1",
     )
 }
@@ -500,6 +501,10 @@ fn the_semantics_a_conclusion_was_drawn_under_travel_with_it() {
         },
         SearchSemantics {
             physical_accounting: "bytes-per-token/v1".into(),
+            ..semantics()
+        },
+        SearchSemantics {
+            ranking_rule: "beam-width-4/v1".into(),
             ..semantics()
         },
     ] {

--- a/crates/larql-vindex/src/format/vindex3/represent/state/snapshot_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/snapshot_tests.rs
@@ -27,6 +27,8 @@
 use std::collections::BTreeMap;
 
 use super::super::compiler::SourceIdentity;
+use super::super::diagnostic::DiagnosticPolicy;
+use super::super::execution_cost::ExecutionCostModel;
 use super::super::map::{Exception, PrecisionMap};
 use super::super::measurement::{EvidenceScale, TailSupportPolicy};
 use super::super::nvfp4_pack::DTYPE_NVFP4;
@@ -34,6 +36,7 @@ use super::super::policy::Role;
 use super::super::quality::{
     kimi_logit_balanced_v1, Criterion, Distribution, LogitEvidence, QualityBank, RoutingEvidence,
 };
+use super::super::search_evidence::SearchCalibrationRegistry;
 use super::*;
 
 // ---------------------------------------------------------------- fixtures
@@ -182,6 +185,41 @@ fn key_for(s: &ResolvedState, scale: EvidenceScale) -> MeasurementKey {
     )
 }
 
+/// The space, config and facts a snapshot is built from. Split so the
+/// tests below vary one at a time.
+fn space() -> SearchSpace {
+    SearchSpace {
+        surface: surface(),
+        base_map: map(vec![]),
+        vocabulary: ActionVocabulary::default(),
+    }
+}
+
+fn config() -> SearchConfig {
+    SearchConfig {
+        objective: Objective::MinimiseLogicalBytes,
+        gate: kimi_logit_balanced_v1(),
+        tail_support: TailSupportPolicy::route_cal_1(),
+        calibrations: SearchCalibrationRegistry::default(),
+        diagnostic_policy: DiagnosticPolicy::bs2_kimi_v1(),
+        semantics: semantics(),
+        ranking: RankingSemantics::new(RankingRule::PhysicalPrizeFirst),
+    }
+}
+
+fn facts(graph: RepresentationStateGraph, measurements: MeasurementRegistry) -> SearchFacts {
+    SearchFacts {
+        graph,
+        measurements,
+        byte_ledgers: BTreeMap::new(),
+        execution_cost: ExecutionCostModel::new(Vec::new()),
+    }
+}
+
+fn snapshot(graph: RepresentationStateGraph, measurements: MeasurementRegistry) -> SearchSnapshot {
+    SearchSnapshot::new(space(), config(), facts(graph, measurements))
+}
+
 /// The Rung 5 record, as FACTS: which states exist, how they were
 /// reached, and what was observed of them. No verdicts.
 fn rung5_snapshot() -> SearchSnapshot {
@@ -222,14 +260,7 @@ fn rung5_snapshot() -> SearchSnapshot {
             .expect("record");
     }
 
-    SearchSnapshot::new(
-        Objective::MinimiseLogicalBytes,
-        kimi_logit_balanced_v1(),
-        TailSupportPolicy::route_cal_1(),
-        semantics(),
-        graph,
-        measurements,
-    )
+    snapshot(graph, measurements)
 }
 
 /// Store it, throw the in-memory object away, and read it back. Every
@@ -348,14 +379,7 @@ fn the_objective_orders_the_admitted_set_and_ties_break_deterministically() {
             )
             .expect("record");
     }
-    let snap = SearchSnapshot::new(
-        Objective::MinimiseLogicalBytes,
-        kimi_logit_balanced_v1(),
-        TailSupportPolicy::route_cal_1(),
-        semantics(),
-        graph,
-        measurements,
-    );
+    let snap = snapshot(graph, measurements);
 
     let admitted = snap.admitted();
     assert_eq!(admitted.len(), 2);
@@ -379,11 +403,7 @@ fn an_authority_pass_admits_and_a_diagnostic_pass_does_not() {
             authority_reading(3.3532e-3, 1427),
         )
         .expect("record");
-    let snap = SearchSnapshot::new(
-        Objective::MinimiseLogicalBytes,
-        kimi_logit_balanced_v1(),
-        TailSupportPolicy::route_cal_1(),
-        semantics(),
+    let snap = snapshot(
         RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, p()),
         measurements,
     );
@@ -451,18 +471,27 @@ fn the_stored_form_carries_no_conclusion() {
 
     // And the facts ARE there, so the emptiness above is not vacuous.
     assert_eq!(json["schema"], SNAPSHOT_SCHEMA);
-    assert_eq!(json["objective"], "MinimiseLogicalBytes");
-    assert_eq!(json["gate"]["id"], "kimi-logit-balanced-v1");
-    assert_eq!(json["graph"]["policy"], "StrictlyImprovingPhysical");
-    assert_eq!(json["graph"]["nodes"].as_object().expect("nodes").len(), 4);
+    assert_eq!(json["config"]["objective"], "MinimiseLogicalBytes");
+    assert_eq!(json["config"]["gate"]["id"], "kimi-logit-balanced-v1");
     assert_eq!(
-        json["measurements"]["observations"]
+        json["facts"]["graph"]["policy"],
+        "StrictlyImprovingPhysical"
+    );
+    assert_eq!(
+        json["facts"]["graph"]["nodes"]
+            .as_object()
+            .expect("nodes")
+            .len(),
+        4
+    );
+    assert_eq!(
+        json["facts"]["measurements"]["observations"]
             .as_array()
             .expect("observations")
             .len(),
         3
     );
-    assert!(json["semantics"]["promotion_rule"].is_string());
+    assert!(json["config"]["semantics"]["promotion_rule"].is_string());
 }
 
 // ------------------------------------------------- decision-procedure drift
@@ -560,11 +589,7 @@ fn a_measurement_of_a_state_this_graph_does_not_hold_is_not_this_frontier() {
             authority_reading(1.0e-3, 10),
         )
         .expect("record");
-    let snap = SearchSnapshot::new(
-        Objective::MinimiseLogicalBytes,
-        kimi_logit_balanced_v1(),
-        TailSupportPolicy::route_cal_1(),
-        semantics(),
+    let snap = snapshot(
         RepresentationStateGraph::new(TransitionPolicy::StrictlyImprovingPhysical, p()),
         measurements,
     );

--- a/crates/larql-vindex/src/format/vindex3/represent/state/surface.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/surface.rs
@@ -1,0 +1,184 @@
+//! **The tensor surface a map resolves against.**
+//!
+//! A surface is the container's own answer to *what tensors exist and
+//! what is each one for*, in the identity the container itself uses:
+//! `(object, tensor)`. That pairing is not a convenience — it is what
+//! [`super::super::plan_roles::PlanRoles`] is keyed by and what
+//! [`super::super::compile::CompilationLedger`] seals against, so a
+//! search state built on anything weaker would be identifying tensors
+//! differently from the two systems that materialise them.
+//!
+//! **Not "sort by tensor name".** A tensor name is unique within an
+//! object and nowhere else; `weight` occurs in almost every object a
+//! container holds. Ordering by name alone would let the surface's
+//! canonical form depend on which object happened to be enumerated
+//! first, which is incidental file order — exactly the kind of thing
+//! that becomes an identity bug six weeks later.
+//!
+//! # What a surface entry carries
+//!
+//! ```text
+//! object    the container's object id       identity
+//! tensor    the tensor name within it       identity
+//! role      what the operator computes with it
+//! shape     what the storage layout has to hold
+//! ```
+//!
+//! Role and shape are in the surface rather than derived at resolution
+//! time because both are the *container's* judgement and both change
+//! what a map resolves to. A tensor reclassified from `decoder-linear`
+//! to `unknown` is a different surface even where the resolved encoding
+//! is unchanged for both, because the set of maps that would compile it
+//! is different. The surface is the model, and the model moved.
+//!
+//! # Aliases
+//!
+//! Two objects may resolve to the same bytes — a tied embedding and
+//! output head being the obvious case. **They are two surface entries,
+//! not one.** A map resolves per `(object, tensor)` and may legitimately
+//! decide differently for each, and REPRESENT compiles one pack per
+//! object; collapsing them would make identity claim an agreement the
+//! compiler does not enforce. Aliasing is a fact about payload bytes,
+//! and payload bytes are already covered by the model identity's
+//! per-segment hashes.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::compile::hash_bytes;
+use super::super::policy::Role;
+use crate::error::VindexError;
+
+/// Separates fields inside one canonical record.
+///
+/// `\u{1}` is not a legal character in a tensor or object name, so no
+/// name can forge a field boundary — the same separator
+/// [`super::super::compile::CompilationLedger`] keys its seals with.
+pub(crate) const FIELD: char = '\u{1}';
+
+/// Separates canonical records from each other.
+pub(crate) const RECORD: char = '\u{2}';
+
+/// Separates the top-level sections of a digest input.
+pub(crate) const SECTION: char = '\u{3}';
+
+/// One tensor on the surface, identified the way the container
+/// identifies it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SurfaceTensor {
+    /// The container's object id.
+    pub object: String,
+    /// The tensor's name within that object.
+    pub tensor: String,
+    /// The role its operator computes with, from the plan where the plan
+    /// binds it and from name classification otherwise. Whichever
+    /// answered, it is the container's judgement and not this module's.
+    pub role: Role,
+    pub shape: Vec<usize>,
+}
+
+impl SurfaceTensor {
+    pub fn new(
+        object: impl Into<String>,
+        tensor: impl Into<String>,
+        role: Role,
+        shape: Vec<usize>,
+    ) -> Self {
+        Self {
+            object: object.into(),
+            tensor: tensor.into(),
+            role,
+            shape,
+        }
+    }
+
+    /// The identity pair. Ordering and lookup use this and nothing else.
+    pub fn key(&self) -> (&str, &str) {
+        (&self.object, &self.tensor)
+    }
+
+    /// This entry's canonical record.
+    ///
+    /// The shape is rendered element-wise rather than through `Debug` so
+    /// the canonical form is a stated format rather than whatever
+    /// `{:?}` prints this release.
+    pub(crate) fn canonical(&self) -> String {
+        let shape = self
+            .shape
+            .iter()
+            .map(|d| d.to_string())
+            .collect::<Vec<_>>()
+            .join("x");
+        format!(
+            "{}{FIELD}{}{FIELD}{}{FIELD}{shape}",
+            self.object,
+            self.tensor,
+            self.role.name()
+        )
+    }
+}
+
+/// **Every tensor of one model, in a deterministic order.**
+///
+/// Construction sorts, so a caller may build a surface in whatever order
+/// it enumerated the container and still obtain the same identity.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct TensorSurface {
+    entries: Vec<SurfaceTensor>,
+}
+
+impl TensorSurface {
+    /// Build a surface, refusing a repeated `(object, tensor)`.
+    ///
+    /// A container cannot present one tensor twice, so a duplicate is a
+    /// bug in whatever built the surface. Deduplicating silently would
+    /// let two disagreeing shapes collapse into whichever arrived last
+    /// and hand back an identity for a model that does not exist; the
+    /// refusal names the pair so the caller can find it.
+    pub fn new(entries: impl IntoIterator<Item = SurfaceTensor>) -> Result<Self, VindexError> {
+        let mut entries: Vec<SurfaceTensor> = entries.into_iter().collect();
+        entries.sort_by(|a, b| a.key().cmp(&b.key()));
+        if let Some(w) = entries.windows(2).find(|w| w[0].key() == w[1].key()) {
+            return Err(VindexError::Parse(format!(
+                "tensor surface names `{}`/`{}` twice — a container presents one tensor \
+                 once, so this surface describes no model",
+                w[0].object, w[0].tensor
+            )));
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn entries(&self) -> &[SurfaceTensor] {
+        &self.entries
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Look one tensor up by its identity pair.
+    pub fn get(&self, object: &str, tensor: &str) -> Option<&SurfaceTensor> {
+        self.entries
+            .binary_search_by(|e| e.key().cmp(&(object, tensor)))
+            .ok()
+            .map(|i| &self.entries[i])
+    }
+
+    /// The surface's canonical form: every record, in key order.
+    pub(crate) fn canonical(&self) -> String {
+        self.entries
+            .iter()
+            .map(SurfaceTensor::canonical)
+            .collect::<Vec<_>>()
+            .join(&RECORD.to_string())
+    }
+
+    /// **What this surface IS.** A digest, so a state identity can name
+    /// the surface it was resolved against without carrying it.
+    pub fn identity(&self) -> String {
+        hash_bytes(self.canonical().as_bytes())
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/tests.rs
@@ -1,0 +1,483 @@
+//! **The identity contract, stated adversarially.**
+//!
+//! Each test below names one way the digest could be wrong. Two failure
+//! directions, and they are not symmetric:
+//!
+//! ```text
+//! SPLIT   one state looks like two   →  the search re-measures what it
+//!                                       has already refused, and every
+//!                                       alternative route to a map
+//!                                       reads as novel
+//! MERGE   two states look like one   →  evidence from one is credited
+//!                                       to the other
+//! ```
+//!
+//! Splitting is the expensive one and merging is the dangerous one, so
+//! both get tests, and the ones that assert *sameness* are as load-
+//! bearing as the ones that assert difference.
+
+use std::collections::BTreeMap;
+
+use super::super::compiler::SourceIdentity;
+use super::super::map::{Exception, PrecisionMap};
+use super::super::nvfp4_pack::DTYPE_NVFP4;
+use super::super::policy::Role;
+use super::*;
+
+// ---------------------------------------------------------------- fixtures
+
+fn model(graph: &str) -> SourceIdentity {
+    SourceIdentity {
+        manifest_hash: "manifest-aaaa".into(),
+        graph_hash: graph.into(),
+        segments: BTreeMap::from([
+            ("target.decoder_stack".to_string(), "seg-dddd".to_string()),
+            ("target.embedding".to_string(), "seg-eeee".to_string()),
+        ]),
+    }
+}
+
+/// A small decoder surface: q/k/v at two depths, all NVFP4-admissible.
+fn decoder_surface() -> TensorSurface {
+    let mut entries = Vec::new();
+    for layer in [0u32, 1] {
+        for proj in ["q_proj", "k_proj", "v_proj"] {
+            entries.push(SurfaceTensor::new(
+                "target.decoder_stack",
+                format!("{layer}.self_attn.{proj}.weight"),
+                Role::DecoderLinear,
+                vec![64, 64],
+            ));
+        }
+    }
+    TensorSurface::new(entries).expect("distinct tensors")
+}
+
+/// A map that compiles decoder-linear to NVFP4, with the given
+/// exceptions, under whatever `name` — the name is a label and the tests
+/// vary it on purpose.
+fn map(name: &str, exceptions: Vec<Exception>) -> PrecisionMap {
+    PrecisionMap {
+        name: name.into(),
+        encoding: DTYPE_NVFP4.into(),
+        roles: vec!["decoder-linear".into()],
+        exceptions,
+    }
+}
+
+fn protect(projection: &str) -> Exception {
+    Exception {
+        projection: Some(projection.into()),
+        layers: None,
+        encoding: None,
+    }
+}
+
+fn compile(projection: &str) -> Exception {
+    Exception {
+        projection: Some(projection.into()),
+        layers: None,
+        encoding: Some(DTYPE_NVFP4.into()),
+    }
+}
+
+fn state(m: &PrecisionMap, surface: &TensorSurface) -> RepresentationState {
+    RepresentationState::resolve(&model("graph-1111"), surface, m, &PackLayoutAdmission)
+}
+
+// ------------------------------------------------------------- determinism
+
+#[test]
+fn the_same_map_on_the_same_model_is_the_same_state() {
+    let s = decoder_surface();
+    let m = map("r1", vec![protect("v_proj")]);
+    assert_eq!(state(&m, &s).id(), state(&m, &s).id());
+}
+
+#[test]
+fn the_order_a_surface_was_enumerated_in_does_not_reach_identity() {
+    // A container is walked object by object and segment by segment;
+    // which tensor arrives first is incidental file order. If it reached
+    // the digest, re-reading the same container on another machine could
+    // manufacture a second state for one model.
+    let forward = decoder_surface();
+    let reversed = {
+        let mut e = forward.entries().to_vec();
+        e.reverse();
+        TensorSurface::new(e).expect("distinct tensors")
+    };
+    assert_eq!(forward.identity(), reversed.identity());
+
+    let m = map("r1", vec![]);
+    assert_eq!(state(&m, &forward).id(), state(&m, &reversed).id());
+}
+
+// ------------------------------------------------- syntax must not split
+
+#[test]
+fn different_recipes_with_identical_resolved_decisions_are_one_state() {
+    // Written differently, decides identically. `q_proj -> NVFP4` is
+    // exactly what the default already does, so the exception is a
+    // no-op — and a search that treated this as an unexplored state
+    // would spend an authority run to learn nothing.
+    let s = decoder_surface();
+    let plain = map("plain", vec![]);
+    let redundant = map("also-plain", vec![compile("q_proj")]);
+
+    assert_eq!(
+        state(&plain, &s).decisions(),
+        state(&redundant, &s).decisions(),
+        "the two maps must resolve identically for this test to mean anything"
+    );
+    assert_eq!(state(&plain, &s).id(), state(&redundant, &s).id());
+}
+
+#[test]
+fn the_maps_name_is_a_label_and_does_not_reach_identity() {
+    let s = decoder_surface();
+    assert_eq!(
+        state(&map("r1-protect-v", vec![protect("v_proj")]), &s).id(),
+        state(&map("candidate-47", vec![protect("v_proj")]), &s).id()
+    );
+}
+
+#[test]
+fn a_shadowed_exception_does_not_move_identity() {
+    // The first match decides, so a second rule for the same projection
+    // can never fire. It changes the text and nothing else.
+    let s = decoder_surface();
+    let one = map("one", vec![protect("v_proj")]);
+    let shadowed = map("shadowed", vec![protect("v_proj"), compile("v_proj")]);
+
+    assert_eq!(state(&one, &s).id(), state(&shadowed, &s).id());
+}
+
+// --------------------------------------------- decisions must not merge
+
+#[test]
+fn exception_order_that_changes_a_decision_moves_identity() {
+    // The same two rules, swapped. Now `v_proj -> NVFP4` fires first and
+    // the protection is the dead rule, so this is a different physical
+    // representation and must not inherit the other's evidence.
+    let s = decoder_surface();
+    let protected = map("protected", vec![protect("v_proj"), compile("v_proj")]);
+    let compiled = map("compiled", vec![compile("v_proj"), protect("v_proj")]);
+
+    assert_ne!(
+        protected.describe(),
+        compiled.describe(),
+        "ordering is the only difference"
+    );
+    assert_ne!(state(&protected, &s).id(), state(&compiled, &s).id());
+}
+
+#[test]
+fn the_same_map_on_a_different_model_is_a_different_state() {
+    let s = decoder_surface();
+    let m = map("r1", vec![protect("v_proj")]);
+    let layout = &PackLayoutAdmission;
+
+    let a = RepresentationState::resolve(&model("graph-1111"), &s, &m, layout);
+    let b = RepresentationState::resolve(&model("graph-2222"), &s, &m, layout);
+    assert_eq!(a.decisions(), b.decisions(), "identical decisions");
+    assert_ne!(
+        a.id(),
+        b.id(),
+        "identical payloads under a different semantic graph are still a different model"
+    );
+
+    // And a changed payload segment, with index and graph unchanged.
+    let mut moved = model("graph-1111");
+    moved
+        .segments
+        .insert("target.decoder_stack".into(), "seg-ffff".into());
+    assert_ne!(
+        a.id(),
+        RepresentationState::resolve(&moved, &s, &m, layout).id()
+    );
+}
+
+// ----------------------------------------------------- surface movement
+
+#[test]
+fn a_reshaped_tensor_moves_identity_though_every_decision_is_unchanged() {
+    // The sharpest form of the surface test: no decision changes at all.
+    // `[128, 64]` is as NVFP4-admissible as `[64, 64]`, so the resolved
+    // vector is byte-identical — and the model is not the same model.
+    let base = decoder_surface();
+    let widened = {
+        let mut e = base.entries().to_vec();
+        e[0].shape = vec![128, 64];
+        TensorSurface::new(e).expect("distinct tensors")
+    };
+    let m = map("r1", vec![]);
+
+    assert_eq!(
+        state(&m, &base).decisions().canonical(),
+        state(&m, &widened).decisions().canonical(),
+        "no decision moved"
+    );
+    assert_ne!(state(&m, &base).id(), state(&m, &widened).id());
+}
+
+#[test]
+fn adding_a_tensor_moves_identity_though_surviving_decisions_are_unchanged() {
+    let base = decoder_surface();
+    let grown = {
+        let mut e = base.entries().to_vec();
+        e.push(SurfaceTensor::new(
+            "target.decoder_stack",
+            "2.self_attn.q_proj.weight",
+            Role::DecoderLinear,
+            vec![64, 64],
+        ));
+        TensorSurface::new(e).expect("distinct tensors")
+    };
+    let m = map("r1", vec![]);
+
+    for d in state(&m, &base).decisions().decisions() {
+        assert_eq!(
+            state(&m, &grown).decisions().get(&d.object, &d.tensor),
+            Some(&d.encoding),
+            "every surviving tensor decides the same"
+        );
+    }
+    assert_ne!(state(&m, &base).id(), state(&m, &grown).id());
+}
+
+#[test]
+fn a_role_reclassification_moves_identity() {
+    // Roles come from the plan where the plan binds an operand and from
+    // name classification otherwise, and that answer has changed before:
+    // 4.05 B Gated DeltaNet weights classified `unknown` because
+    // `_proj_qkv.` is not `_proj.`. No byte on disk moves, but the set
+    // of maps that would compile the tensor does, so it is a different
+    // search problem and must be a different state.
+    //
+    // The map here compiles nothing, so both classifications resolve to
+    // source precision and the decision vector cannot be what separates
+    // them.
+    let base = decoder_surface();
+    let reclassified = {
+        let mut e = base.entries().to_vec();
+        e[0].role = Role::Unknown;
+        TensorSurface::new(e).expect("distinct tensors")
+    };
+    let compiles_nothing = PrecisionMap {
+        name: "source-only".into(),
+        encoding: DTYPE_NVFP4.into(),
+        roles: vec![],
+        exceptions: vec![],
+    };
+
+    assert_eq!(
+        state(&compiles_nothing, &base).decisions().canonical(),
+        state(&compiles_nothing, &reclassified)
+            .decisions()
+            .canonical(),
+        "no decision moved"
+    );
+    assert_ne!(
+        state(&compiles_nothing, &base).id(),
+        state(&compiles_nothing, &reclassified).id()
+    );
+}
+
+// ------------------------------------------------------------- aliasing
+
+#[test]
+fn two_objects_sharing_bytes_are_two_surface_entries() {
+    // A tied embedding and output head are one payload and two objects.
+    // REPRESENT compiles one pack per OBJECT and a map resolves per
+    // `(object, tensor)`, so the surface keeps them apart — collapsing
+    // them would make identity claim an agreement the compiler does not
+    // enforce. That the bytes are shared is already recorded, once, by
+    // the model identity's per-segment hashes.
+    let surface = TensorSurface::new(vec![
+        SurfaceTensor::new("target.embedding", "weight", Role::Embedding, vec![64, 64]),
+        SurfaceTensor::new("target.head", "weight", Role::OutputHead, vec![64, 64]),
+    ])
+    .expect("two objects, one tensor name each");
+    assert_eq!(surface.len(), 2, "same tensor name, different objects");
+
+    let embedding_only = PrecisionMap {
+        name: "embedding-only".into(),
+        encoding: DTYPE_NVFP4.into(),
+        roles: vec!["embedding".into()],
+        exceptions: vec![],
+    };
+    let decided = state(&embedding_only, &surface);
+    assert!(decided
+        .decisions()
+        .get("target.embedding", "weight")
+        .expect("embedding")
+        .is_compiled());
+    assert!(!decided
+        .decisions()
+        .get("target.head", "weight")
+        .expect("head")
+        .is_compiled());
+}
+
+#[test]
+fn a_surface_cannot_name_one_tensor_twice() {
+    // Silently keeping the last would hand back an identity for a model
+    // that does not exist.
+    let err = TensorSurface::new(vec![
+        SurfaceTensor::new(
+            "target.decoder_stack",
+            "0.q.weight",
+            Role::DecoderLinear,
+            vec![64, 64],
+        ),
+        SurfaceTensor::new(
+            "target.decoder_stack",
+            "0.q.weight",
+            Role::DecoderLinear,
+            vec![64, 32],
+        ),
+    ])
+    .expect_err("a duplicate pair is a bug in whatever built the surface");
+    assert!(format!("{err}").contains("0.q.weight"), "{err}");
+}
+
+// -------------------------------------------------- effective, not declared
+
+#[test]
+fn a_layout_refusal_presents_source_and_identifies_as_source() {
+    // `k = 24` is not a multiple of the NVFP4 16-element group, so the
+    // compiler carries the tensor verbatim whatever the map says. A
+    // state that believed it had compiled this tensor would price bytes
+    // it never saved.
+    //
+    // So the refused map and the protecting map are ONE state — same
+    // bytes presented — while the decision vector still says which fact
+    // produced it.
+    let surface = TensorSurface::new(vec![SurfaceTensor::new(
+        "target.decoder_stack",
+        "0.self_attn.q_proj.weight",
+        Role::DecoderLinear,
+        vec![64, 24],
+    )])
+    .expect("one tensor");
+
+    let wants_it = map("wants-it", vec![]);
+    let protects_it = map("protects-it", vec![protect("q_proj")]);
+
+    let refused = state(&wants_it, &surface);
+    let protected = state(&protects_it, &surface);
+
+    assert_eq!(
+        refused
+            .decisions()
+            .get("target.decoder_stack", "0.self_attn.q_proj.weight"),
+        Some(&ResolvedEncoding::LayoutRefused {
+            encoding: DTYPE_NVFP4.into()
+        }),
+        "the map admits it; the layout does not"
+    );
+    assert_eq!(refused.decisions().layout_refused().len(), 1);
+    assert_eq!(protected.decisions().layout_refused().len(), 0);
+    assert_eq!(refused.decisions().compiled(), 0, "nothing was compiled");
+
+    assert_eq!(
+        refused.id(),
+        protected.id(),
+        "both present source bytes, so both are the same representation state"
+    );
+}
+
+#[test]
+fn a_layout_that_declares_no_constraint_does_not_refuse() {
+    // Refusal takes positive evidence from whoever owns the layout. An
+    // oracle with no rule for an encoding must not invent one, or a
+    // tensor leaves the action space forever on no evidence.
+    let surface = TensorSurface::new(vec![SurfaceTensor::new(
+        "target.decoder_stack",
+        "0.self_attn.q_proj.weight",
+        Role::DecoderLinear,
+        vec![64, 24],
+    )])
+    .expect("one tensor");
+    let m = map("wants-it", vec![]);
+
+    let decisions = resolve(&m, &surface, &NoLayoutConstraint);
+    assert_eq!(decisions.compiled(), 1);
+    assert!(decisions.layout_refused().is_empty());
+
+    // And an encoding PackLayoutAdmission holds no rule for is likewise
+    // not refused by it — the NVFP4 group rule is about NVFP4.
+    let q8 = PrecisionMap {
+        name: "q8".into(),
+        encoding: "Q8_0".into(),
+        roles: vec!["decoder-linear".into()],
+        exceptions: vec![],
+    };
+    assert_eq!(resolve(&q8, &surface, &PackLayoutAdmission).compiled(), 1);
+}
+
+// ------------------------------------------------------------- provenance
+
+#[test]
+fn the_canonical_form_is_versioned() {
+    // A persisted DAG that outlives a change to the canonical form must
+    // be recognisably stale rather than silently colliding.
+    assert!(
+        STATE_ID_VERSION.starts_with("represent-state-id/"),
+        "{STATE_ID_VERSION}"
+    );
+}
+
+#[test]
+fn a_state_carries_the_surface_it_was_resolved_against() {
+    // An id names a surface; a reader must be able to check that the
+    // surface in hand is that one without re-deriving the digest.
+    let s = decoder_surface();
+    let m = map("r1", vec![]);
+    assert_eq!(state(&m, &s).surface_identity(), s.identity());
+}
+
+#[test]
+fn an_id_is_short_enough_to_print_and_long_enough_to_be_an_id() {
+    let s = decoder_surface();
+    let id = state(&map("r1", vec![]), &s).id().clone();
+    assert_eq!(id.as_str().len(), 64, "sha256 hex");
+    assert_eq!(id.short().len(), 12);
+    assert!(id.as_str().starts_with(id.short()));
+}
+
+#[test]
+fn a_state_answers_what_it_is_without_re_deriving_it() {
+    // The accessors a DAG node needs before any policy exists: which
+    // model, which tensor, and the printable id an edge or a report
+    // names it by.
+    let s = decoder_surface();
+    let m = map("r1", vec![protect("v_proj")]);
+    let resolved = state(&m, &s);
+
+    assert_eq!(resolved.model(), &model("graph-1111"));
+    assert_eq!(
+        format!("{}", resolved.id()),
+        resolved.id().as_str(),
+        "an id prints as itself"
+    );
+
+    assert!(!s.is_empty());
+    assert_eq!(
+        s.get("target.decoder_stack", "0.self_attn.v_proj.weight")
+            .map(|t| t.role),
+        Some(Role::DecoderLinear)
+    );
+    assert!(
+        s.get("target.decoder_stack", "0.self_attn.no_such.weight")
+            .is_none(),
+        "lookup is by the identity pair, not a prefix match"
+    );
+
+    assert_eq!(resolved.decisions().len(), s.len(), "one decision each");
+    assert!(!resolved.decisions().is_empty());
+
+    let empty = TensorSurface::new(vec![]).expect("an empty surface is a surface");
+    assert!(empty.is_empty());
+    assert!(resolve(&m, &empty, &NoLayoutConstraint).is_empty());
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/transition.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/transition.rs
@@ -1,0 +1,212 @@
+//! **Edges own how you got there. Nodes do not.**
+//!
+//! ```text
+//! A ── +E24 ──────────────────┐
+//!                             ▼
+//!                             C
+//!                             ▲
+//! B ── K24→K25, then +E24 ────┘
+//! ```
+//!
+//! One `C` where the physical state is one physical state, and both
+//! discoveries survive. Baking either recipe into the node would make an
+//! arbitrary one of them read as *the* recipe — which is what R5-F3
+//! caught the hard way, when `P − K25 + H` turned out to be a map
+//! already measured and rejected under a different name.
+//!
+//! # What may travel on an edge, and what may not
+//!
+//! ```text
+//! MAY   the action, for REPRODUCTION
+//! MAY   the physical delta, COMPUTED from two footprints
+//! MAY   provenance: round, rank, script, session, an agent's rationale
+//!
+//! MUST NOT   reach state identity
+//! MUST NOT   enter any prediction, ranking term or cost
+//! ```
+//!
+//! The second prohibition is rung 5's, stated when per-candidate
+//! provenance was first emitted: the action lists are recorded because
+//! reproducing the map needs them *and for no other purpose*. So
+//! [`Action`] carries no ordering and no score, and [`Provenance`] is
+//! narrative — a place to put "rung5/N3, candidate U1, ranked first,
+//! diagnostic 2.1720e-3" without inviting a comparator to read it.
+
+use serde::{Deserialize, Serialize};
+
+use super::identity::RepresentationStateId;
+use super::realization::RealizationId;
+use super::surface::{FIELD, RECORD};
+
+/// What was applied to reach a child state.
+///
+/// Deliberately descriptive and deliberately inert: no `Ord`, no score,
+/// no cost. Two transitions are the same transition when their parent,
+/// child and action identity agree, and nothing else about an action is
+/// consulted by anything.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Action {
+    /// A short name for the move, e.g. `"+E24"`, `"K24→K25"`.
+    pub label: String,
+    /// Admitted actions this move removed, by their programme names.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed: Vec<String>,
+    /// Actions this move added.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added: Vec<String>,
+}
+
+impl Action {
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            removed: Vec::new(),
+            added: Vec::new(),
+        }
+    }
+
+    pub fn removing(mut self, actions: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.removed = actions.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn adding(mut self, actions: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.added = actions.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// What makes two applications of "the same move" the same edge.
+    ///
+    /// The removed and added lists are sorted here and nowhere else: an
+    /// exchange written `-M26 +E24` and one written `+E24 -M26` are the
+    /// same move, while the map's own exception ORDER — which is
+    /// semantic — is a property of the resulting state and was already
+    /// settled by the physical digest.
+    pub fn identity(&self) -> String {
+        let mut removed = self.removed.clone();
+        let mut added = self.added.clone();
+        removed.sort();
+        added.sort();
+        format!(
+            "{}{FIELD}-{}{FIELD}+{}",
+            self.label,
+            removed.join(","),
+            added.join(",")
+        )
+    }
+}
+
+/// Why this edge is in the graph — discovery context, never state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Provenance {
+    /// Who or what discovered it: a rung, a script, a session, an agent.
+    pub by: String,
+    /// Anything worth reading later. Round number, candidate rank,
+    /// diagnostic reading, an agent's rationale — all belong here, as
+    /// text, precisely so that no comparator can compute on them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+impl Provenance {
+    pub fn new(by: impl Into<String>) -> Self {
+        Self {
+            by: by.into(),
+            note: None,
+        }
+    }
+
+    pub fn noting(mut self, note: impl Into<String>) -> Self {
+        self.note = Some(note.into());
+        self
+    }
+}
+
+/// One edge: a move from a parent state to a child state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Transition {
+    parent: RepresentationStateId,
+    child: RepresentationStateId,
+    /// The child realization this move produced. Two moves can reach one
+    /// physical state through different realizations, and the edge
+    /// records which one it actually built.
+    child_realization: RealizationId,
+    action: Action,
+    /// Computed from the two footprints, never supplied. Negative means
+    /// bytes were removed.
+    physical_delta: i64,
+    /// Every discovery of this edge, deduplicated.
+    provenance: Vec<Provenance>,
+}
+
+impl Transition {
+    pub(crate) fn new(
+        parent: RepresentationStateId,
+        child: RepresentationStateId,
+        child_realization: RealizationId,
+        action: Action,
+        physical_delta: i64,
+        provenance: Provenance,
+    ) -> Self {
+        Self {
+            parent,
+            child,
+            child_realization,
+            action,
+            physical_delta,
+            provenance: vec![provenance],
+        }
+    }
+
+    pub fn parent(&self) -> &RepresentationStateId {
+        &self.parent
+    }
+
+    pub fn child(&self) -> &RepresentationStateId {
+        &self.child
+    }
+
+    pub fn child_realization(&self) -> &RealizationId {
+        &self.child_realization
+    }
+
+    pub fn action(&self) -> &Action {
+        &self.action
+    }
+
+    pub fn physical_delta(&self) -> i64 {
+        self.physical_delta
+    }
+
+    pub fn provenance(&self) -> &[Provenance] {
+        &self.provenance
+    }
+
+    /// What makes this edge this edge.
+    ///
+    /// The child REALIZATION is in the key, not merely the physical
+    /// child: a move that reaches the same bytes through a different set
+    /// of decisions is a different move, and collapsing the two would
+    /// undo the separation [`super::realization`] exists to keep.
+    pub(crate) fn identity(&self) -> String {
+        format!(
+            "{}{RECORD}{}{RECORD}{}{RECORD}{}",
+            self.parent,
+            self.child,
+            self.child_realization,
+            self.action.identity()
+        )
+    }
+
+    /// Record another discovery of this same edge.
+    ///
+    /// Re-discovering an edge under provenance already recorded is a
+    /// no-op — a replayed round must not inflate the record. Two
+    /// genuinely different discoverers of one edge is real information
+    /// and is kept.
+    pub(crate) fn observe(&mut self, provenance: Provenance) {
+        if !self.provenance.contains(&provenance) {
+            self.provenance.push(provenance);
+        }
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,8 @@ distributed).
 | [fleet-routing-extensions.md](fleet-routing-extensions.md) | Fleet routing extensions FR1–FR4 — spec + frozen pre-registrations |
 | [fhg.md](fhg.md) | FHG — Fourier heuristic graph programme (behavioural, model-agnostic) |
 | [authority-control-plane.md](authority-control-plane.md) | Authority control plane (EXP-26..38) — layer-mechanism branch closed |
+| [kimi-precision-topology.md](kimi-precision-topology.md) | Kimi Linear 48B — the PRECISION-1 topology, the first complete REPRESENT chain |
+| [represent-optimizer-mcp.md](represent-optimizer-mcp.md) | REPRESENT as a queryable optimiser — map DAG, MCP surface, and the search ladder to MCTS (design) |
 
 ## Positioning
 

--- a/docs/represent-optimizer-mcp.md
+++ b/docs/represent-optimizer-mcp.md
@@ -1,8 +1,8 @@
 # The LARQL Physical Optimizer — evidence-constrained physical-plan search
 
 **Branch `worktree-represent-optimizer-mcp`, based on `origin/main` at
-`8f647872`.** Stage 1 (a-d) is implemented and green; everything below
-it is design.
+`8f647872`.** Stages 1 (a-d) and 2 are implemented and green;
+everything below them is design.
 
 The abstraction is not "quantization search". It is **evidence-
 constrained physical-plan search**, and it is the query optimiser the
@@ -286,7 +286,7 @@ Unconstrained               any edge; a general graph, caller owns
 
 The strict policy is what rung 5 already enforces — N1 pruned `−E26 + H`
 at +1.39 GB and `−K25 + M23` at +2,091,136 B for being physically worse,
-and Ruling 1 lists physical dominance among the four legitimate
+and Ruling 1 lists physical dominance among the three usable
 pre-measurement prunes. It is nonetheless **a policy and not a law**, and
 the programme's own roadmap says when it breaks: once residency joins the
 state and the objective is measured tok/s, a move that *adds* logical
@@ -521,6 +521,110 @@ of states the graph never held → the foreign-state test.
 
 ---
 
+## 4e. Stage 2 — the candidate generator (IMPLEMENTED)
+
+`represent/state/{action_space,candidate}.rs`, 11 tests, 100% on
+`action_space.rs` and 98.8% on `candidate.rs`.
+
+```text
+realization
+    ↓ enumerate legal transformations
+    ↓ resolve the child realization
+    ↓ derive the physical state
+    ↓ price it, from the footprint oracle
+    ↓ apply ONLY registered pre-measurement pruning
+CandidateSet
+```
+
+No ranking, no sensitivity intuition, no family heuristic, no
+`decide_promotion`. One question: *what experiments are legitimately
+available from this realization?*
+
+### Three prunes, not four
+
+Ruling 1's complete list — and my earlier summary said "four legitimate
+prunes", which is wrong:
+
+```text
+1  identical MeasurementKey observed            dedup          USABLE
+2  not physically better than an available map  dominance      USABLE
+3  structurally impossible map                  structural     USABLE
+4  a PROVED monotonicity theorem                NOT CURRENTLY HELD
+```
+
+`PreMeasurementPrune` therefore has **three** variants. The fourth is
+absent by construction rather than present-and-unused, so adding it is a
+visible schema change and not a quiet flag flip.
+
+**Behavioural-superset pruning is not on the list.** Authority refusal
+attaches to the measured map, is not upward-closed under action-set
+inclusion, and "more low precision" is not a behavioural partial order —
+the programme holds evidence against it at every level (R4-F7 sign,
+R4-F2 magnitude, R5-F4 scale N=3 both directions, R5-F9 ordering, R5-F7's
+2.47× between two states). The line:
+
+```text
+"this cannot produce a valid physical experiment"   → prune
+"this probably will not teach us anything"          → NOT a prune
+```
+
+The second belongs downstream in assessment, where it can be argued
+with. Here it would be indistinguishable from the first. A mutation that
+slips it in reddens the test that records the line.
+
+### The conservation law
+
+```text
+enumerated = eligible + already observed + dominated + structural
+```
+
+`Census::conserves()` asserts it, and every disposition is
+`Eligible(candidate)` or `Pruned { action, child_state, reason }` — so
+nothing disappears silently, and *why aren't we exploring E24* is
+answered from a deterministic partition rather than by a language model
+reconstructing a rationale.
+
+### The vocabulary is an input, and enumeration covers it
+
+R5-F6: neighbourhood 1 drew its in-moves from the candidates left
+unpromoted at iteration 4 and never listed `{E20,E22,E23,E24,E25}` —
+two moves worth ~430 MB each were invisible because the vocabulary had
+been mistaken for the last round's leftovers. `ActionVocabulary` holds
+the declared moves; enumeration is every unapplied edit as an addition
+plus every (applied, unapplied) pair as a 1-out/1-in exchange, always
+over the whole vocabulary.
+
+The vocabulary's declaration order also supplies map order, so an
+applied *set* has exactly one map — which is what makes 1a's identity
+contract meaningful over search states rather than only over
+hand-written maps.
+
+### Physics is derived, never asserted
+
+No `MapEdit` carries a byte figure. The generator applies, resolves,
+asks the `Footprint` oracle what parent and child cost, and computes the
+delta — guarding the R5-F5 class where a footprint column was read as a
+saving and overstated a revert 3.39×. Dominance then delegates to
+`TransitionPolicy::admits`, so the generator and the graph cannot give
+two answers to one question.
+
+### Dedup needs the experimental context
+
+The generator never asks *have we measured this state*. It asks about a
+`MeasurementIntent { bank, scale, instrument }`, because 1c proved
+`diagnostic(child) ≠ authority(child)`. A candidate whose exact
+experiment exists is pruned; one whose state carries *other* readings
+arrives eligible with `prior_observations` attached, so an escalation is
+visible rather than silent.
+
+Four mutations, each killing exactly its own tests: dedup on the state
+instead of the intent → 1 red; behavioural-superset pruning slipped in →
+2 red, including the test that records the line; the census dropping a
+category → the conservation assertion; enumeration covering part of the
+vocabulary → 4 red.
+
+---
+
 ## 5. The reward, which must not be diagnostic KL
 
 Rung 4/5 established that diagnostic KL supplies neither magnitude, sign,
@@ -613,8 +717,8 @@ Deliberately boring, so MCTS is a policy swap and not a rewrite.
 | 1b | State graph with **edge** provenance (§4b) | **done** |
 | 1c | `MeasurementKey` + measurement dedup (§4c) | **done** |
 | 1d | Persistent, replayable search state (§4d) | **done** |
-| 2 | Deterministic action generator — exact physical deltas, participation, novelty and admissibility *before* measurement | |
-| 3 | Best-first / beam; establish the objective API and the search/evidence boundary | |
+| 2 | Deterministic action generator (§4e) | **done** |
+| 3 | Best-first / beam; establish the objective API and the search/evidence boundary | next |
 | 4 | MCP facade — inspect state, hypotheses, frontier; request experiments | |
 | 5 | PUCT as another `SearchPolicy`; same states, actions, evidence | |
 | 6 | Extend `PhysicalState` with residency; optimise measured tok/s | |
@@ -682,10 +786,10 @@ Note what may *not* be inferred meanwhile: Ruling 1 forbids pruning
 either candidate for being a superset of a refused map. Authority refusal
 attaches to the measured map, is not upward-closed under action-set
 inclusion, and "more low precision" is not a behavioural partial order.
-The only legitimate pre-measurement prunes are an identical
-`MeasurementKey`, physical dominance, structural impossibility, and a
-proved monotonicity theorem — and no such theorem is currently held.
-**That list is the action generator's entire contract at stage 2.**
+The legitimate pre-measurement prunes are an identical `MeasurementKey`,
+physical dominance and structural impossibility — **three**, plus a
+fourth that would need a proved monotonicity theorem and is explicitly
+NOT HELD. **That list is the action generator's entire contract** (§4e).
 
 Residency will likely make the phenomenon common:
 

--- a/docs/represent-optimizer-mcp.md
+++ b/docs/represent-optimizer-mcp.md
@@ -1,8 +1,8 @@
 # The LARQL Physical Optimizer — evidence-constrained physical-plan search
 
 **Branch `worktree-represent-optimizer-mcp`, based on `origin/main` at
-`8f647872`.** Stage 1a is implemented and green; everything below it is
-design.
+`8f647872`.** Stages 1a-1c are implemented and green; everything below
+them is design.
 
 The abstraction is not "quantization search". It is **evidence-
 constrained physical-plan search**, and it is the query optimiser the
@@ -341,6 +341,97 @@ each killing exactly its own tests:
 
 ---
 
+## 4c. Stage 1c — measurement identity (IMPLEMENTED)
+
+`represent/state/{evidence_bank,instrument,key}.rs`, 14 tests, 100% line
+coverage on all nine state files.
+
+```text
+MeasurementKey { state_id, bank, scale, instrument }
+```
+
+R5-F3 registered the shape; the correction that came with it is why it
+is not keyed on the state alone — that would forbid the diagnostic →
+authority escalation the ladder depends on.
+
+### `QualityBank` was the wrong home, and the reason matters
+
+The plan was to lift bank identity into `QualityBank`. It does not
+belong there: `QualityBank` is *"one bank of measurements over a fixed
+token sequence"* — the **observation** (measured KL, routing evidence,
+margin distributions). The programme's "evidence bank" is the **corpus**
+those were taken over — 256 teacher-forced sequences, a directory with a
+`manifest.json`. One word, two things, and only the second identifies an
+experiment. Before this stage the corpus had no type at all.
+
+Its identity today is a `sha256` of `manifest.json` computed inline in
+the Q2a harness and written to the report as `bank_manifest_sha256`.
+Right instinct, **not sufficient** — because the harness *slices* the
+corpus. `LARQL_Q2A_SEQUENCES` takes 32 of 256, so a 32-sequence and a
+256-sequence reading share a manifest digest while being different
+experiments. That slice is the difference between a diagnostic and an
+authority run, and a key built on the manifest hash alone would have
+called them repeats.
+
+So `EvidenceBankId` digests schema, manifest digest, **the ordered
+samples actually used**, and positions-per-sample — and excludes
+location, timestamp and description. `EvidenceBank::positions()` is
+computed, never multiplied by hand: `LARQL_Q2A_SEQUENCES=256` is
+*sequences*, and 256 × 32 = 8192 *positions* is the confusion that once
+nearly inverted an acceptance check.
+
+### Instrument semantics, not a version string
+
+A version string fails in both directions — it moves on a refactor that
+changes nothing observable, and stays put when someone changes the
+truncation. So `InstrumentSemanticsId` digests declared meaning: metric,
+truncation, aggregation, token selection, procedure. `implementation_note`
+is excluded, so a refactor cannot split a state's evidence.
+
+Truncation is the case already paid for: `min_covered_mass` exists
+because a KL over a truncation covering a third of the mass is a
+different measurement from one covering all of it — top-128 saw 0.307 of
+a first position, top-2048 saw 0.729.
+
+**The limit, stated rather than papered over**: a declaration can lie.
+Change the runner's truncation without changing what it reports and the
+id does not move. The mitigation is construction — build the declaration
+from the constants the runner uses — and this module can make that
+possible, not mandatory.
+
+### What is deliberately absent
+
+No PASS/FAIL, no promotion status, no contract. The key says *what
+experiment was performed against what state*, never what the result
+meant. Classification stays downstream in `Margin`/`Frontier` and
+`decide_promotion`, so a later contract reinterprets observations
+already held instead of making them disappear.
+
+`MeasurementRegistry` stores readings only. Re-recording an identical
+reading is a no-op — a control witness reproducing is what a replayed
+round should do — while a *different* reading under the same key is
+refused: that says the experiment is not reproducible, and quietly
+keeping either would hide it.
+
+### The case that joins 1a, 1b and 1c
+
+```text
+RealizationId differs, RepresentationStateId same
+    action search  → distinguish
+    measurement    → collapse, reuse the observation
+```
+
+A protected tensor and a layout-refused one present identical bytes, so
+a measurement of one *is* a measurement of the other, while the moves
+available from each still differ.
+
+Five mutations, each killing exactly its own tests: key ignores scale →
+2 red; bank id counts samples instead of naming them → 1; instrument id
+ignores truncation → 2; bank id includes its storage location → 1;
+`record` overwrites a contradiction → 1.
+
+---
+
 ## 5. The reward, which must not be diagnostic KL
 
 Rung 4/5 established that diagnostic KL supplies neither magnitude, sign,
@@ -431,8 +522,8 @@ Deliberately boring, so MCTS is a policy swap and not a rewrite.
 |---|---|---|
 | 1a | Resolved-state identity contract + adversarial tests | **done** |
 | 1b | State graph with **edge** provenance (§4b) | **done** |
-| 1c | `MeasurementKey` + measurement dedup | next |
-| 1d | Persistent, replayable search state | |
+| 1c | `MeasurementKey` + measurement dedup (§4c) | **done** |
+| 1d | Persistent, replayable search state | next |
 | 2 | Deterministic action generator — exact physical deltas, participation, novelty and admissibility *before* measurement | |
 | 3 | Best-first / beam; establish the objective API and the search/evidence boundary | |
 | 4 | MCP facade — inspect state, hypotheses, frontier; request experiments | |
@@ -521,19 +612,12 @@ effect on the future physical plan.
 
 ## 9. Open questions
 
-1. **`MeasurementKey` dimensions — mostly settled already.** R5-F3
-   registered them: `{map_hash, bank_manifest, evidence_scale,
-   instrument_semantics}`, with the explicit correction that **dedup on
-   bare `map_hash` is wrong** because it would forbid the
-   diagnostic → authority escalation the whole ladder depends on. In
-   this module's vocabulary `map_hash` becomes `state_id`. Still to
-   settle: whether `QualityGate.id` is already implied by
-   `instrument_semantics` or belongs as its own dimension, and whether
-   execution/backend identity enters the key for benchmark measurements
-   only or for all of them. Note that `bank_manifest` exists in the
-   programme (`17d59a6b…`) but not as a field on `QualityBank`, which
-   carries `positions` and evidence and no id — so bank identity has to
-   be lifted into the type before 1c can key on it.
+1. **How an instrument declaration is bound to the runner.** 1c
+   settled the *shape* of `InstrumentSemanticsId` and left the binding
+   open: nothing forces the Q2a harness to build its declaration from
+   `TOP_N` rather than restating it. Until it does, a silent semantics
+   change is undetectable. The fix is a constructor at the call site,
+   not a validator here.
 2. **Where the DAG persists.** Evidence already lives in the experiments
    ledger; a second store risks two truths. Candidate: the DAG holds
    identities and edges and dereferences every measurement to the ledger

--- a/docs/represent-optimizer-mcp.md
+++ b/docs/represent-optimizer-mcp.md
@@ -1,7 +1,7 @@
 # The LARQL Physical Optimizer — evidence-constrained physical-plan search
 
 **Branch `worktree-represent-optimizer-mcp`, based on `origin/main` at
-`8f647872`.** Stages 1 (a-d) and 2 are implemented and green;
+`8f647872`.** Stages 1 (a-d), 2 and 3 are implemented and green;
 everything below them is design.
 
 The abstraction is not "quantization search". It is **evidence-
@@ -625,6 +625,114 @@ vocabulary → 4 red.
 
 ---
 
+## 4f. Stage 3 — best-first (IMPLEMENTED)
+
+`represent/state/{assess,search_policy}.rs`, 12 tests, 100% on
+`assess.rs` and 98.8% on `search_policy.rs`.
+
+```text
+CandidateSet → Assessment → BestFirst        experiment selection
+Measurements → SearchEvidence → decide_promotion   admissibility
+```
+
+Two different questions, kept apart: a candidate can rank first *for
+measurement* precisely because it is uncertain while being nowhere near
+promotable. `decide_promotion` stays downstream and unweakened.
+
+### Assessment carries ingredients, not a score
+
+`CandidateAssessment` holds a `ranking_score`, and a score is a
+conclusion — that is exactly why 1d could not replay promotion. So
+`Assessment` holds `physical_delta`, `child_bytes`, `intended_key`,
+`prior_observations` and the parent's whole `ConstraintVector`, and a
+score is computed on demand under a named rule (`Assessment::score`) and
+stored nowhere.
+
+The parent's standing is kept whole rather than reduced: the binding
+margin, the headroom and which criterion is scarce are all questions a
+reader may want, and a scalar answers none. It is served at **authority
+scale only** — a diagnostic reading prices nothing against the contract,
+and handing one over as though it did is the inference R5-F4 and R5-F9
+closed.
+
+Sign convention is not flipped anywhere: `physical_delta` stays negative
+for bytes removed, and ordering prefers the most negative.
+
+### One answer, always
+
+The complete order, stated once in `RankingSemantics::tie_break_chain`:
+
+```text
+1  registered rule
+2  greater physical improvement
+3  canonical child state id
+4  canonical child realization id
+5  canonical action identity
+```
+
+Everything after (1) exists so no answer can depend on insertion order,
+map iteration, thread completion or vocabulary traversal. Tested against
+reversed and rotated input, on a genuine tie, and on the case that
+reaches element (4): one physical state, two realizations. Truncating
+the chain reddens two tests.
+
+`RankingRule` has one variant — `PhysicalPrizeFirst` — because one rule
+has actually been used: rung 5 spent its run on the prize (−431,777,920 B
+over −2,091,136 B). `RankingSemanticsId` digests the rule *and the
+chain*, and `SearchSemantics` gained a `ranking_rule` field so a snapshot
+can tell the same observations under best-first-v1 from v2.
+
+### Search orders states; measurement orders experiments
+
+```text
+A --action x--> C (realization r1) ┐
+                                   ├─ one MeasurementKey, run once
+B --action y--> C (realization r2) ┘
+```
+
+`MeasurementOpportunity` groups by experiment, not by realization, so an
+experiment is never scheduled twice in a round — while both routes
+survive inside it because their future action spaces differ. When the
+observation lands both inherit it, since 1c keys evidence on the physical
+state while 1b keeps the realizations apart. Keying opportunities by
+realization instead reddens that test.
+
+### Ruling 3, encoded
+
+```text
+0 eligible  → Exhausted
+1 eligible  → Sole — SELECT it; the diagnostic cannot veto
+> 1         → Ranked — the registered rule chooses which runs first
+```
+
+The middle line is a ruling, not an optimisation: with one opportunity
+"what next?" is already answered, and consulting a diagnostic there
+would promote it into an admissibility screen — the accident that was
+withdrawn.
+
+### What stage 3 does not do, and what it needs
+
+It does not order the **authority escalation** of diagnostically-measured
+candidates, and it does not run promotion. Both go through
+`CandidateAssessment`, which needs two facts a snapshot does not yet
+hold: a per-state `ByteLedger` (per-token reads — *not* `LogicalBytes`,
+which is a whole-map footprint; the newtype exists to keep them apart)
+and an `ExecutionCostModel`. Those are **inputs to add**, not conclusions
+to invent. Adding them is what would close the gap 1d left open.
+
+No information-gain model either. A 40 MB experiment that would resolve
+whether a family of moves is state-dependent may deserve to run before a
+600 MB candidate, and *experimental value* is a real quantity distinct
+from *physical value* — but nothing has measured it, and inventing it
+here would put a heuristic where registered semantics belong.
+
+Four mutations, each killing exactly its own tests: truncating the
+tie-break chain → 2 red; grouping opportunities by realization → 1;
+reporting a sole opportunity as ranked → 1; serving a diagnostic reading
+as the parent's standing → 1.
+
+---
+
 ## 5. The reward, which must not be diagnostic KL
 
 Rung 4/5 established that diagnostic KL supplies neither magnitude, sign,
@@ -718,8 +826,8 @@ Deliberately boring, so MCTS is a policy swap and not a rewrite.
 | 1c | `MeasurementKey` + measurement dedup (§4c) | **done** |
 | 1d | Persistent, replayable search state (§4d) | **done** |
 | 2 | Deterministic action generator (§4e) | **done** |
-| 3 | Best-first / beam; establish the objective API and the search/evidence boundary | next |
-| 4 | MCP facade — inspect state, hypotheses, frontier; request experiments | |
+| 3 | Best-first; the objective API and the search/evidence boundary (§4f) | **done** |
+| 4 | MCP facade — inspect state, hypotheses, frontier; request experiments | next |
 | 5 | PUCT as another `SearchPolicy`; same states, actions, evidence | |
 | 6 | Extend `PhysicalState` with residency; optimise measured tok/s | |
 

--- a/docs/represent-optimizer-mcp.md
+++ b/docs/represent-optimizer-mcp.md
@@ -1,8 +1,8 @@
 # The LARQL Physical Optimizer — evidence-constrained physical-plan search
 
 **Branch `worktree-represent-optimizer-mcp`, based on `origin/main` at
-`8f647872`.** Stages 1a-1c are implemented and green; everything below
-them is design.
+`8f647872`.** Stage 1 (a-d) is implemented and green; everything below
+it is design.
 
 The abstraction is not "quantization search". It is **evidence-
 constrained physical-plan search**, and it is the query optimiser the
@@ -91,7 +91,7 @@ Grounded, all under
 | Concern | Where |
 |---|---|
 | The map as policy, not transcript | `map.rs` — `PrecisionMap`, `Exception`, `resolve`, `conforms` |
-| Behavioural contract + margins | `constraint.rs` — `Margin`, `Frontier`, `binding()`, `admissible()` |
+| Behavioural contract + margins | `constraint.rs` — `Margin`, `ConstraintVector`, `binding()`, `admissible()` |
 | The frozen contract | `quality.rs:764` — `kimi-logit-balanced-v1`; `QualityGate.id` — *"changing a threshold means a NEW id"* |
 | Measurement adequacy | `measurement.rs` — `MeasurementStatus`, `EvidenceScale::{Diagnostic,Authority}` |
 | How a search may *use* a statistic | `search_evidence.rs` — the four-rung ladder, `SearchCalibrationRegistry` |
@@ -403,7 +403,7 @@ possible, not mandatory.
 
 No PASS/FAIL, no promotion status, no contract. The key says *what
 experiment was performed against what state*, never what the result
-meant. Classification stays downstream in `Margin`/`Frontier` and
+meant. Classification stays downstream in `Margin`/`ConstraintVector` and
 `decide_promotion`, so a later contract reinterprets observations
 already held instead of making them disappear.
 
@@ -429,6 +429,95 @@ Five mutations, each killing exactly its own tests: key ignores scale →
 2 red; bank id counts samples instead of naming them → 1; instrument id
 ignores truncation → 2; bank id includes its storage location → 1;
 `record` overwrites a contradiction → 1.
+
+---
+
+## 4d. Stage 1d — the replay gate (IMPLEMENTED)
+
+`represent/state/{semantics,snapshot}.rs`, 9 tests, 100% on `semantics.rs`
+and 99.4% on `snapshot.rs`.
+
+```text
+STORED — facts and configuration
+    schema, objective, gate, tail-support policy, search semantics
+    the state graph      (which states exist, how they were reached)
+    the measurements     (what was observed of them)
+
+NEVER STORED — conclusions
+    admissible / refused      chosen candidate     candidate rank
+    binding constraint        the frontier         "best map"
+    promotion decision        an agent's recommendation
+```
+
+> **Delete every derived conclusion, deserialise the factual state, run
+> the deterministic optimiser, and recover the same conclusion.**
+
+The frontier is recomputed on every call rather than stored: a persisted
+frontier is a second authority that can drift from the graph and
+measurements it came from. Caching is a later optimisation; the gate
+passes without one.
+
+### The replay, on the real numbers
+
+The snapshot is serialised, the in-memory object thrown away, and every
+conclusion below derived from the reloaded facts:
+
+```text
+map   logical bytes     auth kl p99   re-derived      recorded
+P     13,684,764,800    3.3532e-03    admitted        K25 survives
+T1    13,682,673,664    3.6480e-03    REFUSED (kl)    kl 3.648e-3 > 3.500e-3
+S2    13,602,484,352    4.0563e-03    REFUSED         refused
+S1    13,600,393,216    —             MISS            never measured
+```
+
+`binding()` re-derives `KlP99` on the admitted parent — the fact the
+exchange rung exists because of. S1's absence re-derives as a
+*measurement miss*, which is a fact about the record rather than a
+failure. Only `kl_p99`, `min_covered_mass` and the byte figures are
+recorded values; the other criteria are fixtures placed well inside
+their limits so that what the replay turns on is the recorded evidence.
+
+### Semantics have identity too
+
+Six months from now `decide_promotion` legitimately changes, an old
+snapshot replays, and the answer differs while every stored measurement
+is intact. **That is not corruption — the decision procedure changed.**
+So `SearchSemanticsId` digests five normative version identities
+(candidate generation, pre-measurement pruning, evidence interpretation,
+promotion rule, physical accounting), never source hashes, and separates:
+
+```text
+observation replay          same facts, CURRENT rules
+historical decision replay  same facts, the rules OF THE TIME
+```
+
+That is 1c's *observation is not meaning* applied one level up.
+
+### What 1d does not replay, and why that is principled
+
+`decide_promotion` takes a `SearchCandidate` carrying an
+`assessment.ranking_score` — **a conclusion**. Persisting one to make
+promotion replayable would be exactly the cheat this stage forbids;
+re-deriving it needs the assessment layer wired to the graph, which is
+the candidate generator's job at stage 2. So 1d replays the *contract*
+chain — margins, binding constraint, admissibility, refusal and its
+reasons — and does not claim promotion ordering.
+
+### The anti-cheat is structural
+
+A test walks the serialised JSON and fails on any key named
+`admissible`, `admitted`, `refused`, `binding`, `frontier`, `verdict`,
+`promotion`, `rank`, `chosen`, `best`, `recommendation`, `failures`,
+`passed` or `adjudication` — then asserts the *facts* are present, so
+the emptiness is not vacuous. It caught its first real case immediately:
+`SearchSemantics.promotion` is a rule identity, not a decision, and the
+field is now `promotion_rule` so the check can stay blunt instead of
+growing an exemption.
+
+Three mutations, each killing exactly its own test: storing the admitted
+set → the anti-cheat; admission ignoring evidence scale → the
+diagnostic-is-not-an-admission test; the frontier absorbing measurements
+of states the graph never held → the foreign-state test.
 
 ---
 
@@ -523,7 +612,7 @@ Deliberately boring, so MCTS is a policy swap and not a rewrite.
 | 1a | Resolved-state identity contract + adversarial tests | **done** |
 | 1b | State graph with **edge** provenance (§4b) | **done** |
 | 1c | `MeasurementKey` + measurement dedup (§4c) | **done** |
-| 1d | Persistent, replayable search state | next |
+| 1d | Persistent, replayable search state (§4d) | **done** |
 | 2 | Deterministic action generator — exact physical deltas, participation, novelty and admissibility *before* measurement | |
 | 3 | Best-first / beam; establish the objective API and the search/evidence boundary | |
 | 4 | MCP facade — inspect state, hypotheses, frontier; request experiments | |

--- a/docs/represent-optimizer-mcp.md
+++ b/docs/represent-optimizer-mcp.md
@@ -1,7 +1,7 @@
 # The LARQL Physical Optimizer — evidence-constrained physical-plan search
 
 **Branch `worktree-represent-optimizer-mcp`, based on `origin/main` at
-`8f647872`.** Stages 1 (a-d), 2 and 3 are implemented and green;
+`8f647872`.** Stages 1 (a-d), 2, 3 and 3b are implemented and green;
 everything below them is design.
 
 The abstraction is not "quantization search". It is **evidence-
@@ -733,6 +733,96 @@ as the parent's standing → 1.
 
 ---
 
+## 4g. Stage 3b — the chain runs from a snapshot (IMPLEMENTED)
+
+`represent/state/{snapshot,replay_tests}.rs`, 7 tests.
+
+```text
+snapshot facts → action space → assessment → ranking → promotion
+```
+
+with none of the intermediates serialised. 1d closed the contract half
+and left promotion open on principle; 3b adds the two **facts** it
+needed rather than the conclusion it lacked.
+
+### Two gaps, both closed by adding inputs
+
+**The snapshot could not produce an action space.** It held
+`{schema, objective, gate, tail_support, semantics, graph, measurements}`
+— no surface, base map or vocabulary — so nothing could build a
+`Generator` from it, and the stage-3 tests assembled candidates from a
+test rig rather than from reloaded facts.
+
+**Promotion needed a per-state `ByteLedger` and an `ExecutionCostModel`.**
+
+The snapshot is now grouped, which makes the doctrine visible in the
+type:
+
+```text
+SearchSpace   surface, base map, vocabulary        what is searched over
+SearchConfig  objective, gate, tail support,       how facts become
+              calibrations, diagnostic policy,     conclusions
+              semantics, ranking
+SearchFacts   graph, measurements, byte ledgers,   what has been observed
+              execution cost                       and what it costs
+```
+
+`ExecutionCostModel` already had the discipline: it stores measured
+*observations*, each carrying machine, device, backend and compiler
+commit, and `predict()` derives the cost while `status()` refuses to
+call the model calibrated until beta has been shown across separated
+breadths. Nothing about a cost is persisted.
+
+### Promotion reads edges, not candidates
+
+The first wiring fed `promotion_candidates` an eligible `CandidateSet`
+and it returned nothing — correctly. **A measured move is exactly what
+the generator prunes**, because its question is what to try *next*.
+Promotion's question is about what has been built and measured, so it
+reads the graph's edges. Feeding it eligible candidates would ask which
+*unmeasured* move should replace the incumbent, which no evidence can
+answer.
+
+A move is a promotion candidate only when both ends carry a reading at
+the scale **and** both carry a ledger. Otherwise it is skipped, not
+defaulted: a marginal quantity with one end missing is not a smaller
+number, it is no number.
+
+`decide_promotion` is called unmodified, and no proxies are invented —
+a `ProxyObservation` is a registered finding about an instrument, and
+none exists for these statistics.
+
+### A real defect the widening surfaced
+
+`Role`'s `Deserialize` read `<&str>`, which demands a **borrowed**
+string. It worked under `serde_json::from_str` and failed under
+`from_value`, `from_reader` and every binary format, with an
+`invalid type: string, expected a borrowed string` far from the cause.
+A `TensorSurface` carries `Role`s, so a snapshot could not round-trip
+through `serde_json::Value` — and an MCP surface will. Fixed to `Cow`,
+which still borrows where borrowing is possible, and tested through
+both an owning and a reader deserializer.
+
+### The anti-cheat survived the widening
+
+Six new fields, every one a fact or a rule, and the structural check
+still holds. It found its second naming collision:
+`config.calibrations[].verdict` is ROUTE-CAL-1 saying how a statistic
+may be used — a registered finding about an *instrument*, not a
+conclusion about a candidate. Exempted by name, so the check stays blunt
+everywhere else, and `ranking_score`, `selection` and `next_experiment`
+were added to the forbidden list.
+
+### What is real and what is a fixture
+
+The recorded rung-5 numbers — kl p99, logical bytes, covered mass — are
+exercised in §4d against the register. 3b tests the *derivation chain*;
+its per-token ledgers and GPU cost observation are **fixtures**, because
+the record holds no measured GPU time for P, T1 or S2. Inventing one and
+calling it recorded would be worse than saying so.
+
+---
+
 ## 5. The reward, which must not be diagnostic KL
 
 Rung 4/5 established that diagnostic KL supplies neither magnitude, sign,
@@ -827,6 +917,7 @@ Deliberately boring, so MCTS is a policy swap and not a rewrite.
 | 1d | Persistent, replayable search state (§4d) | **done** |
 | 2 | Deterministic action generator (§4e) | **done** |
 | 3 | Best-first; the objective API and the search/evidence boundary (§4f) | **done** |
+| 3b | Promotion-input closure — the chain runs from a snapshot (§4g) | **done** |
 | 4 | MCP facade — inspect state, hypotheses, frontier; request experiments | next |
 | 5 | PUCT as another `SearchPolicy`; same states, actions, evidence | |
 | 6 | Extend `PhysicalState` with residency; optimise measured tok/s | |

--- a/docs/represent-optimizer-mcp.md
+++ b/docs/represent-optimizer-mcp.md
@@ -233,6 +233,114 @@ silently colliding.
 
 ---
 
+## 4b. Stage 1b — the state graph (IMPLEMENTED)
+
+`represent/state/{realization,transition,graph}.rs`, 12 tests, 100% line
+coverage on all six state files.
+
+### Physical identity is not search-context identity
+
+Stage 1a collapses a protection and a layout refusal into one
+`RepresentationStateId`. That is right for evidence and, left alone,
+would have been a 1b information-loss bug — the two are not
+*action*-equivalent:
+
+```text
+                 physical equivalence
+                         │
+                RepresentationStateId
+                   ↑                ↑
+         realization A        realization B
+         X = Source           X = LayoutRefused
+                   │                │
+         "unprotect X" is    nothing compiles X;
+         a legal move        the layout refuses it
+```
+
+So the graph carries two keys:
+
+```text
+RepresentationStateId   what is PRESENTED   → evidence, MeasurementKey
+RealizationId           what is DECIDED     → the action generator
+```
+
+A node is one physical state holding a *set* of realizations. **Evidence
+may deduplicate more aggressively than search may.** `ResolvedEncoding`
+gained `fact()`, and the decision vector gained `canonical_full()`
+alongside `canonical()` — the realization digest reads the refining
+form, the physical digest the collapsed one.
+
+### Earning the word DAG
+
+Acyclicity is a **theorem under a declared policy**, not a property of
+the domain, so the policy is a value on the graph rather than a comment:
+
+```text
+StrictlyImprovingPhysical   every edge strictly reduces LogicalBytes
+                            ⇒ a cycle would need a strictly decreasing
+                              u64 sequence returning to its start
+                            ⇒ no cycles. This is a DAG.
+Unconstrained               any edge; a general graph, caller owns
+                            termination
+```
+
+The strict policy is what rung 5 already enforces — N1 pruned `−E26 + H`
+at +1.39 GB and `−K25 + M23` at +2,091,136 B for being physically worse,
+and Ruling 1 lists physical dominance among the four legitimate
+pre-measurement prunes. It is nonetheless **a policy and not a law**, and
+the programme's own roadmap says when it breaks: once residency joins the
+state and the objective is measured tok/s, a move that *adds* logical
+bytes while freeing unified memory for resident experts is exactly what
+the search must be able to make. The type is therefore
+`RepresentationStateGraph`, the policy is recorded and serialised, and a
+graph built under one policy is recognisably not a graph built under the
+other.
+
+One consequence worth naming: a cost-neutral edge is refused too. From a
+layout-refused realization, "unprotect" changes the facts and no bytes at
+all — physical dominance prunes it anyway, and admitting it would put a
+zero-weight edge into the structure the strict decrease is what keeps
+acyclic.
+
+### Edges own how you got there
+
+```text
+Transition { parent, child, child_realization, action, physical_delta, provenance }
+```
+
+`physical_delta` is **computed** from two footprints, never supplied —
+R5-F5 read a footprint column as a saving and overstated an expert revert
+by 3.39×, so `LogicalBytes` is a newtype that keeps footprint, per-token
+read and delta apart. Edge identity is
+`(parent, child, child_realization, action)`, with the action's removed
+and added lists sorted, so `+q +k` and `+k +q` are one move while a
+different *destination realization* is a different move. Re-discovering
+an edge under provenance already recorded is a no-op; a genuinely
+different discoverer is kept.
+
+Round number, candidate rank, diagnostic reading and an agent's rationale
+all live in `Provenance.note` as **text**, precisely so that no
+comparator can compute on them — rung 5's rule that the action lists are
+recorded for reproduction *and for no other purpose*.
+
+One graph holds one model and one surface: a map's physical prize is a
+property of the model it resolves against, and mixing them would hold
+costs that cannot be compared.
+
+### The tests, and that they can fail
+
+The six that were asked for, plus five refusal guards. Four mutations,
+each killing exactly its own tests:
+
+| Mutation | Killed |
+|---|---|
+| realization digest reads the *collapsed* form | `one_physical_state_keeps_both_realizations`, `…serialization…` (2) |
+| `observe()` always appends provenance | `rediscovering_an_edge…` (1) |
+| policy admits a cost-neutral edge (`<=` for `<`) | `a_transition_that_does_not_improve_physically…` (1) |
+| edge identity drops the action | `different_recipes_with_one_effective_representation…` (1) |
+
+---
+
 ## 5. The reward, which must not be diagnostic KL
 
 Rung 4/5 established that diagnostic KL supplies neither magnitude, sign,
@@ -322,8 +430,8 @@ Deliberately boring, so MCTS is a policy swap and not a rewrite.
 | # | Rung | State |
 |---|---|---|
 | 1a | Resolved-state identity contract + adversarial tests | **done** |
-| 1b | DAG with **edge** provenance | next |
-| 1c | `MeasurementKey` + measurement dedup | |
+| 1b | State graph with **edge** provenance (§4b) | **done** |
+| 1c | `MeasurementKey` + measurement dedup | next |
 | 1d | Persistent, replayable search state | |
 | 2 | Deterministic action generator — exact physical deltas, participation, novelty and admissibility *before* measurement | |
 | 3 | Best-first / beam; establish the objective API and the search/evidence boundary | |

--- a/docs/represent-optimizer-mcp.md
+++ b/docs/represent-optimizer-mcp.md
@@ -1,0 +1,437 @@
+# The LARQL Physical Optimizer — evidence-constrained physical-plan search
+
+**Branch `worktree-represent-optimizer-mcp`, based on `origin/main` at
+`8f647872`.** Stage 1a is implemented and green; everything below it is
+design.
+
+The abstraction is not "quantization search". It is **evidence-
+constrained physical-plan search**, and it is the query optimiser the
+*model-is-a-database* thesis was always going to need:
+
+```text
+logical model  →  candidate physical plans  →  cost model
+                                                   ↓
+                                         evidence constraints
+                                                   ↓
+                                          physical model plan
+```
+
+The eventual request is one sentence — *run K3 as fast as possible on
+this MacBook while satisfying `balanced-v1`* — and the search runs over
+representation × residency × storage × execution strategy to produce a
+measured, evidence-backed plan.
+
+MCTS is not the architecture. It is one `SearchPolicy` among Greedy,
+BestFirst, Beam and PUCT, and it is **not yet earned** (§8).
+
+---
+
+## 1. Epistemic responsibilities
+
+```text
+VINDEX3                 what is this model / state, exactly?
+REPRESENT / RESIDENCY   what transformations are legal?
+Evidence                what have we actually established?
+Optimizer               which states are worth exploring?
+AI                      what scientific question should we ask next?
+```
+
+Five different questions, five different authorities, and the value of
+the design is that they do not leak into each other. The agent is not
+handed an optimiser and told to improvise; it operates a scientific
+instrument whose definitions of identity, admissibility, measurement and
+evidence exist independently of it.
+
+```text
+> Diagnostic chooses what to measure next; authority decides what is
+> admissible.  Extend one level: the AI chooses what question to ask
+> next; the optimiser and the evidence system decide what is true.
+```
+
+REPRESENT does not know MCTS exists. Neither does RESIDENCY, and
+certainly not VINDEX3. The search engine asks only
+`state.actions()`, `state.apply(action)`, `state.cost()`,
+`evidence.for(state)`.
+
+---
+
+## 2. Three objects, not one node
+
+The mistake to avoid is a fat `MapNode` mixing immutable truth with
+mutable search statistics. Split:
+
+```text
+PhysicalState {          // immutable truth, hashed
+    id, representation, residency, execution,
+    physical_cost, structural_properties,
+}
+
+Evidence {               // keyed BY state, never part of it
+    state_id, diagnostic, authority, benchmarks, provenance,
+}
+
+SearchNode {             // the policy's business alone
+    state_id, visits, value, prior, expanded_actions,
+}
+```
+
+Today `PhysicalState` has exactly one component —
+[`RepresentationState`](../crates/larql-vindex/src/format/vindex3/represent/state/identity.rs) —
+and residency and execution join at stage 6. That widening is why the
+identity contract below is written to compose rather than to be the
+whole story.
+
+---
+
+## 3. What already existed
+
+Grounded, all under
+`crates/larql-vindex/src/format/vindex3/represent/`:
+
+| Concern | Where |
+|---|---|
+| The map as policy, not transcript | `map.rs` — `PrecisionMap`, `Exception`, `resolve`, `conforms` |
+| Behavioural contract + margins | `constraint.rs` — `Margin`, `Frontier`, `binding()`, `admissible()` |
+| The frozen contract | `quality.rs:764` — `kimi-logit-balanced-v1`; `QualityGate.id` — *"changing a threshold means a NEW id"* |
+| Measurement adequacy | `measurement.rs` — `MeasurementStatus`, `EvidenceScale::{Diagnostic,Authority}` |
+| How a search may *use* a statistic | `search_evidence.rs` — the four-rung ladder, `SearchCalibrationRegistry` |
+| Promotion that cannot scalarise a proxy | `decision.rs` — `decide_promotion`, `PromotionDecision::Ambiguous` |
+| Physical accounting | `physical.rs`, `byte_ledger.rs` |
+| Causal reach of an action | `participation.rs` — `ParticipationDeclaration` |
+| Container identity, three levels | `compiler.rs` — `SourceIdentity` (index, semantic graph, payload segments) |
+| A worked end-to-end chain | [kimi-precision-topology.md](kimi-precision-topology.md) |
+
+`search_evidence.rs` and `decision.rs` are what make an MCP surface safe
+to expose at all: `OrderingProxy` licenses order and never magnitude, and
+disagreeing proxies are refused rather than scalarised. A persuasive
+agent cannot talk past either.
+
+**Absent before this branch** (grep, not recollection): no
+`MeasurementKey`, no map identity of any kind, no DAG/frontier/policy,
+no MCP anywhere in the workspace. `SearchCandidate` is a *round*
+abstraction with no memory across rounds.
+
+---
+
+## 4. Stage 1a — the identity contract (IMPLEMENTED)
+
+`represent/state/{surface,resolved,identity}.rs`, 18 tests, 100% line
+coverage on all three files.
+
+### The normative invariant
+
+> **If two maps cause VINDEX3 to present exactly the same representation
+> decision for every tensor of the same model surface, they are the same
+> search state.**
+
+```text
+RepresentationStateId = H( model_identity,
+                           tensor_surface_identity,
+                           effective_decision_vector )
+```
+
+```text
+IN   model identity      SourceIdentity — index, semantic graph, payload
+                         segments. The same map on two models is two
+                         states, and the graph level catches identical
+                         payloads under different semantics.
+IN   tensor surface      every (object, tensor, role, shape), digested.
+IN   effective decisions what is presented, per tensor.
+
+OUT  rule syntax         ordering that changes no decision, shadowed
+                         exceptions, redundant defaults, the map's
+                         `name`, the recipe that built it.
+OUT  evidence            a measurement DESCRIBES a state.
+OUT  search history      different paths converge to one node.
+OUT  the contract        a representation is the same representation
+                         under another contract. Contract, bank and
+                         execution belong to the MEASUREMENT key.
+```
+
+Folding `balanced-v1` into the digest would identify an *experimental
+context* rather than a representation, and the same bytes measured under
+a second contract would arrive as an unrelated state with no shared
+physical accounting.
+
+### Two things the spec did not anticipate
+
+**Effective, not declared.** A map can say *compile this* and the
+storage layout refuse it — NVFP4 holds 2-D matrices whose `k` is a
+multiple of 16, and `represent/mod.rs` carries anything else verbatim
+whatever the policy said. A state built on the *declared* decision would
+believe it had compiled tensors still sitting at source precision and
+would price bytes it never saved. So `ResolvedEncoding` has three
+variants and the digest reads `effective()`:
+
+```text
+map says          layout says       presented       counts as
+compile NVFP4     can hold it       NVFP4           Compiled
+compile NVFP4     k not a multiple  source bytes    LayoutRefused
+source precision  —                 source bytes    Source
+```
+
+`LayoutRefused` and `Source` are one state and two facts. Identity
+collapses them; the decision vector keeps them apart, because the action
+generator needs the difference — unprotecting is a legal move, and
+un-refusing a layout is not a move at all.
+
+`LayoutAdmission` is a trait, and an implementation holding no rule for
+an encoding answers *not refused*. Refusal takes positive evidence from
+whoever owns the layout: a refusal invented here would delete a tensor
+from the action space forever, whereas an over-admission surfaces as a
+resolved-decision mismatch the first time anything is compiled.
+
+**Role is in the surface.** 4.05 B Gated DeltaNet weights once
+classified `unknown` because `_proj_qkv.` is not `_proj.`. No byte on
+disk moves when that is fixed, but the set of maps that would compile the
+tensor does — a different search problem, so a different state.
+
+**Tensor identity is `(object, tensor)`**, not a sorted name. That is
+what `plan_roles::PlanRoles` is keyed by and what
+`CompilationLedger` seals against; `weight` occurs in almost every
+object, so ordering by name alone would let incidental file order reach
+the digest. Aliased objects (a tied embedding and output head) stay
+**two** surface entries: a map resolves per `(object, tensor)` and
+REPRESENT compiles one pack per object, so collapsing them would claim an
+agreement the compiler does not enforce. That the bytes are shared is
+already recorded once, by the model identity's per-segment hashes.
+
+### The tests
+
+Six from the spec, plus the alias case, plus five the implementation
+earned:
+
+```text
+same map + same model                        → same id
+different recipes, identical decisions       → same id
+shadowed exception added                     → same id
+the map's `name` changed                     → same id
+surface enumeration order reversed           → same id
+exception ordering that changes a decision   → different id
+same map, different model (graph; segment)   → different id
+tensor reshaped, every decision unchanged    → different id
+tensor added, survivors unchanged            → different id
+role reclassified, every decision unchanged  → different id
+aliased objects                              → two entries, independently decided
+duplicate (object, tensor)                   → refused, not silently deduped
+layout refusal                               → same id as protection, distinct fact
+an oracle with no rule                       → does not refuse
+```
+
+**Verified they can fail.** Three mutations of the implementation, each
+killing exactly its own tests and nothing else:
+
+| Mutation | Killed |
+|---|---|
+| surface identity dropped from the digest | `a_reshaped_tensor…`, `a_role_reclassification…` (2) |
+| model identity dropped from the digest | `the_same_map_on_a_different_model…` (1) |
+| `LayoutRefused` no longer collapses to source | `a_layout_refusal_presents_source…` (1) |
+
+The canonical form is versioned (`represent-state-id/v1`) so a persisted
+DAG that outlives a change to it is recognisably stale rather than
+silently colliding.
+
+---
+
+## 5. The reward, which must not be diagnostic KL
+
+Rung 4/5 established that diagnostic KL supplies neither magnitude, sign,
+authority scaling, nor parent-relative ordering. Feeding it to a policy
+as a scalar reward reintroduces every one of those with a UCB formula on
+top. So the value function is stratified by evidence class and only the
+top stratum produces a number priced against the contract:
+
+```text
+authority-admitted   measured objective (tok/s) / physical cost
+authority-refused    terminal for this identity — but the ACTION is not
+                     globally poisoned (R5-F6): the same action from a
+                     different parent is a different, unmeasured state
+diagnostically seen  optimistic physical prize
+                       × evidence confidence (SearchEvidence rank)
+                       × novelty
+unmeasured           prior only — physical prize is exact, the rest is a hint
+```
+
+`SearchEvidence::is_priceable()` already returns false for
+`OrderingProxy`; the policy must call it. Turning a diagnostic reading
+into an admission probability is legitimate only after a calibration
+demonstrating magnitude transfer, and that calibration has a home:
+`SearchCalibrationRegistry`.
+
+PUCT over vanilla UCT, when it arrives, because real priors exist: exact
+physical gain, depth/family history, arm and router position, structural
+participation, and the set of already-explored identities. Priors say
+where to look; authority says what survives.
+
+---
+
+## 6. The MCP surface — intent, not tree operations
+
+The agent must not become a `for` loop. An interface of
+`search.expand(node)` / `search.observe(result)` puts the LLM inside the
+optimiser's inner loop and costs 40,000 round trips at K3 scale. Those
+calls exist, as a debug surface. The **primary** interface is intent:
+
+```text
+optimize.search(objective = throughput,
+                constraints = ["balanced-v1"],
+                budget = { diagnostic: 30, authority: 5, benchmark: 2 })
+
+optimize.status()
+optimize.frontier()
+optimize.explain(state)
+optimize.next_experiment()
+```
+
+The deterministic optimiser performs hundreds or thousands of cheap
+expansions internally. The agent is engaged where reasoning is actually
+useful — *we have two competing hypotheses for E24; would an exchange
+experiment distinguish state dependence; is this worth an authority run;
+the frontier has collapsed onto tiny physical gains.*
+
+Three namespaces (one server, three prefixes to start):
+
+```text
+represent.*   numerical representation search
+residency.*   placement / cache / prefetch / external storage
+evidence.*    banks, contracts, provenance, comparison, authority
+```
+
+`search.neighbours` is the tool that justifies the exercise: not blind
+tensor mutations, but actions annotated with family, depth, arm, position
+relative to the router, downstream router reach, encoding transition,
+exact logical byte saving, and which structural statistics the action can
+participate in (`participation.rs`).
+
+### The tool that must not exist
+
+```text
+accept_candidate(candidate, reason = "AI judgement")     ✗ never
+```
+
+Admission stays mechanical: `measure.authority(...)` → `AuthorityResult`,
+`contract.evaluate(...)` → PASS | FAIL | Unscorable. The agent chooses
+what to ask; it gets no vote on what the answer means.
+
+---
+
+## 7. Implementation sequence
+
+Deliberately boring, so MCTS is a policy swap and not a rewrite.
+
+| # | Rung | State |
+|---|---|---|
+| 1a | Resolved-state identity contract + adversarial tests | **done** |
+| 1b | DAG with **edge** provenance | next |
+| 1c | `MeasurementKey` + measurement dedup | |
+| 1d | Persistent, replayable search state | |
+| 2 | Deterministic action generator — exact physical deltas, participation, novelty and admissibility *before* measurement | |
+| 3 | Best-first / beam; establish the objective API and the search/evidence boundary | |
+| 4 | MCP facade — inspect state, hypotheses, frontier; request experiments | |
+| 5 | PUCT as another `SearchPolicy`; same states, actions, evidence | |
+| 6 | Extend `PhysicalState` with residency; optimise measured tok/s | |
+
+Provenance lives on **incoming edges**, not baked into the node:
+
+```text
+A --[Q6 E24]-------------------→ C
+B --[exchange K24→K25, +E24]---→ C
+```
+
+One `C`, several explanations of how it was reached. That is what makes
+`optimize.explain(state)` able to separate *state identity* from
+*discovery path* — the distinction the experiment ledger currently makes
+by hand.
+
+### The stage-1 exit gate
+
+> Replay a real Rung 4/5 sequence **from the initial map and the recorded
+> measurements — not the recorded decisions** — and reproduce candidate
+> identity, dedup, evidence applicability and promotion decisions without
+> consulting the experiment ledger.
+
+Deriving the decisions again is the point. Replaying stored decisions
+would prove serialisation; deriving them proves the optimiser state
+contains enough to replace what currently lives in the ledger and in an
+operator's head.
+
+---
+
+## 8. Where MCTS becomes earned
+
+Not yet. State dependence alone only makes greedy ranking questionable.
+The result that settles it is **path-dependent option value**:
+
+```text
+             +E24
+      A ─────────────→ FAIL
+
+      │ -K24 / +K25
+      ▼
+      B ─────────────→ C   PASS, −600 MB
+             +E24
+```
+
+where reaching `B` required an apparently inferior intermediate move.
+Beam search recovers some of that; MCTS assigns value to a state because
+of its *descendants*.
+
+The K24 state-dependence observed so far is diagnostic-scale (5.358e-3
+at `{E26,M26}` against 2.172e-3 at `{E26,K25}`, 2.47×), and
+`search_evidence.rs` is explicit that diagnostic scale cannot carry the
+claim. So the falsifier is **an authority-scale parent-dependent
+reversal**.
+
+**That experiment is already registered and running.** Rung 5's
+neighbourhood 3 — `U1 = P−M26+E24` and `U2 = P−K25+E24`, ~430 MB each —
+puts the E24 action, authority-refused as E24b at 4.298e-3 under
+*lighter* all-Q8 arms, into two different representation states. A PASS
+is exactly the shape above: an action refused in one state proving
+admissible in another. Until it returns, best-first is sufficient and
+this section is a plan, not a justification.
+
+Note what may *not* be inferred meanwhile: Ruling 1 forbids pruning
+either candidate for being a superset of a refused map. Authority refusal
+attaches to the measured map, is not upward-closed under action-set
+inclusion, and "more low precision" is not a behavioural partial order.
+The only legitimate pre-measurement prunes are an identical
+`MeasurementKey`, physical dominance, structural impossibility, and a
+proved monotonicity theorem — and no such theorem is currently held.
+**That list is the action generator's entire contract at stage 2.**
+
+Residency will likely make the phenomenon common:
+
+```text
+representation change → frees 700 MB UMA → 6 more experts resident
+                      → fewer external reads → +4 tok/s
+```
+
+There the action's value is not its local byte saving at all; it is its
+effect on the future physical plan.
+
+---
+
+## 9. Open questions
+
+1. **`MeasurementKey` dimensions — mostly settled already.** R5-F3
+   registered them: `{map_hash, bank_manifest, evidence_scale,
+   instrument_semantics}`, with the explicit correction that **dedup on
+   bare `map_hash` is wrong** because it would forbid the
+   diagnostic → authority escalation the whole ladder depends on. In
+   this module's vocabulary `map_hash` becomes `state_id`. Still to
+   settle: whether `QualityGate.id` is already implied by
+   `instrument_semantics` or belongs as its own dimension, and whether
+   execution/backend identity enters the key for benchmark measurements
+   only or for all of them. Note that `bank_manifest` exists in the
+   programme (`17d59a6b…`) but not as a field on `QualityBank`, which
+   carries `positions` and evidence and no id — so bank identity has to
+   be lifted into the type before 1c can key on it.
+2. **Where the DAG persists.** Evidence already lives in the experiments
+   ledger; a second store risks two truths. Candidate: the DAG holds
+   identities and edges and dereferences every measurement to the ledger
+   rather than copying it.
+3. **Crate boundary.** A thin `larql-represent-mcp` binary over public
+   `represent::*` types is the obvious eventual shape, but stage 1 stays
+   inside `larql-vindex` and moves only when the transport forces it.
+4. **When `residency.*` joins the state.** Sharing the DAG from stage 1
+   is cleaner and makes stage 1 much larger; stage 6 is the current plan.


### PR DESCRIPTION
## The claim

> Given persisted physical state, measurements, costs and normative search
> semantics, LARQL can reconstruct the representation search — candidate
> generation, assessment, ranking and promotion — **without persisting any of
> those conclusions**.

That moves the scientific state of a REPRESENT search out of the experiment
ledger and an operator's memory, and into a deterministic, replayable object.

All of it lives in `crates/larql-vindex/src/format/vindex3/represent/state/`.
`docs/represent-optimizer-mcp.md` carries the design and every stage's findings.

## Three identities, because they answer three different questions

```text
RepresentationStateId   what is PRESENTED   → evidence, measurement dedup
RealizationId           what is DECIDED     → the action space
MeasurementKey          what was OBSERVED   → have we already run this?
```

A tensor held at source precision by a *protection* and one held there by a
*layout refusal* present identical bytes: one physical state, and a measurement
of either is a measurement of both. They are not the same **realization** — you
can unprotect a tensor and you cannot un-refuse a layout — so a node is one
physical state holding a set of realizations. **Evidence may deduplicate more
aggressively than search may**, and that is the point of the split.

Identity is over the *resolved decision vector*, never the rule text. A shadowed
exception, a redundant default and a different map `name` all resolve to the
same state; the same map over two models does not. This is what R5-F3 caught the
hard way, when an exchange re-derived a map already measured and rejected under
another name.

## Facts, never conclusions

`SearchSnapshot` is grouped so the doctrine is visible in the type:

```text
SearchSpace   surface, base map, vocabulary        what is searched over
SearchConfig  objective, gate, tail support,       how facts become
              calibrations, diagnostic policy,     conclusions
              semantics, ranking
SearchFacts   graph, measurements, byte ledgers,   what has been observed
              execution cost                       and what it costs
```

Nothing derived is stored: no admissibility, no rank, no binding constraint, no
frontier, no promotion. A test walks the serialised JSON and fails on any key
that names a conclusion, then asserts the facts *are* present so the emptiness
is not vacuous. It has caught two naming collisions so far, both real:
`SearchSemantics.promotion` (renamed `promotion_rule`) and
`calibrations[].verdict` (a registered finding about an *instrument*, exempted
by name so the check stays blunt).

The frontier is recomputed on every call rather than cached — a persisted
frontier is a second authority that can drift from the graph it came from.

## Complete action accounting

Every declared move ends in exactly one place:

```text
generated              N
structural invalid     …
physical dominance     …
already measured       …
eligible               …
                      ───
                       N     ← asserted by Census::conserves()
```

The prune list is Ruling 1's, checked against the register rather than recalled:
**three usable categories**, plus a fourth that would need a proved monotonicity
theorem and is *not held*. `PreMeasurementPrune` therefore has three variants and
the fourth is absent by construction, so adding it is a visible schema change.

**Behavioural-superset pruning is not on the list.** Authority refusal attaches
to the measured map, is not upward-closed under action-set inclusion, and "more
low precision" is not a behavioural partial order. A test records the line, and a
mutation that slips such a prune in reddens it.

The move vocabulary is an **input**, not something inferred: R5-F6 was a
vocabulary failure, not a ranking failure — a round drew its in-moves from the
previous round's leftovers and made two ~430 MB moves invisible. No policy can
recover a state whose move was never declared.

## Measurement and search are separated

A measured move disappears from *what to try next* — the generator prunes it —
while remaining available to promotion through the graph's **edges**. Wiring
promotion to eligible candidates instead returns nothing, correctly: that would
ask which *unmeasured* move should replace the incumbent, and no evidence can
answer it.

Two routes to one physical state schedule **one** experiment, and both routes
survive inside it because their future action spaces differ. When the observation
lands, both inherit it.

## Determinism

Best-first's order is stated once and complete:

```text
registered rule → greater physical improvement → child state id
               → child realization id → action identity
```

Everything after the rule exists so that no answer depends on insertion order,
map iteration, thread completion or vocabulary traversal. Tested against
reversed and rotated input, on a genuine tie, and on the case that reaches the
fourth element — one physical state, two realizations.

`decide_promotion` is called unmodified. It already refuses to scalarise
disagreeing proxies, and making ranking convenient is not a reason to weaken it.

## Real replay

The rung-5 record, serialised and reloaded, with the live object discarded:

| map | logical bytes | auth kl p99 | re-derived | recorded |
|---|---|---|---|---|
| P | 13,684,764,800 | 3.3532e-03 | admitted | K25 survives |
| T1 | 13,682,673,664 | 3.6480e-03 | REFUSED (kl) | 3.648e-3 > 3.500e-3 |
| S2 | 13,602,484,352 | 4.0563e-03 | REFUSED | refused |
| S1 | 13,600,393,216 | — | measurement MISS | never measured |

`binding()` re-derives `KlP99`. S1's absence re-derives as a *miss* — a fact
about the record, not a failure.

**Evidence honesty:** the promotion replay's per-token ledgers and GPU cost
observation are explicitly **fixtures**. The historical record holds no measured
GPU timing for P, T1 or S2, and inventing one and calling it recorded would be
worse than saying so. The contract half above is against the register.

## A defect that argues for this sequencing

`Role::deserialize` read `<&str>`, demanding a **borrowed** string. It worked
under `serde_json::from_str` and failed under `from_value`, `from_reader` and
every binary format, reporting `invalid type: string, expected a borrowed
string` far from the cause. `TensorSurface` carries `Role`s, so a snapshot could
not round-trip through `serde_json::Value`. Building persistence before transport
flushed out a failure an owning JSON deserializer would otherwise have found much
later. Fixed to `Cow`; tested through both an owning and a reader deserializer.

## Explicitly out of scope

```text
This PR establishes the deterministic physical-optimizer kernel.
It does not expose transport, agent control, or speculative search policies.
MCP will be a facade over this substrate; PUCT/MCTS remains gated on
authority-scale evidence of parent-dependent admissibility.
```

Also not claimed: ordering the *authority escalation* of diagnostically-measured
candidates, and any information-gain model. *Experimental value* is a real
quantity distinct from *physical value*, nothing has measured it, and inventing
it would put a heuristic where registered semantics belong.

## Gates

- `cargo test -p larql-vindex` — **4,120 passed / 0 failed**
- `cargo fmt -p larql-vindex --check` — clean
- `cargo clippy -p larql-vindex --all-targets -- -D warnings` — clean
- Every new file at or above the 90% per-file coverage floor; most at 100%
- **26 targeted mutations** across the seven stages, each verified to kill only
  its own tests — including the anti-cheat, the tie-break chain, the
  realization split, the conservation law and the superset-pruning line

## Reading the commits

They are ordered as the architecture is, one equivalence or responsibility each:

```text
6a2dc66b  what state exists
6bec0b43  what search context exists
2bce633d  what experiment exists
0a96d80e  what facts persist
b7170125  what may be tried
45ac42b5  what should be tried
a08ff8d9  what may be promoted
```
