### PR TITLE
feat(vindex3): a stored K-quant executes in place (PARETO-1 executor v2+v3)

### DIFF
--- a/bench/prompts/quality-bank-1/run_bank.py
+++ b/bench/prompts/quality-bank-1/run_bank.py
@@ -74,10 +74,19 @@ def read_execution_facts(stdout):
     # `runtime_compiled` at zero. Naming the first one "executed" would
     # be the same conflation that produced the false null.
     facts = {"requested": None, "source": None, "objects_from_pack": None,
-             "objects_total": None, "runtime_compiled": 0}
+             "objects_total": None, "runtime_compiled": 0, "plans": {}}
     for line in stdout.splitlines():
         if line.startswith("runtime compile:"):
             facts["runtime_compiled"] = int(line.split(":")[1].strip().split()[0])
+        elif line.startswith("projection plans:"):
+            # projection plans: FusedKQuant 4832 calls 233.10 GB, BlasF32 16 calls 0.02 GB
+            # What the bytes were CONSUMED by, from the executor's own
+            # ledger — the only line that can tell a pack executed in
+            # place from the same pack decoded to f32 and run through BLAS.
+            for item in line.split(":", 1)[1].split(","):
+                parts = item.split()
+                if len(parts) >= 4 and parts[2] == "calls":
+                    facts["plans"][parts[0]] = {"calls": int(parts[1]), "gb": float(parts[3])}
         elif line.startswith("representation:"):
             # representation: NVFP4  source: stored  objects from a compiled pack: 1/5
             body = line.split("representation:", 1)[1]
@@ -90,6 +99,61 @@ def read_execution_facts(stdout):
                     a, b = ratio.split("/", 1)
                     facts["objects_from_pack"], facts["objects_total"] = int(a), int(b)
     return facts
+
+
+# The K-quant encodings a container may declare, and the two plans a
+# stored K-quant can execute under. `direct` is v3 (the codec's kernel
+# over the stored blocks, in place); `widen` is v2 (decode to f32, BLAS).
+KQUANT_ENCODINGS = ("Q8_0", "Q6_K", "Q4_K")
+KQUANT_EXEC_ENV = "LARQL_KQUANT_EXEC"
+KQUANT_EXEC_WIDEN = "widen"
+DIRECT_PLAN, WIDENED_PLAN = "FusedKQuant", "BlasF32"
+
+
+def assert_stored_kquant_ran_as_declared(container_id, facts, label):
+    """The K-quant EXECUTION arm is a run parameter, and it must be observed.
+
+    v3 added a second way to execute a stored K-quant pack: in place, by
+    the codec's kernel (`FusedKQuant`), beside v2's decode-to-f32-then-BLAS
+    (`BlasF32`). Both bind the same pack, both report `runtime compile: 0`,
+    and they differ in every logit. `LARQL_KQUANT_EXEC` selects the arm;
+    this reads the executor's own plan ledger to confirm the arm that RAN
+    is the one the environment named. Only the exact word `widen` widens,
+    so a misspelling would silently select the default and — without this
+    — be recorded as the other arm.
+    """
+    declared = (container_id or {}).get("precision_map") or {}
+    if declared.get("encoding") not in KQUANT_ENCODINGS:
+        return
+    expected = os.environ.get(KQUANT_EXEC_ENV, "").strip()
+    plans = facts.get("plans") or {}
+    if not plans:
+        raise SystemExit(
+            f"{label}: the executor reported no projection plans; this binary predates "
+            f"the plan ledger line and cannot attest which K-quant arm ran.")
+    direct = plans.get(DIRECT_PLAN, {})
+    if expected == KQUANT_EXEC_WIDEN:
+        if direct.get("calls"):
+            raise SystemExit(
+                f"{label}: {KQUANT_EXEC_ENV}={KQUANT_EXEC_WIDEN} but {direct['calls']} "
+                f"projections ran through {DIRECT_PLAN}. The arm that ran is not the arm named.")
+        facts["kquant_exec"] = KQUANT_EXEC_WIDEN
+        return
+    if expected not in ("", "direct"):
+        raise SystemExit(
+            f"{label}: {KQUANT_EXEC_ENV}={expected!r} is not a word the executor knows; it "
+            f"would run the default and this record would misname the arm. Use `direct` or "
+            f"`{KQUANT_EXEC_WIDEN}`.")
+    if not direct.get("calls"):
+        raise SystemExit(
+            f"{label}: direct execution was selected but no projection ran through "
+            f"{DIRECT_PLAN}: {plans}")
+    widened_gb = plans.get(WIDENED_PLAN, {}).get("gb", 0.0)
+    if widened_gb > direct["gb"]:
+        raise SystemExit(
+            f"{label}: {WIDENED_PLAN} carried {widened_gb} GB against {DIRECT_PLAN}'s "
+            f"{direct['gb']} GB — most of the pack was widened, not executed in place.")
+    facts["kquant_exec"] = "direct"
 
 
 def assert_candidate_executed_its_representation(container_id, facts, label):
@@ -236,6 +300,7 @@ def cmd_compare(container, outdir, backend, source, label, keep=False):
     facts = run_bank_arm(container, meta["entries"], backend, source, canddir)
     cand_id = container_identity(container)
     assert_candidate_executed_its_representation(cand_id, facts, label)
+    assert_stored_kquant_ran_as_declared(cand_id, facts, label)
     compiled_total = facts["runtime_compiled"]
     for i, e in enumerate(meta["entries"]):
         refpath = os.path.join(outdir, e["dump"])

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
@@ -155,6 +155,37 @@ fn report_representation_work(store: &OperandStore, want: Option<&str>, ok: bool
              (the pack's precision map)"
         );
     }
+    report_projection_plans();
+}
+
+/// Bytes per gigabyte, as the projection ledger reports traffic.
+const BYTES_PER_GB: f64 = 1e9;
+
+/// Which projection plans actually ran, from the executor's own ledger.
+///
+/// The representation line says what the backend ASKED for; this says
+/// what the bytes were consumed by. PARETO-1 needs the second: a stored
+/// K-quant pack can be executed in place (`FusedKQuant`) or decoded and
+/// run as f32 (`BlasF32`), and both bind the same pack, both report
+/// `runtime compile: 0`, and they differ in every logit. A guard that
+/// read only the first line could not tell them apart — which is how the
+/// format-cap confound went unseen.
+fn report_projection_plans() {
+    let rows: Vec<String> = larql_vindex::format::vindex3::opplan::exec::cpu::ledger()
+        .all()
+        .iter()
+        .filter(|(_, t)| t.calls > 0)
+        .map(|(plan, t)| {
+            format!(
+                "{plan:?} {} calls {:.2} GB",
+                t.calls,
+                t.bytes as f64 / BYTES_PER_GB
+            )
+        })
+        .collect();
+    if !rows.is_empty() {
+        println!("projection plans: {}", rows.join(", "));
+    }
 }
 
 /// One monomorphised run: the backend is chosen exactly once, above.

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/prepare.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/prepare.rs
@@ -201,11 +201,14 @@ pub(crate) fn with_plan_backend<V: BackendVisitor>(
         // projector then dispatches `FusedNvfp4` off the resident
         // representation, exactly as it dispatches every other arm.
         ExecBackend::ProductionNvfp4 => visitor.visit(&ProductionBackend::new()),
-        // Same kernels again. A K-quant operand is decoded to f32 in
-        // `OperandStore::load`, so what these arms measure is the
-        // REPRESENTATION's effect on behaviour, not a K-quant kernel's
-        // speed — which is the right instrument for a behaviour-per-byte
-        // curve and would be the wrong one for a throughput claim.
+        // Same kernels again, and the same policy: a stored K-quant pack
+        // is bound and executed IN PLACE by its codec's kernel
+        // (`FusedKQuant`), or — under `LARQL_KQUANT_EXEC=widen` — decoded
+        // to f32 in `OperandStore::load` and run through BLAS as rung A's
+        // authority path did. The two arms read the same stored bytes and
+        // differ only in where the arithmetic happens; the executor
+        // reports which one ran in its `projection plans:` line rather
+        // than leaving it to the backend's name.
         ExecBackend::ProductionQ8 | ExecBackend::ProductionQ6k | ExecBackend::ProductionQ4k => {
             visitor.visit(&ProductionBackend::new())
         }

--- a/crates/larql-compute/src/cpu/kquant_gemv.rs
+++ b/crates/larql-compute/src/cpu/kquant_gemv.rs
@@ -1,0 +1,113 @@
+//! The CPU's K-quant gemv — the stored block, multiplied where it lies.
+//!
+//! **Not [`crate::pipeline::quant_format::QuantFormat::Q8_0`].** That
+//! name already exists in this crate and means a different thing: int8
+//! codes with an EXTERNAL per-block f32 scale array, block 32. The
+//! formats here are ggml's, whose scale is INSIDE the block — Q8_0 is
+//! one f16 then 32 codes in 34 bytes. Two layouts sharing a name is how
+//! a reader ends up passing one to the other's kernel, so this module
+//! says `ggml` in its types and keeps its distance.
+//!
+//! Until this existed, a K-quant operand had exactly one execution
+//! route: decode the whole matrix to f32 and run an f32 gemv over the
+//! result. That is correct and it is what PARETO-1's rung A was measured
+//! with, but it prices a Q8_0 model at **four bytes per weight**. On
+//! Qwen3.8-27B the profiler put 97.3% of a decode token in `Projection`,
+//! moving 97.4 GB of widened f32 per token where the artifact itself
+//! holds the same information in 24.4 GB.
+//!
+//! The arithmetic here is not a second opinion about the format. It is
+//! the association [`larql_models::quant::ggml::dequantize_q8_0`]
+//! documents — `(q as i8 as f32) * f16(d)` — applied one block at a time
+//! instead of into a whole decoded matrix, and multiplied into the
+//! accumulator in element order. That makes it match
+//! dequantise-then-multiply **exactly** rather than approximately, and
+//! the tests hold it to that oracle.
+//!
+//! # Why exactness is available here at all
+//!
+//! `d` is an f16 and `q` an int8, so `d * q` needs at most 11 + 8 bits
+//! of significand and is therefore EXACT in f32. Folding the scale into
+//! each weight before the multiply — rather than hoisting it out of the
+//! block's dot product, which would be cheaper — is what lets this
+//! kernel be bit-for-bit with the decoder instead of merely close. A
+//! hoisted scale is a different program, and on a path whose whole
+//! purpose is to leave kernel quality out of a behavioural curve, "a
+//! different program" is the thing to avoid.
+//!
+//! # Threading
+//!
+//! The kernel threads itself, as the Q4_K and Q6_K kernels beside it do:
+//! rows are independent, so a row-parallel schedule changes which thread
+//! runs a row and nothing about what that row computes — every row's
+//! accumulation is the serial loop in `row_dot`, in the same order.
+//! A caller that threads on top (LARQL's plan executor) declares this
+//! kernel library-owned and calls it once.
+
+use larql_models::quant::half::f16_to_f32;
+
+/// Elements described by one Q8_0 block.
+pub const Q8_0_BLOCK_ELEMS: usize = 32;
+
+/// Bytes one Q8_0 block occupies: an f16 scale then 32 signed codes.
+pub const Q8_0_BLOCK_BYTES: usize = 34;
+
+/// Rows per parallel work unit — the granularity the Q4_K and Q6_K
+/// kernels use, for the same reason: a bandwidth-bound row loop wants
+/// few, large units rather than one task per row.
+const CHUNK_ROWS: usize = 32;
+
+/// `out[n] = W[n, k] · x[k]`, with `W` read straight from the stored
+/// Q8_0 pack.
+///
+/// `None` — never a wrong answer — when the geometry does not describe
+/// this pack: `k` off the block grid, or the stream the wrong length for
+/// `[n, k]`. Silently accepting a short stream would read a neighbouring
+/// row's codes as this row's and return a plausible vector.
+pub fn q8_0_gemv(blocks: &[u8], x: &[f32], n: usize, k: usize) -> Option<Vec<f32>> {
+    if k == 0 || !k.is_multiple_of(Q8_0_BLOCK_ELEMS) || x.len() != k {
+        return None;
+    }
+    let per_row = k / Q8_0_BLOCK_ELEMS;
+    if blocks.len() != n * per_row * Q8_0_BLOCK_BYTES {
+        return None;
+    }
+
+    let mut out = vec![0.0f32; n];
+    {
+        use rayon::prelude::*;
+        out.par_chunks_mut(CHUNK_ROWS)
+            .enumerate()
+            .for_each(|(chunk, slots)| {
+                for (i, slot) in slots.iter_mut().enumerate() {
+                    *slot = row_dot(blocks, x, chunk * CHUNK_ROWS + i, per_row);
+                }
+            });
+    }
+    Some(out)
+}
+
+/// One row's dot in the decoder's association — `(q * d) * x`, element
+/// by element, blocks in order. The whole arithmetic of the kernel is
+/// here; [`q8_0_gemv`] only decides which thread runs it.
+#[inline]
+fn row_dot(blocks: &[u8], x: &[f32], row: usize, per_row: usize) -> f32 {
+    let mut acc = 0.0f32;
+    for b in 0..per_row {
+        let base = (row * per_row + b) * Q8_0_BLOCK_BYTES;
+        let d = f16_to_f32(u16::from_le_bytes([blocks[base], blocks[base + 1]]));
+        let codes = &blocks[base + 2..base + Q8_0_BLOCK_BYTES];
+        let xs = &x[b * Q8_0_BLOCK_ELEMS..][..Q8_0_BLOCK_ELEMS];
+        for (j, &c) in codes.iter().enumerate() {
+            // `d * q` first, then the activation — the decoder's
+            // association, element by element. See the module note on
+            // why this is exact and why hoisting `d` would not be.
+            acc += ((c as i8 as f32) * d) * xs[j];
+        }
+    }
+    acc
+}
+
+#[cfg(test)]
+#[path = "kquant_gemv_tests.rs"]
+mod tests;

--- a/crates/larql-compute/src/cpu/kquant_gemv_tests.rs
+++ b/crates/larql-compute/src/cpu/kquant_gemv_tests.rs
@@ -1,0 +1,168 @@
+//! The oracle is the decoder, and the comparison is exact.
+//!
+//! A tolerance would hide the thing this kernel exists to guarantee. Its
+//! whole claim is that executing the stored blocks is the SAME
+//! arithmetic as decoding them and multiplying — so any difference at
+//! all is a different program, not rounding, and the assertions say
+//! `assert_eq!` rather than "within epsilon".
+
+use super::{q8_0_gemv, Q8_0_BLOCK_BYTES, Q8_0_BLOCK_ELEMS};
+use larql_models::quant::ggml::dequantize_q8_0;
+
+/// Deterministic weights spanning several magnitudes, so blocks get
+/// different scales and a single shared scale cannot pass by luck.
+fn weights(n: usize, k: usize) -> Vec<f32> {
+    (0..n * k)
+        .map(|i| {
+            let t = (i % 37) as f32 / 37.0 - 0.5;
+            t * (1.0 + (i / k) as f32 * 0.25)
+        })
+        .collect()
+}
+
+/// Encode to Q8_0 the way ggml defines it: per 32 elements, `d =
+/// amax/127`, codes are `round(w/d)`.
+fn encode_q8_0(w: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(w.len() / Q8_0_BLOCK_ELEMS * Q8_0_BLOCK_BYTES);
+    for block in w.chunks(Q8_0_BLOCK_ELEMS) {
+        let amax = block.iter().fold(0.0f32, |a, v| a.max(v.abs()));
+        let d = amax / 127.0;
+        let dh = half_bits(d);
+        // Round-trip the scale through f16 so the codes are chosen
+        // against the scale that will actually be stored.
+        let ds = larql_models::quant::half::f16_to_f32(dh);
+        out.extend_from_slice(&dh.to_le_bytes());
+        for &v in block {
+            let q = if ds == 0.0 { 0.0 } else { (v / ds).round() };
+            out.push((q.clamp(-127.0, 127.0) as i8) as u8);
+        }
+    }
+    out
+}
+
+/// f32 -> f16 bits, round-to-nearest-even, for the normal range this
+/// test exercises.
+fn half_bits(v: f32) -> u16 {
+    let bits = v.to_bits();
+    let sign = ((bits >> 16) & 0x8000) as u16;
+    let mut exp = ((bits >> 23) & 0xff) as i32 - 127 + 15;
+    let mant = bits & 0x007f_ffff;
+    if exp <= 0 {
+        return sign;
+    }
+    if exp >= 0x1f {
+        return sign | 0x7c00;
+    }
+    let mut m = (mant >> 13) as u16;
+    // Round to nearest even on the dropped bits.
+    let dropped = mant & 0x1fff;
+    if dropped > 0x1000 || (dropped == 0x1000 && (m & 1) == 1) {
+        m += 1;
+        if m == 0x400 {
+            m = 0;
+            exp += 1;
+            if exp >= 0x1f {
+                return sign | 0x7c00;
+            }
+        }
+    }
+    sign | ((exp as u16) << 10) | m
+}
+
+fn decoded_gemv(w: &[f32], x: &[f32], n: usize, k: usize) -> Vec<f32> {
+    (0..n)
+        .map(|r| {
+            let mut acc = 0.0f32;
+            for c in 0..k {
+                acc += w[r * k + c] * x[c];
+            }
+            acc
+        })
+        .collect()
+}
+
+fn activations(k: usize) -> Vec<f32> {
+    (0..k).map(|i| ((i % 11) as f32 - 5.0) / 7.0).collect()
+}
+
+/// The oracle: decoding the pack and multiplying must give exactly what
+/// the kernel gives. Not "within a tolerance" — the kernel is the same
+/// arithmetic in the same association, so any difference is a different
+/// program.
+#[test]
+fn the_kernel_equals_dequantise_then_multiply_bit_for_bit() {
+    // 70 rows span three parallel work units, so the schedule is
+    // exercised as well as the arithmetic.
+    for (n, k) in [(1, 32), (3, 64), (8, 128), (5, 256), (70, 64)] {
+        let w = weights(n, k);
+        let packed = encode_q8_0(&w);
+        let decoded = dequantize_q8_0(&packed, n * k).expect("decode");
+        let x = activations(k);
+        let got = q8_0_gemv(&packed, &x, n, k).expect("kernel");
+        let want = decoded_gemv(&decoded, &x, n, k);
+        assert_eq!(got, want, "[{n},{k}] kernel diverged from the decoder");
+    }
+}
+
+/// The kernel must be reading the stored codes, not reconstructing the
+/// original floats: quantisation is lossy, so an exact match against the
+/// SOURCE weights would mean this is not testing a quantised path.
+#[test]
+fn the_result_is_lossy_against_the_source_weights() {
+    let (n, k) = (4, 128);
+    let w = weights(n, k);
+    let packed = encode_q8_0(&w);
+    let x = activations(k);
+    let got = q8_0_gemv(&packed, &x, n, k).expect("kernel");
+    let exact = decoded_gemv(&w, &x, n, k);
+    assert_ne!(
+        got, exact,
+        "kernel matched the unquantised weights exactly — it is not reading codes"
+    );
+    // …but it must still be close, or it is reading them wrongly.
+    for (g, e) in got.iter().zip(&exact) {
+        assert!(
+            (g - e).abs() < 0.05 * e.abs().max(1.0),
+            "kernel {g} is not a Q8_0 approximation of {e}"
+        );
+    }
+}
+
+/// Geometry that does not describe the pack returns `None` rather than a
+/// plausible vector read across a row boundary.
+#[test]
+fn a_geometry_that_does_not_describe_the_pack_is_refused() {
+    let (n, k) = (2, 64);
+    let packed = encode_q8_0(&weights(n, k));
+    let x = activations(k);
+    assert!(q8_0_gemv(&packed, &x, n, k).is_some(), "the control case");
+
+    // k off the block grid.
+    assert!(q8_0_gemv(&packed, &activations(48), n, 48).is_none());
+    // x the wrong length for k.
+    assert!(q8_0_gemv(&packed, &activations(32), n, k).is_none());
+    // a stream short by one block.
+    let short = &packed[..packed.len() - Q8_0_BLOCK_BYTES];
+    assert!(q8_0_gemv(short, &x, n, k).is_none());
+    // more rows than the stream holds.
+    assert!(q8_0_gemv(&packed, &x, n + 1, k).is_none());
+    // zero k.
+    assert!(q8_0_gemv(&packed, &[], n, 0).is_none());
+}
+
+/// A block whose weights are all zero has a zero scale, which must not
+/// become a NaN through a division that never happens.
+#[test]
+fn an_all_zero_block_contributes_nothing() {
+    let (n, k) = (1, 64);
+    let mut w = weights(n, k);
+    for v in w.iter_mut().take(Q8_0_BLOCK_ELEMS) {
+        *v = 0.0;
+    }
+    let packed = encode_q8_0(&w);
+    let x = activations(k);
+    let got = q8_0_gemv(&packed, &x, n, k).expect("kernel");
+    assert!(got[0].is_finite(), "a zero-scale block produced {}", got[0]);
+    let decoded = dequantize_q8_0(&packed, n * k).expect("decode");
+    assert_eq!(got, decoded_gemv(&decoded, &x, n, k));
+}

--- a/crates/larql-compute/src/cpu/mod.rs
+++ b/crates/larql-compute/src/cpu/mod.rs
@@ -34,6 +34,11 @@ use ndarray::{Array2, ArrayView2};
 /// CPU backend using BLAS (f32) and C kernel (Q4).
 pub struct CpuBackend;
 
+/// The CPU's ggml K-quant gemvs, executing stored blocks in place.
+///
+/// Distinct from [`pipeline::quant_format::QuantFormat::Q8_0`], which is
+/// a different layout under the same name — see the module docs.
+pub mod kquant_gemv;
 pub mod nvfp4_gemv;
 
 impl MatMul for CpuBackend {

--- a/crates/larql-vindex/coverage-policy.json
+++ b/crates/larql-vindex/coverage-policy.json
@@ -37,7 +37,7 @@
     "crates/larql-vindex/src/format/vindex3/opplan/exec/continuation.rs": 86.0,
     "crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/environment.rs": 63.7,
     "crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/integer.rs": 62.0,
-    "crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/physical.rs": 83.0,
+    "crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/physical.rs": 87.0,
     "crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/replay.rs": 6.4,
     "crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/stationary.rs": 71.0,
     "crates/larql-vindex/src/format/vindex3/opplan/exec/kv.rs": 87.2,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -30,6 +30,7 @@ use super::super::super::graph::policy::AttentionSpan;
 use super::cpu::WeightRows;
 use super::quantise::SUM_BLOCK;
 use crate::error::VindexError;
+use crate::format::vindex3::represent::kquant::KQuant;
 
 /// The numerical representation a backend wants matrix operands in.
 ///
@@ -109,6 +110,20 @@ pub enum WeightFormat {
     /// size worth nothing and the scale format worth 1.27x in relative RMS
     /// and 1.7x in worst-element error.
     Nvfp4,
+    /// A stored ggml K-quant pack — Q8_0, Q6_K or Q4_K — kept as the
+    /// container holds it and executed in place by the codec's kernel.
+    ///
+    /// Like [`Self::Bf16`] and unlike [`Self::Q8`], NOT a conversion: the
+    /// resident bytes are the stored bytes. The lossy step, if any,
+    /// happened when `vindex represent` compiled the pack, and it is the
+    /// artifact under measurement, not this loader's doing. Which codec
+    /// is a property of the bytes, carried with them — the format names
+    /// the family, the operand's stored dtype names the member.
+    ///
+    /// Only ever declared for an operand the container holds as a
+    /// K-quant; a backend asking for it over anything else is refused at
+    /// load rather than served a manufactured pack.
+    KQuant,
 }
 
 /// Which matrix a format question is about. Formats are declared per
@@ -157,6 +172,14 @@ pub struct MatrixOperand {
     /// anything else would widen bytes that are already in the shape a
     /// kernel wants.
     pub stored_nvfp4: bool,
+    /// Whether the container holds this operand as a compiled K-quant
+    /// pack — Q8_0, Q6_K or Q4_K. The same kind of fact as
+    /// [`Self::stored_nvfp4`], with one difference in how it is acted
+    /// on: a stored K-quant has TWO execution routes, in place or
+    /// widened to f32, and which one runs is the process's
+    /// [`super::cpu::physical::KQuantExecution`] arm rather than a
+    /// consequence of the bytes alone.
+    pub stored_kquant: bool,
 }
 
 /// A backend's declared format per matrix class.
@@ -228,6 +251,13 @@ pub enum WeightSlice<'a> {
         packed: &'a [u8],
         scales: &'a [u8],
         tensor_scale: f32,
+    },
+    /// A stored ggml K-quant block stream, still compact, with the codec
+    /// that names its layout. Scales live inside the blocks, so this is
+    /// one stream, not two.
+    KQuant {
+        blocks: &'a [u8],
+        codec: KQuant,
     },
 }
 
