### PR TITLE
Canonical search state, and K3 physical opportunity from execution touch

### DIFF
--- a/crates/larql-cli/src/commands/primary/k3_ledger/access.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/access.rs
@@ -1,0 +1,223 @@
+//! **Physical existence is not execution touch.**
+//!
+//! K3-DENSE-1 found two modelling errors in the dense ledger, and they
+//! partly cancelled — which is exactly why the aggregate looked believable
+//! for six weeks.
+//!
+//! ```text
+//! layer 0 is structurally DENSE, not MoE      +1.07 GB  undercount
+//! embed_tokens is a GATHER, not a full read   -2.35 GB  overcount
+//!                                             ---------
+//!                                             -1.28 GB  net
+//! ```
+//!
+//! Both came from one assumption: that a tensor's presence in the
+//! checkpoint means the whole tensor is read on every forward pass. It
+//! does not.
+//!
+//! - `embed_tokens` is `[163840, 7168]`, 2,348.81 MB. A decode step reads
+//!   **one row** — 14.3 KB. `lm_head` is the same shape and genuinely IS
+//!   a full read, because it is a matmul over the vocabulary. They are
+//!   untied (`tie_word_embeddings: false`), so this is two tensors of
+//!   identical size with completely different access.
+//! - `first_k_dense_replace: 1` makes layer 0 a DENSE layer: it has a
+//!   `[33792, 7168]` MLP and no shared experts, no LatentMoE wrapper and
+//!   no router. Modelling all 93 layers as MoE credits it with 0.38 GB it
+//!   does not have and omits 1.45 GB it does.
+//!
+//! So access semantics are a TYPE. A family declares how it is touched,
+//! and the ledger multiplies bytes by that rather than by 1.
+//!
+//! This is the same lesson as R4-F9 one layer up: there, physical file
+//! length was not representation size. Here, resident footprint is not
+//! activated traffic. Three quantities, three authorities:
+//!
+//! ```text
+//! resident footprint    what must fit in memory
+//! activated per token   what must move per token   <- the ledger's subject
+//! logical bytes         what the representation costs
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// How a tensor is touched during one decode step.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum AccessMode {
+    /// Every byte is read on every forward pass. Attention projections,
+    /// `lm_head`, shared experts.
+    FullRead,
+    /// A gather: only `rows_per_token` of `total_rows` are touched.
+    /// `embed_tokens`.
+    Gather {
+        rows_per_token: u64,
+        total_rows: u64,
+    },
+    /// Only `active` of `total` units are touched, chosen per token.
+    /// The MXFP4 expert bank.
+    Routed { active: u64, total: u64 },
+}
+
+impl AccessMode {
+    /// Bytes actually moved per token, given the tensor's resident size.
+    pub fn activated_bytes(&self, resident_bytes: u64) -> u64 {
+        match self {
+            Self::FullRead => resident_bytes,
+            Self::Gather {
+                rows_per_token,
+                total_rows,
+            } => {
+                if *total_rows == 0 {
+                    0
+                } else {
+                    // Integer-safe: divide before multiplying would lose a
+                    // row's worth on every gather.
+                    (resident_bytes as u128 * *rows_per_token as u128 / *total_rows as u128) as u64
+                }
+            }
+            Self::Routed { active, total } => {
+                if *total == 0 {
+                    0
+                } else {
+                    (resident_bytes as u128 * *active as u128 / *total as u128) as u64
+                }
+            }
+        }
+    }
+
+    /// Whether the whole tensor moves. Only `FullRead` may be priced by
+    /// its resident size.
+    pub fn is_full_read(&self) -> bool {
+        matches!(self, Self::FullRead)
+    }
+}
+
+/// What a layer actually contains.
+///
+/// `first_k_dense_replace` layers are Dense; the rest are MoE. Treating
+/// them uniformly is the layer-0 error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LayerKind {
+    /// A dense FFN, no router, no experts, no shared experts.
+    Dense,
+    /// Router + shared experts + LatentMoE wrapper + routed bank.
+    Moe,
+}
+
+/// Which layers are dense and which are MoE.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LayerTopology {
+    /// Total decoder layers.
+    pub n_layers: usize,
+    /// Leading layers replaced by a dense FFN.
+    pub n_dense: usize,
+}
+
+impl LayerTopology {
+    /// Build a topology, clamping `n_dense` to the layer count.
+    pub fn new(n_layers: usize, n_dense: usize) -> Self {
+        Self {
+            n_layers,
+            n_dense: n_dense.min(n_layers),
+        }
+    }
+
+    /// What layer `index` is.
+    pub fn kind(&self, index: usize) -> LayerKind {
+        if index < self.n_dense {
+            LayerKind::Dense
+        } else {
+            LayerKind::Moe
+        }
+    }
+
+    /// How many MoE layers there are — the multiplier for shared experts,
+    /// the LatentMoE wrapper and the router.
+    pub fn n_moe(&self) -> usize {
+        self.n_layers - self.n_dense
+    }
+
+    /// How many dense layers there are.
+    pub fn n_dense(&self) -> usize {
+        self.n_dense
+    }
+}
+
+/// One measured weight family and how it is touched.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Family {
+    /// Name as it appears in a report.
+    pub name: String,
+    /// Resident bytes for ONE unit, measured from a safetensors header.
+    pub bytes_per_unit: u64,
+    /// How many units the model has.
+    pub units: usize,
+    /// How one unit is touched per token.
+    pub access: AccessMode,
+}
+
+impl Family {
+    /// A family read in full on every pass.
+    pub fn full_read(name: impl Into<String>, bytes_per_unit: u64, units: usize) -> Self {
+        Self {
+            name: name.into(),
+            bytes_per_unit,
+            units,
+            access: AccessMode::FullRead,
+        }
+    }
+
+    /// Total bytes that must be RESIDENT.
+    pub fn resident_bytes(&self) -> u64 {
+        self.bytes_per_unit * self.units as u64
+    }
+
+    /// Total bytes ACTIVATED per token.
+    pub fn activated_bytes(&self) -> u64 {
+        self.access.activated_bytes(self.bytes_per_unit) * self.units as u64
+    }
+}
+
+/// The measured dense-side census: every BF16 family and its access.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DenseCensus {
+    /// Families, largest activated first.
+    pub families: Vec<Family>,
+}
+
+impl DenseCensus {
+    /// Build a census, ordering by activated bytes so a report cannot lead
+    /// with a family that does not dominate.
+    pub fn new(mut families: Vec<Family>) -> Self {
+        families.sort_by_key(|f| std::cmp::Reverse(f.activated_bytes()));
+        Self { families }
+    }
+
+    /// Bytes that must be resident, across every family.
+    pub fn resident_bytes(&self) -> u64 {
+        self.families.iter().map(Family::resident_bytes).sum()
+    }
+
+    /// Bytes moved per token, across every family.
+    pub fn activated_bytes(&self) -> u64 {
+        self.families.iter().map(Family::activated_bytes).sum()
+    }
+
+    /// A family by name.
+    pub fn family(&self, name: &str) -> Option<&Family> {
+        self.families.iter().find(|f| f.name == name)
+    }
+
+    /// The share of activated traffic one family carries.
+    pub fn activated_share(&self, name: &str) -> f64 {
+        let total = self.activated_bytes();
+        if total == 0 {
+            return 0.0;
+        }
+        self.family(name)
+            .map_or(0.0, |f| f.activated_bytes() as f64 / total as f64)
+    }
+}
+
+#[cfg(test)]
+#[path = "access_tests.rs"]
+mod access_tests;

--- a/crates/larql-cli/src/commands/primary/k3_ledger/access_tests.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/access_tests.rs
@@ -1,0 +1,252 @@
+//! K3-LEDGER-2. The two K3-DENSE-1 errors, made unrepresentable.
+//!
+//! Every byte figure below was measured from `moonshotai/Kimi-K3`
+//! safetensors headers on 2026-09-03 via HTTP range requests — no weights
+//! downloaded. A census that stops reproducing them has changed meaning.
+
+use super::*;
+
+// Measured per-unit resident bytes, BF16.
+const KDA_ATTN: u64 = 887_800_000; // layer 49: q,k,v,g,o each 176.16 MB
+const MLA_ATTN: u64 = 464_390_000; // layer 3: g_proj + o_proj dominate
+const SHARED: u64 = 264_240_000; // 3 x [6144,7168]
+const LATENT: u64 = 102_770_000; // routed_expert up/down [3584,7168] + norm
+const ROUTER: u64 = 12_850_000; // gate [896,7168]
+const DENSE0_MLP: u64 = 1_453_320_000; // layer 0: 3 x [33792,7168]
+                                       // EXACT, not the rounded 2348.81 MB display figure: 163840 * 7168 * 2.
+                                       // A rounded constant divides to 14,335 and quietly loses a byte per row.
+const LM_HEAD: u64 = 2_348_810_240; // [163840,7168]
+const EMBED: u64 = 2_348_810_240; // [163840,7168] — SAME SIZE, different access
+const NORMS: u64 = 60_000;
+
+const N_KDA: usize = 69;
+const N_MLA: usize = 24;
+const N_MOE: usize = 92;
+const N_LAYERS: usize = 93;
+
+fn k3_dense_census() -> DenseCensus {
+    DenseCensus::new(vec![
+        Family::full_read("KDA self_attn", KDA_ATTN, N_KDA),
+        Family::full_read("shared_experts", SHARED, N_MOE),
+        Family::full_read("MLA self_attn", MLA_ATTN, N_MLA),
+        Family::full_read("LatentMoE wrapper", LATENT, N_MOE),
+        Family::full_read("lm_head", LM_HEAD, 1),
+        Family::full_read("dense layer-0 MLP", DENSE0_MLP, 1),
+        Family::full_read("router", ROUTER, N_MOE),
+        Family::full_read("norms / res_proj", NORMS, N_LAYERS),
+        Family {
+            name: "embed_tokens".into(),
+            bytes_per_unit: EMBED,
+            units: 1,
+            access: AccessMode::Gather {
+                rows_per_token: 1,
+                total_rows: 163_840,
+            },
+        },
+    ])
+}
+
+// ---- the embed/lm_head asymmetry -------------------------------------
+
+#[test]
+fn two_tensors_of_identical_size_move_wildly_different_bytes() {
+    let c = k3_dense_census();
+    let head = c.family("lm_head").expect("lm_head");
+    let embed = c.family("embed_tokens").expect("embed_tokens");
+
+    assert_eq!(
+        head.resident_bytes(),
+        embed.resident_bytes(),
+        "untied, and byte-identical in the checkpoint"
+    );
+    assert_eq!(
+        head.activated_bytes(),
+        LM_HEAD,
+        "a matmul over the vocabulary IS a full read"
+    );
+    assert_eq!(
+        embed.activated_bytes(),
+        EMBED / 163_840,
+        "a gather touches ONE row — 14.3 KB, not 2.35 GB"
+    );
+    assert!(
+        embed.activated_bytes() < head.activated_bytes() / 100_000,
+        "the overcount this removes is five orders of magnitude"
+    );
+}
+
+#[test]
+fn a_gather_cannot_be_priced_as_a_full_read() {
+    let g = AccessMode::Gather {
+        rows_per_token: 1,
+        total_rows: 163_840,
+    };
+    assert!(!g.is_full_read());
+    assert!(AccessMode::FullRead.is_full_read());
+    assert_eq!(
+        g.activated_bytes(2_348_810_240),
+        14_336,
+        "7168 cols x 2 bytes"
+    );
+}
+
+#[test]
+fn a_gather_of_every_row_equals_a_full_read() {
+    let g = AccessMode::Gather {
+        rows_per_token: 128,
+        total_rows: 128,
+    };
+    assert_eq!(g.activated_bytes(4096), 4096);
+}
+
+#[test]
+fn empty_denominators_do_not_divide_by_zero() {
+    assert_eq!(
+        AccessMode::Gather {
+            rows_per_token: 1,
+            total_rows: 0
+        }
+        .activated_bytes(99),
+        0
+    );
+    assert_eq!(
+        AccessMode::Routed {
+            active: 16,
+            total: 0
+        }
+        .activated_bytes(99),
+        0
+    );
+}
+
+#[test]
+fn routed_access_prices_the_active_fraction() {
+    // K3's own 16-of-896.
+    let r = AccessMode::Routed {
+        active: 16,
+        total: 896,
+    };
+    assert_eq!(r.activated_bytes(896_000), 16_000);
+    assert!(!r.is_full_read());
+}
+
+#[test]
+fn a_gather_on_a_huge_tensor_does_not_overflow() {
+    // resident * rows would exceed u64 without the u128 widening.
+    let g = AccessMode::Gather {
+        rows_per_token: 163_839,
+        total_rows: 163_840,
+    };
+    let big = 2_348_810_240u64;
+    assert_eq!(g.activated_bytes(big), big * 163_839 / 163_840);
+}
+
+// ---- layer topology --------------------------------------------------
+
+#[test]
+fn layer_zero_is_dense_and_the_rest_are_moe() {
+    let t = LayerTopology::new(93, 1);
+    assert_eq!(t.kind(0), LayerKind::Dense, "first_k_dense_replace = 1");
+    assert_eq!(t.kind(1), LayerKind::Moe);
+    assert_eq!(t.kind(92), LayerKind::Moe);
+    assert_eq!(
+        t.n_moe(),
+        92,
+        "shared experts, wrapper and router multiply by THIS"
+    );
+    assert_eq!(t.n_dense(), 1);
+}
+
+#[test]
+fn a_topology_cannot_claim_more_dense_layers_than_it_has() {
+    let t = LayerTopology::new(4, 99);
+    assert_eq!(t.n_dense(), 4);
+    assert_eq!(t.n_moe(), 0);
+}
+
+// ---- the K3-DENSE-1 decomposition, pinned ----------------------------
+
+#[test]
+fn the_measured_k3_decomposition_holds() {
+    let c = k3_dense_census();
+    let gb = |b: u64| b as f64 / 1e9;
+
+    assert!(
+        (gb(c.activated_bytes()) - 111.16).abs() < 0.05,
+        "{}",
+        gb(c.activated_bytes())
+    );
+    assert!(
+        (gb(c.resident_bytes()) - 113.51).abs() < 0.05,
+        "resident includes the whole embed table: {}",
+        gb(c.resident_bytes())
+    );
+    // Resident exceeds activated by exactly the embed table it never reads.
+    let diff = c.resident_bytes() - c.activated_bytes();
+    assert!((gb(diff) - 2.35).abs() < 0.01, "{}", gb(diff));
+}
+
+#[test]
+fn kda_attention_dominates_by_a_factor_of_two_and_a_half() {
+    let c = k3_dense_census();
+    assert_eq!(
+        c.families[0].name, "KDA self_attn",
+        "the census leads with the largest"
+    );
+    assert!((c.activated_share("KDA self_attn") - 0.551).abs() < 0.005);
+    assert!((c.activated_share("shared_experts") - 0.219).abs() < 0.005);
+
+    let kda = c.family("KDA self_attn").unwrap().activated_bytes();
+    let next = c.family("shared_experts").unwrap().activated_bytes();
+    assert!(
+        kda as f64 / next as f64 > 2.5,
+        "KDA must lead the next family by >2.5x, got {:.2}",
+        kda as f64 / next as f64
+    );
+}
+
+#[test]
+fn the_latent_moe_wrapper_is_a_third_of_the_routed_traffic_it_serves() {
+    // 9.45 GB of always-on BF16 wrapping a 25.83 GB MXFP4 bank. The routed
+    // side is NOT "already at its codec floor with nothing left to do".
+    let c = k3_dense_census();
+    let wrapper = c.family("LatentMoE wrapper").unwrap().activated_bytes() as f64;
+    assert!((wrapper / 1e9 - 9.45).abs() < 0.05);
+    assert!((wrapper / 25.83e9 - 0.366).abs() < 0.01);
+}
+
+#[test]
+fn the_census_orders_by_activated_not_resident() {
+    // embed_tokens is the joint-largest RESIDENT family and nearly the
+    // smallest ACTIVATED one. Ordering by the wrong quantity would put it
+    // near the top of a traffic report.
+    let c = k3_dense_census();
+    let names: Vec<&str> = c.families.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names[0], "KDA self_attn");
+    assert_eq!(*names.last().unwrap(), "embed_tokens");
+}
+
+#[test]
+fn an_unknown_family_has_no_share_and_no_entry() {
+    let c = k3_dense_census();
+    assert!(
+        c.family("vision_tower").is_none(),
+        "vision is excluded, not zero"
+    );
+    assert_eq!(c.activated_share("vision_tower"), 0.0);
+}
+
+#[test]
+fn an_empty_census_has_no_shares() {
+    let c = DenseCensus::new(vec![]);
+    assert_eq!(c.activated_bytes(), 0);
+    assert_eq!(c.resident_bytes(), 0);
+    assert_eq!(c.activated_share("anything"), 0.0);
+}
+
+#[test]
+fn a_census_round_trips_through_serde() {
+    let c = k3_dense_census();
+    let back: DenseCensus = serde_json::from_str(&serde_json::to_string(&c).unwrap()).unwrap();
+    assert_eq!(c, back);
+}

