### PR TITLE
REPRESENT codec contract: the representation/execution trait, extracted from the five stored encodings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,7 @@ Or via the Makefile: `make python-setup | python-build | python-test | python-cl
 - LQL language spec: [crates/larql-lql/docs/spec.md](crates/larql-lql/docs/spec.md) (v0.4)
 - Vindex file format: [crates/larql-vindex/docs/format-spec.md](crates/larql-vindex/docs/format-spec.md) (VINDEX2); VINDEX3: [crates/larql-vindex/docs/vindex3-format-spec.md](crates/larql-vindex/docs/vindex3-format-spec.md) (container ABI) + [docs/vindex3-format.md](docs/vindex3-format.md) (model-system spec) + [docs/vindex3-runtime.md](docs/vindex3-runtime.md) (runtime/serving)
 - Operations + patches: [crates/larql-vindex/docs/operations-spec.md](crates/larql-vindex/docs/operations-spec.md)
+- Representation/execution contract (`RepresentationCodec`, the codec registry, the four-proofs programme): [docs/represent-codec-contract.md](docs/represent-codec-contract.md)
 - Ecosystem (HF publish, Vindexfile): [crates/larql-vindex/docs/ecosystem-spec.md](crates/larql-vindex/docs/ecosystem-spec.md)
 - Inference engine internals: [docs/inference-engine.md](docs/inference-engine.md), [docs/ffn-graph-layer.md](docs/ffn-graph-layer.md)
 - Trace format (.bin/.bndx/.ctxt): [crates/larql-inference/docs/trace-format.md](crates/larql-inference/docs/trace-format.md), [docs/residual-trace.md](docs/residual-trace.md)

--- a/crates/larql-vindex/src/format/vindex3/graph/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/graph/build.rs
@@ -918,9 +918,9 @@ fn carve_expert_banks(
 /// packed e2m1 nibbles and the e8m0 scales, both stored as `U8`.
 const MXFP4_BLOCKS_SUFFIX: &str = "_blocks";
 const MXFP4_SCALES_SUFFIX: &str = "_scales";
-/// The encoding name a declared MXFP4 tensor is placed under, in the same
-/// vocabulary as the region formats a container writes.
-const MXFP4_ENCODING: &str = "MXFP4";
+/// The encoding name a declared MXFP4 tensor is placed under — the
+/// codec's own label, so the graph and the registry cannot spell it apart.
+const MXFP4_ENCODING: &str = crate::format::vindex3::represent::codec::codecs::mxfp4::DTYPE_MXFP4;
 
 /// The encoding one tensor is placed under: its shard dtype, unless the
 /// checkpoint's declared stored representation says those bytes are

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
@@ -380,6 +380,11 @@ impl RoutedOperands {
         };
         let hidden = op.router.shape.get(1).copied().unwrap_or(0);
         let inter = op.expert_intermediate_size;
+        // The bank first: its geometry is DECLARED — `k` follows from the
+        // router's declared width — and a stray width refuses on the
+        // declaration, before any operand's bytes are read.
+        let gate_up_bank = load_packed(store, gate_up, op, FUSED_BRANCHES * inter, hidden, format)?;
+        let down_bank = load_packed(store, down, op, hidden, inter, format)?;
         Ok(Self {
             router: store.load(&op.router)?,
             router_bias: op.router_bias.as_ref().map(|b| store.load(b)).transpose()?,
@@ -394,9 +399,9 @@ impl RoutedOperands {
                 .map(|s| store.load(s))
                 .transpose()?,
             router_norm_eps: op.router_norm_eps,
-            gate_up: load_packed(store, gate_up, op, FUSED_BRANCHES * inter, hidden, format)?,
+            gate_up: gate_up_bank,
             gate_up_bias: gate_up.bias.as_ref().map(|b| store.load(b)).transpose()?,
-            down: load_packed(store, down, op, hidden, inter, format)?,
+            down: down_bank,
             down_bias: down.bias.as_ref().map(|b| store.load(b)).transpose()?,
         })
     }
@@ -413,6 +418,13 @@ fn load_packed(
     format: WeightFormat,
 ) -> Result<Vec<LoadedWeight>, VindexError> {
     let name = projection.weights.tensor.as_str();
+    // Declared geometry before bytes: a `k` the group cannot tile is a
+    // fact about the op, and refusing it costs no read.
+    if op.expert_format == ExpertFormat::PackedMxfp4 && !k.is_multiple_of(MXFP4_GROUP_ELEMS) {
+        return Err(VindexError::Parse(format!(
+            "`{name}`: k={k} is not a multiple of the MXFP4 group"
+        )));
+    }
     let raw = store.load_raw(&projection.weights)?;
     match op.expert_format {
         ExpertFormat::PackedMxfp4 => {
@@ -424,11 +436,6 @@ fn load_packed(
             let scales = store.load_raw(scales_ref)?;
             expect_dtype(&raw.dtype, DTYPE_U8, name)?;
             expect_dtype(&scales.dtype, DTYPE_U8, &scales_ref.tensor)?;
-            if !k.is_multiple_of(MXFP4_GROUP_ELEMS) {
-                return Err(VindexError::Parse(format!(
-                    "`{name}`: k={k} is not a multiple of the MXFP4 group"
-                )));
-            }
             let groups = k / MXFP4_GROUP_ELEMS;
             let block_stride = rows * groups * MXFP4_GROUP_BYTES;
             let scale_stride = rows * groups;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
@@ -375,44 +375,30 @@ impl OperandStore {
         Ok(())
     }
 
-    /// Load one operand as f32 values.
+    /// Load one operand as f32 values — the mandatory decode realization
+    /// of whichever codec the stored dtype names.
     ///
-    /// A compiled NVFP4 pack decodes here rather than in [`widen`],
-    /// because decoding it needs the operand's SHAPE — the group stream
-    /// is indexed per row — and `widen` sees only bytes and a dtype
-    /// label. Consumers that want the compact form for a kernel take
-    /// [`Self::load_raw`]; this is for the ones that need values, which
-    /// on a recurrence is most of them.
+    /// One dispatch, through the codec registry, for every encoding a
+    /// segment can hold: a float widens, a K-quant or an NVFP4 pack
+    /// decodes through its own layout, and a dtype no codec is registered
+    /// for is refused naming the ones that are. Consumers that want the
+    /// compact form for a kernel take [`Self::load_raw`]; this is for the
+    /// ones that need values, which on a recurrence is most of them.
     ///
-    /// The decode is lossy in exactly the way the pack is: these are the
-    /// 4-bit values, widened, not the checkpoint's originals. That is
-    /// the point — it is what makes an NVFP4 representation measurable
-    /// on a stack the device cannot run.
+    /// The decode is lossy in exactly the way the representation is:
+    /// a pack's 4-bit values widened, not the checkpoint's originals.
+    /// That is the point — it is what makes a compact representation
+    /// measurable on a stack the device cannot run.
     pub fn load(&self, operand: &OperandRef) -> Result<Vec<f32>, VindexError> {
+        use crate::format::vindex3::represent::codec::{CodecRegistry, RepresentationExtent};
         let raw = self.load_raw(operand)?;
-        if raw.dtype == crate::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4 {
-            return decode_nvfp4_operand(&raw.bytes, &operand.shape, &operand.tensor);
-        }
-        // A K-quant decodes here for the same reason NVFP4 does: the
-        // block count comes from the operand's SHAPE, and `widen` sees
-        // only bytes and a dtype label. It stays out of `widen` rather
-        // than growing a shape parameter there, so the one function that
-        // answers "what does this dtype mean as f32, from bytes alone"
-        // keeps meaning exactly that.
-        if let Some(k) = crate::format::vindex3::represent::kquant::lookup(&raw.dtype) {
-            let elements = operand
-                .shape
-                .iter()
-                .try_fold(1usize, |a, d| a.checked_mul(*d))
-                .ok_or_else(|| {
-                    VindexError::Parse(format!(
-                        "tensor `{}`: shape {:?} overflows an element count",
-                        operand.tensor, operand.shape
-                    ))
-                })?;
-            return k.decode(&raw.bytes, elements, &operand.tensor);
-        }
-        widen(&raw.dtype, &raw.bytes, &operand.tensor)
+        let codec = CodecRegistry::builtin().resolve(&raw.dtype, &operand.tensor)?;
+        Ok(codec.decode_packed(
+            &raw.bytes,
+            &operand.shape,
+            RepresentationExtent::TERMINAL,
+            &operand.tensor,
+        )?)
     }
 
     /// This store's process-unique identity.
@@ -505,27 +491,6 @@ impl OperandStore {
 pub struct RawOperand {
     pub dtype: String,
     pub bytes: Vec<u8>,
-}
-
-/// Decode a stored NVFP4 pack to f32, through the format's own layout
-/// and the reference decoder — no second opinion about the arithmetic.
-pub(crate) fn decode_nvfp4_operand(
-    bytes: &[u8],
-    shape: &[usize],
-    name: &str,
-) -> Result<Vec<f32>, VindexError> {
-    use crate::format::vindex3::represent::nvfp4_pack::{split, PackLayout};
-    let layout = PackLayout::derive(shape, name)?;
-    let (packed, scales, tensor_scale) = split(bytes, &layout, name)?;
-    let mut out = vec![0.0f32; layout.rows * layout.k];
-    let matrix = larql_models::quant::nvfp4::Nvfp4Matrix {
-        packed: packed.to_vec(),
-        scales: scales.to_vec(),
-        tensor_scale,
-    };
-    larql_models::quant::nvfp4::dequantize_into(&matrix, layout.rows, layout.k, &mut out)
-        .map_err(|e| VindexError::Parse(format!("tensor `{name}`: NVFP4 decode: {e}")))?;
-    Ok(out)
 }
 
 /// Widen stored bytes to f32 — judged dtypes only, fail-closed.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/nvfp4_decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/nvfp4_decode.rs
@@ -13,7 +13,8 @@
 //! plumbing, not the format's accuracy. What must be exact is the
 //! SHAPE: the same count of values, in the same order.
 
-use crate::format::vindex3::opplan::exec::operands::decode_nvfp4_operand;
+use crate::format::vindex3::represent::codec::codecs::nvfp4::NVFP4;
+use crate::format::vindex3::represent::codec::{RepresentationCodec, RepresentationExtent};
 use crate::format::vindex3::represent::nvfp4_pack::{encode, PackLayout};
 
 const ROWS: usize = 3;
@@ -46,7 +47,14 @@ fn a_pack_round_trips_through_its_own_layout() {
         "the framed pack is exactly the layout's size"
     );
 
-    let decoded = decode_nvfp4_operand(&stored, &shape, "round-trip").expect("decode");
+    let decoded = NVFP4
+        .decode_packed(
+            &stored,
+            &shape,
+            RepresentationExtent::TERMINAL,
+            "round-trip",
+        )
+        .expect("decode");
     assert_eq!(
         decoded.len(),
         original.len(),
@@ -93,7 +101,9 @@ fn a_truncated_pack_refuses_rather_than_decoding_what_is_there() {
 
     let short = &stored[..stored.len() - 1];
     assert!(
-        decode_nvfp4_operand(short, &shape, "truncated").is_err(),
+        NVFP4
+            .decode_packed(short, &shape, RepresentationExtent::TERMINAL, "truncated")
+            .is_err(),
         "one byte short is still short"
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
@@ -23,7 +23,10 @@ use super::quantise::{quantise_q4, quantise_q8, Q4_BLOCK, Q8_BLOCK};
 use crate::error::VindexError;
 use crate::format::vindex3::opplan::OperandRef;
 use crate::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4;
-use larql_models::quant::mxfp4::{e8m0_to_f32, MXFP4_TABLE};
+// MXFP4 group geometry — per row, `k/32` groups of 16 packed bytes (lo
+// nibble first) plus one e8m0 scale byte each — is the models crate's,
+// so the kernel's layout contract and the codec's have one definition.
+use larql_models::quant::mxfp4::{e8m0_to_f32, MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS, MXFP4_TABLE};
 
 /// Alignment (and length granularity) of f16 weight allocations:
 /// the Apple-GPU page size. A page-aligned, page-multiple allocation
@@ -497,11 +500,6 @@ fn widen_raw(raw: &super::operands::RawOperand, name: &str) -> Result<Vec<f32>, 
     super::operands::widen(&raw.dtype, &raw.bytes, name)
 }
 
-/// MXFP4 group geometry, matching the kernel's layout contract exactly:
-/// per row, `k/32` groups of 16 packed bytes (lo nibble first) plus one
-/// e8m0 scale byte each.
-const MXFP4_GROUP_ELEMS: usize = 32;
-const MXFP4_GROUP_BYTES: usize = 16;
 /// e2m1's largest magnitude; the shared exponent is chosen so the
 /// group's max maps at or below it, saturating the rare overshoot.
 const MXFP4_MAX_MAG: f32 = 6.0;

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/capability.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/capability.rs
@@ -1,0 +1,115 @@
+//! What a codec can be asked for, declared so the planner refuses by name.
+//!
+//! `row_random_access: bool` was the first cut and the property is not
+//! boolean: an entropy-coded stream is sequential, a K-quant is addressable
+//! at its 256-element block, a float is addressable anywhere. Walk FFN needs
+//! arbitrary rows and a stream-sequential codec cannot serve it — the
+//! preflight question is "does the representation provide what the plan
+//! requires", asked here, rather than a kernel discovering it.
+
+use super::error::CodecError;
+
+/// How finely stored bytes can be addressed without decoding what
+/// precedes them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessGranularity {
+    /// Only from the start: a decode window advances through the stream.
+    Sequential,
+    /// Any whole block of `elems` elements.
+    BlockRandom { elems: usize },
+    /// Any row, because rows are whole blocks by construction.
+    RowRandom,
+    /// Any element.
+    ElementRandom,
+}
+
+impl AccessGranularity {
+    /// Rank on the ladder; a finer granularity provides every coarser one.
+    const fn rank(self) -> u8 {
+        match self {
+            Self::Sequential => 0,
+            Self::BlockRandom { .. } => 1,
+            Self::RowRandom => 2,
+            Self::ElementRandom => 3,
+        }
+    }
+
+    pub fn name(self) -> String {
+        match self {
+            Self::Sequential => "sequential".into(),
+            Self::BlockRandom { elems } => format!("block-random ({elems} elements)"),
+            Self::RowRandom => "row-random".into(),
+            Self::ElementRandom => "element-random".into(),
+        }
+    }
+
+    /// Whether this granularity serves `required`.
+    ///
+    /// Block-random does not serve a row requirement on its own: whether a
+    /// row is a whole number of blocks is a fact about the tensor, and a
+    /// codec whose rows are block-aligned by construction declares
+    /// [`Self::RowRandom`] instead.
+    pub fn provides(self, required: RequiredAccess) -> bool {
+        self.rank() >= required.granularity().rank()
+    }
+}
+
+/// What an execution plan needs to address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequiredAccess {
+    /// The whole tensor, front to back.
+    Sequential,
+    /// Arbitrary rows — an expert slot, a Walk FFN feature.
+    RowRandom,
+    /// Arbitrary elements — a browse gather.
+    ElementRandom,
+}
+
+impl RequiredAccess {
+    const fn granularity(self) -> AccessGranularity {
+        match self {
+            Self::Sequential => AccessGranularity::Sequential,
+            Self::RowRandom => AccessGranularity::RowRandom,
+            Self::ElementRandom => AccessGranularity::ElementRandom,
+        }
+    }
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Sequential => "sequential",
+            Self::RowRandom => "row-random",
+            Self::ElementRandom => "element-random",
+        }
+    }
+}
+
+/// The access, grouping and alignment one codec declares.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CodecCapabilities {
+    pub access: AccessGranularity,
+    /// Elements sharing one scale — 1 where nothing is shared.
+    pub group_elems: usize,
+    /// `k` must be a whole number of these.
+    pub row_align_elems: usize,
+    /// Byte alignment the widest field in the stored bytes needs.
+    pub physical_align_bytes: usize,
+}
+
+impl CodecCapabilities {
+    /// Refuse, by name, a plan this representation cannot address.
+    pub fn require(&self, required: RequiredAccess, label: &str) -> Result<(), CodecError> {
+        if self.access.provides(required) {
+            return Ok(());
+        }
+        Err(CodecError::AccessRefused {
+            label: label.into(),
+            provided: self.access.name(),
+            required: required.name().into(),
+        })
+    }
+
+    /// Whether a row of `k` elements is addressable under this codec.
+    pub fn admits_k(&self, k: usize) -> bool {
+        self.row_align_elems > 0 && k.is_multiple_of(self.row_align_elems)
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/float.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/float.rs
@@ -1,0 +1,196 @@
+//! Float tensor tables — the boring baseline, and the proof that the
+//! contract costs a flat codec nothing.
+
+use std::ops::Range;
+
+use super::super::capability::{AccessGranularity, CodecCapabilities};
+use super::super::error::CodecError;
+use super::super::extent::{ExtentCertificate, RepresentationExtent, BITS_PER_BYTE};
+use super::super::geometry::RowGeometry;
+use super::super::residency::{Acceleration, ResidencyProfile};
+use super::super::streams::{CodecOperands, StreamSpec, VALUES};
+use super::super::RepresentationCodec;
+use super::vocabulary::{SCALE_NONE, UNGROUPED};
+use crate::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
+use crate::format::vindex3::opplan::exec::operands::widen;
+use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
+
+/// ABI revision of the float row layouts. Little-endian rows of one
+/// fixed-width element have not changed and will not.
+pub const FLOAT_REVISION: u32 = 1;
+
+/// Region order of a float tensor: one row-major, little-endian stream.
+const LAYOUT_ROW_MAJOR_LE: &str = "row-major-le";
+
+const FLOAT_STREAMS: [StreamSpec; 1] = [VALUES];
+
+/// The three float element types a segment stores.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloatDtype {
+    Bf16,
+    F16,
+    F32,
+}
+
+impl FloatDtype {
+    /// The segment `dtype` label.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Bf16 => "BF16",
+            Self::F16 => "F16",
+            Self::F32 => "F32",
+        }
+    }
+
+    pub const fn width_bytes(self) -> usize {
+        match self {
+            Self::Bf16 | Self::F16 => std::mem::size_of::<u16>(),
+            Self::F32 => std::mem::size_of::<f32>(),
+        }
+    }
+
+    /// The element grid, as the ABI identity names it.
+    const fn element(self) -> &'static str {
+        match self {
+            Self::Bf16 => "bf16",
+            Self::F16 => "ieee-f16",
+            Self::F32 => "ieee-f32",
+        }
+    }
+}
+
+/// A float tensor table: rows of one fixed-width element.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FloatCodec {
+    dtype: FloatDtype,
+}
+
+pub const BF16: FloatCodec = FloatCodec {
+    dtype: FloatDtype::Bf16,
+};
+pub const F16: FloatCodec = FloatCodec {
+    dtype: FloatDtype::F16,
+};
+pub const F32: FloatCodec = FloatCodec {
+    dtype: FloatDtype::F32,
+};
+
+impl FloatCodec {
+    pub const fn dtype(&self) -> FloatDtype {
+        self.dtype
+    }
+
+    fn bits_per_weight(&self) -> f64 {
+        self.dtype.width_bytes() as f64 * BITS_PER_BYTE
+    }
+
+    fn row_bytes(&self, k: usize) -> usize {
+        k * self.dtype.width_bytes()
+    }
+}
+
+impl RepresentationCodec for FloatCodec {
+    fn encoding_label(&self) -> &'static str {
+        self.dtype.label()
+    }
+
+    fn identity(&self) -> CodecIdentity {
+        CodecIdentity {
+            family: self.dtype.label().into(),
+            revision: FLOAT_REVISION,
+            group_elems: UNGROUPED,
+            element: self.dtype.element().into(),
+            group_scale: SCALE_NONE.into(),
+            tensor_scale: SCALE_NONE.into(),
+            layout: LAYOUT_ROW_MAJOR_LE.into(),
+        }
+    }
+
+    fn streams(&self) -> &'static [StreamSpec] {
+        &FLOAT_STREAMS
+    }
+
+    fn capabilities(&self) -> CodecCapabilities {
+        CodecCapabilities {
+            access: AccessGranularity::ElementRandom,
+            group_elems: UNGROUPED,
+            row_align_elems: UNGROUPED,
+            physical_align_bytes: self.dtype.width_bytes(),
+        }
+    }
+
+    fn extents(&self) -> Vec<ExtentCertificate> {
+        vec![ExtentCertificate::terminal(self.bits_per_weight())]
+    }
+
+    fn stored_bytes(
+        &self,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<u64, CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let label = self.encoding_label();
+        let elements = RowGeometry::of(shape, label, tensor)?.elements(label, tensor)?;
+        Ok((elements * self.dtype.width_bytes()) as u64)
+    }
+
+    fn validate(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        let need = self.stored_bytes(shape, extent, tensor)? as usize;
+        operands.stream_of_len(VALUES, need, self.encoding_label(), tensor)?;
+        Ok(())
+    }
+
+    fn decode_rows(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        rows: Range<usize>,
+        extent: RepresentationExtent,
+        dst: &mut [f32],
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let label = self.encoding_label();
+        let geometry = RowGeometry::of(shape, label, tensor)?;
+        geometry.check_rows(&rows, label, tensor)?;
+        geometry.check_destination(&rows, dst.len(), tensor)?;
+        let row_bytes = self.row_bytes(geometry.k);
+        let bytes = operands.stream_of_len(VALUES, rows.end * row_bytes, label, tensor)?;
+        let span = &bytes[rows.start * row_bytes..rows.end * row_bytes];
+        let values = widen(label, span, tensor).map_err(|e| CodecError::Decode {
+            tensor: tensor.into(),
+            label: label.into(),
+            detail: e.to_string(),
+        })?;
+        dst.copy_from_slice(&values);
+        Ok(())
+    }
+
+    fn decode_residency(&self) -> ResidencyProfile {
+        ResidencyProfile::DECODED_F32
+    }
+
+    fn accelerations(&self) -> Vec<Acceleration> {
+        let stored = ResidencyProfile::stored(self.bits_per_weight());
+        match self.dtype {
+            FloatDtype::Bf16 => vec![
+                Acceleration::cpu(PhysicalProjectionPlan::FusedBf16, stored),
+                Acceleration::cpu(PhysicalProjectionPlan::Bf16xQ8, stored),
+            ],
+            FloatDtype::F32 => vec![
+                Acceleration::cpu(PhysicalProjectionPlan::BlasF32, stored),
+                Acceleration::cpu(PhysicalProjectionPlan::ScalarF32, stored),
+            ],
+            // A device residency format: the CPU executor has no f16
+            // kernel, and says so rather than widening in silence.
+            FloatDtype::F16 => Vec::new(),
+        }
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/kquant.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/kquant.rs
@@ -1,0 +1,138 @@
+//! The ggml K-quants and Q8_0: blocked codes with their scales inline.
+//!
+//! One stream, because the scales ride inside the blocks; row-random,
+//! because the container refuses a row that is not a whole number of
+//! blocks, so every row starts on one. No direct realization on this
+//! executor: the V3 CPU plan set has no K-quant kernel, and the trait
+//! says so instead of routing through a decode nobody declared. The
+//! grouped Metal kernels that serve K-quant expert banks are a device
+//! realization, declared by the crate that owns them.
+
+use std::ops::Range;
+
+use super::super::capability::{AccessGranularity, CodecCapabilities};
+use super::super::error::CodecError;
+use super::super::extent::{ExtentCertificate, RepresentationExtent};
+use super::super::geometry::RowGeometry;
+use super::super::residency::ResidencyProfile;
+use super::super::streams::{CodecOperands, StreamSpec, VALUES};
+use super::super::RepresentationCodec;
+use crate::format::vindex3::represent::kquant::{self, KQuant};
+use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
+
+/// The widest field in a ggml block is an f16 scale.
+const BLOCK_FIELD_ALIGN_BYTES: usize = std::mem::size_of::<u16>();
+
+const KQUANT_STREAMS: [StreamSpec; 1] = [VALUES];
+
+/// One compilable K-quant, as a codec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KQuantCodec {
+    quant: KQuant,
+}
+
+pub const Q4_K: KQuantCodec = KQuantCodec {
+    quant: kquant::Q4_K,
+};
+pub const Q6_K: KQuantCodec = KQuantCodec {
+    quant: kquant::Q6_K,
+};
+pub const Q8_0: KQuantCodec = KQuantCodec {
+    quant: kquant::Q8_0,
+};
+
+impl KQuantCodec {
+    pub const fn quant(&self) -> KQuant {
+        self.quant
+    }
+
+    fn row_bytes(&self, k: usize) -> usize {
+        k / self.quant.elements_per_block * self.quant.bytes_per_block
+    }
+}
+
+impl RepresentationCodec for KQuantCodec {
+    fn encoding_label(&self) -> &'static str {
+        self.quant.name
+    }
+
+    fn identity(&self) -> CodecIdentity {
+        self.quant.codec_identity()
+    }
+
+    fn streams(&self) -> &'static [StreamSpec] {
+        &KQUANT_STREAMS
+    }
+
+    fn capabilities(&self) -> CodecCapabilities {
+        CodecCapabilities {
+            access: AccessGranularity::RowRandom,
+            group_elems: self.quant.elements_per_block,
+            row_align_elems: self.quant.elements_per_block,
+            physical_align_bytes: BLOCK_FIELD_ALIGN_BYTES,
+        }
+    }
+
+    fn extents(&self) -> Vec<ExtentCertificate> {
+        vec![ExtentCertificate::terminal(self.quant.bits_per_weight())]
+    }
+
+    fn stored_bytes(
+        &self,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<u64, CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let label = self.encoding_label();
+        let geometry = RowGeometry::of(shape, label, tensor)?;
+        geometry.check_group(self.quant.elements_per_block, label, tensor)?;
+        Ok((geometry.rows * self.row_bytes(geometry.k)) as u64)
+    }
+
+    fn validate(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        let need = self.stored_bytes(shape, extent, tensor)? as usize;
+        operands.stream_of_len(VALUES, need, self.encoding_label(), tensor)?;
+        Ok(())
+    }
+
+    fn decode_rows(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        rows: Range<usize>,
+        extent: RepresentationExtent,
+        dst: &mut [f32],
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let label = self.encoding_label();
+        let geometry = RowGeometry::of(shape, label, tensor)?;
+        geometry.check_group(self.quant.elements_per_block, label, tensor)?;
+        geometry.check_rows(&rows, label, tensor)?;
+        geometry.check_destination(&rows, dst.len(), tensor)?;
+        let row_bytes = self.row_bytes(geometry.k);
+        let bytes = operands.stream_of_len(VALUES, rows.end * row_bytes, label, tensor)?;
+        let span = &bytes[rows.start * row_bytes..rows.end * row_bytes];
+        let values = self
+            .quant
+            .decode(span, rows.len() * geometry.k, tensor)
+            .map_err(|e| CodecError::Decode {
+                tensor: tensor.into(),
+                label: label.into(),
+                detail: e.to_string(),
+            })?;
+        dst.copy_from_slice(&values);
+        Ok(())
+    }
+
+    fn decode_residency(&self) -> ResidencyProfile {
+        ResidencyProfile::DECODED_F32
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/lyrw2.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/lyrw2.rs
@@ -1,0 +1,97 @@
+//! How a LYRW v2 bank's region schema reaches the contract.
+//!
+//! A bank region declares a format tag, a packing and, for a split
+//! codec, the `pair_id` that binds its values region to its scales
+//! region. None of that is a codec: it is the STORAGE ARRANGEMENT that
+//! supplies a codec's streams. So this module answers two questions and
+//! nothing else — which registered codec a format tag names, and how a
+//! packing supplies that codec's streams — and refuses, by tag, what this
+//! build recognises but cannot execute. Reading preserves such tags;
+//! capability checking refuses them (spec §6.5, §11).
+
+use super::super::error::CodecError;
+use super::super::extent::RepresentationExtent;
+use super::super::streams::{CodecOperands, NamedStreams, GROUP_SCALES, VALUES};
+use super::super::RepresentationCodec;
+use super::float::{BF16, F16, F32};
+use super::kquant::{Q4_K, Q6_K, Q8_0};
+use super::mxfp4::DTYPE_MXFP4;
+use super::nvfp4::NVFP4;
+use crate::format::lyrw2::region_format::{Packing, RegionFormat};
+
+/// The codec label a region format names, or `None` where this build
+/// recognises the tag and registers no codec for it.
+///
+/// `None` is not "unknown": `Q4_0`, `Fp4Larql` and `Mxfp8` are tags this
+/// reader preserves faithfully and this executor cannot serve, and a
+/// caller that needs them gets a refusal naming the tag, not a guess.
+pub fn codec_label(format: RegionFormat) -> Option<&'static str> {
+    Some(match format {
+        RegionFormat::F32 => F32.encoding_label(),
+        RegionFormat::F16 => F16.encoding_label(),
+        RegionFormat::BF16 => BF16.encoding_label(),
+        RegionFormat::Q4K => Q4_K.encoding_label(),
+        RegionFormat::Q6K => Q6_K.encoding_label(),
+        RegionFormat::Q8_0 => Q8_0.encoding_label(),
+        RegionFormat::Mxfp4 => DTYPE_MXFP4,
+        RegionFormat::Nvfp4 => NVFP4.encoding_label(),
+        RegionFormat::Q4_0
+        | RegionFormat::Fp4Larql
+        | RegionFormat::Mxfp8
+        | RegionFormat::Unknown(_) => return None,
+    })
+}
+
+/// How a region's packing supplies a codec's streams.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionBinding {
+    /// The region alone is the whole operand: one contiguous payload.
+    Single,
+    /// The region holds codes; the scales are in the partner named by
+    /// `pair_id`.
+    PairedValues,
+    /// The region holds scales for the partner named by `pair_id`.
+    PairedScales,
+}
+
+pub fn region_binding(packing: Packing) -> Option<RegionBinding> {
+    match packing {
+        Packing::RowMajor | Packing::BlocksWithScalesInline => Some(RegionBinding::Single),
+        Packing::BlocksValues => Some(RegionBinding::PairedValues),
+        Packing::BlocksScales => Some(RegionBinding::PairedScales),
+        Packing::Unknown(_) => None,
+    }
+}
+
+/// Bind a bank region — with its paired scales region, if the packing
+/// names one — onto `codec`'s streams, and validate the result.
+///
+/// Without a scales region the codec binds the payload as one row; a
+/// codec whose streams are stored apart then refuses by name. With one,
+/// the two regions are the codes and group-scale streams, and a codec
+/// that declares no scales stream refuses a partner it cannot consume.
+pub fn bind_region<'a>(
+    codec: &dyn RepresentationCodec,
+    shape: &[usize],
+    values: &'a [u8],
+    scales: Option<&'a [u8]>,
+    tensor: &str,
+) -> Result<CodecOperands<'a>, CodecError> {
+    let streams = match scales {
+        None => codec.bind_packed(values, shape, tensor)?,
+        Some(scales) => {
+            if !codec.streams().contains(&GROUP_SCALES) {
+                return Err(CodecError::UnexpectedStream {
+                    tensor: tensor.into(),
+                    label: codec.encoding_label().into(),
+                    stream: GROUP_SCALES.name.into(),
+                    declared: codec.streams().iter().map(|s| s.name.to_string()).collect(),
+                });
+            }
+            NamedStreams::single(VALUES, values).with(GROUP_SCALES, scales)
+        }
+    };
+    let operands = CodecOperands::from_streams(streams);
+    codec.validate(&operands, shape, RepresentationExtent::TERMINAL, tensor)?;
+    Ok(operands)
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/mod.rs
@@ -1,0 +1,23 @@
+//! The encodings this build registers, each an implementation of
+//! [`super::RepresentationCodec`] over numerics that already existed.
+//!
+//! Nothing here defines arithmetic. Every decode routes through the
+//! decoder the workspace already judged — `larql_models::quant` for the
+//! grids, the operand widener for the floats — so registering a codec
+//! adds a *declaration*, never a second opinion about what bytes mean.
+
+pub mod float;
+pub mod kquant;
+pub mod lyrw2;
+pub mod mxfp4;
+pub mod nvfp4;
+
+/// Vocabulary shared by the identities and capabilities below.
+pub(crate) mod vocabulary {
+    /// No scale at this level of an identity.
+    pub const SCALE_NONE: &str = "none";
+    /// Nothing is shared between elements: a group of one.
+    pub const UNGROUPED: usize = 1;
+    /// A stream of bytes needs no wider alignment than a byte.
+    pub const BYTE_ALIGN: usize = 1;
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/mxfp4.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/mxfp4.rs
@@ -1,0 +1,153 @@
+//! MXFP4: codes and e8m0 group scales stored APART — the multi-stream
+//! witness. It does not override [`RepresentationCodec::bind_packed`], so
+//! handing it one slice is refused by name, which is the answer
+//! `QuantMatVec` could only give as `None`.
+
+use std::ops::Range;
+
+use larql_models::quant::mxfp4::{dequantize_expert, MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS};
+
+use super::super::capability::{AccessGranularity, CodecCapabilities};
+use super::super::error::CodecError;
+use super::super::extent::{ExtentCertificate, RepresentationExtent, BITS_PER_BYTE};
+use super::super::geometry::RowGeometry;
+use super::super::residency::ResidencyProfile;
+use super::super::streams::{CodecOperands, StreamSpec, GROUP_SCALES, VALUES};
+use super::super::RepresentationCodec;
+use super::vocabulary::{BYTE_ALIGN, SCALE_NONE};
+use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
+
+/// The segment / graph label for natively stored MXFP4 bytes.
+pub const DTYPE_MXFP4: &str = "MXFP4";
+/// The ABI family, spelled the way `nvfp4` is.
+pub const MXFP4_FAMILY: &str = "mxfp4";
+/// ABI revision: OCP microscaling e2m1 codes, lo nibble first, one e8m0
+/// scale per 32 — unchanged since the format was admitted.
+pub const MXFP4_REVISION: u32 = 1;
+
+/// One e8m0 scale per group.
+const E8M0_SCALE_BYTES: usize = 1;
+const ELEMENT_E2M1: &str = "e2m1";
+const GROUP_SCALE_E8M0: &str = "e8m0";
+/// Two streams, each its own region.
+const LAYOUT_APART: &str = "codes;group_scales";
+
+const MXFP4_STREAMS: [StreamSpec; 2] = [VALUES, GROUP_SCALES];
+
+/// Natively stored MXFP4.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Mxfp4Codec;
+
+pub const MXFP4: Mxfp4Codec = Mxfp4Codec;
+
+impl Mxfp4Codec {
+    /// 4.25: sixteen code bytes and one scale byte per thirty-two.
+    pub const fn bits_per_weight() -> f64 {
+        (MXFP4_GROUP_BYTES + E8M0_SCALE_BYTES) as f64 * BITS_PER_BYTE / MXFP4_GROUP_ELEMS as f64
+    }
+
+    fn geometry(shape: &[usize], tensor: &str) -> Result<(RowGeometry, usize), CodecError> {
+        let geometry = RowGeometry::of(shape, DTYPE_MXFP4, tensor)?;
+        let groups = geometry.check_group(MXFP4_GROUP_ELEMS, DTYPE_MXFP4, tensor)?;
+        Ok((geometry, groups))
+    }
+}
+
+impl RepresentationCodec for Mxfp4Codec {
+    fn encoding_label(&self) -> &'static str {
+        DTYPE_MXFP4
+    }
+
+    fn identity(&self) -> CodecIdentity {
+        CodecIdentity {
+            family: MXFP4_FAMILY.into(),
+            revision: MXFP4_REVISION,
+            group_elems: MXFP4_GROUP_ELEMS,
+            element: ELEMENT_E2M1.into(),
+            group_scale: GROUP_SCALE_E8M0.into(),
+            tensor_scale: SCALE_NONE.into(),
+            layout: LAYOUT_APART.into(),
+        }
+    }
+
+    fn streams(&self) -> &'static [StreamSpec] {
+        &MXFP4_STREAMS
+    }
+
+    fn capabilities(&self) -> CodecCapabilities {
+        CodecCapabilities {
+            access: AccessGranularity::RowRandom,
+            group_elems: MXFP4_GROUP_ELEMS,
+            row_align_elems: MXFP4_GROUP_ELEMS,
+            physical_align_bytes: BYTE_ALIGN,
+        }
+    }
+
+    fn extents(&self) -> Vec<ExtentCertificate> {
+        vec![ExtentCertificate::terminal(Self::bits_per_weight())]
+    }
+
+    fn stored_bytes(
+        &self,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<u64, CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let (geometry, groups) = Self::geometry(shape, tensor)?;
+        let per_row = groups * (MXFP4_GROUP_BYTES + E8M0_SCALE_BYTES);
+        Ok((geometry.rows * per_row) as u64)
+    }
+
+    fn validate(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let (geometry, groups) = Self::geometry(shape, tensor)?;
+        let cells = geometry.rows * groups;
+        operands.stream_of_len(VALUES, cells * MXFP4_GROUP_BYTES, DTYPE_MXFP4, tensor)?;
+        operands.stream_of_len(GROUP_SCALES, cells * E8M0_SCALE_BYTES, DTYPE_MXFP4, tensor)?;
+        Ok(())
+    }
+
+    fn decode_rows(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        rows: Range<usize>,
+        extent: RepresentationExtent,
+        dst: &mut [f32],
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let (geometry, groups) = Self::geometry(shape, tensor)?;
+        geometry.check_rows(&rows, DTYPE_MXFP4, tensor)?;
+        geometry.check_destination(&rows, dst.len(), tensor)?;
+        let code_row = groups * MXFP4_GROUP_BYTES;
+        let scale_row = groups * E8M0_SCALE_BYTES;
+        let codes = operands.stream_of_len(VALUES, rows.end * code_row, DTYPE_MXFP4, tensor)?;
+        let scales =
+            operands.stream_of_len(GROUP_SCALES, rows.end * scale_row, DTYPE_MXFP4, tensor)?;
+        let values = dequantize_expert(
+            &codes[rows.start * code_row..rows.end * code_row],
+            &scales[rows.start * scale_row..rows.end * scale_row],
+            rows.len(),
+            groups,
+        )
+        .map_err(|e| CodecError::Decode {
+            tensor: tensor.into(),
+            label: DTYPE_MXFP4.into(),
+            detail: e.to_string(),
+        })?;
+        dst.copy_from_slice(&values);
+        Ok(())
+    }
+
+    fn decode_residency(&self) -> ResidencyProfile {
+        ResidencyProfile::DECODED_F32
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/nvfp4.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/nvfp4.rs
@@ -1,0 +1,186 @@
+//! NVFP4: three streams packed into one row with a split the shape
+//! derives — the codec that overrides [`RepresentationCodec::bind_packed`]
+//! because its streams are stored together, not apart.
+
+use std::ops::Range;
+
+use larql_models::quant::nvfp4::{
+    dequantize_into, Nvfp4Matrix, NVFP4_GROUP_BYTES, NVFP4_GROUP_ELEMS,
+};
+
+use super::super::capability::{AccessGranularity, CodecCapabilities};
+use super::super::error::CodecError;
+use super::super::extent::{ExtentCertificate, RepresentationExtent, BITS_PER_BYTE};
+use super::super::geometry::RowGeometry;
+use super::super::residency::{Acceleration, ResidencyProfile};
+use super::super::streams::{
+    CodecOperands, NamedStreams, StreamSpec, GROUP_SCALES, TENSOR_SCALE, VALUES,
+};
+use super::super::RepresentationCodec;
+use crate::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
+use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
+use crate::format::vindex3::represent::nvfp4_pack::{PackLayout, DTYPE_NVFP4};
+
+/// One E4M3 scale per group.
+const E4M3_SCALE_BYTES: usize = 1;
+/// The f32 tensor scale, little-endian.
+const TENSOR_SCALE_BYTES: usize = std::mem::size_of::<f32>();
+
+const NVFP4_STREAMS: [StreamSpec; 3] = [VALUES, GROUP_SCALES, TENSOR_SCALE];
+
+/// The compiled NVFP4 pack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Nvfp4Codec;
+
+pub const NVFP4: Nvfp4Codec = Nvfp4Codec;
+
+impl Nvfp4Codec {
+    /// 4.5: eight code bytes and one scale byte per sixteen elements. The
+    /// tensor scale amortises to nothing.
+    pub const fn bits_per_weight() -> f64 {
+        (NVFP4_GROUP_BYTES + E4M3_SCALE_BYTES) as f64 * BITS_PER_BYTE / NVFP4_GROUP_ELEMS as f64
+    }
+
+    /// The pack layout is the one derivation of NVFP4 geometry — its
+    /// refusal of a row the group cannot tile is the codec's refusal.
+    fn layout(shape: &[usize], tensor: &str) -> Result<PackLayout, CodecError> {
+        let geometry = RowGeometry::of(shape, DTYPE_NVFP4, tensor)?;
+        PackLayout::derive(&[geometry.rows, geometry.k], tensor).map_err(|e| CodecError::Geometry {
+            tensor: tensor.into(),
+            label: DTYPE_NVFP4.into(),
+            shape: shape.to_vec(),
+            why: e.to_string(),
+        })
+    }
+
+    fn map_err(tensor: &str, detail: impl ToString) -> CodecError {
+        CodecError::Decode {
+            tensor: tensor.into(),
+            label: DTYPE_NVFP4.into(),
+            detail: detail.to_string(),
+        }
+    }
+}
+
+impl RepresentationCodec for Nvfp4Codec {
+    fn encoding_label(&self) -> &'static str {
+        DTYPE_NVFP4
+    }
+
+    fn identity(&self) -> CodecIdentity {
+        CodecIdentity::nvfp4_v1()
+    }
+
+    fn streams(&self) -> &'static [StreamSpec] {
+        &NVFP4_STREAMS
+    }
+
+    fn capabilities(&self) -> CodecCapabilities {
+        CodecCapabilities {
+            access: AccessGranularity::RowRandom,
+            group_elems: NVFP4_GROUP_ELEMS,
+            row_align_elems: NVFP4_GROUP_ELEMS,
+            physical_align_bytes: TENSOR_SCALE_BYTES,
+        }
+    }
+
+    fn extents(&self) -> Vec<ExtentCertificate> {
+        vec![ExtentCertificate::terminal(Self::bits_per_weight())]
+    }
+
+    fn stored_bytes(
+        &self,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<u64, CodecError> {
+        self.certificate_at(extent, tensor)?;
+        Ok(Self::layout(shape, tensor)?.total_len as u64)
+    }
+
+    /// Codes, group scales and the tensor scale are one row; the split is
+    /// arithmetic from the shape, and this is where it happens.
+    fn bind_packed<'a>(
+        &self,
+        payload: &'a [u8],
+        shape: &[usize],
+        tensor: &str,
+    ) -> Result<NamedStreams<'a>, CodecError> {
+        let layout = Self::layout(shape, tensor)?;
+        if payload.len() != layout.total_len {
+            return Err(CodecError::StreamLength {
+                tensor: tensor.into(),
+                label: DTYPE_NVFP4.into(),
+                stream: VALUES.name.into(),
+                need: layout.total_len,
+                have: payload.len(),
+            });
+        }
+        Ok(NamedStreams::new()
+            .with(VALUES, &payload[..layout.packed_len])
+            .with(
+                GROUP_SCALES,
+                &payload[layout.scales_offset()..layout.tensor_scale_offset()],
+            )
+            .with(TENSOR_SCALE, &payload[layout.tensor_scale_offset()..]))
+    }
+
+    fn validate(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let layout = Self::layout(shape, tensor)?;
+        operands.stream_of_len(VALUES, layout.packed_len, DTYPE_NVFP4, tensor)?;
+        operands.stream_of_len(GROUP_SCALES, layout.scales_len, DTYPE_NVFP4, tensor)?;
+        operands.stream_of_len(TENSOR_SCALE, TENSOR_SCALE_BYTES, DTYPE_NVFP4, tensor)?;
+        Ok(())
+    }
+
+    fn decode_rows(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        rows: Range<usize>,
+        extent: RepresentationExtent,
+        dst: &mut [f32],
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let layout = Self::layout(shape, tensor)?;
+        let geometry = RowGeometry {
+            rows: layout.rows,
+            k: layout.k,
+        };
+        geometry.check_rows(&rows, DTYPE_NVFP4, tensor)?;
+        geometry.check_destination(&rows, dst.len(), tensor)?;
+        let code_row = layout.groups * NVFP4_GROUP_BYTES;
+        let scale_row = layout.groups * E4M3_SCALE_BYTES;
+        let codes = operands.stream_of_len(VALUES, rows.end * code_row, DTYPE_NVFP4, tensor)?;
+        let scales =
+            operands.stream_of_len(GROUP_SCALES, rows.end * scale_row, DTYPE_NVFP4, tensor)?;
+        let tail = operands.stream_of_len(TENSOR_SCALE, TENSOR_SCALE_BYTES, DTYPE_NVFP4, tensor)?;
+        let matrix = Nvfp4Matrix {
+            packed: codes[rows.start * code_row..rows.end * code_row].to_vec(),
+            scales: scales[rows.start * scale_row..rows.end * scale_row].to_vec(),
+            tensor_scale: f32::from_le_bytes([tail[0], tail[1], tail[2], tail[3]]),
+        };
+        dequantize_into(&matrix, rows.len(), layout.k, dst).map_err(|e| Self::map_err(tensor, e))
+    }
+
+    fn decode_residency(&self) -> ResidencyProfile {
+        ResidencyProfile::DECODED_F32
+    }
+
+    fn accelerations(&self) -> Vec<Acceleration> {
+        // The loader copies a pack's regions into page-aligned buffers
+        // and changes no value: rebound, not stored in place.
+        vec![Acceleration::cpu(
+            PhysicalProjectionPlan::FusedNvfp4,
+            ResidencyProfile::rebound(Self::bits_per_weight()),
+        )]
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/error.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/error.rs
@@ -1,0 +1,152 @@
+//! Every way a codec refuses, each naming what was asked and what is there.
+//!
+//! A refusal that names only one side sends someone to the wrong remedy: a
+//! stream missing from a binding is fixed at the binding site, a family
+//! nobody registered is fixed by registering it, and a revision this build
+//! does not implement is fixed by recompiling the pack. Only the pair
+//! distinguishes them, so every variant carries both.
+
+use crate::error::VindexError;
+
+/// Why a codec, or the registry in front of it, cannot honour a request.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum CodecError {
+    #[error(
+        "tensor `{tensor}`: representation `{label}` is not registered; registered: [{}]",
+        registered.join(", ")
+    )]
+    UnknownEncoding {
+        tensor: String,
+        label: String,
+        registered: Vec<String>,
+    },
+
+    #[error(
+        "tensor `{tensor}`: `{label}` needs stream `{stream}`, which was not bound; bound: [{}]",
+        bound.join(", ")
+    )]
+    MissingStream {
+        tensor: String,
+        label: String,
+        stream: String,
+        bound: Vec<String>,
+    },
+
+    #[error(
+        "tensor `{tensor}`: `{label}` stores its streams apart ({}); one payload cannot be \
+         bound to it — bind each stream by name",
+        streams.join(", ")
+    )]
+    StreamsStoredApart {
+        tensor: String,
+        label: String,
+        streams: Vec<String>,
+    },
+
+    #[error(
+        "tensor `{tensor}`: `{label}` declares no stream `{stream}`; declared: [{}]",
+        declared.join(", ")
+    )]
+    UnexpectedStream {
+        tensor: String,
+        label: String,
+        stream: String,
+        declared: Vec<String>,
+    },
+
+    #[error("tensor `{tensor}`: `{label}` stream `{stream}` is {have} bytes; {need} needed")]
+    StreamLength {
+        tensor: String,
+        label: String,
+        stream: String,
+        need: usize,
+        have: usize,
+    },
+
+    #[error("tensor `{tensor}`: shape {shape:?} cannot hold `{label}`: {why}")]
+    Geometry {
+        tensor: String,
+        label: String,
+        shape: Vec<usize>,
+        why: String,
+    },
+
+    #[error(
+        "tensor `{tensor}`: `{label}` has no extent at depth {depth}; it declares {available}"
+    )]
+    ExtentUnavailable {
+        tensor: String,
+        label: String,
+        depth: u32,
+        available: u32,
+    },
+
+    #[error("tensor `{tensor}`: rows {start}..{end} exceed the {rows} rows `{label}` holds")]
+    RowRange {
+        tensor: String,
+        label: String,
+        start: usize,
+        end: usize,
+        rows: usize,
+    },
+
+    #[error("tensor `{tensor}`: destination holds {have} floats; {need} needed")]
+    Destination {
+        tensor: String,
+        need: usize,
+        have: usize,
+    },
+
+    #[error("tensor `{tensor}`: decoding `{label}`: {detail}")]
+    Decode {
+        tensor: String,
+        label: String,
+        detail: String,
+    },
+
+    #[error("`{label}` provides {provided} access; the plan requires {required}")]
+    AccessRefused {
+        label: String,
+        provided: String,
+        required: String,
+    },
+
+    #[error(
+        "representation family `{family}` is not registered; registered: [{}]",
+        registered.join(", ")
+    )]
+    UnknownFamily {
+        family: String,
+        registered: Vec<String>,
+    },
+
+    #[error(
+        "`{family}` ABI revision {found} was compiled by another build; this one implements \
+         revision {implemented}. Recompile the representation from its canonical source \
+         rather than decoding it under new rules."
+    )]
+    AbiRevision {
+        family: String,
+        found: u32,
+        implemented: u32,
+    },
+
+    #[error(
+        "`{family}` revision {revision} declares geometry this build does not produce \
+         ({declared}); the index disagrees with its own revision"
+    )]
+    AbiGeometry {
+        family: String,
+        revision: u32,
+        declared: String,
+    },
+
+    #[error("codec registry: `{label}` is registered twice")]
+    DuplicateLabel { label: String },
+}
+
+impl From<CodecError> for VindexError {
+    fn from(e: CodecError) -> Self {
+        VindexError::Parse(e.to_string())
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/extent.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/extent.rs
@@ -1,0 +1,68 @@
+//! How much of a representation, and what that much certifies.
+//!
+//! Today every codec is terminal: one extent, depth 0, the whole encoding.
+//! A progressive codec — `R = R_0 + Δ_1 + … + Δ_n` — exposes one extent per
+//! admissible prefix, each with its own cost and its own error bound, and
+//! residency can then ask for the cheapest extent that satisfies a
+//! requirement rather than for a named dtype. The dimension is in the
+//! selection contract now, while every implementation answers `depth 0`,
+//! because retrofitting it into stored variants later is the expensive
+//! version of the same change.
+
+/// Bits in a byte, for bits-per-weight arithmetic.
+pub const BITS_PER_BYTE: f64 = 8.0;
+
+/// A prefix of a representation. `depth` counts refinements past the base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RepresentationExtent {
+    pub depth: u32,
+}
+
+impl RepresentationExtent {
+    /// The whole of a terminal representation, and the base of a
+    /// progressive one.
+    pub const TERMINAL: Self = Self { depth: 0 };
+
+    pub const fn at_depth(depth: u32) -> Self {
+        Self { depth }
+    }
+}
+
+/// A reconstruction bound a codec is prepared to certify for an extent.
+///
+/// Absent means "measured, not declared": the K-quant and FP4 codecs this
+/// build ships have their reconstruction error measured per encoder and
+/// per tensor, and a number stated here would promote one measurement to
+/// a property of the format.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ErrorRadius {
+    /// Relative RMS of `decode(encode(x)) - x` over the codec's domain.
+    pub relative_rms: f64,
+}
+
+/// What one extent costs and what it certifies.
+///
+/// Deliberately says nothing about *fidelity to a source*: that is a
+/// property of an instance — set at extraction from provenance and carried
+/// by the stored variant — not of the encoding. A native MXFP4 checkpoint
+/// stored as MXFP4 is source-exact; the same bytes compiled from bf16 are
+/// approximate; the codec is the same in both.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ExtentCertificate {
+    pub extent: RepresentationExtent,
+    /// Asymptotic stored bits per weight at this extent, block overheads
+    /// included and whole-tensor scales amortised away.
+    pub bits_per_weight: f64,
+    pub radius: Option<ErrorRadius>,
+}
+
+impl ExtentCertificate {
+    /// The one certificate a terminal codec carries.
+    pub const fn terminal(bits_per_weight: f64) -> Self {
+        Self {
+            extent: RepresentationExtent::TERMINAL,
+            bits_per_weight,
+            radius: None,
+        }
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/geometry.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/geometry.rs
@@ -1,0 +1,105 @@
+//! What a shape means, decided once for every codec.
+
+use std::ops::Range;
+
+use super::error::CodecError;
+
+/// `[rows, k]` as every codec in this module reads a shape.
+///
+/// The last axis is `k` — the axis blocks, groups and scales run along —
+/// and every leading axis multiplies into `rows`. So a bias `[n]` is one
+/// row of `n`, a matrix `[out, in]` is `out` rows of `in`, and an expert
+/// bank `[experts, out, in]` is `experts * out` rows of `in`. One rule,
+/// so a codec cannot read a bank one way and a matrix another, and a
+/// scalar `[]` is a single element rather than a special case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RowGeometry {
+    pub rows: usize,
+    pub k: usize,
+}
+
+impl RowGeometry {
+    pub fn of(shape: &[usize], label: &str, tensor: &str) -> Result<Self, CodecError> {
+        let Some((&k, leading)) = shape.split_last() else {
+            return Ok(Self { rows: 1, k: 1 });
+        };
+        let rows = leading
+            .iter()
+            .try_fold(1usize, |acc, d| acc.checked_mul(*d))
+            .ok_or_else(|| CodecError::Geometry {
+                tensor: tensor.into(),
+                label: label.into(),
+                shape: shape.to_vec(),
+                why: "the row count overflows".into(),
+            })?;
+        Ok(Self { rows, k })
+    }
+
+    /// `rows * k`, refusing overflow rather than wrapping into a plausible
+    /// small number.
+    pub fn elements(self, label: &str, tensor: &str) -> Result<usize, CodecError> {
+        self.rows
+            .checked_mul(self.k)
+            .ok_or_else(|| CodecError::Geometry {
+                tensor: tensor.into(),
+                label: label.into(),
+                shape: vec![self.rows, self.k],
+                why: "the element count overflows".into(),
+            })
+    }
+
+    /// Refuse a row range that reaches past what the tensor holds.
+    pub fn check_rows(
+        self,
+        rows: &Range<usize>,
+        label: &str,
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        if rows.start > rows.end || rows.end > self.rows {
+            return Err(CodecError::RowRange {
+                tensor: tensor.into(),
+                label: label.into(),
+                start: rows.start,
+                end: rows.end,
+                rows: self.rows,
+            });
+        }
+        Ok(())
+    }
+
+    /// Refuse a `k` that is not a whole number of `group` elements — the
+    /// refusal every grouped codec makes, worded once. Returns the group
+    /// count.
+    pub fn check_group(self, group: usize, label: &str, tensor: &str) -> Result<usize, CodecError> {
+        if group == 0 || !self.k.is_multiple_of(group) {
+            return Err(CodecError::Geometry {
+                tensor: tensor.into(),
+                label: label.into(),
+                shape: vec![self.rows, self.k],
+                why: format!(
+                    "k={} is not a whole number of {group}-element groups",
+                    self.k
+                ),
+            });
+        }
+        Ok(self.k / group)
+    }
+
+    /// Refuse a destination that does not hold exactly `rows` rows.
+    pub fn check_destination(
+        self,
+        rows: &Range<usize>,
+        dst_len: usize,
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        let need = rows.len() * self.k;
+        if dst_len != need {
+            return Err(CodecError::Destination {
+                tensor: tensor.into(),
+                need,
+                have: dst_len,
+            });
+        }
+        Ok(())
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/mod.rs
@@ -1,0 +1,214 @@
+//! **The representation/execution contract** — what every stored encoding
+//! must declare before LARQL will plan, bind, or execute it.
+//!
+//! This is not a quantisation trait. It is extracted from the encodings
+//! the container already carries — float tensor tables, the K-quants,
+//! NVFP4, MXFP4, and the LYRW v2 banks that pair their scales — and its
+//! test is that nothing about any of them is privileged in it. Six
+//! things it gets right, each already paid for once in this tree:
+//!
+//! ```text
+//! identity        an ABI family + revision the file names independently
+//!                 of whichever implementation is registered
+//! streams         an operand is a NAMED SET of streams, plus the
+//!                 represented objects it may depend on — not one &[u8]
+//! capabilities    access granularity, logical grouping, physical
+//!                 alignment: declared, checked in preflight, refused by name
+//! extents         depth, with a certificate per admissible prefix; every
+//!                 codec today answers depth 0
+//! decode          MANDATORY, range-aware, to canonical f32 — the universal
+//!                 correctness surface; kernels are acceleration, never
+//!                 semantics
+//! realizations    residency is declared per REALIZATION: the decode
+//!                 realization and each direct kernel carry their own
+//!                 profile, so a fallback is a different realization with
+//!                 a different declared cost, never a quiet substitution
+//! ```
+//!
+//! Two rules follow. *Adding a codec requires proving representation
+//! correctness; adding a kernel must not change it.* And a codec with no
+//! direct realization is not a defect: it executes through the reference
+//! path, flagged — the `representable-but-no-kernel` rung of spec §11,
+//! made structural.
+//!
+//! The programme this opens — progressive, codebook-dependent and
+//! entropy-coded representations as forcing tests of the abstraction —
+//! is in `docs/represent-codec-contract.md`.
+
+pub mod capability;
+pub mod codecs;
+pub mod error;
+pub mod extent;
+pub mod geometry;
+pub mod registry;
+pub mod residency;
+pub mod streams;
+
+#[cfg(test)]
+mod tests;
+
+use std::ops::Range;
+
+pub use capability::{AccessGranularity, CodecCapabilities, RequiredAccess};
+pub use error::CodecError;
+pub use extent::{ErrorRadius, ExtentCertificate, RepresentationExtent};
+pub use geometry::RowGeometry;
+pub use registry::CodecRegistry;
+pub use residency::{Acceleration, AccelerationBackend, ResidencyClass, ResidencyProfile};
+pub use streams::{AuxiliaryOperands, CodecOperands, NamedStreams, StreamRole, StreamSpec};
+
+use super::nvfp4_pack::CodecIdentity;
+
+/// One stored encoding's contract with the planner and the executor.
+pub trait RepresentationCodec: Send + Sync {
+    /// The label a container writes — the segment `dtype`, the graph's
+    /// `Representation.encoding`, a precision map's `encoding`.
+    fn encoding_label(&self) -> &'static str;
+
+    /// The decode ABI: family, revision, geometry. What `index.json`
+    /// carries so the file names its contract independently of the
+    /// implementation registered to serve it.
+    fn identity(&self) -> CodecIdentity;
+
+    /// The streams one encoded operand is made of, in declaration order.
+    fn streams(&self) -> &'static [StreamSpec];
+
+    /// What this encoding can be asked for.
+    fn capabilities(&self) -> CodecCapabilities;
+
+    /// Every admissible extent, the base first. A terminal codec has one.
+    fn extents(&self) -> Vec<ExtentCertificate>;
+
+    /// Bytes a tensor of `shape` occupies at `extent`, or why it cannot.
+    fn stored_bytes(
+        &self,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<u64, CodecError>;
+
+    /// Bind one contiguous payload — a tensor-table row — onto this
+    /// codec's streams.
+    ///
+    /// The default serves every single-stream codec and refuses every
+    /// other: a codec whose streams are stored apart cannot be handed one
+    /// slice, which is the wall `QuantMatVec` hit and this trait exists
+    /// to remove. A codec that packs several streams into one row with a
+    /// derivable split overrides this.
+    fn bind_packed<'a>(
+        &self,
+        payload: &'a [u8],
+        shape: &[usize],
+        tensor: &str,
+    ) -> Result<NamedStreams<'a>, CodecError> {
+        let _ = shape;
+        match self.streams() {
+            [only] => Ok(NamedStreams::single(*only, payload)),
+            many => Err(CodecError::StreamsStoredApart {
+                tensor: tensor.into(),
+                label: self.encoding_label().into(),
+                streams: many.iter().map(|s| s.name.to_string()).collect(),
+            }),
+        }
+    }
+
+    /// Refuse operands inconsistent with `shape` at `extent`.
+    fn validate(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<(), CodecError>;
+
+    /// **The mandatory realization.** Decode `rows` of a tensor of `shape`
+    /// at `extent` into `dst`, which holds exactly `rows.len() * k` floats.
+    ///
+    /// Range-aware from the start, because a decode that can only answer
+    /// "everything" makes the universal fallback unusable for a sparse
+    /// plan and inexpressible for a progressive one.
+    fn decode_rows(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        rows: Range<usize>,
+        extent: RepresentationExtent,
+        dst: &mut [f32],
+        tensor: &str,
+    ) -> Result<(), CodecError>;
+
+    /// What the decode realization makes resident. Required, so an
+    /// undeclared path is unrepresentable rather than discouraged.
+    fn decode_residency(&self) -> ResidencyProfile;
+
+    /// Direct realizations, each with its own declared residency.
+    /// None is a legitimate answer: the codec executes through decode,
+    /// flagged.
+    fn accelerations(&self) -> Vec<Acceleration> {
+        Vec::new()
+    }
+
+    // ── Provided ──────────────────────────────────────────────────────
+
+    /// The certificate for `extent`, or a refusal naming what is declared.
+    fn certificate_at(
+        &self,
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<ExtentCertificate, CodecError> {
+        let extents = self.extents();
+        extents
+            .iter()
+            .find(|c| c.extent == extent)
+            .copied()
+            .ok_or_else(|| CodecError::ExtentUnavailable {
+                tensor: tensor.into(),
+                label: self.encoding_label().into(),
+                depth: extent.depth,
+                available: extents.len() as u32,
+            })
+    }
+
+    /// Decode every row at `extent`.
+    fn decode_all(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<Vec<f32>, CodecError> {
+        let label = self.encoding_label();
+        let geometry = RowGeometry::of(shape, label, tensor)?;
+        let mut out = vec![0.0f32; geometry.elements(label, tensor)?];
+        self.decode_rows(operands, shape, 0..geometry.rows, extent, &mut out, tensor)?;
+        Ok(out)
+    }
+
+    /// Bind, validate and decode one contiguous payload — the path a
+    /// tensor-table operand takes to f32.
+    fn decode_packed(
+        &self,
+        payload: &[u8],
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<Vec<f32>, CodecError> {
+        let operands = CodecOperands::from_streams(self.bind_packed(payload, shape, tensor)?);
+        self.validate(&operands, shape, extent, tensor)?;
+        self.decode_all(&operands, shape, extent, tensor)
+    }
+}
+
+/// A codec is named by its label and its ABI in every diagnostic.
+impl std::fmt::Debug for dyn RepresentationCodec + '_ {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let id = self.identity();
+        write!(
+            f,
+            "codec {} ({} r{})",
+            self.encoding_label(),
+            id.family,
+            id.revision
+        )
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/registry.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/registry.rs
@@ -1,0 +1,130 @@
+//! The codecs this build can serve, addressed by the label a container
+//! writes and by the ABI family an index declares.
+//!
+//! Two keys because they answer different questions. A segment's `dtype`
+//! asks "which codec reads these bytes"; a pack's `codec` entry asks "is
+//! the contract these bytes were written under the one this build
+//! implements". The second is [`Self::admit`], and it is what stops an
+//! improved encoder from silently redefining every artifact on disk.
+
+use std::sync::OnceLock;
+
+use super::codecs::{float, kquant, mxfp4, nvfp4};
+use super::error::CodecError;
+use super::RepresentationCodec;
+use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
+
+/// Registered codecs, in registration order.
+#[derive(Default)]
+pub struct CodecRegistry {
+    codecs: Vec<Box<dyn RepresentationCodec>>,
+}
+
+impl CodecRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a codec, refusing a label or family already taken.
+    pub fn register(mut self, codec: Box<dyn RepresentationCodec>) -> Result<Self, CodecError> {
+        let label = codec.encoding_label();
+        let family = codec.identity().family;
+        if self.by_label(label).is_some() {
+            return Err(CodecError::DuplicateLabel {
+                label: label.into(),
+            });
+        }
+        if self.by_family(&family).is_some() {
+            return Err(CodecError::DuplicateLabel { label: family });
+        }
+        self.codecs.push(codec);
+        Ok(self)
+    }
+
+    /// The codecs this build ships.
+    pub fn builtin() -> &'static CodecRegistry {
+        static BUILTIN: OnceLock<CodecRegistry> = OnceLock::new();
+        BUILTIN.get_or_init(|| {
+            Self::new()
+                .register(Box::new(float::BF16))
+                .and_then(|r| r.register(Box::new(float::F16)))
+                .and_then(|r| r.register(Box::new(float::F32)))
+                .and_then(|r| r.register(Box::new(kquant::Q4_K)))
+                .and_then(|r| r.register(Box::new(kquant::Q6_K)))
+                .and_then(|r| r.register(Box::new(kquant::Q8_0)))
+                .and_then(|r| r.register(Box::new(nvfp4::NVFP4)))
+                .and_then(|r| r.register(Box::new(mxfp4::MXFP4)))
+                .expect("the built-in codecs carry distinct labels and families")
+        })
+    }
+
+    pub fn codecs(&self) -> impl Iterator<Item = &dyn RepresentationCodec> {
+        self.codecs.iter().map(|c| c.as_ref())
+    }
+
+    pub fn by_label(&self, label: &str) -> Option<&dyn RepresentationCodec> {
+        self.codecs().find(|c| c.encoding_label() == label)
+    }
+
+    pub fn by_family(&self, family: &str) -> Option<&dyn RepresentationCodec> {
+        self.codecs().find(|c| c.identity().family == family)
+    }
+
+    /// Registered labels, in registration order — what a refusal lists.
+    pub fn labels(&self) -> Vec<String> {
+        self.codecs()
+            .map(|c| c.encoding_label().to_string())
+            .collect()
+    }
+
+    pub fn families(&self) -> Vec<String> {
+        self.codecs().map(|c| c.identity().family).collect()
+    }
+
+    /// The codec `label` names, or a refusal naming the registered ones.
+    pub fn resolve(
+        &self,
+        label: &str,
+        tensor: &str,
+    ) -> Result<&dyn RepresentationCodec, CodecError> {
+        self.by_label(label)
+            .ok_or_else(|| CodecError::UnknownEncoding {
+                tensor: tensor.into(),
+                label: label.into(),
+                registered: self.labels(),
+            })
+    }
+
+    /// Refuse a pack this build cannot decode under the rules it was
+    /// written under.
+    ///
+    /// Three refusals, told apart because their remedies differ: an
+    /// unregistered family, a revision another build wrote, and a
+    /// same-revision identity whose geometry disagrees with what that
+    /// revision means — a corrupted or hand-edited index, not version
+    /// skew.
+    pub fn admit(&self, id: &CodecIdentity) -> Result<&dyn RepresentationCodec, CodecError> {
+        let codec = self
+            .by_family(&id.family)
+            .ok_or_else(|| CodecError::UnknownFamily {
+                family: id.family.clone(),
+                registered: self.families(),
+            })?;
+        let want = codec.identity();
+        if id.revision != want.revision {
+            return Err(CodecError::AbiRevision {
+                family: id.family.clone(),
+                found: id.revision,
+                implemented: want.revision,
+            });
+        }
+        if *id != want {
+            return Err(CodecError::AbiGeometry {
+                family: id.family.clone(),
+                revision: id.revision,
+                declared: format!("{id:?}"),
+            });
+        }
+        Ok(codec)
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/residency.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/residency.rs
@@ -1,0 +1,114 @@
+//! What executing a representation makes resident — declared per
+//! realization, never per codec.
+//!
+//! A codec has one mandatory realization, decode to f32, and any number
+//! of direct ones. They do not share a residency story: stored Q4_K
+//! through a direct kernel touches 4.5 bits a weight, and the same bytes
+//! decoded and staged touch 32. So the declaration belongs to the
+//! realization, and a planner that selects one selects its cost with it.
+//! That is what closes the silent-fallback hole: "planned direct, kernel
+//! unavailable, quietly decode and stage" is no longer one path with a
+//! surprise in it — it is a different realization with a different
+//! declared profile, and the trace can name both.
+
+use super::capability::RequiredAccess;
+use super::extent::BITS_PER_BYTE;
+use crate::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
+
+/// Width of the canonical decode target.
+pub const F32_WIDTH_BYTES: usize = std::mem::size_of::<f32>();
+
+/// Whether the bytes executed are the bytes stored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResidencyClass {
+    /// The stored bytes themselves, bound in place.
+    Stored,
+    /// The stored bytes, copied once for alignment; no value changes.
+    Rebound,
+    /// A widened image of the stored values, computed at load.
+    TransientDecoded,
+    /// A re-quantised image: the values resident are not the values
+    /// stored. The only lossy residency, and it says so.
+    TransientRequantised,
+}
+
+impl ResidencyClass {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Stored => "stored",
+            Self::Rebound => "rebound",
+            Self::TransientDecoded => "transient-decoded",
+            Self::TransientRequantised => "transient-requantised",
+        }
+    }
+
+    /// Whether the resident values equal the stored values.
+    pub const fn preserves_values(self) -> bool {
+        !matches!(self, Self::TransientRequantised)
+    }
+}
+
+/// Bytes a weight touches at serve time under one realization.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResidencyProfile {
+    pub class: ResidencyClass,
+    /// Bytes of resident image per logical weight.
+    pub bytes_per_weight: f64,
+}
+
+impl ResidencyProfile {
+    /// The canonical decode realization's profile: an f32 image.
+    pub const DECODED_F32: Self = Self {
+        class: ResidencyClass::TransientDecoded,
+        bytes_per_weight: F32_WIDTH_BYTES as f64,
+    };
+
+    /// A direct realization over stored bytes at `bits_per_weight`.
+    pub const fn stored(bits_per_weight: f64) -> Self {
+        Self {
+            class: ResidencyClass::Stored,
+            bytes_per_weight: bits_per_weight / BITS_PER_BYTE,
+        }
+    }
+
+    /// A direct realization over an aligned copy of the stored bytes.
+    pub const fn rebound(bits_per_weight: f64) -> Self {
+        Self {
+            class: ResidencyClass::Rebound,
+            bytes_per_weight: bits_per_weight / BITS_PER_BYTE,
+        }
+    }
+}
+
+/// Where a direct realization runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccelerationBackend {
+    /// This crate's CPU executor. Device backends declare their own
+    /// realizations from the peer crate that owns the kernels.
+    Cpu,
+}
+
+/// One direct realization a codec offers, with the cost it declares.
+///
+/// `plan` is positive evidence: the kernel exists because the plan names
+/// it, and a codec cannot claim an acceleration the executor does not
+/// have.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Acceleration {
+    pub backend: AccelerationBackend,
+    pub plan: PhysicalProjectionPlan,
+    pub residency: ResidencyProfile,
+    /// What the kernel addresses; a plan needing more is refused by name.
+    pub requires: RequiredAccess,
+}
+
+impl Acceleration {
+    pub const fn cpu(plan: PhysicalProjectionPlan, residency: ResidencyProfile) -> Self {
+        Self {
+            backend: AccelerationBackend::Cpu,
+            plan,
+            residency,
+            requires: RequiredAccess::RowRandom,
+        }
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/streams.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/streams.rs
@@ -1,0 +1,180 @@
+//! The operands a decode consumes: named byte streams, and the represented
+//! objects a stream may depend on for its meaning.
+//!
+//! `&[u8]` was the wall two formats already hit — ternary's per-channel
+//! scales and MXFP4's e8m0 exponents had nowhere to ride a single slice, so
+//! both were routed to dedicated kernels outside the trait that should have
+//! served them. A named set of streams is the first repair. The second is
+//! [`AuxiliaryOperands`]: a codebook is not a stream of this tensor's bytes,
+//! it is another represented object, and a decode that depends on one has
+//! admitted a representation dependency. Naming that today, while it is
+//! empty, is what keeps the first VQ codec from turning the stream set
+//! into a disguised dependency graph.
+
+use std::collections::BTreeMap;
+
+use super::error::CodecError;
+use crate::format::vindex3::opplan::OperandRef;
+
+/// What one stream carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamRole {
+    /// The element codes themselves, scales inline or not.
+    Values,
+    /// One scale per group of elements.
+    GroupScales,
+    /// One scale for the whole tensor.
+    TensorScale,
+}
+
+/// One stream a codec declares.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamSpec {
+    pub name: &'static str,
+    pub role: StreamRole,
+}
+
+/// The stream every codec has: its codes.
+pub const VALUES: StreamSpec = StreamSpec {
+    name: "values",
+    role: StreamRole::Values,
+};
+/// Per-group scales stored apart from the codes.
+pub const GROUP_SCALES: StreamSpec = StreamSpec {
+    name: "group_scales",
+    role: StreamRole::GroupScales,
+};
+/// A whole-tensor scale stored apart from the codes.
+pub const TENSOR_SCALE: StreamSpec = StreamSpec {
+    name: "tensor_scale",
+    role: StreamRole::TensorScale,
+};
+
+/// Bound streams, by declared name.
+#[derive(Debug, Clone, Default)]
+pub struct NamedStreams<'a> {
+    streams: Vec<(&'static str, &'a [u8])>,
+}
+
+impl<'a> NamedStreams<'a> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// One stream — the shape every inline-scale codec binds.
+    pub fn single(spec: StreamSpec, bytes: &'a [u8]) -> Self {
+        Self::new().with(spec, bytes)
+    }
+
+    /// Bind `spec`, replacing an earlier binding of the same name.
+    pub fn with(mut self, spec: StreamSpec, bytes: &'a [u8]) -> Self {
+        self.streams.retain(|(name, _)| *name != spec.name);
+        self.streams.push((spec.name, bytes));
+        self
+    }
+
+    pub fn get(&self, spec: StreamSpec) -> Option<&'a [u8]> {
+        self.streams
+            .iter()
+            .find(|(name, _)| *name == spec.name)
+            .map(|(_, bytes)| *bytes)
+    }
+
+    /// Bound names, in binding order — what a refusal lists.
+    pub fn names(&self) -> Vec<String> {
+        self.streams.iter().map(|(n, _)| (*n).to_string()).collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.streams.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.streams.is_empty()
+    }
+}
+
+/// Other represented objects a decode depends on, by the name the codec
+/// gives the dependency. Empty for every codec this build ships; the
+/// slot exists so a codebook arrives as a dependency and not as a stream.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AuxiliaryOperands {
+    operands: BTreeMap<String, OperandRef>,
+}
+
+impl AuxiliaryOperands {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with(mut self, name: impl Into<String>, operand: OperandRef) -> Self {
+        self.operands.insert(name.into(), operand);
+        self
+    }
+
+    pub fn get(&self, name: &str) -> Option<&OperandRef> {
+        self.operands.get(name)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.operands.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.operands.len()
+    }
+}
+
+/// Everything one decode consumes.
+#[derive(Debug, Clone, Default)]
+pub struct CodecOperands<'a> {
+    pub streams: NamedStreams<'a>,
+    pub auxiliaries: AuxiliaryOperands,
+}
+
+impl<'a> CodecOperands<'a> {
+    pub fn from_streams(streams: NamedStreams<'a>) -> Self {
+        Self {
+            streams,
+            auxiliaries: AuxiliaryOperands::new(),
+        }
+    }
+
+    /// The stream `spec` names, or a refusal listing what was bound.
+    pub fn stream(
+        &self,
+        spec: StreamSpec,
+        label: &str,
+        tensor: &str,
+    ) -> Result<&'a [u8], CodecError> {
+        self.streams
+            .get(spec)
+            .ok_or_else(|| CodecError::MissingStream {
+                tensor: tensor.into(),
+                label: label.into(),
+                stream: spec.name.into(),
+                bound: self.streams.names(),
+            })
+    }
+
+    /// The stream `spec` names, refusing one shorter than `need` bytes.
+    pub fn stream_of_len(
+        &self,
+        spec: StreamSpec,
+        need: usize,
+        label: &str,
+        tensor: &str,
+    ) -> Result<&'a [u8], CodecError> {
+        let bytes = self.stream(spec, label, tensor)?;
+        if bytes.len() < need {
+            return Err(CodecError::StreamLength {
+                tensor: tensor.into(),
+                label: label.into(),
+                stream: spec.name.into(),
+                need,
+                have: bytes.len(),
+            });
+        }
+        Ok(bytes)
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/baseline.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/baseline.rs
@@ -1,0 +1,126 @@
+//! The tables that stated these facts before the contract existed agree
+//! with it — the witness that the trait was extracted, not invented.
+//!
+//! Each of these facts had at least two homes: block bytes in the K-quant
+//! table and in the expert-encoding match, group sizes in the models crate
+//! and the loader, alignment in the segment writer and the binder. The
+//! codec is now the derivation; these tests pin the older statements to
+//! it so that a drift fails here and not in a 20 GB segment.
+
+use super::*;
+use crate::format::vindex3::represent::physical::{ExpertEncoding, WEIGHT_BINDING_ALIGN};
+use larql_models::quant::nvfp4::NVFP4_GROUP_ELEMS;
+
+#[test]
+fn the_expert_encoding_table_prices_a_matrix_as_the_codec_does() {
+    let registry = CodecRegistry::builtin();
+    for (encoding, label) in [
+        (ExpertEncoding::Bf16, "BF16"),
+        (ExpertEncoding::Q80, "Q8_0"),
+        (ExpertEncoding::Q6K, "Q6_K"),
+        (ExpertEncoding::Q4K, "Q4_K"),
+    ] {
+        assert_eq!(encoding.name(), label);
+        let codec = registry.resolve(label, TENSOR).unwrap();
+        for (n, k) in [(1, 256), (7, 512), (64, 4096)] {
+            assert_eq!(
+                encoding.matrix_bytes(n, k).unwrap(),
+                codec
+                    .stored_bytes(&[n, k], RepresentationExtent::TERMINAL, TENSOR)
+                    .unwrap(),
+                "{label} [{n}, {k}]"
+            );
+        }
+        // And both refuse a row that is not a whole number of blocks.
+        assert_eq!(
+            encoding.matrix_bytes(2, 100).is_err(),
+            codec
+                .stored_bytes(&[2, 100], RepresentationExtent::TERMINAL, TENSOR)
+                .is_err(),
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn the_kquant_table_s_bits_are_the_certificate_s() {
+    for codec in [Q4_K, Q6_K, Q8_0] {
+        let quant = codec.quant();
+        let cert = codec.extents()[0];
+        assert_eq!(cert.bits_per_weight, quant.bits_per_weight());
+        assert_eq!(
+            cert.bits_per_weight,
+            quant.bytes_per_block as f64 * extent::BITS_PER_BYTE / quant.elements_per_block as f64
+        );
+        assert_eq!(codec.capabilities().group_elems, quant.elements_per_block);
+        assert_eq!(codec.identity().group_elems, quant.elements_per_block);
+    }
+}
+
+#[test]
+fn the_nvfp4_pack_layout_is_the_codec_s_geometry() {
+    for (rows, k) in [(1usize, 16usize), (3, 256), (1024, 4096)] {
+        let layout = PackLayout::derive(&[rows, k], TENSOR).unwrap();
+        assert_eq!(
+            layout.total_len as u64,
+            NVFP4
+                .stored_bytes(&[rows, k], RepresentationExtent::TERMINAL, TENSOR)
+                .unwrap()
+        );
+    }
+    // The layout's per-tensor figure converges on the certificate's
+    // asymptotic one as the tensor scale amortises.
+    let large = PackLayout::derive(&[1024, 4096], TENSOR).unwrap();
+    assert!((large.bits_per_weight() - NVFP4.extents()[0].bits_per_weight).abs() < 1e-3);
+    assert_eq!(NVFP4.capabilities().group_elems, NVFP4_GROUP_ELEMS);
+    assert_eq!(NVFP4.identity().group_elems, NVFP4_GROUP_ELEMS);
+}
+
+#[test]
+fn mxfp4_geometry_is_the_models_crate_s_and_nothing_else() {
+    assert_eq!(MXFP4.capabilities().group_elems, MXFP4_GROUP_ELEMS);
+    assert_eq!(MXFP4.identity().group_elems, MXFP4_GROUP_ELEMS);
+    let (rows, k) = (5usize, 96usize);
+    let groups = k / MXFP4_GROUP_ELEMS;
+    assert_eq!(
+        MXFP4
+            .stored_bytes(&[rows, k], RepresentationExtent::TERMINAL, TENSOR)
+            .unwrap(),
+        (rows * groups * (MXFP4_GROUP_BYTES + 1)) as u64
+    );
+    assert_eq!(MXFP4.extents()[0].bits_per_weight, 4.25);
+}
+
+#[test]
+fn a_conforming_container_s_alignment_satisfies_every_codec_s_widest_field() {
+    // The execution binding requirement (4 bytes, measured) is the
+    // conformance bar; no codec may need more than a conforming segment
+    // provides, or the Kimi container's 4-aligned expert segment would be
+    // condemned for no measurable reason.
+    for codec in builtin() {
+        assert!(
+            codec.capabilities().physical_align_bytes as u64 <= WEIGHT_BINDING_ALIGN,
+            "{}",
+            codec.encoding_label()
+        );
+    }
+}
+
+#[test]
+fn the_float_widths_are_the_element_widths() {
+    for (codec, width) in [(BF16, 2usize), (F16, 2), (F32, 4)] {
+        assert_eq!(codec.dtype().width_bytes(), width);
+        assert_eq!(codec.capabilities().physical_align_bytes, width);
+        assert_eq!(
+            codec.extents()[0].bits_per_weight,
+            width as f64 * extent::BITS_PER_BYTE
+        );
+        assert_eq!(
+            codec
+                .stored_bytes(&[ROWS, K], RepresentationExtent::TERMINAL, TENSOR)
+                .unwrap(),
+            (ROWS * K * width) as u64
+        );
+        assert_eq!(codec.identity().family, codec.encoding_label());
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/capability.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/capability.rs
@@ -1,0 +1,74 @@
+//! The access ladder, and refusals that name both sides.
+
+use super::*;
+
+#[test]
+fn a_finer_granularity_provides_every_coarser_requirement() {
+    use AccessGranularity as G;
+    use RequiredAccess as R;
+    let ladder = [
+        G::Sequential,
+        G::BlockRandom { elems: 256 },
+        G::RowRandom,
+        G::ElementRandom,
+    ];
+    for (i, provided) in ladder.iter().enumerate() {
+        assert!(provided.provides(R::Sequential), "{provided:?}");
+        assert_eq!(provided.provides(R::RowRandom), i >= 2, "{provided:?}");
+        assert_eq!(provided.provides(R::ElementRandom), i >= 3, "{provided:?}");
+    }
+    // Block-random is not row-random: whether a row is whole blocks is a
+    // fact about the tensor, not the codec.
+    assert!(!G::BlockRandom { elems: 256 }.provides(R::RowRandom));
+}
+
+#[test]
+fn granularities_and_requirements_have_names_a_refusal_can_carry() {
+    assert_eq!(AccessGranularity::Sequential.name(), "sequential");
+    assert_eq!(
+        AccessGranularity::BlockRandom { elems: 256 }.name(),
+        "block-random (256 elements)"
+    );
+    assert_eq!(AccessGranularity::RowRandom.name(), "row-random");
+    assert_eq!(AccessGranularity::ElementRandom.name(), "element-random");
+    assert_eq!(RequiredAccess::Sequential.name(), "sequential");
+    assert_eq!(RequiredAccess::RowRandom.name(), "row-random");
+    assert_eq!(RequiredAccess::ElementRandom.name(), "element-random");
+}
+
+#[test]
+fn a_refusal_names_what_is_provided_and_what_is_required() {
+    let sequential = CodecCapabilities {
+        access: AccessGranularity::Sequential,
+        group_elems: 1,
+        row_align_elems: 1,
+        physical_align_bytes: 1,
+    };
+    sequential
+        .require(RequiredAccess::Sequential, "zstd-bf16")
+        .unwrap();
+    let err = sequential
+        .require(RequiredAccess::RowRandom, "zstd-bf16")
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "`zstd-bf16` provides sequential access; the plan requires row-random"
+    );
+}
+
+#[test]
+fn row_admission_is_a_whole_number_of_the_alignment_and_zero_admits_nothing() {
+    let caps = CodecCapabilities {
+        access: AccessGranularity::RowRandom,
+        group_elems: 32,
+        row_align_elems: 32,
+        physical_align_bytes: 1,
+    };
+    assert!(caps.admits_k(64));
+    assert!(!caps.admits_k(48));
+    let degenerate = CodecCapabilities {
+        row_align_elems: 0,
+        ..caps
+    };
+    assert!(!degenerate.admits_k(64));
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/contract.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/contract.rs
@@ -1,0 +1,185 @@
+//! What every registered codec must declare — checked over all of them.
+
+use super::*;
+use crate::format::vindex3::opplan::exec::backend::WeightFormat;
+
+#[test]
+fn every_codec_names_itself_and_its_abi_is_admitted_back_to_it() {
+    let registry = CodecRegistry::builtin();
+    for codec in builtin() {
+        let label = codec.encoding_label();
+        assert!(!label.is_empty());
+        let id = codec.identity();
+        assert!(!id.family.is_empty(), "{label} names no family");
+        let admitted = registry
+            .admit(&id)
+            .unwrap_or_else(|e| panic!("{label}: {e}"));
+        assert_eq!(admitted.encoding_label(), label);
+        assert_eq!(registry.by_label(label).unwrap().identity(), id);
+    }
+}
+
+#[test]
+fn every_codec_declares_its_values_stream_first_and_only_once() {
+    for codec in builtin() {
+        let streams = codec.streams();
+        assert_eq!(streams[0], VALUES, "{}", codec.encoding_label());
+        let values = streams
+            .iter()
+            .filter(|s| s.role == StreamRole::Values)
+            .count();
+        assert_eq!(values, 1, "{}", codec.encoding_label());
+    }
+}
+
+#[test]
+fn every_codec_is_terminal_today_and_says_so_at_any_other_depth() {
+    for codec in builtin() {
+        let label = codec.encoding_label();
+        let extents = codec.extents();
+        assert_eq!(extents.len(), 1, "{label}");
+        assert_eq!(extents[0].extent, RepresentationExtent::TERMINAL, "{label}");
+        assert!(extents[0].bits_per_weight > 0.0 && extents[0].bits_per_weight <= 32.0);
+        assert!(
+            extents[0].radius.is_none(),
+            "{label}: no radius is declared, only measured"
+        );
+        assert_eq!(
+            codec
+                .certificate_at(RepresentationExtent::TERMINAL, TENSOR)
+                .unwrap(),
+            extents[0]
+        );
+        let deeper = RepresentationExtent::at_depth(1);
+        let err = codec.certificate_at(deeper, TENSOR).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                CodecError::ExtentUnavailable {
+                    depth: 1,
+                    available: 1,
+                    ..
+                }
+            ),
+            "{label}: {err}"
+        );
+        assert!(matches!(
+            codec.stored_bytes(&[ROWS, K], deeper, TENSOR).unwrap_err(),
+            CodecError::ExtentUnavailable { .. }
+        ));
+    }
+}
+
+#[test]
+fn every_codec_admits_its_own_alignment_and_refuses_access_it_lacks() {
+    for codec in builtin() {
+        let label = codec.encoding_label();
+        let caps = codec.capabilities();
+        assert!(caps.admits_k(caps.row_align_elems), "{label}");
+        assert!(caps.admits_k(K), "{label}: the fixture width is admissible");
+        if caps.row_align_elems > 1 {
+            assert!(!caps.admits_k(caps.row_align_elems + 1), "{label}");
+        }
+        assert!(
+            caps.group_elems >= 1 && caps.row_align_elems >= caps.group_elems,
+            "{label}"
+        );
+        caps.require(RequiredAccess::Sequential, label).unwrap();
+        caps.require(RequiredAccess::RowRandom, label).unwrap();
+        let element = caps.require(RequiredAccess::ElementRandom, label);
+        assert_eq!(
+            element.is_ok(),
+            caps.access == AccessGranularity::ElementRandom,
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn the_mandatory_realization_widens_to_f32_for_every_codec() {
+    for codec in builtin() {
+        assert_eq!(
+            codec.decode_residency(),
+            ResidencyProfile::DECODED_F32,
+            "{}",
+            codec.encoding_label()
+        );
+    }
+}
+
+/// The label a CPU plan's resident format corresponds to.
+fn label_of(format: WeightFormat) -> Option<&'static str> {
+    match format {
+        WeightFormat::F32 => Some("F32"),
+        WeightFormat::Bf16 => Some("BF16"),
+        WeightFormat::F16 => Some("F16"),
+        WeightFormat::Nvfp4 => Some("NVFP4"),
+        WeightFormat::Mxfp4 => Some("MXFP4"),
+        // Runtime re-quantisations of a float source: no stored codec.
+        WeightFormat::Q8 | WeightFormat::Q4 => None,
+    }
+}
+
+#[test]
+fn every_acceleration_runs_over_the_stored_bytes_and_names_a_plan_for_them() {
+    for codec in builtin() {
+        let label = codec.encoding_label();
+        let bpw = codec.extents()[0].bits_per_weight;
+        for accel in codec.accelerations() {
+            assert_eq!(accel.backend, AccelerationBackend::Cpu, "{label}");
+            assert!(accel.residency.class.preserves_values(), "{label}");
+            assert!(
+                matches!(
+                    accel.residency.class,
+                    ResidencyClass::Stored | ResidencyClass::Rebound
+                ),
+                "{label}: a direct realization touches stored bytes, got {:?}",
+                accel.residency.class
+            );
+            let touched = accel.residency.bytes_per_weight * extent::BITS_PER_BYTE;
+            assert!((touched - bpw).abs() < 1e-9, "{label}: {touched} vs {bpw}");
+            assert_eq!(accel.requires, RequiredAccess::RowRandom, "{label}");
+            assert_eq!(
+                label_of(accel.plan.format()),
+                Some(label),
+                "{label}: {:?}",
+                accel.plan
+            );
+        }
+    }
+}
+
+#[test]
+fn codecs_with_no_direct_cpu_realization_say_so_rather_than_claim_one() {
+    let without: Vec<&str> = builtin()
+        .into_iter()
+        .filter(|c| c.accelerations().is_empty())
+        .map(|c| c.encoding_label())
+        .collect();
+    assert_eq!(without, ["F16", "Q4_K", "Q6_K", "Q8_0", "MXFP4"]);
+    let with: Vec<&str> = builtin()
+        .into_iter()
+        .filter(|c| !c.accelerations().is_empty())
+        .map(|c| c.encoding_label())
+        .collect();
+    assert_eq!(with, ["BF16", "F32", "NVFP4"]);
+}
+
+#[test]
+fn stored_bytes_are_the_certificate_s_bits_at_scale() {
+    // The certificate is asymptotic; on a large matrix the exact byte
+    // count must agree with it to the per-tensor overhead.
+    let shape = [4096usize, 4096];
+    for codec in builtin() {
+        let label = codec.encoding_label();
+        let bytes = codec
+            .stored_bytes(&shape, RepresentationExtent::TERMINAL, TENSOR)
+            .unwrap() as f64;
+        let bpw = bytes * extent::BITS_PER_BYTE / (shape[0] * shape[1]) as f64;
+        let declared = codec.extents()[0].bits_per_weight;
+        assert!(
+            (bpw - declared).abs() < 1e-3,
+            "{label}: {bpw} vs {declared}"
+        );
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/decode.rs
@@ -1,0 +1,166 @@
+//! Each codec decodes to exactly what the path it replaced decoded to.
+//!
+//! The reference on every arm is the decoder the executor already used
+//! — the operand widener, `KQuant::decode`, the NVFP4 pack split and the
+//! models-crate MXFP4 decoder — so the trait is shown to be an
+//! extraction and not a second opinion.
+
+use super::*;
+use crate::format::vindex3::opplan::exec::operands::widen;
+use crate::format::vindex3::represent::nvfp4_pack::split;
+use larql_models::quant::mxfp4::dequantize_expert;
+use larql_models::quant::nvfp4::{dequantize_into, Nvfp4Matrix};
+
+/// One unit in the last place of a bf16 mantissa (7 bits), relative.
+const BF16_RELATIVE_STEP: f32 = 1.0 / 128.0;
+
+fn decoded(fixture: &Fixture) -> Vec<f32> {
+    fixture
+        .codec
+        .decode_all(
+            &fixture.operands(),
+            &fixture.shape,
+            RepresentationExtent::TERMINAL,
+            TENSOR,
+        )
+        .unwrap_or_else(|e| panic!("{}: {e}", fixture.label()))
+}
+
+#[test]
+fn floats_decode_through_the_operand_widener() {
+    for fixture in fixtures().iter().filter(|f| f.codec.streams().len() == 1) {
+        let label = fixture.label();
+        if !["BF16", "F16", "F32"].contains(&label) {
+            continue;
+        }
+        let expected = widen(label, &fixture.buffers[0], TENSOR).unwrap();
+        assert_eq!(decoded(fixture), expected, "{label}");
+        // And a float is a float: the ramp survives to the narrowest
+        // mantissa here (bf16's 7 bits), which is a plumbing check — a
+        // row read from the wrong place would miss by the ramp's span.
+        let values = ramp(ROWS * K);
+        let span = values.iter().fold(0.0f32, |m, v| m.max(v.abs()));
+        let worst = decoded(fixture)
+            .iter()
+            .zip(&values)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        assert!(
+            worst <= span * BF16_RELATIVE_STEP,
+            "{label}: worst {worst} of span {span}"
+        );
+    }
+}
+
+#[test]
+fn kquants_decode_through_the_workspace_decoder() {
+    for codec in [Q4_K, Q6_K, Q8_0] {
+        let fixture = fixtures()
+            .into_iter()
+            .find(|f| f.label() == codec.encoding_label())
+            .unwrap();
+        let expected = codec
+            .quant()
+            .decode(&fixture.buffers[0], ROWS * K, TENSOR)
+            .unwrap();
+        assert_eq!(decoded(&fixture), expected, "{}", codec.encoding_label());
+    }
+}
+
+#[test]
+fn nvfp4_decodes_through_the_pack_split_and_the_reference_decoder() {
+    let fixture = fixtures()
+        .into_iter()
+        .find(|f| f.label() == "NVFP4")
+        .unwrap();
+    let layout = PackLayout::derive(&fixture.shape, TENSOR).unwrap();
+    let (packed, scales, tensor_scale) = split(&fixture.buffers[0], &layout, TENSOR).unwrap();
+    let matrix = Nvfp4Matrix {
+        packed: packed.to_vec(),
+        scales: scales.to_vec(),
+        tensor_scale,
+    };
+    let mut expected = vec![0.0f32; ROWS * K];
+    dequantize_into(&matrix, ROWS, K, &mut expected).unwrap();
+    assert_eq!(decoded(&fixture), expected);
+    // Bound through the packed row, the three streams are the pack's
+    // three regions, in order.
+    let operands = fixture.operands();
+    assert_eq!(
+        operands.streams.names(),
+        ["values", "group_scales", "tensor_scale"]
+    );
+    let tail = operands.stream(TENSOR_SCALE, "NVFP4", TENSOR).unwrap();
+    assert_eq!(tail.len(), std::mem::size_of::<f32>());
+}
+
+#[test]
+fn mxfp4_decodes_its_two_streams_through_the_models_crate() {
+    let fixture = fixtures()
+        .into_iter()
+        .find(|f| f.label() == DTYPE_MXFP4)
+        .unwrap();
+    let groups = K / MXFP4_GROUP_ELEMS;
+    let expected =
+        dequantize_expert(&fixture.buffers[0], &fixture.buffers[1], ROWS, groups).unwrap();
+    assert_eq!(decoded(&fixture), expected);
+}
+
+#[test]
+fn mxfp4_refuses_one_payload_by_naming_the_streams_it_keeps_apart() {
+    let err = MXFP4.bind_packed(&[0u8; 64], &[1, 32], TENSOR).unwrap_err();
+    assert_eq!(
+        err,
+        CodecError::StreamsStoredApart {
+            tensor: TENSOR.into(),
+            label: DTYPE_MXFP4.into(),
+            streams: vec!["values".into(), "group_scales".into()],
+        }
+    );
+    assert!(
+        err.to_string().contains("bind each stream by name"),
+        "{err}"
+    );
+    // And therefore the packed path refuses too, before any decode.
+    assert!(MXFP4
+        .decode_packed(&[0u8; 64], &[1, 32], RepresentationExtent::TERMINAL, TENSOR)
+        .is_err());
+}
+
+#[test]
+fn decode_packed_is_bind_then_validate_then_decode_for_every_packed_codec() {
+    for fixture in fixtures().iter().filter(|f| f.packed) {
+        let via_packed = fixture
+            .codec
+            .decode_packed(
+                &fixture.buffers[0],
+                &fixture.shape,
+                RepresentationExtent::TERMINAL,
+                TENSOR,
+            )
+            .unwrap_or_else(|e| panic!("{}: {e}", fixture.label()));
+        assert_eq!(via_packed, decoded(fixture), "{}", fixture.label());
+    }
+}
+
+#[test]
+fn every_fixture_validates_and_is_the_size_the_codec_declares() {
+    for fixture in fixtures() {
+        let operands = fixture.operands();
+        fixture
+            .codec
+            .validate(
+                &operands,
+                &fixture.shape,
+                RepresentationExtent::TERMINAL,
+                TENSOR,
+            )
+            .unwrap_or_else(|e| panic!("{}: {e}", fixture.label()));
+        let declared = fixture
+            .codec
+            .stored_bytes(&fixture.shape, RepresentationExtent::TERMINAL, TENSOR)
+            .unwrap();
+        let held: usize = fixture.buffers.iter().map(Vec::len).sum();
+        assert_eq!(held as u64, declared, "{}", fixture.label());
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/geometry.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/geometry.rs
@@ -1,0 +1,72 @@
+//! One reading of a shape, for every rank.
+
+use super::*;
+
+const LABEL: &str = "X";
+
+#[test]
+fn the_last_axis_is_k_and_the_rest_fold_into_rows() {
+    let of = |shape: &[usize]| RowGeometry::of(shape, LABEL, TENSOR).unwrap();
+    assert_eq!(of(&[]), RowGeometry { rows: 1, k: 1 });
+    assert_eq!(of(&[7]), RowGeometry { rows: 1, k: 7 });
+    assert_eq!(of(&[3, 4]), RowGeometry { rows: 3, k: 4 });
+    assert_eq!(of(&[2, 3, 4]), RowGeometry { rows: 6, k: 4 });
+    assert_eq!(of(&[2, 3, 4]).elements(LABEL, TENSOR).unwrap(), 24);
+}
+
+#[test]
+fn overflow_is_refused_rather_than_wrapped() {
+    let err = RowGeometry::of(&[usize::MAX, 2, 2], LABEL, TENSOR).unwrap_err();
+    assert!(
+        matches!(&err, CodecError::Geometry { why, .. } if why.contains("row count")),
+        "{err}"
+    );
+    let huge = RowGeometry::of(&[usize::MAX, usize::MAX], LABEL, TENSOR).unwrap();
+    let err = huge.elements(LABEL, TENSOR).unwrap_err();
+    assert!(
+        matches!(&err, CodecError::Geometry { why, .. } if why.contains("element count")),
+        "{err}"
+    );
+}
+
+#[test]
+fn a_row_range_must_lie_within_the_rows_and_be_ordered() {
+    let g = RowGeometry { rows: 3, k: 8 };
+    g.check_rows(&(0..3), LABEL, TENSOR).unwrap();
+    g.check_rows(&(1..1), LABEL, TENSOR).unwrap();
+    for bad in [0..4, 3..4] {
+        let err = g.check_rows(&bad, LABEL, TENSOR).unwrap_err();
+        assert!(matches!(err, CodecError::RowRange { rows: 3, .. }), "{err}");
+    }
+    #[allow(clippy::reversed_empty_ranges)]
+    let reversed = 2..1;
+    assert!(g.check_rows(&reversed, LABEL, TENSOR).is_err());
+}
+
+#[test]
+fn a_group_must_divide_k_and_a_zero_group_is_no_group() {
+    let g = RowGeometry { rows: 1, k: 64 };
+    assert_eq!(g.check_group(32, LABEL, TENSOR).unwrap(), 2);
+    assert_eq!(g.check_group(64, LABEL, TENSOR).unwrap(), 1);
+    let err = g.check_group(48, LABEL, TENSOR).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "tensor `layer.0.w`: shape [1, 64] cannot hold `X`: k=64 is not a whole number of 48-element groups"
+    );
+    assert!(g.check_group(0, LABEL, TENSOR).is_err());
+}
+
+#[test]
+fn the_destination_must_hold_exactly_the_requested_rows() {
+    let g = RowGeometry { rows: 3, k: 8 };
+    g.check_destination(&(1..3), 16, TENSOR).unwrap();
+    let err = g.check_destination(&(1..3), 17, TENSOR).unwrap_err();
+    assert_eq!(
+        err,
+        CodecError::Destination {
+            tensor: TENSOR.into(),
+            need: 16,
+            have: 17
+        }
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/lyrw2.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/lyrw2.rs
@@ -1,0 +1,129 @@
+//! A LYRW v2 region schema reaches the contract, or is refused by tag.
+
+use super::*;
+use crate::format::lyrw2::region_format::{Packing, RegionFormat};
+use crate::format::vindex3::represent::codec::codecs::lyrw2::{
+    bind_region, codec_label, region_binding, RegionBinding,
+};
+
+#[test]
+fn every_registered_region_format_names_a_built_in_codec() {
+    let registry = CodecRegistry::builtin();
+    for (format, label) in [
+        (RegionFormat::F32, "F32"),
+        (RegionFormat::F16, "F16"),
+        (RegionFormat::BF16, "BF16"),
+        (RegionFormat::Q4K, "Q4_K"),
+        (RegionFormat::Q6K, "Q6_K"),
+        (RegionFormat::Q8_0, "Q8_0"),
+        (RegionFormat::Mxfp4, "MXFP4"),
+        (RegionFormat::Nvfp4, "NVFP4"),
+    ] {
+        assert_eq!(codec_label(format), Some(label), "{format:?}");
+        assert!(registry.by_label(label).is_some(), "{label}");
+    }
+}
+
+#[test]
+fn a_recognised_tag_with_no_codec_is_none_not_a_guess() {
+    for format in [
+        RegionFormat::Q4_0,
+        RegionFormat::Fp4Larql,
+        RegionFormat::Mxfp8,
+        RegionFormat::Unknown(99),
+    ] {
+        assert_eq!(codec_label(format), None, "{format:?}");
+    }
+}
+
+#[test]
+fn a_packing_says_how_the_streams_arrive() {
+    assert_eq!(
+        region_binding(Packing::RowMajor),
+        Some(RegionBinding::Single)
+    );
+    assert_eq!(
+        region_binding(Packing::BlocksWithScalesInline),
+        Some(RegionBinding::Single)
+    );
+    assert_eq!(
+        region_binding(Packing::BlocksValues),
+        Some(RegionBinding::PairedValues)
+    );
+    assert_eq!(
+        region_binding(Packing::BlocksScales),
+        Some(RegionBinding::PairedScales)
+    );
+    assert_eq!(region_binding(Packing::Unknown(7)), None);
+}
+
+#[test]
+fn a_paired_mxfp4_region_binds_both_streams_and_validates() {
+    let fixture = fixtures()
+        .into_iter()
+        .find(|f| f.label() == DTYPE_MXFP4)
+        .unwrap();
+    let operands = bind_region(
+        &MXFP4,
+        &fixture.shape,
+        &fixture.buffers[0],
+        Some(&fixture.buffers[1]),
+        TENSOR,
+    )
+    .unwrap();
+    assert_eq!(operands.streams.names(), ["values", "group_scales"]);
+    assert!(operands.auxiliaries.is_empty());
+}
+
+#[test]
+fn an_mxfp4_region_without_its_partner_is_refused_by_name() {
+    let fixture = fixtures()
+        .into_iter()
+        .find(|f| f.label() == DTYPE_MXFP4)
+        .unwrap();
+    let err = bind_region(&MXFP4, &fixture.shape, &fixture.buffers[0], None, TENSOR).unwrap_err();
+    assert!(
+        matches!(err, CodecError::StreamsStoredApart { .. }),
+        "{err}"
+    );
+}
+
+#[test]
+fn a_partner_the_codec_never_declared_is_refused_by_name() {
+    let fixture = fixtures()
+        .into_iter()
+        .find(|f| f.label() == "Q6_K")
+        .unwrap();
+    let scales = [0u8; 8];
+    let err = bind_region(
+        &Q6_K,
+        &fixture.shape,
+        &fixture.buffers[0],
+        Some(&scales),
+        TENSOR,
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        CodecError::UnexpectedStream {
+            tensor: TENSOR.into(),
+            label: "Q6_K".into(),
+            stream: "group_scales".into(),
+            declared: vec!["values".into()],
+        }
+    );
+    assert!(err.to_string().contains("declares no stream"), "{err}");
+}
+
+#[test]
+fn an_inline_region_binds_as_one_payload_and_a_short_one_is_refused() {
+    let fixture = fixtures()
+        .into_iter()
+        .find(|f| f.label() == "Q6_K")
+        .unwrap();
+    let operands = bind_region(&Q6_K, &fixture.shape, &fixture.buffers[0], None, TENSOR).unwrap();
+    assert_eq!(operands.streams.names(), ["values"]);
+    let short = &fixture.buffers[0][..fixture.buffers[0].len() / 2];
+    let err = bind_region(&Q6_K, &fixture.shape, short, None, TENSOR).unwrap_err();
+    assert!(matches!(err, CodecError::StreamLength { .. }), "{err}");
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/mod.rs
@@ -1,0 +1,198 @@
+//! The contract's tests, and the fixtures they share.
+//!
+//! Every codec the registry ships is exercised through the SAME table, so
+//! a test that passes for the floats and fails for MXFP4 is a statement
+//! about MXFP4's declaration and not about the test.
+
+mod baseline;
+mod capability;
+mod contract;
+mod decode;
+mod geometry;
+mod lyrw2;
+mod ranges;
+mod registry;
+mod residency;
+mod streams;
+
+use super::codecs::float::{BF16, F16, F32};
+use super::codecs::kquant::{Q4_K, Q6_K, Q8_0};
+use super::codecs::mxfp4::{DTYPE_MXFP4, MXFP4};
+use super::codecs::nvfp4::NVFP4;
+// Named explicitly: the `streams` TEST module below shadows the crate's
+// `streams` module for every file under it.
+use super::streams::{GROUP_SCALES, TENSOR_SCALE, VALUES};
+use super::*;
+use crate::format::vindex3::opplan::exec::weights::{quantize_mxfp4, LoadedWeight};
+use crate::format::vindex3::represent::nvfp4_pack::{encode as encode_nvfp4, PackLayout};
+use larql_models::quant::half::{encode_bf16, encode_f16};
+use larql_models::quant::mxfp4::{MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS};
+
+pub(super) const TENSOR: &str = "layer.0.w";
+/// Every fixture is this shape: three rows of one K-quant super-block,
+/// which is also a whole number of every smaller group.
+pub(super) const ROWS: usize = 3;
+pub(super) const K: usize = 256;
+
+/// Values that are not symmetric about zero and not periodic in any
+/// block size, so a row or block read from the wrong place is visible.
+pub(super) fn ramp(n: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| (i as f32 * 0.37 - 7.0) * 0.03125 + (i % 13) as f32 * 0.01)
+        .collect()
+}
+
+pub(super) fn builtin() -> Vec<&'static dyn RepresentationCodec> {
+    CodecRegistry::builtin().codecs().collect()
+}
+
+/// One encoded fixture: the bytes a container would hold, and how they
+/// bind onto the codec's streams.
+pub(super) struct Fixture {
+    pub codec: &'static dyn RepresentationCodec,
+    pub shape: Vec<usize>,
+    /// Owned stream bytes in declaration order.
+    pub buffers: Vec<Vec<u8>>,
+    /// Whether the buffers are one packed payload (bound through
+    /// `bind_packed`) or one buffer per declared stream.
+    pub packed: bool,
+}
+
+impl Fixture {
+    pub fn operands(&self) -> CodecOperands<'_> {
+        if self.packed {
+            let streams = self
+                .codec
+                .bind_packed(&self.buffers[0], &self.shape, TENSOR)
+                .expect("a packed fixture binds");
+            return CodecOperands::from_streams(streams);
+        }
+        let mut streams = NamedStreams::new();
+        for (spec, bytes) in self.codec.streams().iter().zip(&self.buffers) {
+            streams = streams.with(*spec, bytes);
+        }
+        CodecOperands::from_streams(streams)
+    }
+
+    pub fn label(&self) -> &'static str {
+        self.codec.encoding_label()
+    }
+}
+
+/// A fixture per built-in codec, all of `[ROWS, K]`.
+pub(super) fn fixtures() -> Vec<Fixture> {
+    let shape = vec![ROWS, K];
+    let values = ramp(ROWS * K);
+    let f32_bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let packed = |codec: &'static dyn RepresentationCodec, bytes: Vec<u8>| Fixture {
+        codec,
+        shape: shape.clone(),
+        buffers: vec![bytes],
+        packed: true,
+    };
+    let mut out = vec![
+        packed(&BF16, encode_bf16(&values)),
+        packed(&F16, encode_f16(&values)),
+        packed(&F32, f32_bytes),
+    ];
+    for k in [Q4_K, Q6_K, Q8_0] {
+        let bytes = k.quant().encode(&values, TENSOR).expect("encodes");
+        out.push(Fixture {
+            codec: match k.quant().name {
+                "Q4_K" => &Q4_K,
+                "Q6_K" => &Q6_K,
+                _ => &Q8_0,
+            },
+            shape: shape.clone(),
+            buffers: vec![bytes],
+            packed: true,
+        });
+    }
+    let layout = PackLayout::derive(&shape, TENSOR).expect("layout");
+    let matrix = larql_models::quant::nvfp4::quantize(&values, ROWS, K).expect("nvfp4");
+    out.push(packed(
+        &NVFP4,
+        encode_nvfp4(&matrix, &layout, TENSOR).expect("packs"),
+    ));
+    let LoadedWeight::Mxfp4 { packed, scales } =
+        quantize_mxfp4(&values, ROWS, K, TENSOR).expect("mxfp4")
+    else {
+        panic!("quantize_mxfp4 yields the MXFP4 residency");
+    };
+    let groups = K / MXFP4_GROUP_ELEMS;
+    out.push(Fixture {
+        codec: &MXFP4,
+        shape,
+        buffers: vec![
+            packed.as_slice()[..ROWS * groups * MXFP4_GROUP_BYTES].to_vec(),
+            scales.as_slice()[..ROWS * groups].to_vec(),
+        ],
+        packed: false,
+    });
+    assert_eq!(out.len(), builtin().len(), "one fixture per built-in codec");
+    assert!(out.iter().any(|f| f.label() == DTYPE_MXFP4));
+    out
+}
+
+/// A foreign implementor that overrides nothing optional, so the trait's
+/// defaults are exercised by a codec this crate does not otherwise ship.
+pub(super) struct Stub {
+    pub label: &'static str,
+    pub identity: super::super::nvfp4_pack::CodecIdentity,
+    pub streams: &'static [StreamSpec],
+}
+
+impl RepresentationCodec for Stub {
+    fn encoding_label(&self) -> &'static str {
+        self.label
+    }
+    fn identity(&self) -> super::super::nvfp4_pack::CodecIdentity {
+        self.identity.clone()
+    }
+    fn streams(&self) -> &'static [StreamSpec] {
+        self.streams
+    }
+    fn capabilities(&self) -> CodecCapabilities {
+        CodecCapabilities {
+            access: AccessGranularity::Sequential,
+            group_elems: 1,
+            row_align_elems: 1,
+            physical_align_bytes: 1,
+        }
+    }
+    fn extents(&self) -> Vec<ExtentCertificate> {
+        vec![ExtentCertificate::terminal(1.0)]
+    }
+    fn stored_bytes(
+        &self,
+        _: &[usize],
+        _: RepresentationExtent,
+        _: &str,
+    ) -> Result<u64, CodecError> {
+        Ok(0)
+    }
+    fn validate(
+        &self,
+        _: &CodecOperands<'_>,
+        _: &[usize],
+        _: RepresentationExtent,
+        _: &str,
+    ) -> Result<(), CodecError> {
+        Ok(())
+    }
+    fn decode_rows(
+        &self,
+        _: &CodecOperands<'_>,
+        _: &[usize],
+        _: std::ops::Range<usize>,
+        _: RepresentationExtent,
+        dst: &mut [f32],
+        _: &str,
+    ) -> Result<(), CodecError> {
+        dst.fill(0.0);
+        Ok(())
+    }
+    fn decode_residency(&self) -> ResidencyProfile {
+        ResidencyProfile::DECODED_F32
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/ranges.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/ranges.rs
@@ -1,0 +1,175 @@
+//! Range-aware decode, and the refusals around it — over every codec.
+
+use super::*;
+
+fn whole(fixture: &Fixture) -> Vec<f32> {
+    fixture
+        .codec
+        .decode_all(
+            &fixture.operands(),
+            &fixture.shape,
+            RepresentationExtent::TERMINAL,
+            TENSOR,
+        )
+        .unwrap()
+}
+
+#[test]
+fn a_row_range_decodes_to_that_slice_of_the_whole() {
+    for fixture in fixtures() {
+        let label = fixture.label();
+        let all = whole(&fixture);
+        for (start, end) in [(0, 1), (1, 3), (2, 3), (0, 3), (1, 1)] {
+            let mut dst = vec![f32::NAN; (end - start) * K];
+            fixture
+                .codec
+                .decode_rows(
+                    &fixture.operands(),
+                    &fixture.shape,
+                    start..end,
+                    RepresentationExtent::TERMINAL,
+                    &mut dst,
+                    TENSOR,
+                )
+                .unwrap_or_else(|e| panic!("{label} rows {start}..{end}: {e}"));
+            assert_eq!(dst, all[start * K..end * K], "{label} rows {start}..{end}");
+        }
+    }
+}
+
+#[test]
+fn a_row_range_past_the_end_is_refused_naming_the_rows_held() {
+    for fixture in fixtures() {
+        let mut dst = vec![0.0; K];
+        let err = fixture
+            .codec
+            .decode_rows(
+                &fixture.operands(),
+                &fixture.shape,
+                ROWS..ROWS + 1,
+                RepresentationExtent::TERMINAL,
+                &mut dst,
+                TENSOR,
+            )
+            .unwrap_err();
+        assert!(
+            matches!(&err, CodecError::RowRange { start, end, rows, .. } if *start == ROWS && *end == ROWS + 1 && *rows == ROWS),
+            "{}: {err}",
+            fixture.label()
+        );
+    }
+}
+
+#[test]
+fn a_destination_of_the_wrong_size_is_refused_before_any_byte_is_read() {
+    for fixture in fixtures() {
+        let mut dst = vec![0.0; K + 1];
+        let err = fixture
+            .codec
+            .decode_rows(
+                &fixture.operands(),
+                &fixture.shape,
+                0..1,
+                RepresentationExtent::TERMINAL,
+                &mut dst,
+                TENSOR,
+            )
+            .unwrap_err();
+        assert!(
+            matches!(&err, CodecError::Destination { need, have, .. } if *need == K && *have == K + 1),
+            "{}: {err}",
+            fixture.label()
+        );
+    }
+}
+
+#[test]
+fn a_stream_shorter_than_the_shape_implies_is_refused_by_stream_name() {
+    for fixture in fixtures() {
+        let label = fixture.label();
+        let mut streams = NamedStreams::new();
+        for (spec, bytes) in fixture.codec.streams().iter().zip(&fixture.buffers) {
+            streams = streams.with(*spec, &bytes[..bytes.len() - 1]);
+        }
+        // A packed codec that derives its split refuses at the bind.
+        if fixture.packed && fixture.codec.streams().len() > 1 {
+            let short = &fixture.buffers[0][..fixture.buffers[0].len() - 1];
+            let err = fixture
+                .codec
+                .bind_packed(short, &fixture.shape, TENSOR)
+                .unwrap_err();
+            assert!(
+                matches!(err, CodecError::StreamLength { .. }),
+                "{label}: {err}"
+            );
+            continue;
+        }
+        let operands = CodecOperands::from_streams(streams);
+        let err = fixture
+            .codec
+            .validate(
+                &operands,
+                &fixture.shape,
+                RepresentationExtent::TERMINAL,
+                TENSOR,
+            )
+            .unwrap_err();
+        assert!(
+            matches!(&err, CodecError::StreamLength { stream, .. } if stream == "values"),
+            "{label}: {err}"
+        );
+    }
+}
+
+#[test]
+fn a_row_the_codec_cannot_block_is_refused_by_group() {
+    // 100 is not a whole number of any group these codecs use; the
+    // floats accept anything.
+    for codec in builtin() {
+        let label = codec.encoding_label();
+        let result = codec.stored_bytes(&[2, 100], RepresentationExtent::TERMINAL, TENSOR);
+        let group = codec.capabilities().row_align_elems;
+        if group == 1 {
+            assert_eq!(
+                result.unwrap(),
+                200 * codec.capabilities().physical_align_bytes as u64,
+                "{label}"
+            );
+            continue;
+        }
+        let err = result.unwrap_err();
+        // Worded by whichever derivation owns the geometry — the shared
+        // row helper or NVFP4's pack layout — but always naming the group.
+        assert!(
+            matches!(&err, CodecError::Geometry { why, .. } if why.contains(&format!("{group}-element group"))),
+            "{label}: {err}"
+        );
+    }
+}
+
+#[test]
+fn a_missing_stream_is_named_together_with_what_was_bound() {
+    let fixture = fixtures()
+        .into_iter()
+        .find(|f| f.label() == DTYPE_MXFP4)
+        .unwrap();
+    let only_values =
+        CodecOperands::from_streams(NamedStreams::single(VALUES, &fixture.buffers[0]));
+    let err = MXFP4
+        .validate(
+            &only_values,
+            &fixture.shape,
+            RepresentationExtent::TERMINAL,
+            TENSOR,
+        )
+        .unwrap_err();
+    assert_eq!(
+        err,
+        CodecError::MissingStream {
+            tensor: TENSOR.into(),
+            label: DTYPE_MXFP4.into(),
+            stream: "group_scales".into(),
+            bound: vec!["values".into()],
+        }
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/registry.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/registry.rs
@@ -1,0 +1,180 @@
+//! The registry: two keys, three refusals, no duplicates.
+
+use super::*;
+use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
+
+#[test]
+fn the_built_in_registry_carries_the_eight_encodings_in_declaration_order() {
+    assert_eq!(
+        CodecRegistry::builtin().labels(),
+        ["BF16", "F16", "F32", "Q4_K", "Q6_K", "Q8_0", "NVFP4", "MXFP4"]
+    );
+    assert_eq!(
+        CodecRegistry::builtin().families(),
+        ["BF16", "F16", "F32", "Q4_K", "Q6_K", "Q8_0", "nvfp4", "mxfp4"]
+    );
+}
+
+#[test]
+fn a_label_and_a_family_resolve_to_the_same_codec() {
+    let registry = CodecRegistry::builtin();
+    for codec in builtin() {
+        let id = codec.identity();
+        let by_family = registry.by_family(&id.family).unwrap();
+        assert_eq!(by_family.encoding_label(), codec.encoding_label());
+        // A diagnostic names the codec by label and ABI.
+        assert_eq!(
+            format!("{by_family:?}"),
+            format!(
+                "codec {} ({} r{})",
+                codec.encoding_label(),
+                id.family,
+                id.revision
+            )
+        );
+        assert_eq!(
+            registry
+                .resolve(codec.encoding_label(), TENSOR)
+                .unwrap()
+                .encoding_label(),
+            codec.encoding_label()
+        );
+    }
+}
+
+#[test]
+fn an_unregistered_label_is_refused_naming_every_registered_one() {
+    let err = CodecRegistry::builtin()
+        .resolve("Q5_K", TENSOR)
+        .unwrap_err();
+    assert_eq!(
+        err,
+        CodecError::UnknownEncoding {
+            tensor: TENSOR.into(),
+            label: "Q5_K".into(),
+            registered: CodecRegistry::builtin().labels(),
+        }
+    );
+    let text = err.to_string();
+    assert!(
+        text.contains("is not registered") && text.contains("Q6_K"),
+        "{text}"
+    );
+}
+
+#[test]
+fn admit_refuses_a_future_revision_an_alien_family_and_disagreeing_geometry() {
+    let registry = CodecRegistry::builtin();
+    registry.admit(&CodecIdentity::nvfp4_v1()).unwrap();
+
+    let mut future = CodecIdentity::nvfp4_v1();
+    future.revision += 1;
+    let err = registry.admit(&future).unwrap_err();
+    assert!(
+        matches!(err, CodecError::AbiRevision { found, implemented, .. } if found == implemented + 1)
+    );
+    let text = err.to_string();
+    assert!(
+        text.contains("another build") && text.contains("Recompile"),
+        "{text}"
+    );
+
+    let mut alien = CodecIdentity::nvfp4_v1();
+    alien.family = "vq-codebook".into();
+    let err = registry.admit(&alien).unwrap_err();
+    assert!(
+        matches!(&err, CodecError::UnknownFamily { registered, .. } if registered == &registry.families())
+    );
+    assert!(err.to_string().contains("is not registered"));
+
+    let mut bad = CodecIdentity::nvfp4_v1();
+    bad.group_elems = 32;
+    let err = registry.admit(&bad).unwrap_err();
+    assert!(matches!(err, CodecError::AbiGeometry { revision: 1, .. }));
+    assert!(err.to_string().contains("disagrees with its own revision"));
+}
+
+#[test]
+fn the_identity_gate_the_index_calls_is_the_registry_s() {
+    // `CodecIdentity::admit` is the entry the operand store uses; it must
+    // be the same decision, worded the same way.
+    let mut future = CodecIdentity::nvfp4_v1();
+    future.revision += 1;
+    let via_identity = future.admit().unwrap_err().to_string();
+    let via_registry = CodecRegistry::builtin()
+        .admit(&future)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        via_identity.ends_with(&via_registry),
+        "{via_identity:?} should carry {via_registry:?} intact"
+    );
+    for k in [Q4_K, Q6_K, Q8_0] {
+        k.identity().admit().unwrap();
+        let mut other = k.identity();
+        other.family = "mxfp4".into();
+        assert!(
+            other.admit().is_err(),
+            "{}: mxfp4's family does not admit a K-quant's geometry",
+            k.encoding_label()
+        );
+    }
+}
+
+#[test]
+fn registering_a_duplicate_label_or_family_is_refused() {
+    let err = CodecRegistry::new()
+        .register(Box::new(BF16))
+        .and_then(|r| r.register(Box::new(BF16)))
+        .err()
+        .unwrap();
+    assert_eq!(
+        err,
+        CodecError::DuplicateLabel {
+            label: "BF16".into()
+        }
+    );
+
+    let alias = Stub {
+        label: "BF16-ALIAS",
+        identity: BF16.identity(),
+        streams: &[VALUES],
+    };
+    let err = CodecRegistry::new()
+        .register(Box::new(BF16))
+        .and_then(|r| r.register(Box::new(alias)))
+        .err()
+        .unwrap();
+    assert_eq!(
+        err,
+        CodecError::DuplicateLabel {
+            label: "BF16".into()
+        }
+    );
+}
+
+#[test]
+fn a_foreign_codec_registers_and_gets_the_trait_defaults() {
+    let mut identity = NVFP4.identity();
+    identity.family = "stub".into();
+    let stub = Stub {
+        label: "STUB",
+        identity,
+        streams: &[VALUES],
+    };
+    let registry = CodecRegistry::new().register(Box::new(stub)).unwrap();
+    let codec = registry.resolve("STUB", TENSOR).unwrap();
+    assert!(
+        codec.accelerations().is_empty(),
+        "the default offers no acceleration"
+    );
+    let bound = codec.bind_packed(&[1, 2, 3], &[3], TENSOR).unwrap();
+    assert_eq!(bound.names(), ["values"]);
+    assert_eq!(
+        codec
+            .decode_packed(&[1, 2, 3], &[3], RepresentationExtent::TERMINAL, TENSOR)
+            .unwrap(),
+        [0.0; 3]
+    );
+    assert_eq!(registry.codecs().count(), 1);
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/residency.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/residency.rs
@@ -1,0 +1,74 @@
+//! Residency profiles, extents and the declared-cost arithmetic.
+
+use super::*;
+use crate::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
+
+#[test]
+fn the_decode_profile_is_an_f32_image_and_direct_profiles_are_the_stored_bits() {
+    let decoded = ResidencyProfile::DECODED_F32;
+    assert_eq!(decoded.class, ResidencyClass::TransientDecoded);
+    assert_eq!(decoded.bytes_per_weight, 4.0);
+
+    let stored = ResidencyProfile::stored(4.5);
+    assert_eq!(stored.class, ResidencyClass::Stored);
+    assert_eq!(stored.bytes_per_weight, 0.5625);
+
+    let rebound = ResidencyProfile::rebound(16.0);
+    assert_eq!(rebound.class, ResidencyClass::Rebound);
+    assert_eq!(rebound.bytes_per_weight, 2.0);
+}
+
+#[test]
+fn only_requantisation_changes_the_values_and_every_class_has_a_name() {
+    use ResidencyClass as C;
+    for (class, name, preserves) in [
+        (C::Stored, "stored", true),
+        (C::Rebound, "rebound", true),
+        (C::TransientDecoded, "transient-decoded", true),
+        (C::TransientRequantised, "transient-requantised", false),
+    ] {
+        assert_eq!(class.name(), name);
+        assert_eq!(class.preserves_values(), preserves, "{name}");
+    }
+}
+
+#[test]
+fn an_acceleration_names_its_plan_its_cost_and_row_access() {
+    let accel = Acceleration::cpu(
+        PhysicalProjectionPlan::FusedBf16,
+        ResidencyProfile::stored(16.0),
+    );
+    assert_eq!(accel.backend, AccelerationBackend::Cpu);
+    assert_eq!(accel.plan, PhysicalProjectionPlan::FusedBf16);
+    assert_eq!(accel.residency.bytes_per_weight, 2.0);
+    assert_eq!(accel.requires, RequiredAccess::RowRandom);
+}
+
+#[test]
+fn extents_are_ordered_by_depth_and_a_terminal_certificate_carries_no_radius() {
+    assert_eq!(RepresentationExtent::TERMINAL.depth, 0);
+    assert_eq!(RepresentationExtent::at_depth(2).depth, 2);
+    assert!(RepresentationExtent::TERMINAL < RepresentationExtent::at_depth(1));
+    let cert = ExtentCertificate::terminal(4.5);
+    assert_eq!(cert.extent, RepresentationExtent::TERMINAL);
+    assert_eq!(cert.bits_per_weight, 4.5);
+    assert_eq!(cert.radius, None);
+    let bounded = ExtentCertificate {
+        extent: RepresentationExtent::at_depth(1),
+        bits_per_weight: 3.0,
+        radius: Some(ErrorRadius { relative_rms: 0.05 }),
+    };
+    assert_eq!(bounded.radius.unwrap().relative_rms, 0.05);
+}
+
+#[test]
+fn a_codec_error_becomes_a_parse_error_with_its_text_intact() {
+    let err = CodecError::Destination {
+        tensor: TENSOR.into(),
+        need: 1,
+        have: 2,
+    };
+    let text = err.to_string();
+    let vindex: crate::error::VindexError = err.into();
+    assert!(vindex.to_string().contains(&text));
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/streams.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/streams.rs
@@ -1,0 +1,72 @@
+//! Named streams and auxiliary operands: binding, lookup, refusal.
+
+use super::*;
+use crate::format::vindex3::opplan::OperandRef;
+
+#[test]
+fn a_stream_bound_twice_is_replaced_and_order_is_binding_order() {
+    let a = [1u8, 2];
+    let b = [3u8];
+    let c = [4u8, 5, 6];
+    let streams = NamedStreams::new()
+        .with(VALUES, &a)
+        .with(GROUP_SCALES, &b)
+        .with(VALUES, &c);
+    assert_eq!(streams.names(), ["group_scales", "values"]);
+    assert_eq!(streams.get(VALUES), Some(&c[..]));
+    assert_eq!(streams.get(GROUP_SCALES), Some(&b[..]));
+    assert_eq!(streams.get(TENSOR_SCALE), None);
+    assert_eq!(streams.len(), 2);
+    assert!(!streams.is_empty());
+    assert!(NamedStreams::new().is_empty());
+}
+
+#[test]
+fn a_missing_stream_lists_what_was_bound_and_a_short_one_says_how_short() {
+    let bytes = [0u8; 4];
+    let operands = CodecOperands::from_streams(NamedStreams::single(VALUES, &bytes));
+    let err = operands.stream(GROUP_SCALES, "X", TENSOR).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "tensor `layer.0.w`: `X` needs stream `group_scales`, which was not bound; bound: [values]"
+    );
+    assert_eq!(
+        operands.stream_of_len(VALUES, 4, "X", TENSOR).unwrap(),
+        &bytes[..]
+    );
+    let err = operands.stream_of_len(VALUES, 5, "X", TENSOR).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "tensor `layer.0.w`: `X` stream `values` is 4 bytes; 5 needed"
+    );
+}
+
+#[test]
+fn auxiliary_operands_are_named_dependencies_and_empty_by_default() {
+    let operands = CodecOperands::default();
+    assert!(operands.auxiliaries.is_empty());
+    assert_eq!(operands.auxiliaries.len(), 0);
+    let codebook = OperandRef {
+        object: "target.codebook".into(),
+        tensor: "0.codebook".into(),
+        dtype: "F16".into(),
+        shape: vec![256, 8],
+    };
+    let aux = AuxiliaryOperands::new().with("codebook", codebook.clone());
+    assert_eq!(aux.get("codebook"), Some(&codebook));
+    assert_eq!(aux.get("scales"), None);
+    assert_eq!(aux.len(), 1);
+    assert!(!aux.is_empty());
+    let with_aux = CodecOperands {
+        streams: NamedStreams::new(),
+        auxiliaries: aux,
+    };
+    assert_eq!(with_aux.auxiliaries.len(), 1);
+}
+
+#[test]
+fn stream_roles_are_what_the_declared_specs_say() {
+    assert_eq!(VALUES.role, StreamRole::Values);
+    assert_eq!(GROUP_SCALES.role, StreamRole::GroupScales);
+    assert_eq!(TENSOR_SCALE.role, StreamRole::TensorScale);
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -49,6 +49,7 @@ pub mod arena;
 pub mod assessment;
 pub mod bank;
 pub mod byte_ledger;
+pub mod codec;
 pub mod compile;
 pub mod compiler;
 pub mod constraint;

--- a/crates/larql-vindex/src/format/vindex3/represent/nvfp4_pack.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/nvfp4_pack.rs
@@ -297,47 +297,16 @@ impl CodecIdentity {
     /// Refuse a pack this build cannot decode under the rules it was
     /// written under.
     ///
-    /// Two representation families reach here. NVFP4 is one contract;
-    /// each K-quant is its OWN family rather than a revision of a shared
-    /// one, because `Q4_K` and `Q6_K` are different block layouts and a
-    /// shared family would let a reader that implements one accept the
-    /// other's bytes on a revision match.
+    /// The decision is the codec registry's
+    /// ([`super::codec::CodecRegistry::admit`]): every registered family
+    /// is its OWN contract — `Q4_K` and `Q6_K` are different block
+    /// layouts, and filing them under one family would let a reader that
+    /// implements one accept the other's bytes on a revision match.
     pub fn admit(&self) -> Result<(), VindexError> {
-        let want = match super::kquant::lookup(&self.family) {
-            Some(k) => k.codec_identity(),
-            None => Self::nvfp4_v1(),
-        };
-        if self.family != want.family {
-            return Err(VindexError::Parse(format!(
-                "representation family `{}` is not `{}`, nor one of {}",
-                self.family,
-                want.family,
-                super::kquant::compilable_names()
-            )));
-        }
-        if self.revision != want.revision {
-            return Err(VindexError::Parse(format!(
-                "`{}` ABI revision {} was compiled by another build; this one \
-                 implements revision {}. Recompile the representation from its \
-                 canonical source rather than decoding it under new rules.",
-                self.family, self.revision, want.revision
-            )));
-        }
-        // A same-revision pack whose geometry disagrees is a corrupted or
-        // hand-edited index, not a version skew — say so differently.
-        if self.group_elems != want.group_elems
-            || self.element != want.element
-            || self.group_scale != want.group_scale
-            || self.tensor_scale != want.tensor_scale
-            || self.layout != want.layout
-        {
-            return Err(VindexError::Parse(format!(
-                "`{}` revision {} declares geometry this build does not \
-                 produce ({:?}); the index disagrees with its own revision",
-                self.family, self.revision, self
-            )));
-        }
-        Ok(())
+        super::codec::CodecRegistry::builtin()
+            .admit(self)
+            .map(|_| ())
+            .map_err(Into::into)
     }
 }
 

--- a/crates/larql-vindex/src/format/vindex3/represent/physical.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/physical.rs
@@ -427,6 +427,10 @@ impl ExpertLayout {
     }
 }
 
+/// What a bank-pricing refusal names as its operand: a bank is priced
+/// per projection, not per named tensor.
+const EXPERT_BANK_OPERAND: &str = "expert-bank";
+
 /// A physical representation a grouped kernel can execute.
 ///
 /// The backend's job is to answer whether it can run one of these, never
@@ -464,32 +468,14 @@ impl ExpertEncoding {
     }
 
     /// Bytes an `[n, k]` matrix occupies in this encoding.
+    ///
+    /// Priced by the codec the encoding names, so the block geometry has
+    /// one home: a table here that repeated it was the drift the codec
+    /// contract exists to remove.
     pub fn matrix_bytes(self, n: usize, k: usize) -> Result<u64, VindexError> {
-        match self {
-            ExpertEncoding::Bf16 => Ok((n * k) as u64 * 2),
-            ExpertEncoding::Q80 => {
-                if !k.is_multiple_of(32) {
-                    return Err(VindexError::Parse(format!(
-                        "k={k} is not a whole number of 32-element blocks for Q8_0"
-                    )));
-                }
-                Ok((n * k / 32) as u64 * 34)
-            }
-            ExpertEncoding::Q6K | ExpertEncoding::Q4K => {
-                if !k.is_multiple_of(256) {
-                    return Err(VindexError::Parse(format!(
-                        "k={k} is not a whole number of 256-element superblocks for {}",
-                        self.name()
-                    )));
-                }
-                let per = if self == ExpertEncoding::Q6K {
-                    210
-                } else {
-                    144
-                };
-                Ok((n * k / 256) as u64 * per)
-            }
-        }
+        use super::codec::{CodecRegistry, RepresentationExtent};
+        let codec = CodecRegistry::builtin().resolve(self.name(), EXPERT_BANK_OPERAND)?;
+        Ok(codec.stored_bytes(&[n, k], RepresentationExtent::TERMINAL, EXPERT_BANK_OPERAND)?)
     }
 }
 

--- a/crates/larql-vindex/src/format/vindex3/represent/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/tests.rs
@@ -536,9 +536,17 @@ fn a_future_abi_revision_is_refused_rather_than_decoded() {
     assert!(err.contains("another build"), "{err}");
     assert!(err.contains("Recompile"), "{err}");
 
+    // A family nothing registers is refused as unknown. (`mxfp4` was the
+    // alien here until the codec registry admitted it as a family of its
+    // own; NVFP4's geometry under that name is now a geometry
+    // disagreement, asserted below, not an unknown family.)
     let mut alien = nvfp4_pack::CodecIdentity::nvfp4_v1();
-    alien.family = "mxfp4".into();
+    alien.family = "vq-codebook".into();
     assert!(alien.admit().unwrap_err().to_string().contains("is not"));
+    let mut misfiled = nvfp4_pack::CodecIdentity::nvfp4_v1();
+    misfiled.family = "mxfp4".into();
+    let err = misfiled.admit().unwrap_err().to_string();
+    assert!(err.contains("disagrees with its own revision"), "{err}");
 
     // Same revision, disagreeing geometry: a corrupted or hand-edited
     // index, and named differently so it is not mistaken for version skew.

--- a/docs/represent-codec-contract.md
+++ b/docs/represent-codec-contract.md
@@ -1,0 +1,124 @@
+# The representation/execution contract
+
+**Status:** rung 1 landed — the trait, extracted from the five encodings the
+container already carries, with the registry in front of it and three
+consumers rewired to it. Code: `crates/larql-vindex/src/format/vindex3/represent/codec/`.
+
+## Why a contract, and why now
+
+VINDEX3's claim is that it can describe what a model *means* independently of
+how that meaning is physically represented, resident, or lowered for
+execution. Until this rung, that claim was carried by discipline rather than
+by a type: the facts a stored encoding has to declare were scattered across
+seven surfaces — a K-quant geometry table, an expert-encoding match, the
+NVFP4 pack layout, private group constants in the loader, the runtime's
+residency-format enum, the compute crate's `QuantMatVec` dispatch and the
+K3 ledger's maturity ladder — and two formats (ternary I2_S and MXFP4) had
+already been routed *around* the trait that should have served them
+because a single `&[u8]` had nowhere to put their scales.
+
+Left alone, the next hard model's physical constraints would have defined
+the abstraction. The contract is written before K3 and residency become
+dominant, so that they plug into it rather than shape it.
+
+## The contract
+
+`RepresentationCodec` is not a quantisation trait. Six things it gets
+right, each already paid for once in this tree:
+
+| Concern | What the codec declares | Why it is there |
+| --- | --- | --- |
+| identity | `encoding_label()` — the label a container writes; `identity()` — ABI family + revision + geometry | the file names its contract independently of whichever implementation is registered |
+| streams | `streams()` — a **named set**; `CodecOperands` = streams + `AuxiliaryOperands` | one slice was the wall MXFP4 and I2_S hit; auxiliaries are represented objects a decode depends on (a codebook), named now while empty |
+| capabilities | access granularity (sequential / block / row / element), logical grouping, physical alignment | the planner refuses by name in preflight — Walk FFN needs rows and a stream-sequential codec cannot serve it — rather than a kernel discovering it |
+| extents | `extents()` — one certificate per admissible depth, bits/weight and an optional error radius | every codec answers depth 0 today; a progressive codec exposes one per prefix, and residency can then ask for *enough representation* |
+| decode | `decode_rows()` — **mandatory**, range-aware, to canonical f32 | the universal correctness surface; kernels are acceleration, never semantics |
+| realizations | `decode_residency()` required; `accelerations()` each carry their own `ResidencyProfile` | residency belongs to the realization, so a fallback is a different realization with a different declared cost, never a quiet substitution |
+
+Two rules follow. *Adding a codec requires proving representation
+correctness; adding a kernel must not change it.* And a codec with no direct
+realization is not a defect: it executes through the reference path, flagged
+— spec §11's `representable-but-no-kernel`, made structural.
+
+What a certificate deliberately does **not** say: fidelity to a source. That
+is a property of an instance, set at extraction from provenance and carried
+by the stored variant. A native MXFP4 checkpoint stored as MXFP4 is
+source-exact; the same bytes compiled from bf16 are approximate; the codec is
+the same in both.
+
+## What rung 1 extracted
+
+Five encodings, none privileged:
+
+| Codec | Streams | Access | bits/weight | CPU direct realization |
+| --- | --- | --- | --- | --- |
+| BF16 / F16 / F32 tensor tables | 1 | element-random | 16 / 16 / 32 | bf16: `FusedBf16`, `Bf16xQ8`; f32: `BlasF32`, `ScalarF32`; f16: none |
+| Q4_K / Q6_K / Q8_0 (scales inline) | 1 | row-random | 4.5 / 6.5625 / 8.5 | none on the V3 CPU executor |
+| NVFP4 (one row, split derived from shape) | 3, via `bind_packed` | row-random | 4.5 | `FusedNvfp4` (rebound) |
+| MXFP4 (codes and e8m0 scales **apart**) | 2 | row-random | 4.25 | none on the V3 CPU executor |
+| LYRW v2 banks | — | — | — | a *storage arrangement*: `RegionFormat` → codec label, `Packing` → single / paired-values / paired-scales binding |
+
+The multi-stream witness is MXFP4: it does not override `bind_packed`, so
+handing it one payload is refused naming both streams — the answer
+`QuantMatVec` could only give as `None`.
+
+Consumers now derived from the codec rather than restating its facts:
+
+- `OperandStore::load` dispatches every stored dtype through the registry
+  (floats, K-quants, NVFP4; an unregistered dtype is refused naming the
+  registered ones).
+- `CodecIdentity::admit` is the registry's `admit` — unknown family,
+  foreign revision and disagreeing geometry stay three distinct refusals.
+- `ExpertEncoding::matrix_bytes` prices a bank through the codec.
+- The loader's MXFP4 group constants and the graph builder's MXFP4 label
+  each have one home.
+
+Tests (`codec/tests/`) run every check over the whole registry, pin each
+codec's decode to the path it replaced, and pin the older tables to the
+codec — so a drift fails in a unit test rather than in a 20 GB segment.
+
+## Boundaries of this rung — stated, not implied
+
+- **The executor does not yet select a realization through the trait.**
+  `PhysicalProjectionPlan` still chooses; the codec *declares* which plans
+  serve it (positive evidence, keyed to the plan enum) and what each costs.
+  The trace record `requested / selected / reason / residency` is the next
+  rung.
+- **Only CPU realizations are declared.** Device kernels (NVFP4 and MXFP4 on
+  Metal, the grouped K-quant expert kernels) are declared by the peer crate
+  that owns them, not claimed here.
+- **K-quant packs have no direct realization on the V3 CPU path.** That is
+  the truth of `PhysicalProjectionPlan` today; the K3 ledger's `Production`
+  rung for Q4_K/Q6_K refers to the V2 `QuantMatVec` executor.
+- **Loading is stricter than before, in two places.** A K-quant row must
+  be a whole number of blocks — the compiler always enforced this at write
+  time and the loader now enforces it at read time, so a `[2, 128]` Q6_K
+  tensor, decodable and meaningless before, is refused. And a float operand
+  whose bytes are shorter than its declared shape implies is refused rather
+  than silently decoded short. The routed-FFN loader consequently checks
+  the expert bank's *declared* geometry before it reads any operand, which
+  its own test had always claimed ("refuses before touching the bytes") and
+  which only held before because the widener under-decoded in silence.
+
+## The programme this opens
+
+Four proofs, each with a minimal witness, then adversarial confirmations:
+
+| Proof | Witness | Forces |
+| --- | --- | --- |
+| Representation is not a dtype | progressive / residual codec (`R = R₀ + Δ₁ + … + Δₙ`) | extents with meaning; prefix identity; residency choosing depth; "enough representation" as a planner request |
+| Representation is not self-contained bytes | VQ / codebook | `AuxiliaryOperands` in anger: an encoded operand depending on another represented object |
+| Storage is not execution residency | entropy-coded bf16 (zstd / ANS) | sequential access refused by name for row plans; storage / decoded / executable / workspace residency told apart |
+| Canonical semantics are source-independent | HF round-trip, then `.fs3`/`.fsc` lowering | meaning → foreign vocabulary without special-case reconstruction |
+
+Adversarial confirmations: ternary / base-243 (element and byte boundaries
+diverge), per-row mixed rate (shape does not determine offset), permutation
+sidecar (physical order is not logical order), MLX lowering. If any of these
+takes major surgery, the representation layer is still leaking a
+physical-layout assumption.
+
+Order: entropy-coded bf16 first — it is cheap and tells immediately whether
+the extracted contract preserved an mmap / random-access assumption. Then
+progressive. Then VQ. If those three arrive without changing the trait, it
+is frozen, and LARQL no longer knows what quantisation formats exist — only
+what properties an executable representation must declare.


### PR DESCRIPTION
Rung 1 of the REPRESENT codec-contract programme: `RepresentationCodec`, extracted from the five encodings the container already carries, with the registry in front of it and three consumers rewired to it. Design and programme: `docs/represent-codec-contract.md`.

## What it declares

| concern | declaration |
| --- | --- |
| identity | ABI family + revision + geometry (`CodecIdentity`), so the file names its contract independently of the registered implementation |
| streams | a **named set** plus `AuxiliaryOperands` (empty today; a codebook arrives as a dependency, not a stream) |
| capabilities | access granularity ladder, logical grouping, physical alignment; refused by name in preflight |
| extents | one certificate per depth; every codec answers depth 0 |
| decode | **mandatory**, range-aware, to canonical f32 |
| realizations | residency declared per realization: the decode path and each direct kernel carry their own profile |

## Extracted, not designed

- BF16/F16/F32, Q4_K/Q6_K/Q8_0, NVFP4, MXFP4 in one registry; LYRW v2 enters as a storage arrangement (`RegionFormat` → codec, `Packing` → single / paired binding).
- MXFP4 is the multi-stream witness: it takes the default `bind_packed` and is refused by name when handed one payload. NVFP4 overrides it with the shape-derived split.
- `OperandStore::load`, `CodecIdentity::admit` and `ExpertEncoding::matrix_bytes` now derive from the codec; the loader's MXFP4 constants and the graph's MXFP4 label each have one home.
- Tests run every check over the whole registry, pin each codec's decode to the path it replaced, and pin the older tables to the codec.

## Behaviour changes

- A K-quant row must be a whole number of blocks at read time (the compiler always required it at write time).
- A float operand shorter than its declared shape is refused rather than decoded short. That exposed the routed-FFN loader reading the router before checking declared bank geometry; it now checks geometry first, as its own test had always claimed.
- `mxfp4` is a registered family, so two tests that borrowed it as an "alien" migrated.

## Stated boundaries

The executor still selects plans itself and emits no requested/selected/reason trace; only CPU realizations are declared; K-quants have no direct realization on the V3 CPU path. Next rung: entropy-coded bf16 as the hostile sixth codec.

## Gates

3955 lib tests + all 33 targets and doctests; clippy `--all-targets -D warnings`; fmt; doc links; per-file coverage ≥90% on every new file (lowest 93.6%).
