### PR TITLE
test(vindex3): reach the mixer-on-hyper-connection arm, and bind sites lazily

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/build.rs
@@ -658,27 +658,6 @@ pub fn plan_component_ops(
         let get = |role: OperandRole| &slot[&role];
         let policy = &attention_table[layer];
         let geometry = layer_geometry(layer);
-        // The two sites, bound iff the component declares the topology.
-        // Closure required all six on every transformer layer, so the
-        // lookups are total here; the mixer arms below never reach this
-        // under the topology (closure refused them as unjudged).
-        let hc_site = |mix_fn: OperandRole, base: OperandRole, scale: OperandRole| HcSiteOp {
-            mix_fn: operand(&stack_id, get(mix_fn)),
-            base: operand(&stack_id, get(base)),
-            scale: operand(&stack_id, get(scale)),
-        };
-        let hyper_connection_sites = hyper_connection.map(|_| HyperConnectionLayerOp {
-            attention: hc_site(
-                OperandRole::HcAttnMixFn,
-                OperandRole::HcAttnBase,
-                OperandRole::HcAttnScale,
-            ),
-            ffn: hc_site(
-                OperandRole::HcFfnMixFn,
-                OperandRole::HcFfnBase,
-                OperandRole::HcFfnScale,
-            ),
-        });
         // A mixer-only layer, on operand evidence: the fused five-way
         // `in_proj` is the discriminator (no other operator's role table
         // can put it in `slot`). Its whole program is the mixer — one
@@ -969,6 +948,31 @@ pub fn plan_component_ops(
         let layer_scale = slot
             .get(&OperandRole::LayerScalar)
             .map(|t| operand(&stack_id, t));
+        // The two sites, bound iff the component declares the topology.
+        // Built HERE, in the transformer arm, and not above the mixer
+        // arms: closure required all six on every transformer layer, so
+        // the lookups are total for this layer kind — and a mixer layer
+        // under the topology never reaches this point, because closure
+        // refused it as unjudged. Binding eagerly for every layer kind
+        // would turn that refusal's absence into an index panic instead
+        // of the named defect.
+        let hc_site = |mix_fn: OperandRole, base: OperandRole, scale: OperandRole| HcSiteOp {
+            mix_fn: operand(&stack_id, get(mix_fn)),
+            base: operand(&stack_id, get(base)),
+            scale: operand(&stack_id, get(scale)),
+        };
+        let hyper_connection_sites = hyper_connection.map(|_| HyperConnectionLayerOp {
+            attention: hc_site(
+                OperandRole::HcAttnMixFn,
+                OperandRole::HcAttnBase,
+                OperandRole::HcAttnScale,
+            ),
+            ffn: hc_site(
+                OperandRole::HcFfnMixFn,
+                OperandRole::HcFfnBase,
+                OperandRole::HcFfnScale,
+            ),
+        });
         let consumed = slot.len() + bank_slot.map_or(0, |b| b.len());
         layers.push(LayerPlan {
             declared_norm_eps: surface.norm.pre.eps,

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/wave18_hc_carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/wave18_hc_carriage.rs
@@ -860,3 +860,125 @@ fn k3s_residual_operands_are_not_sinkhorn_sites_under_any_stream_count() {
         );
     }
 }
+
+// ── The mixer-on-hyper-connection arm, reached ──
+
+/// **The unjudged arm is reachable, and its `||` is load-bearing.** PR
+/// #417's advisory mutation run replaced `is_mamba2() || is_conv_qkv()`
+/// with `&&` in the arm that refuses a hyper-connected component's
+/// mixer-only layer, and nothing noticed — no fixture declared the
+/// topology on a Mamba2 stack. This one does: the pure-SSM miniature with
+/// `hc_mult`, `hc_sinkhorn_iters` and `hc_eps` added to its own config.
+///
+/// What the arm protects against is stated by the control below: without
+/// the declaration the same estate CLOSES, so under the declaration a
+/// build that lost this arm would plan a hyper-connected component whose
+/// every layer carries no site — a plan that disagrees with itself. The
+/// refusal must name every layer, because the traversal has no judged
+/// form for a one-sublayer block in a bundle, and a stack that is
+/// refused on layer 0 alone would read as "layer 1 is fine".
+#[test]
+fn a_hyper_connected_mixer_only_stack_is_refused_as_unjudged_on_every_layer() {
+    use super::mamba2::miniature_mamba2;
+    use larql_models::inventory::build_inventory;
+
+    let plan_mixer = |declare_topology: bool| {
+        let dir = tempfile::tempdir().unwrap();
+        miniature_mamba2(dir.path(), None);
+        if declare_topology {
+            // The fixture writes a bare `Infinity`, deliberately, so its
+            // config is not JSON to serde. Declare the topology as a text
+            // insertion at the opening brace instead.
+            let path = dir.path().join("config.json");
+            let config = std::fs::read_to_string(&path).unwrap();
+            let declared = config.replacen(
+                '{',
+                &format!(
+                    "{{\"hc_mult\":{STREAMS},\"hc_sinkhorn_iters\":{SINKHORN_ITERS},\
+                     \"hc_eps\":{SINKHORN_EPS},"
+                ),
+                1,
+            );
+            std::fs::write(&path, declared).unwrap();
+        }
+        let inventory = build_inventory(dir.path()).unwrap();
+        // The declaration reached the resolved surface — so a refusal
+        // below is the arm's, not a parse that silently dropped the keys.
+        let topology = inventory
+            .resolved
+            .execution
+            .as_ref()
+            .and_then(|e| e.residual_topology);
+        assert_eq!(
+            topology.map(|t| t.streams()),
+            Some(if declare_topology { STREAMS } else { 1 })
+        );
+        let named = vec![("mamba2-mini".to_string(), inventory)];
+        let system = plan_system(&named);
+        let container = tempfile::tempdir().unwrap();
+        encode_graph(&system.graph, &named, container.path()).unwrap();
+        let inspection = inspect_container(container.path(), false).unwrap();
+        let layers = inspection
+            .graph
+            .components
+            .iter()
+            .find(|c| c.id == "target")
+            .expect("the mixer stack is the target component")
+            .num_layers;
+        (
+            plan_component_ops(&inspection, container.path(), "target").unwrap(),
+            layers,
+        )
+    };
+
+    // The control first: the same estate, one stream, closes.
+    let (plain, layers) = plan_mixer(false);
+    assert!(plain.closed(), "{:?}", plain.defects);
+    assert!(layers >= 2, "the fixture must have more than one layer");
+
+    // Under the declaration: refused on EVERY layer, by name, and for
+    // nothing else.
+    let (hyper, _) = plan_mixer(true);
+    assert!(hyper.plan.is_none());
+    let mut refused_layers: Vec<usize> = hyper
+        .outcome_layers_refused_for(HC_ON_MIXER_FACT_FRAGMENT)
+        .collect();
+    refused_layers.sort_unstable();
+    assert_eq!(
+        refused_layers,
+        (0..layers).collect::<Vec<_>>(),
+        "every mixer layer must be refused: {:?}",
+        hyper.defects
+    );
+    assert_eq!(
+        hyper.defects.len(),
+        layers,
+        "the arm is the ONLY refusal on this estate: {:?}",
+        hyper.defects
+    );
+}
+
+/// The fact the arm reports, as `ClosureDefect::UnjudgedSemantic` spells
+/// it. Matched as a fragment so the layer suffix can vary.
+const HC_ON_MIXER_FACT_FRAGMENT: &str = "hyper-connection sites on a mixer-only layer";
+
+trait RefusedLayers {
+    /// The layer index named by every `UnjudgedSemantic` defect whose
+    /// fact carries `fragment` and the required-by names the traversal.
+    fn outcome_layers_refused_for(&self, fragment: &str) -> impl Iterator<Item = usize> + '_;
+}
+
+impl RefusedLayers for OpPlanOutcome {
+    fn outcome_layers_refused_for(&self, fragment: &str) -> impl Iterator<Item = usize> + '_ {
+        let fragment = fragment.to_string();
+        self.defects.iter().filter_map(move |d| match d {
+            ClosureDefect::UnjudgedSemantic {
+                fact, required_by, ..
+            } if fact.contains(&fragment) && required_by.contains("traversal") => fact
+                .rsplit("(layer ")
+                .next()
+                .and_then(|tail| tail.trim_end_matches(')').parse().ok()),
+            _ => None,
+        })
+    }
+}


### PR DESCRIPTION
Closes the one surviving mutant PR #417's advisory mutation run left open.

**The finding.** `||` → `&&` in the arm that refuses a hyper-connected component's Mamba2 / conv-QKV layer survived because no fixture declared the topology on a mixer stack. Measured: the arm is reachable (the declaration reaches the resolved surface through the generic parser and the mixer placement), so this was an untested claim, not an equivalent mutant.

**The test.** The pure-SSM miniature with `hc_mult`, `hc_sinkhorn_iters`, `hc_eps` added to its own config. Asserts: the declaration reaches `resolved.execution.residual_topology`; every mixer layer is refused as unjudged, by name; nothing else is refused; the same estate without the declaration closes. Under the mutant it fails by assertion.

**One hardening the mutant exposed.** Before this change the mutant failed the test by an *index panic* in `plan_component_ops`: the site-binding closure ran eagerly for every layer kind, so a mixer layer that slipped past the arm indexed a site operand it does not have. The sites are now bound in the transformer arm only, where closure has made the lookups total.

Gates: fmt, clippy `--all-targets -D warnings`, 666 opplan/graph tests green; mutation re-checked on the final source.