--- a/crates/larql-cli/src/commands/primary/k3_ledger/actions.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/actions.rs
@@ -1,0 +1,282 @@
+//! **K3-ACTIONS-1 — the complete physical action catalogue, weight-free.**
+//!
+//! Every dense-side representation action K3 admits, with its exact
+//! physical opportunity, derived from headers alone. No forward pass, no
+//! weights, no behavioural claim of any kind.
+//!
+//! ```text
+//! family x layer x codec  ->  resident saving, activated saving
+//! ```
+//!
+//! This is what a beam search will generate candidates from, and what
+//! prices them. Behaviour is measured later and separately; nothing here
+//! predicts it.
+//!
+//! # Representation is not execution role
+//!
+//! The LatentMoE wrapper — `routed_expert_up_proj` / `down_proj`, 9.45
+//! GB/token across 92 layers — is dense BF16 by REPRESENTATION and routed
+//! by FUNCTION. It wraps the MXFP4 expert bank, at 36.6% of the size of
+//! the traffic it serves.
+//!
+//! ```text
+//! representation   dense BF16
+//! execution role   routed-path always-on
+//! ```
+//!
+//! Filing it simply under "dense" would lose the fact that compressing it
+//! changes the balance between compute and expert-fetch on the routed
+//! path, not just total bandwidth. [`ExecutionRole`] keeps the two axes
+//! apart, the way [`super::access::AccessMode`] keeps existence apart from
+//! touch.
+
+use serde::{Deserialize, Serialize};
+
+use super::access::{AccessMode, DenseCensus};
+
+/// Where a family sits in the execution graph.
+///
+/// Orthogonal to how it is represented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExecutionRole {
+    /// Always-on and not attached to routing: attention, norms.
+    DensePath,
+    /// BF16 machinery on the ROUTED path, read every token whatever the
+    /// router picks: the LatentMoE wrapper and the router itself.
+    RoutedPathAlwaysOn,
+    /// The vocabulary surfaces — head and embeddings.
+    Vocabulary,
+}
+
+impl ExecutionRole {
+    /// How a report names it.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::DensePath => "dense-path",
+            Self::RoutedPathAlwaysOn => "routed-path always-on",
+            Self::Vocabulary => "vocabulary",
+        }
+    }
+
+    /// Classify a census family by name.
+    ///
+    /// The wrapper and router are the two BF16 surfaces attached to routed
+    /// execution; everything else on the dense side is genuinely dense.
+    pub fn of(family: &str) -> Self {
+        match family {
+            "LatentMoE wrapper" | "router" => Self::RoutedPathAlwaysOn,
+            "lm_head" | "embed_tokens" => Self::Vocabulary,
+            _ => Self::DensePath,
+        }
+    }
+}
+
+/// What one action COVERS.
+///
+/// The distinction is load-bearing and easy to lose:
+///
+/// ```text
+/// KDA family    -> Q8   saves 28.71 GB/token   a physical CEILING
+/// one KDA layer -> Q8   saves    415.9 MB      a search CANDIDATE
+/// ```
+///
+/// A family-wide figure is what the opportunity would be if EVERY member
+/// moved and every one of them earned it behaviourally. It is not a thing
+/// anyone can measure in one authority run. Reading it as an atomic
+/// candidate would let a beam policy — or an agent — propose "quantise
+/// KDA" as though it were one decision with one verdict, which is the
+/// scalarization error one level up from proxies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActionScope {
+    /// One unit. The natural atomic search candidate.
+    Layer,
+    /// Every unit of a family. A ceiling, never a candidate.
+    Family,
+    /// Every family sharing an [`ExecutionRole`]. Also a ceiling.
+    RoleGroup,
+}
+
+impl ActionScope {
+    /// Whether one authority run could decide this action.
+    ///
+    /// Only `Layer` can. The others aggregate members that must each earn
+    /// their own admission.
+    pub fn is_atomic_candidate(self) -> bool {
+        matches!(self, Self::Layer)
+    }
+
+    /// How a report names it.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Layer => "layer",
+            Self::Family => "family (CEILING)",
+            Self::RoleGroup => "role group (CEILING)",
+        }
+    }
+}
+
+/// A serving format and its ALL-IN width.
+///
+/// All-in includes block scales — R0: never quote a width without saying
+/// which convention it is in. Q8_0 is 34 bytes per 32 values, not 32.
+///
+/// `Serialize` only: the `&'static str` name keeps the table a `const`,
+/// and an [`Action`] records the codec by value rather than borrowing it.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct Codec {
+    /// How a report names it.
+    pub name: &'static str,
+    /// All-in bits per weight.
+    pub all_in_bits: f64,
+}
+
+/// The codecs a dense BF16 surface could move to.
+pub const DENSE_CODECS: [Codec; 4] = [
+    Codec {
+        name: "Q8_0",
+        all_in_bits: 8.5,
+    },
+    Codec {
+        name: "Q6_K",
+        all_in_bits: 6.5625,
+    },
+    Codec {
+        name: "Q4_K",
+        all_in_bits: 4.5,
+    },
+    Codec {
+        name: "MXFP4",
+        all_in_bits: 4.25,
+    },
+];
+
+/// One representation action, priced.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Action {
+    /// Which census family.
+    pub family: String,
+    /// What this action covers — and therefore whether it is a candidate
+    /// or a ceiling.
+    pub scope: ActionScope,
+    /// Where it sits in the execution graph.
+    pub role: ExecutionRole,
+    /// How it is touched.
+    pub access: AccessMode,
+    /// How many units the action covers. A whole-family action covers all
+    /// of them; a per-layer action covers one.
+    pub units: usize,
+    /// Bytes resident today, across `units`.
+    pub resident_before: u64,
+    /// Bytes activated per token today, across `units`.
+    pub activated_before: u64,
+    /// The target format's name.
+    pub codec: String,
+    /// Its all-in width.
+    pub codec_all_in_bits: f64,
+    /// Bytes resident after.
+    pub resident_after: u64,
+    /// Bytes activated per token after.
+    pub activated_after: u64,
+}
+
+impl Action {
+    /// Resident bytes freed.
+    pub fn resident_saving(&self) -> u64 {
+        self.resident_before.saturating_sub(self.resident_after)
+    }
+
+    /// Activated bytes per token removed.
+    pub fn activated_saving(&self) -> u64 {
+        self.activated_before.saturating_sub(self.activated_after)
+    }
+}
+
+/// Price one family at one codec, from its BF16 figures.
+///
+/// `stored_bits` is what the family is stored at now — read from the
+/// checkpoint, never assumed (K3-LEDGER-1b).
+pub fn price(
+    family: &str,
+    scope: ActionScope,
+    access: AccessMode,
+    units: usize,
+    resident_before: u64,
+    activated_before: u64,
+    codec: Codec,
+    stored_bits: f64,
+) -> Option<Action> {
+    if stored_bits <= 0.0 || codec.all_in_bits <= 0.0 {
+        return None;
+    }
+    let ratio = codec.all_in_bits / stored_bits;
+    Some(Action {
+        family: family.to_string(),
+        scope,
+        role: ExecutionRole::of(family),
+        access,
+        units,
+        resident_before,
+        activated_before,
+        codec: codec.name.to_string(),
+        codec_all_in_bits: codec.all_in_bits,
+        resident_after: (resident_before as f64 * ratio) as u64,
+        activated_after: (activated_before as f64 * ratio) as u64,
+    })
+}
+
+/// The complete catalogue: every census family at every dense codec.
+///
+/// Emits BOTH scopes: the family-wide ceiling AND the per-unit candidate,
+/// so a consumer never has to divide by `units` itself and never has to
+/// guess which kind of figure it is holding.
+pub fn catalogue(census: &DenseCensus, stored_bits: f64) -> Vec<Action> {
+    let mut out = Vec::new();
+    for f in &census.families {
+        for codec in DENSE_CODECS {
+            if f.units > 1 {
+                if let Some(a) = price(
+                    &f.name,
+                    ActionScope::Layer,
+                    f.access,
+                    1,
+                    f.bytes_per_unit,
+                    f.access.activated_bytes(f.bytes_per_unit),
+                    codec,
+                    stored_bits,
+                ) {
+                    out.push(a);
+                }
+            }
+            if let Some(a) = price(
+                &f.name,
+                ActionScope::Family,
+                f.access,
+                f.units,
+                f.resident_bytes(),
+                f.activated_bytes(),
+                codec,
+                stored_bits,
+            ) {
+                out.push(a);
+            }
+        }
+    }
+    out.sort_by_key(|a| std::cmp::Reverse(a.activated_saving()));
+    out
+}
+
+/// Total activated saving if EVERY dense family moved to one codec.
+///
+/// A physical ceiling and nothing more: it assumes every action succeeds
+/// behaviourally, which is the entire programme stated as a premise.
+pub fn whole_side_ceiling(census: &DenseCensus, stored_bits: f64, codec: Codec) -> u64 {
+    catalogue(census, stored_bits)
+        .iter()
+        .filter(|a| a.codec == codec.name && a.scope == ActionScope::Family)
+        .map(Action::activated_saving)
+        .sum()
+}
+
+#[cfg(test)]
+#[path = "actions_tests.rs"]
+mod actions_tests;

--- a/crates/larql-cli/src/commands/primary/k3_ledger/actions_tests.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/actions_tests.rs
@@ -1,0 +1,282 @@
+//! K3-ACTIONS-1. Physical opportunity only — no test here asserts, implies
+//! or predicts any behavioural consequence.
+
+use super::super::geometry::k3_reference;
+use super::*;
+
+fn census() -> DenseCensus {
+    k3_reference().dense_census
+}
+
+const BF16: f64 = 16.0;
+const GB: f64 = 1e9;
+
+fn q8() -> Codec {
+    DENSE_CODECS[0]
+}
+
+// ---- representation vs execution role --------------------------------
+
+#[test]
+fn the_latent_moe_wrapper_is_dense_by_representation_and_routed_by_function() {
+    assert_eq!(
+        ExecutionRole::of("LatentMoE wrapper"),
+        ExecutionRole::RoutedPathAlwaysOn
+    );
+    assert_eq!(
+        ExecutionRole::of("router"),
+        ExecutionRole::RoutedPathAlwaysOn
+    );
+    assert_eq!(
+        ExecutionRole::RoutedPathAlwaysOn.label(),
+        "routed-path always-on",
+        "filing it as plain dense loses where compressing it acts"
+    );
+}
+
+#[test]
+fn attention_is_dense_path_and_the_head_is_vocabulary() {
+    assert_eq!(ExecutionRole::of("KDA self_attn"), ExecutionRole::DensePath);
+    assert_eq!(
+        ExecutionRole::of("shared_experts"),
+        ExecutionRole::DensePath
+    );
+    assert_eq!(ExecutionRole::of("lm_head"), ExecutionRole::Vocabulary);
+    assert_eq!(ExecutionRole::of("embed_tokens"), ExecutionRole::Vocabulary);
+    assert_eq!(ExecutionRole::DensePath.label(), "dense-path");
+    assert_eq!(ExecutionRole::Vocabulary.label(), "vocabulary");
+}
+
+// ---- codec conventions -----------------------------------------------
+
+#[test]
+fn codec_widths_are_all_in_not_payload() {
+    // R0. Q8_0 is 34 bytes per 32 values, so 8.5 — not 8.
+    assert_eq!(q8().all_in_bits, 8.5);
+    assert_eq!(DENSE_CODECS[1].all_in_bits, 6.5625, "Q6_K");
+    assert_eq!(
+        DENSE_CODECS[3].all_in_bits, 4.25,
+        "MXFP4 is 4.25 all-in, not 4.0"
+    );
+}
+
+// ---- pricing ---------------------------------------------------------
+
+#[test]
+fn a_gathers_saving_is_on_what_it_touches_not_what_it_stores() {
+    // embed_tokens: 2.35 GB resident, 14 KB activated. Compressing it frees
+    // resident memory and removes almost no traffic. Pricing it by resident
+    // size would make it look like a 1.2 GB traffic win.
+    let c = census();
+    let f = c.family("embed_tokens").unwrap();
+    let a = price(
+        "embed_tokens",
+        ActionScope::Family,
+        f.access,
+        f.units,
+        f.resident_bytes(),
+        f.activated_bytes(),
+        q8(),
+        BF16,
+    )
+    .unwrap();
+    assert!(
+        (a.resident_saving() as f64 / GB - 1.101).abs() < 0.01,
+        "a real resident win"
+    );
+    assert!(a.activated_saving() < 10_000, "and almost no traffic win");
+}
+
+#[test]
+fn kda_is_the_largest_single_action_at_every_codec() {
+    let cat = catalogue(&census(), BF16);
+    let top = &cat[0];
+    assert_eq!(top.family, "KDA self_attn");
+    assert_eq!(
+        top.codec, "MXFP4",
+        "sorted by saving, so the deepest codec leads"
+    );
+    assert!(
+        (top.activated_saving() as f64 / GB - 44.99).abs() < 0.05,
+        "KDA @ MXFP4 got {:.2} GB",
+        top.activated_saving() as f64 / GB
+    );
+    // The conservative end of the same family.
+    let q8 = cat
+        .iter()
+        .find(|a| a.family == "KDA self_attn" && a.codec == "Q8_0")
+        .unwrap();
+    assert!(
+        (q8.activated_saving() as f64 / GB - 28.71).abs() < 0.05,
+        "KDA @ Q8 got {:.2} GB",
+        q8.activated_saving() as f64 / GB
+    );
+    // Even the CONSERVATIVE KDA action exceeds all routed traffic.
+    assert!(q8.activated_saving() as f64 / GB > 25.83);
+}
+
+#[test]
+fn one_kda_layer_is_of_the_order_of_the_whole_kimi_exchange_neighbourhood() {
+    // Kimi's largest exchange neighbourhood was ~430 MB, and it took five
+    // authority runs to close. ONE K3 KDA layer at Q8 is that size.
+    let c = census();
+    let f = c.family("KDA self_attn").unwrap();
+    let per_layer = f.bytes_per_unit;
+    let saved = per_layer - (per_layer as f64 * 8.5 / 16.0) as u64;
+    assert!(
+        (saved as f64 / 1e6 - 415.9).abs() < 1.0,
+        "one KDA layer at Q8 saves {:.1} MB",
+        saved as f64 / 1e6
+    );
+}
+
+#[test]
+fn savings_scale_monotonically_with_codec_width() {
+    let cat = catalogue(&census(), BF16);
+    let kda: Vec<&Action> = cat.iter().filter(|a| a.family == "KDA self_attn").collect();
+    let q8 = kda.iter().find(|a| a.codec == "Q8_0").unwrap();
+    let q6 = kda.iter().find(|a| a.codec == "Q6_K").unwrap();
+    let q4 = kda.iter().find(|a| a.codec == "Q4_K").unwrap();
+    assert!(q8.activated_saving() < q6.activated_saving());
+    assert!(q6.activated_saving() < q4.activated_saving());
+}
+
+#[test]
+fn a_codec_no_narrower_than_the_stored_width_saves_nothing() {
+    let c = census();
+    let f = c.family("KDA self_attn").unwrap();
+    let wide = Codec {
+        name: "BF16",
+        all_in_bits: 16.0,
+    };
+    let a = price(
+        "KDA self_attn",
+        ActionScope::Family,
+        f.access,
+        f.units,
+        f.resident_bytes(),
+        f.activated_bytes(),
+        wide,
+        BF16,
+    )
+    .unwrap();
+    assert_eq!(a.activated_saving(), 0, "saturating, never negative");
+    assert_eq!(a.resident_saving(), 0);
+}
+
+#[test]
+fn a_zero_or_negative_width_is_refused_not_divided_by() {
+    let c = census();
+    let f = c.family("KDA self_attn").unwrap();
+    let bad = Codec {
+        name: "zero",
+        all_in_bits: 0.0,
+    };
+    assert!(price("x", ActionScope::Family, f.access, 1, 1, 1, bad, BF16).is_none());
+    assert!(price("x", ActionScope::Family, f.access, 1, 1, 1, q8(), 0.0).is_none());
+}
+
+// ---- the catalogue ---------------------------------------------------
+
+#[test]
+fn the_catalogue_covers_every_family_at_every_codec_in_both_scopes() {
+    let c = census();
+    let cat = catalogue(&c, BF16);
+    let multi = c.families.iter().filter(|f| f.units > 1).count();
+    assert_eq!(cat.len(), (c.families.len() + multi) * DENSE_CODECS.len());
+    // Single-unit families have no separate per-layer scope to offer.
+    assert!(cat
+        .iter()
+        .filter(|a| a.family == "lm_head")
+        .all(|a| a.scope == ActionScope::Family));
+}
+
+#[test]
+fn a_family_wide_figure_is_a_ceiling_and_a_layer_is_the_candidate() {
+    let cat = catalogue(&census(), BF16);
+    let family = cat
+        .iter()
+        .find(|a| {
+            a.family == "KDA self_attn" && a.codec == "Q8_0" && a.scope == ActionScope::Family
+        })
+        .unwrap();
+    let layer = cat
+        .iter()
+        .find(|a| a.family == "KDA self_attn" && a.codec == "Q8_0" && a.scope == ActionScope::Layer)
+        .unwrap();
+
+    assert!(
+        !family.scope.is_atomic_candidate(),
+        "no ONE run can decide 69 layers"
+    );
+    assert!(layer.scope.is_atomic_candidate());
+    assert!(family.scope.label().contains("CEILING"));
+    assert_eq!(layer.scope.label(), "layer");
+
+    assert_eq!(family.units, 69);
+    assert_eq!(layer.units, 1);
+    // 28.71 GB vs 415.9 MB — the same arithmetic, wildly different claims.
+    assert!((family.activated_saving() as f64 / GB - 28.71).abs() < 0.05);
+    assert!((layer.activated_saving() as f64 / 1e6 - 415.9).abs() < 1.0);
+    assert_eq!(family.activated_saving() / 69, layer.activated_saving());
+}
+
+#[test]
+fn ceilings_sum_family_scope_only_and_do_not_double_count() {
+    // Both scopes are in the catalogue; a ceiling that summed both would
+    // report roughly 1 + 1/69 of the truth.
+    let c = census();
+    let by_hand: u64 = catalogue(&c, BF16)
+        .iter()
+        .filter(|a| a.codec == "Q8_0" && a.scope == ActionScope::Family)
+        .map(Action::activated_saving)
+        .sum();
+    assert_eq!(whole_side_ceiling(&c, BF16, DENSE_CODECS[0]), by_hand);
+}
+
+#[test]
+fn whole_side_ceilings_are_physical_not_behavioural() {
+    let c = census();
+    // If EVERY dense family moved, activated traffic falls by these. Each
+    // assumes the entire REPRESENT programme succeeded.
+    let q8 = whole_side_ceiling(&c, BF16, DENSE_CODECS[0]) as f64 / GB;
+    let q6 = whole_side_ceiling(&c, BF16, DENSE_CODECS[1]) as f64 / GB;
+    let q4 = whole_side_ceiling(&c, BF16, DENSE_CODECS[2]) as f64 / GB;
+    assert!((q8 - 52.11).abs() < 0.05, "Q8 ceiling {q8:.2}");
+    assert!((q6 - 65.57).abs() < 0.05, "Q6 ceiling {q6:.2}");
+    assert!((q4 - 79.90).abs() < 0.05, "Q4 ceiling {q4:.2}");
+    // Against 111.16 GB of dense traffic and 25.83 GB routed.
+    assert!(
+        q8 > 25.83,
+        "even Q8 across the dense side exceeds ALL routed traffic"
+    );
+}
+
+#[test]
+fn the_routed_path_always_on_surfaces_are_a_named_slice_of_the_catalogue() {
+    let cat = catalogue(&census(), BF16);
+    let routed_side: u64 = cat
+        .iter()
+        .filter(|a| {
+            a.role == ExecutionRole::RoutedPathAlwaysOn
+                && a.codec == "Q8_0"
+                // Family scope ONLY: the catalogue also carries per-layer
+                // entries, and summing both reports ~1 + 1/92 of the truth.
+                && a.scope == ActionScope::Family
+        })
+        .map(Action::activated_saving)
+        .sum();
+    // Wrapper + router at Q8: 10.63 GB x (1 - 8.5/16).
+    assert!(
+        (routed_side as f64 / GB - 4.99).abs() < 0.05,
+        "got {:.2} GB",
+        routed_side as f64 / GB
+    );
+}
+
+#[test]
+fn an_action_round_trips_through_serde() {
+    let a = catalogue(&census(), BF16).remove(0);
+    let back: Action = serde_json::from_str(&serde_json::to_string(&a).unwrap()).unwrap();
+    assert_eq!(a, back);
+}