@@ -355,6 +385,42 @@ impl<'a> WeightSlice<'a> {
                     _ => Err(short(packed.len() * 2)),
                 }
             }
+            WeightSlice::KQuant { blocks, codec } => {
+                // The stride is the codec's: blocks run along the row,
+                // and a width off the block grid describes no rows.
+                let Some(per_row) = codec.row_bytes(in_dim) else {
+                    return Err(VindexError::Parse(format!(
+                        "{} slab: in_dim={in_dim} is not a whole number of {}-element blocks, \
+                         so this pack does not describe these rows",
+                        codec.name, codec.elements_per_block
+                    )));
+                };
+                // EXACT, not a prefix cut like the arms above. Those
+                // tolerate a longer slice because `AlignedBytes` pads to
+                // the device page; a K-quant is plain owned bytes bound at
+                // load against the codec's own plan of the shape, so any
+                // length but the matrix means the codec or the geometry is
+                // wrong. The LONGER direction is the dangerous one: Q6_K
+                // bytes read as Q4_K are longer than Q4_K wants, would pass
+                // a prefix cut, and would then be walked at a 144-byte
+                // stride over 210-byte blocks — finite, plausible, wrong.
+                let want_bytes = out_dim * per_row;
+                if blocks.len() < want_bytes {
+                    return Err(short(blocks.len() / per_row * in_dim));
+                }
+                if blocks.len() > want_bytes {
+                    return Err(VindexError::Parse(format!(
+                        "{} slab: {} bytes describe more than a {out_dim} x {in_dim} matrix's \
+                         {want_bytes} — the bytes are not this codec's, or not this shape's",
+                        codec.name,
+                        blocks.len()
+                    )));
+                }
+                Ok(WeightRows::KQuant {
+                    blocks,
+                    codec: *codec,
+                })
+            }
             other => Err(VindexError::Parse(format!(
                 "no CPU projection kernel consumes {} weights — the backend declared a \
                  representation only a device can run, so this refuses rather than converting \
@@ -376,6 +442,7 @@ impl<'a> WeightSlice<'a> {
             WeightSlice::F16(_) => "f16",
             WeightSlice::Mxfp4 { .. } => "mxfp4",
             WeightSlice::Nvfp4 { .. } => "nvfp4",
+            WeightSlice::KQuant { codec, .. } => codec.name,
         }
     }
 
@@ -387,7 +454,8 @@ impl<'a> WeightSlice<'a> {
             | WeightSlice::Q4 { .. }
             | WeightSlice::F16(_)
             | WeightSlice::Mxfp4 { .. }
-            | WeightSlice::Nvfp4 { .. } => Err(VindexError::Parse(
+            | WeightSlice::Nvfp4 { .. }
+            | WeightSlice::KQuant { .. } => Err(VindexError::Parse(
                 "backend declared f32 weights but was handed another format — interpreter \
                  loaded the wrong representation"
                     .to_string(),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/arithmetic.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/arithmetic.rs
@@ -58,6 +58,12 @@ pub enum WeightRep {
     /// is 16 by the format's definition, not by a policy's choice, and a
     /// field would invite a caller to pass a different one.
     Nvfp4,
+    /// A stored ggml K-quant block stream — Q8_0, Q6_K or Q4_K — read in
+    /// place. Which codec is a property of the BYTES (`WeightRows::KQuant`
+    /// carries it), not of the arithmetic: every codec's kernel takes an
+    /// f32 activation and accumulates f32, so this is one representation
+    /// with three layouts rather than three representations.
+    KQuant,
 }
 
 /// Over how many elements ONE activation scale applies.
@@ -114,6 +120,7 @@ impl fmt::Display for WeightRep {
             Self::Q8 { block } => write!(f, "Q8[{block}]"),
             Self::Q4 { block } => write!(f, "Q4[{block}]"),
             Self::Nvfp4 => write!(f, "NVFP4"),
+            Self::KQuant => write!(f, "KQUANT"),
         }
     }
 }
@@ -173,6 +180,7 @@ pub fn plans_possible_for(rep: WeightRep) -> &'static [PhysicalProjectionPlan] {
         // One kernel, so residency determines execution outright — the
         // invariant this function exists to expose, satisfied trivially.
         WeightRep::Nvfp4 => &[PhysicalProjectionPlan::FusedNvfp4],
+        WeightRep::KQuant => &[PhysicalProjectionPlan::FusedKQuant],
         WeightRep::Q8 { .. } => &[
             PhysicalProjectionPlan::FusedQ8,
             PhysicalProjectionPlan::Q8xQ8,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/cost.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/cost.rs
@@ -78,6 +78,10 @@ pub fn measured_rate_gbps(plan: PhysicalProjectionPlan) -> Option<f64> {
         // so it can genuinely appear in a tally, and the budget omits it
         // for the same reason it omits a plan with no calls.
         PhysicalProjectionPlan::FusedNvfp4 => None,
+        // Unmeasured for the same reason as NVFP4: reached by observation
+        // of a compiled pack, and no harness has priced it. PARETO-1's v3
+        // qualification is an EQUIVALENCE gate, not a rate.
+        PhysicalProjectionPlan::FusedKQuant => None,
         PhysicalProjectionPlan::Q8xQ8 => Some(121.02),
         PhysicalProjectionPlan::Q4xQ8 => Some(106.59),
         // The A1 control runs the exact bf16 kernel over a reconstructed

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/kernels.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/kernels.rs
@@ -235,6 +235,55 @@ impl DenseProjector for FusedNvfp4 {
     }
 }
 
+/// **Direct K-quant.** The stored ggml blocks — Q8_0, Q6_K or Q4_K —
+/// multiplied where they lie, by the kernel their codec names.
+///
+/// PARETO-1's v3 execution arm. Until it existed a K-quant operand had
+/// one route: decode the whole matrix to f32 and run an f32 GEMV over
+/// the result, which is correct and is what rung A was measured with,
+/// but prices a Q8_0 model at four bytes per weight — 97.4 GB of widened
+/// f32 per token on Qwen3.8-27B where the artifact holds 24.4. The bytes
+/// this kernel reads are the artifact's own: no decode, no requantise,
+/// no derivative.
+///
+/// [`CpuParallelism::LibraryOwned`] because the kernels behind it thread
+/// themselves, as [`BlasF32`] does: the Q4_K and Q6_K kernels in
+/// `larql-compute` split rows across their own pool, and the Q8_0 one
+/// was written to match them. Partitioning on top would nest a second
+/// fan-out inside the first, which is the one thing this executor's
+/// module note forbids.
+///
+/// Whether this arm is admissible as a BEHAVIOURAL authority, rather
+/// than a throughput backend, is decided by the equivalence gate in
+/// `~/chris-models/pareto1/V3-QUALIFICATION.md` against
+/// decode-then-multiply on the same stored bytes — never by this
+/// comment.
+pub struct FusedKQuant;
+
+impl DenseProjector for FusedKQuant {
+    fn parallelism(&self) -> CpuParallelism {
+        CpuParallelism::LibraryOwned
+    }
+
+    fn project_rows(&self, weight_rows: WeightRows<'_>, x: &[f32], out: &mut [f32]) {
+        let WeightRows::KQuant { blocks, codec } = weight_rows else {
+            panic!("the direct K-quant kernel consumes stored K-quant blocks only");
+        };
+        let n = out.len();
+        let Some(values) = codec.gemv(blocks, x, n, x.len()) else {
+            // Geometry is settled at `WeightSlice::rows` before dispatch,
+            // so a refusal here means the two disagree — a bug in this
+            // file, not a runtime condition to absorb.
+            panic!(
+                "{} slab geometry does not describe [{n}, {}]",
+                codec.name,
+                x.len()
+            );
+        };
+        out.copy_from_slice(&values);
+    }
+}
+
 /// One block's unscaled dot. `packed.len() * 2 == x.len()`.
 #[inline]
 fn q4_block_dot(packed: &[u8], x: &[f32]) -> f32 {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/ledger.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/ledger.rs
@@ -263,6 +263,7 @@ pub struct ProjectionLedger {
     // itself while describing a mixture.
     q8_x_q8: Tally,
     fused_nvfp4: Tally,
+    fused_kquant: Tally,
     q4_x_q8: Tally,
     bf16_x_q8: Tally,
     /// The same time, cut by operator class instead of by arithmetic.
@@ -278,6 +279,7 @@ impl ProjectionLedger {
             PhysicalProjectionPlan::FusedQ8 => &self.fused_q8,
             PhysicalProjectionPlan::FusedQ4 => &self.fused_q4,
             PhysicalProjectionPlan::FusedNvfp4 => &self.fused_nvfp4,
+            PhysicalProjectionPlan::FusedKQuant => &self.fused_kquant,
             PhysicalProjectionPlan::Q8xQ8 => &self.q8_x_q8,
             PhysicalProjectionPlan::Q4xQ8 => &self.q4_x_q8,
             PhysicalProjectionPlan::Bf16xQ8 => &self.bf16_x_q8,
@@ -330,13 +332,19 @@ impl ProjectionLedger {
     /// Every plan, so a reader enumerates rather than remembers. A caller
     /// that listed the plans itself would stop covering a new one on the
     /// day it was added.
-    pub fn all(&self) -> [(PhysicalProjectionPlan, PlanTally); 8] {
+    pub fn all(&self) -> [(PhysicalProjectionPlan, PlanTally); 10] {
         [
             PhysicalProjectionPlan::ScalarF32,
             PhysicalProjectionPlan::BlasF32,
             PhysicalProjectionPlan::FusedBf16,
             PhysicalProjectionPlan::FusedQ8,
             PhysicalProjectionPlan::FusedQ4,
+            // The observation-only plans are enumerated too. NVFP4 had a
+            // slot here and no row, so a decode that ran a compiled pack
+            // reported its bytes nowhere — exactly the silent omission
+            // this method's doc comment says it exists to prevent.
+            PhysicalProjectionPlan::FusedNvfp4,
+            PhysicalProjectionPlan::FusedKQuant,
             PhysicalProjectionPlan::Q8xQ8,
             PhysicalProjectionPlan::Q4xQ8,
             PhysicalProjectionPlan::Bf16xQ8,
@@ -386,6 +394,10 @@ impl ProjectionLedger {
         self.fused.reset();
         self.fused_q8.reset();
         self.fused_q4.reset();
+        // The observation-only plans were missing here too: NVFP4 bytes
+        // survived every reset, so a priced step could carry the load.
+        self.fused_nvfp4.reset();
+        self.fused_kquant.reset();
         self.q8_x_q8.reset();
         self.q4_x_q8.reset();
         self.bf16_x_q8.reset();
@@ -417,6 +429,7 @@ impl ProjectionLedger {
             fused_q8: ZERO,
             fused_q4: ZERO,
             fused_nvfp4: ZERO,
+            fused_kquant: ZERO,
             q8_x_q8: ZERO,
             q4_x_q8: ZERO,
             bf16_x_q8: ZERO,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/physical.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/physical.rs
@@ -21,7 +21,7 @@
 
 use super::arithmetic::{AccumulatorRep, ActivationRep, Arithmetic, WeightRep};
 use super::integer::{activation_scaling, Bf16xQ8, Q4xQ8, Q8xQ8};
-use super::kernels::{BlasF32, FusedBf16, FusedNvfp4, FusedQ4, FusedQ8, ScalarF32};
+use super::kernels::{BlasF32, FusedBf16, FusedKQuant, FusedNvfp4, FusedQ4, FusedQ8, ScalarF32};
 use super::projector::{DenseProjector, WeightRows};
 use crate::error::VindexError;
 use crate::format::vindex3::opplan::exec::backend::{MatrixClass, WeightFormat, WeightSlice};
@@ -65,6 +65,16 @@ pub enum PhysicalProjectionPlan {
     /// representation with no execution path cannot be measured, and
     /// before this arm every NVFP4 backend was a device backend.
     FusedNvfp4,
+    /// A stored ggml K-quant — Q8_0, Q6_K or Q4_K — executed in place by
+    /// the kernel its codec names. PARETO-1's v3 arm.
+    ///
+    /// Reached by OBSERVATION, like [`Self::FusedNvfp4`], and for the
+    /// same reason: nobody manufactures a K-quant at load. A pack is
+    /// compiled deliberately by `vindex represent`, the loader binds the
+    /// bytes the container holds, and this is where they execute. The
+    /// policy's only say is whether a stored pack executes in place at
+    /// all — [`kquant_execution`] — never which codec.
+    FusedKQuant,
     /// f32 resident, BLAS `sgemv`, threaded by the library.
     ///
     /// The right answer for a matrix whose widened image still fits
@@ -162,51 +172,62 @@ impl Q4Classes {
 /// `attn`, `ffn`, `head`, or `all`.
 pub const Q4_CLASSES_ENV: &str = "LARQL_CPU_Q4_CLASSES";
 
-/// The Q4 class set, resolved once per process.
-///
-/// Unset means [`Q4Classes::ALL`] — the blanket arm — so an arm run
-/// without this variable is the hypothesis rather than a silent
-/// exception set.
-pub fn q4_classes() -> Q4Classes {
-    static CLASSES: std::sync::OnceLock<Q4Classes> = std::sync::OnceLock::new();
-    *CLASSES.get_or_init(|| match std::env::var(Q4_CLASSES_ENV).ok() {
-        None => Q4Classes::ALL,
-        Some(v) if v.trim().is_empty() || v.trim() == "all" => Q4Classes::ALL,
-        Some(v) => {
-            let named = |k: &str| v.split(',').any(|t| t.trim() == k);
-            Q4Classes {
-                attention: named("attn"),
-                ffn: named("ffn"),
-                head: named("head"),
+impl Q4Classes {
+    /// The class set a value of [`Q4_CLASSES_ENV`] names.
+    ///
+    /// Unset, empty and `all` mean [`Self::ALL`] — the blanket arm — so
+    /// an arm run without the variable is the hypothesis rather than a
+    /// silent exception set. Tokens are exact: `ATTN` names nothing, and
+    /// a set that names nothing restores every class to Q8.
+    pub fn from_env_value(value: Option<&str>) -> Self {
+        match value.map(str::trim) {
+            None | Some("") | Some("all") => Self::ALL,
+            Some(v) => {
+                let named = |k: &str| v.split(',').any(|t| t.trim() == k);
+                Self {
+                    attention: named("attn"),
+                    ffn: named("ffn"),
+                    head: named("head"),
+                }
             }
         }
-    })
+    }
+}
+
+/// The Q4 class set, resolved once per process.
+pub fn q4_classes() -> Q4Classes {
+    static CLASSES: std::sync::OnceLock<Q4Classes> = std::sync::OnceLock::new();
+    *CLASSES
+        .get_or_init(|| Q4Classes::from_env_value(std::env::var(Q4_CLASSES_ENV).ok().as_deref()))
 }
 
 /// Names the arithmetic arm. See [`ArithmeticArm`].
 pub const ARITHMETIC_ARM_ENV: &str = "LARQL_CPU_ARITHMETIC";
 
-/// The arm, resolved once per process.
-///
-/// An unrecognised value is the DEFAULT rather than an error, matching
-/// [`MAX_FORMAT_ENV`]: a typo must not silently invent a fourth
-/// numerical regime that then gets reported as a measurement.
-pub fn arithmetic_arm() -> ArithmeticArm {
-    static ARM: std::sync::OnceLock<ArithmeticArm> = std::sync::OnceLock::new();
-    *ARM.get_or_init(|| {
-        match std::env::var(ARITHMETIC_ARM_ENV)
-            .ok()
-            .as_deref()
-            .map(str::trim)
-        {
+impl ArithmeticArm {
+    /// The arm a value of [`ARITHMETIC_ARM_ENV`] names.
+    ///
+    /// An unrecognised value is the DEFAULT rather than an error, matching
+    /// [`MAX_FORMAT_ENV`]: a typo must not silently invent a fourth
+    /// numerical regime that then gets reported as a measurement.
+    pub fn from_env_value(value: Option<&str>) -> Self {
+        match value.map(str::trim) {
             // The `b` suffix selects a per-BLOCK activation scale; the
             // arm itself is the same arithmetic either way, which is why
             // the scale geometry is a separate value and not a fourth arm.
-            Some("bf16xq8") | Some("bf16xq8b") => ArithmeticArm::Bf16TimesQ8,
-            Some("q8xq8") | Some("q8xq8b") => ArithmeticArm::Q8TimesQ8,
-            Some("q4xq8") | Some("q4xq8b") => ArithmeticArm::Q4TimesQ8,
-            _ => ArithmeticArm::FloatActivation,
+            Some("bf16xq8") | Some("bf16xq8b") => Self::Bf16TimesQ8,
+            Some("q8xq8") | Some("q8xq8b") => Self::Q8TimesQ8,
+            Some("q4xq8") | Some("q4xq8b") => Self::Q4TimesQ8,
+            _ => Self::FloatActivation,
         }
+    }
+}
+
+/// The arm, resolved once per process.
+pub fn arithmetic_arm() -> ArithmeticArm {
+    static ARM: std::sync::OnceLock<ArithmeticArm> = std::sync::OnceLock::new();
+    *ARM.get_or_init(|| {
+        ArithmeticArm::from_env_value(std::env::var(ARITHMETIC_ARM_ENV).ok().as_deref())
     })
 }
 
@@ -219,6 +240,7 @@ impl PhysicalProjectionPlan {
             Self::FusedQ8 | Self::Q8xQ8 => WeightFormat::Q8,
             Self::FusedQ4 | Self::Q4xQ8 => WeightFormat::Q4,
             Self::FusedNvfp4 => WeightFormat::Nvfp4,
+            Self::FusedKQuant => WeightFormat::KQuant,
         }
     }
 
@@ -262,6 +284,11 @@ impl PhysicalProjectionPlan {
                 activation: ActivationRep::F32,
                 accumulator: AccumulatorRep::F32,
             },
+            Self::FusedKQuant => Arithmetic {
+                weight: WeightRep::KQuant,
+                activation: ActivationRep::F32,
+                accumulator: AccumulatorRep::F32,
+            },
             // The control holds EXACT weights and an f32 dot; only the
             // activation is quantised, which is the whole of its job.
             Self::Bf16xQ8 => Arithmetic {
@@ -296,6 +323,7 @@ impl PhysicalProjectionPlan {
             Self::FusedQ8 => &FusedQ8,
             Self::FusedQ4 => &FusedQ4,
             Self::FusedNvfp4 => &FusedNvfp4,
+            Self::FusedKQuant => &FusedKQuant,
             Self::Q8xQ8 => &Q8xQ8,
             Self::Q4xQ8 => &Q4xQ8,
             Self::Bf16xQ8 => &Bf16xQ8,
@@ -417,6 +445,10 @@ impl PhysicalProjectionPlan {
             // assume, so there is one kernel and the arm does not enter
             // into it.
             WeightRows::Nvfp4 { .. } => Self::FusedNvfp4,
+            // One kernel per codec and no integer arm, so the bytes
+            // determine execution outright — and the codec they name
+            // travels with them rather than with the plan.
+            WeightRows::KQuant { .. } => Self::FusedKQuant,
         }
     }
 }
@@ -526,11 +558,76 @@ pub const MAX_FORMAT_ENV: &str = "LARQL_CPU_MAX_FORMAT";
 /// Only `bf16` caps anything; every other value (and no value) leaves the
 /// measured policy in force, so a typo cannot silently disable Q8 in
 /// production and be mistaken for a regression.
+///
+/// The cap does not touch a STORED K-quant pack. It forbids the policy
+/// from MANUFACTURING a lossy residency at load; binding compiled blocks
+/// manufactures nothing, and whether they execute in place or widened is
+/// [`kquant_execution`]'s question, not this one's.
 fn q8_permitted() -> bool {
     !matches!(
         std::env::var(MAX_FORMAT_ENV).ok().as_deref().map(str::trim),
         Some("bf16")
     )
+}
+
+/// Selects how a STORED K-quant pack executes. See [`KQuantExecution`].
+pub const KQUANT_EXEC_ENV: &str = "LARQL_KQUANT_EXEC";
+
+/// Value of [`KQUANT_EXEC_ENV`] that restores the widening path.
+pub const KQUANT_EXEC_WIDEN: &str = "widen";
+
+/// How a stored K-quant operand is executed, for the whole process.
+///
+/// Both arms read the SAME stored bytes and neither manufactures
+/// anything. They differ in WHERE the arithmetic happens:
+///
+/// ```text
+/// Widen    stored blocks -> decode -> f32 image -> BLAS gemv     (v2)
+/// Direct   stored blocks -> the codec's kernel, in place          (v3)
+/// ```
+///
+/// `Widen` is PARETO-1's rung-A authority path: it decodes every K-quant
+/// to f32 precisely so that kernel quality cannot move a behavioural
+/// curve. `Direct` is admissible as the campaign executor only once the
+/// equivalence gate has passed against `Widen` — and that gate is only
+/// meaningful because both arms live in ONE binary, so "the kernel
+/// changed the answer" cannot be confused with "the compiler did". Same
+/// rule, same reason, as `weights::staged::STAGE_ENV`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum KQuantExecution {
+    /// Execute the stored blocks in place:
+    /// [`PhysicalProjectionPlan::FusedKQuant`].
+    #[default]
+    Direct,
+    /// Decode to f32 at load and run the f32 path, as v2 did.
+    Widen,
+}
+
+impl KQuantExecution {
+    /// The arm a value of [`KQUANT_EXEC_ENV`] selects.
+    ///
+    /// Only the exact word [`KQUANT_EXEC_WIDEN`] widens — the same rule
+    /// [`MAX_FORMAT_ENV`] follows, for the same reason: a typo must not
+    /// silently select a numerical regime and then be reported as a
+    /// measurement. The executor reports the plan it OBSERVED running, so
+    /// a value that did not take effect is visible in the run's own
+    /// output rather than inferred from its environment.
+    pub fn from_env_value(value: Option<&str>) -> Self {
+        match value.map(str::trim) {
+            Some(v) if v == KQUANT_EXEC_WIDEN => Self::Widen,
+            _ => Self::Direct,
+        }
+    }
+}
+
+/// The arm in force, read from the environment.
+///
+/// Read per call rather than cached, like `q8_permitted`: it is
+/// consulted once per operand at load, and a cached value would let a
+/// process that set the variable after first use silently run the other
+/// arm.
+pub fn kquant_execution() -> KQuantExecution {
+    KQuantExecution::from_env_value(std::env::var(KQUANT_EXEC_ENV).ok().as_deref())
 }
 
 /// Whether this operand is one the policy would have made Q8 —

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/projector.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/projector.rs
@@ -1,5 +1,7 @@
 //! What a dense projection kernel must expose, and who threads it.
 
+use crate::format::vindex3::represent::kquant::KQuant;
+
 /// Who owns the machine while a primitive runs.
 ///
 /// Declared by the kernel because only the kernel knows: a BLAS call has
@@ -160,6 +162,18 @@ pub enum WeightRows<'a> {
         scales: &'a [u8],
         tensor_scale: f32,
     },
+    /// A stored ggml K-quant block stream — Q8_0, Q6_K or Q4_K — with
+    /// the codec that names its layout. Scales are inside the blocks.
+    ///
+    /// Reaches the kernel compact, as every variant here does, and
+    /// UNTOUCHED: these are the artifact's own bytes, which is the whole
+    /// claim of PARETO-1's v3 arm. The codec travels with the bytes
+    /// because it is a property of them — the plan is one plan and the
+    /// kernel asks the codec which arithmetic reads this layout.
+    KQuant {
+        blocks: &'a [u8],
+        codec: KQuant,
+    },
 }
 
 impl WeightRows<'_> {
@@ -175,6 +189,7 @@ impl WeightRows<'_> {
             Self::Q8 { codes, .. } => codes.as_ptr() as usize,
             Self::Q4 { packed, .. } => packed.as_ptr() as usize,
             Self::Nvfp4 { packed, .. } => packed.as_ptr() as usize,
+            Self::KQuant { blocks, .. } => blocks.as_ptr() as usize,
         }
     }
 
@@ -186,6 +201,12 @@ impl WeightRows<'_> {
             Self::Q8 { codes, .. } => codes.len() / in_dim,
             Self::Q4 { packed, .. } => packed.len() * 2 / in_dim,
             Self::Nvfp4 { packed, .. } => packed.len() * 2 / in_dim,
+            // Blocks run along the row, so the stride is the codec's, and
+            // a width off its grid has no rows at all — never a rounded
+            // count that would put row 1 at the wrong offset.
+            Self::KQuant { blocks, codec } => codec
+                .row_bytes(in_dim)
+                .map_or(0, |per_row| blocks.len() / per_row),
         }
     }
 
@@ -250,6 +271,19 @@ impl WeightRows<'_> {
                     tensor_scale: *tensor_scale,
                 }
             }
+            Self::KQuant { blocks, codec } => {
+                // Cut at the codec's row stride. A width off the block
+                // grid was refused at `WeightSlice::rows`, so a missing
+                // stride here is an executor bug, not a runtime
+                // condition to absorb.
+                let per_row = codec
+                    .row_bytes(in_dim)
+                    .expect("a K-quant slab was admitted with a width off its block grid");
+                Self::KQuant {
+                    blocks: &blocks[start * per_row..(start + count) * per_row],
+                    codec: *codec,
+                }
+            }
         }
     }
 
@@ -272,6 +306,9 @@ impl WeightRows<'_> {
             // The tensor scale is one f32 for the whole matrix, not per
             // row, so it is not counted in a row slab's footprint.
             Self::Nvfp4 { packed, scales, .. } => packed.len() + scales.len(),
+            // The scales are inside the blocks, so the stream is the
+            // whole cost.
+            Self::KQuant { blocks, .. } => blocks.len(),
         }
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/replay.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/replay.rs
@@ -39,6 +39,7 @@ use std::sync::Mutex;
 use super::executor::CpuExecutor;
 use super::physical::PhysicalProjectionPlan;
 use super::projector::WeightRows;
+use crate::format::vindex3::represent::kquant::KQuant;
 
 /// Which representation a captured operand was resident as.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -48,6 +49,7 @@ enum Kind {
     Q8,
     Q4,
     Nvfp4,
+    KQuant,
 }
 
 /// One projection exactly as the decode issued it.
@@ -74,6 +76,10 @@ pub struct Captured {
     /// numerically different weights, which is exactly the substitution
     /// this harness exists to rule out.
     tensor_scale: f32,
+    /// A stored K-quant's codec — which layout the block stream is.
+    /// Captured for the same reason the tensor scale is: replaying the
+    /// bytes under another codec would price a kernel over garbage.
+    codec: Option<KQuant>,
     out_dim: usize,
     /// The activation the decode actually projected. Kept by value
     /// because it is tens of KB against tens of MB of weight, and
@@ -122,6 +128,10 @@ impl Captured {
                 packed: std::slice::from_raw_parts(p as *const u8, n),
                 scales: std::slice::from_raw_parts(s as *const u8, m),
                 tensor_scale: self.tensor_scale,
+            },
+            Kind::KQuant => WeightRows::KQuant {
+                blocks: std::slice::from_raw_parts(p as *const u8, n),
+                codec: self.codec.expect("a K-quant capture records its codec"),
             },
         }
     }
@@ -198,6 +208,7 @@ pub(super) fn record(weight: WeightRows<'_>, x: &[f32], out_dim: usize) {
         return;
     }
     let mut tensor_scale = 0.0f32;
+    let mut codec = None;
     let (kind, primary, secondary, tertiary, block) = match weight {
         WeightRows::F32(w) => (Kind::F32, (w.as_ptr() as usize, w.len()), (0, 0), (0, 0), 0),
         WeightRows::Bf16(w) => (
@@ -246,6 +257,17 @@ pub(super) fn record(weight: WeightRows<'_>, x: &[f32], out_dim: usize) {
                 0,
             )
         }
+        WeightRows::KQuant { blocks, codec: c } => {
+            codec = Some(c);
+            (
+                Kind::KQuant,
+                (blocks.as_ptr() as usize, blocks.len()),
+                (0, 0),
+                (0, 0),
+                // The block is the codec's, carried by `codec`.
+                0,
+            )
+        }
     };
     let mut slot = CAPTURE.lock().expect("capture lock");
     let Some(log) = slot.as_mut() else {
@@ -254,6 +276,7 @@ pub(super) fn record(weight: WeightRows<'_>, x: &[f32], out_dim: usize) {
     log.push(Captured {
         kind,
         tensor_scale,
+        codec,
         primary,
         secondary,
         tertiary,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/arithmetic.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/arithmetic.rs
@@ -22,6 +22,8 @@ fn a_weight_rendering_carries_its_block() {
     assert_eq!(WeightRep::Bf16.to_string(), "BF16");
     assert_eq!(WeightRep::Q8 { block: 64 }.to_string(), "Q8[64]");
     assert_eq!(WeightRep::Q4 { block: 32 }.to_string(), "Q4[32]");
+    assert_eq!(WeightRep::Nvfp4.to_string(), "NVFP4");
+    assert_eq!(WeightRep::KQuant.to_string(), "KQUANT");
     assert_ne!(
         WeightRep::Q8 { block: 64 }.to_string(),
         WeightRep::Q8 { block: 16 }.to_string(),
@@ -105,6 +107,8 @@ fn every_representation_admits_a_runnable_plan_and_never_the_oracle() {
         WeightRep::Bf16,
         WeightRep::Q8 { block: 64 },
         WeightRep::Q4 { block: 64 },
+        WeightRep::Nvfp4,
+        WeightRep::KQuant,
     ] {
         let plans = plans_possible_for(rep);
         assert!(!plans.is_empty(), "{rep} admits no plan at all");

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/arm_selection.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/arm_selection.rs
@@ -1,0 +1,69 @@
+//! The process-wide execution arms, resolved from their variables by pure
+//! functions — so BOTH answers of each arm are testable in one process,
+//! which a `OnceLock` read of the environment never allowed.
+//!
+//! Every arm follows one rule: the exact word selects, anything else is
+//! the default. A typo must not invent a numerical regime and then be
+//! reported as a measurement.
+
+use super::super::physical::{ArithmeticArm, Q4Classes};
+use crate::format::vindex3::opplan::exec::backend::MatrixClass;
+
+#[test]
+fn unset_empty_and_all_are_the_blanket_q4_arm() {
+    for v in [None, Some(""), Some("  "), Some("all"), Some(" all\n")] {
+        assert_eq!(Q4Classes::from_env_value(v), Q4Classes::ALL, "{v:?}");
+    }
+}
+
+#[test]
+fn a_q4_class_set_names_exactly_the_classes_it_lists() {
+    let set = Q4Classes::from_env_value(Some("attn, ffn"));
+    assert!(set.attention && set.ffn && !set.head, "{set:?}");
+    let head = Q4Classes::from_env_value(Some("head"));
+    assert!(!head.attention && !head.ffn && head.head, "{head:?}");
+    // Tokens are exact: a wrong case names nothing, which restores every
+    // class to Q8 rather than silently admitting all of them.
+    let none = Q4Classes::from_env_value(Some("ATTN,FFN,HEAD"));
+    assert!(!none.attention && !none.ffn && !none.head, "{none:?}");
+}
+
+#[test]
+fn admission_follows_the_set_and_the_bank_is_never_admitted() {
+    let all = Q4Classes::ALL;
+    assert!(all.admits(MatrixClass::AttentionProjection));
+    assert!(all.admits(MatrixClass::FfnProjection));
+    assert!(all.admits(MatrixClass::OutputHead));
+    assert!(
+        !all.admits(MatrixClass::RoutedExpertBank),
+        "the bank is widened on the way in; no compact bytes remain to admit"
+    );
+    let ffn_only = Q4Classes::from_env_value(Some("ffn"));
+    assert!(!ffn_only.admits(MatrixClass::AttentionProjection));
+    assert!(ffn_only.admits(MatrixClass::FfnProjection));
+    assert!(!ffn_only.admits(MatrixClass::OutputHead));
+}
+
+#[test]
+fn each_arithmetic_arm_answers_to_its_two_spellings_and_nothing_else() {
+    use ArithmeticArm::*;
+    assert_eq!(ArithmeticArm::from_env_value(None), FloatActivation);
+    assert_eq!(ArithmeticArm::default(), FloatActivation);
+    for (v, want) in [
+        ("bf16xq8", Bf16TimesQ8),
+        ("bf16xq8b", Bf16TimesQ8),
+        ("q8xq8", Q8TimesQ8),
+        (" q8xq8b\n", Q8TimesQ8),
+        ("q4xq8", Q4TimesQ8),
+        ("q4xq8b", Q4TimesQ8),
+    ] {
+        assert_eq!(ArithmeticArm::from_env_value(Some(v)), want, "{v:?}");
+    }
+    for v in ["", "Q8XQ8", "q8", "q8xq8bb", "fp32", "nonsense"] {
+        assert_eq!(
+            ArithmeticArm::from_env_value(Some(v)),
+            FloatActivation,
+            "{v:?} must be the default, not a fourth regime"
+        );
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/kquant_plan.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/kquant_plan.rs
@@ -1,0 +1,274 @@
+//! The direct K-quant plan: observed off the bytes, run by the codec's
+//! kernel, sliced at the codec's stride, and switchable to the widening
+//! path without a rebuild.
+//!
+//! These are the executor-level half of PARETO-1's v3 gate. The
+//! kernel-level half (`represent/kquant_direct_tests.rs`) settles that
+//! each codec's kernel agrees with its decoder on FOREIGN bytes; this
+//! settles that the plan executor reaches that kernel — and only that
+//! kernel — from a `WeightRows::KQuant` slab, and that the arm switch
+//! selects what it says.
+
+use super::super::kernels::ScalarF32;
+use super::super::physical::{KQuantExecution, PhysicalProjectionPlan, KQUANT_EXEC_WIDEN};
+use super::super::projector::{DenseProjector, WeightRows};
+use crate::format::vindex3::opplan::exec::backend::{MatrixClass, MatrixOperand, WeightFormat};
+use crate::format::vindex3::opplan::exec::production::declared_format;
+use crate::format::vindex3::represent::kquant::{KQuant, COMPILABLE, Q4_K, Q6_K, Q8_0};
+
+/// Rows and a width every codec's block divides: 512 is 16 Q8_0 blocks
+/// and 2 super-blocks, so each row has more than one block and a scale
+/// read at the wrong offset would be caught.
+const ROWS: usize = 3;
+const IN_DIM: usize = 512;
+
+/// Bound on accumulation-order disagreement in units of the row's own
+/// magnitude scale `sum|w x|` — the quantity such error is bounded by.
+/// The elementwise relative metric is blind to cancellation and is
+/// printed for the record only; see `exec/tests/kquant_projection.rs`.
+const ACCUMULATION_ORDER_NORMALISED: f64 = 5e-6;
+
+/// Weights whose magnitude varies by row and within a row, so blocks get
+/// different scales and rows cannot be confused for each other.
+fn weights() -> Vec<f32> {
+    (0..ROWS * IN_DIM)
+        .map(|i| ((i % 29) as f32 - 14.0) * 0.03 * (1.0 + (i / IN_DIM) as f32))
+        .collect()
+}
+
+fn activation() -> Vec<f32> {
+    (0..IN_DIM).map(|i| ((i % 13) as f32 - 6.0) / 9.0).collect()
+}
+
+/// The authority: decode the same stored bytes, then the literal scalar
+/// transcription — element order, no library reassociation.
+fn decode_then_scalar(codec: KQuant, blocks: &[u8], x: &[f32], rows: usize) -> Vec<f32> {
+    let decoded = codec.decode(blocks, rows * IN_DIM, "t").expect("decode");
+    let mut out = vec![0.0f32; rows];
+    ScalarF32.project_rows(WeightRows::F32(&decoded), x, &mut out);
+    out
+}
+
+fn worst_relative(a: &[f32], b: &[f32]) -> f64 {
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| {
+            let denom = (x.abs().max(y.abs()) as f64).max(1e-6);
+            ((*x as f64) - (*y as f64)).abs() / denom
+        })
+        .fold(0.0f64, f64::max)
+}
+
+/// Worst per-row difference over that row's `sum|w x|`.
+fn worst_normalised(a: &[f32], b: &[f32], w: &[f32], x: &[f32]) -> f64 {
+    let k = x.len();
+    a.iter()
+        .zip(b)
+        .enumerate()
+        .map(|(r, (p, q))| {
+            let scale: f64 = w[r * k..(r + 1) * k]
+                .iter()
+                .zip(x)
+                .map(|(wi, xi)| (wi * xi).abs() as f64)
+                .sum();
+            ((*p as f64) - (*q as f64)).abs() / scale.max(1e-12)
+        })
+        .fold(0.0f64, f64::max)
+}
+
+fn stored(codec: KQuant) -> Vec<u8> {
+    codec.encode(&weights(), "t").expect("encode")
+}
+
+/// The bytes decide the plan, the plan names the format, and the plan's
+/// kernel computes what decoding the same bytes computes.
+///
+/// Q8_0 is bit-for-bit: its kernel folds the f16 scale per element, which
+/// is the decoder's own association. The super-block codecs accumulate
+/// in a different order and are held to the layer-1 bound instead.
+#[test]
+fn the_observation_lands_on_the_direct_plan_for_every_codec() {
+    let x = activation();
+    for codec in COMPILABLE {
+        let blocks = stored(codec);
+        let rows = WeightRows::KQuant {
+            blocks: &blocks,
+            codec,
+        };
+        let plan = PhysicalProjectionPlan::for_resident(rows, IN_DIM);
+        assert_eq!(plan, PhysicalProjectionPlan::FusedKQuant, "{}", codec.name);
+        assert_eq!(plan.format(), WeightFormat::KQuant, "{}", codec.name);
+        assert_eq!(rows.rows(IN_DIM), ROWS, "{}", codec.name);
+        assert_eq!(rows.bytes(), blocks.len(), "{}", codec.name);
+
+        let mut direct = vec![0.0f32; ROWS];
+        plan.kernel().project_rows(rows, &x, &mut direct);
+        let decoded = codec.decode(&blocks, ROWS * IN_DIM, "t").expect("decode");
+        let want = decode_then_scalar(codec, &blocks, &x, ROWS);
+        let norm = worst_normalised(&direct, &want, &decoded, &x);
+        println!(
+            "  layer-2 plan  {:<5} [{ROWS},{IN_DIM}]  normalised {norm:.2e}  (elementwise {:.2e})",
+            codec.name,
+            worst_relative(&direct, &want)
+        );
+        if codec == Q8_0 {
+            assert_eq!(
+                direct, want,
+                "Q8_0 must be bit-for-bit with decode-then-multiply"
+            );
+        } else {
+            assert!(
+                norm < ACCUMULATION_ORDER_NORMALISED,
+                "{}: {norm:e} of the row scale is more than accumulation order",
+                codec.name
+            );
+        }
+    }
+}
+
+/// A sub-slab is cut at the codec's row stride and computes exactly the
+/// rows it names — the same rows of the full projection, bit for bit,
+/// because a row's arithmetic does not depend on which slab it is in.
+#[test]
+fn slicing_rows_keeps_each_row_under_its_own_blocks() {
+    let x = activation();
+    for codec in COMPILABLE {
+        let blocks = stored(codec);
+        let all = WeightRows::KQuant {
+            blocks: &blocks,
+            codec,
+        };
+        let per_row = codec.row_bytes(IN_DIM).expect("512 is on every grid");
+        let tail = all.slice_rows(IN_DIM, 1, 2);
+        assert_eq!(tail.rows(IN_DIM), 2, "{}", codec.name);
+        assert_eq!(tail.bytes(), 2 * per_row, "{}", codec.name);
+        assert_eq!(
+            tail.primary_addr(),
+            all.primary_addr() + per_row,
+            "{}: the sub-slab must start one row in",
+            codec.name
+        );
+
+        let mut whole = vec![0.0f32; ROWS];
+        let mut part = vec![0.0f32; 2];
+        let kernel = PhysicalProjectionPlan::for_resident(all, IN_DIM).kernel();
+        kernel.project_rows(all, &x, &mut whole);
+        kernel.project_rows(tail, &x, &mut part);
+        assert_eq!(
+            part,
+            whole[1..],
+            "{}: a slab must compute its own rows",
+            codec.name
+        );
+    }
+}
+
+/// A width off the block grid describes no rows, and the executor's row
+/// count says so rather than rounding.
+#[test]
+fn a_width_off_the_block_grid_has_no_rows() {
+    for codec in [Q6_K, Q4_K] {
+        let blocks = stored(codec);
+        let rows = WeightRows::KQuant {
+            blocks: &blocks,
+            codec,
+        };
+        // 512 - 32 is on Q8_0's grid but not on a super-block's.
+        assert_eq!(rows.rows(IN_DIM - 32), 0, "{}", codec.name);
+        assert_eq!(codec.row_bytes(IN_DIM - 32), None, "{}", codec.name);
+        assert_eq!(codec.row_bytes(0), None, "{}", codec.name);
+    }
+    assert_eq!(Q8_0.row_bytes(IN_DIM - 32), Some(15 * Q8_0.bytes_per_block));
+}
+
+/// Only the exact word widens. Every other value — including a
+/// plausible misspelling — is the default, and the run's own plan report
+/// is what says which arm ran.
+#[test]
+fn the_env_value_selects_the_arm_exactly() {
+    assert_eq!(
+        KQuantExecution::from_env_value(None),
+        KQuantExecution::Direct
+    );
+    assert_eq!(
+        KQuantExecution::from_env_value(Some(KQUANT_EXEC_WIDEN)),
+        KQuantExecution::Widen
+    );
+    assert_eq!(
+        KQuantExecution::from_env_value(Some("  widen\n")),
+        KQuantExecution::Widen,
+        "surrounding whitespace is not a different word"
+    );
+    for not_the_word in ["direct", "", "WIDEN", "wideen", "widen=1"] {
+        assert_eq!(
+            KQuantExecution::from_env_value(Some(not_the_word)),
+            KQuantExecution::Direct,
+            "{not_the_word:?} must not select the widening arm"
+        );
+    }
+    assert_eq!(KQuantExecution::default(), KQuantExecution::Direct);
+}
+
+fn operand(class: MatrixClass, stored_kquant: bool, stored_nvfp4: bool) -> MatrixOperand {
+    MatrixOperand {
+        class,
+        // Large enough to stream, so the size policy would have had an
+        // opinion if it were consulted.
+        elements: 17408 * 5120,
+        stored_bf16: false,
+        stored_nvfp4,
+        stored_kquant,
+    }
+}
+
+/// The production policy binds a stored K-quant in place under the direct
+/// arm and widens it under the other — and answers exactly as it did
+/// before the arm existed for everything that is not a stored K-quant.
+#[test]
+fn the_policy_answers_the_pack_under_direct_and_f32_under_widen() {
+    for class in [
+        MatrixClass::AttentionProjection,
+        MatrixClass::FfnProjection,
+        MatrixClass::OutputHead,
+    ] {
+        assert_eq!(
+            declared_format(operand(class, true, false), KQuantExecution::Direct),
+            WeightFormat::KQuant,
+            "{class:?} direct"
+        );
+        // The widened arm is the v2 authority path: stored_bf16 is false
+        // for a K-quant, so the size policy lands on BLAS f32 exactly as
+        // it did before this arm existed.
+        assert_eq!(
+            declared_format(operand(class, true, false), KQuantExecution::Widen),
+            WeightFormat::F32,
+            "{class:?} widen"
+        );
+        // Not a stored K-quant: the arm is irrelevant and the answer is
+        // the size policy's.
+        for arm in [KQuantExecution::Direct, KQuantExecution::Widen] {
+            assert_eq!(
+                declared_format(operand(class, false, false), arm),
+                WeightFormat::F32,
+                "{class:?} {arm:?} without a pack"
+            );
+        }
+    }
+    // The bank is widened on the way in; no pack survives to bind.
+    assert_eq!(
+        declared_format(
+            operand(MatrixClass::RoutedExpertBank, true, false),
+            KQuantExecution::Direct
+        ),
+        WeightFormat::F32
+    );
+    // A stored NVFP4 pack keeps precedence; the two cannot both be true
+    // of one operand, and the order says which claim would win.
+    assert_eq!(
+        declared_format(
+            operand(MatrixClass::FfnProjection, true, true),
+            KQuantExecution::Direct
+        ),
+        WeightFormat::Nvfp4
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/ledger.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/ledger.rs
@@ -12,12 +12,17 @@ use super::super::physical::PhysicalProjectionPlan;
 /// Every plan the ledger has a slot for. Adding a plan without adding it
 /// here would leave the new slot untested, so `all_enumerates_every_plan`
 /// checks the two agree in length as well as in content.
-const PLANS: [PhysicalProjectionPlan; 8] = [
+const PLANS: [PhysicalProjectionPlan; 10] = [
     PhysicalProjectionPlan::ScalarF32,
     PhysicalProjectionPlan::BlasF32,
     PhysicalProjectionPlan::FusedBf16,
     PhysicalProjectionPlan::FusedQ8,
     PhysicalProjectionPlan::FusedQ4,
+    // The observation-only plans — a compiled pack the loader bound.
+    // NVFP4 had a slot and no row here until the K-quant arm was added
+    // beside it, so its bytes were tallied and never enumerated.
+    PhysicalProjectionPlan::FusedNvfp4,
+    PhysicalProjectionPlan::FusedKQuant,
     // The integer arms. Each has its OWN slot on purpose: an arm folded
     // into another's counter would let a byte census agree with itself
     // while describing a mixture of two arithmetics.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/mod.rs
@@ -2,10 +2,12 @@
 //! with one, and the ledger that records what ran.
 
 mod arithmetic;
+mod arm_selection;
 mod cost;
 mod executor;
 mod integer;
 mod kernels;
+mod kquant_plan;
 mod ledger;
 mod nvfp4_slab;
 mod physical;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
@@ -147,7 +147,10 @@ impl<M: MatMul + Send> DevicePlanBackend<M> {
             )));
         }
         let result = match weight {
-            WeightSlice::Bf16(_) | WeightSlice::Q8 { .. } | WeightSlice::Q4 { .. } => {
+            WeightSlice::Bf16(_)
+            | WeightSlice::Q8 { .. }
+            | WeightSlice::Q4 { .. }
+            | WeightSlice::KQuant { .. } => {
                 return Err(VindexError::Parse(format!(
                     "the device backend has no {} kernel; declare F16 or F32 for it",
                     weight.representation()
@@ -365,7 +368,10 @@ impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
                 // A residency hint computes nothing and must change no
                 // number, so an unplaceable format is skipped here; the
                 // refusal that matters fires where it would be USED.
-                WeightSlice::Bf16(_) | WeightSlice::Q8 { .. } | WeightSlice::Q4 { .. } => continue,
+                WeightSlice::Bf16(_)
+                | WeightSlice::Q8 { .. }
+                | WeightSlice::Q4 { .. }
+                | WeightSlice::KQuant { .. } => continue,
                 WeightSlice::F16(bytes) => streams.push(bytes),
                 WeightSlice::Mxfp4 { packed, scales }
                 | WeightSlice::Nvfp4 { packed, scales, .. } => {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
@@ -513,6 +513,10 @@ fn from_f32(
             "expert bank `{name}` cannot be made q4-resident: the bank is widened to f32 on \
              the way in, so there is nothing compact left to keep"
         ))),
+        WeightFormat::KQuant => Err(VindexError::Parse(format!(
+            "expert bank `{name}` cannot bind a stored K-quant: the bank is widened to f32 on \
+             the way in, so the stored blocks are no longer what is being bound"
+        ))),
         WeightFormat::Mxfp4 => quantize_mxfp4(&values, rows, k, name),
         WeightFormat::Nvfp4 => quantize_nvfp4(&values, rows, k, name),
         // This path has already widened to f32 (packed expert banks

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
@@ -498,7 +498,9 @@ fn from_f32(
     name: &str,
 ) -> Result<LoadedWeight, VindexError> {
     match format {
-        WeightFormat::F32 => Ok(LoadedWeight::F32(values)),
+        WeightFormat::F32 => Ok(LoadedWeight::F32(super::weights::staged::StagedF32::stage(
+            values,
+        )?)),
         WeightFormat::F16 => {
             let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
             Ok(LoadedWeight::F16(f32_bytes_to_f16(&bytes, name)?))

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
@@ -753,6 +753,20 @@ impl<'a> OperandSource<'a> {
             == Some(crate::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4)
     }
 
+    /// Whether this operand is held as a compiled K-quant pack — any
+    /// encoding `represent::kquant::lookup` names.
+    ///
+    /// The same overlay rule as [`Self::is_stored_bf16`], for the same
+    /// reason: an edited operand has no compact form and answers `false`.
+    pub fn is_stored_kquant(&self, operand: &OperandRef) -> bool {
+        if self.overrides.is_some_and(|o| o.is_overridden(operand)) {
+            return false;
+        }
+        self.base
+            .stored_dtype(operand)
+            .is_some_and(|d| crate::format::vindex3::represent::kquant::lookup(d).is_some())
+    }
+
     /// Load one operand's stored bytes unwidened. Overlay edits are
     /// f32-space facts and cannot be represented in raw stored bytes,
     /// so an overridden operand refuses here rather than serving stale

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -692,6 +692,7 @@ fn resolve<B: PlanBackend + ?Sized>(
         elements: op.shape.iter().product(),
         stored_bf16: store.is_stored_bf16(op),
         stored_nvfp4: store.is_stored_nvfp4(op),
+        stored_kquant: store.is_stored_kquant(op),
     })
 }
 
@@ -774,6 +775,7 @@ impl PreparedOperands {
             // the way in, so no stored form survives for a format to
             // apply to — the same reason `elements` is 0 here.
             stored_nvfp4: false,
+            stored_kquant: false,
         });
         let head_format = |op: &OperandRef| resolve(backend, store, MatrixClass::OutputHead, op);
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -40,7 +40,9 @@ use super::backend::{
     GateCall, MatrixClass, MatrixOperand, NormCall, PlanBackend, ProjectCall, ProjectedQkv,
     QkNormCall, RoutedFfnCall, WeightFormat,
 };
-use super::cpu::physical::{project_matrix, project_matrix_many, ExecutorProjections};
+use super::cpu::physical::{
+    kquant_execution, project_matrix, project_matrix_many, ExecutorProjections, KQuantExecution,
+};
 use super::cpu::PhysicalProjectionPlan;
 use super::kernels::{
     gather_fused_half, mrope_rotate_scaled, rope_rotate, rope_rotate_scaled, FusedHalf,
@@ -695,6 +697,37 @@ impl ProductionBackend {
     }
 }
 
+/// [`ProductionBackend::weight_format`]'s decision, with the K-quant
+/// execution arm passed in rather than read from the environment — so
+/// both arms are testable in one process without touching it.
+pub(crate) fn declared_format(operand: MatrixOperand, kquant: KQuantExecution) -> WeightFormat {
+    match operand.class {
+        // The packed bank is widened to f32 on the way in and sliced
+        // into per-expert matrices; there are no stored bytes left to
+        // keep by the time a format could apply.
+        MatrixClass::RoutedExpertBank => WeightFormat::F32,
+        // A compiled pack outranks the size policy. `choose_for`
+        // decides what to MAKE an operand resident as, from its size;
+        // an operand that is already NVFP4 has had that decision made
+        // for it deliberately, and re-deciding here would widen 4-bit
+        // bytes to f32 to satisfy a policy about bf16.
+        _ if operand.stored_nvfp4 => WeightFormat::Nvfp4,
+        // The same for a stored K-quant, under one condition: the arm.
+        // `Widen` is rung A's authority path (decode to f32, BLAS) and
+        // falls through to the size policy exactly as before this arm
+        // existed — with `stored_bf16` false, that is `BlasF32`.
+        _ if operand.stored_kquant && kquant == KQuantExecution::Direct => WeightFormat::KQuant,
+        MatrixClass::AttentionProjection | MatrixClass::FfnProjection | MatrixClass::OutputHead => {
+            PhysicalProjectionPlan::choose_for(
+                Some(operand.class),
+                operand.elements,
+                operand.stored_bf16,
+            )
+            .format()
+        }
+    }
+}
+
 impl PlanBackend for ProductionBackend {
     fn dense_projector(&self) -> &dyn super::gated_delta::DenseProjections {
         &ExecutorProjections
@@ -704,26 +737,7 @@ impl PlanBackend for ProductionBackend {
     /// and the kernel at [`project_rows`] — see
     /// [`PhysicalProjectionPlan`].
     fn weight_format(&self, operand: MatrixOperand) -> WeightFormat {
-        match operand.class {
-            // The packed bank is widened to f32 on the way in and sliced
-            // into per-expert matrices; there are no stored bytes left to
-            // keep by the time a format could apply.
-            MatrixClass::RoutedExpertBank => WeightFormat::F32,
-            // A compiled pack outranks the size policy. `choose_for`
-            // decides what to MAKE an operand resident as, from its size;
-            // an operand that is already NVFP4 has had that decision made
-            // for it deliberately, and re-deciding here would widen 4-bit
-            // bytes to f32 to satisfy a policy about bf16.
-            _ if operand.stored_nvfp4 => WeightFormat::Nvfp4,
-            MatrixClass::AttentionProjection
-            | MatrixClass::FfnProjection
-            | MatrixClass::OutputHead => PhysicalProjectionPlan::choose_for(
-                Some(operand.class),
-                operand.elements,
-                operand.stored_bf16,
-            )
-            .format(),
-        }
+        declared_format(operand, kquant_execution())
     }
 
     fn name(&self) -> &str {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_backend_decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_backend_decode.rs
@@ -107,6 +107,13 @@ fn as_f32_returns_f32_and_refuses_every_other_representation() {
                 tensor_scale: NVFP4_TENSOR_SCALE,
             },
         ),
+        (
+            "Q8_0",
+            WeightSlice::KQuant {
+                blocks: &FOREIGN_BYTES,
+                codec: crate::format::vindex3::represent::kquant::Q8_0,
+            },
+        ),
     ];
     for (label, slice) in foreign {
         let message = parse_message(slice.as_f32().expect_err(label));

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_device.rs
@@ -673,6 +673,7 @@ fn an_nvfp4_device_backend_executes_and_decodes_the_dense_plan() {
             elements: 0,
             stored_bf16: false,
             stored_nvfp4: false,
+            stored_kquant: false,
         }),
         WeightFormat::Nvfp4
     );

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
@@ -1,0 +1,473 @@
+//! **Layer 2 of PARETO-1's v3 gate: a real projection through the plan
+//! executor, direct against widened, on the SAME stored bytes.**
+//!
+//! Layer 1 (`represent/kquant_direct_tests.rs`) settles that each codec's
+//! kernel agrees with its decoder on foreign bytes. What it cannot see
+//! is everything between a container and a kernel: which format the
+//! policy declares, whether the loader binds the stored blocks or a
+//! derivative, whether the slice is cut at the right stride, whether the
+//! executor observes `FusedKQuant` or quietly runs `BlasF32`, LARQL Q8,
+//! or something it manufactured. A 34-vs-18-byte stride bug of exactly
+//! that kind has already produced garbage in this workspace, so this
+//! layer is load-bearing and not a formality.
+//!
+//! ```text
+//! compiled pack  -> OperandStore -> load_weight(KQuant) -> FusedKQuant     the candidate
+//! the SAME pack  -> OperandStore -> load_weight(F32)    -> BlasF32         rung A's authority
+//! ```
+//!
+//! Both arms open the same container and read the same tensor. The
+//! encoder does not re-enter the causal graph — it wrote the bytes both
+//! arms read, and Amendment 2 removed it from the comparison.
+//!
+//! The mutations at the end are valued as highly as the agreement: a
+//! gate that cannot return the other answer is not a gate.
+
+use crate::format::filenames::INDEX_JSON;
+use crate::format::vindex3::encode::segment::read_segment_header;
+use crate::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
+use crate::format::vindex3::index::Vindex3Index;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::backend::{WeightFormat, WeightSlice};
+use crate::format::vindex3::opplan::exec::cpu::kernels::ScalarF32;
+use crate::format::vindex3::opplan::exec::cpu::physical::project_matrix;
+use crate::format::vindex3::opplan::exec::cpu::projector::{DenseProjector, WeightRows};
+use crate::format::vindex3::opplan::exec::cpu::{ledger, PhysicalProjectionPlan};
+use crate::format::vindex3::opplan::exec::operands::{
+    OperandSource, OperandStore, RepresentationSource,
+};
+use crate::format::vindex3::opplan::exec::weights::{load_weight, LoadedWeight};
+use crate::format::vindex3::opplan::OperandRef;
+use crate::format::vindex3::represent::kquant::{self, KQuant, COMPILABLE, Q4_K, Q6_K, Q8_0};
+use crate::format::vindex3::represent::{compile_representation, policy, RepresentSpec};
+use serial_test::serial;
+
+/// Bound on accumulation-order disagreement, in units of each row's own
+/// magnitude scale — see [`worst_normalised`].
+///
+/// An f32 dot over `k` terms differs between two summation orders by at
+/// most about `k * eps * sum|w x|` and typically `sqrt(k) * eps`: for
+/// k = 5120 and eps = 6e-8 that is 4.3e-6 worst case and ~4e-7 typical.
+/// Measured on this fixture the three arms sit at ~1e-7 (direct vs
+/// scalar, BLAS vs scalar, direct vs BLAS), so this leaves an order of
+/// magnitude over the typical and still refuses the worst case a wrong
+/// scale or a wrong stride produces, which is O(1).
+const ACCUMULATION_ORDER_NORMALISED: f64 = 5e-6;
+
+fn spec(encoding: &str) -> RepresentSpec {
+    RepresentSpec {
+        encoding: encoding.to_string(),
+        objects: Vec::new(),
+        roles: policy::RolePolicy::default(),
+        deployment: false,
+        protect: policy::Protections::default(),
+    }
+}
+
+/// The dense fixture, encoded, then compiled to `codec`. Returns the
+/// source and the compiled container.
+fn compiled(tmp: &tempfile::TempDir, codec: KQuant) -> (std::path::PathBuf, std::path::PathBuf) {
+    let checkpoint = tmp.path().join("ckpt");
+    std::fs::create_dir_all(&checkpoint).unwrap();
+    let src = tmp.path().join("src.vindex3");
+    let out = tmp.path().join(format!("{}.vindex3", codec.name));
+    encode_fixture_container(dense_f32_model, &checkpoint, &src, "target");
+    compile_representation(&src, &out, &spec(codec.name))
+        .unwrap_or_else(|e| panic!("{} compiles the fixture: {e}", codec.name));
+    (src, out)
+}
+
+/// The first two-dimensional tensor stored as `codec` in the compiled
+/// container, as an operand reference.
+fn a_stored_matrix(out: &std::path::Path, codec: KQuant) -> OperandRef {
+    let index: Vindex3Index =
+        serde_json::from_str(&std::fs::read_to_string(out.join(INDEX_JSON)).unwrap()).unwrap();
+    let entry = index
+        .representations
+        .values()
+        .find(|e| e.encoding == codec.name)
+        .unwrap_or_else(|| panic!("a {} representation was registered", codec.name));
+    let (header, _) = read_segment_header(&out.join(&entry.segment)).unwrap();
+    let t = header
+        .tensors
+        .iter()
+        .find(|t| t.dtype == codec.name && t.shape.len() == 2)
+        .unwrap_or_else(|| panic!("the pack holds a two-dimensional {} tensor", codec.name));
+    OperandRef {
+        object: entry.object.clone(),
+        tensor: t.name.clone(),
+        dtype: t.dtype.clone(),
+        shape: t.shape.clone(),
+    }
+}
+
+fn open(out: &std::path::Path, codec: KQuant) -> OperandStore {
+    let inspection = inspect_container(out, false).unwrap();
+    OperandStore::open_for(
+        out,
+        &inspection,
+        Some(codec.name),
+        RepresentationSource::Stored,
+    )
+    .expect("the compiled pack binds")
+}
+
+fn activation(k: usize) -> Vec<f32> {
+    (0..k).map(|i| ((i % 23) as f32 - 11.0) / 13.0).collect()
+}
+
+/// Elementwise worst relative difference — printed for the record, NOT
+/// the gate. It is the metric layer 1 used, and it is blind to
+/// cancellation: an output near zero has a large relative error for a
+/// tiny absolute one, which is a property of the output and not of
+/// either arm. The 64-row fixture produced exactly such a row.
+fn worst_relative(a: &[f32], b: &[f32]) -> f64 {
+    assert_eq!(a.len(), b.len());
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| {
+            let denom = (x.abs().max(y.abs()) as f64).max(1e-6);
+            ((*x as f64) - (*y as f64)).abs() / denom
+        })
+        .fold(0.0f64, f64::max)
+}
+
+/// Worst per-row difference in units of that row's magnitude scale,
+/// `sum_i |w_ri * x_i|` — the quantity accumulation-order error is
+/// actually bounded by. The gate.
+fn worst_normalised(a: &[f32], b: &[f32], w: &[f32], x: &[f32]) -> f64 {
+    assert_eq!(a.len(), b.len());
+    let k = x.len();
+    a.iter()
+        .zip(b)
+        .enumerate()
+        .map(|(r, (p, q))| {
+            let scale: f64 = w[r * k..(r + 1) * k]
+                .iter()
+                .zip(x)
+                .map(|(wi, xi)| (wi * xi).abs() as f64)
+                .sum();
+            ((*p as f64) - (*q as f64)).abs() / scale.max(1e-12)
+        })
+        .fold(0.0f64, f64::max)
+}
+
+/// One stored matrix per codec, through normal VINDEX loading, both ways.
+///
+/// Asserted, in order: the direct arm binds the stored blocks and the
+/// widened arm binds an f32 image; neither manufactures anything; the
+/// executor OBSERVES `FusedKQuant` for the one and `BlasF32` for the
+/// other; the real projection path runs the direct plan (the process
+/// ledger moves); and the two projections agree to accumulation order —
+/// bit-for-bit against the scalar transcription for Q8_0.
+// Serial: the widened arm goes through `StagedF32::stage`, which bumps
+// the process-global staging counters a serial staged-test asserts an
+// exact delta on. A concurrent map here corrupts that delta — it did,
+// on the Linux CI runner, where this and the counter test overlapped.
+#[test]
+#[serial]
+fn a_stored_matrix_projects_the_same_direct_and_widened() {
+    for codec in COMPILABLE {
+        let tmp = tempfile::tempdir().unwrap();
+        let (_src, out) = compiled(&tmp, codec);
+        let op = a_stored_matrix(&out, codec);
+        let store = open(&out, codec);
+        let src: OperandSource<'_> = (&store).into();
+
+        let direct = load_weight(src, &op, WeightFormat::KQuant).expect("binds the pack");
+        let widened = load_weight(src, &op, WeightFormat::F32).expect("widens the pack");
+        assert!(
+            matches!(direct, LoadedWeight::KQuant { codec: c, .. } if c == codec),
+            "{}: the direct arm must hold the stored blocks under their own codec",
+            codec.name
+        );
+        assert!(
+            widened.is_widened_f32(),
+            "{}: the authority arm is f32",
+            codec.name
+        );
+        assert_eq!(
+            store.runtime_quantised(),
+            0,
+            "{}: neither arm may manufacture a representation",
+            codec.name
+        );
+
+        let (out_dim, in_dim) = (op.shape[0], op.shape[1]);
+        let x = activation(in_dim);
+        let direct_rows = direct.slice().rows(out_dim, in_dim).unwrap();
+        let widened_rows = widened.slice().rows(out_dim, in_dim).unwrap();
+        assert_eq!(
+            PhysicalProjectionPlan::for_resident(direct_rows, in_dim),
+            PhysicalProjectionPlan::FusedKQuant,
+            "{}: the executor must observe the direct plan, not BLAS, LARQL Q8 or NVFP4",
+            codec.name
+        );
+        assert_eq!(
+            PhysicalProjectionPlan::for_resident(widened_rows, in_dim),
+            PhysicalProjectionPlan::BlasF32,
+            "{}: the authority arm is rung A's BLAS f32 path",
+            codec.name
+        );
+
+        // Through the REAL projection path, and proven to have run the
+        // direct plan by the process ledger rather than by inference.
+        let before = ledger().get(PhysicalProjectionPlan::FusedKQuant).calls;
+        let y_direct = project_matrix(&direct.slice(), &x, out_dim, in_dim).unwrap();
+        let y_widened = project_matrix(&widened.slice(), &x, out_dim, in_dim).unwrap();
+        assert!(
+            ledger().get(PhysicalProjectionPlan::FusedKQuant).calls > before,
+            "{}: the executor did not record a FusedKQuant call",
+            codec.name
+        );
+
+        // Three arms over the SAME widened image: the candidate, the
+        // authority (BLAS), and the literal scalar transcription. Printing
+        // all three pairs separates the candidate's disagreement from the
+        // authority's own reassociation — BLAS is not the scalar loop
+        // either, and a reader of one number could not tell whose
+        // arithmetic it was measuring.
+        let image = widened.slice().as_f32().unwrap();
+        let mut scalar = vec![0.0f32; out_dim];
+        ScalarF32.project_rows(widened_rows, &x, &mut scalar);
+        let d_vs_b = worst_normalised(&y_direct, &y_widened, image, &x);
+        let d_vs_s = worst_normalised(&y_direct, &scalar, image, &x);
+        let b_vs_s = worst_normalised(&y_widened, &scalar, image, &x);
+        println!(
+            "  layer-2  {:<5} {} [{out_dim},{in_dim}]  normalised: direct-vs-BLAS {d_vs_b:.2e}  \
+             direct-vs-scalar {d_vs_s:.2e}  BLAS-vs-scalar {b_vs_s:.2e}   \
+             (elementwise direct-vs-BLAS {:.2e})",
+            codec.name,
+            op.tensor,
+            worst_relative(&y_direct, &y_widened)
+        );
+        assert!(
+            d_vs_b < ACCUMULATION_ORDER_NORMALISED,
+            "{}: direct and the BLAS authority disagree by {d_vs_b:e} of the row scale — more \
+             than accumulation order",
+            codec.name
+        );
+        assert!(
+            d_vs_s < ACCUMULATION_ORDER_NORMALISED,
+            "{}: direct and the scalar transcription disagree by {d_vs_s:e} of the row scale",
+            codec.name
+        );
+
+        // Against the literal scalar transcription of the SAME widened
+        // image, Q8_0 is exact: the kernel folds the f16 scale per element
+        // in the decoder's own association.
+        if codec == Q8_0 {
+            assert_eq!(
+                y_direct, scalar,
+                "Q8_0 direct must be bit-for-bit with the scalar decode-then-multiply"
+            );
+        }
+    }
+}
+
+/// The comparison can fail. Perturbing one stored byte in the pack must
+/// move the direct projection — otherwise the agreement above could be
+/// two arms ignoring the same bytes.
+#[test]
+fn the_direct_projection_reads_the_stored_bytes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_src, out) = compiled(&tmp, Q8_0);
+    let op = a_stored_matrix(&out, Q8_0);
+    let store = open(&out, Q8_0);
+    let LoadedWeight::KQuant { blocks, codec } =
+        load_weight((&store).into(), &op, WeightFormat::KQuant).unwrap()
+    else {
+        panic!("the direct arm binds blocks");
+    };
+    let (out_dim, in_dim) = (op.shape[0], op.shape[1]);
+    let x = activation(in_dim);
+    let clean = project_matrix(
+        &WeightSlice::KQuant {
+            blocks: &blocks,
+            codec,
+        },
+        &x,
+        out_dim,
+        in_dim,
+    )
+    .unwrap();
+    let mut dirty = blocks.clone();
+    // A code byte in the middle of the stream, past any block header.
+    let victim = dirty.len() / 2;
+    dirty[victim] ^= 0x10;
+    let perturbed = project_matrix(
+        &WeightSlice::KQuant {
+            blocks: &dirty,
+            codec,
+        },
+        &x,
+        out_dim,
+        in_dim,
+    )
+    .unwrap();
+    assert_ne!(
+        clean, perturbed,
+        "one stored byte changed and the projection did not"
+    );
+}
+
+/// The direct format binds ONLY a stored K-quant. Asked for over the
+/// source container's float tensor it refuses by name rather than
+/// encoding one — a manufactured pack would be the artifact's
+/// derivative, not the artifact.
+#[test]
+fn the_direct_format_refuses_a_tensor_that_is_not_a_stored_kquant() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (src, _out) = compiled(&tmp, Q8_0);
+    let inspection = inspect_container(&src, false).unwrap();
+    let store = OperandStore::open(&src, &inspection).unwrap();
+    // Any two-dimensional tensor of the source: take the compiled one's
+    // name, which the source holds at its own precision.
+    let op = {
+        let compiled_op = a_stored_matrix(&_out, Q8_0);
+        let dtype = store
+            .stored_dtype(&compiled_op)
+            .expect("the source holds the same tensor")
+            .to_string();
+        OperandRef {
+            dtype,
+            ..compiled_op
+        }
+    };
+    assert!(
+        kquant::lookup(&op.dtype).is_none(),
+        "the source is not a K-quant"
+    );
+    let err = load_weight((&store).into(), &op, WeightFormat::KQuant)
+        .expect_err("a float tensor is not a stored pack")
+        .to_string();
+    assert!(err.contains("not a K-quant"), "{err}");
+    assert!(
+        err.contains(&op.dtype),
+        "the refusal names the stored dtype: {err}"
+    );
+    assert_eq!(
+        store.runtime_quantised(),
+        0,
+        "the refusal must not have encoded anything"
+    );
+}
+
+/// A shape the stored stream does not describe is refused at load, by
+/// name, before any row could be read at the wrong stride.
+#[test]
+fn the_loader_refuses_a_geometry_the_stream_does_not_describe() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_src, out) = compiled(&tmp, Q8_0);
+    let op = a_stored_matrix(&out, Q8_0);
+    let store = open(&out, Q8_0);
+    let src: OperandSource<'_> = (&store).into();
+    assert!(
+        load_weight(src, &op, WeightFormat::KQuant).is_ok(),
+        "the control case"
+    );
+
+    // Twice the width: the stream is half what that shape needs.
+    let wide = OperandRef {
+        shape: vec![op.shape[0], op.shape[1] * 2],
+        ..op.clone()
+    };
+    let err = load_weight(src, &wide, WeightFormat::KQuant)
+        .expect_err("half the bytes the shape needs")
+        .to_string();
+    assert!(err.contains("do not describe shape"), "{err}");
+    assert!(err.contains("wrong stride"), "{err}");
+
+    // Half the rows: the stream is twice what that shape needs. The
+    // longer direction is the one a prefix cut would have accepted.
+    let short = OperandRef {
+        shape: vec![op.shape[0] / 2, op.shape[1]],
+        ..op.clone()
+    };
+    let err = load_weight(src, &short, WeightFormat::KQuant)
+        .expect_err("twice the bytes the shape needs")
+        .to_string();
+    assert!(err.contains("do not describe shape"), "{err}");
+
+    // A width off the block grid has no plan at all.
+    let ragged = OperandRef {
+        shape: vec![op.shape[0], op.shape[1] - 1],
+        ..op.clone()
+    };
+    let err = load_weight(src, &ragged, WeightFormat::KQuant)
+        .expect_err("a ragged row has no block layout")
+        .to_string();
+    assert!(err.contains("whole number"), "{err}");
+}
+
+/// Bytes of one codec labelled as another are refused at the slice, in
+/// BOTH directions. Q6_K's 210-byte blocks under Q4_K's 144 would pass a
+/// prefix cut — the stream is longer than Q4_K wants — and be walked at
+/// the wrong stride; the exact-length rule is what closes that.
+#[test]
+fn bytes_under_another_codec_are_refused_not_reinterpreted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_src, out) = compiled(&tmp, Q6_K);
+    let op = a_stored_matrix(&out, Q6_K);
+    let store = open(&out, Q6_K);
+    let LoadedWeight::KQuant { blocks, codec } =
+        load_weight((&store).into(), &op, WeightFormat::KQuant).unwrap()
+    else {
+        panic!("the direct arm binds blocks");
+    };
+    assert_eq!(codec, Q6_K);
+    let (out_dim, in_dim) = (op.shape[0], op.shape[1]);
+
+    let as_q6 = WeightSlice::KQuant {
+        blocks: &blocks,
+        codec: Q6_K,
+    };
+    assert!(as_q6.rows(out_dim, in_dim).is_ok(), "the control case");
+
+    // Q6_K bytes, read as Q4_K: LONGER than the shape needs.
+    let as_q4 = WeightSlice::KQuant {
+        blocks: &blocks,
+        codec: Q4_K,
+    };
+    let err = as_q4
+        .rows(out_dim, in_dim)
+        .expect_err("210-byte blocks are not 144-byte blocks")
+        .to_string();
+    assert!(err.contains("more than"), "{err}");
+    assert!(
+        err.contains("Q4_K"),
+        "the refusal names the codec that was asked: {err}"
+    );
+
+    // Q6_K bytes, read as Q8_0: SHORTER than the shape needs (272 bytes a
+    // row against 210), the direction a prefix cut also catches.
+    let as_q8 = WeightSlice::KQuant {
+        blocks: &blocks,
+        codec: Q8_0,
+    };
+    let err = as_q8
+        .rows(out_dim, in_dim)
+        .expect_err("34-byte blocks over 256 elements need more than Q6_K's 210")
+        .to_string();
+    assert!(err.contains("resident"), "{err}");
+
+    // The right codec at the wrong stride: twice the width.
+    let err = as_q6
+        .rows(out_dim, in_dim * 2)
+        .expect_err("the stream holds half of that")
+        .to_string();
+    assert!(err.contains("resident"), "{err}");
+    // A width off the grid.
+    let err = as_q6
+        .rows(out_dim, in_dim - 1)
+        .expect_err("a ragged width is not on the block grid")
+        .to_string();
+    assert!(err.contains("whole number"), "{err}");
+
+    // And the row view, once admitted, is cut at Q6_K's stride and not
+    // at any other's.
+    let WeightRows::KQuant { blocks: cut, .. } = as_q6.rows(out_dim, in_dim).unwrap() else {
+        panic!("a K-quant slice yields K-quant rows");
+    };
+    assert_eq!(cut.len(), out_dim * Q6_K.row_bytes(in_dim).unwrap());
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection_real.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection_real.rs
@@ -1,0 +1,227 @@
+//! Layer 2 of PARETO-1's v3 gate on a REAL anchor: the largest and the
+//! smallest stored K-quant matrices of the first compiled object, loaded
+//! through normal VINDEX loading, direct against widened.
+//!
+//! Ignored unless `LARQL_KQUANT_ANCHOR` names a compiled container. The
+//! committed fixture test beside this one (`kquant_projection.rs`) runs
+//! the same claims on a 64-wide model in CI; this one runs them on
+//! Qwen3.8-27B's `17408 x 5120` and `48 x 5120` shapes, where the row
+//! stride is thousands of blocks and a stride bug has room to show.
+//!
+//! Numbers are PRINTED, not only thresholded, because layer 2 of the gate
+//! is a record in the campaign file and "passed" hides whether the
+//! agreement was 1e-7 or 4e-6.
+
+use crate::format::filenames::INDEX_JSON;
+use crate::format::vindex3::encode::segment::read_segment_header;
+use crate::format::vindex3::index::Vindex3Index;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::backend::WeightFormat;
+use crate::format::vindex3::opplan::exec::cpu::kernels::ScalarF32;
+use crate::format::vindex3::opplan::exec::cpu::physical::project_matrix;
+use crate::format::vindex3::opplan::exec::cpu::projector::DenseProjector;
+use crate::format::vindex3::opplan::exec::cpu::{ledger, PhysicalProjectionPlan};
+use crate::format::vindex3::opplan::exec::operands::{
+    OperandSource, OperandStore, RepresentationSource,
+};
+use crate::format::vindex3::opplan::exec::weights::{load_weight, LoadedWeight};
+use crate::format::vindex3::opplan::OperandRef;
+use crate::format::vindex3::represent::kquant;
+
+/// Names the compiled container to test against.
+const ANCHOR_ENV: &str = "LARQL_KQUANT_ANCHOR";
+
+/// Bound on accumulation-order disagreement in units of each row's own
+/// magnitude scale `sum|w x|` — the same gate as the fixture test, for
+/// the same reason: the elementwise relative metric is blind to
+/// cancellation, and a 5120-wide real row cancels more often than a
+/// fixture's. k = 5120 puts the typical `sqrt(k) * eps` at ~4e-7 and the
+/// worst case `k * eps` at 3e-4 relative to the row scale; the arms sit
+/// at ~1e-7 and this bound refuses an O(1) stride or scale error.
+const ACCUMULATION_ORDER_NORMALISED: f64 = 5e-6;
+
+fn activation(k: usize) -> Vec<f32> {
+    (0..k).map(|i| ((i % 23) as f32 - 11.0) / 13.0).collect()
+}
+
+/// Printed for the record; blind to cancellation, so not the gate.
+fn worst_relative(a: &[f32], b: &[f32]) -> f64 {
+    assert_eq!(a.len(), b.len());
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| {
+            let denom = (x.abs().max(y.abs()) as f64).max(1e-6);
+            ((*x as f64) - (*y as f64)).abs() / denom
+        })
+        .fold(0.0f64, f64::max)
+}
+
+/// Worst per-row difference over that row's `sum|w x|`. The gate.
+fn worst_normalised(a: &[f32], b: &[f32], w: &[f32], x: &[f32]) -> f64 {
+    assert_eq!(a.len(), b.len());
+    let k = x.len();
+    a.iter()
+        .zip(b)
+        .enumerate()
+        .map(|(r, (p, q))| {
+            let scale: f64 = w[r * k..(r + 1) * k]
+                .iter()
+                .zip(x)
+                .map(|(wi, xi)| (wi * xi).abs() as f64)
+                .sum();
+            ((*p as f64) - (*q as f64)).abs() / scale.max(1e-12)
+        })
+        .fold(0.0f64, f64::max)
+}
+
+/// The largest and smallest two-dimensional K-quant tensors of the first
+/// compiled object, with the codec the container declares.
+fn extremes(root: &std::path::Path) -> (kquant::KQuant, Vec<OperandRef>) {
+    let index: Vindex3Index =
+        serde_json::from_str(&std::fs::read_to_string(root.join(INDEX_JSON)).unwrap()).unwrap();
+    let map = index
+        .precision_map
+        .as_ref()
+        .expect("an anchor declares its precision map");
+    let codec = kquant::lookup(&map.encoding)
+        .unwrap_or_else(|| panic!("`{}` is not a K-quant this executor runs", map.encoding));
+    let entry = index
+        .representations
+        .values()
+        .find(|e| e.encoding == codec.name)
+        .expect("a compiled representation");
+    let (header, _) = read_segment_header(&root.join(&entry.segment)).unwrap();
+    let mut matrices: Vec<&_> = header
+        .tensors
+        .iter()
+        .filter(|t| t.dtype == codec.name && t.shape.len() == 2)
+        .collect();
+    assert!(
+        !matrices.is_empty(),
+        "the pack holds two-dimensional {} tensors",
+        codec.name
+    );
+    matrices.sort_by_key(|t| t.shape.iter().product::<usize>());
+    let pick = |t: &crate::format::vindex3::encode::segment::SegmentTensor| OperandRef {
+        object: entry.object.clone(),
+        tensor: t.name.clone(),
+        dtype: t.dtype.clone(),
+        shape: t.shape.clone(),
+    };
+    let mut ops = vec![pick(matrices[0])];
+    if matrices.len() > 1 {
+        ops.push(pick(matrices[matrices.len() - 1]));
+    }
+    (codec, ops)
+}
+
+#[test]
+#[ignore = "needs LARQL_KQUANT_ANCHOR naming a compiled K-quant container"]
+fn a_real_anchor_projects_the_same_direct_and_widened() {
+    let Some(root) = std::env::var_os(ANCHOR_ENV).map(std::path::PathBuf::from) else {
+        panic!("set {ANCHOR_ENV} to a compiled container");
+    };
+    let (codec, ops) = extremes(&root);
+    let inspection = inspect_container(&root, false).unwrap();
+    let store = OperandStore::open_for(
+        &root,
+        &inspection,
+        Some(codec.name),
+        RepresentationSource::Stored,
+    )
+    .expect("the anchor binds under `stored`");
+    let src: OperandSource<'_> = (&store).into();
+
+    for op in &ops {
+        let started = std::time::Instant::now();
+        let direct = load_weight(src, op, WeightFormat::KQuant).expect("binds the pack");
+        let load_direct = started.elapsed();
+        let started = std::time::Instant::now();
+        let widened = load_weight(src, op, WeightFormat::F32).expect("widens the pack");
+        let load_widened = started.elapsed();
+        assert!(matches!(direct, LoadedWeight::KQuant { codec: c, .. } if c == codec));
+        assert!(widened.is_widened_f32());
+        assert_eq!(store.runtime_quantised(), 0, "nothing may be manufactured");
+
+        let (out_dim, in_dim) = (op.shape[0], op.shape[1]);
+        let x = activation(in_dim);
+        assert_eq!(
+            PhysicalProjectionPlan::for_resident(
+                direct.slice().rows(out_dim, in_dim).unwrap(),
+                in_dim
+            ),
+            PhysicalProjectionPlan::FusedKQuant
+        );
+        assert_eq!(
+            PhysicalProjectionPlan::for_resident(
+                widened.slice().rows(out_dim, in_dim).unwrap(),
+                in_dim
+            ),
+            PhysicalProjectionPlan::BlasF32
+        );
+
+        let before = ledger().get(PhysicalProjectionPlan::FusedKQuant).calls;
+        // Each arm twice: the first direct call pays the kernel pool's
+        // start-up, and a "22 ms for 261 KB" first reading is that cost,
+        // not the kernel's. The second call is reported.
+        let y_direct = project_matrix(&direct.slice(), &x, out_dim, in_dim).unwrap();
+        let started = std::time::Instant::now();
+        let again = project_matrix(&direct.slice(), &x, out_dim, in_dim).unwrap();
+        let t_direct = started.elapsed();
+        assert_eq!(y_direct, again, "the direct arm must be deterministic");
+        let y_widened = project_matrix(&widened.slice(), &x, out_dim, in_dim).unwrap();
+        let started = std::time::Instant::now();
+        let again = project_matrix(&widened.slice(), &x, out_dim, in_dim).unwrap();
+        let t_widened = started.elapsed();
+        assert_eq!(y_widened, again, "the BLAS arm must be deterministic");
+        assert!(ledger().get(PhysicalProjectionPlan::FusedKQuant).calls > before);
+
+        // The literal scalar transcription over the same widened image,
+        // so the authority's own reassociation is visible beside the
+        // candidate's.
+        let image = widened.slice().as_f32().unwrap();
+        let mut scalar = vec![0.0f32; out_dim];
+        ScalarF32.project_rows(
+            widened.slice().rows(out_dim, in_dim).unwrap(),
+            &x,
+            &mut scalar,
+        );
+        let d_vs_b = worst_normalised(&y_direct, &y_widened, image, &x);
+        let d_vs_s = worst_normalised(&y_direct, &scalar, image, &x);
+        let b_vs_s = worst_normalised(&y_widened, &scalar, image, &x);
+        println!(
+            "  layer-2 real  {:<5} {:<36} [{out_dim},{in_dim}]  normalised: direct-vs-BLAS \
+             {d_vs_b:.2e}  direct-vs-scalar {d_vs_s:.2e}  BLAS-vs-scalar {b_vs_s:.2e}  \
+             (elementwise direct-vs-BLAS {:.2e})  resident {} B direct / {} B widened  \
+             load {:.2}s / {:.2}s  project(warm) {:.2} ms / {:.2} ms",
+            codec.name,
+            op.tensor,
+            worst_relative(&y_direct, &y_widened),
+            direct.resident_bytes(),
+            widened.resident_bytes(),
+            load_direct.as_secs_f64(),
+            load_widened.as_secs_f64(),
+            t_direct.as_secs_f64() * 1e3,
+            t_widened.as_secs_f64() * 1e3,
+        );
+        assert!(
+            d_vs_b < ACCUMULATION_ORDER_NORMALISED,
+            "{} {}: direct and the BLAS authority disagree by {d_vs_b:e} of the row scale",
+            codec.name,
+            op.tensor
+        );
+        assert!(
+            d_vs_s < ACCUMULATION_ORDER_NORMALISED,
+            "{} {}: direct and the scalar transcription disagree by {d_vs_s:e} of the row scale",
+            codec.name,
+            op.tensor
+        );
+        if codec == kquant::Q8_0 {
+            assert_eq!(
+                y_direct, scalar,
+                "Q8_0 direct must be bit-for-bit with the scalar decode-then-multiply on the \
+                 real anchor"
+            );
+        }
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -82,6 +82,8 @@ mod generate_metal;
 mod generate_real;
 mod golden;
 mod kernels;
+mod kquant_projection;
+mod kquant_projection_real;
 mod kv;
 mod llama3_rope;
 mod observe;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
@@ -22,6 +22,7 @@ use super::operands::{OperandSource, RepresentationSource};
 use super::quantise::{quantise_q4, quantise_q8, Q4_BLOCK, Q8_BLOCK};
 use crate::error::VindexError;
 use crate::format::vindex3::opplan::OperandRef;
+use crate::format::vindex3::represent::kquant::{self, KQuant};
 use crate::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4;
 // MXFP4 group geometry — per row, `k/32` groups of 16 packed bytes (lo
 // nibble first) plus one e8m0 scale byte each — is the models crate's,
@@ -157,6 +158,18 @@ pub enum LoadedWeight {
         scales: AlignedBytes,
         tensor_scale: f32,
     },
+    /// A compiled ggml K-quant pack, byte-for-byte as the container holds
+    /// it, with the codec that names its layout.
+    ///
+    /// The cheapest load after [`Self::Bf16`]: the bytes are read and
+    /// kept. No decode, no requantise — PARETO-1's v3 arm, whose whole
+    /// claim is that the bytes the kernel reads are the artifact's own.
+    /// Plain owned bytes rather than [`AlignedBytes`]: no device wraps a
+    /// K-quant, so page alignment would buy nothing here.
+    KQuant {
+        blocks: Vec<u8>,
+        codec: KQuant,
+    },
 }
 
 pub mod staged;
@@ -190,6 +203,7 @@ impl LoadedWeight {
             LoadedWeight::Nvfp4 { packed, scales, .. } => {
                 packed.as_slice().len() + scales.as_slice().len()
             }
+            LoadedWeight::KQuant { blocks, .. } => blocks.len(),
         }
     }
 
@@ -231,6 +245,7 @@ impl LoadedWeight {
                     of(scales.as_slice().as_ptr(), scales.as_slice().len()),
                 ]
             }
+            LoadedWeight::KQuant { blocks, .. } => vec![of(blocks.as_ptr(), blocks.len())],
         }
     }
 
@@ -284,6 +299,10 @@ impl LoadedWeight {
                 packed: packed.as_slice(),
                 scales: scales.as_slice(),
                 tensor_scale: *tensor_scale,
+            },
+            LoadedWeight::KQuant { blocks, codec } => WeightSlice::KQuant {
+                blocks,
+                codec: *codec,
             },
         }
     }
@@ -370,33 +389,7 @@ pub fn load_weight(
             // the whole load is a read: no widening to f32, no requantise,
             // no arithmetic at all. That is the point of persisting it.
             let raw = store.load_raw(operand)?;
-            // The map is the authority a pack is supposed to satisfy, so
-            // `stored` checks conformance rather than taking the bytes'
-            // word for what program they implement. A pack that compiled a
-            // tensor the map protects is not a pack for this program, and
-            // silently executing it would mean running something other
-            // than what the container declares.
-            if let (Some(program), true) = (
-                store.store().program(),
-                store.store().is_stored(&operand.object),
-            ) {
-                // Resolved through the store, which reads the plan
-                // first and the name heuristics second — the same order
-                // the compiler used. Calling `classify` directly here
-                // was the miss that made a correctly compiled pack fail
-                // its own conformance check.
-                let role = store
-                    .store()
-                    .role_of(&operand.object, &operand.tensor, &operand.shape);
-                if !program.conforms(role, &operand.tensor, &raw.dtype) {
-                    return Err(VindexError::Parse(format!(
-                        "tensor `{}` is stored as `{}`, which the container's \
-                         precision map `{}` does not permit — the pack does not \
-                         implement the program the container declares",
-                        operand.tensor, raw.dtype, program.name
-                    )));
-                }
-            }
+            check_pack_conforms(store, operand, &raw.dtype)?;
             if raw.dtype == DTYPE_NVFP4 {
                 return nvfp4_from_stored(&raw.bytes, rows, k, &operand.tensor);
             }
@@ -434,6 +427,7 @@ pub fn load_weight(
             let values = widen_raw(&raw, &operand.tensor)?;
             quantize_nvfp4(&values, rows, k, &operand.tensor)
         }
+        WeightFormat::KQuant => kquant_from_stored(store, operand),
         WeightFormat::F16 => {
             let raw = store.load_raw(operand)?;
             match raw.dtype.as_str() {
@@ -452,6 +446,85 @@ pub fn load_weight(
             }
         }
     }
+}
+
+/// Refuse a stored tensor whose dtype the container's precision map does
+/// not permit.
+///
+/// The map is the authority a pack is supposed to satisfy, so `stored`
+/// checks conformance rather than taking the bytes' word for what program
+/// they implement. A pack that compiled a tensor the map protects is not
+/// a pack for this program, and silently executing it would mean running
+/// something other than what the container declares. Shared by every arm
+/// that binds stored compiled bytes, so the NVFP4 and K-quant paths
+/// cannot drift in what they check.
+fn check_pack_conforms(
+    store: OperandSource<'_>,
+    operand: &OperandRef,
+    dtype: &str,
+) -> Result<(), VindexError> {
+    if let (Some(program), true) = (
+        store.store().program(),
+        store.store().is_stored(&operand.object),
+    ) {
+        // Resolved through the store, which reads the plan first and the
+        // name heuristics second — the same order the compiler used.
+        // Calling `classify` directly here was the miss that made a
+        // correctly compiled pack fail its own conformance check.
+        let role = store
+            .store()
+            .role_of(&operand.object, &operand.tensor, &operand.shape);
+        if !program.conforms(role, &operand.tensor, dtype) {
+            return Err(VindexError::Parse(format!(
+                "tensor `{}` is stored as `{dtype}`, which the container's precision map \
+                 `{}` does not permit — the pack does not implement the program the \
+                 container declares",
+                operand.tensor, program.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Bind a compiled K-quant pack: read the stored blocks and keep them.
+///
+/// No decode happens here and none may: if this path ever widened a
+/// block or re-encoded one, the executed bytes would be a derivative of
+/// the artifact rather than the artifact, and the v3 gate's claim — the
+/// SAME stored bytes, two arithmetics — would be void. The geometry is
+/// checked against the codec's own plan of the operand's shape, so a
+/// stream of the wrong length for `[out, in]` is refused here by name
+/// rather than read at the wrong stride by a kernel.
+fn kquant_from_stored(
+    store: OperandSource<'_>,
+    operand: &OperandRef,
+) -> Result<LoadedWeight, VindexError> {
+    let raw = store.load_raw(operand)?;
+    let Some(codec) = kquant::lookup(&raw.dtype) else {
+        return Err(VindexError::Parse(format!(
+            "tensor `{}` is `{}`, not a K-quant this executor runs in place ({}) — direct \
+             K-quant residency binds stored blocks and performs no conversion",
+            operand.tensor,
+            raw.dtype,
+            kquant::compilable_names()
+        )));
+    };
+    check_pack_conforms(store, operand, &raw.dtype)?;
+    let want = codec.plan(&operand.shape, &operand.tensor)?;
+    if raw.bytes.len() != want {
+        return Err(VindexError::Parse(format!(
+            "tensor `{}`: {} bytes of {} do not describe shape {:?}, which needs {want} — \
+             refusing rather than reading rows at the wrong stride",
+            operand.tensor,
+            raw.bytes.len(),
+            codec.name,
+            operand.shape
+        )));
+    }
+    Ok(LoadedWeight::KQuant {
+        blocks: raw.bytes,
+        codec,
+    })
 }
 
 /// Bind a compiled NVFP4 pack: copy each region into a page-aligned

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
@@ -27,6 +27,7 @@ use crate::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4;
 // nibble first) plus one e8m0 scale byte each — is the models crate's,
 // so the kernel's layout contract and the codec's have one definition.
 use larql_models::quant::mxfp4::{e8m0_to_f32, MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS, MXFP4_TABLE};
+use staged::StagedF32;
 
 /// Alignment (and length granularity) of f16 weight allocations:
 /// the Apple-GPU page size. A page-aligned, page-multiple allocation
@@ -122,7 +123,7 @@ impl Drop for AlignedBytes {
 /// backend declared.
 #[derive(Debug)]
 pub enum LoadedWeight {
-    F32(Vec<f32>),
+    F32(StagedF32),
     /// Symmetric int8 codes plus one f32 scale per [`Q8_BLOCK`]
     /// elements. The only LOSSY residency format on this path: the values
     /// resident are not the values stored.
@@ -157,6 +158,9 @@ pub enum LoadedWeight {
         tensor_scale: f32,
     },
 }
+
+pub mod staged;
+pub use staged::StagedF32 as F32Image;
 
 impl LoadedWeight {
     /// The borrowed view a call struct carries.
@@ -293,7 +297,7 @@ pub fn load_weight(
     format: WeightFormat,
 ) -> Result<LoadedWeight, VindexError> {
     match format {
-        WeightFormat::F32 => Ok(LoadedWeight::F32(store.load(operand)?)),
+        WeightFormat::F32 => Ok(LoadedWeight::F32(StagedF32::stage(store.load(operand)?)?)),
         WeightFormat::Q8 => {
             let in_dim = operand.shape.get(1).copied().ok_or_else(|| {
                 VindexError::Parse(format!(
@@ -647,5 +651,7 @@ fn nearest_mxfp4_code(v: f32) -> u8 {
     }
 }
 
+#[cfg(test)]
+mod staged_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged.rs
@@ -1,0 +1,264 @@
+//! Where a widened f32 weight image LIVES, which is not what it holds.
+//!
+//! [`LoadedWeight::F32`](super::LoadedWeight::F32) is the residency of
+//! last resort: it is what a matrix falls to when the stored bytes are
+//! neither bf16 nor a format the policy may re-quantise. A K-quant
+//! operand executed under `LARQL_CPU_MAX_FORMAT=bf16` is exactly that
+//! case — the pack decodes to f32, `Q8` residency is forbidden, and
+//! there are no stored bf16 code units to borrow. The image is then
+//! twice the checkpoint's size, and on PARETO-1's rung A that measured
+//! **96.8 GB RSS against a 45.36 GB bf16 decoder**, which the operating
+//! system killed on a 128 GB machine before a single anchor-bank
+//! evaluation completed.
+//!
+//! The values are not the problem. An anonymous `Vec<f32>` is: it is
+//! dirty, private memory the kernel cannot reclaim under pressure, so
+//! the process either fits or dies. The same bytes in a file-backed
+//! mapping are clean — evictable when memory is short, re-read when
+//! touched again — and the arithmetic that reads them cannot tell the
+//! difference, because they are the same bytes.
+//!
+//! ```text
+//! decode (unchanged) -> f32 values -> staging file -> mapped &[f32] -> backend
+//! ```
+//!
+//! This deliberately changes RESIDENCY ONLY. It does not round, it does
+//! not re-quantise, and it does not decode lazily: a per-use decoder
+//! would re-expand tens of gigabytes of K-quant weights on every token,
+//! trading a memory problem for a much larger time one.
+//!
+//! # One arena, not one file per weight
+//!
+//! Every staged image lives at a page-aligned offset in a single
+//! unlinked file. One inode, one descriptor, and nothing to clean up:
+//! the file is removed the moment it is created, so the bytes live
+//! exactly as long as the process holds the handle, including if it is
+//! killed.
+
+use std::io::{Seek, SeekFrom, Write};
+use std::ops::Deref;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use crate::error::VindexError;
+
+/// Directory the staging arena is created in. Defaults to the platform
+/// temporary directory, which is the wrong volume when the model is
+/// larger than it — hence an override that names one explicitly.
+pub const STAGE_DIR_ENV: &str = "LARQL_F32_STAGE_DIR";
+
+/// Smallest image worth staging, in bytes.
+///
+/// Staging a small operand costs a page fault to save a few kilobytes,
+/// and a model's norm and bias vectors are numerous enough that mapping
+/// each one would add more mappings than it saves bytes. The default
+/// sits well below the matrices that dominate a decoder — Qwen3.8's
+/// `in_proj_qkv` is 105 MB widened — and well above the glue.
+pub const STAGE_MIN_BYTES_ENV: &str = "LARQL_F32_STAGE_MIN_BYTES";
+
+/// Default for [`STAGE_MIN_BYTES_ENV`].
+pub const DEFAULT_STAGE_MIN_BYTES: usize = 16 * 1024 * 1024;
+
+/// Set to `off` to keep every f32 image anonymous, as it was before
+/// staging existed.
+///
+/// This is not a convenience. It is what makes the equivalence claim
+/// testable inside ONE binary: the same build, the same weights, the
+/// same arithmetic, differing only in where the bytes sit. A control
+/// that requires two builds cannot separate "staging changed the answer"
+/// from "the compiler did".
+pub const STAGE_ENV: &str = "LARQL_F32_STAGE";
+
+/// Value of [`STAGE_ENV`] that disables staging.
+pub const STAGE_OFF: &str = "off";
+
+/// Page granularity for arena offsets. `mmap` refuses an unaligned
+/// offset, so each image starts on a boundary and the padding between
+/// them is never read.
+const ARENA_PAGE: u64 = 16 * 1024;
+
+fn env_flag_disabled() -> bool {
+    std::env::var(STAGE_ENV)
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        .map(|v| v.eq_ignore_ascii_case(STAGE_OFF))
+        .unwrap_or(false)
+}
+
+fn min_bytes() -> usize {
+    std::env::var(STAGE_MIN_BYTES_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(DEFAULT_STAGE_MIN_BYTES)
+}
+
+/// Bytes staged into the arena so far, for the residency report.
+static STAGED_BYTES: AtomicU64 = AtomicU64::new(0);
+/// Images staged so far.
+static STAGED_IMAGES: AtomicU64 = AtomicU64::new(0);
+
+/// Total bytes this process has staged to the arena.
+pub fn staged_bytes() -> u64 {
+    STAGED_BYTES.load(Ordering::Relaxed)
+}
+
+/// Number of f32 images this process has staged.
+pub fn staged_images() -> u64 {
+    STAGED_IMAGES.load(Ordering::Relaxed)
+}
+
+struct Arena {
+    file: std::fs::File,
+    next: u64,
+}
+
+static ARENA: OnceLock<Mutex<Arena>> = OnceLock::new();
+
+fn arena() -> Result<&'static Mutex<Arena>, VindexError> {
+    // `OnceLock::get_or_init` cannot fail, so the fallible open happens
+    // first and its error is reported rather than swallowed into a
+    // silent fall back to anonymous memory — which is the exact failure
+    // this module exists to make impossible.
+    if let Some(a) = ARENA.get() {
+        return Ok(a);
+    }
+    let dir = std::env::var_os(STAGE_DIR_ENV)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    let path = dir.join(format!("larql-f32-stage-{}.bin", std::process::id()));
+    let file = std::fs::OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|e| {
+            VindexError::Parse(format!(
+                "f32 staging arena `{}` could not be created: {e}. Set `{STAGE_DIR_ENV}` to a \
+                 writable directory on a volume with room for the widened model, or \
+                 `{STAGE_ENV}={STAGE_OFF}` to keep every image in anonymous memory",
+                path.display()
+            ))
+        })?;
+    // Unlink immediately: the descriptor keeps the inode alive, so the
+    // bytes vanish when this process exits however it exits. A staging
+    // file that outlives a killed run is a disk leak nobody will notice
+    // until the volume is full.
+    std::fs::remove_file(&path).map_err(|e| {
+        VindexError::Parse(format!(
+            "f32 staging arena `{}` could not be unlinked: {e}",
+            path.display()
+        ))
+    })?;
+    Ok(ARENA.get_or_init(|| Mutex::new(Arena { file, next: 0 })))
+}
+
+/// An f32 weight image, either owned outright or mapped from the arena.
+///
+/// Derefs to `[f32]`, so every reader sees one type and no kernel needs
+/// to know which it got.
+#[derive(Debug)]
+pub struct StagedF32(Inner);
+
+enum Inner {
+    Owned(Vec<f32>),
+    Mapped { map: memmap2::Mmap, elements: usize },
+}
+
+impl std::fmt::Debug for Inner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Inner::Owned(v) => write!(f, "Owned({} f32)", v.len()),
+            Inner::Mapped { elements, .. } => write!(f, "Mapped({elements} f32)"),
+        }
+    }
+}
+
+impl StagedF32 {
+    /// Put `values` wherever policy says they belong.
+    ///
+    /// Small images stay owned; large ones move to the arena and the
+    /// `Vec` is dropped, so the peak anonymous footprint is one operand
+    /// rather than the whole model.
+    pub fn stage(values: Vec<f32>) -> Result<Self, VindexError> {
+        let bytes = std::mem::size_of_val(&values[..]);
+        // An empty image is owned whatever the threshold says: a
+        // zero-length mapping is an error on every platform, and a
+        // threshold of zero would otherwise walk straight into it.
+        if values.is_empty() || env_flag_disabled() || bytes < min_bytes() {
+            return Ok(Self(Inner::Owned(values)));
+        }
+        // One lock for write AND map. Releasing it between the two would
+        // let a second thread claim the same offset it just reserved,
+        // and the corruption would land in weights rather than in an
+        // error.
+        let mut a = arena()?
+            .lock()
+            .map_err(|_| VindexError::Parse("f32 staging arena lock poisoned".into()))?;
+        let offset = a.next;
+        // SAFETY of the later cast rests on this: the mapping starts at a
+        // page boundary, so the mapped address is 4-byte aligned for f32.
+        let padded = (bytes as u64).div_ceil(ARENA_PAGE) * ARENA_PAGE;
+        a.file
+            .seek(SeekFrom::Start(offset))
+            // The image's own bytes, verbatim. No conversion happens here
+            // and none may: this function's whole contract is that what
+            // comes back out is what went in.
+            .and_then(|_| a.file.write_all(f32_bytes(&values)))
+            .and_then(|_| a.file.set_len(offset + padded))
+            .map_err(|e| VindexError::Parse(format!("f32 staging write failed: {e}")))?;
+        a.next = offset + padded;
+        let map = unsafe {
+            memmap2::MmapOptions::new()
+                .offset(offset)
+                .len(bytes)
+                .map(&a.file)
+        }
+        .map_err(|e| VindexError::Parse(format!("f32 staging map failed: {e}")))?;
+        STAGED_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+        STAGED_IMAGES.fetch_add(1, Ordering::Relaxed);
+        Ok(Self(Inner::Mapped {
+            map,
+            elements: values.len(),
+        }))
+    }
+
+    /// Whether these bytes are file-backed, for the residency report.
+    pub fn is_mapped(&self) -> bool {
+        matches!(self.0, Inner::Mapped { .. })
+    }
+}
+
+/// `values` as the bytes that represent them, with no reinterpretation.
+fn f32_bytes(values: &[f32]) -> &[u8] {
+    // SAFETY: f32 has no padding and no invalid bit patterns, so any
+    // f32 slice is a valid byte slice of four times the length.
+    unsafe {
+        std::slice::from_raw_parts(values.as_ptr().cast::<u8>(), std::mem::size_of_val(values))
+    }
+}
+
+impl Deref for StagedF32 {
+    type Target = [f32];
+
+    fn deref(&self) -> &[f32] {
+        match &self.0 {
+            Inner::Owned(v) => v,
+            Inner::Mapped { map, elements } => {
+                let bytes = &map[..];
+                // SAFETY: the mapping begins at a page boundary so the
+                // pointer is 4-byte aligned; `elements` counts exactly
+                // the f32 values written at this offset; the file is
+                // unlinked and privately mapped, so nothing else can
+                // write to these bytes for the mapping's lifetime.
+                unsafe { std::slice::from_raw_parts(bytes.as_ptr().cast::<f32>(), *elements) }
+            }
+        }
+    }
+}
+
+impl From<Vec<f32>> for StagedF32 {
+    fn from(values: Vec<f32>) -> Self {
+        Self(Inner::Owned(values))
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged.rs
@@ -77,20 +77,30 @@ pub const STAGE_OFF: &str = "off";
 /// them is never read.
 const ARENA_PAGE: u64 = 16 * 1024;
 
-fn env_flag_disabled() -> bool {
-    std::env::var(STAGE_ENV)
-        .ok()
-        .as_deref()
+/// Whether a value of [`STAGE_ENV`] turns staging off: the word
+/// [`STAGE_OFF`], any case, and nothing else.
+pub(super) fn staging_disabled_by(value: Option<&str>) -> bool {
+    value
         .map(str::trim)
         .map(|v| v.eq_ignore_ascii_case(STAGE_OFF))
         .unwrap_or(false)
 }
 
-fn min_bytes() -> usize {
-    std::env::var(STAGE_MIN_BYTES_ENV)
-        .ok()
+fn env_flag_disabled() -> bool {
+    staging_disabled_by(std::env::var(STAGE_ENV).ok().as_deref())
+}
+
+/// The threshold a value of [`STAGE_MIN_BYTES_ENV`] sets, or the default
+/// when it is absent or not a number — a typo must not stage every
+/// norm vector or none of the matrices.
+pub(super) fn min_bytes_from(value: Option<&str>) -> usize {
+    value
         .and_then(|v| v.trim().parse().ok())
         .unwrap_or(DEFAULT_STAGE_MIN_BYTES)
+}
+
+fn min_bytes() -> usize {
+    min_bytes_from(std::env::var(STAGE_MIN_BYTES_ENV).ok().as_deref())
 }
 
 /// Bytes staged into the arena so far, for the residency report.
@@ -108,8 +118,9 @@ pub fn staged_images() -> u64 {
     STAGED_IMAGES.load(Ordering::Relaxed)
 }
 
-struct Arena {
-    file: std::fs::File,
+#[derive(Debug)]
+pub(super) struct Arena {
+    pub(super) file: std::fs::File,
     next: u64,
 }
 
@@ -126,6 +137,17 @@ fn arena() -> Result<&'static Mutex<Arena>, VindexError> {
     let dir = std::env::var_os(STAGE_DIR_ENV)
         .map(std::path::PathBuf::from)
         .unwrap_or_else(std::env::temp_dir);
+    let arena = open_arena(&dir)?;
+    Ok(ARENA.get_or_init(|| Mutex::new(arena)))
+}
+
+/// Create the arena file under `dir` and unlink it at once.
+///
+/// Separate from [`arena`] so the fallible part is testable on its own:
+/// the process-wide `OnceLock` can only be initialised once, so a test
+/// of the failure path through `arena()` would depend on whether any
+/// other test had staged an image first.
+pub(super) fn open_arena(dir: &std::path::Path) -> Result<Arena, VindexError> {
     let path = dir.join(format!("larql-f32-stage-{}.bin", std::process::id()));
     let file = std::fs::OpenOptions::new()
         .create_new(true)
@@ -150,7 +172,7 @@ fn arena() -> Result<&'static Mutex<Arena>, VindexError> {
             path.display()
         ))
     })?;
-    Ok(ARENA.get_or_init(|| Mutex::new(Arena { file, next: 0 })))
+    Ok(Arena { file, next: 0 })
 }
 
 /// An f32 weight image, either owned outright or mapped from the arena.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged_tests.rs
@@ -1,0 +1,226 @@
+//! What staging must preserve, and what it must not do quietly.
+//!
+//! Every test here compares BIT PATTERNS rather than values. An f32
+//! comparison would call two different NaNs equal and would call `-0.0`
+//! equal to `0.0`, so a staging path that normalised either would pass a
+//! value-equality test and change a model's arithmetic. The claim this
+//! module makes is that the bytes come back unchanged, and that is the
+//! claim the tests check.
+
+use super::staged::{
+    staged_bytes, staged_images, StagedF32, DEFAULT_STAGE_MIN_BYTES, STAGE_ENV,
+    STAGE_MIN_BYTES_ENV, STAGE_OFF,
+};
+use serial_test::serial;
+
+/// The environment is process-global, so every test sets what it needs
+/// and puts it back. `min` of `Some(n)` stages anything at or above `n`.
+fn with_env<T>(stage_off: bool, min: Option<usize>, f: impl FnOnce() -> T) -> T {
+    let prev_off = std::env::var(STAGE_ENV).ok();
+    let prev_min = std::env::var(STAGE_MIN_BYTES_ENV).ok();
+    if stage_off {
+        std::env::set_var(STAGE_ENV, STAGE_OFF);
+    } else {
+        std::env::remove_var(STAGE_ENV);
+    }
+    match min {
+        Some(n) => std::env::set_var(STAGE_MIN_BYTES_ENV, n.to_string()),
+        None => std::env::remove_var(STAGE_MIN_BYTES_ENV),
+    }
+    let out = f();
+    match prev_off {
+        Some(v) => std::env::set_var(STAGE_ENV, v),
+        None => std::env::remove_var(STAGE_ENV),
+    }
+    match prev_min {
+        Some(v) => std::env::set_var(STAGE_MIN_BYTES_ENV, v),
+        None => std::env::remove_var(STAGE_MIN_BYTES_ENV),
+    }
+    out
+}
+
+fn bits(v: &[f32]) -> Vec<u32> {
+    v.iter().map(|x| x.to_bits()).collect()
+}
+
+/// The values a float format can lose if anything reinterprets it:
+/// signed zeroes, both infinities, a signalling and a quiet NaN, and the
+/// smallest subnormal.
+fn adversarial(n: usize) -> Vec<f32> {
+    let seeds = [
+        0.0f32,
+        -0.0,
+        f32::INFINITY,
+        f32::NEG_INFINITY,
+        f32::from_bits(0x7fc0_0001),
+        f32::from_bits(0x7f80_0001),
+        f32::from_bits(0x0000_0001),
+        f32::MIN_POSITIVE,
+        f32::MAX,
+        f32::MIN,
+        1.0,
+        -1.0,
+    ];
+    (0..n)
+        .map(|i| {
+            if i < seeds.len() {
+                seeds[i]
+            } else {
+                // Deterministic filler that spans exponents.
+                f32::from_bits(0x3f80_0000u32.wrapping_add((i as u32).wrapping_mul(0x0001_1111)))
+            }
+        })
+        .collect()
+}
+
+#[test]
+#[serial]
+fn an_owned_image_reads_back_exactly() {
+    let values = adversarial(64);
+    let staged = StagedF32::from(values.clone());
+    assert!(!staged.is_mapped());
+    assert_eq!(bits(&staged), bits(&values));
+}
+
+#[test]
+#[serial]
+fn a_mapped_image_reads_back_bit_identically() {
+    // 4 KB of f32 against a 1 KB threshold: comfortably staged, and
+    // small enough that the test costs nothing.
+    let values = adversarial(1024);
+    let staged = with_env(false, Some(1024), || StagedF32::stage(values.clone()))
+        .expect("staging a 4 KB image");
+    assert!(
+        staged.is_mapped(),
+        "a 4 KB image against a 1 KB threshold must be mapped, or this test proves nothing"
+    );
+    assert_eq!(
+        bits(&staged),
+        bits(&values),
+        "staged bytes differ from the values written"
+    );
+}
+
+#[test]
+#[serial]
+fn the_control_that_proves_the_comparison_can_fail() {
+    // The bit comparison above is only evidence if it can say no.
+    let a = adversarial(1024);
+    let mut b = a.clone();
+    b[7] = f32::from_bits(a[7].to_bits() ^ 1);
+    assert_ne!(bits(&a), bits(&b));
+}
+
+#[test]
+#[serial]
+fn negative_zero_and_nan_survive_the_round_trip() {
+    let values = vec![
+        -0.0f32,
+        0.0,
+        f32::from_bits(0x7fc0_0001),
+        f32::from_bits(0xffc0_0002),
+    ]
+    .into_iter()
+    .cycle()
+    .take(1024)
+    .collect::<Vec<_>>();
+    let staged = with_env(false, Some(1024), || StagedF32::stage(values.clone())).expect("staging");
+    assert!(staged.is_mapped());
+    // Value equality would pass here even if -0.0 became 0.0.
+    assert_eq!(bits(&staged), bits(&values));
+    assert!(staged[0].is_sign_negative(), "-0.0 lost its sign");
+    assert!(staged[2].is_nan(), "a NaN stopped being a NaN");
+}
+
+#[test]
+#[serial]
+fn an_image_below_the_threshold_stays_owned() {
+    let values = adversarial(16);
+    let staged = with_env(false, Some(DEFAULT_STAGE_MIN_BYTES), || {
+        StagedF32::stage(values.clone())
+    })
+    .expect("staging");
+    assert!(!staged.is_mapped());
+    assert_eq!(bits(&staged), bits(&values));
+}
+
+#[test]
+#[serial]
+fn the_environment_can_turn_staging_off_entirely() {
+    let values = adversarial(1024);
+    let staged =
+        with_env(true, Some(1), || StagedF32::stage(values.clone())).expect("staging disabled");
+    assert!(
+        !staged.is_mapped(),
+        "`{STAGE_ENV}={STAGE_OFF}` must keep the image anonymous — the v1/v2 equivalence \
+         control depends on this arm existing in one binary"
+    );
+    assert_eq!(bits(&staged), bits(&values));
+}
+
+#[test]
+#[serial]
+fn two_staged_images_do_not_overlap_in_the_arena() {
+    // The offset arithmetic is the one place a bug would silently serve
+    // one weight's bytes for another's.
+    let a = adversarial(1024);
+    let b: Vec<f32> = a
+        .iter()
+        .map(|x| f32::from_bits(x.to_bits() ^ 0x00ff_00ff))
+        .collect();
+    let (sa, sb) = with_env(false, Some(1024), || {
+        (
+            StagedF32::stage(a.clone()).expect("stage a"),
+            StagedF32::stage(b.clone()).expect("stage b"),
+        )
+    });
+    assert!(sa.is_mapped() && sb.is_mapped());
+    assert_eq!(bits(&sa), bits(&a));
+    assert_eq!(bits(&sb), bits(&b));
+    assert_ne!(
+        bits(&sa),
+        bits(&sb),
+        "the two images must be distinguishable"
+    );
+}
+
+#[test]
+#[serial]
+fn an_odd_length_image_keeps_its_last_element() {
+    // A length that is not a multiple of the page, so the mapping's tail
+    // is inside the padding.
+    let values = adversarial(1031);
+    let staged = with_env(false, Some(1024), || StagedF32::stage(values.clone())).expect("staging");
+    assert!(staged.is_mapped());
+    assert_eq!(staged.len(), 1031);
+    assert_eq!(bits(&staged), bits(&values));
+}
+
+#[test]
+#[serial]
+fn the_counters_only_move_for_mapped_images() {
+    let before_bytes = staged_bytes();
+    let before_images = staged_images();
+    let small = with_env(false, Some(DEFAULT_STAGE_MIN_BYTES), || {
+        StagedF32::stage(adversarial(4))
+    })
+    .expect("staging");
+    assert!(!small.is_mapped());
+    assert_eq!(staged_bytes(), before_bytes);
+    assert_eq!(staged_images(), before_images);
+
+    let big = with_env(false, Some(1024), || StagedF32::stage(adversarial(1024))).expect("staging");
+    assert!(big.is_mapped());
+    assert_eq!(staged_bytes(), before_bytes + 4096);
+    assert_eq!(staged_images(), before_images + 1);
+}
+
+#[test]
+#[serial]
+fn an_empty_image_is_owned_rather_than_mapped() {
+    // Zero bytes is below any threshold, and a zero-length mapping is an
+    // error on every platform — so the branch must not be taken.
+    let staged = with_env(false, Some(0), || StagedF32::stage(Vec::new())).expect("staging");
+    assert!(!staged.is_mapped());
+    assert!(staged.is_empty());
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged_tests.rs
@@ -224,3 +224,85 @@ fn an_empty_image_is_owned_rather_than_mapped() {
     assert!(!staged.is_mapped());
     assert!(staged.is_empty());
 }
+
+/// Only the word `off`, in any case, turns staging off. `0`, `false` and
+/// `on` are not spellings of it and leave staging on — a value that did
+/// not take effect would otherwise be recorded as an arm that ran.
+#[test]
+fn only_the_off_word_disables_staging_in_any_case() {
+    use super::staged::staging_disabled_by;
+    assert!(!staging_disabled_by(None));
+    for v in ["off", "OFF", " Off\n"] {
+        assert!(staging_disabled_by(Some(v)), "{v:?}");
+    }
+    for v in ["", "0", "false", "on", "off please"] {
+        assert!(!staging_disabled_by(Some(v)), "{v:?}");
+    }
+}
+
+/// The threshold is a number or the default — never zero from a typo,
+/// which would stage every norm vector, and never "everything owned".
+#[test]
+fn the_threshold_parses_a_number_and_falls_back_on_anything_else() {
+    use super::staged::{min_bytes_from, DEFAULT_STAGE_MIN_BYTES};
+    assert_eq!(min_bytes_from(None), DEFAULT_STAGE_MIN_BYTES);
+    assert_eq!(min_bytes_from(Some("1024")), 1024);
+    assert_eq!(min_bytes_from(Some(" 7 ")), 7);
+    assert_eq!(min_bytes_from(Some("0")), 0);
+    for v in ["", "lots", "-1", "1e6"] {
+        assert_eq!(min_bytes_from(Some(v)), DEFAULT_STAGE_MIN_BYTES, "{v:?}");
+    }
+}
+
+/// The arena is unlinked the moment it exists, so nothing outlives the
+/// process — and the unlinked descriptor is still a writable file.
+#[test]
+fn the_arena_file_is_unlinked_the_moment_it_exists() {
+    use super::staged::open_arena;
+    use std::io::Write;
+    let dir = tempfile::tempdir().unwrap();
+    let mut arena = open_arena(dir.path()).expect("a writable directory holds an arena");
+    assert_eq!(
+        std::fs::read_dir(dir.path()).unwrap().count(),
+        0,
+        "the arena must not be visible in the directory"
+    );
+    arena
+        .file
+        .write_all(&[0u8; 64])
+        .expect("the unlinked descriptor is still writable");
+    assert_eq!(arena.file.metadata().unwrap().len(), 64);
+}
+
+/// A directory that cannot hold the arena is a refusal that names the
+/// two ways out, never a silent fall back to anonymous memory — the
+/// exact failure this module exists to make impossible.
+#[test]
+fn an_arena_that_cannot_be_created_is_refused_naming_the_remedy() {
+    use super::staged::{open_arena, STAGE_DIR_ENV, STAGE_ENV};
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("no-such-dir");
+    let err = open_arena(&missing)
+        .expect_err("a missing directory cannot hold the arena")
+        .to_string();
+    assert!(err.contains("could not be created"), "{err}");
+    assert!(
+        err.contains(STAGE_DIR_ENV) && err.contains(STAGE_ENV),
+        "the refusal must name both ways out: {err}"
+    );
+    assert!(err.contains("no-such-dir"), "{err}");
+}
+
+/// Debug says WHERE an image lives and how big it is, never its values —
+/// a 17408 x 5120 matrix printed elementwise is not a diagnostic.
+#[test]
+#[serial]
+fn debug_names_the_residency_and_the_count_not_the_values() {
+    let owned = StagedF32::from(vec![1.0f32, 2.0]);
+    assert_eq!(format!("{owned:?}"), "StagedF32(Owned(2 f32))");
+    let mapped = with_env(false, Some(0), || {
+        StagedF32::stage(vec![1.0f32; 4]).unwrap()
+    });
+    assert!(mapped.is_mapped());
+    assert_eq!(format!("{mapped:?}"), "StagedF32(Mapped(4 f32))");
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/tests.rs
@@ -181,7 +181,7 @@ fn the_nvfp4_loader_fails_closed_on_bad_geometry() {
 fn every_loaded_variant_accounts_for_itself() {
     let page = DEVICE_PAGE_ALIGN;
     let cases: Vec<(LoadedWeight, usize, bool, &str)> = vec![
-        (LoadedWeight::F32(vec![0.0; 16]), 64, true, "f32"),
+        (LoadedWeight::F32(vec![0.0; 16].into()), 64, true, "f32"),
         (
             LoadedWeight::Q8 {
                 codes: vec![0i8; 64],
@@ -240,7 +240,7 @@ fn every_loaded_variant_accounts_for_itself() {
 /// obvious: Q8 holds three buffers, bf16 one.
 #[test]
 fn resident_bytes_counts_every_buffer_a_variant_holds() {
-    let f32w = LoadedWeight::F32(vec![0.0f32; 100]);
+    let f32w = LoadedWeight::F32(vec![0.0f32; 100].into());
     assert_eq!(f32w.resident_bytes(), 400, "f32 is four bytes an element");
 
     // Q8: codes + scales + the optional sums index.
@@ -299,7 +299,7 @@ fn resident_bytes_counts_every_buffer_a_variant_holds() {
 /// allocates one matrix and reuses it.
 #[test]
 fn allocations_enumerate_each_backing_buffer_separately() {
-    let f32w = LoadedWeight::F32(vec![0.0f32; 100]);
+    let f32w = LoadedWeight::F32(vec![0.0f32; 100].into());
     assert_eq!(f32w.allocations().len(), 1);
     assert_eq!(f32w.allocations()[0].1, 400);
 
@@ -379,7 +379,7 @@ fn allocations_enumerate_each_backing_buffer_separately() {
 /// the variant, never inferred from a size.
 #[test]
 fn only_the_widened_variant_admits_to_being_widened() {
-    assert!(LoadedWeight::F32(vec![0.0; 4]).is_widened_f32());
+    assert!(LoadedWeight::F32(vec![0.0; 4].into()).is_widened_f32());
     assert!(!LoadedWeight::Bf16(AlignedBytes::zeroed(8)).is_widened_f32());
     assert!(!LoadedWeight::Q8 {
         codes: vec![0i8; 8],
@@ -471,7 +471,9 @@ fn each_resident_variant_slices_as_its_own_representation() {
     }
 
     assert_eq!(
-        LoadedWeight::F32(vec![0.0; 8]).slice().representation(),
+        LoadedWeight::F32(vec![0.0; 8].into())
+            .slice()
+            .representation(),
         "f32"
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/tests.rs
@@ -223,6 +223,17 @@ fn every_loaded_variant_accounts_for_itself() {
             false,
             "nvfp4",
         ),
+        // Plain owned bytes, so the census charges exactly the stream —
+        // no page padding, and the codec's name is the representation.
+        (
+            LoadedWeight::KQuant {
+                blocks: vec![0u8; 2 * kquant::Q6_K.bytes_per_block],
+                codec: kquant::Q6_K,
+            },
+            2 * kquant::Q6_K.bytes_per_block,
+            false,
+            "Q6_K",
+        ),
     ];
     for (loaded, bytes, widened, name) in cases {
         assert_eq!(loaded.resident_bytes(), bytes, "{name} miscounts its bytes");

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/kquant.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/kquant.rs
@@ -2,11 +2,12 @@
 //!
 //! One stream, because the scales ride inside the blocks; row-random,
 //! because the container refuses a row that is not a whole number of
-//! blocks, so every row starts on one. No direct realization on this
-//! executor: the V3 CPU plan set has no K-quant kernel, and the trait
-//! says so instead of routing through a decode nobody declared. The
-//! grouped Metal kernels that serve K-quant expert banks are a device
-//! realization, declared by the crate that owns them.
+//! blocks, so every row starts on one. Directly realized on this
+//! executor by [`PhysicalProjectionPlan::FusedKQuant`], which runs the
+//! stored blocks in place through the codec's own kernel — a `stored`
+//! residency at the block's own bit width, not a decode to f32. The
+//! grouped Metal kernels that serve K-quant expert banks are a separate
+//! device realization, declared by the crate that owns them.
 
 use std::ops::Range;
 
@@ -14,9 +15,10 @@ use super::super::capability::{AccessGranularity, CodecCapabilities};
 use super::super::error::CodecError;
 use super::super::extent::{ExtentCertificate, RepresentationExtent};
 use super::super::geometry::RowGeometry;
-use super::super::residency::ResidencyProfile;
+use super::super::residency::{Acceleration, ResidencyProfile};
 use super::super::streams::{CodecOperands, StreamSpec, VALUES};
 use super::super::RepresentationCodec;
+use crate::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
 use crate::format::vindex3::represent::kquant::{self, KQuant};
 use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
 
@@ -134,5 +136,22 @@ impl RepresentationCodec for KQuantCodec {
 
     fn decode_residency(&self) -> ResidencyProfile {
         ResidencyProfile::DECODED_F32
+    }
+
+    fn accelerations(&self) -> Vec<Acceleration> {
+        // The stored blocks are executed in place by the codec's own
+        // kernel — no decode, no re-quantise. One plan serves all three
+        // K-quants: the codec identity rides in the bound operand, not in
+        // the resident `WeightFormat`, so `WeightFormat::KQuant` names the
+        // family and the bytes name the member. `stored`, at the block's
+        // own bit width, because that is what the kernel touches.
+        //
+        // Qualified end to end as PARETO-1's v3 arm: on Qwen3.8-27B the
+        // direct path matched decode-then-f32-GEMV to 5 orders below the
+        // pre-registered KL gate on all three K-quant anchors.
+        vec![Acceleration::cpu(
+            PhysicalProjectionPlan::FusedKQuant,
+            ResidencyProfile::stored(self.quant.bits_per_weight()),
+        )]
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/contract.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/contract.rs
@@ -117,6 +117,10 @@ fn label_of(format: WeightFormat) -> Option<&'static str> {
         WeightFormat::Mxfp4 => Some("MXFP4"),
         // Runtime re-quantisations of a float source: no stored codec.
         WeightFormat::Q8 | WeightFormat::Q4 => None,
+        // The three K-quants share one resident format — the codec rides
+        // in the bound operand, not the format — so this cannot name one.
+        // `every_acceleration_...` checks the family membership directly.
+        WeightFormat::KQuant => None,
     }
 }
 
@@ -139,12 +143,25 @@ fn every_acceleration_runs_over_the_stored_bytes_and_names_a_plan_for_them() {
             let touched = accel.residency.bytes_per_weight * extent::BITS_PER_BYTE;
             assert!((touched - bpw).abs() < 1e-9, "{label}: {touched} vs {bpw}");
             assert_eq!(accel.requires, RequiredAccess::RowRandom, "{label}");
-            assert_eq!(
-                label_of(accel.plan.format()),
-                Some(label),
-                "{label}: {:?}",
-                accel.plan
-            );
+            // A codec's direct plan names it. The K-quants are the one
+            // family that shares a resident format (`WeightFormat::KQuant`,
+            // the codec carried by the operand): there the plan names the
+            // FAMILY, and the label is Q4_K/Q6_K/Q8_0.
+            if matches!(label, "Q4_K" | "Q6_K" | "Q8_0") {
+                assert_eq!(
+                    accel.plan.format(),
+                    WeightFormat::KQuant,
+                    "{label}: {:?}",
+                    accel.plan
+                );
+            } else {
+                assert_eq!(
+                    label_of(accel.plan.format()),
+                    Some(label),
+                    "{label}: {:?}",
+                    accel.plan
+                );
+            }
         }
     }
 }
@@ -156,13 +173,15 @@ fn codecs_with_no_direct_cpu_realization_say_so_rather_than_claim_one() {
         .filter(|c| c.accelerations().is_empty())
         .map(|c| c.encoding_label())
         .collect();
-    assert_eq!(without, ["F16", "Q4_K", "Q6_K", "Q8_0", "MXFP4"]);
+    // K-quants gained a direct CPU realization (FusedKQuant); only the
+    // formats with no in-place kernel remain here.
+    assert_eq!(without, ["F16", "MXFP4"]);
     let with: Vec<&str> = builtin()
         .into_iter()
         .filter(|c| !c.accelerations().is_empty())
         .map(|c| c.encoding_label())
         .collect();
-    assert_eq!(with, ["BF16", "F32", "NVFP4"]);
+    assert_eq!(with, ["BF16", "F32", "Q4_K", "Q6_K", "Q8_0", "NVFP4"]);
 }
 
 #[test]

--- a/crates/larql-vindex/src/format/vindex3/represent/kquant.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/kquant.rs
@@ -214,6 +214,61 @@ impl KQuant {
 }
 
 impl KQuant {
+    /// Stored bytes one `[_, in_dim]` row occupies, or `None` when the
+    /// row is not a whole number of blocks and therefore has no layout.
+    ///
+    /// Blocks run along the row (see [`Self::plan`]), so this is the
+    /// stride every row-addressed consumer — a slab cut, a kernel — must
+    /// use. `None` rather than a rounded stride: a stride that rounded
+    /// would place every row after the first at the wrong offset and
+    /// return finite, plausible numbers.
+    pub fn row_bytes(&self, in_dim: usize) -> Option<usize> {
+        if in_dim == 0 || !in_dim.is_multiple_of(self.elements_per_block) {
+            return None;
+        }
+        Some(in_dim / self.elements_per_block * self.bytes_per_block)
+    }
+
+    /// `out[n] = W[n, k] · x[k]`, with `W` read straight from these
+    /// stored blocks — no decode to a whole f32 matrix first.
+    ///
+    /// **The association is the codec's, not the executor's.** Which
+    /// kernel answers for which encoding is decided here, beside
+    /// [`Self::encode`] and [`Self::decode`], so there is one place a
+    /// reader can check that the bytes a name denotes reach the kernel
+    /// that reads that layout. This workspace has already seen what
+    /// happens when that lives elsewhere: ggml Q8_0 blocks (34 bytes)
+    /// routed through a kernel expecting another 32-value layout, read
+    /// at the wrong stride, producing garbage. `larql-compute` still
+    /// carries a `QuantFormat::Q8_0` that means int8 codes with an
+    /// EXTERNAL f32 scale stream; ggml's Q8_0 never reaches it from here.
+    ///
+    /// `None` when the geometry does not describe the blocks: the row
+    /// stride is checked against the stream before any kernel sees it,
+    /// so a stream of the right total length under the wrong shape is
+    /// refused by the codec that knows the layout rather than by
+    /// whichever kernel happens to notice.
+    ///
+    /// This is the direct-execution arm PARETO-1's v3 gate qualifies
+    /// against decode-then-multiply on the same stored bytes; layer 1 of
+    /// that gate calls exactly this function.
+    pub fn gemv(&self, blocks: &[u8], x: &[f32], rows: usize, in_dim: usize) -> Option<Vec<f32>> {
+        use larql_compute::backend::QuantMatVec;
+        use larql_compute::cpu::{kquant_gemv, CpuBackend};
+        use larql_compute::QuantFormat;
+        if self.row_bytes(in_dim)? * rows != blocks.len() || x.len() != in_dim {
+            return None;
+        }
+        match self.name {
+            "Q8_0" => kquant_gemv::q8_0_gemv(blocks, x, rows, in_dim),
+            "Q6_K" => CpuBackend.quant_matvec(QuantFormat::Q6_K, blocks, x, rows, in_dim),
+            "Q4_K" => CpuBackend.quant_matvec(QuantFormat::Q4_K, blocks, x, rows, in_dim),
+            _ => None,
+        }
+    }
+}
+
+impl KQuant {
     /// The decode contract these bytes are written under.
     ///
     /// A K-quant is its own **family**, not a revision of one: `Q4_K` and
@@ -252,3 +307,7 @@ mod tests;
 #[cfg(test)]
 #[path = "kquant_conformance_tests.rs"]
 mod conformance_tests;
+
+#[cfg(test)]
+#[path = "kquant_direct_tests.rs"]
+mod direct_tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/kquant_direct_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/kquant_direct_tests.rs
@@ -1,0 +1,253 @@
+//! Does executing the stored blocks give what decoding them gives?
+//!
+//! `kquant_conformance_tests.rs` settles that we READ the ecosystem's
+//! bytes correctly. This settles a different claim, and the difference
+//! matters: **"a kernel exists" and "a kernel implements exactly the
+//! comparison the authority path makes" are separate facts.** PARETO-1
+//! rung A decodes every K-quant to f32 and runs an f32 GEMV precisely so
+//! that kernel quality cannot move a behavioural curve. Executing the
+//! blocks directly is a different program, and it is only admissible as
+//! the campaign executor if it agrees with the one it replaces.
+//!
+//! ```text
+//! the SAME stored bytes
+//!     ├─ decode -> f32 -> multiply    the authority path
+//!     └─ direct K-quant GEMV          the candidate
+//! ```
+//!
+//! The bytes are llama.cpp's, from `ggml_kquant_golden.json`, so neither
+//! side can be right for the wrong reason: this is not LARQL's encoder
+//! checked against LARQL's decoder checked against LARQL's kernel.
+//!
+//! Layer 1 of the gate frozen in `~/chris-models/pareto1/V3-QUALIFICATION.md`
+//! (the gate section as frozen hashed 9ddcc968…; the file has since had
+//! RESULTS appended below it and its hash moves with them, the thresholds
+//! do not). Layer 2 — a real projection through `PhysicalProjectionPlan`
+//! — is `exec/tests/kquant_projection.rs`; layer 3, end-to-end logits, is
+//! the one that carries the KL thresholds and runs against the anchors.
+
+use larql_compute::backend::QuantMatVec;
+use larql_compute::cpu::CpuBackend;
+use larql_compute::QuantFormat;
+
+use crate::format::vindex3::represent::kquant;
+
+#[derive(serde::Deserialize)]
+struct Golden {
+    cases: Vec<Case>,
+}
+
+#[derive(serde::Deserialize)]
+struct Case {
+    encoding: String,
+    elements: usize,
+    quantised_hex: String,
+}
+
+fn golden() -> Golden {
+    serde_json::from_str(include_str!("fixtures/ggml_kquant_golden.json"))
+        .expect("the golden fixture parses")
+}
+
+fn hex_to_bytes(hex: &str) -> Vec<u8> {
+    (0..hex.len() / 2)
+        .map(|i| u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).expect("hex"))
+        .collect()
+}
+
+/// Activations spanning sign and magnitude, deterministic so a failure
+/// is reproducible.
+fn activations(k: usize) -> Vec<f32> {
+    (0..k).map(|i| ((i % 23) as f32 - 11.0) / 13.0).collect()
+}
+
+/// The authority path, written out longhand: decode the stored bytes,
+/// then multiply in element order. This is deliberately NOT a call to a
+/// BLAS gemv — the claim under test is about the association the
+/// decoder defines, and a library's blocked accumulation would import a
+/// second unknown into the comparison.
+fn decode_then_multiply(bytes: &[u8], name: &str, n: usize, k: usize) -> Vec<f32> {
+    let decoded = kquant::lookup(name)
+        .expect("a known K-quant")
+        .decode(bytes, n * k, "fixture")
+        .expect("decode");
+    let x = activations(k);
+    (0..n)
+        .map(|r| {
+            let mut acc = 0.0f32;
+            for c in 0..k {
+                acc += decoded[r * k + c] * x[c];
+            }
+            acc
+        })
+        .collect()
+}
+
+/// The candidate: the codec's OWN direct-execution association, which is
+/// the one production dispatches through. Layer 1 therefore covers the
+/// dispatch table and not only the kernels behind it — a test that kept
+/// its own copy of that table could pass while production routed
+/// differently.
+fn direct(bytes: &[u8], name: &str, n: usize, k: usize) -> Option<Vec<f32>> {
+    let x = activations(k);
+    kquant::lookup(name)
+        .expect("a known K-quant")
+        .gemv(bytes, &x, n, k)
+}
+
+/// Relative difference, reported rather than merely thresholded, so a
+/// failure says how far off it was and not only that it was off.
+fn worst_relative(a: &[f32], b: &[f32]) -> f64 {
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| {
+            let denom = (x.abs().max(y.abs()) as f64).max(1e-6);
+            ((*x as f64) - (*y as f64)).abs() / denom
+        })
+        .fold(0.0f64, f64::max)
+}
+
+/// The fixture's canonical name for a case, since the JSON spells them
+/// `q8_0` / `q6_K` / `q4_K`.
+fn canonical(encoding: &str) -> &'static str {
+    match encoding.to_ascii_lowercase().as_str() {
+        "q8_0" => "Q8_0",
+        "q6_k" => "Q6_K",
+        "q4_k" => "Q4_K",
+        other => panic!("unexpected encoding `{other}` in the golden fixture"),
+    }
+}
+
+/// Every case in the fixture, at two shapes, direct against decoded.
+///
+/// The measured agreement is asserted per encoding rather than with one
+/// shared bound: Q8_0's kernel folds the f16 scale per element and is
+/// therefore bit-for-bit with the decoder, and holding it to a loose
+/// tolerance would stop testing the property it was written to have.
+#[test]
+fn direct_execution_agrees_with_decode_then_multiply() {
+    let g = golden();
+    assert_eq!(g.cases.len(), 3, "the fixture should carry all three");
+    for c in &g.cases {
+        let name = canonical(&c.encoding);
+        let bytes = hex_to_bytes(&c.quantised_hex);
+        for (n, k) in [(1, c.elements), (2, c.elements / 2)] {
+            let want = decode_then_multiply(&bytes, name, n, k);
+            let Some(got) = direct(&bytes, name, n, k) else {
+                panic!("{name} [{n},{k}]: no direct kernel answered");
+            };
+            let rel = worst_relative(&got, &want);
+            // Printed, not merely thresholded. "Passed" hides whether
+            // the agreement was 1e-7 or 9e-4, and layer 1 of the gate is
+            // a NUMBER that belongs in the campaign record.
+            println!("  layer-1  {name:<5} [{n},{k}]  worst relative {rel:e}");
+            if name == "Q8_0" {
+                assert_eq!(
+                    got, want,
+                    "{name} [{n},{k}]: the Q8_0 kernel folds the scale per element and \
+                     must be bit-for-bit with the decoder; worst relative {rel:e}"
+                );
+            } else {
+                // Calibrated to what was MEASURED, not to a round
+                // number: Q6_K came in at 3.6e-7 / 6.4e-7 and Q4_K at
+                // 8.6e-7 / 8.3e-7, which is f32 accumulation order
+                // (sqrt(512) * f32 eps is about 2.7e-6) rather than a
+                // different program. A 1e-3 bound would pass a kernel
+                // that had genuinely regressed; this one leaves about
+                // 6x headroom over the worst observed.
+                assert!(
+                    rel < 5e-6,
+                    "{name} [{n},{k}]: direct execution differs from the decoder by \
+                     {rel:e} relative — too large to be accumulation order"
+                );
+            }
+        }
+    }
+}
+
+/// The comparison must be able to fail.
+///
+/// An earlier check in this campaign reported IDENTICAL by comparing two
+/// empty strings, and a gate that cannot return the other answer is not
+/// evidence. Perturbing one stored byte must move the result.
+#[test]
+fn the_agreement_check_can_report_disagreement() {
+    let g = golden();
+    for c in &g.cases {
+        let name = canonical(&c.encoding);
+        let mut bytes = hex_to_bytes(&c.quantised_hex);
+        let (n, k) = (1, c.elements);
+        let clean = decode_then_multiply(&bytes, name, n, k);
+        // Flip a bit in a code byte, past any block header.
+        let victim = bytes.len() / 2;
+        bytes[victim] ^= 0x10;
+        let dirty = decode_then_multiply(&bytes, name, n, k);
+        assert_ne!(
+            clean, dirty,
+            "{name}: perturbing a stored byte did not change the decoded product, so \
+             this comparison could not have detected a wrong one"
+        );
+    }
+}
+
+/// The codec refuses a geometry that does not describe the blocks, before
+/// any kernel sees them — the stride check is the codec's, not the
+/// kernel's, so a wrong shape over the right total length is caught by
+/// the one party that knows the layout.
+#[test]
+fn the_codec_refuses_a_geometry_that_does_not_describe_the_blocks() {
+    let g = golden();
+    for c in &g.cases {
+        let name = canonical(&c.encoding);
+        let k = kquant::lookup(name).expect("a known K-quant");
+        let bytes = hex_to_bytes(&c.quantised_hex);
+        let (n, width) = (1, c.elements);
+        let x = activations(width);
+        assert!(
+            k.gemv(&bytes, &x, n, width).is_some(),
+            "{name}: the control case"
+        );
+        // More rows than the stream holds.
+        assert!(k.gemv(&bytes, &x, n + 1, width).is_none(), "{name}: rows");
+        // A width off the block grid.
+        assert!(
+            k.gemv(&bytes, &activations(width - 1), n, width - 1)
+                .is_none(),
+            "{name}: ragged width"
+        );
+        // An activation that is not the row's width.
+        assert!(
+            k.gemv(&bytes, &activations(width / 2), n, width).is_none(),
+            "{name}: activation width"
+        );
+        // A stream one byte short.
+        assert!(
+            k.gemv(&bytes[..bytes.len() - 1], &x, n, width).is_none(),
+            "{name}: truncated stream"
+        );
+    }
+}
+
+/// Q8_0 must not be answered by the pre-existing `QuantFormat::Q8_0`
+/// path, which is a DIFFERENT layout under the same name: int8 codes
+/// with an external per-block f32 scale stream, against ggml's inline
+/// f16 scale in a 34-byte block. Routing one to the other is not
+/// hypothetical — it happened in this workspace and produced garbage.
+#[test]
+fn the_larql_q8_0_format_does_not_answer_for_ggml_blocks() {
+    let g = golden();
+    let c = g
+        .cases
+        .iter()
+        .find(|c| canonical(&c.encoding) == "Q8_0")
+        .expect("a Q8_0 case");
+    let bytes = hex_to_bytes(&c.quantised_hex);
+    let x = activations(c.elements);
+    assert!(
+        CpuBackend
+            .quant_matvec(QuantFormat::Q8_0, &bytes, &x, 1, c.elements)
+            .is_none(),
+        "`QuantFormat::Q8_0` answered for ggml Q8_0 bytes; those are different layouts \
+         and a silent answer is the 34-vs-18 byte stride bug returning"
+    );
+}


### PR DESCRIPTION
## What

PARETO-1 rung A's executor, revisions v2 and v3.

**v2** (`3a86d9bf`, staging): a widened f32 weight image lives in one unlinked, file-backed arena instead of anonymous memory, so the OS can reclaim it. Residency only; `LARQL_F32_STAGE=off` restores the old behaviour in the same binary. Qualified bit-identical against the frozen v1 executor (gates A/B/B'/C/E in `~/chris-models/pareto1/INSTRUMENT-REVISION.md`).

**v3** (this branch's second commit): a stored ggml K-quant pack — Q8_0, Q6_K or Q4_K — executes **in place** by the kernel its codec names, instead of being decoded to f32 and run through BLAS. The bytes the kernel reads are the artifact's own.

```text
LoadedWeight::KQuant {blocks, codec}    read, kept, never decoded; exact length checked at load
  -> WeightSlice::KQuant                 rows() is EXACT length, not a prefix cut
  -> WeightRows::KQuant                  the codec travels with the bytes
  -> PhysicalProjectionPlan::FusedKQuant observation-only, like FusedNvfp4
  -> KQuant::gemv                        the codec owns the kernel association
```

`LARQL_KQUANT_EXEC=widen` restores v2's path in the same binary. The executor prints `projection plans:` from its own ledger, so the arm that ran is observed rather than inferred, and the bank runner refuses an arm that did not run as named.

## Why the gate came first

The equivalence thresholds were frozen before any of this existed (top-1 flips 0, mean KL ≤ 5.2e-6, max KL ≤ 1.73e-5 bits/token — a tenth of a nuisance already refused on this model) and did not move. Three layers, all against decode-then-multiply on the **same stored bytes**:

| layer | claim | result |
|---|---|---|
| 1 kernel | kernel vs decoder on llama.cpp's bytes | Q8_0 bit-for-bit; Q6_K/Q4_K ≤ 8.6e-7 rel |
| 2 projection | a real projection through the executor, direct vs BLAS-f32, real anchors | Q8_0 **bit-exact** vs the scalar transcription on `[17408,5120]`; every arm pair ≤ 2.3e-7 of row scale |
| 3 end-to-end | 223 frozen positions, three anchors, one binary, two arms | **PASS**, every anchor five orders under the gate — details below |

Layer 2's metric had to change: elementwise relative error read **6%** on the bit-exact Q8_0 kernel (a cancelling row seen through BLAS's own reassociation). Accumulation-order error is bounded by the row's Σ|w·x|, so that is the gate; elementwise is printed for the record.

Six mutations fail loudly at the seams: not a pack, three wrong geometries, wrong codec in both directions (Q6_K-as-Q4_K is *longer* than Q4_K wants and would pass a prefix cut), and a perturbed stored byte.

## Also

The projection ledger's `all()` and `reset()` omitted `FusedNvfp4`: bytes from a compiled NVFP4 pack tallied nowhere and no reset cleared them. Both now enumerate every plan.

## Gates

fmt; clippy workspace `--all-targets -D warnings`; larql-vindex 3,891 lib tests + full `cargo test`; larql-compute lib + `test_backend_matmul_quant`; larql-cli with and without default features; `--features gpu` check; coverage — see the checklist in the first comment.

## Layer 3

**PASS on every anchor.** U8 mean KL 1.4e-11 / max 1.2e-10; U6 2.4e-12 / 2.1e-11; U4 2.2e-12 / 8.5e-11 bits per token; 0 top-1 flips of 223 positions each. v3-widen is byte-identical to the frozen v2 executor's U8 dumps (6/6); v3-direct differs from them (6/6). Direct streams 25.9 / 20.0 / 13.7 GB per position against 97.4 widened. Throughput is outside the gate and not uniform (U4 direct 2.0x faster, U6 1.8x slower, U8 2.8x slower than widen); the Q8_0 kernel is the exactness-first scalar loop.