--- a/crates/larql-cli/src/commands/primary/k3_ledger/args.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/args.rs
@@ -37,6 +37,15 @@ pub struct K3LedgerArgs {
     #[arg(long, global = true, default_value_t = 1.0)]
     pub dequant_efficiency: f64,
 
+    /// Price the dense side at a HYPOTHETICAL width instead of the one the
+    /// checkpoint stores.
+    ///
+    /// K3-L1-F1: this used to be a hardcoded 4.25 with no way to ask for the
+    /// truth. It is now opt-in, and every row produced under it is labelled
+    /// HYPOTHETICAL. Omit it to price the model as it actually is.
+    #[arg(long, global = true)]
+    pub hypothetical_dense_bits: Option<f64>,
+
     /// Emit the full record as JSON instead of a table.
     #[arg(long, global = true)]
     pub json: bool,
@@ -56,6 +65,12 @@ pub enum K3LedgerCmd {
     TranscodeScan(TranscodeScanArgs),
     /// Composed per-class ceiling, and the R4 best case for each proposed lever.
     Ceilings(CeilingsArgs),
+    /// Witness that one measured layer represents its whole family, by
+    /// reading EVERY layer's safetensors header. Turns the census's
+    /// "x69" from an assumption into a structural fact.
+    Homogeneity(HomogeneityArgs),
+    /// K3-ACTIONS-1: the weight-free physical action catalogue.
+    Actions(ActionsArgs),
     /// Which containers hold MXFP4 exactly, and at what width. Decided by
     /// counting the source alphabet — takes no checkpoint and no network.
     Formats,
@@ -302,4 +317,24 @@ pub struct CeilingsArgs {
     /// Serving format for the routed experts, in all-in bits per weight.
     #[arg(long, default_value_t = 4.25)]
     pub routed_bits: f64,
+}
+
+#[derive(Debug, Args)]
+pub struct HomogeneityArgs {
+    /// Shard-name template; `{}` is the 1-based shard number, zero-padded.
+    #[arg(long, default_value = "model-{:05}-of-000096.safetensors")]
+    pub shard_template: String,
+    /// Stop after this many layers. 0 means every layer.
+    #[arg(long, default_value_t = 0)]
+    pub limit: usize,
+}
+
+#[derive(Debug, Args)]
+pub struct ActionsArgs {
+    /// Show only actions at or above this activated saving, in GB/token.
+    #[arg(long, default_value_t = 0.5)]
+    pub min_gb: f64,
+    /// Include family-wide CEILING rows alongside per-layer candidates.
+    #[arg(long, default_value_t = true)]
+    pub ceilings: bool,
 }

--- a/crates/larql-cli/src/commands/primary/k3_ledger/block.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/block.rs
@@ -187,7 +187,7 @@ pub fn evaluate(
     let accepted = draft.accepted_at_width(width);
     let union_equivalents = geom.expert_union(width) / geom.top_k as f64;
 
-    let dense = geom.dense_bytes(p.dense_all_in_bits) * reuse.dense;
+    let dense = geom.dense_bytes(p.dense_all_in_bits(geom)) * reuse.dense;
     let routed = geom.routed_bytes_per_position() * p.routed_retention * reuse.routed;
     let bytes_per_pass = dense + routed + state.total(width);
 
@@ -227,7 +227,7 @@ pub fn dense_alone_refuses(
     state: StateTraffic,
     target_tok_s: f64,
 ) -> bool {
-    let dense = geom.dense_bytes(p.dense_all_in_bits) * reuse.dense + state.total(width);
+    let dense = geom.dense_bytes(p.dense_all_in_bits(geom)) * reuse.dense + state.total(width);
     p.budget_per_token(target_tok_s) * accepted <= dense
 }
 
@@ -255,6 +255,7 @@ pub fn sweep<'a>(
 
 #[cfg(test)]
 mod tests {
+    use super::super::geometry::DENSE_4_25;
     use super::*;
     use crate::commands::primary::k3_ledger::geometry::k3_reference;
 
@@ -292,7 +293,14 @@ mod tests {
     fn routed_term_is_carried_not_dropped() {
         // v1's error: scaling the routed-zeroed ceiling by T. Adding routed
         // bytes must always reduce the achievable rate.
-        let (g, p, d) = (k3_reference(), ServingPremises::default(), dspark());
+        let (g, p, d) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+            dspark(),
+        );
         let st = StateTraffic::default();
         let with_routed = evaluate(&g, &p, &d, 4, PhysicalReuse::assumed_ideal(3.9), st, 20.0);
         let without = evaluate(&g, &p, &d, 4, PhysicalReuse::assumed_ideal(0.0), st, 20.0);
@@ -303,7 +311,14 @@ mod tests {
     fn twenty_tok_s_needs_far_more_than_the_withdrawn_block_length() {
         // The withdrawn claim was L ~= 1.6. Carrying the routed term, no width
         // near that reaches the target under banked retention.
-        let (g, p, d) = (k3_reference(), ServingPremises::default(), dspark());
+        let (g, p, d) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+            dspark(),
+        );
         let rows = sweep(&g, &p, &d, &[2, 3, 4], StateTraffic::default(), 20.0);
         for r in &rows {
             assert!(
@@ -317,7 +332,14 @@ mod tests {
 
     #[test]
     fn rho_max_has_an_interior_optimum() {
-        let (g, p, d) = (k3_reference(), ServingPremises::default(), dspark());
+        let (g, p, d) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+            dspark(),
+        );
         let widths: Vec<u32> = (1..=12).collect();
         let rows = sweep(&g, &p, &d, &widths, StateTraffic::default(), 20.0);
         let best = rows
@@ -337,7 +359,14 @@ mod tests {
         // R6: the ideal is an assumption and the record must say so.
         let ideal = PhysicalReuse::assumed_ideal(3.0);
         assert!(!ideal.measured);
-        let (g, p, d) = (k3_reference(), ServingPremises::default(), dspark());
+        let (g, p, d) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+            dspark(),
+        );
         let row = evaluate(&g, &p, &d, 4, ideal, StateTraffic::default(), 20.0);
         assert!(row.rests_on_assumptions);
     }
@@ -346,7 +375,14 @@ mod tests {
     fn a_token_loop_destroys_the_amortisation() {
         // Without grouping and block GEMM, speculation improves orchestration
         // and leaves weight traffic nearly unchanged.
-        let (g, p, d) = (k3_reference(), ServingPremises::default(), dspark());
+        let (g, p, d) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+            dspark(),
+        );
         let st = StateTraffic::default();
         let grouped = evaluate(&g, &p, &d, 6, PhysicalReuse::assumed_ideal(5.74), st, 20.0);
         let looped = evaluate(&g, &p, &d, 6, PhysicalReuse::token_loop(6), st, 20.0);
@@ -357,7 +393,14 @@ mod tests {
     fn state_traffic_lowers_the_optimum_when_it_is_priced() {
         // S(T) scales with width while A(T) saturates, so pricing it must not
         // move the optimum upward.
-        let (g, p, d) = (k3_reference(), ServingPremises::default(), dspark());
+        let (g, p, d) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+            dspark(),
+        );
         let widths: Vec<u32> = (1..=12).collect();
         let best = |st: StateTraffic| {
             sweep(&g, &p, &d, &widths, st, 20.0)
@@ -377,7 +420,13 @@ mod tests {
 
     #[test]
     fn dense_alone_refuses_when_acceptance_is_too_low() {
-        let (g, p) = (k3_reference(), ServingPremises::default());
+        let (g, p) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+        );
         let (r, st) = (PhysicalReuse::assumed_ideal(1.0), StateTraffic::default());
         assert!(dense_alone_refuses(&g, &p, 1.0, 7, r, st, 20.0));
         assert!(!dense_alone_refuses(&g, &p, 3.85, 7, r, st, 20.0));

--- a/crates/larql-cli/src/commands/primary/k3_ledger/fetch.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/fetch.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeMap;
 
 use serde_json::Value;
 
+use super::access::{AccessMode, DenseCensus, Family, LayerTopology};
 use super::geometry::K3Geometry;
 
 const SAFETENSORS_LEN_PREFIX: u64 = 8;
@@ -216,6 +217,139 @@ fn layer_list(cfg: &Value, key: &str) -> Vec<usize> {
         .unwrap_or_default()
 }
 
+/// All-in bits per weight for the families `quantization_config.ignore`
+/// excludes, from the checkpoint's own `dtype`.
+///
+/// K3-L1-F1: this is the number the ledger used to hardcode at 4.25. The
+/// routed side has always been derived; now the dense side is too.
+fn dense_stored(cfg: &Value) -> (f64, String) {
+    let dtype = cfg
+        .get("dtype")
+        .or_else(|| cfg.get("torch_dtype"))
+        .and_then(Value::as_str)
+        .unwrap_or("bfloat16");
+    let bits = match dtype {
+        "float32" | "float" => 32.0,
+        "float64" | "double" => 64.0,
+        _ => 16.0,
+    };
+    let label = match dtype {
+        "bfloat16" => "BF16".to_string(),
+        "float16" | "half" => "FP16".to_string(),
+        other => other.to_uppercase(),
+    };
+    (bits, label)
+}
+
+/// Split one layer's header into dense families by tensor name.
+///
+/// The patterns are the checkpoint's own: `quantization_config.ignore`
+/// names `self_attn`, `shared_experts` and `mlp.*_proj`, and the LatentMoE
+/// wrapper and router sit beside them under `block_sparse_moe`.
+fn family_split(header: &Value) -> BTreeMap<&'static str, u64> {
+    let mut out: BTreeMap<&'static str, u64> = BTreeMap::new();
+    let Some(obj) = header.as_object() else {
+        return out;
+    };
+    for (name, entry) in obj {
+        if name == "__metadata__" {
+            continue;
+        }
+        // Routed experts are not dense. `shared_experts` must not be caught
+        // by the `.experts.` test — it is BF16 and always-on.
+        if name.contains(".experts.") && !name.contains("shared_experts") {
+            continue;
+        }
+        let family = if name.contains("shared_experts") {
+            "shared_experts"
+        } else if name.contains("self_attn") {
+            "self_attn"
+        } else if name.contains("routed_expert_") {
+            "LatentMoE wrapper"
+        } else if name.contains("block_sparse_moe.gate") {
+            "router"
+        } else if name.contains("mlp.") {
+            "dense MLP"
+        } else {
+            "norms / res_proj"
+        };
+        *out.entry(family).or_default() += tensor_bytes(entry);
+    }
+    out
+}
+
+/// The measured dense census: every BF16 family and how it is TOUCHED.
+///
+/// K3-LEDGER-2. `embed_tokens` and `lm_head` are byte-identical and untied;
+/// only the head is a full read. Layer 0 is dense, so shared experts, the
+/// wrapper and the router multiply by `n_moe()`, not by `n_layers`.
+fn dense_census(
+    cfg: &Value,
+    kda: &BTreeMap<&'static str, u64>,
+    mla: &BTreeMap<&'static str, u64>,
+    topo: LayerTopology,
+    n_kda: usize,
+    n_mla: usize,
+) -> DenseCensus {
+    let hidden = usize_at(cfg, "hidden_size") as u64;
+    let vocab = usize_at(cfg, "vocab_size") as u64;
+    let ffn = usize_at(cfg, "intermediate_size") as u64;
+    let dtype_bytes = 2u64;
+    let get = |m: &BTreeMap<&'static str, u64>, k: &str| m.get(k).copied().unwrap_or(0);
+
+    // A dense layer has no shared experts, wrapper or router; it has an MLP.
+    let dense0 = 3 * ffn * hidden * dtype_bytes;
+    let head = vocab * hidden * dtype_bytes;
+
+    DenseCensus::new(vec![
+        Family::full_read("KDA self_attn", get(kda, "self_attn"), n_kda),
+        Family::full_read("shared_experts", get(kda, "shared_experts"), topo.n_moe()),
+        Family::full_read("MLA self_attn", get(mla, "self_attn"), n_mla),
+        Family::full_read(
+            "LatentMoE wrapper",
+            get(kda, "LatentMoE wrapper"),
+            topo.n_moe(),
+        ),
+        Family::full_read("lm_head", head, 1),
+        Family::full_read("dense layer-0 MLP", dense0, topo.n_dense()),
+        Family::full_read("router", get(kda, "router"), topo.n_moe()),
+        Family::full_read(
+            "norms / res_proj",
+            get(kda, "norms / res_proj"),
+            topo.n_layers,
+        ),
+        Family {
+            name: "embed_tokens".into(),
+            bytes_per_unit: head,
+            units: 1,
+            // A gather, not a matmul. This is the -2.35 GB correction.
+            access: AccessMode::Gather {
+                rows_per_token: 1,
+                total_rows: vocab,
+            },
+        },
+    ])
+}
+
+/// One layer's family byte profile, from its shard header alone.
+///
+/// Layer `n` lives in shard `n + 1` — verified against layers 0, 3 and 49.
+pub fn layer_profile(
+    repo: &Repo,
+    template: &str,
+    layer: usize,
+) -> Result<super::homogeneity::LayerProfile, Box<dyn std::error::Error>> {
+    let shard = template.replace("{:05}", &format!("{:05}", layer + 1));
+    let header = repo.shard_header(&shard)?;
+    Ok(super::homogeneity::LayerProfile {
+        index: layer,
+        families: family_split(&header)
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect(),
+    })
+}
+
 pub fn load_geometry(
     repo: &Repo,
     kda_shard: &str,
@@ -239,9 +373,23 @@ pub fn load_geometry(
     }
 
     let n_layers = usize_at(&cfg, "num_hidden_layers");
-    let full_attn = layer_list(&cfg, "full_attn_layers").len();
-    let kda = layer_list(&cfg, "kda_layers").len();
+    let full_attn_list = layer_list(&cfg, "full_attn_layers");
+    let kda_list = layer_list(&cfg, "kda_layers");
+    let full_attn = full_attn_list.len();
+    let kda = kda_list.len();
+    // 1-indexed in the config, 0-indexed in tensor names.
+    let kda_layer_indices: Vec<usize> = kda_list.iter().filter_map(|l| l.checked_sub(1)).collect();
     let vocab = usize_at(&cfg, "vocab_size") as u64;
+    let (dense_stored_bits, dense_stored_label) = dense_stored(&cfg);
+    let topology = LayerTopology::new(n_layers, usize_at(&cfg, "first_k_dense_replace"));
+    let census = dense_census(
+        &cfg,
+        &family_split(&kda_hdr),
+        &family_split(&mla_hdr),
+        topology,
+        if kda > 0 { kda } else { n_layers - full_attn },
+        full_attn,
+    );
     let hidden = usize_at(&cfg, "hidden_size");
 
     Ok(K3Geometry {
@@ -260,6 +408,11 @@ pub fn load_geometry(
         mla_layer_dense_params: mla_dense,
         // Untied embed + lm_head. Vision is deliberately excluded.
         embedding_params: 2 * vocab * hidden as u64,
+        dense_stored_bits,
+        dense_stored_label,
+        kda_layer_indices,
+        topology,
+        dense_census: census,
         vision_included: false,
     })
 }

--- a/crates/larql-cli/src/commands/primary/k3_ledger/frontier.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/frontier.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::geometry::{BitConvention, K3Geometry, MXFP4_PAYLOAD_BITS};
+use super::geometry::{BitConvention, DensePricing, K3Geometry, MXFP4_PAYLOAD_BITS};
 
 /// Measured attainable bandwidth, not spec sheet (`project_memory_bandwidth_roofline`).
 pub const BW_GPU_GB_S: f64 = 367.0;
@@ -29,7 +29,9 @@ pub struct ServingPremises {
     /// the MXFP4 kernel bench (DEC-8.8). The banked Q4K band is 0.74-0.86.
     pub dequant_efficiency: f64,
     pub routed_retention: f64,
-    pub dense_all_in_bits: f64,
+    /// How the dense side is priced. Defaults to the checkpoint's own
+    /// representation; a hypothetical must be asked for and is labelled.
+    pub dense: DensePricing,
 }
 
 impl Default for ServingPremises {
@@ -38,7 +40,7 @@ impl Default for ServingPremises {
             bandwidth_gb_s: BW_GPU_GB_S,
             dequant_efficiency: 1.0,
             routed_retention: 2.0 / 3.0,
-            dense_all_in_bits: 4.25,
+            dense: DensePricing::AsStored,
         }
     }
 }
@@ -47,6 +49,12 @@ impl ServingPremises {
     /// Bytes per second actually available.
     pub fn effective_bw(&self) -> f64 {
         self.bandwidth_gb_s * 1e9 * self.dequant_efficiency
+    }
+
+    /// All-in bits the dense side is priced at, resolved against the
+    /// checkpoint.
+    pub fn dense_all_in_bits(&self, geom: &K3Geometry) -> f64 {
+        self.dense.all_in_bits(geom)
     }
 
     /// Bytes a token may read at `target` tokens/second.
@@ -129,7 +137,7 @@ pub fn frontier_row(geom: &K3Geometry, p: &ServingPremises, target: f64) -> Fron
 /// target, that lever cannot decide the target — however good its result. One
 /// division, run before an experiment is designed.
 pub fn expert_side_ceiling_tok_s(geom: &K3Geometry, p: &ServingPremises) -> f64 {
-    p.effective_bw() / geom.dense_bytes(p.dense_all_in_bits)
+    p.effective_bw() / geom.dense_bytes(p.dense_all_in_bits(geom))
 }
 
 /// Whether an expert-side experiment could decide `target` at all.
@@ -143,6 +151,7 @@ pub fn frontier(geom: &K3Geometry, p: &ServingPremises, targets: &[f64]) -> Vec<
 
 #[cfg(test)]
 mod tests {
+    use super::super::geometry::DENSE_4_25;
     use super::*;
     use crate::commands::primary::k3_ledger::geometry::k3_reference;
 
@@ -153,13 +162,25 @@ mod tests {
     #[test]
     fn expert_side_ceiling_is_the_governing_constant() {
         // 12.3 tok/s with dense at 4-bit: no expert-side result can exceed it.
-        let ceiling = expert_side_ceiling_tok_s(&k3_reference(), &ServingPremises::default());
+        let ceiling = expert_side_ceiling_tok_s(
+            &k3_reference(),
+            &ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+        );
         approx(ceiling, 12.3, 0.2);
     }
 
     #[test]
     fn r4_refuses_twenty_tok_s_for_every_expert_side_lever() {
-        let (g, p) = (k3_reference(), ServingPremises::default());
+        let (g, p) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+        );
         assert!(!expert_side_can_decide(&g, &p, 20.0));
         assert!(!expert_side_can_decide(&g, &p, 14.0));
         assert!(expert_side_can_decide(&g, &p, 8.0));
@@ -184,13 +205,26 @@ mod tests {
 
     #[test]
     fn twenty_tok_s_is_not_a_quantisation_problem() {
-        let row = frontier_row(&k3_reference(), &ServingPremises::default(), 20.0);
+        let row = frontier_row(
+            &k3_reference(),
+            &ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+            20.0,
+        );
         assert_eq!(row.verdict, DenseVerdict::NewModelProgramme);
     }
 
     #[test]
     fn the_ladder_separates_into_difficulty_classes() {
-        let (g, p) = (k3_reference(), ServingPremises::default());
+        let (g, p) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+        );
         let rows = frontier(&g, &p, &[8.0, 10.0, 12.0, 14.0, 20.0]);
         let verdicts: Vec<_> = rows.iter().map(|r| r.verdict).collect();
         // Under the BANKED up-fold retention (2/3). These are harsher than the
@@ -205,7 +239,13 @@ mod tests {
 
     #[test]
     fn requirement_tightens_monotonically_with_the_target() {
-        let (g, p) = (k3_reference(), ServingPremises::default());
+        let (g, p) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+        );
         let rows = frontier(&g, &p, &[6.0, 8.0, 10.0, 12.0, 14.0, 20.0]);
         for w in rows.windows(2) {
             assert!(w[1].payload_bits < w[0].payload_bits);
@@ -217,7 +257,10 @@ mod tests {
         // The banked Metal band is 0.74-0.86, so this is not hypothetical: the
         // 10 tok/s row moves from credible-3-bit to serious-stretch-2-bit.
         let g = k3_reference();
-        let ideal = ServingPremises::default();
+        let ideal = ServingPremises {
+            dense: DENSE_4_25,
+            ..Default::default()
+        };
         let real = ServingPremises {
             dequant_efficiency: 0.80,
             ..Default::default()
@@ -236,7 +279,10 @@ mod tests {
     #[test]
     fn retention_defaults_to_the_banked_up_fold_not_to_one_point_eight_seven() {
         // Regression guard: 1.87 was the R4 zero-out ratio wearing the wrong hat.
-        let p = ServingPremises::default();
+        let p = ServingPremises {
+            dense: DENSE_4_25,
+            ..Default::default()
+        };
         approx(
             p.routed_retention,
             k3_reference().up_fold_retention(),

--- a/crates/larql-cli/src/commands/primary/k3_ledger/geometry.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/geometry.rs
@@ -13,6 +13,10 @@
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+use super::access::{AccessMode, Family};
+use super::access::{DenseCensus, LayerTopology};
+
 /// Bytes per weight for MXFP4: 4-bit codeword plus one 8-bit block scale per 32.
 ///
 /// Two conventions travel with any bit-width quoted against this (standing rule
@@ -20,6 +24,60 @@ use serde::{Deserialize, Serialize};
 /// MXFP4 is 4.0 payload / 4.25 all-in. They diverge by 0.25 bits, which is
 /// immaterial at 4-bit and decisive at 1-bit.
 pub const MXFP4_BYTES_PER_WEIGHT: f64 = 0.53125;
+
+/// **K3-L1-F1 — price what is REPRESENTED NOW, not what the optimiser hopes
+/// to make it become.**
+///
+/// The routed side has always derived its bit-width from the checkpoint
+/// (`ScenarioPremises::routed_all_in_bits`), "rather than assumed, so it
+/// stays honest if the codec changes". The dense side did not: it carried a
+/// hardcoded `4.25` with no flag to override it, so every report priced
+/// K3's BF16 dense surfaces as though the entire dense-side REPRESENT
+/// programme had already landed.
+///
+/// The gap is not small. K3's dense side is BF16 today —
+/// `quantization_config.ignore` names `self_attn`, `shared_experts`,
+/// `mlp.(gate|up|gate_up|down)_proj`, `lm_head`, `vision_tower` — so the
+/// real dense read is 112.42 GB/token against the 29.86 GB that was
+/// printed. A future hypothetical was being reported as today's source
+/// model.
+///
+/// So a hypothetical is now a DIFFERENT VARIANT, not a different number,
+/// and reports can tell them apart.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+pub enum DensePricing {
+    /// Price the dense side exactly as the checkpoint stores it.
+    #[default]
+    AsStored,
+    /// A width the caller asked for. Every report MUST label it.
+    Hypothetical { all_in_bits: f64 },
+}
+
+impl DensePricing {
+    /// Resolve against the checkpoint. `AsStored` reads the geometry.
+    pub fn all_in_bits(&self, geom: &K3Geometry) -> f64 {
+        match self {
+            Self::AsStored => geom.dense_stored_bits,
+            Self::Hypothetical { all_in_bits } => *all_in_bits,
+        }
+    }
+
+    /// Whether this is a width the checkpoint does not have.
+    pub fn is_hypothetical(&self) -> bool {
+        matches!(self, Self::Hypothetical { .. })
+    }
+
+    /// How a report must describe it.
+    pub fn label(&self, geom: &K3Geometry) -> String {
+        match self {
+            Self::AsStored => format!("{} AS STORED", geom.dense_stored_label),
+            Self::Hypothetical { all_in_bits } => format!(
+                "{all_in_bits:.4} bpw HYPOTHETICAL — the checkpoint stores {} at {:.4}",
+                geom.dense_stored_label, geom.dense_stored_bits
+            ),
+        }
+    }
+}
 pub const MXFP4_PAYLOAD_BITS: f64 = 4.0;
 pub const SCALE_BITS_PER_WEIGHT: f64 = 8.0 / 32.0;
 
@@ -50,6 +108,26 @@ pub struct K3Geometry {
     pub mla_layer_dense_params: u64,
     /// Embedding + LM head parameters. Vision is EXCLUDED — see `vision_excluded`.
     pub embedding_params: u64,
+    /// All-in bits per weight the dense families are ACTUALLY stored at,
+    /// from the checkpoint's own `dtype` for the families
+    /// `quantization_config.ignore` excludes. K3: BF16, 16.0.
+    pub dense_stored_bits: f64,
+    /// Human label for that representation, e.g. `BF16`.
+    pub dense_stored_label: String,
+    /// 0-based tensor indices of the KDA layers, from the config's own
+    /// `linear_attn_config.kda_layers`. NOT reconstructed from a stride:
+    /// K3's `full_attn_layers` tail is `..., 88, 92, 93` — irregular — so
+    /// any periodic reconstruction is right by luck.
+    pub kda_layer_indices: Vec<usize>,
+    /// Which layers are dense and which are MoE. K3-LEDGER-2: the
+    /// multiplier for shared experts, the wrapper and the router is
+    /// `n_moe()`, never `n_layers`.
+    pub topology: LayerTopology,
+    /// Every BF16 family and HOW IT IS TOUCHED. The authority for dense
+    /// activated bytes — `dense_params` derives from this rather than
+    /// summing tensor sizes, so a gather can never be priced as a full
+    /// read.
+    pub dense_census: DenseCensus,
     /// Always false-if-honest: the ledger sums `language_model` layers plus text
     /// embeddings only. `vision_tower` + `mm_projector` are ~2 GB BF16 by
     /// residual against the published repo size, under 2% of the dense term. A
@@ -63,11 +141,17 @@ impl K3Geometry {
         self.n_layers.saturating_sub(self.n_dense_layers)
     }
 
-    /// Always-on parameters read once per forward pass, whatever it emits.
+    /// Always-on parameters ACTIVATED per token.
+    ///
+    /// K3-LEDGER-2: derived from [`DenseCensus`], which prices each family
+    /// by its `AccessMode`. Summing tensor sizes instead is what made
+    /// `embed_tokens` — a 2.35 GB gather that moves 14 KB — look like a
+    /// full read, and what gave layer 0 a router it does not have.
     pub fn dense_params(&self) -> u64 {
-        self.n_kda_layers as u64 * self.kda_layer_dense_params
-            + self.n_mla_layers as u64 * self.mla_layer_dense_params
-            + self.embedding_params
+        if self.dense_stored_bits <= 0.0 {
+            return 0;
+        }
+        (self.dense_census.activated_bytes() as f64 * 8.0 / self.dense_stored_bits) as u64
     }
 
     /// Routed-expert parameters activated per token position.
@@ -159,6 +243,13 @@ impl BitConvention {
     }
 }
 
+/// The 4.25-bpw dense premise every ledger row was computed under before
+/// K3-L1-F1. Tests written in that world name it rather than inheriting it
+/// from a default, so moving the default cannot silently change what they
+/// claim.
+#[cfg(test)]
+pub(crate) const DENSE_4_25: DensePricing = DensePricing::Hypothetical { all_in_bits: 4.25 };
+
 #[cfg(test)]
 pub(crate) fn k3_reference() -> K3Geometry {
     // The real moonshotai/Kimi-K3 geometry, measured 2026-07-31 from config.json
@@ -178,6 +269,41 @@ pub(crate) fn k3_reference() -> K3Geometry {
         kda_layer_dense_params: 633_700_000,
         mla_layer_dense_params: 422_200_000,
         embedding_params: 2 * 163_840 * 7_168,
+        // quantization_config ignores every dense family; dtype is bfloat16.
+        dense_stored_bits: 16.0,
+        dense_stored_label: "BF16".to_string(),
+        kda_layer_indices: (1..=93)
+            .filter(|l| !(l % 4 == 0 || *l > 91))
+            .map(|l| l - 1)
+            .collect(),
+        topology: LayerTopology::new(93, 1),
+        // K3-DENSE-1, measured from safetensors headers 2026-09-03 (layer 49
+        // KDA, layer 3 MLA, layer 0 dense, shard 94 head/embed). EXACT byte
+        // counts, never rounded MB — a rounded constant divides wrong.
+        dense_census: DenseCensus::new(vec![
+            // 5 x [12288,7168] q/k/v/g/o + convs, f_a/f_b, b_proj, dt_bias.
+            Family::full_read("KDA self_attn", 887_800_832, 69),
+            // 3 x [6144,7168] — 184 shared experts across 92 MoE layers.
+            Family::full_read("shared_experts", 264_241_152, 92),
+            // g_proj + o_proj [12288,7168] dominate; q_a/q_b/kv_a/kv_b.
+            Family::full_read("MLA self_attn", 464_392_192, 24),
+            // routed_expert up/down [3584,7168] — BF16 around an MXFP4 bank.
+            Family::full_read("LatentMoE wrapper", 102_767_616, 92),
+            Family::full_read("lm_head", 2_348_810_240, 1),
+            // 3 x [33792,7168]. first_k_dense_replace = 1, so ONE layer.
+            Family::full_read("dense layer-0 MLP", 1_453_326_336, 1),
+            Family::full_read("router", 12_848_640, 92),
+            Family::full_read("norms / res_proj", 86_016, 93),
+            Family {
+                name: "embed_tokens".to_string(),
+                bytes_per_unit: 2_348_810_240,
+                units: 1,
+                access: AccessMode::Gather {
+                    rows_per_token: 1,
+                    total_rows: 163_840,
+                },
+            },
+        ]),
         vision_included: false,
     }
 }
@@ -203,9 +329,14 @@ mod tests {
 
     #[test]
     fn activated_params_match_the_published_figure() {
-        // Published ~104.2B; measured 104.83B, agreeing to 0.6%.
+        // **K3-LEDGER-2 corroboration.** This test used to read "Published
+        // ~104.2B; measured 104.83B, agreeing to 0.6%" — the 0.6% gap WAS
+        // the modelling error. Pricing `embed_tokens` as a gather and layer
+        // 0 as dense lands on 104.2007B, matching the published activated
+        // count to four significant figures. An external check the old
+        // model failed and the corrected one passes.
         let g = k3_reference();
-        approx(g.activated_params() as f64 / 1e9, 104.83, 0.15);
+        approx(g.activated_params() as f64 / 1e9, 104.20, 0.01);
     }
 
     #[test]

--- a/crates/larql-cli/src/commands/primary/k3_ledger/homogeneity.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/homogeneity.rs
@@ -1,0 +1,192 @@
+//! **Is one measured layer representative of its family?**
+//!
+//! [`super::access::DenseCensus`] multiplies ONE measured KDA layer by 69
+//! and ONE measured MLA layer by 24. That is sound only if layers within a
+//! family are structurally identical, which the shard sizes suggest and
+//! nothing had checked.
+//!
+//! The assumption is load-bearing: every per-layer opportunity figure in
+//! K3-PRECISION-1A divides by it. So it is witnessed from headers BEFORE
+//! any weight is read, rather than discovered incidentally later.
+//!
+//! ```text
+//! ASSUMED     layer 49 x 69 == every KDA layer
+//! WITNESSED   all 69 KDA layers carry the same roles at the same bytes
+//! ```
+//!
+//! A family is homogeneous when every member has the same set of family
+//! roles AND the same total bytes per role. Both halves matter: equal
+//! totals with different roles would be a different layer that happens to
+//! weigh the same, which is exactly the failure a byte-only check misses.
+//!
+//! [`super::access::LayerKind`] decides which families a layer SHOULD
+//! have — a dense layer legitimately has no router, and flagging that as
+//! heterogeneity would be reporting the topology as a defect.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::access::{LayerKind, LayerTopology};
+
+/// One layer's measured family byte totals.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LayerProfile {
+    /// Layer index, 0-based against tensor names.
+    pub index: usize,
+    /// Family name -> total bytes in that family for this layer.
+    pub families: BTreeMap<String, u64>,
+}
+
+impl LayerProfile {
+    /// Total bytes across every family.
+    pub fn total_bytes(&self) -> u64 {
+        self.families.values().sum()
+    }
+}
+
+/// Why a family is not homogeneous.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Divergence {
+    /// A layer carries a different set of roles than the family's first.
+    RoleSetDiffers {
+        /// The layer that differs.
+        index: usize,
+        /// What it has.
+        found: Vec<String>,
+        /// What the reference layer has.
+        expected: Vec<String>,
+    },
+    /// A role is present everywhere but weighs differently.
+    ByteCountDiffers {
+        /// The layer that differs.
+        index: usize,
+        /// Which role.
+        role: String,
+        /// Its bytes here.
+        found: u64,
+        /// Its bytes in the reference layer.
+        expected: u64,
+    },
+}
+
+/// The verdict for one family.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FamilyWitness {
+    /// Which family — `KDA`, `MLA`, `MoE`.
+    pub family: String,
+    /// How many layers were checked.
+    pub members: usize,
+    /// The layer every other was compared against.
+    pub reference: usize,
+    /// Everything that differed. Empty means witnessed homogeneous.
+    pub divergences: Vec<Divergence>,
+}
+
+impl FamilyWitness {
+    /// Whether multiplying the reference layer by `members` is a witnessed
+    /// fact rather than an assumption.
+    pub fn is_homogeneous(&self) -> bool {
+        self.divergences.is_empty()
+    }
+}
+
+/// Check one family's layers against the first of them.
+///
+/// `roles` restricts the comparison to the families that layer kind is
+/// expected to have — a dense layer has no router, and reporting that as
+/// heterogeneity would be reporting the topology.
+pub fn witness_family(
+    family: &str,
+    layers: &[LayerProfile],
+    roles: &[&str],
+) -> Option<FamilyWitness> {
+    let (reference, rest) = layers.split_first()?;
+    fn keep<'a>(p: &'a LayerProfile, roles: &[&str]) -> BTreeMap<&'a str, u64> {
+        p.families
+            .iter()
+            .filter(|(k, _)| roles.contains(&k.as_str()))
+            .map(|(k, v)| (k.as_str(), *v))
+            .collect()
+    }
+    let want = keep(reference, roles);
+    let mut divergences = Vec::new();
+
+    for layer in rest {
+        let got = keep(layer, roles);
+        if got.keys().ne(want.keys()) {
+            divergences.push(Divergence::RoleSetDiffers {
+                index: layer.index,
+                found: got.keys().map(|s| (*s).to_string()).collect(),
+                expected: want.keys().map(|s| (*s).to_string()).collect(),
+            });
+            continue;
+        }
+        for (role, bytes) in &want {
+            let found = got.get(role).copied().unwrap_or(0);
+            if found != *bytes {
+                divergences.push(Divergence::ByteCountDiffers {
+                    index: layer.index,
+                    role: (*role).to_string(),
+                    found,
+                    expected: *bytes,
+                });
+            }
+        }
+    }
+    Some(FamilyWitness {
+        family: family.to_string(),
+        members: layers.len(),
+        reference: reference.index,
+        divergences,
+    })
+}
+
+/// The whole-model witness: attention families and the MoE surfaces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HomogeneityWitness {
+    /// One entry per family checked.
+    pub families: Vec<FamilyWitness>,
+}
+
+impl HomogeneityWitness {
+    /// Build the witness from every layer profile and the model's topology.
+    ///
+    /// `kda_layers` is the 0-based tensor index set for the KDA family; the
+    /// rest of the decoder is MLA. MoE surfaces are checked across every
+    /// layer the topology calls `Moe`, regardless of attention family.
+    pub fn build(profiles: &[LayerProfile], kda_layers: &[usize], topology: LayerTopology) -> Self {
+        let pick = |f: &dyn Fn(&LayerProfile) -> bool| -> Vec<LayerProfile> {
+            profiles.iter().filter(|p| f(p)).cloned().collect()
+        };
+        let kda = pick(&|p| kda_layers.contains(&p.index));
+        let mla = pick(&|p| !kda_layers.contains(&p.index));
+        let moe = pick(&|p| topology.kind(p.index) == LayerKind::Moe);
+        let dense = pick(&|p| topology.kind(p.index) == LayerKind::Dense);
+
+        let mut families = Vec::new();
+        families.extend(witness_family("KDA self_attn", &kda, &["self_attn"]));
+        families.extend(witness_family("MLA self_attn", &mla, &["self_attn"]));
+        families.extend(witness_family(
+            "MoE surfaces",
+            &moe,
+            &["shared_experts", "LatentMoE wrapper", "router"],
+        ));
+        families.extend(witness_family("dense MLP", &dense, &["dense MLP"]));
+        Self { families }
+    }
+
+    /// Whether every family checked is homogeneous.
+    pub fn all_homogeneous(&self) -> bool {
+        self.families.iter().all(FamilyWitness::is_homogeneous)
+    }
+
+    /// Every divergence found, across all families.
+    pub fn divergence_count(&self) -> usize {
+        self.families.iter().map(|f| f.divergences.len()).sum()
+    }
+}
+
+#[cfg(test)]
+#[path = "homogeneity_tests.rs"]
+mod homogeneity_tests;

--- a/crates/larql-cli/src/commands/primary/k3_ledger/homogeneity_tests.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/homogeneity_tests.rs
@@ -1,0 +1,193 @@
+//! The census multiplies one layer by 69. This is what turns that into a
+//! witnessed fact — and what it must refuse to call homogeneous.
+
+use super::*;
+
+fn profile(index: usize, pairs: &[(&str, u64)]) -> LayerProfile {
+    LayerProfile {
+        index,
+        families: pairs.iter().map(|(k, v)| ((*k).to_string(), *v)).collect(),
+    }
+}
+
+/// Three KDA layers with K3's measured attention weight.
+fn kda(indices: &[usize]) -> Vec<LayerProfile> {
+    indices
+        .iter()
+        .map(|i| profile(*i, &[("self_attn", 887_800_832)]))
+        .collect()
+}
+
+#[test]
+fn identical_layers_are_witnessed_homogeneous() {
+    let w = witness_family("KDA", &kda(&[1, 2, 3]), &["self_attn"]).expect("non-empty");
+    assert!(w.is_homogeneous());
+    assert_eq!(w.members, 3);
+    assert_eq!(w.reference, 1, "the first layer is the reference");
+    assert!(w.divergences.is_empty());
+}
+
+#[test]
+fn one_byte_of_difference_refuses_the_witness() {
+    let mut layers = kda(&[1, 2, 3]);
+    layers[2].families.insert("self_attn".into(), 887_800_831);
+    let w = witness_family("KDA", &layers, &["self_attn"]).unwrap();
+    assert!(!w.is_homogeneous());
+    assert_eq!(
+        w.divergences,
+        vec![Divergence::ByteCountDiffers {
+            index: 3,
+            role: "self_attn".into(),
+            found: 887_800_831,
+            expected: 887_800_832,
+        }]
+    );
+}
+
+#[test]
+fn equal_bytes_with_different_roles_is_still_heterogeneous() {
+    // The failure a byte-only check misses: same weight, different layer.
+    let a = profile(1, &[("self_attn", 100), ("router", 50)]);
+    let b = profile(2, &[("self_attn", 100), ("LatentMoE wrapper", 50)]);
+    assert_eq!(a.total_bytes(), b.total_bytes(), "identical totals");
+
+    let w = witness_family(
+        "MoE",
+        &[a, b],
+        &["self_attn", "router", "LatentMoE wrapper"],
+    )
+    .unwrap();
+    assert!(
+        !w.is_homogeneous(),
+        "equal totals must not pass as equal structure"
+    );
+    assert!(matches!(
+        w.divergences[0],
+        Divergence::RoleSetDiffers { index: 2, .. }
+    ));
+}
+
+#[test]
+fn a_role_set_difference_does_not_also_report_byte_differences() {
+    // One finding per layer: a layer with the wrong roles is reported once,
+    // not once per role it happens to weigh differently.
+    let a = profile(1, &[("self_attn", 100), ("router", 50)]);
+    let b = profile(2, &[("self_attn", 999)]);
+    let w = witness_family("X", &[a, b], &["self_attn", "router"]).unwrap();
+    assert_eq!(w.divergences.len(), 1);
+}
+
+#[test]
+fn roles_outside_the_checked_set_are_ignored() {
+    // A KDA check must not fail because two layers differ on something it
+    // is not asking about.
+    let a = profile(1, &[("self_attn", 100), ("norms / res_proj", 7)]);
+    let b = profile(2, &[("self_attn", 100), ("norms / res_proj", 9)]);
+    let w = witness_family("KDA", &[a, b], &["self_attn"]).unwrap();
+    assert!(w.is_homogeneous());
+}
+
+#[test]
+fn an_empty_family_yields_no_witness() {
+    assert!(witness_family("KDA", &[], &["self_attn"]).is_none());
+}
+
+#[test]
+fn a_single_member_family_is_trivially_homogeneous() {
+    let w = witness_family("dense MLP", &kda(&[0]), &["self_attn"]).unwrap();
+    assert!(w.is_homogeneous());
+    assert_eq!(w.members, 1);
+}
+
+// ---- the whole-model shape -------------------------------------------
+
+/// K3 in miniature: layer 0 dense, 1-3 MoE, layer 2 the MLA one.
+fn k3_shaped() -> Vec<LayerProfile> {
+    vec![
+        profile(
+            0,
+            &[("self_attn", 887_800_832), ("dense MLP", 1_453_326_336)],
+        ),
+        profile(
+            1,
+            &[
+                ("self_attn", 887_800_832),
+                ("shared_experts", 264_241_152),
+                ("LatentMoE wrapper", 102_767_616),
+                ("router", 12_848_640),
+            ],
+        ),
+        profile(
+            2,
+            &[
+                ("self_attn", 464_392_192),
+                ("shared_experts", 264_241_152),
+                ("LatentMoE wrapper", 102_767_616),
+                ("router", 12_848_640),
+            ],
+        ),
+        profile(
+            3,
+            &[
+                ("self_attn", 887_800_832),
+                ("shared_experts", 264_241_152),
+                ("LatentMoE wrapper", 102_767_616),
+                ("router", 12_848_640),
+            ],
+        ),
+    ]
+}
+
+#[test]
+fn the_dense_layer_lacking_a_router_is_topology_not_heterogeneity() {
+    // Layer 0 has no router, shared experts or wrapper. Reporting that as a
+    // divergence would be reporting `first_k_dense_replace` as a defect.
+    let w = HomogeneityWitness::build(&k3_shaped(), &[0, 1, 3], LayerTopology::new(4, 1));
+    assert!(w.all_homogeneous(), "{:?}", w.families);
+    assert_eq!(w.divergence_count(), 0);
+
+    let names: Vec<&str> = w.families.iter().map(|f| f.family.as_str()).collect();
+    assert!(names.contains(&"KDA self_attn"));
+    assert!(names.contains(&"MLA self_attn"));
+    assert!(names.contains(&"MoE surfaces"));
+}
+
+#[test]
+fn kda_and_mla_are_checked_separately_not_against_each_other() {
+    // They legitimately differ — 887.80 MB vs 464.39 MB. A single
+    // whole-model check would call that heterogeneity.
+    let w = HomogeneityWitness::build(&k3_shaped(), &[0, 1, 3], LayerTopology::new(4, 1));
+    let kda = w
+        .families
+        .iter()
+        .find(|f| f.family == "KDA self_attn")
+        .unwrap();
+    let mla = w
+        .families
+        .iter()
+        .find(|f| f.family == "MLA self_attn")
+        .unwrap();
+    assert_eq!(kda.members, 3);
+    assert_eq!(mla.members, 1);
+    assert!(kda.is_homogeneous() && mla.is_homogeneous());
+}
+
+#[test]
+fn a_divergent_moe_layer_is_caught_across_attention_families() {
+    // MoE surfaces are checked over every MoE layer, KDA and MLA alike, so
+    // a wrapper that differs only on MLA layers cannot hide.
+    let mut layers = k3_shaped();
+    layers[2].families.insert("LatentMoE wrapper".into(), 1);
+    let w = HomogeneityWitness::build(&layers, &[0, 1, 3], LayerTopology::new(4, 1));
+    assert!(!w.all_homogeneous());
+    assert_eq!(w.divergence_count(), 1);
+}
+
+#[test]
+fn a_witness_round_trips_through_serde() {
+    let w = HomogeneityWitness::build(&k3_shaped(), &[0, 1, 3], LayerTopology::new(4, 1));
+    let back: HomogeneityWitness =
+        serde_json::from_str(&serde_json::to_string(&w).unwrap()).unwrap();
+    assert_eq!(w, back);
+    assert_eq!(profile(7, &[("a", 1), ("b", 2)]).total_bytes(), 3);
+}

--- a/crates/larql-cli/src/commands/primary/k3_ledger/mod.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/mod.rs
@@ -6,6 +6,11 @@
 //!
 //! Module map:
 //!
+//!   access    — HOW a tensor is touched: FullRead / Gather / Routed, plus
+//!               the dense/MoE layer topology. Physical existence is not
+//!               execution touch (pure, gated).
+//!   actions   — K3-ACTIONS-1: the weight-free physical action catalogue.
+//!               Representation is not execution role (pure, gated).
 //!   args      — clap surface (`budget` / `touch` / `frontier` / `block`).
 //!   geometry  — measured checkpoint shape; nothing derived (pure, gated).
 //!   budget    — DEC-8.0 miss budget and read-granularity (pure, gated).
@@ -18,6 +23,8 @@
 //!   freqmass  — frequency-mass coverage: static / adaptive / oracle / null.
 //!               Model-agnostic and symbol-agnostic; grades the resident bank,
 //!               the static slice, and compact-dense with one instrument (pure).
+//!   homogeneity — is ONE measured layer representative of its family?
+//!               Witnesses it from headers before any weight is read (pure).
 //!   kda_a_log — is A_log per-head or per-channel? Fails closed (pure).
 //!   kda_graph — which KDA projections share one input, for rotation (pure).
 //!   scenario  — the premises a `frontier` row is conditional on (pure).
@@ -43,6 +50,8 @@
 //! was arithmetic over correct measurements, so the arithmetic carries unit
 //! tests and the network does not.
 
+pub mod access;
+pub mod actions;
 pub mod args;
 pub mod block;
 pub mod budget;
@@ -57,6 +66,7 @@ pub mod freqmass;
 mod freqmass_tests;
 pub mod frontier;
 pub mod geometry;
+pub mod homogeneity;
 pub mod kda_a_log;
 pub mod kda_graph;
 mod report;
@@ -103,11 +113,17 @@ pub fn run(args: K3LedgerArgs) -> Result<(), Box<dyn std::error::Error>> {
     let premises = frontier::ServingPremises {
         bandwidth_gb_s: args.bandwidth_gb_s,
         dequant_efficiency: args.dequant_efficiency,
+        dense: match args.hypothetical_dense_bits {
+            Some(all_in_bits) => geometry::DensePricing::Hypothetical { all_in_bits },
+            None => geometry::DensePricing::AsStored,
+        },
         ..Default::default()
     };
 
     match &args.cmd {
         args::K3LedgerCmd::Budget(a) => report::budget(&geom, a, args.json),
+        args::K3LedgerCmd::Homogeneity(a) => report::homogeneity(&repo, &geom, a, args.json),
+        args::K3LedgerCmd::Actions(a) => report::actions(&geom, a, args.json),
         args::K3LedgerCmd::Touch(a) => report::touch(&geom, &premises, a, args.json),
         args::K3LedgerCmd::Frontier(a) => report::frontier(&geom, &premises, a, args.json),
         args::K3LedgerCmd::Block(a) => report::block(&geom, &premises, a, args.json),

--- a/crates/larql-cli/src/commands/primary/k3_ledger/report.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/report.rs
@@ -132,11 +132,16 @@ pub fn touch(geom: &K3Geometry, p: &ServingPremises, a: &TouchArgs, as_json: boo
     header(geom);
     println!();
     println!(
-        "--- per-token touch at {:.2} all-in bits ---",
-        p.dense_all_in_bits
+        "--- per-token touch: dense {:.2} all-in bits [{}] ---",
+        p.dense_all_in_bits(geom),
+        p.dense.label(geom)
     );
     println!(
-        "  dense (irreducible) {:>7.2} GB -> {:>5.1} tok/s",
+        // NOT "irreducible": this 111 GB is exactly what REPRESENT exists to
+        // reduce. What is irreducible is that these operations are ACTIVATED
+        // every token under the current execution graph — a statement about
+        // the graph, never about the representation's byte width.
+        "  dense (always-on, full-read) {:>7.2} GB -> {:>5.1} tok/s",
         l.dense_bytes / 1e9,
         l.tok_s_dense_only
     );
@@ -147,9 +152,62 @@ pub fn touch(geom: &K3Geometry, p: &ServingPremises, a: &TouchArgs, as_json: boo
         l.tok_s_total
     );
     println!();
+    // Two different shares, printed together on purpose. The param share is
+    // representation-independent; the BYTE share is what a bandwidth lever
+    // actually acts on, and they diverge by 28 points on today's K3 because
+    // dense is BF16 and routed is MXFP4. Printing only the first next to a
+    // table of bytes is how a 53.6% reads as though it described traffic.
+    // K3-DENSE-1. The census is the ledger's own answer to "what IS the
+    // dense side", and it is ordered by ACTIVATED bytes — `embed_tokens` is
+    // the joint-largest RESIDENT family and nearly the smallest activated
+    // one, so ordering by footprint would put it at the top of a traffic
+    // report.
+    println!();
     println!(
-        "  dense is {:.1}% of activated params — the LARGER half",
-        100.0 * l.dense_share
+        "--- dense families, by activated bytes/token [{}] ---",
+        p.dense.label(geom)
+    );
+    println!(
+        "  {:<22} {:>9} {:>7} {:>10}  access",
+        "family", "activated", "share", "resident"
+    );
+    for f in &geom.dense_census.families {
+        println!(
+            "  {:<22} {:>7.2} GB {:>6.1}% {:>8.2} GB  {}",
+            f.name,
+            f.activated_bytes() as f64 / 1e9,
+            100.0 * geom.dense_census.activated_share(&f.name),
+            f.resident_bytes() as f64 / 1e9,
+            if f.access.is_full_read() {
+                "full read"
+            } else {
+                "gather"
+            }
+        );
+    }
+    println!(
+        "  {:<22} {:>7.2} GB {:>6} {:>8.2} GB",
+        "TOTAL",
+        geom.dense_census.activated_bytes() as f64 / 1e9,
+        "100.0%",
+        geom.dense_census.resident_bytes() as f64 / 1e9
+    );
+    println!(
+        "  resident exceeds activated by {:.2} GB — the embed table that is \
+         never read in full",
+        (geom.dense_census.resident_bytes() - geom.dense_census.activated_bytes()) as f64 / 1e9
+    );
+    println!(
+        "  layer topology: {} dense + {} MoE = {} (first_k_dense_replace)",
+        geom.topology.n_dense(),
+        geom.topology.n_moe(),
+        geom.topology.n_layers
+    );
+    println!();
+    println!(
+        "  dense is {:.1}% of activated params, and {:.1}% of TODAY'S BYTES",
+        100.0 * l.dense_share,
+        100.0 * l.dense_bytes / l.total_bytes
     );
     println!(
         "  expert-side levers cap at {:.2}x; {:.2}x needed for {} tok/s",
@@ -306,8 +364,10 @@ pub fn frontier(geom: &K3Geometry, p: &ServingPremises, a: &FrontierArgs, as_jso
         println!();
         println!("--- R4 zero-out: routed traffic deleted entirely ---");
         println!(
-            "  dense at {:.2} bits caps decode at {:.1} tok/s",
-            p.dense_all_in_bits, ceiling
+            "  dense at {:.2} bits [{}] caps decode at {:.1} tok/s",
+            p.dense_all_in_bits(geom),
+            p.dense.label(geom),
+            ceiling
         );
         println!("  >> no expert-side experiment can decide any target above {ceiling:.1}");
     }
@@ -1412,5 +1472,135 @@ pub fn formats(as_json: bool) -> R {
         Container::Q6K.all_in_bits() / floor.all_in_bits()
     );
     println!("  Everything below this bar requires approximation, not encoding.");
+    Ok(())
+}
+
+/// `k3-ledger homogeneity` — read every layer's header and witness that
+/// one measured layer represents its family.
+pub fn homogeneity(
+    repo: &super::fetch::Repo,
+    geom: &K3Geometry,
+    a: &super::args::HomogeneityArgs,
+    as_json: bool,
+) -> R {
+    use super::homogeneity::HomogeneityWitness;
+
+    let n = if a.limit == 0 {
+        geom.n_layers
+    } else {
+        a.limit.min(geom.n_layers)
+    };
+    eprintln!("reading {n} layer headers (headers only, no weights)");
+    let mut profiles = Vec::with_capacity(n);
+    for layer in 0..n {
+        profiles.push(super::fetch::layer_profile(repo, &a.shard_template, layer)?);
+        if (layer + 1) % 10 == 0 {
+            eprintln!("  {} / {n}", layer + 1);
+        }
+    }
+    let w = HomogeneityWitness::build(&profiles, &geom.kda_layer_indices, geom.topology);
+
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(&w)?);
+        return Ok(());
+    }
+    println!();
+    println!("--- family homogeneity, from {n} layer headers ---");
+    for f in &w.families {
+        println!(
+            "  {:<16} {:>3} layers, ref layer {:>2}  {}",
+            f.family,
+            f.members,
+            f.reference,
+            if f.is_homogeneous() {
+                "WITNESSED HOMOGENEOUS".to_string()
+            } else {
+                format!("{} DIVERGENCES", f.divergences.len())
+            }
+        );
+        for d in f.divergences.iter().take(5) {
+            println!("      {d:?}");
+        }
+        if let Some(r) = profiles.iter().find(|p| p.index == f.reference) {
+            println!(
+                "      reference layer total {:.2} MB",
+                r.total_bytes() as f64 / 1e6
+            );
+        }
+    }
+    println!();
+    if w.all_homogeneous() {
+        println!(
+            "  VERDICT: the census may multiply ONE measured layer by its family \
+             count — that is now a WITNESSED FACT, not an assumption."
+        );
+    } else {
+        println!(
+            "  VERDICT: {} divergences — the census's per-family multiplication \
+             is NOT sound as stated.",
+            w.divergence_count()
+        );
+    }
+    Ok(())
+}
+
+/// `k3-ledger actions` — K3-ACTIONS-1, the physical action catalogue.
+///
+/// Physical opportunity only. Nothing here is a behavioural claim, and a
+/// `family (CEILING)` row is not something one authority run can decide.
+pub fn actions(geom: &K3Geometry, a: &super::args::ActionsArgs, as_json: bool) -> R {
+    use super::actions::{catalogue, whole_side_ceiling, ActionScope, DENSE_CODECS};
+
+    let cat = catalogue(&geom.dense_census, geom.dense_stored_bits);
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(&cat)?);
+        return Ok(());
+    }
+    header(geom);
+    println!();
+    println!(
+        "--- K3-ACTIONS-1: physical opportunity from {} ---",
+        geom.dense_stored_label
+    );
+    println!("  NO behavioural claim. A CEILING row is not an atomic candidate.");
+    println!();
+    println!(
+        "  {:<18} {:<7} {:<16} {:>10} {:>10}  execution role",
+        "family", "codec", "scope", "activated", "resident"
+    );
+    for act in &cat {
+        if !a.ceilings && act.scope != ActionScope::Layer {
+            continue;
+        }
+        let gb = act.activated_saving() as f64 / 1e9;
+        if gb < a.min_gb && act.scope != ActionScope::Layer {
+            continue;
+        }
+        println!(
+            "  {:<18} {:<7} {:<16} {:>7.2} GB {:>7.2} GB  {}",
+            act.family,
+            act.codec,
+            act.scope.label(),
+            gb,
+            act.resident_saving() as f64 / 1e9,
+            act.role.label()
+        );
+    }
+    let candidates = cat.iter().filter(|a| a.scope.is_atomic_candidate()).count();
+    println!();
+    println!(
+        "  {candidates} atomic candidates (one authority run each); the rest are \
+         CEILINGS that aggregate members which must each earn their own admission"
+    );
+    println!();
+    println!("  --- whole-dense-side ceilings (every family moves AND earns it) ---");
+    for codec in DENSE_CODECS {
+        println!(
+            "  {:<7} {:>7.2} GB/token removed of {:.2} GB dense",
+            codec.name,
+            whole_side_ceiling(&geom.dense_census, geom.dense_stored_bits, codec) as f64 / 1e9,
+            geom.dense_census.activated_bytes() as f64 / 1e9
+        );
+    }
     Ok(())
 }

--- a/crates/larql-cli/src/commands/primary/k3_ledger/scenario.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/scenario.rs
@@ -40,7 +40,7 @@ pub const SCENARIO_BANNER: &str = "SCENARIO, NOT A WHOLE-MODEL CEILING";
 pub const BITS_COLUMN_MEANING: &str = "required_dense_bits_under_assumptions";
 
 /// The premises one frontier table was computed against.
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ScenarioPremises {
     pub routed_retention: f64,
     /// `1 / retention` — the reduction credited to the routed path.
@@ -55,6 +55,11 @@ pub struct ScenarioPremises {
     pub bandwidth_gb_s: f64,
     /// Used only for the R4 zero-out ceiling, not for the table rows.
     pub dense_all_in_bits: f64,
+    /// K3-L1-F1: true when the dense side is priced at a width the
+    /// checkpoint does not have. Such a row describes a FUTURE model.
+    pub dense_is_hypothetical: bool,
+    /// How the dense pricing must be described.
+    pub dense_label: String,
 }
 
 impl ScenarioPremises {
@@ -70,7 +75,9 @@ impl ScenarioPremises {
             routed_all_in_bits: geom.routed_bytes_per_position() * 8.0 / routed_params as f64,
             scalar_efficiency: p.dequant_efficiency,
             bandwidth_gb_s: p.bandwidth_gb_s,
-            dense_all_in_bits: p.dense_all_in_bits,
+            dense_all_in_bits: p.dense_all_in_bits(geom),
+            dense_is_hypothetical: p.dense.is_hypothetical(),
+            dense_label: p.dense.label(geom),
         }
     }
 
@@ -87,6 +94,12 @@ impl ScenarioPremises {
     /// Conditions that, unstated, would let a row be quoted beyond its evidence.
     pub fn warnings(&self) -> Vec<&'static str> {
         let mut w = Vec::new();
+        if self.dense_is_hypothetical {
+            w.push(
+                "! DENSE PRICED AT A WIDTH THE CHECKPOINT DOES NOT HAVE — this row \
+                 describes a FUTURE representation, not the source model (K3-L1-F1)",
+            );
+        }
         if self.efficiency_is_ideal() {
             w.push(
                 "efficiency 1.00 is IDEAL — no measured kernel reaches it (banked band 0.74-0.86)",

--- a/crates/larql-cli/src/commands/primary/k3_ledger/touch.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/touch.rs
@@ -40,7 +40,7 @@ pub struct TouchLedger {
 pub fn touch_ledger(geom: &K3Geometry, p: &ServingPremises, target_tok_s: f64) -> TouchLedger {
     let dense_params = geom.dense_params();
     let routed_params = geom.routed_activated_params();
-    let dense = geom.dense_bytes(p.dense_all_in_bits);
+    let dense = geom.dense_bytes(p.dense_all_in_bits(geom));
     let routed = geom.routed_bytes_per_position();
     let total = dense + routed;
     let budget = p.budget_per_token(target_tok_s);
@@ -78,7 +78,7 @@ pub fn slice_composition(
     tier: &SliceTier,
 ) -> SliceComposition {
     let payload = geom.branch_bytes[1] as f64;
-    let expert_budget = (tier.size_bytes - geom.dense_bytes(p.dense_all_in_bits)).max(0.0);
+    let expert_budget = (tier.size_bytes - geom.dense_bytes(p.dense_all_in_bits(geom))).max(0.0);
     let resident = expert_budget / payload;
     let total_slots = (geom.n_experts * geom.n_moe_layers()) as f64;
     let fraction = resident / total_slots;
@@ -91,7 +91,119 @@ pub fn slice_composition(
 }
 
 #[cfg(test)]
+mod k3_l1_f1_tests {
+    use super::super::frontier::ServingPremises;
+    use super::super::geometry::{k3_reference, DensePricing};
+    use super::*;
+
+    /// **K3-L1-F1.** The ledger printed `dense 29.86 GB/token` while
+    /// describing a checkpoint whose dense side is BF16. These two cases are
+    /// the same model; only the pricing premise differs, and the ledger must
+    /// never again present the second while describing the first.
+    #[test]
+    fn the_source_model_and_the_hypothetical_are_pinned_apart() {
+        let g = k3_reference();
+
+        // 1. K3 AS IT IS: dense BF16, routed MXFP4.
+        let source = ServingPremises {
+            dense: DensePricing::AsStored,
+            ..Default::default()
+        };
+        let dense_now = g.dense_bytes(source.dense_all_in_bits(&g));
+        assert!(
+            (dense_now / 1e9 - 111.16).abs() < 0.05,
+            "dense BF16 activated must be 111.16 GB/token, got {:.2}",
+            dense_now / 1e9
+        );
+        assert!(!source.dense.is_hypothetical());
+        assert!(source.dense.label(&g).contains("AS STORED"));
+
+        // 2. The 4.25 bpw HYPOTHETICAL the ledger used to print silently.
+        let hypothetical = ServingPremises {
+            dense: DensePricing::Hypothetical { all_in_bits: 4.25 },
+            ..Default::default()
+        };
+        let dense_hyp = g.dense_bytes(hypothetical.dense_all_in_bits(&g));
+        assert!(
+            (dense_hyp / 1e9 - 29.53).abs() < 0.05,
+            "the 4.25 bpw row, on the CORRECTED activated params, got {:.2}",
+            dense_hyp / 1e9
+        );
+        assert!(hypothetical.dense.is_hypothetical());
+        assert!(
+            hypothetical.dense.label(&g).contains("HYPOTHETICAL"),
+            "a width the checkpoint does not have MUST say so"
+        );
+
+        // 3. And the gap is the whole dense-side REPRESENT prize.
+        assert!(
+            (dense_now / dense_hyp - 3.76).abs() < 0.01,
+            "BF16/4.25 must be 3.76x, got {:.3}",
+            dense_now / dense_hyp
+        );
+    }
+
+    /// The DEFAULT must price reality. This is the regression: the old
+    /// default was the hypothetical.
+    #[test]
+    fn the_default_prices_the_checkpoint_not_a_future_representation() {
+        let g = k3_reference();
+        let p = ServingPremises::default();
+        assert_eq!(p.dense, DensePricing::AsStored);
+        assert_eq!(p.dense_all_in_bits(&g), 16.0, "K3 dense is BF16");
+        assert_ne!(
+            p.dense_all_in_bits(&g),
+            4.25,
+            "the hardcoded 4.25 default is what K3-L1-F1 removed"
+        );
+    }
+
+    /// Today's real per-token read, both halves, from the source model.
+    #[test]
+    fn todays_total_read_is_137_gb_not_56() {
+        let g = k3_reference();
+        let p = ServingPremises::default();
+        let l = touch_ledger(&g, &p, 20.0);
+        let total_gb = l.total_bytes / 1e9;
+        assert!(
+            (total_gb - 136.99).abs() < 0.1,
+            "source model reads 136.99 GB/token, got {total_gb:.2}"
+        );
+        // The historical 55.69 GB total assumed the dense programme had landed.
+        assert!(total_gb > 130.0, "55.69 GB was a post-REPRESENT number");
+    }
+
+    /// A hypothetical dense price is exactly the kind of unstated condition
+    /// `warnings()` exists to surface.
+    #[test]
+    fn a_hypothetical_dense_price_raises_a_warning() {
+        use super::super::scenario::ScenarioPremises;
+        let g = k3_reference();
+        let honest = ScenarioPremises::describe(&g, &ServingPremises::default());
+        assert!(!honest.dense_is_hypothetical);
+        assert!(
+            !honest
+                .warnings()
+                .iter()
+                .any(|w| w.contains("DENSE PRICED AT")),
+            "pricing the real model warns about nothing"
+        );
+
+        let hyp = ScenarioPremises::describe(
+            &g,
+            &ServingPremises {
+                dense: DensePricing::Hypothetical { all_in_bits: 4.25 },
+                ..Default::default()
+            },
+        );
+        assert!(hyp.dense_is_hypothetical);
+        assert!(hyp.warnings().iter().any(|w| w.contains("DENSE PRICED AT")));
+    }
+}
+
+#[cfg(test)]
 mod tests {
+    use super::super::geometry::DENSE_4_25;
     use super::*;
     use crate::commands::primary::k3_ledger::geometry::k3_reference;
 
@@ -100,7 +212,14 @@ mod tests {
     }
 
     fn ledger() -> TouchLedger {
-        touch_ledger(&k3_reference(), &ServingPremises::default(), 20.0)
+        touch_ledger(
+            &k3_reference(),
+            &ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+            20.0,
+        )
     }
 
     #[test]
@@ -120,7 +239,13 @@ mod tests {
 
     #[test]
     fn dense_alone_exceeds_the_whole_twenty_tok_s_budget() {
-        let (g, p) = (k3_reference(), ServingPremises::default());
+        let (g, p) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+        );
         let l = touch_ledger(&g, &p, 20.0);
         assert!(l.dense_bytes > p.budget_per_token(20.0));
     }
@@ -146,7 +271,13 @@ mod tests {
 
     #[test]
     fn a_demo_slice_holds_only_a_few_percent_of_experts() {
-        let (g, p) = (k3_reference(), ServingPremises::default());
+        let (g, p) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+        );
         for gb in [55.0, 60.0, 65.0] {
             let c = slice_composition(
                 &g,
@@ -166,7 +297,13 @@ mod tests {
 
     #[test]
     fn a_slice_smaller_than_the_dense_half_holds_no_experts() {
-        let (g, p) = (k3_reference(), ServingPremises::default());
+        let (g, p) = (
+            k3_reference(),
+            ServingPremises {
+                dense: DENSE_4_25,
+                ..Default::default()
+            },
+        );
         let c = slice_composition(&g, &p, &SliceTier { size_bytes: 10.0e9 });
         approx(c.resident_experts, 0.0, 1e-9);
     }

--- a/crates/larql-cli/src/commands/primary/k3_ledger/transport_bpw.rs
+++ b/crates/larql-cli/src/commands/primary/k3_ledger/transport_bpw.rs
@@ -106,7 +106,7 @@ pub struct TransportContext {
 }
 
 pub fn context(geom: &K3Geometry, p: &ServingPremises, link_gb_s: f64) -> TransportContext {
-    let dense = geom.dense_bytes(p.dense_all_in_bits);
+    let dense = geom.dense_bytes(p.dense_all_in_bits(geom));
     let routed = geom.routed_bytes_per_position();
     let link = link_gb_s * 1e9;
     TransportContext {
@@ -199,6 +199,7 @@ pub fn kill_table(
 
 #[cfg(test)]
 mod tests {
+    use super::super::geometry::DENSE_4_25;
     use super::*;
     use crate::commands::primary::k3_ledger::geometry::k3_reference;
 
@@ -207,7 +208,10 @@ mod tests {
     }
 
     fn ctx() -> (TransportContext, ServingPremises) {
-        let p = ServingPremises::default();
+        let p = ServingPremises {
+            dense: DENSE_4_25,
+            ..Default::default()
+        };
         (context(&k3_reference(), &p, 3.5), p)
     }
 

--- a/crates/larql-vindex/src/format/vindex3/represent/state.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state.rs
@@ -72,7 +72,9 @@
 
 pub mod accounting;
 pub mod action_space;
+pub mod allocation;
 pub mod assess;
+pub mod authority;
 pub mod bind;
 pub mod candidate;
 pub mod evidence_bank;

--- a/crates/larql-vindex/src/format/vindex3/represent/state/allocation.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/allocation.rs
@@ -1,0 +1,241 @@
+//! **R5-F11 — what evidence must we purchase next?**
+//!
+//! A distinct question from the two either side of it, and it had no home
+//! before this module:
+//!
+//! ```text
+//! Selection            what does the search frontier contain?
+//! EvidenceAllocation   what evidence must we PURCHASE next?      <- here
+//! Measurement          what was observed?
+//! AuthorityState       did the frozen contract pass?
+//! Robustness           how decisive is that evidence?
+//! Promotion            what map may become parent?
+//! ```
+//!
+//! Each stage's authority, stated once:
+//!
+//! ```text
+//! search        may propose
+//! selection     may preserve ambiguity
+//! allocation    may expand measurement
+//! budget        may refuse expenditure
+//! measurement   observes
+//! authority     decides contract truth
+//! robustness    characterises evidence
+//! promotion     changes parent
+//! ```
+//!
+//! > **A resource decision may restrict WHETHER evidence is purchased; it
+//! > may never change WHAT THE EVIDENCE SAYS.**
+//!
+//! That is the boundary this module exists to hold, and there is
+//! deliberately nowhere in the pipeline for a resource decision to
+//! masquerade as behavioural evidence.
+//!
+//! [`super::search_policy::Selection`] answers the first and always names
+//! ONE experiment, correctly: it orders experiments by priority.
+//! [`super::super::decision::decide_promotion`] answers the last and owns
+//! ADMISSIBILITY ambiguity. Neither answers what happens when the
+//! ordering evidence cannot legitimately collapse the frontier at all.
+//!
+//! # Where this came from
+//!
+//! Rung 5's N3 put two candidates on the frontier that were
+//! Pareto-incomparable on two validly participating proxies — U2 better
+//! on kl, U1 better on route flip rate. Choosing U2 because kl was the
+//! binding constraint would have installed a new policy invented after
+//! seeing the numbers: *when proxies conflict, prefer the proxy attached
+//! to the currently binding constraint*. That is scalarization wearing a
+//! different hat, and the 0.49% byte lead and the one-flip difference die
+//! to the same objection.
+//!
+//! Measuring both was what revealed the frontier did not exist at
+//! authority scale — U2 dominated U1 on BOTH statistics at 8,192
+//! positions. One run would have adjudicated an artefact.
+//!
+//! # The invariant
+//!
+//! > **Allocation may EXPAND measurement when evidence cannot
+//! > legitimately collapse the frontier. It may not MANUFACTURE an
+//! > ordering.**
+//!
+//! # What this deliberately does NOT say
+//!
+//! The historical ruling read "ambiguous -> measure all at authority".
+//! That fused two things. N3 needed paired *selection-authority* runs
+//! because authority was the next registered scale for that ladder, not
+//! because ambiguity implies authority. A later programme might resolve a
+//! 256-position ambiguity on a 2,048-position bank before buying two
+//! 8,192-position authority runs.
+//!
+//! So [`EvidenceAllocation`] says WHICH states need evidence, and
+//! [`AllocationPolicy`] says at what scale — two questions, two types,
+//! because fusing "frontier members" with "8,192 authority" would bake a
+//! ladder's accident into the vocabulary.
+
+use serde::{Deserialize, Serialize};
+
+use super::search_policy::SelectionShape;
+use crate::format::vindex3::represent::measurement::EvidenceScale;
+
+/// What evidence the next round must purchase.
+///
+/// Generic over the subject so the allocator is not tied to one
+/// experiment representation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EvidenceAllocation<S> {
+    /// Nothing to buy. The neighbourhood is closed.
+    None,
+    /// One experiment resolves the round.
+    One(S),
+    /// The ordering evidence cannot collapse these, so every one of them
+    /// is measured. **Not "several promoted"** — evidence acquisition
+    /// required BECAUSE the search cannot legitimately choose.
+    Frontier(Vec<S>),
+}
+
+impl<S> EvidenceAllocation<S> {
+    /// How many experiments this round buys.
+    pub fn len(&self) -> usize {
+        match self {
+            Self::None => 0,
+            Self::One(_) => 1,
+            Self::Frontier(v) => v.len(),
+        }
+    }
+
+    /// Whether nothing is to be measured.
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    /// Whether the round had to expand because evidence could not choose.
+    pub fn is_expanded(&self) -> bool {
+        matches!(self, Self::Frontier(_))
+    }
+
+    /// The subjects, in allocation order.
+    pub fn subjects(&self) -> &[S] {
+        match self {
+            Self::None => &[],
+            Self::One(s) => std::slice::from_ref(s),
+            Self::Frontier(v) => v,
+        }
+    }
+}
+
+/// At what scale, and within what budget, an allocation is purchased.
+///
+/// Separate from [`EvidenceAllocation`] on purpose: which states need
+/// evidence is a property of the ordering, and what it costs to look is a
+/// property of the ladder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AllocationPolicy {
+    /// The next sanctioned scale for this round. NOT necessarily
+    /// authority — a ladder may register an intermediate resolution bank.
+    pub next_scale: EvidenceScale,
+    /// The most experiments one round may buy. `None` is unbounded.
+    ///
+    /// A cap may refuse a round outright; it may never TRIM a frontier to
+    /// fit, because trimming is choosing, and choosing is what the
+    /// frontier says cannot be done.
+    pub max_experiments: Option<usize>,
+}
+
+impl AllocationPolicy {
+    /// A policy buying at `next_scale` with no cap.
+    pub fn at(next_scale: EvidenceScale) -> Self {
+        Self {
+            next_scale,
+            max_experiments: None,
+        }
+    }
+
+    /// Cap how many experiments a round may buy.
+    pub fn with_budget(mut self, max_experiments: usize) -> Self {
+        self.max_experiments = Some(max_experiments);
+        self
+    }
+
+    /// Whether this allocation fits the budget.
+    ///
+    /// Returns the allocation unchanged when it fits, and
+    /// [`BudgetRefusal`] when it does not. **There is no third answer**:
+    /// silently returning a shortened frontier is the failure this type
+    /// exists to prevent.
+    pub fn admits<S>(
+        &self,
+        allocation: EvidenceAllocation<S>,
+    ) -> Result<EvidenceAllocation<S>, BudgetRefusal> {
+        match self.max_experiments {
+            Some(cap) if allocation.len() > cap => Err(BudgetRefusal {
+                required: allocation.len(),
+                budget: cap,
+                scale: self.next_scale,
+            }),
+            _ => Ok(allocation),
+        }
+    }
+}
+
+/// A round the budget cannot buy.
+///
+/// Carries what it would have cost, so the decision to raise the budget
+/// or defer the round is made with the number in hand — and so that a
+/// deferred ambiguity is visibly deferred rather than quietly resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BudgetRefusal {
+    /// Experiments the frontier requires.
+    pub required: usize,
+    /// Experiments the policy allows.
+    pub budget: usize,
+    /// The scale they would have been bought at.
+    pub scale: EvidenceScale,
+}
+
+/// Whether the frontier's members can be ordered against each other.
+///
+/// Supplied by the caller because comparability is a property of the
+/// evidence layer — [`super::super::participation`] decides which
+/// statistics a candidate may be ranked on, and this module must not
+/// re-derive that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FrontierOrdering {
+    /// The evidence resolves them; take the leader.
+    Resolved,
+    /// Valid evidence disagrees. The frontier stands.
+    Incomparable,
+}
+
+/// Turn a [`Selection`] into what must actually be measured.
+///
+/// `unresolved` is the frontier the selection could not collapse, used
+/// only when `ordering` is [`FrontierOrdering::Incomparable`].
+pub fn allocate<S: Clone>(
+    selection: SelectionShape,
+    leading: S,
+    unresolved: &[S],
+    ordering: FrontierOrdering,
+) -> EvidenceAllocation<S> {
+    match (selection, ordering) {
+        (SelectionShape::Exhausted, _) => EvidenceAllocation::None,
+        // A sole candidate is selected because there is nothing to rank
+        // (Ruling 3). Ambiguity cannot arise with one member, whatever
+        // the caller claims about ordering.
+        (SelectionShape::Sole, _) => EvidenceAllocation::One(leading),
+        (SelectionShape::Ranked, FrontierOrdering::Resolved) => EvidenceAllocation::One(leading),
+        (SelectionShape::Ranked, FrontierOrdering::Incomparable) => {
+            if unresolved.len() <= 1 {
+                // Nothing to expand to. An "incomparable" claim over one
+                // member is a caller error, not a frontier.
+                EvidenceAllocation::One(leading)
+            } else {
+                EvidenceAllocation::Frontier(unresolved.to_vec())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "allocation_tests.rs"]
+mod allocation_tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/state/allocation_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/allocation_tests.rs
@@ -1,0 +1,207 @@
+//! R5-F11, ported from rung 5's N3 onto the canonical substrate.
+//!
+//! The N3 numbers are the fixture on purpose: an allocator that stops
+//! reproducing U1/U2's behaviour has changed meaning, whatever it says in
+//! the abstract.
+
+use super::super::search_policy::SelectionShape;
+use super::*;
+
+/// N3's two candidates. U2 better on kl (3.0700e-3 vs 3.1217e-3), U1
+/// better on route flip rate (0.19922 vs 0.20312). Both validly
+/// participate in both statistics — the conflict is REAL, unlike R4-F10's.
+const U1: &str = "U1";
+const U2: &str = "U2";
+
+fn ranked() -> SelectionShape {
+    SelectionShape::Ranked
+}
+
+// ---- the invariant ---------------------------------------------------
+
+#[test]
+fn incomparable_valid_evidence_expands_rather_than_choosing() {
+    let a = allocate(ranked(), U1, &[U1, U2], FrontierOrdering::Incomparable);
+    assert_eq!(a, EvidenceAllocation::Frontier(vec![U1, U2]));
+    assert!(a.is_expanded(), "the search could not legitimately choose");
+    assert_eq!(a.len(), 2);
+    assert_eq!(a.subjects(), &[U1, U2]);
+}
+
+#[test]
+fn resolved_evidence_takes_the_leader_and_does_not_expand() {
+    let a = allocate(ranked(), U2, &[U1, U2], FrontierOrdering::Resolved);
+    assert_eq!(a, EvidenceAllocation::One(U2));
+    assert!(!a.is_expanded());
+}
+
+#[test]
+fn a_sole_candidate_cannot_be_ambiguous_whatever_the_caller_claims() {
+    // Ruling 3: it is selected because there is nothing to rank. An
+    // "incomparable" claim over one member is a caller error.
+    assert_eq!(
+        allocate(
+            SelectionShape::Sole,
+            U1,
+            &[U1, U2],
+            FrontierOrdering::Incomparable
+        ),
+        EvidenceAllocation::One(U1)
+    );
+}
+
+#[test]
+fn an_incomparable_claim_over_one_member_is_not_a_frontier() {
+    let a = allocate(ranked(), U1, &[U1], FrontierOrdering::Incomparable);
+    assert_eq!(a, EvidenceAllocation::One(U1));
+    assert!(!a.is_expanded());
+}
+
+#[test]
+fn an_exhausted_selection_buys_nothing() {
+    let a: EvidenceAllocation<&str> = allocate(
+        SelectionShape::Exhausted,
+        U1,
+        &[U1, U2],
+        FrontierOrdering::Incomparable,
+    );
+    assert_eq!(a, EvidenceAllocation::None);
+    assert!(a.is_empty());
+    assert_eq!(a.len(), 0);
+    assert!(a.subjects().is_empty());
+}
+
+// ---- the R5-N3 witness, in full --------------------------------------
+
+#[test]
+fn r5_n3_the_frontier_survives_input_order_and_cannot_be_collapsed() {
+    // Forward and reverse must allocate the same SET — R4-F12 recurred
+    // once already while this substrate was being built, and it was a
+    // permutation test that normalised both sides which hid it. Compare
+    // the records the allocator produced.
+    let fwd = allocate(ranked(), U1, &[U1, U2], FrontierOrdering::Incomparable);
+    let rev = allocate(ranked(), U2, &[U2, U1], FrontierOrdering::Incomparable);
+    assert!(fwd.is_expanded() && rev.is_expanded());
+    let (mut a, mut b) = (fwd.subjects().to_vec(), rev.subjects().to_vec());
+    a.sort_unstable();
+    b.sort_unstable();
+    assert_eq!(
+        a, b,
+        "the same two members, whichever order they arrived in"
+    );
+
+    // And the leader argument — which differs between the two calls — must
+    // not appear as a winner anywhere in an expanded allocation.
+    assert_eq!(fwd.len(), 2);
+    assert_eq!(rev.len(), 2);
+}
+
+#[test]
+fn physical_gain_cannot_collapse_an_incomparable_frontier() {
+    // U1 saved 431,777,920 bytes against U2's 429,686,784 — MORE — and
+    // the round still refuses to choose. R4-F6: gain separates only what
+    // the proxies call EQUAL; it may never buy past a conflict.
+    let a = allocate(ranked(), U1, &[U1, U2], FrontierOrdering::Incomparable);
+    assert!(a.is_expanded(), "a 2,091,136-byte lead is not an ordering");
+}
+
+// ---- allocation is not authority -------------------------------------
+
+#[test]
+fn the_scale_is_the_policys_and_is_not_baked_into_the_allocation() {
+    // The historical ruling read "ambiguous -> measure all at authority".
+    // N3 needed authority because that was ITS next registered scale.
+    let diag = AllocationPolicy::at(EvidenceScale::Diagnostic);
+    let auth = AllocationPolicy::at(EvidenceScale::Authority);
+    assert_ne!(diag, auth);
+    assert_eq!(diag.next_scale, EvidenceScale::Diagnostic);
+    assert!(diag.max_experiments.is_none());
+
+    // The same allocation is purchasable at either scale.
+    let a = allocate(ranked(), U1, &[U1, U2], FrontierOrdering::Incomparable);
+    assert!(diag.admits(a.clone()).is_ok());
+    assert!(auth.admits(a).is_ok());
+}
+
+#[test]
+fn a_budget_refuses_a_round_it_cannot_buy_and_never_trims_it() {
+    // Trimming is choosing, and choosing is what the frontier says cannot
+    // be done. There is no third answer.
+    let policy = AllocationPolicy::at(EvidenceScale::Authority).with_budget(1);
+    let a = allocate(ranked(), U1, &[U1, U2], FrontierOrdering::Incomparable);
+    match policy.admits(a) {
+        Err(BudgetRefusal {
+            required,
+            budget,
+            scale,
+        }) => {
+            assert_eq!(required, 2);
+            assert_eq!(budget, 1);
+            assert_eq!(scale, EvidenceScale::Authority);
+        }
+        Ok(other) => panic!("a budget must refuse, never shorten: {:?}", other.len()),
+    }
+}
+
+#[test]
+fn an_underfunded_policy_refuses_the_whole_frontier_rather_than_buying_a_subset() {
+    // The invariant most likely to be broken by a future "helpful"
+    // optimisation, and the one that matters most when authority runs are
+    // expensive. An agent may say "budget permits one run but the
+    // unresolved allocation requires two". The optimizer's answer is
+    // INSUFFICIENT EVIDENCE BUDGET — never "I will measure the one I
+    // think is better", because that is a resource decision masquerading
+    // as behavioural evidence.
+    let frontier = allocate(ranked(), U1, &[U1, U2], FrontierOrdering::Incomparable);
+    let members = frontier.len();
+
+    for budget in 1..members {
+        let policy = AllocationPolicy::at(EvidenceScale::Authority).with_budget(budget);
+        match policy.admits(frontier.clone()) {
+            Err(refusal) => {
+                assert_eq!(refusal.required, members);
+                assert_eq!(refusal.budget, budget);
+            }
+            Ok(bought) => panic!(
+                "budget {budget} bought {} of {members} — a PROPER SUBSET of an \
+                 incomparable frontier is a choice the evidence did not support",
+                bought.len()
+            ),
+        }
+    }
+
+    // And it is the WHOLE frontier or nothing: a sufficient budget buys
+    // every member, never a truncation that happens to fit.
+    let enough = AllocationPolicy::at(EvidenceScale::Authority).with_budget(members);
+    assert_eq!(enough.admits(frontier.clone()).unwrap().len(), members);
+}
+
+#[test]
+fn a_budget_that_fits_passes_the_allocation_through_unchanged() {
+    let policy = AllocationPolicy::at(EvidenceScale::Authority).with_budget(2);
+    let a = allocate(ranked(), U1, &[U1, U2], FrontierOrdering::Incomparable);
+    assert_eq!(policy.admits(a.clone()).unwrap(), a);
+}
+
+#[test]
+fn a_one_experiment_round_fits_a_one_experiment_budget() {
+    let policy = AllocationPolicy::at(EvidenceScale::Diagnostic).with_budget(1);
+    let a = allocate(ranked(), U2, &[U1, U2], FrontierOrdering::Resolved);
+    assert!(policy.admits(a).is_ok());
+}
+
+#[test]
+fn allocations_round_trip_through_serde() {
+    for a in [
+        EvidenceAllocation::<&str>::None,
+        EvidenceAllocation::One(U1),
+        EvidenceAllocation::Frontier(vec![U1, U2]),
+    ] {
+        let back: EvidenceAllocation<String> =
+            serde_json::from_str(&serde_json::to_string(&a).unwrap()).unwrap();
+        assert_eq!(back.len(), a.len());
+    }
+    let p = AllocationPolicy::at(EvidenceScale::Authority).with_budget(3);
+    let back: AllocationPolicy = serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
+    assert_eq!(p, back);
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/authority.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/authority.rs
@@ -1,0 +1,295 @@
+//! **Admission and robustness are two independent state machines.**
+//!
+//! Rung 5's T1 candidate failed its selection bank at `kl_p99 3.6480e-3`
+//! against a `3.5e-3` threshold. That settled ADMISSION permanently. It
+//! did not settle whether the refusal was DECISIVE: the margin was
+//! `-1.4797e-4` against a measured cross-bank disagreement guard of
+//! `1.7494e-4`, so one bank could not classify itself.
+//!
+//! The held-out bank returned `3.7821e-3` — a determinate refusal at
+//! `-1.61` bands — and the two banks agreed to within `1.3408e-4`, inside
+//! the guard. **T1 looked boundary-adjacent and was not.** The selection
+//! bank was simply the more favourable slice (R5-F10).
+//!
+//! ```text
+//! ADMISSION                      ROBUSTNESS
+//! any measured bank FAILS        the WORST bank's position relative to
+//!   -> Refused, FINAL              the guard, and whether banks AGREE
+//! a held-out PASS cannot         classifies DECISIVENESS, never
+//!   resurrect it                   admissibility
+//! ```
+//!
+//! > Stop on selection FAIL for ADMISSION. Continue within the guard when
+//! > replication is required to classify DECISIVENESS.
+//!
+//! # Why they must not be one value
+//!
+//! Collapsing them invites an unregistered escalation contract — bank 3
+//! passes narrowly, so bank 4? majority? worst-of-three? — invented after
+//! a result exists. K25 was admitted on a contract it satisfied (both
+//! banks, no failures) while sitting `+0.08` bands inside the threshold.
+//! Its admission is not in doubt; its robustness is BoundaryAdjacent. Two
+//! facts, two fields.
+//!
+//! # What a search may do with each
+//!
+//! A tree search may treat [`Robustness`] as exploration priority — a
+//! single-bank near-boundary reading is low-confidence. It may NOT treat
+//! it as a probability of PASS: R5-F10 showed the SIGN of the resolution
+//! is not predictable from the first bank. K25 resolved upward to a
+//! replicated pass; T1 resolved downward to a determinate refusal, from
+//! the same `INDETERMINATE` starting classification.
+//!
+//! [`AuthorityState`] is the contract. Nothing in a search policy may
+//! write to it.
+//!
+//! # Why this lives in `state/` and stays TWO enums
+//!
+//! The rest of the search substrate is here, so a contract standing that
+//! lived in `represent/` would be a second place to ask what a state's
+//! status is. But being given somewhere convenient to put them is not a
+//! reason to merge them into one richer status enum: admission is a
+//! CONTRACT and robustness is a property of the EVIDENCE, and a single
+//! value would let a search policy's confidence and a gate's verdict be
+//! read off each other. They are computed from the same bank outcomes by
+//! two functions that do not consult one another.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// One bank's verdict on one map.
+///
+/// `passed_contract` is the gate's own answer, not a comparison this
+/// module performs: a contract may fail a map on a statistic that is not
+/// `binding_value` at all, and re-deriving it here would silently narrow
+/// the contract to one dimension.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BankOutcome {
+    /// Which evidence bank produced this.
+    pub bank: String,
+    /// The contract's verdict, as the gate reported it.
+    pub passed_contract: bool,
+    /// The binding statistic's value, for band classification.
+    pub binding_value: f64,
+}
+
+impl BankOutcome {
+    /// Record one bank's verdict.
+    pub fn new(bank: impl Into<String>, passed_contract: bool, binding_value: f64) -> Self {
+        Self {
+            bank: bank.into(),
+            passed_contract,
+            binding_value,
+        }
+    }
+}
+
+/// The measured cross-bank disagreement guard.
+///
+/// Not an invented safety factor: it is the maximum selection-versus-
+/// held-out disagreement this programme has observed on the SAME map.
+/// A margin inside it is a slice difference, not a signal.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct DisagreementGuard {
+    /// Threshold the binding statistic is judged against.
+    pub threshold: f64,
+    /// Half-width of the guard, in the statistic's own units.
+    pub band: f64,
+}
+
+impl DisagreementGuard {
+    /// Build a guard. `band` must be positive and finite, or the
+    /// classification below is meaningless.
+    pub fn new(threshold: f64, band: f64) -> Option<Self> {
+        (band > 0.0 && band.is_finite() && threshold.is_finite())
+            .then_some(Self { threshold, band })
+    }
+
+    /// Where one reading sits relative to the guard.
+    pub fn position(&self, value: f64) -> BandPosition {
+        let margin = self.threshold - value;
+        if margin > self.band {
+            BandPosition::ClearOfThreshold
+        } else if margin < -self.band {
+            BandPosition::BeyondThreshold
+        } else {
+            BandPosition::Indeterminate
+        }
+    }
+
+    /// Margin in bands: positive is inside the threshold.
+    pub fn bands(&self, value: f64) -> f64 {
+        (self.threshold - value) / self.band
+    }
+}
+
+/// One reading's position relative to the guard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BandPosition {
+    /// Inside the threshold by more than one band.
+    ClearOfThreshold,
+    /// Within one band of the threshold, either side. One bank cannot
+    /// classify itself here.
+    Indeterminate,
+    /// Outside the threshold by more than one band.
+    BeyondThreshold,
+}
+
+/// **The contract.** What a map is permitted to be.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AuthorityState {
+    /// Every required bank returned a passing contract verdict.
+    Admitted,
+    /// A measured bank failed the contract. Final — a later passing bank
+    /// cannot resurrect it.
+    Refused,
+    /// Passing so far, but fewer banks than the contract requires.
+    Pending,
+}
+
+impl fmt::Display for AuthorityState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Admitted => "Admitted",
+            Self::Refused => "Refused",
+            Self::Pending => "Pending",
+        })
+    }
+}
+
+impl AuthorityState {
+    /// Derive admission from bank verdicts alone.
+    ///
+    /// `banks_required` is stated by the caller because it is a property
+    /// of the contract, not of this code — reading it from the number of
+    /// banks that happen to have run is how an unregistered escalation
+    /// contract gets invented.
+    pub fn of(outcomes: &[BankOutcome], banks_required: usize) -> Self {
+        if outcomes.iter().any(|o| !o.passed_contract) {
+            return Self::Refused;
+        }
+        if outcomes.len() >= banks_required && !outcomes.is_empty() {
+            Self::Admitted
+        } else {
+            Self::Pending
+        }
+    }
+
+    /// Whether this state can still change with more evidence.
+    ///
+    /// `Refused` cannot: that is the asymmetry.
+    pub fn is_final(&self) -> bool {
+        matches!(self, Self::Admitted | Self::Refused)
+    }
+}
+
+/// **Search policy only.** How decisive the evidence is.
+///
+/// Never consulted by the contract, and never writable from one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Robustness {
+    /// One bank only. Cannot classify decisiveness at all.
+    Unreplicated,
+    /// Replicated pass, worst bank clear of the threshold.
+    ReplicatedInterior,
+    /// Replicated, but the worst bank sits inside the guard. K25's state.
+    BoundaryAdjacent,
+    /// Replicated refusal, worst bank determinate. T1's state.
+    ReplicatedRefusal,
+    /// Banks fall on opposite sides of the threshold.
+    CrossBankDisagreement,
+}
+
+impl fmt::Display for Robustness {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Unreplicated => "Unreplicated",
+            Self::ReplicatedInterior => "ReplicatedInterior",
+            Self::BoundaryAdjacent => "BoundaryAdjacent",
+            Self::ReplicatedRefusal => "ReplicatedRefusal",
+            Self::CrossBankDisagreement => "CrossBankDisagreement",
+        })
+    }
+}
+
+impl Robustness {
+    /// Classify decisiveness from the readings and the guard.
+    ///
+    /// Disagreement is judged on the CONTRACT VERDICTS, not on the
+    /// binding value straddling the threshold: a map can fail a contract
+    /// on a statistic this guard does not describe, and calling that
+    /// agreement because two kl values sit on one side would report a
+    /// stability the evidence does not have.
+    pub fn of(outcomes: &[BankOutcome], guard: DisagreementGuard) -> Self {
+        if outcomes.len() < 2 {
+            return Self::Unreplicated;
+        }
+        let passed = outcomes.iter().filter(|o| o.passed_contract).count();
+        if passed != 0 && passed != outcomes.len() {
+            return Self::CrossBankDisagreement;
+        }
+        // All banks agree on the verdict. The WORST reading decides how
+        // decisively — worst meaning largest, since the guard is an upper
+        // threshold on a cost.
+        let worst = outcomes
+            .iter()
+            .map(|o| o.binding_value)
+            .fold(f64::NEG_INFINITY, f64::max);
+        match (passed == outcomes.len(), guard.position(worst)) {
+            (true, BandPosition::ClearOfThreshold) => Self::ReplicatedInterior,
+            (true, _) => Self::BoundaryAdjacent,
+            (false, BandPosition::BeyondThreshold) => Self::ReplicatedRefusal,
+            (false, _) => Self::BoundaryAdjacent,
+        }
+    }
+
+    /// Whether a search should treat this map's position as low
+    /// confidence when ordering exploration.
+    ///
+    /// **Not a probability of PASS.** R5-F10: the sign of the resolution
+    /// is not predictable from the first bank.
+    pub fn is_low_confidence(&self) -> bool {
+        matches!(
+            self,
+            Self::Unreplicated | Self::BoundaryAdjacent | Self::CrossBankDisagreement
+        )
+    }
+}
+
+/// A map's complete authority record: the contract's answer and the
+/// evidence's decisiveness, side by side and never merged.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MapOutcome {
+    /// The contract's answer.
+    pub authority: AuthorityState,
+    /// How decisive the evidence is. Search policy only.
+    pub robustness: Robustness,
+    /// The bank verdicts this was derived from.
+    pub outcomes: Vec<BankOutcome>,
+}
+
+impl MapOutcome {
+    /// Derive both state machines from the same evidence, independently.
+    pub fn of(outcomes: Vec<BankOutcome>, guard: DisagreementGuard, banks_required: usize) -> Self {
+        Self {
+            authority: AuthorityState::of(&outcomes, banks_required),
+            robustness: Robustness::of(&outcomes, guard),
+            outcomes,
+        }
+    }
+
+    /// The worst binding value across banks, if any bank ran.
+    pub fn worst_binding(&self) -> Option<f64> {
+        self.outcomes
+            .iter()
+            .map(|o| o.binding_value)
+            .fold(None, |acc: Option<f64>, v| {
+                Some(acc.map_or(v, |a| a.max(v)))
+            })
+    }
+}
+
+#[cfg(test)]
+#[path = "authority_tests.rs"]
+mod authority_tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/state/authority_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/authority_tests.rs
@@ -1,0 +1,284 @@
+//! Ruling 2 and R5-F10, pinned to the measurements that produced them.
+//!
+//! Ported onto the canonical `state/` substrate when the duplicate
+//! map-search modules were retired; the implementation moved, the
+//! evidence did not.
+//!
+//! The rung-5 numbers are used as fixtures on purpose: a classifier that
+//! stops reproducing K25's and T1's recorded classifications has changed
+//! meaning, whatever its tests say in the abstract.
+
+use super::*;
+
+/// The guard rung 5 measured: threshold `kl_p99_max`, band from this
+/// programme's own selection-versus-held-out disagreement (N=3).
+fn guard() -> DisagreementGuard {
+    DisagreementGuard::new(3.5e-3, 1.7494e-4).expect("a positive finite band")
+}
+
+// ---- the guard --------------------------------------------------------
+
+#[test]
+fn a_band_must_be_positive_and_finite() {
+    assert!(DisagreementGuard::new(3.5e-3, 0.0).is_none());
+    assert!(DisagreementGuard::new(3.5e-3, -1.0).is_none());
+    assert!(DisagreementGuard::new(3.5e-3, f64::INFINITY).is_none());
+    assert!(DisagreementGuard::new(f64::NAN, 1.0).is_none());
+    assert!(DisagreementGuard::new(3.5e-3, 1.7494e-4).is_some());
+}
+
+#[test]
+fn band_positions_reproduce_the_recorded_classifications() {
+    let g = guard();
+    // K25 worst bank: admitted, but only +0.08 bands inside.
+    assert_eq!(g.position(3.485444e-3), BandPosition::Indeterminate);
+    // T1 selection: -0.85 bands, one bank cannot classify itself.
+    assert_eq!(g.position(3.6480e-3), BandPosition::Indeterminate);
+    // T1 held-out: -1.61 bands, determinate.
+    assert_eq!(g.position(3.7821e-3), BandPosition::BeyondThreshold);
+    // E26: +2.01 bands.
+    assert_eq!(g.position(3.148652e-3), BandPosition::ClearOfThreshold);
+    // U1: -4.69 bands, and S2 at -3.18.
+    assert_eq!(g.position(4.3197e-3), BandPosition::BeyondThreshold);
+    assert_eq!(g.position(4.0563e-3), BandPosition::BeyondThreshold);
+}
+
+#[test]
+fn bands_are_signed_with_positive_meaning_inside() {
+    let g = guard();
+    assert!((g.bands(3.485444e-3) - 0.0832).abs() < 5e-4, "K25 +0.08");
+    assert!(
+        (g.bands(3.6480e-3) + 0.8458).abs() < 5e-4,
+        "T1 selection -0.85"
+    );
+    assert!(
+        (g.bands(3.7821e-3) + 1.6124).abs() < 5e-4,
+        "T1 held-out -1.61"
+    );
+    assert!((g.bands(4.0563e-3) + 3.1801).abs() < 5e-4, "S2 -3.18");
+}
+
+// ---- admission is the contract, and a FAIL is final -------------------
+
+#[test]
+fn one_failing_bank_refuses_permanently() {
+    let sel = BankOutcome::new("selection", false, 3.6480e-3);
+    assert_eq!(
+        AuthorityState::of(std::slice::from_ref(&sel), 2),
+        AuthorityState::Refused
+    );
+
+    // A later PASSING bank cannot resurrect it. This is the asymmetry.
+    let held = BankOutcome::new("held-out", true, 3.1e-3);
+    assert_eq!(AuthorityState::of(&[sel, held], 2), AuthorityState::Refused);
+}
+
+#[test]
+fn passing_fewer_banks_than_required_is_pending_not_admitted() {
+    let sel = BankOutcome::new("selection", true, 3.3532e-3);
+    assert_eq!(
+        AuthorityState::of(std::slice::from_ref(&sel), 2),
+        AuthorityState::Pending
+    );
+    assert!(!AuthorityState::Pending.is_final());
+
+    let held = BankOutcome::new("held-out", true, 3.485444e-3);
+    assert_eq!(
+        AuthorityState::of(&[sel, held], 2),
+        AuthorityState::Admitted
+    );
+}
+
+#[test]
+fn no_evidence_is_pending_never_admitted() {
+    assert_eq!(AuthorityState::of(&[], 2), AuthorityState::Pending);
+    assert_eq!(AuthorityState::of(&[], 0), AuthorityState::Pending);
+}
+
+#[test]
+fn admitted_and_refused_are_final() {
+    assert!(AuthorityState::Admitted.is_final());
+    assert!(AuthorityState::Refused.is_final());
+    assert_eq!(AuthorityState::Admitted.to_string(), "Admitted");
+    assert_eq!(AuthorityState::Refused.to_string(), "Refused");
+    assert_eq!(AuthorityState::Pending.to_string(), "Pending");
+}
+
+// ---- robustness is decisiveness, and only that ------------------------
+
+#[test]
+fn one_bank_cannot_classify_decisiveness() {
+    let one = [BankOutcome::new("selection", false, 3.6480e-3)];
+    assert_eq!(Robustness::of(&one, guard()), Robustness::Unreplicated);
+    assert!(Robustness::Unreplicated.is_low_confidence());
+}
+
+#[test]
+fn k25_is_admitted_and_boundary_adjacent() {
+    let banks = [
+        BankOutcome::new("selection", true, 3.3532e-3),
+        BankOutcome::new("held-out", true, 3.485444e-3),
+    ];
+    assert_eq!(AuthorityState::of(&banks, 2), AuthorityState::Admitted);
+    assert_eq!(
+        Robustness::of(&banks, guard()),
+        Robustness::BoundaryAdjacent
+    );
+    assert!(Robustness::BoundaryAdjacent.is_low_confidence());
+}
+
+#[test]
+fn t1_is_refused_and_its_refusal_is_replicated() {
+    let banks = [
+        BankOutcome::new("selection", false, 3.6480e-3),
+        BankOutcome::new("held-out", false, 3.7821e-3),
+    ];
+    assert_eq!(AuthorityState::of(&banks, 2), AuthorityState::Refused);
+    assert_eq!(
+        Robustness::of(&banks, guard()),
+        Robustness::ReplicatedRefusal
+    );
+    assert!(!Robustness::ReplicatedRefusal.is_low_confidence());
+}
+
+#[test]
+fn r5_f10_the_same_starting_classification_resolves_both_ways() {
+    // K25 and T1 BOTH began INDETERMINATE on their first bank — K25 at
+    // +0.84 bands inside, T1 at -0.85 outside, and neither clears the
+    // guard. On bank one they are the same classification.
+    let g = guard();
+    assert_eq!(g.position(3.3532e-3), BandPosition::Indeterminate);
+    assert_eq!(g.position(3.6480e-3), BandPosition::Indeterminate);
+
+    // K25 resolved UP to a replicated pass; T1 resolved DOWN to a
+    // determinate refusal. The sign of the resolution is not predictable
+    // from the first bank, which is why this may never be a probability.
+    let k25 = [
+        BankOutcome::new("selection", true, 3.3532e-3),
+        BankOutcome::new("held-out", true, 3.485444e-3),
+    ];
+    let t1 = [
+        BankOutcome::new("selection", false, 3.6480e-3),
+        BankOutcome::new("held-out", false, 3.7821e-3),
+    ];
+    assert_eq!(Robustness::of(&k25, g), Robustness::BoundaryAdjacent);
+    assert_eq!(Robustness::of(&t1, g), Robustness::ReplicatedRefusal);
+}
+
+#[test]
+fn banks_disagreeing_on_the_verdict_is_its_own_state() {
+    let banks = [
+        BankOutcome::new("selection", true, 3.40e-3),
+        BankOutcome::new("held-out", false, 3.60e-3),
+    ];
+    assert_eq!(
+        Robustness::of(&banks, guard()),
+        Robustness::CrossBankDisagreement
+    );
+    assert!(Robustness::CrossBankDisagreement.is_low_confidence());
+    // And admission is still Refused: one bank failed the contract.
+    assert_eq!(AuthorityState::of(&banks, 2), AuthorityState::Refused);
+}
+
+#[test]
+fn disagreement_is_judged_on_verdicts_not_on_the_binding_value() {
+    // Both readings sit clear of the threshold on the binding statistic,
+    // but one bank FAILED the contract — on some other statistic. That is
+    // disagreement, and calling it agreement would report a stability the
+    // evidence does not have.
+    let banks = [
+        BankOutcome::new("selection", true, 3.0e-3),
+        BankOutcome::new("held-out", false, 3.0e-3),
+    ];
+    assert_eq!(
+        Robustness::of(&banks, guard()),
+        Robustness::CrossBankDisagreement
+    );
+}
+
+#[test]
+fn a_replicated_pass_clear_of_the_band_is_interior() {
+    let banks = [
+        BankOutcome::new("selection", true, 2.9737e-3),
+        BankOutcome::new("held-out", true, 3.148652e-3),
+    ];
+    assert_eq!(
+        Robustness::of(&banks, guard()),
+        Robustness::ReplicatedInterior
+    );
+    assert!(!Robustness::ReplicatedInterior.is_low_confidence());
+    assert_eq!(
+        Robustness::ReplicatedInterior.to_string(),
+        "ReplicatedInterior"
+    );
+}
+
+#[test]
+fn a_replicated_refusal_inside_the_band_is_boundary_adjacent_not_decisive() {
+    let banks = [
+        BankOutcome::new("selection", false, 3.55e-3),
+        BankOutcome::new("held-out", false, 3.56e-3),
+    ];
+    assert_eq!(
+        Robustness::of(&banks, guard()),
+        Robustness::BoundaryAdjacent
+    );
+}
+
+#[test]
+fn the_worst_bank_decides_not_the_first_or_the_mean() {
+    // Order must not matter, and a favourable first bank must not carry.
+    let a = [
+        BankOutcome::new("selection", false, 3.6480e-3),
+        BankOutcome::new("held-out", false, 3.7821e-3),
+    ];
+    let b = [
+        BankOutcome::new("held-out", false, 3.7821e-3),
+        BankOutcome::new("selection", false, 3.6480e-3),
+    ];
+    assert_eq!(Robustness::of(&a, guard()), Robustness::of(&b, guard()));
+}
+
+// ---- the two machines, side by side and never merged ------------------
+
+#[test]
+fn map_outcome_derives_both_independently() {
+    let t1 = MapOutcome::of(
+        vec![
+            BankOutcome::new("selection", false, 3.6480e-3),
+            BankOutcome::new("held-out", false, 3.7821e-3),
+        ],
+        guard(),
+        2,
+    );
+    assert_eq!(t1.authority, AuthorityState::Refused);
+    assert_eq!(t1.robustness, Robustness::ReplicatedRefusal);
+    assert_eq!(t1.worst_binding(), Some(3.7821e-3));
+    assert_eq!(
+        t1.outcomes.len(),
+        2,
+        "the evidence is kept, not just its verdict"
+    );
+}
+
+#[test]
+fn an_outcome_with_no_banks_has_no_worst_binding() {
+    let none = MapOutcome::of(vec![], guard(), 2);
+    assert_eq!(none.worst_binding(), None);
+    assert_eq!(none.authority, AuthorityState::Pending);
+    assert_eq!(none.robustness, Robustness::Unreplicated);
+}
+
+#[test]
+fn a_map_outcome_round_trips_through_serde() {
+    let m = MapOutcome::of(
+        vec![BankOutcome::new("selection", true, 3.3532e-3)],
+        guard(),
+        2,
+    );
+    let back: MapOutcome = serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
+    assert_eq!(m, back);
+    let g: DisagreementGuard =
+        serde_json::from_str(&serde_json::to_string(&guard()).unwrap()).unwrap();
+    assert_eq!(g, guard());
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/state/search_policy.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/search_policy.rs
@@ -61,6 +61,8 @@
 
 use std::collections::BTreeMap;
 
+use serde::{Deserialize, Serialize};
+
 use super::assess::{Assessment, ParentStanding, RankingSemantics};
 use super::candidate::CandidateSet;
 use super::identity::RepresentationStateId;
@@ -118,7 +120,32 @@ pub enum Selection {
     },
 }
 
+/// What a [`Selection`] IS, without its payload.
+///
+/// The allocation layer downstream decides what to buy from the SHAPE of
+/// a selection and never from the opportunity inside it. Naming that
+/// keeps `allocation` independent of how an opportunity is built, so it
+/// can be reasoned about — and tested — without resolving a state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SelectionShape {
+    /// Nothing eligible.
+    Exhausted,
+    /// Exactly one, so there is nothing to rank.
+    Sole,
+    /// More than one, ordered by the registered rule.
+    Ranked,
+}
+
 impl Selection {
+    /// This selection's shape, discarding the payload.
+    pub fn shape(&self) -> SelectionShape {
+        match self {
+            Self::Exhausted => SelectionShape::Exhausted,
+            Self::Sole(_) => SelectionShape::Sole,
+            Self::Ranked { .. } => SelectionShape::Ranked,
+        }
+    }
+
     pub fn opportunity(&self) -> Option<&MeasurementOpportunity> {
         match self {
             Self::Exhausted => None,


### PR DESCRIPTION
Two theses, kept as separate commits because they answer different
questions. Both sit on #409's canonical `represent/state/`.

## 7c17aae7 — admission, robustness and evidence allocation become state

Three semantics, each forced by a measured rung-5 finding rather than by
symmetry.

**`state/authority.rs`** — admission and robustness are two INDEPENDENT
state machines. A selection FAIL settles admission permanently; it does
not settle decisiveness. T1 read boundary-adjacent at -0.85 bands on one
bank and resolved to a determinate refusal at -1.61 on the second, while
K25 resolved the other way from the same INDETERMINATE start. So
robustness may inform exploration priority and may never be read as a
probability of PASS. They are not folded into one status enum despite
`state/` offering a convenient home: admission is a CONTRACT, robustness
is a property of the EVIDENCE, and one value would let a policy's
confidence and a gate's verdict be read off each other.

**`state/allocation.rs`** — R5-F11 had a home in neither `Selection` nor
`decide_promotion`. Selection orders experiments and always names one;
promotion owns admissibility ambiguity. Neither answers what to buy when
the ordering evidence cannot legitimately collapse the frontier.

```text
search        may propose
selection     may preserve ambiguity
allocation    may expand measurement
budget        may refuse expenditure
measurement   observes
authority     decides contract truth
robustness    characterises evidence
promotion     changes parent
```

> A resource decision may restrict WHETHER evidence is purchased; it may
> never change WHAT THE EVIDENCE SAYS.

`AllocationPolicy::admits` therefore refuses a round it cannot buy and
never trims it — trimming is choosing, and choosing is what the frontier
says cannot be done. The witness sweeps every under-budget value, so the
invariant is a property rather than an example: there is no representable
middle state where resource pressure becomes a ranking function.

Scale is deliberately not baked in. The historical ruling read
"ambiguous -> measure all at authority"; N3 needed authority because that
was ITS next registered scale. A later ladder may resolve a 256-position
ambiguity on a 2,048-position bank first.

### This replaces a parallel substrate, and the migration witness is behavioural

An earlier version of this branch carried its own `map_identity`,
`map_graph` and `frontier`. #409 covers each better — `PreMeasurementPrune`'s
fourth variant is "absent by construction rather than present-and-unused",
`tie_break_chain()` is five levels deep against three, and it separates
`RealizationId` from `RepresentationStateId`. Retiring the duplicate also
caught a divergence two green suites could not: the retired
`MeasurementKey` needed `Ord` on `EvidenceScale`, which #409 declines by
design, ordering its key by digest so the scale need not "grow an ordering
it has no meaning for".

The witness that the swap was safe is not textual. Five BF16->Q8 KDA
probes on Kimi-Linear-48B were re-measured after the substrate changed
beneath them, and every bank was **deep-equal** — same maps, same bank,
bit-identical observations.

## c99daffb — K3 physical opportunity comes from execution touch

The k3-ledger priced K3 as though REPRESENT had already succeeded on the
whole dense side, and two modelling errors partly cancelled so the
aggregate looked believable.

**K3-LEDGER-1b** — `dense_all_in_bits` was a hardcoded 4.25 with no flag
to ask for the truth. `DensePricing::{AsStored, Hypothetical}` makes a
hypothetical a different VARIANT rather than a different number;
`AsStored` resolves against the checkpoint's own `dtype`.

```text
dense 4.25 bpw    29.86 GB/token   what was printed
dense BF16       112.42 GB/token   what K3 actually stores
```

**K3-LEDGER-2** — physical existence is not execution touch. `AccessMode`
separates FullRead from Gather and Routed; `LayerTopology` makes layer 0
structurally dense. `lm_head` and `embed_tokens` are byte-identical
`[163840,7168]` tensors, untied, and only the head is a full read — one
moves 2.35 GB per token, the other 14,336 bytes.

The correction lands on an external check the old model failed. A test
comment read *"Published ~104.2B; measured 104.83B, agreeing to 0.6%"* —
that 0.6% gap WAS the error. Corrected: **104.2007 B** activated params.

**Homogeneity witnessed, not assumed.** `k3-ledger homogeneity` reads all
93 layer headers and checks role SET and bytes PER ROLE — equal totals
with different roles must not pass. All four families homogeneous, so the
census's x69/x24/x92 are facts.

**K3-ACTIONS-1** — the weight-free action catalogue, with `ActionScope`
distinguishing a ceiling from a candidate:

```text
KDA -> Q8   family ceiling  28.71 GB/token   69 admissions
KDA -> Q8   atomic layer     0.42 GB/token   one authority run
```

Machine-readable, so a beam policy or an agent cannot read the family
figure as one decision with one verdict. `ExecutionRole` keeps
representation and execution position apart: the LatentMoE wrapper and
router are dense BF16 by representation and routed-path by function.

The result that reorders the programme: **the conservative KDA action —
Q8, one family — removes 28.71 GB/token, more than the entire routed
expert traffic of 25.83 GB.**

Every figure is measured from safetensors headers over HTTP range
requests. No weights read, no behavioural claim made.

## Gates

```text
larql-vindex   fmt clean   clippy --all-targets --features gpu -D warnings clean   3852 pass
larql-cli      fmt clean   clippy --all-targets -D warnings clean                   873 pass
```
