### PR TITLE
Stage 5a-0: the teacher-forced measurement becomes a callable, refusing procedure (Kimi qualification pending)

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_native_parity.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_native_parity.rs
@@ -24,9 +24,12 @@ use larql_compute_metal::MetalBackend;
 use serde_json::Value;
 
 use super::kda_q8_real::build_layers;
-use super::q2a_teacher_forced::{env_dir, run_sequence, sequence_embeddings, BANK_ENV, SOURCE_ENV};
 use crate::format::vindex3::opplan::exec::kimi_source::{KdaOverlay, KimiSourceModel};
 use crate::format::vindex3::opplan::exec::stack_metal::{DeviceAttn, DeviceLayer, HybridStack};
+use crate::format::vindex3::represent::measure::teacher_forced::{
+    env_dir, run_sequence, sequence_embeddings,
+};
+use crate::format::vindex3::represent::measure::{BANK_ENV, SOURCE_ENV};
 
 const KDA_CANDIDATE_ENV: &str = "LARQL_KIMI_KDA_CANDIDATE";
 /// Sequences for the end-to-end logit comparison. Two is enough: the
@@ -137,9 +140,10 @@ fn native_kda_bytes_and_logits_are_bit_equal_to_the_transient_arm() {
     let mut b = assemble(native);
     metal.seal_weight_regions();
     for seq in 0..SEQUENCES {
-        let rows = sequence_embeddings(&bank_dir, seq, positions, g.hidden);
-        let la = run_sequence(&metal, &mut a, &rows, g.hidden);
-        let lb = run_sequence(&metal, &mut b, &rows, g.hidden);
+        let rows = sequence_embeddings(&bank_dir, seq, positions, g.hidden)
+            .expect("the corpus sequence reads");
+        let la = run_sequence(&metal, &mut a, &rows, g.hidden).expect("the arm runs");
+        let lb = run_sequence(&metal, &mut b, &rows, g.hidden).expect("the arm runs");
         for (pos, ((va, _), (vb, _))) in la.into_iter().zip(lb).enumerate() {
             assert!(
                 va.iter().zip(&vb).all(|(x, y)| x.to_bits() == y.to_bits()),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kda_q8_real.rs
@@ -32,12 +32,13 @@ use larql_compute_metal::trait_impl::kimi_layer::ExpertEncoding as MetalEncoding
 use larql_compute_metal::MetalBackend;
 use serde_json::Value;
 
-use super::q2a_teacher_forced::{
-    env_dir, observation, run_sequence, sequence_embeddings, BANK_ENV, CANDIDATE_ENV, SOURCE_ENV,
-};
 use crate::format::vindex3::opplan::exec::kimi_source::{CandidateOverlay, KimiSourceModel};
 use crate::format::vindex3::opplan::exec::stack_metal::{DeviceAttn, DeviceLayer, HybridStack};
 use crate::format::vindex3::represent::bank::BankBuilder;
+use crate::format::vindex3::represent::measure::teacher_forced::{
+    env_dir, observation, run_sequence, sequence_embeddings,
+};
+use crate::format::vindex3::represent::measure::{BANK_ENV, CANDIDATE_ENV, SOURCE_ENV};
 use crate::format::vindex3::represent::physical::{
     EncodedRegion, ExpertEncoding as PhysEncoding, PhysicalStore, SharedExpertBinding,
 };
@@ -666,9 +667,10 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
     {
         let mut builder = BankBuilder::new();
         for seq in 0..NULL_SEQUENCES {
-            let rows = sequence_embeddings(&bank_dir, seq, positions, g.hidden);
-            let a = run_sequence(&metal, &mut baseline, &rows, g.hidden);
-            let b = run_sequence(&metal, &mut null_partner, &rows, g.hidden);
+            let rows = sequence_embeddings(&bank_dir, seq, positions, g.hidden)
+                .expect("the corpus sequence reads");
+            let a = run_sequence(&metal, &mut baseline, &rows, g.hidden).expect("the arm runs");
+            let b = run_sequence(&metal, &mut null_partner, &rows, g.hidden).expect("the arm runs");
             for (pos, ((la, ta), (lb, tb))) in a.into_iter().zip(b).enumerate() {
                 builder.observe(&observation(seq, pos, &la, &ta, &lb, &tb));
             }
@@ -699,9 +701,10 @@ fn one_kda_layers_projections_at_q8_through_the_consequence_metrics() {
     // KL by position index, across sequences — the token-distance curve.
     let mut kl_by_pos: Vec<Vec<f64>> = vec![Vec::new(); positions];
     for seq in 0..sequences {
-        let rows = sequence_embeddings(&bank_dir, seq, positions, g.hidden);
-        let base = run_sequence(&metal, &mut baseline, &rows, g.hidden);
-        let cand = run_sequence(&metal, &mut candidate, &rows, g.hidden);
+        let rows = sequence_embeddings(&bank_dir, seq, positions, g.hidden)
+            .expect("the corpus sequence reads");
+        let base = run_sequence(&metal, &mut baseline, &rows, g.hidden).expect("the arm runs");
+        let cand = run_sequence(&metal, &mut candidate, &rows, g.hidden).expect("the arm runs");
         for (pos, ((lb, tb), (lc, tc))) in base.into_iter().zip(cand).enumerate() {
             kl_by_pos[pos].push(full_kl(&lb, &lc));
             builder.observe(&observation(seq, pos, &lb, &tb, &lc, &tc));

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_decode_bench.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_decode_bench.rs
@@ -44,11 +44,12 @@ use super::kda_q8_real::{
     assemble, assemble_with_head, build_layers, build_layers_scoped, head_q8, layer_list,
     LAYER_ENV, MLA_ENV, SHARED_ENV,
 };
-use super::q2a_teacher_forced::{
-    build_stack, env_dir, sequence_embeddings, BANK_ENV, CANDIDATE_ENV, SOURCE_ENV,
-};
 use crate::format::vindex3::opplan::exec::kimi_source::{CandidateOverlay, KimiSourceModel};
 use crate::format::vindex3::opplan::exec::stack_metal::HybridStack;
+use crate::format::vindex3::represent::measure::teacher_forced::{
+    build_stack, env_dir, sequence_embeddings,
+};
+use crate::format::vindex3::represent::measure::{BANK_ENV, CANDIDATE_ENV, SOURCE_ENV};
 
 /// Tokens per measured block. At the BF16 stack's known ~27 ms/token a
 /// 128-token block is ~3.5 s — long enough to average submission
@@ -181,8 +182,8 @@ fn decode_rate_of_the_candidate_map_beside_its_own_bf16_baseline() {
         )
     } else {
         (
-            build_stack(&metal, &model, None),
-            build_stack(&metal, &model, Some(&overlay)),
+            build_stack(&metal, &model, None).expect("the baseline arm loads"),
+            build_stack(&metal, &model, Some(&overlay)).expect("the candidate arm loads"),
         )
     };
     metal.seal_weight_regions();
@@ -212,7 +213,9 @@ fn decode_rate_of_the_candidate_map_beside_its_own_bf16_baseline() {
     // deterministically.
     let seqs_needed = (tokens.max(WARMUP_TOKENS)).div_ceil(positions).max(1);
     let rows: Vec<Vec<Vec<f32>>> = (0..seqs_needed)
-        .map(|s| sequence_embeddings(&bank_dir, s, positions, hidden))
+        .map(|s| {
+            sequence_embeddings(&bank_dir, s, positions, hidden).expect("the corpus sequence reads")
+        })
         .collect();
 
     for (name, stack) in [("baseline", &mut baseline), ("candidate", &mut candidate)] {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_teacher_forced.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_teacher_forced.rs
@@ -1,26 +1,17 @@
-//! **The teacher-forced quality runner** — two arms through the real
-//! mixed Metal stack, loaded from the source VINDEX3 container itself:
+//! **The teacher-forced runner, as a witness rather than an
+//! implementation.**
 //!
-//! ```text
-//! baseline    every routed layer   -> source expert_bank   (BF16, Table)
-//! candidate   the overlay's layers -> compiled banks       (Identity,
-//!             each at its map's encoding — Q8_0, Q6_K, or a composed
-//!             map holding several layers at different encodings)
-//!             everything else      -> the SAME source stores
-//! ```
+//! Every validity condition this file used to assert now lives in
+//! `represent::measure::teacher_forced` as a typed refusal — see that
+//! module's conservation inventory for where each one went. What
+//! remains here is the claim a test is entitled to make:
 //!
-//! The changed variable is exactly the candidate's compiled scope:
-//! source BF16 bytes vs the persistent bytes the compiler sealed.
-//! Router, norms, attention, shared experts, state initialisation and
-//! the teacher-forced token prefix are identical by construction — and
-//! asserted, not assumed, per compiled layer.
+//! > this known experiment should qualify.
 //!
-//! **The verdict semantics follow scale.** Below `positions_min` (4096)
-//! this is a DIAGNOSTIC: the gate must refuse on positions however
-//! flattering the numbers, and the harness asserts that refusal. At
-//! 8192 (`LARQL_Q2A_SEQUENCES=256`) the verdict IS the product — frozen
-//! `kimi-logit-v3` decides, the report is written BEFORE any verdict
-//! assertion, and a FAIL is a result, not a harness failure.
+//! plus two checks that were never about the measurement's validity and
+//! would have muddled ownership by moving: the sub-4096 refusal is a
+//! claim about [`QualityGate::evaluate`], and the operand-removal
+//! control is a claim about `verify_complete`.
 //!
 //! ```text
 //! LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.aligned.vindex3 \
@@ -30,814 +21,100 @@
 //!   cargo test -p larql-vindex --features gpu --release --lib q2a_teacher_forced -- --nocapture
 //! ```
 
-use std::path::{Path, PathBuf};
-use std::time::Instant;
-
-use larql_compute::backend::ComputeBackend;
-use larql_compute_metal::trait_impl::kimi_layer::ExecutionTrace;
-use larql_compute_metal::MetalBackend;
-use serde_json::Value;
-
-use crate::format::vindex3::opplan::exec::kimi_source::{
-    verify_complete, CandidateOverlay, KimiSourceModel,
+use crate::format::vindex3::opplan::exec::kimi_source::{verify_complete, CandidateOverlay};
+use crate::format::vindex3::represent::measure::teacher_forced::measure_teacher_forced;
+use crate::format::vindex3::represent::measure::{
+    TeacherForcedRequest, BANK_ENV, CANDIDATE_ENV, SOURCE_ENV,
 };
-use crate::format::vindex3::opplan::exec::stack::{LayerSpec, LayerState};
-use crate::format::vindex3::opplan::exec::stack_metal::{DeviceLayer, HybridStack};
-use crate::format::vindex3::represent::bank::{
-    BankBuilder, PositionObservation, Top1Change, TopKChange,
-};
-use crate::format::vindex3::represent::measure::TeacherForcedRequest;
-use crate::format::vindex3::represent::physical::{ExpertEncoding, ProjectionAddressing};
-use crate::format::vindex3::represent::quality::{
-    kimi_logit_v1, kimi_logit_v2, Criterion, QualityEvidence,
-};
-
-pub(super) use crate::format::vindex3::represent::measure::{BANK_ENV, CANDIDATE_ENV, SOURCE_ENV};
-/// Sequences the null arm re-runs — enough positions for the all-zero
-/// claim to cover real routing variety, cheap enough not to double the
-/// run.
-const NULL_SEQUENCES: usize = 4;
-/// Baseline top-N kept per position. KL is exact on the mass these
-/// carry; the minimum covered mass is reported so a too-flat position
-/// announces itself.
-///
-/// 128 covered only 31 % of the baseline's mass at the worst position
-/// of the first run — a teacher-forced sequence's FIRST position has no
-/// context, so its distribution is close to flat over 163,840 ids and a
-/// short truncation sees almost none of it. Widening costs nothing
-/// measurable (the rank sort already runs for argmax and top-10) and
-/// buys a KL that is exact on most of the distribution instead of a
-/// third of it.
-const TOP_N: usize = 2048;
-/// Where the machine-readable closure reports are written, one per
-/// labelled run.
-fn report_path(label: &str) -> String {
-    format!("/tmp/kimi_{label}_report.json")
-}
-
-pub(super) fn env_dir(var: &str) -> Option<PathBuf> {
-    std::env::var_os(var).map(PathBuf::from)
-}
-
-fn logsumexp(v: &[f32]) -> f32 {
-    let m = v.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-    m + v.iter().map(|x| (x - m).exp()).sum::<f32>().ln()
-}
-
-fn argmax(v: &[f32]) -> usize {
-    v.iter()
-        .enumerate()
-        .max_by(|a, b| a.1.partial_cmp(b.1).expect("logits are never NaN"))
-        .expect("non-empty")
-        .0
-}
-
-fn top_k_ids(logits: &[f32], k: usize) -> Vec<usize> {
-    let mut idx: Vec<usize> = (0..logits.len()).collect();
-    idx.sort_unstable_by(|&a, &b| {
-        logits[b]
-            .partial_cmp(&logits[a])
-            .expect("logits are never NaN")
-            .then(a.cmp(&b))
-    });
-    idx.truncate(k);
-    idx
-}
-
-/// One position's paired measurement, from both arms' full logit
-/// vectors, traced routes, and the router's own scores.
-#[allow(clippy::too_many_arguments)]
-pub(super) fn observation(
-    seq: usize,
-    pos: usize,
-    baseline: &[f32],
-    base_trace: &ExecutionTrace,
-    candidate: &[f32],
-    cand_trace: &ExecutionTrace,
-) -> PositionObservation {
-    let top_ids = top_k_ids(baseline, TOP_N);
-    PositionObservation {
-        sequence: seq as u32,
-        position: pos as u32,
-        baseline_logits: top_ids.iter().map(|&i| baseline[i]).collect(),
-        candidate_logits: top_ids.iter().map(|&i| candidate[i]).collect(),
-        top_ids: top_ids.iter().map(|&i| i as u32).collect(),
-        baseline_logsumexp: logsumexp(baseline),
-        candidate_logsumexp: logsumexp(candidate),
-        baseline_argmax: argmax(baseline) as u32,
-        candidate_argmax: argmax(candidate) as u32,
-        baseline_top10: top_k_ids(baseline, 10).iter().map(|&i| i as u32).collect(),
-        candidate_top10: top_k_ids(candidate, 10).iter().map(|&i| i as u32).collect(),
-        // Every changed route WEIGHED — how close the decision was and
-        // how much mixture mass moved — from the router's own selection
-        // scores, so a near-tie swap and an overturned decision are
-        // distinguishable rather than both being "one flip".
-        route_changes: PositionObservation::weigh_route_changes(
-            &base_trace.routes,
-            &cand_trace.routes,
-            &base_trace.selection_scores,
-            &base_trace.combine_weights,
-            &cand_trace.combine_weights,
-        ),
-        // The top-10 change WEIGHED, recorded only where the ordering
-        // actually moved: a position that did not move says nothing
-        // about how close the ones that did were.
-        top10_change: weigh_top_k(baseline, candidate, 10),
-        // The argmax flip weighed, when the winner changed.
-        top1_change: weigh_top_1(baseline, candidate),
-        baseline_routes: base_trace.routes.clone(),
-        candidate_routes: cand_trace.routes.clone(),
-    }
-}
-
-/// **What a top-k reordering actually was**, or `None` if the ordering
-/// did not change.
-///
-/// Four facts, because the count answers none of them: how close the
-/// boundary was, what the CANDIDATE did to that same pair, how much
-/// probability mass moved, and how far anything travelled in rank.
-fn weigh_top_k(baseline: &[f32], candidate: &[f32], k: usize) -> Option<TopKChange> {
-    let (b_top, c_top) = (top_k_ids(baseline, k), top_k_ids(candidate, k));
-    if b_top == c_top {
-        return None;
-    }
-    // The boundary the baseline drew, and what the candidate did to
-    // exactly those two ids. Comparing the two is the measurement a
-    // worst-case `max|dlogit|` over the whole vocabulary cannot give.
-    let ranked = top_k_ids(baseline, k + 1);
-    let (boundary_margin, candidate_margin_same_ids) = if ranked.len() == k + 1 {
-        let (lo, hi) = (ranked[k - 1], ranked[k]);
-        (baseline[lo] - baseline[hi], candidate[lo] - candidate[hi])
-    } else {
-        (f32::NAN, f32::NAN)
-    };
-
-    // Half the L1 between the arms' top-k mass, each normalised over
-    // its own k — the top-k analogue of the routed-mixture distance.
-    let softmax_over = |logits: &[f32], ids: &[usize]| -> Vec<(usize, f32)> {
-        let m = ids
-            .iter()
-            .map(|i| logits[*i])
-            .fold(f32::NEG_INFINITY, f32::max);
-        let exps: Vec<f32> = ids.iter().map(|i| (logits[*i] - m).exp()).collect();
-        let sum: f32 = exps.iter().sum();
-        ids.iter().zip(exps).map(|(i, e)| (*i, e / sum)).collect()
-    };
-    let (bp, cp) = (
-        softmax_over(baseline, &b_top),
-        softmax_over(candidate, &c_top),
-    );
-    let mass_of = |v: &[(usize, f32)], id: usize| {
-        v.iter()
-            .find(|(i, _)| *i == id)
-            .map(|(_, p)| *p)
-            .unwrap_or(0.0)
-    };
-    let mut union: Vec<usize> = b_top.iter().chain(&c_top).copied().collect();
-    union.sort_unstable();
-    union.dedup();
-    let mass_displaced = 0.5
-        * union
-            .iter()
-            .map(|id| (mass_of(&bp, *id) - mass_of(&cp, *id)).abs())
-            .sum::<f32>();
-
-    // How far anything travelled. An id present in one arm's top-k and
-    // absent from the other is located in the other's FULL ordering, so
-    // an outsider arriving from rank 400 is not scored as a 1-place
-    // move.
-    let rank_in = |ordering: &[usize], id: usize, full: &[f32]| -> usize {
-        ordering
-            .iter()
-            .position(|x| *x == id)
-            .unwrap_or_else(|| full.iter().filter(|v| **v > full[id]).count())
-    };
-    let max_rank_displacement = union
-        .iter()
-        .map(|id| {
-            let b = rank_in(&b_top, *id, baseline);
-            let c = rank_in(&c_top, *id, candidate);
-            b.abs_diff(c) as u32
-        })
-        .max()
-        .unwrap_or(0);
-
-    Some(TopKChange {
-        boundary_margin,
-        candidate_margin_same_ids,
-        mass_displaced,
-        max_rank_displacement,
-    })
-}
-
-/// **What an argmax flip actually was**, or `None` if the winner did
-/// not change.
-///
-/// Distinguishes a coin-flip between near-equal candidates from an
-/// overturned confident choice — two events the flip count scores
-/// identically, and the strictest criterion in the contract.
-fn weigh_top_1(baseline: &[f32], candidate: &[f32]) -> Option<Top1Change> {
-    let (b_win, c_win) = (argmax(baseline), argmax(candidate));
-    if b_win == c_win {
-        return None;
-    }
-    // Exact probabilities over the FULL vocabulary, so the mass is the
-    // model's own belief rather than a renormalised truncation.
-    let lse = logsumexp(baseline);
-    let p = |id: usize| (baseline[id] - lse).exp();
-    Some(Top1Change {
-        // What the baseline held its winner by, over the pair that
-        // actually swapped.
-        boundary_margin: baseline[b_win] - baseline[c_win],
-        // And what the candidate holds the reversed choice by.
-        candidate_margin_same_ids: candidate[c_win] - candidate[b_win],
-        // The probability the baseline gave up by switching.
-        mass_displaced: p(b_win) - p(c_win),
-    })
-}
-
-/// Per-sequence embedding rows from the exported bank.
-pub(super) fn sequence_embeddings(
-    dir: &Path,
-    seq: usize,
-    positions: usize,
-    hidden: usize,
-) -> Vec<Vec<f32>> {
-    let bytes = std::fs::read(dir.join(format!("seq_{seq}.f32")))
-        .unwrap_or_else(|e| panic!("seq_{seq}.f32: {e}"));
-    assert_eq!(
-        bytes.len(),
-        positions * hidden * 4,
-        "seq_{seq} must hold {positions}x{hidden} f32 rows"
-    );
-    bytes
-        .chunks_exact(hidden * 4)
-        .map(|row| {
-            row.chunks_exact(4)
-                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                .collect()
-        })
-        .collect()
-}
-
-/// Build one arm: every layer on device, the head riding the last
-/// epoch. `overlay` present = the candidate arm.
-pub(super) fn build_stack<'a>(
-    metal: &MetalBackend,
-    model: &KimiSourceModel,
-    overlay: Option<&CandidateOverlay>,
-) -> HybridStack<'a> {
-    let n = model.geometry.num_layers;
-    let mut device: Vec<Option<DeviceLayer>> = Vec::with_capacity(n);
-    for i in 0..n {
-        device.push(Some(model.device_layer(metal, i, overlay).unwrap_or_else(
-            |e| panic!("layer {i} must load with zero missing operands: {e}"),
-        )));
-    }
-    // Register the per-stack owned attention banks (the mmap-backed
-    // stores are registered once by the caller).
-    for d in device.iter().flatten() {
-        for bank in d.attention_banks() {
-            metal.register_weight_region(bank);
-        }
-    }
-    let host: Vec<Option<(LayerSpec<'a>, LayerState)>> = (0..n).map(|_| None).collect();
-    let mut stack = HybridStack::new(device, host);
-    assert!(
-        stack.attach_head(model.head().expect("the head must load")),
-        "the stack ends on a device layer, so the head must attach"
-    );
-    stack
-}
-
-/// Run `positions` teacher-forced steps of one sequence through one
-/// arm, returning each position's full logits and its execution trace.
-pub(super) fn run_sequence(
-    metal: &MetalBackend,
-    stack: &mut HybridStack<'_>,
-    rows: &[Vec<f32>],
-    hidden: usize,
-) -> Vec<(Vec<f32>, ExecutionTrace)> {
-    stack
-        .reset_states()
-        .expect("an all-device stack resets cleanly");
-    let mut out = Vec::with_capacity(rows.len());
-    for row in rows {
-        let mut trace = ExecutionTrace {
-            // The router's own selection scores and combine weights, so
-            // a routing change can be WEIGHED rather than counted.
-            // ~27 KB a token, read after the chain's single wait.
-            want_selection_scores: true,
-            ..ExecutionTrace::default()
-        };
-        let (logits, _traces, _t) = stack
-            .forward_traced(metal, row, hidden, Some(&mut trace))
-            .expect("the teacher-forced step must not refuse");
-        out.push((logits, trace));
-    }
-    out
-}
+use crate::format::vindex3::represent::quality::Criterion;
 
 #[test]
-fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
-    // **The environment form is an ADAPTER.** It builds the request a
-    // prepared experiment would build and runs nothing of its own, so
-    // there is one procedure rather than an env path and a direct path
-    // that could drift.
+fn the_teacher_forced_measurement_qualifies_and_the_gate_refuses_on_positions() {
     let Some(request) = TeacherForcedRequest::from_env() else {
         eprintln!("skipped: set {SOURCE_ENV}, {CANDIDATE_ENV} and {BANK_ENV}");
         return;
     };
-    // Refused before anything is loaded: an unknown gate, an empty
-    // slice, a missing artifact. The gate is RESOLVED here and used
-    // below — the runner no longer holds one.
-    let requested_gate = request
-        .admit()
-        .expect("the request names what this build performs");
-    let (source_dir, candidate_dir, bank_dir) = (
-        request.source.clone(),
-        request.candidate.clone(),
-        request.quality_bank.clone(),
+    let receipt = measure_teacher_forced(&request).expect("the measurement is admissible");
+
+    // The whole of this test's claim about validity: the production
+    // procedure checked everything, and says so.
+    assert!(
+        receipt.qualifies(),
+        "the run skipped a validity condition: {:?}",
+        receipt.verified
     );
-    let sequences = || request.sequences;
-    // The residency SET would try to wire ~94 GB of expert bank, past
-    // the wired-collector wall (~45 GB). This run uses registered
-    // regions under IMPLICIT residency; refusing is better than
-    // silently degrading into a measurement of the collector.
-    if std::env::var("LARQL_RESIDENCY_SET").is_ok() {
-        panic!("unset LARQL_RESIDENCY_SET: the bank run must use implicit residency");
-    }
-    let Some(metal) = MetalBackend::new() else {
-        #[cfg(target_os = "macos")]
-        panic!("MetalBackend::new() returned None on macOS — the shader library failed");
-        #[cfg(not(target_os = "macos"))]
-        return;
-    };
-
-    let manifest: Value =
-        serde_json::from_slice(&std::fs::read(bank_dir.join("manifest.json")).expect("manifest"))
-            .expect("bank manifest parses");
-    let positions_per_seq = manifest["positions"].as_u64().unwrap() as usize;
-    let bank_hidden = manifest["hidden"].as_u64().unwrap() as usize;
-
-    let t0 = Instant::now();
-    let model = KimiSourceModel::open(&source_dir).expect("source container opens");
-    let g = model.geometry.clone();
     assert_eq!(
-        g.hidden, bank_hidden,
-        "the bank was exported for this model"
+        receipt.gate.id, request.gate,
+        "judged by the gate requested"
     );
-    let overlay =
-        CandidateOverlay::open(&candidate_dir, &source_dir, &g).expect("candidate overlay opens");
+    assert_eq!(receipt.verified.gate_evaluated, request.gate);
     eprintln!(
-        "[q2a] source + candidate opened in {:.1}s; candidate compiles layers {:?}",
-        t0.elapsed().as_secs_f64(),
-        overlay.compiled_layers()
-    );
-    // The EARLIEST compiled layer (verify_complete sorts): the one
-    // layer whose router input is untouched in BOTH arms, so its own
-    // routing must be identical — the cascade/local discriminator. A
-    // composed map's later compiled layers see moved hidden states and
-    // may legitimately route differently.
-    let overlay_layer = overlay.compiled_layers()[0] as usize;
-    let compiled_set: Vec<usize> = overlay
-        .compiled_layers()
-        .iter()
-        .map(|&l| l as usize)
-        .collect();
-
-    // ── Load both arms; the loader refuses on any missing operand. ──
-    let t1 = Instant::now();
-    let moe_layers: Vec<u32> = (g.dense_prefix_layers..g.num_layers)
-        .map(|l| l as u32)
-        .collect();
-    let registered = model
-        .register_stores(&metal, &moe_layers)
-        .expect("stores register");
-    overlay.register_store(&metal);
-    let mut baseline = build_stack(&metal, &model, None);
-    let mut candidate = build_stack(&metal, &model, Some(&overlay));
-    metal.seal_weight_regions();
-    eprintln!(
-        "[q2a] both arms loaded in {:.1}s ({registered} mmap store regions registered, \
-         implicit residency)",
-        t1.elapsed().as_secs_f64()
+        "[q2a] {} positions, gate {}, verdict {}; report at {}",
+        receipt.verified.positions,
+        receipt.gate.id,
+        if receipt.verdict_passed {
+            "PASS"
+        } else {
+            "FAIL"
+        },
+        receipt.report_path
     );
 
-    // ── Physical attribution: the intended stores are the bound ones,
-    //    at EVERY compiled layer — a composed map earns the check per
-    //    layer, at that layer's own encoding. ──
-    for &probe_layer in &compiled_set {
-        let probe_b = model
-            .device_layer(&metal, probe_layer, None)
-            .expect("baseline probe layer");
-        let probe_c = model
-            .device_layer(&metal, probe_layer, Some(&overlay))
-            .expect("candidate probe layer");
-        // The BASELINE arm is entirely source-backed, whatever the
-        // candidate's scope.
-        for (name, proj) in [
-            ("gate", &probe_b.bank.gate),
-            ("up", &probe_b.bank.up),
-            ("down", &probe_b.bank.down),
-        ] {
-            assert_eq!(
-                proj.store_id(),
-                "kimi-source-expert-bank",
-                "baseline {name}"
-            );
-            assert_eq!(proj.encoding(), ExpertEncoding::Bf16, "baseline {name}");
-        }
-        // The CANDIDATE arm substitutes exactly the projections the
-        // overlay compiled, and leaves the rest source-backed — the
-        // asymmetry a projection-scoped experiment IS.
-        let compiled: Vec<&str> = overlay
-            .compiled_projections()
-            .iter()
-            .map(String::as_str)
-            .collect();
-        assert!(!compiled.is_empty(), "an overlay must compile something");
-        for (name, proj, spelling) in [
-            ("gate", &probe_c.bank.gate, "w1"),
-            ("up", &probe_c.bank.up, "w3"),
-            ("down", &probe_c.bank.down, "w2"),
-        ] {
-            let want_candidate = compiled.contains(&spelling);
-            let (store, enc) = if want_candidate {
-                (
-                    "kimi-candidate-bank",
-                    overlay
-                        .encoding_of(probe_layer as u32)
-                        .expect("the probed layer is compiled"),
-                )
-            } else {
-                ("kimi-source-expert-bank", ExpertEncoding::Bf16)
-            };
-            assert_eq!(proj.store_id(), store, "candidate {name}");
-            assert_eq!(proj.encoding(), enc, "candidate {name}");
-            // A source-backed projection of the candidate arm must be
-            // the SAME BYTES as the baseline's — pointer-identical, so
-            // the only difference between the arms is the compiled one.
-            if !want_candidate {
-                let b = match name {
-                    "gate" => &probe_b.bank.gate,
-                    "up" => &probe_b.bank.up,
-                    _ => &probe_b.bank.down,
-                };
-                assert_eq!(
-                    proj.region.region.bytes().as_ptr(),
-                    b.region.region.bytes().as_ptr(),
-                    "{name} is outside the scope, so both arms must bind one object"
-                );
-            }
-        }
-        for (name, proj) in [
-            ("gate", &probe_c.bank.gate),
-            ("up", &probe_c.bank.up),
-            ("down", &probe_c.bank.down),
-        ] {
-            // Only a COMPILED projection is identity-addressed. A
-            // projection-scoped candidate leaves the others
-            // table-addressed over the source, and that asymmetry
-            // inside one layer is the thing this binding exists to
-            // express.
-            let is_candidate = proj.store_id() == "kimi-candidate-bank";
-            match (&proj.addressing, is_candidate) {
-                (ProjectionAddressing::Identity { experts, .. }, true) => assert_eq!(
-                    *experts, g.experts,
-                    "{name} is compiled, so it addresses EVERY expert by identity — any \
-                     route, including one the baseline never took, resolves"
-                ),
-                (ProjectionAddressing::Table(_), false) => {}
-                (a, c) => panic!("{name}: compiled={c} but addressed by {a:?}"),
-            }
-        }
-        let shared = probe_c
-            .bank
-            .shared
-            .as_ref()
-            .expect("candidate layer keeps its shared expert");
-        assert_eq!(shared.gate.store_id(), "kimi-source-decoder-stack");
-        assert_eq!(shared.gate.encoding, ExpertEncoding::Bf16);
-        // A layer the overlay does NOT compile is the same physical
-        // bytes in both arms — pointer-identical, not merely same-named.
-        // A layer the overlay does NOT compile — the first routed one
-        // outside the compiled set. A composed map may compile a whole
-        // band, so "the one after" is not necessarily source-backed.
-        let neighbour = (g.dense_prefix_layers..g.num_layers)
-            .find(|l| !compiled_set.contains(l))
-            .expect("the neighbour probe needs a routed source-precision layer");
-        let nb = model.device_layer(&metal, neighbour, None).expect("nb");
-        let nc = model
-            .device_layer(&metal, neighbour, Some(&overlay))
-            .expect("nc");
-        assert_eq!(nc.bank.gate.store_id(), "kimi-source-expert-bank");
-        assert_eq!(
-            nb.bank.gate.region.region.bytes().as_ptr(),
-            nc.bank.gate.region.region.bytes().as_ptr(),
-            "layer {neighbour} must be the SAME mapped bytes in both arms"
+    // ── A claim about the GATE, not about the measurement. ──
+    if receipt.bank.positions < 4096 {
+        assert!(
+            !receipt.verdict_passed,
+            "a sub-4096-position bank can never pass this gate"
         );
-        let checked = overlay
-            .verify_reads_match_seals(probe_layer as u32, 16)
-            .expect("the bytes the loader reads must be the bytes the compiler sealed");
-        eprintln!(
-            "[q2a] attribution: {} — compiled projections {:?} from kimi-candidate-bank/{}, \
-             the rest source/BF16 and pointer-identical to the baseline; shared from decoder \
-             stack in both; layer {neighbour} pointer-identical; {checked} compiled operands \
-             hash-match their seals",
-            overlay.scope(),
-            compiled,
-            overlay
-                .encoding_of(probe_layer as u32)
-                .expect("the probed layer is compiled")
-                .name(),
+        assert!(
+            receipt
+                .verdict_failures
+                .iter()
+                .any(|f| f.starts_with(Criterion::Positions.name()) && f.contains("< 4096")),
+            "the refusal must name the positions criterion: {:?}",
+            receipt.verdict_failures
+        );
+        assert!(
+            !receipt
+                .verdict_failures
+                .iter()
+                .any(|f| f.starts_with(Criterion::CoveredMass.name())),
+            "this bank's truncation must be wide enough to judge: {:?}",
+            receipt.verdict_failures
         );
     }
 
-    // ── The null arm: BF16 against itself must be EXACTLY zero. ──
-    let t2 = Instant::now();
-    {
-        let mut null_partner = build_stack(&metal, &model, None);
-        let mut builder = BankBuilder::new();
-        for seq in 0..NULL_SEQUENCES {
-            let rows = sequence_embeddings(&bank_dir, seq, positions_per_seq, g.hidden);
-            let a = run_sequence(&metal, &mut baseline, &rows, g.hidden);
-            let b = run_sequence(&metal, &mut null_partner, &rows, g.hidden);
-            for (pos, ((la, ta), (lb, tb))) in a.into_iter().zip(b).enumerate() {
-                builder.observe(&observation(seq, pos, &la, &ta, &lb, &tb));
-            }
-        }
-        let null_bank = builder.finish();
-        assert_eq!(
-            null_bank.positions,
-            (NULL_SEQUENCES * positions_per_seq) as u64
-        );
-        assert_eq!(
-            null_bank.logits.kl_p99, 0.0,
-            "null arm KL must be exactly zero"
-        );
-        assert_eq!(
-            null_bank.logits.max_logit_delta, 0.0,
-            "null arm logits must be bit-equal"
-        );
-        assert_eq!(null_bank.logits.top1_flips, 0);
-        assert_eq!(null_bank.logits.top10_changes, 0);
-        assert_eq!(null_bank.routing.route_flips, 0);
-        assert_eq!(null_bank.routing.positions_with_route_change, 0);
-        eprintln!(
-            "[q2a] null arm: {} positions, everything exactly zero ({:.1}s)",
-            null_bank.positions,
-            t2.elapsed().as_secs_f64()
-        );
-    }
-
-    // ── The measurement: 32 sequences x 32 teacher-forced positions. ──
-    let t3 = Instant::now();
-    let mut builder = BankBuilder::new();
-    let mut candidate_l1_routed: std::collections::BTreeSet<u32> =
-        std::collections::BTreeSet::new();
-    let mut baseline_l1_routed: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
-    for seq in 0..sequences() {
-        let rows = sequence_embeddings(&bank_dir, seq, positions_per_seq, g.hidden);
-        let base = run_sequence(&metal, &mut baseline, &rows, g.hidden);
-        let cand = run_sequence(&metal, &mut candidate, &rows, g.hidden);
-        for (pos, ((lb, tb), (lc, tc))) in base.into_iter().zip(cand).enumerate() {
-            baseline_l1_routed.extend(tb.routes[overlay_layer].iter().copied());
-            candidate_l1_routed.extend(tc.routes[overlay_layer].iter().copied());
-            builder.observe(&observation(seq, pos, &lb, &tb, &lc, &tc));
-        }
-    }
-    let min_covered = builder.min_covered_mass();
-    let bank = builder.finish();
-    let run_s = t3.elapsed().as_secs_f64();
-    assert_eq!(bank.positions, (sequences() * positions_per_seq) as u64);
-
-    // ── The verdicts. v3 is the frozen authority; v1 and v2 are
-    // reported because every earlier claim in this programme cited
-    // them and a reader needs to compare like with like. ──
-    let evidence = QualityEvidence {
-        gate: requested_gate.clone(),
-        bank: bank.clone(),
-    };
-    let verdict = evidence.verdict();
-    let v1_verdict = kimi_logit_v1().evaluate(&bank);
-    let v2_verdict = kimi_logit_v2().evaluate(&bank);
-
-    // ── The closure report — written BEFORE any verdict assertion, so
-    // a refused run still leaves its evidence on disk. An 8192-position
-    // measurement that panics after the numbers exist and before the
-    // write has destroyed twenty minutes of instrument time; that
-    // happened once and must not happen again. ──
-    //
-    // The bank's identity travels with the report: /tmp has proven
-    // ephemeral, and a verdict whose evidence names no bank cannot be
-    // distinguished from a verdict on a different one.
-    let bank_manifest_sha256 = {
-        use sha2::{Digest, Sha256};
-        let bytes = std::fs::read(bank_dir.join("manifest.json")).expect("bank manifest reads");
-        format!("{:x}", Sha256::digest(&bytes))
-    };
-    let label = request.label.clone();
-    let report = serde_json::json!({
-        "run": label,
-        "gate": evidence.gate,
-        "authority_report": evidence.report(),
-        "verdict_passed": verdict.passed(),
-        "verdict_failures": verdict.failures.iter()
-            .map(|(c, d)| format!("{}: {d}", c.name())).collect::<Vec<_>>(),
-        "verdict_failures_v2": v2_verdict.failures.iter()
-            .map(|(c, d)| format!("{}: {d}", c.name())).collect::<Vec<_>>(),
-        "verdict_failures_v1": v1_verdict.failures.iter()
-            .map(|(c, d)| format!("{}: {d}", c.name())).collect::<Vec<_>>(),
-        "candidate_map": overlay.index.map.name,
-        "candidate_layers": overlay.compiled_layers(),
-        "bank_manifest_sha256": bank_manifest_sha256,
-        "bank": bank,
-        "positions": bank.positions,
-        "sequences": sequences(),
-        "top_n": TOP_N,
-        "min_covered_mass": min_covered,
-        "stores": {
-            "baseline_layer1_routed": "kimi-source-expert-bank (BF16, Table)",
-            "candidate_layer1_routed": format!(
-                "kimi-candidate-bank ({}, Identity)",
-                overlay
-                    .encoding_of(overlay_layer as u32)
-                    .expect("the probed layer is compiled")
-                    .name()
-            ),
-            "shared_experts": "kimi-source-decoder-stack (BF16, both arms)",
-        },
-        "layer1_routed_experts": {
-            "baseline_distinct": baseline_l1_routed.len(),
-            "candidate_distinct": candidate_l1_routed.len(),
-            "candidate_only": candidate_l1_routed.difference(&baseline_l1_routed).count(),
-        },
-        "wall_seconds": run_s,
-    });
-    let path = report_path(&label);
-    std::fs::write(
-        &path,
-        serde_json::to_vec_pretty(&report).expect("serialises"),
+    // ── A claim about `verify_complete`, not about this run: removing
+    //    one compiled operand a candidate route consumed must refuse at
+    //    load rather than fall back to source bytes. ──
+    let overlay = CandidateOverlay::open(
+        &request.candidate,
+        &request.source,
+        &crate::format::vindex3::opplan::exec::kimi_source::KimiSourceModel::open(&request.source)
+            .expect("source opens")
+            .geometry,
     )
-    .expect("report writes");
-
-    if bank.positions < 4096 {
-        // ── The Q2a design run is NON-PROMOTABLE: the gate must refuse
-        // on sample count, whatever the numbers say. ──
-        assert!(
-            !verdict.passed(),
-            "a sub-4096-position bank can never pass kimi-logit-v3"
-        );
-        assert!(
-            verdict
-                .failures
-                .iter()
-                .any(|(c, d)| *c == Criterion::Positions && d.contains("< 4096")),
-            "the refusal must name the positions criterion: {verdict:?}"
-        );
-        assert!(
-            evidence.proven_by().is_none(),
-            "nothing may cite this run as quality proof"
-        );
-        // The coverage criterion is satisfied here, so the refusal is
-        // about sample count and the candidate's own numbers — not
-        // about an instrument that could not see.
-        assert!(
-            !verdict
-                .failures
-                .iter()
-                .any(|(c, _)| *c == Criterion::CoveredMass),
-            "this bank's truncation must be wide enough to judge: {verdict:?}"
-        );
-    }
-    // At promotable scale the verdict IS the product: frozen v3
-    // decides, the report already holds the evidence either way, and a
-    // FAIL is a result — not a harness failure. Nothing is asserted.
-
-    // ── Adversarial no-fallback control: remove ONE compiled operand a
-    //    candidate route actually consumed; the overlay must refuse. ──
-    let touched = *candidate_l1_routed
-        .iter()
-        .next()
-        .expect("the candidate routed at least once");
-    // A projection the overlay ACTUALLY compiled — a scoped candidate
-    // holds one, and naming a projection it left at source would test
-    // nothing but the fixture.
-    let scoped_projection = overlay
-        .compiled_projections()
-        .first()
-        .expect("an overlay compiles at least one projection")
-        .clone();
-    let tensor =
-        format!("{overlay_layer}.block_sparse_moe.experts.{touched}.{scoped_projection}.weight");
-    let mut mutated = overlay.index.clone();
-    let key = mutated
+    .expect("candidate overlay opens");
+    let geometry =
+        crate::format::vindex3::opplan::exec::kimi_source::KimiSourceModel::open(&request.source)
+            .expect("source opens")
+            .geometry;
+    let (key, tensor) = overlay
+        .index
         .ledger
         .sealed
         .iter()
-        .find(|(_, seal)| seal.tensor == tensor)
-        .map(|(k, _)| k.clone())
-        .unwrap_or_else(|| panic!("the routed operand `{tensor}` must have been sealed"));
+        .next()
+        .map(|(k, seal)| (k.clone(), seal.tensor.clone()))
+        .expect("a compiled overlay seals at least one operand");
+    let mut mutated = overlay.index.clone();
     mutated.ledger.sealed.remove(&key);
-    let refusal = verify_complete(&mutated, &g).expect_err(
+    let refusal = verify_complete(&mutated, &geometry).expect_err(
         "an incomplete compiled bank must refuse at load, never fall back to source bytes",
     );
     assert!(
         format!("{refusal}").contains(&tensor),
         "the refusal must name the missing operand: {refusal}"
     );
-    verify_complete(&overlay.index, &g).expect("control: the untouched ledger verifies");
-
-    eprintln!(
-        "[q2a] {} positions in {run_s:.1}s ({:.1} ms/position/arm)",
-        bank.positions,
-        1000.0 * run_s / (2.0 * bank.positions as f64),
-    );
-    eprintln!(
-        "[q2a] kl p50/p95/p99 {:.3e}/{:.3e}/{:.3e}  max|dlogit| {:.3e}  top1 flips {}  \
-         top10 changes {}  (min covered mass {min_covered:.6})",
-        bank.logits.kl_p50,
-        bank.logits.kl_p95,
-        bank.logits.kl_p99,
-        bank.logits.max_logit_delta,
-        bank.logits.top1_flips,
-        bank.logits.top10_changes,
-    );
-    eprintln!(
-        "[q2a] routing: {} flips over {} positions in {} layer(s), FIRST at layer {:?} \
-         (perturbed layer is {overlay_layer}); its expert union baseline {} vs candidate {} \
-         ({} candidate-only)",
-        bank.routing.route_flips,
-        bank.routing.positions_with_route_change,
-        bank.routing.layers_with_route_change,
-        bank.routing.first_layer_with_route_change,
-        baseline_l1_routed.len(),
-        candidate_l1_routed.len(),
-        candidate_l1_routed.difference(&baseline_l1_routed).count(),
-    );
-    // **Severity, not count.** Whether the changed routes were
-    // near-ties the perturbation nudged across, or decisions the router
-    // held with confidence — the difference the flip count cannot show.
-    if let Some(m) = &bank.routing.route_margin {
-        eprintln!(
-            "[q2a] route margins ({} changes): min {:.3e} p50 {:.3e} p95 {:.3e} max {:.3e}",
-            m.count, m.min, m.p50, m.p95, m.max
-        );
-    }
-    if let Some(m) = &bank.routing.route_weight_mass_moved {
-        eprintln!(
-            "[q2a] mixture mass moved: min {:.4} p50 {:.4} p95 {:.4} max {:.4} \
-             (1.0 = the routed mixture replaced outright)",
-            m.min, m.p50, m.p95, m.max
-        );
-    }
-    if let (Some(b), Some(c), Some(m)) = (
-        &bank.top1_margin,
-        &bank.top1_candidate_margin,
-        &bank.top1_mass_displaced,
-    ) {
-        eprintln!(
-            "[q2a] top-1 flips ({}): the margin the BASELINE held its winner by, over the \
-             pair that swapped — p50 {:.3e} max {:.3e}; the candidate's own margin p50 \
-             {:.3e} max {:.3e}; probability given up p50 {:.4} p95 {:.4} max {:.4}",
-            b.count, b.p50, b.max, c.p50, c.max, m.p50, m.p95, m.max
-        );
-    }
-    if let (Some(b), Some(c)) = (&bank.top10_margin, &bank.top10_candidate_margin) {
-        eprintln!(
-            "[q2a] top-10 boundary at the {} changed positions: baseline gap p50 {:.3e} \
-             max {:.3e}; the CANDIDATE's gap at the same two ids p50 {:.3e} max {:.3e}",
-            b.count, b.p50, b.max, c.p50, c.max
-        );
-    }
-    if let (Some(m), Some(r)) = (&bank.top10_mass_displaced, &bank.top10_rank_displacement) {
-        eprintln!(
-            "[q2a] top-10 consequence: mass displaced p50 {:.4} p95 {:.4} max {:.4}; \
-             furthest rank move p50 {:.0} p95 {:.0} max {:.0}",
-            m.p50, m.p95, m.max, r.p50, r.p95, r.max
-        );
-    }
-    // The attribution the shallowest-layer number exists for: a
-    // perturbed layer that keeps its OWN routing while later ones move
-    // is a cascade through the residual stream, not a different
-    // selection at the layer under test.
-    if let Some(first) = bank.routing.first_layer_with_route_change {
-        eprintln!(
-            "[q2a] mechanism: {}",
-            if first as usize > overlay_layer {
-                "CASCADE — the perturbed layer routes identically; later routers see a \
-                 moved hidden state"
-            } else {
-                "LOCAL — the perturbed layer's own expert selection changed"
-            }
-        );
-    }
-    eprintln!("\n{}", evidence.report());
-    eprintln!(
-        "[q2a] verdict: {} (v2 would say: {}; v1: {}) — report at {path}",
-        verdict.describe(),
-        v2_verdict.describe(),
-        v1_verdict.describe()
-    );
+    verify_complete(&overlay.index, &geometry).expect("control: the untouched ledger verifies");
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_teacher_forced.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/q2a_teacher_forced.rs
@@ -46,36 +46,13 @@ use crate::format::vindex3::opplan::exec::stack_metal::{DeviceLayer, HybridStack
 use crate::format::vindex3::represent::bank::{
     BankBuilder, PositionObservation, Top1Change, TopKChange,
 };
+use crate::format::vindex3::represent::measure::TeacherForcedRequest;
 use crate::format::vindex3::represent::physical::{ExpertEncoding, ProjectionAddressing};
 use crate::format::vindex3::represent::quality::{
-    kimi_logit_v1, kimi_logit_v2, kimi_logit_v3, Criterion, QualityEvidence,
+    kimi_logit_v1, kimi_logit_v2, Criterion, QualityEvidence,
 };
 
-pub(super) const SOURCE_ENV: &str = "LARQL_KIMI_VINDEX3";
-pub(super) const CANDIDATE_ENV: &str = "LARQL_KIMI_Q6_CANDIDATE";
-pub(super) const BANK_ENV: &str = "LARQL_KIMI_QUALITY_BANK";
-
-/// Q2a's slice of the exported bank: 32 of the 256 sequences.
-///
-/// Overridable, because SCOPE SEARCH is now the experiment and a
-/// diagnostic that only has to separate "this projection cascades" from
-/// "this one does not" does not need the full slice. Q2a's own headline
-/// run is 32; a projection or depth probe is 8.
-const SEQUENCES_ENV: &str = "LARQL_Q2A_SEQUENCES";
-const SEQUENCES: usize = 32;
-
-fn sequences() -> usize {
-    std::env::var(SEQUENCES_ENV)
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(SEQUENCES)
-}
-
-/// A label for the report, so a sweep's outputs do not overwrite each
-/// other and each names the scope it measured.
-fn run_label() -> String {
-    std::env::var("LARQL_Q2A_LABEL").unwrap_or_else(|_| "q2a".to_string())
-}
+pub(super) use crate::format::vindex3::represent::measure::{BANK_ENV, CANDIDATE_ENV, SOURCE_ENV};
 /// Sequences the null arm re-runs — enough positions for the all-zero
 /// claim to cover real routing variety, cheap enough not to double the
 /// run.
@@ -363,14 +340,26 @@ pub(super) fn run_sequence(
 
 #[test]
 fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
-    let (Some(source_dir), Some(candidate_dir), Some(bank_dir)) = (
-        env_dir(SOURCE_ENV),
-        env_dir(CANDIDATE_ENV),
-        env_dir(BANK_ENV),
-    ) else {
+    // **The environment form is an ADAPTER.** It builds the request a
+    // prepared experiment would build and runs nothing of its own, so
+    // there is one procedure rather than an env path and a direct path
+    // that could drift.
+    let Some(request) = TeacherForcedRequest::from_env() else {
         eprintln!("skipped: set {SOURCE_ENV}, {CANDIDATE_ENV} and {BANK_ENV}");
         return;
     };
+    // Refused before anything is loaded: an unknown gate, an empty
+    // slice, a missing artifact. The gate is RESOLVED here and used
+    // below — the runner no longer holds one.
+    let requested_gate = request
+        .admit()
+        .expect("the request names what this build performs");
+    let (source_dir, candidate_dir, bank_dir) = (
+        request.source.clone(),
+        request.candidate.clone(),
+        request.quality_bank.clone(),
+    );
+    let sequences = || request.sequences;
     // The residency SET would try to wire ~94 GB of expert bank, past
     // the wired-collector wall (~45 GB). This run uses registered
     // regions under IMPLICIT residency; refusing is better than
@@ -627,7 +616,7 @@ fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
     // reported because every earlier claim in this programme cited
     // them and a reader needs to compare like with like. ──
     let evidence = QualityEvidence {
-        gate: kimi_logit_v3(),
+        gate: requested_gate.clone(),
         bank: bank.clone(),
     };
     let verdict = evidence.verdict();
@@ -648,7 +637,7 @@ fn q2a_teacher_forced_quality_bank_runs_and_the_gate_refuses_on_positions() {
         let bytes = std::fs::read(bank_dir.join("manifest.json")).expect("bank manifest reads");
         format!("{:x}", Sha256::digest(&bytes))
     };
-    let label = run_label();
+    let label = request.label.clone();
     let report = serde_json::json!({
         "run": label,
         "gate": evidence.gate,

--- a/crates/larql-vindex/src/format/vindex3/represent/measure.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure.rs
@@ -1,0 +1,242 @@
+//! **What a measurement run is asked to do — as data, not as
+//! environment.**
+//!
+//! Stage 4/4b closed the read path: a stored record derives what
+//! experiment should run next. Stage 5 is the authority to CAUSE that
+//! experiment, and it has a precondition nothing had checked:
+//!
+//! > **A prepared experiment must not describe a run more precisely
+//! > than the executor can be instructed to perform.**
+//!
+//! The teacher-forced runner violated it. Its gate was a literal —
+//! `kimi_logit_v3()` — while an optimiser record declares
+//! `kimi-logit-balanced-v1`; its slice was an environment variable
+//! read at the point of use; its label the same. Sealing those fields
+//! into a `PreparedExperimentId` would have attested to DECLARED
+//! INTENT and not to caused execution, which is the accounting
+//! declaration-versus-procedure gap (4b-c) one level up:
+//!
+//! ```text
+//! declared   the experiment's gate, slice, label
+//! held       a name beside a run that read a constant
+//! missing    an executor that CONSUMES them
+//! ```
+//!
+//! So the request comes first. Every control is a field, resolved by
+//! name and refused when unknown; the environment form becomes an
+//! ADAPTER that builds one, not a second way to run.
+//!
+//! ```text
+//! environment variables  ─┐
+//!                         ├─→ TeacherForcedRequest ─→ one procedure
+//! a prepared experiment  ─┘
+//! ```
+//!
+//! One path, so "the env invocation and the direct invocation agree"
+//! is true by construction rather than by a comparison that needs a
+//! 48 B model to run.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::quality::{gate_by_id, QualityGate};
+use crate::error::VindexError;
+
+/// The procedure this request names.
+///
+/// One variant today. Written as an enum so a second measurement
+/// procedure arrives as a visible schema change rather than as a
+/// caller's assumption, and so a record naming a procedure this build
+/// does not implement is refused rather than run under whichever one
+/// happened to be compiled in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MeasurementProcedure {
+    /// Two arms through the real stack over a teacher-forced corpus:
+    /// baseline from the source container, candidate from an overlay.
+    TeacherForcedTwoArm,
+}
+
+/// The name `MeasurementProcedure::TeacherForcedTwoArm` answers to.
+pub const TEACHER_FORCED_TWO_ARM: &str = "teacher-forced-two-arm/v1";
+
+impl MeasurementProcedure {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::TeacherForcedTwoArm => TEACHER_FORCED_TWO_ARM,
+        }
+    }
+
+    /// Resolve a declared procedure, refusing what this build cannot
+    /// perform. The same discipline as `layout_admission` and
+    /// `compiled_bytes`: a record names it, this resolves it, nothing
+    /// defaults.
+    pub fn by_name(name: &str) -> Result<Self, VindexError> {
+        match name {
+            TEACHER_FORCED_TWO_ARM => Ok(Self::TeacherForcedTwoArm),
+            other => Err(VindexError::Parse(format!(
+                "no measurement procedure named `{other}` is implemented by this build — a \
+                 run under another procedure would produce a reading nobody asked for"
+            ))),
+        }
+    }
+}
+
+/// **Everything a teacher-forced run is instructed with.**
+///
+/// Paths are where the artifacts are; every other field is a CONTROL,
+/// and each one has to change the run or it does not belong here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeacherForcedRequest {
+    pub procedure: MeasurementProcedure,
+    /// The container the baseline arm is loaded from.
+    pub source: PathBuf,
+    /// The compiled overlay the candidate arm substitutes.
+    pub candidate: PathBuf,
+    /// The exported teacher-forced corpus.
+    pub quality_bank: PathBuf,
+    /// How many of the corpus's sequences to consume.
+    ///
+    /// Part of the evidence bank's IDENTITY, not a convenience: a
+    /// 32-sequence and a 256-sequence reading share a manifest hash
+    /// while being different experiments — the difference between a
+    /// diagnostic and an authority (1c).
+    pub sequences: usize,
+    /// The gate the verdict is drawn under, BY NAME.
+    ///
+    /// Resolved through `gate_by_id`, which refuses an unknown name.
+    /// The runner used to hold a literal here, so a record could
+    /// declare one gate and the run be judged by another.
+    pub gate: String,
+    /// Names the run's report, so a sweep's outputs do not overwrite
+    /// each other. The one field that is not a control — it changes
+    /// where evidence lands and nothing about what is measured.
+    pub label: String,
+}
+
+/// Environment variables the adapter reads. Named here so the adapter
+/// and its test cannot disagree about the spelling.
+pub const SOURCE_ENV: &str = "LARQL_KIMI_VINDEX3";
+pub const CANDIDATE_ENV: &str = "LARQL_KIMI_Q6_CANDIDATE";
+pub const BANK_ENV: &str = "LARQL_KIMI_QUALITY_BANK";
+pub const SEQUENCES_ENV: &str = "LARQL_Q2A_SEQUENCES";
+pub const LABEL_ENV: &str = "LARQL_Q2A_LABEL";
+pub const GATE_ENV: &str = "LARQL_Q2A_GATE";
+
+/// Q2a's slice of the exported bank when none is named: 32 of 256.
+pub const DEFAULT_SEQUENCES: usize = 32;
+/// The gate the teacher-forced runner has always judged by.
+///
+/// A default the ADAPTER applies, so the historic command line keeps
+/// meaning what it meant. It is not a fallback inside the procedure:
+/// the request always carries a name, and an unnamed one never reaches
+/// the run.
+pub const DEFAULT_GATE: &str = "kimi-logit-v3";
+pub const DEFAULT_LABEL: &str = "q2a";
+
+impl TeacherForcedRequest {
+    /// Build a request directly — the form a prepared experiment uses.
+    pub fn new(
+        source: impl Into<PathBuf>,
+        candidate: impl Into<PathBuf>,
+        quality_bank: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            procedure: MeasurementProcedure::TeacherForcedTwoArm,
+            source: source.into(),
+            candidate: candidate.into(),
+            quality_bank: quality_bank.into(),
+            sequences: DEFAULT_SEQUENCES,
+            gate: DEFAULT_GATE.to_string(),
+            label: DEFAULT_LABEL.to_string(),
+        }
+    }
+
+    pub fn with_sequences(mut self, sequences: usize) -> Self {
+        self.sequences = sequences;
+        self
+    }
+
+    pub fn with_gate(mut self, gate: impl Into<String>) -> Self {
+        self.gate = gate.into();
+        self
+    }
+
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = label.into();
+        self
+    }
+
+    /// **The environment form, as an ADAPTER.**
+    ///
+    /// `None` when the three artifact paths are not all set, which is
+    /// how the in-crate runner has always skipped without a model. It
+    /// builds the same request a caller would and runs nothing itself,
+    /// so there is one procedure and not two.
+    pub fn from_env() -> Option<Self> {
+        Self::from_vars(|var| std::env::var(var).ok())
+    }
+
+    /// The adapter's whole behaviour, over a lookup rather than the
+    /// process environment.
+    ///
+    /// Separated so it can be tested without `set_var`, which races
+    /// against every other test in the binary — the environment is
+    /// process-global and the harness runs in parallel. A test that
+    /// mutated it would be measuring scheduling.
+    pub fn from_vars(lookup: impl Fn(&str) -> Option<String>) -> Option<Self> {
+        let (source, candidate, quality_bank) = (
+            lookup(SOURCE_ENV)?,
+            lookup(CANDIDATE_ENV)?,
+            lookup(BANK_ENV)?,
+        );
+        Some(
+            Self::new(source, candidate, quality_bank)
+                .with_sequences(
+                    lookup(SEQUENCES_ENV)
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(DEFAULT_SEQUENCES),
+                )
+                .with_gate(lookup(GATE_ENV).unwrap_or_else(|| DEFAULT_GATE.into()))
+                .with_label(lookup(LABEL_ENV).unwrap_or_else(|| DEFAULT_LABEL.into())),
+        )
+    }
+
+    /// The gate this request is judged under, or a refusal naming it.
+    pub fn resolve_gate(&self) -> Result<QualityGate, VindexError> {
+        gate_by_id(&self.gate)
+    }
+
+    /// Refuse a request this build cannot perform, before anything is
+    /// loaded.
+    ///
+    /// Cheap checks only, and deliberately so: what remains — that the
+    /// bank was exported for this model, that the overlay compiles
+    /// something, that both arms bind the bytes they claim — needs the
+    /// artifacts open, and belongs to the run rather than to the
+    /// request.
+    pub fn admit(&self) -> Result<QualityGate, VindexError> {
+        MeasurementProcedure::by_name(self.procedure.name())?;
+        if self.sequences == 0 {
+            return Err(VindexError::Parse(
+                "a measurement over zero sequences has no positions, and a gate that judges \
+                 on tail statistics would be reading an empty distribution"
+                    .into(),
+            ));
+        }
+        for (what, path) in [
+            ("source", &self.source),
+            ("candidate", &self.candidate),
+            ("quality bank", &self.quality_bank),
+        ] {
+            if !Path::new(path).exists() {
+                return Err(VindexError::Parse(format!(
+                    "the {what} at `{}` is not there — a run cannot be prepared against an \
+                     artifact that does not exist",
+                    path.display()
+                )));
+            }
+        }
+        self.resolve_gate()
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/measure/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure/mod.rs
@@ -37,6 +37,39 @@
 //! 48 B model to run.
 
 pub mod outcome;
+#[cfg(all(feature = "gpu", target_os = "macos"))]
+pub mod teacher_forced;
+
+#[cfg(not(all(feature = "gpu", target_os = "macos")))]
+use outcome::ExecutionFailure;
+use outcome::MeasurementRefusal;
+
+/// **Run the procedure a request names, or refuse because this binary
+/// cannot.**
+///
+/// The teacher-forced runner needs Metal and macOS, so on any other
+/// build it does not exist. That absence must reach a caller as a
+/// REFUSAL and not as a compile-time hole: `PreparedExperiment` has to
+/// decide whether something is executable on the machine in front of
+/// it, and "the symbol is missing" is not an answer it can act on.
+#[cfg(all(feature = "gpu", target_os = "macos"))]
+pub fn run(
+    request: &TeacherForcedRequest,
+) -> Result<teacher_forced::MeasurementReceipt, MeasurementRefusal> {
+    teacher_forced::measure_teacher_forced(request)
+}
+
+/// The same entry point on a build that cannot perform it.
+#[cfg(not(all(feature = "gpu", target_os = "macos")))]
+pub fn run(request: &TeacherForcedRequest) -> Result<(), MeasurementRefusal> {
+    Err(ExecutionFailure::BackendUnavailable {
+        detail: format!(
+            "`{}` needs a macOS build with the `gpu` feature, and this binary is neither",
+            request.procedure.name()
+        ),
+    }
+    .into())
+}
 
 use std::path::{Path, PathBuf};
 

--- a/crates/larql-vindex/src/format/vindex3/represent/measure/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure/mod.rs
@@ -36,6 +36,8 @@
 //! is true by construction rather than by a comparison that needs a
 //! 48 B model to run.
 
+pub mod outcome;
+
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};

--- a/crates/larql-vindex/src/format/vindex3/represent/measure/outcome.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure/outcome.rs
@@ -73,7 +73,11 @@
 //! 535            neighbour pointer identity       Inadmissible::ProtectedOperandChanged
 //! 506,512        identity vs table addressing     Inadmissible::AddressingMismatch
 //! 542            reads match seals                Inadmissible::SealMismatch
-//! 741            the routed operand was sealed    Inadmissible::OperandNotSealed
+//! 741            the routed operand was sealed    STAYS IN THE TEST — it is how the
+//!                                                 operand-removal control FINDS a seal to
+//!                                                 remove, not a condition of the run. The
+//!                                                 audit caught this: the variant the first
+//!                                                 inventory assigned here went unused.
 //! 571,613        position counts                  Inadmissible::PositionCountMismatch
 //! 575,579,583-6  the null arm is exactly zero     Inadmissible::NullArmNotZero
 //! (5a-0a)        the gate evaluated is the one
@@ -198,8 +202,6 @@ pub enum Inadmissible {
     /// `verify_reads_match_seals`. Without it, "the candidate" is
     /// whatever is on disk under a path the overlay names.
     SealMismatch { layer: u32, detail: String },
-    /// A routed operand carries no seal to check against.
-    OperandNotSealed { tensor: String },
     /// The bank does not hold the positions the request asked for.
     ///
     /// `assert_eq!(bank.positions, sequences * positions_per_seq)`. A

--- a/crates/larql-vindex/src/format/vindex3/represent/measure/outcome.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure/outcome.rs
@@ -1,0 +1,243 @@
+//! **Execution failure is not validity failure.**
+//!
+//! The teacher-forced runner is not a benchmark with some assertions
+//! around it. Reading it, it is five claims at once:
+//!
+//! ```text
+//! measurement
+//! + candidate-scope proof
+//! + physical-attribution proof
+//! + non-candidate identity proof
+//! + seal/read consistency proof
+//! ```
+//!
+//! which is why extracting "the part that computes KL" would be
+//! dangerous: the numbers are computable without any of the other four,
+//! and would look exactly the same.
+//!
+//! As a `#[cfg(test)]` harness those four were `assert!`, and a test
+//! runner turned a violation into a red test. A CALLABLE procedure has
+//! no test runner, so each becomes a typed refusal — and the two kinds
+//! must not be confused:
+//!
+//! ```text
+//! ExecutionFailure    nothing was measured
+//!                     retry, fix the machine, open the file
+//!
+//! Inadmissible        numbers may exist and are NOT evidence
+//!                     the run happened and proved nothing
+//! ```
+//!
+//! An agent told only "it failed" would retry the second class forever.
+//! An agent told "the candidate arm read bytes outside its sealed
+//! scope" knows the experiment was mis-prepared, not unlucky.
+//!
+//! # Every variant is a check that exists
+//!
+//! Nothing here is anticipated. Each one is a condition
+//! `q2a_teacher_forced` asserts today, and each variant's doc names
+//! what it was. That is the foreign reference: the vocabulary is
+//! derived from a harness that has produced real Rung 4/5 verdicts,
+//! not designed against an imagined one.
+
+use serde::{Deserialize, Serialize};
+
+/// The run could not be performed. Nothing was measured.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExecutionFailure {
+    /// No Metal device. On macOS the shader library failed to build;
+    /// elsewhere there is no backend at all.
+    BackendUnavailable { detail: String },
+    /// A named artifact would not open.
+    ArtifactUnreadable {
+        what: String,
+        path: String,
+        detail: String,
+    },
+    /// A layer did not load with zero missing operands.
+    ///
+    /// `build_stack` panics here: *"layer {i} must load with zero
+    /// missing operands"*. A partly-loaded arm is not a cheaper arm, it
+    /// is a different model.
+    LayerIncomplete { layer: usize, detail: String },
+    /// The stack ends on a device layer, so the head must attach.
+    HeadDidNotAttach,
+    /// A teacher-forced step refused mid-sequence.
+    StepRefused {
+        sequence: usize,
+        position: usize,
+        detail: String,
+    },
+}
+
+/// The run happened and its numbers are not admissible evidence.
+///
+/// The distinction that matters: every one of these can occur with a
+/// complete, plausible-looking set of logits already computed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Inadmissible {
+    /// The residency SET would wire ~94 GB of expert bank, past the
+    /// wired-collector wall (~45 GB), and the run would degrade into a
+    /// measurement of the collector rather than of the representation.
+    ///
+    /// The harness panics on `LARQL_RESIDENCY_SET` for exactly this.
+    ResidencyModeWouldBeMeasured { detail: String },
+    /// The corpus was exported for a different model.
+    ///
+    /// `assert_eq!(g.hidden, bank_hidden, "the bank was exported for
+    /// this model")`. Teacher-forced rows of the wrong width are not a
+    /// smaller experiment; they are a different one.
+    CorpusNotForThisModel {
+        corpus_hidden: usize,
+        model_hidden: usize,
+    },
+    /// The overlay compiles nothing, so the two arms are one arm and
+    /// the changed variable does not exist.
+    CandidateCompilesNothing,
+    /// An arm bound a store or encoding it was not supposed to.
+    ///
+    /// Covers both directions the harness checks per compiled layer:
+    /// the BASELINE must be entirely source-backed at BF16 whatever the
+    /// candidate's scope, and the CANDIDATE must substitute exactly the
+    /// projections the overlay compiled and leave the rest
+    /// source-backed.
+    UnexpectedPhysicalRead {
+        arm: String,
+        layer: usize,
+        projection: String,
+        expected_store: String,
+        actual_store: String,
+    },
+    /// A projection OUTSIDE the candidate's scope was not the same
+    /// bytes in both arms.
+    ///
+    /// The harness compares `region.bytes().as_ptr()` — pointer-
+    /// identical, not merely same-named — because the only difference
+    /// between the arms must be the compiled one.
+    ProtectedOperandChanged { layer: usize, projection: String },
+    /// A compiled projection was not identity-addressed over every
+    /// expert, or an uncompiled one was not table-addressed.
+    ///
+    /// A compiled projection must resolve ANY route, including one the
+    /// baseline never took; a projection-scoped candidate leaves the
+    /// others table-addressed over the source, and that asymmetry
+    /// inside one layer is what the binding exists to express.
+    AddressingMismatch {
+        layer: usize,
+        projection: String,
+        detail: String,
+    },
+    /// The bytes the loader read are not the bytes the compiler sealed.
+    ///
+    /// `verify_reads_match_seals`. Without it, "the candidate" is
+    /// whatever is on disk under a path the overlay names.
+    SealMismatch { layer: u32, detail: String },
+    /// A routed operand carries no seal to check against.
+    OperandNotSealed { tensor: String },
+    /// The bank does not hold the positions the request asked for.
+    ///
+    /// `assert_eq!(bank.positions, sequences * positions_per_seq)`. A
+    /// gate judging on tail statistics over a different position count
+    /// is judging a different experiment (1c).
+    PositionCountMismatch { expected: u64, measured: u64 },
+    /// The verdict was drawn under a gate other than the requested one.
+    ///
+    /// The defect 5a-0a closed structurally, kept here because a
+    /// receipt must be able to SAY it rather than rely on the code
+    /// still being right.
+    GateMismatch {
+        requested: String,
+        evaluated: String,
+    },
+}
+
+/// Why a measurement produced no admissible reading.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MeasurementRefusal {
+    Execution(ExecutionFailure),
+    Inadmissible(Inadmissible),
+}
+
+impl MeasurementRefusal {
+    /// Whether anything was measured at all.
+    ///
+    /// The question an agent needs answered before deciding to retry:
+    /// an execution failure may succeed next time, and an inadmissible
+    /// run produces the same non-evidence however often it is repeated.
+    pub fn nothing_was_measured(&self) -> bool {
+        matches!(self, Self::Execution(_))
+    }
+
+    /// Whether repeating this run unchanged could produce evidence.
+    pub fn worth_retrying(&self) -> bool {
+        self.nothing_was_measured()
+    }
+}
+
+impl std::fmt::Display for MeasurementRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Execution(e) => write!(f, "the run could not be performed: {e:?}"),
+            Self::Inadmissible(i) => write!(
+                f,
+                "the run produced numbers that are not admissible evidence: {i:?}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MeasurementRefusal {}
+
+impl From<ExecutionFailure> for MeasurementRefusal {
+    fn from(e: ExecutionFailure) -> Self {
+        Self::Execution(e)
+    }
+}
+
+impl From<Inadmissible> for MeasurementRefusal {
+    fn from(i: Inadmissible) -> Self {
+        Self::Inadmissible(i)
+    }
+}
+
+/// **What was checked, recorded rather than asserted.**
+///
+/// The other half of turning assertions into a contract: a condition
+/// that merely fails loudly leaves no trace when it passes, and a
+/// receipt that cannot say what it verified is indistinguishable from
+/// one that verified nothing.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct VerifiedFacts {
+    /// Layers the overlay compiles, as the run observed them.
+    pub compiled_layers: Vec<u32>,
+    /// Projections the overlay compiles, in the container's spelling.
+    pub compiled_projections: Vec<String>,
+    /// Compiled layers at which both arms were checked to bind the
+    /// stores they claimed.
+    pub attribution_checked_layers: Vec<usize>,
+    /// Operands whose read bytes hash-matched their seals.
+    pub seal_checked_operands: usize,
+    /// A routed layer OUTSIDE the compiled set, checked to be
+    /// pointer-identical in both arms.
+    pub invariant_neighbour_layer: Option<usize>,
+    /// Positions actually measured.
+    pub positions: u64,
+    /// The gate the verdict was drawn under, as evaluated.
+    pub gate_evaluated: String,
+}
+
+impl VerifiedFacts {
+    /// Whether this run checked everything an admissible reading needs.
+    ///
+    /// Explicit rather than a count: a run that verified four of five
+    /// conditions has not verified 80% of anything.
+    pub fn complete(&self) -> bool {
+        !self.compiled_layers.is_empty()
+            && !self.compiled_projections.is_empty()
+            && self.attribution_checked_layers.len() == self.compiled_layers.len()
+            && self.seal_checked_operands > 0
+            && self.invariant_neighbour_layer.is_some()
+            && self.positions > 0
+            && !self.gate_evaluated.is_empty()
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/measure/outcome.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure/outcome.rs
@@ -40,6 +40,72 @@
 //! derived from a harness that has produced real Rung 4/5 verdicts,
 //! not designed against an imagined one.
 
+//! # The conservation inventory
+//!
+//! The compiler cannot tell whether a check got WEAKER, so the move of
+//! the harness body into a callable procedure is specified here first.
+//! Every assertion site in `q2a_teacher_forced`'s test function is
+//! listed with where its authority goes, and the review question
+//! becomes *where did each one go* rather than *does the new function
+//! look equivalent*.
+//!
+//! ```text
+//! harness site   what it asserts                  new authority
+//! ────────────────────────────────────────────────────────────────────
+//! 372            Metal present                    ExecutionFailure::BackendUnavailable
+//! 378-9,384,391  artifacts open and parse         ExecutionFailure::ArtifactUnreadable
+//! 416            stores register                  ExecutionFailure::ArtifactUnreadable
+//! 294 (helper)   layer loads, zero missing        ExecutionFailure::LayerIncomplete
+//! 308 (helper)   head attaches                    ExecutionFailure::HeadDidNotAttach
+//! 267 (helper)   sequence file reads, right size  ExecutionFailure::ArtifactUnreadable
+//! 338 (helper)   the step does not refuse         ExecutionFailure::StepRefused
+//! 433,436        probe layers load                ExecutionFailure::LayerIncomplete
+//! 530,533        neighbour probes load            ExecutionFailure::LayerIncomplete
+//!
+//! 368            LARQL_RESIDENCY_SET unset        Inadmissible::ResidencyModeWouldBeMeasured
+//! 386            bank hidden == model hidden      Inadmissible::CorpusNotForThisModel
+//! 459            the overlay compiles something   Inadmissible::CandidateCompilesNothing
+//! 444,449        baseline is source-backed BF16   Inadmissible::UnexpectedPhysicalRead
+//! 476,477        candidate matches its scope      Inadmissible::UnexpectedPhysicalRead
+//! 520,521        shared expert from the stack     Inadmissible::UnexpectedPhysicalRead
+//! 534            neighbour is source-backed       Inadmissible::UnexpectedPhysicalRead
+//! 487            out-of-scope pointer identity    Inadmissible::ProtectedOperandChanged
+//! 535            neighbour pointer identity       Inadmissible::ProtectedOperandChanged
+//! 506,512        identity vs table addressing     Inadmissible::AddressingMismatch
+//! 542            reads match seals                Inadmissible::SealMismatch
+//! 741            the routed operand was sealed    Inadmissible::OperandNotSealed
+//! 571,613        position counts                  Inadmissible::PositionCountMismatch
+//! 575,579,583-6  the null arm is exactly zero     Inadmissible::NullArmNotZero
+//! (5a-0a)        the gate evaluated is the one
+//!                requested                        Inadmissible::GateMismatch
+//!
+//! 391,459,471    which layers/projections         VerifiedFacts::compiled_layers,
+//!                the overlay compiles             VerifiedFacts::compiled_projections
+//! 430-521        per-layer attribution done       VerifiedFacts::attribution_checked_layers
+//! 542            operands whose reads matched     VerifiedFacts::seal_checked_operands
+//! 529            the invariant neighbour          VerifiedFacts::invariant_neighbour_layer
+//! 613            positions measured               VerifiedFacts::positions
+//! 630            the gate evaluated               VerifiedFacts::gate_evaluated
+//!
+//! 688-706        a sub-4096 bank cannot pass      STAYS IN THE TEST. A claim about the
+//!                                                 GATE, already enforced by
+//!                                                 `QualityGate::evaluate`, not a validity
+//!                                                 condition of the measurement.
+//! 723-750        removing a sealed operand makes  STAYS IN THE TEST. A claim about
+//!                `verify_complete` refuse         `verify_complete`, not about this run.
+//! ```
+//!
+//! Two sites are deliberately NOT production authority, and saying so
+//! is part of the inventory: a check that moves for tidiness is as lost
+//! as one that vanishes.
+//!
+//! **The inventory has already earned itself.** `NullArmNotZero` is
+//! absent from the first pass of this vocabulary, which was written
+//! after reading the harness once. Walking it assertion by assertion
+//! found it — and it is the most dangerous condition in the set,
+//! because a non-deterministic device yields a plausible KL that is
+//! entirely artifact while every other check still passes.
+
 use serde::{Deserialize, Serialize};
 
 /// The run could not be performed. Nothing was measured.
@@ -74,7 +140,7 @@ pub enum ExecutionFailure {
 ///
 /// The distinction that matters: every one of these can occur with a
 /// complete, plausible-looking set of logits already computed.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Inadmissible {
     /// The residency SET would wire ~94 GB of expert bank, past the
     /// wired-collector wall (~45 GB), and the run would degrade into a
@@ -140,6 +206,21 @@ pub enum Inadmissible {
     /// gate judging on tail statistics over a different position count
     /// is judging a different experiment (1c).
     PositionCountMismatch { expected: u64, measured: u64 },
+    /// The baseline arm compared against ITSELF was not exactly zero.
+    ///
+    /// The determinism control, and the one the first pass of this
+    /// vocabulary missed — found by walking the harness assertion by
+    /// assertion rather than by reasoning about what it "should"
+    /// check. `assert_eq!(null_bank.logits.kl_p99, 0.0, "null arm KL
+    /// must be exactly zero")`, plus bit-equal logits and zero flips
+    /// and route changes.
+    ///
+    /// It is the most dangerous condition in the list: a
+    /// non-deterministic device produces a plausible KL that is
+    /// entirely artifact, and every other check here would still pass.
+    /// Metal decode non-determinism has been a real defect on this
+    /// stack before.
+    NullArmNotZero { statistic: String, observed: f64 },
     /// The verdict was drawn under a gate other than the requested one.
     ///
     /// The defect 5a-0a closed structurally, kept here because a
@@ -152,7 +233,7 @@ pub enum Inadmissible {
 }
 
 /// Why a measurement produced no admissible reading.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum MeasurementRefusal {
     Execution(ExecutionFailure),
     Inadmissible(Inadmissible),

--- a/crates/larql-vindex/src/format/vindex3/represent/measure/teacher_forced.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure/teacher_forced.rs
@@ -1,0 +1,927 @@
+//! **The teacher-forced quality runner** — two arms through the real
+//! mixed Metal stack, loaded from the source VINDEX3 container itself:
+//!
+//! ```text
+//! baseline    every routed layer   -> source expert_bank   (BF16, Table)
+//! candidate   the overlay's layers -> compiled banks       (Identity,
+//!             each at its map's encoding — Q8_0, Q6_K, or a composed
+//!             map holding several layers at different encodings)
+//!             everything else      -> the SAME source stores
+//! ```
+//!
+//! The changed variable is exactly the candidate's compiled scope:
+//! source BF16 bytes vs the persistent bytes the compiler sealed.
+//! Router, norms, attention, shared experts, state initialisation and
+//! the teacher-forced token prefix are identical by construction — and
+//! asserted, not assumed, per compiled layer.
+//!
+//! **The verdict semantics follow scale.** Below `positions_min` (4096)
+//! this is a DIAGNOSTIC: the gate must refuse on positions however
+//! flattering the numbers, and the harness asserts that refusal. At
+//! 8192 (`LARQL_Q2A_SEQUENCES=256`) the verdict IS the product — frozen
+//! `kimi-logit-v3` decides, the report is written BEFORE any verdict
+//! assertion, and a FAIL is a result, not a harness failure.
+//!
+//! ```text
+//! LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.aligned.vindex3 \
+//! LARQL_KIMI_Q6_CANDIDATE=/tmp/kimi-q80-l25.vindex3 \
+//! LARQL_KIMI_QUALITY_BANK=/tmp/kimi_quality_bank \
+//! LARQL_Q2A_SEQUENCES=8 LARQL_Q2A_LABEL=q80-l25 \
+//!   cargo test -p larql-vindex --features gpu --release --lib q2a_teacher_forced -- --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use larql_compute::backend::ComputeBackend;
+use larql_compute_metal::trait_impl::kimi_layer::ExecutionTrace;
+use larql_compute_metal::MetalBackend;
+use serde_json::Value;
+
+use crate::format::vindex3::opplan::exec::kimi_source::{CandidateOverlay, KimiSourceModel};
+use crate::format::vindex3::opplan::exec::stack::{LayerSpec, LayerState};
+use crate::format::vindex3::opplan::exec::stack_metal::{DeviceLayer, HybridStack};
+use crate::format::vindex3::represent::bank::{
+    BankBuilder, PositionObservation, Top1Change, TopKChange,
+};
+use crate::format::vindex3::represent::measure::outcome::{
+    ExecutionFailure, Inadmissible, MeasurementRefusal, VerifiedFacts,
+};
+use crate::format::vindex3::represent::measure::TeacherForcedRequest;
+use crate::format::vindex3::represent::physical::{ExpertEncoding, ProjectionAddressing};
+use crate::format::vindex3::represent::quality::QualityBank;
+use crate::format::vindex3::represent::quality::{
+    kimi_logit_v1, kimi_logit_v2, QualityEvidence, QualityGate,
+};
+
+/// The stores an arm may bind, by the id the loader registers them
+/// under. Named, because an attribution refusal that compared string
+/// literals would be one typo away from never firing.
+const SOURCE_EXPERT_BANK: &str = "kimi-source-expert-bank";
+const CANDIDATE_BANK: &str = "kimi-candidate-bank";
+const SOURCE_DECODER_STACK: &str = "kimi-source-decoder-stack";
+
+/// **What a completed measurement produced, and what it verified.**
+///
+/// The verdict travels as a recorded fact rather than as authority:
+/// this says what the gate decided, and promotion remains the
+/// optimiser's to derive. Execution establishes *experiment X produced
+/// observation Y*, never *therefore Y is preferred*.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct MeasurementReceipt {
+    /// The request as performed, so a receipt names its own experiment.
+    pub request: TeacherForcedRequest,
+    /// The gate actually evaluated — checked against the request.
+    pub gate: QualityGate,
+    /// Every validity condition this run checked.
+    pub verified: VerifiedFacts,
+    pub bank: QualityBank,
+    pub min_covered_mass: f64,
+    pub wall_seconds: f64,
+    /// Where the closure report was written, before any verdict was
+    /// drawn: a refused run still leaves its evidence on disk.
+    pub report_path: String,
+    pub verdict_passed: bool,
+    pub verdict_failures: Vec<String>,
+}
+
+impl MeasurementReceipt {
+    /// Whether this reading may enter the evidence system.
+    ///
+    /// NOT whether it passed. A refused candidate that was measured
+    /// correctly is admissible evidence of a refusal; a passing
+    /// candidate whose run skipped a validity check is not evidence of
+    /// anything.
+    pub fn qualifies(&self) -> bool {
+        self.verified.complete()
+    }
+}
+
+pub use crate::format::vindex3::represent::measure::{BANK_ENV, CANDIDATE_ENV, SOURCE_ENV};
+/// Sequences the null arm re-runs — enough positions for the all-zero
+/// claim to cover real routing variety, cheap enough not to double the
+/// run.
+const NULL_SEQUENCES: usize = 4;
+/// Baseline top-N kept per position. KL is exact on the mass these
+/// carry; the minimum covered mass is reported so a too-flat position
+/// announces itself.
+///
+/// 128 covered only 31 % of the baseline's mass at the worst position
+/// of the first run — a teacher-forced sequence's FIRST position has no
+/// context, so its distribution is close to flat over 163,840 ids and a
+/// short truncation sees almost none of it. Widening costs nothing
+/// measurable (the rank sort already runs for argmax and top-10) and
+/// buys a KL that is exact on most of the distribution instead of a
+/// third of it.
+const TOP_N: usize = 2048;
+/// Where the machine-readable closure reports are written, one per
+/// labelled run.
+fn report_path(label: &str) -> String {
+    format!("/tmp/kimi_{label}_report.json")
+}
+
+pub fn env_dir(var: &str) -> Option<PathBuf> {
+    std::env::var_os(var).map(PathBuf::from)
+}
+
+fn logsumexp(v: &[f32]) -> f32 {
+    let m = v.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    m + v.iter().map(|x| (x - m).exp()).sum::<f32>().ln()
+}
+
+fn argmax(v: &[f32]) -> usize {
+    v.iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).expect("logits are never NaN"))
+        .expect("non-empty")
+        .0
+}
+
+fn top_k_ids(logits: &[f32], k: usize) -> Vec<usize> {
+    let mut idx: Vec<usize> = (0..logits.len()).collect();
+    idx.sort_unstable_by(|&a, &b| {
+        logits[b]
+            .partial_cmp(&logits[a])
+            .expect("logits are never NaN")
+            .then(a.cmp(&b))
+    });
+    idx.truncate(k);
+    idx
+}
+
+/// One position's paired measurement, from both arms' full logit
+/// vectors, traced routes, and the router's own scores.
+#[allow(clippy::too_many_arguments)]
+pub fn observation(
+    seq: usize,
+    pos: usize,
+    baseline: &[f32],
+    base_trace: &ExecutionTrace,
+    candidate: &[f32],
+    cand_trace: &ExecutionTrace,
+) -> PositionObservation {
+    let top_ids = top_k_ids(baseline, TOP_N);
+    PositionObservation {
+        sequence: seq as u32,
+        position: pos as u32,
+        baseline_logits: top_ids.iter().map(|&i| baseline[i]).collect(),
+        candidate_logits: top_ids.iter().map(|&i| candidate[i]).collect(),
+        top_ids: top_ids.iter().map(|&i| i as u32).collect(),
+        baseline_logsumexp: logsumexp(baseline),
+        candidate_logsumexp: logsumexp(candidate),
+        baseline_argmax: argmax(baseline) as u32,
+        candidate_argmax: argmax(candidate) as u32,
+        baseline_top10: top_k_ids(baseline, 10).iter().map(|&i| i as u32).collect(),
+        candidate_top10: top_k_ids(candidate, 10).iter().map(|&i| i as u32).collect(),
+        // Every changed route WEIGHED — how close the decision was and
+        // how much mixture mass moved — from the router's own selection
+        // scores, so a near-tie swap and an overturned decision are
+        // distinguishable rather than both being "one flip".
+        route_changes: PositionObservation::weigh_route_changes(
+            &base_trace.routes,
+            &cand_trace.routes,
+            &base_trace.selection_scores,
+            &base_trace.combine_weights,
+            &cand_trace.combine_weights,
+        ),
+        // The top-10 change WEIGHED, recorded only where the ordering
+        // actually moved: a position that did not move says nothing
+        // about how close the ones that did were.
+        top10_change: weigh_top_k(baseline, candidate, 10),
+        // The argmax flip weighed, when the winner changed.
+        top1_change: weigh_top_1(baseline, candidate),
+        baseline_routes: base_trace.routes.clone(),
+        candidate_routes: cand_trace.routes.clone(),
+    }
+}
+
+/// **What a top-k reordering actually was**, or `None` if the ordering
+/// did not change.
+///
+/// Four facts, because the count answers none of them: how close the
+/// boundary was, what the CANDIDATE did to that same pair, how much
+/// probability mass moved, and how far anything travelled in rank.
+fn weigh_top_k(baseline: &[f32], candidate: &[f32], k: usize) -> Option<TopKChange> {
+    let (b_top, c_top) = (top_k_ids(baseline, k), top_k_ids(candidate, k));
+    if b_top == c_top {
+        return None;
+    }
+    // The boundary the baseline drew, and what the candidate did to
+    // exactly those two ids. Comparing the two is the measurement a
+    // worst-case `max|dlogit|` over the whole vocabulary cannot give.
+    let ranked = top_k_ids(baseline, k + 1);
+    let (boundary_margin, candidate_margin_same_ids) = if ranked.len() == k + 1 {
+        let (lo, hi) = (ranked[k - 1], ranked[k]);
+        (baseline[lo] - baseline[hi], candidate[lo] - candidate[hi])
+    } else {
+        (f32::NAN, f32::NAN)
+    };
+
+    // Half the L1 between the arms' top-k mass, each normalised over
+    // its own k — the top-k analogue of the routed-mixture distance.
+    let softmax_over = |logits: &[f32], ids: &[usize]| -> Vec<(usize, f32)> {
+        let m = ids
+            .iter()
+            .map(|i| logits[*i])
+            .fold(f32::NEG_INFINITY, f32::max);
+        let exps: Vec<f32> = ids.iter().map(|i| (logits[*i] - m).exp()).collect();
+        let sum: f32 = exps.iter().sum();
+        ids.iter().zip(exps).map(|(i, e)| (*i, e / sum)).collect()
+    };
+    let (bp, cp) = (
+        softmax_over(baseline, &b_top),
+        softmax_over(candidate, &c_top),
+    );
+    let mass_of = |v: &[(usize, f32)], id: usize| {
+        v.iter()
+            .find(|(i, _)| *i == id)
+            .map(|(_, p)| *p)
+            .unwrap_or(0.0)
+    };
+    let mut union: Vec<usize> = b_top.iter().chain(&c_top).copied().collect();
+    union.sort_unstable();
+    union.dedup();
+    let mass_displaced = 0.5
+        * union
+            .iter()
+            .map(|id| (mass_of(&bp, *id) - mass_of(&cp, *id)).abs())
+            .sum::<f32>();
+
+    // How far anything travelled. An id present in one arm's top-k and
+    // absent from the other is located in the other's FULL ordering, so
+    // an outsider arriving from rank 400 is not scored as a 1-place
+    // move.
+    let rank_in = |ordering: &[usize], id: usize, full: &[f32]| -> usize {
+        ordering
+            .iter()
+            .position(|x| *x == id)
+            .unwrap_or_else(|| full.iter().filter(|v| **v > full[id]).count())
+    };
+    let max_rank_displacement = union
+        .iter()
+        .map(|id| {
+            let b = rank_in(&b_top, *id, baseline);
+            let c = rank_in(&c_top, *id, candidate);
+            b.abs_diff(c) as u32
+        })
+        .max()
+        .unwrap_or(0);
+
+    Some(TopKChange {
+        boundary_margin,
+        candidate_margin_same_ids,
+        mass_displaced,
+        max_rank_displacement,
+    })
+}
+
+/// **What an argmax flip actually was**, or `None` if the winner did
+/// not change.
+///
+/// Distinguishes a coin-flip between near-equal candidates from an
+/// overturned confident choice — two events the flip count scores
+/// identically, and the strictest criterion in the contract.
+fn weigh_top_1(baseline: &[f32], candidate: &[f32]) -> Option<Top1Change> {
+    let (b_win, c_win) = (argmax(baseline), argmax(candidate));
+    if b_win == c_win {
+        return None;
+    }
+    // Exact probabilities over the FULL vocabulary, so the mass is the
+    // model's own belief rather than a renormalised truncation.
+    let lse = logsumexp(baseline);
+    let p = |id: usize| (baseline[id] - lse).exp();
+    Some(Top1Change {
+        // What the baseline held its winner by, over the pair that
+        // actually swapped.
+        boundary_margin: baseline[b_win] - baseline[c_win],
+        // And what the candidate holds the reversed choice by.
+        candidate_margin_same_ids: candidate[c_win] - candidate[b_win],
+        // The probability the baseline gave up by switching.
+        mass_displaced: p(b_win) - p(c_win),
+    })
+}
+
+/// Per-sequence embedding rows from the exported bank.
+pub fn sequence_embeddings(
+    dir: &Path,
+    seq: usize,
+    positions: usize,
+    hidden: usize,
+) -> Result<Vec<Vec<f32>>, ExecutionFailure> {
+    let path = dir.join(format!("seq_{seq}.f32"));
+    let unreadable = |detail: String| ExecutionFailure::ArtifactUnreadable {
+        what: format!("corpus sequence {seq}"),
+        path: path.display().to_string(),
+        detail,
+    };
+    let bytes = std::fs::read(&path).map_err(|e| unreadable(e.to_string()))?;
+    if bytes.len() != positions * hidden * 4 {
+        return Err(unreadable(format!(
+            "holds {} bytes, not the {positions}x{hidden} f32 rows the manifest declares",
+            bytes.len()
+        )));
+    }
+    Ok(bytes
+        .chunks_exact(hidden * 4)
+        .map(|row| {
+            row.chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect()
+        })
+        .collect())
+}
+
+/// Build one arm: every layer on device, the head riding the last
+/// epoch. `overlay` present = the candidate arm.
+pub fn build_stack<'a>(
+    metal: &MetalBackend,
+    model: &KimiSourceModel,
+    overlay: Option<&CandidateOverlay>,
+) -> Result<HybridStack<'a>, ExecutionFailure> {
+    let n = model.geometry.num_layers;
+    let mut device: Vec<Option<DeviceLayer>> = Vec::with_capacity(n);
+    for i in 0..n {
+        device.push(Some(model.device_layer(metal, i, overlay).map_err(
+            |e| ExecutionFailure::LayerIncomplete {
+                layer: i,
+                detail: e.to_string(),
+            },
+        )?));
+    }
+    // Register the per-stack owned attention banks (the mmap-backed
+    // stores are registered once by the caller).
+    for d in device.iter().flatten() {
+        for bank in d.attention_banks() {
+            metal.register_weight_region(bank);
+        }
+    }
+    let host: Vec<Option<(LayerSpec<'a>, LayerState)>> = (0..n).map(|_| None).collect();
+    let mut stack = HybridStack::new(device, host);
+    let head = model
+        .head()
+        .map_err(|e| ExecutionFailure::ArtifactUnreadable {
+            what: "output head".into(),
+            path: String::new(),
+            detail: e.to_string(),
+        })?;
+    if !stack.attach_head(head) {
+        return Err(ExecutionFailure::HeadDidNotAttach);
+    }
+    Ok(stack)
+}
+
+/// Run `positions` teacher-forced steps of one sequence through one
+/// arm, returning each position's full logits and its execution trace.
+pub fn run_sequence(
+    metal: &MetalBackend,
+    stack: &mut HybridStack<'_>,
+    rows: &[Vec<f32>],
+    hidden: usize,
+) -> Result<Vec<(Vec<f32>, ExecutionTrace)>, ExecutionFailure> {
+    stack
+        .reset_states()
+        .map_err(|e| ExecutionFailure::StepRefused {
+            sequence: 0,
+            position: 0,
+            detail: format!("the stack did not reset: {e}"),
+        })?;
+    let mut out = Vec::with_capacity(rows.len());
+    for (position, row) in rows.iter().enumerate() {
+        let mut trace = ExecutionTrace {
+            // The router's own selection scores and combine weights, so
+            // a routing change can be WEIGHED rather than counted.
+            // ~27 KB a token, read after the chain's single wait.
+            want_selection_scores: true,
+            ..ExecutionTrace::default()
+        };
+        let (logits, _traces, _t) = stack
+            .forward_traced(metal, row, hidden, Some(&mut trace))
+            .map_err(|e| ExecutionFailure::StepRefused {
+                sequence: 0,
+                position,
+                detail: e.to_string(),
+            })?;
+        out.push((logits, trace));
+    }
+    Ok(out)
+}
+
+/// **Run the teacher-forced two-arm measurement.**
+///
+/// Every condition that made this trustworthy as a `#[cfg(test)]`
+/// harness is preserved as a typed refusal — see
+/// [`outcome`](super::outcome) for the conservation inventory naming
+/// where each one went. A test runner would have turned a violated
+/// `assert!` red; a caller gets `Inadmissible` instead, and can tell it
+/// from an `ExecutionFailure` that is worth retrying.
+pub fn measure_teacher_forced(
+    request: &TeacherForcedRequest,
+) -> Result<MeasurementReceipt, MeasurementRefusal> {
+    // Refused before anything is loaded: an unknown gate, an unknown
+    // procedure, an empty slice, a missing artifact.
+    let requested_gate = request.admit().map_err(|e| {
+        MeasurementRefusal::Execution(ExecutionFailure::ArtifactUnreadable {
+            what: "request".into(),
+            path: request.source.display().to_string(),
+            detail: e.to_string(),
+        })
+    })?;
+    let (source_dir, candidate_dir, bank_dir) = (
+        request.source.clone(),
+        request.candidate.clone(),
+        request.quality_bank.clone(),
+    );
+    let sequences = || request.sequences;
+    let mut verified = VerifiedFacts::default();
+    // The residency SET would try to wire ~94 GB of expert bank, past
+    // the wired-collector wall (~45 GB). This run uses registered
+    // regions under IMPLICIT residency; refusing is better than
+    // silently degrading into a measurement of the collector.
+    if std::env::var("LARQL_RESIDENCY_SET").is_ok() {
+        return Err(Inadmissible::ResidencyModeWouldBeMeasured {
+            detail: "LARQL_RESIDENCY_SET is set: the run would wire ~94 GB of expert bank \
+                     past the ~45 GB collector wall and measure the collector"
+                .into(),
+        }
+        .into());
+    }
+    let Some(metal) = MetalBackend::new() else {
+        return Err(ExecutionFailure::BackendUnavailable {
+            detail: "MetalBackend::new() returned None — the shader library failed to build".into(),
+        }
+        .into());
+    };
+
+    let unreadable = |what: &str, path: &Path, detail: String| {
+        MeasurementRefusal::Execution(ExecutionFailure::ArtifactUnreadable {
+            what: what.into(),
+            path: path.display().to_string(),
+            detail,
+        })
+    };
+    let manifest_path = bank_dir.join("manifest.json");
+    let manifest: Value = std::fs::read(&manifest_path)
+        .map_err(|e| unreadable("quality bank manifest", &manifest_path, e.to_string()))
+        .and_then(|b| {
+            serde_json::from_slice(&b)
+                .map_err(|e| unreadable("quality bank manifest", &manifest_path, e.to_string()))
+        })?;
+    let field = |k: &str| {
+        manifest[k].as_u64().map(|v| v as usize).ok_or_else(|| {
+            unreadable(
+                "quality bank manifest",
+                &manifest_path,
+                format!("`{k}` is missing or not a number"),
+            )
+        })
+    };
+    let positions_per_seq = field("positions")?;
+    let bank_hidden = field("hidden")?;
+
+    let t0 = Instant::now();
+    let model = KimiSourceModel::open(&source_dir)
+        .map_err(|e| unreadable("source container", &source_dir, e.to_string()))?;
+    let g = model.geometry.clone();
+    if g.hidden != bank_hidden {
+        return Err(Inadmissible::CorpusNotForThisModel {
+            corpus_hidden: bank_hidden,
+            model_hidden: g.hidden,
+        }
+        .into());
+    }
+    let overlay = CandidateOverlay::open(&candidate_dir, &source_dir, &g)
+        .map_err(|e| unreadable("candidate overlay", &candidate_dir, e.to_string()))?;
+    if overlay.compiled_layers().is_empty() {
+        return Err(Inadmissible::CandidateCompilesNothing.into());
+    }
+    verified.compiled_layers = overlay.compiled_layers().to_vec();
+    verified.compiled_projections = overlay.compiled_projections().to_vec();
+    eprintln!(
+        "[q2a] source + candidate opened in {:.1}s; candidate compiles layers {:?}",
+        t0.elapsed().as_secs_f64(),
+        overlay.compiled_layers()
+    );
+    // The EARLIEST compiled layer (verify_complete sorts): the one
+    // layer whose router input is untouched in BOTH arms, so its own
+    // routing must be identical — the cascade/local discriminator. A
+    // composed map's later compiled layers see moved hidden states and
+    // may legitimately route differently.
+    let overlay_layer = overlay.compiled_layers()[0] as usize;
+    let compiled_set: Vec<usize> = overlay
+        .compiled_layers()
+        .iter()
+        .map(|&l| l as usize)
+        .collect();
+
+    // ── Load both arms; the loader refuses on any missing operand. ──
+    let t1 = Instant::now();
+    let moe_layers: Vec<u32> = (g.dense_prefix_layers..g.num_layers)
+        .map(|l| l as u32)
+        .collect();
+    let registered = model
+        .register_stores(&metal, &moe_layers)
+        .map_err(|e| unreadable("source stores", &source_dir, e.to_string()))?;
+    overlay.register_store(&metal);
+    let mut baseline = build_stack(&metal, &model, None)?;
+    let mut candidate = build_stack(&metal, &model, Some(&overlay))?;
+    metal.seal_weight_regions();
+    eprintln!(
+        "[q2a] both arms loaded in {:.1}s ({registered} mmap store regions registered, \
+         implicit residency)",
+        t1.elapsed().as_secs_f64()
+    );
+    // ── Physical attribution: the intended stores are the bound ones,
+    //    at EVERY compiled layer — a composed map earns the check per
+    //    layer, at that layer's own encoding. Every violation below is
+    //    INADMISSIBLE rather than a failure: the logits would still
+    //    compute, and would be a measurement of something else.
+    for &probe_layer in &compiled_set {
+        let probe_b = model.device_layer(&metal, probe_layer, None).map_err(|e| {
+            ExecutionFailure::LayerIncomplete {
+                layer: probe_layer,
+                detail: e.to_string(),
+            }
+        })?;
+        let probe_c = model
+            .device_layer(&metal, probe_layer, Some(&overlay))
+            .map_err(|e| ExecutionFailure::LayerIncomplete {
+                layer: probe_layer,
+                detail: e.to_string(),
+            })?;
+        let unexpected = |arm: &str, projection: &str, want: &str, got: &str| {
+            MeasurementRefusal::Inadmissible(Inadmissible::UnexpectedPhysicalRead {
+                arm: arm.into(),
+                layer: probe_layer,
+                projection: projection.into(),
+                expected_store: want.into(),
+                actual_store: got.into(),
+            })
+        };
+
+        // The BASELINE arm is entirely source-backed, whatever the
+        // candidate's scope.
+        for (name, proj) in [
+            ("gate", &probe_b.bank.gate),
+            ("up", &probe_b.bank.up),
+            ("down", &probe_b.bank.down),
+        ] {
+            if proj.store_id() != SOURCE_EXPERT_BANK {
+                return Err(unexpected(
+                    "baseline",
+                    name,
+                    SOURCE_EXPERT_BANK,
+                    proj.store_id(),
+                ));
+            }
+            if proj.encoding() != ExpertEncoding::Bf16 {
+                return Err(unexpected(
+                    "baseline",
+                    name,
+                    "BF16",
+                    &format!("{:?}", proj.encoding()),
+                ));
+            }
+        }
+
+        // The CANDIDATE arm substitutes exactly the projections the
+        // overlay compiled, and leaves the rest source-backed — the
+        // asymmetry a projection-scoped experiment IS.
+        let compiled: Vec<&str> = overlay
+            .compiled_projections()
+            .iter()
+            .map(String::as_str)
+            .collect();
+        for (name, proj, spelling) in [
+            ("gate", &probe_c.bank.gate, "w1"),
+            ("up", &probe_c.bank.up, "w3"),
+            ("down", &probe_c.bank.down, "w2"),
+        ] {
+            let want_candidate = compiled.contains(&spelling);
+            let (store, enc) = if want_candidate {
+                (
+                    CANDIDATE_BANK,
+                    overlay.encoding_of(probe_layer as u32).map_err(|e| {
+                        MeasurementRefusal::Inadmissible(Inadmissible::AddressingMismatch {
+                            layer: probe_layer,
+                            projection: name.into(),
+                            detail: format!(
+                                "the layer is in the compiled set and declares no encoding: {e}"
+                            ),
+                        })
+                    })?,
+                )
+            } else {
+                (SOURCE_EXPERT_BANK, ExpertEncoding::Bf16)
+            };
+            if proj.store_id() != store {
+                return Err(unexpected("candidate", name, store, proj.store_id()));
+            }
+            if proj.encoding() != enc {
+                return Err(unexpected(
+                    "candidate",
+                    name,
+                    &format!("{enc:?}"),
+                    &format!("{:?}", proj.encoding()),
+                ));
+            }
+            // A source-backed projection of the candidate arm must be
+            // the SAME BYTES as the baseline's — pointer-identical, so
+            // the only difference between the arms is the compiled one.
+            if !want_candidate {
+                let b = match name {
+                    "gate" => &probe_b.bank.gate,
+                    "up" => &probe_b.bank.up,
+                    _ => &probe_b.bank.down,
+                };
+                if proj.region.region.bytes().as_ptr() != b.region.region.bytes().as_ptr() {
+                    return Err(Inadmissible::ProtectedOperandChanged {
+                        layer: probe_layer,
+                        projection: name.into(),
+                    }
+                    .into());
+                }
+            }
+        }
+
+        // Only a COMPILED projection is identity-addressed. A
+        // projection-scoped candidate leaves the others table-addressed
+        // over the source, and that asymmetry inside one layer is the
+        // thing this binding exists to express.
+        for (name, proj) in [
+            ("gate", &probe_c.bank.gate),
+            ("up", &probe_c.bank.up),
+            ("down", &probe_c.bank.down),
+        ] {
+            let is_candidate = proj.store_id() == CANDIDATE_BANK;
+            let mismatch = |detail: String| {
+                MeasurementRefusal::Inadmissible(Inadmissible::AddressingMismatch {
+                    layer: probe_layer,
+                    projection: name.into(),
+                    detail,
+                })
+            };
+            match (&proj.addressing, is_candidate) {
+                (ProjectionAddressing::Identity { experts, .. }, true) => {
+                    if *experts != g.experts {
+                        return Err(mismatch(format!(
+                            "compiled, so it must address every one of {} experts by identity \
+                             — any route, including one the baseline never took, must resolve \
+                             — and it addresses {experts}",
+                            g.experts
+                        )));
+                    }
+                }
+                (ProjectionAddressing::Table(_), false) => {}
+                (a, c) => return Err(mismatch(format!("compiled={c} but addressed by {a:?}"))),
+            }
+        }
+
+        let shared = probe_c
+            .bank
+            .shared
+            .as_ref()
+            .ok_or_else(|| unexpected("candidate", "shared", SOURCE_DECODER_STACK, "absent"))?;
+        if shared.gate.store_id() != SOURCE_DECODER_STACK {
+            return Err(unexpected(
+                "candidate",
+                "shared",
+                SOURCE_DECODER_STACK,
+                shared.gate.store_id(),
+            ));
+        }
+        if shared.gate.encoding != ExpertEncoding::Bf16 {
+            return Err(unexpected(
+                "candidate",
+                "shared",
+                "BF16",
+                &format!("{:?}", shared.gate.encoding),
+            ));
+        }
+
+        // A layer the overlay does NOT compile is the same physical
+        // bytes in both arms — pointer-identical, not merely same-named.
+        let neighbour = (g.dense_prefix_layers..g.num_layers)
+            .find(|l| !compiled_set.contains(l))
+            .ok_or(MeasurementRefusal::Inadmissible(
+                Inadmissible::CandidateCompilesNothing,
+            ))?;
+        let nb = model.device_layer(&metal, neighbour, None).map_err(|e| {
+            ExecutionFailure::LayerIncomplete {
+                layer: neighbour,
+                detail: e.to_string(),
+            }
+        })?;
+        let nc = model
+            .device_layer(&metal, neighbour, Some(&overlay))
+            .map_err(|e| ExecutionFailure::LayerIncomplete {
+                layer: neighbour,
+                detail: e.to_string(),
+            })?;
+        if nc.bank.gate.store_id() != SOURCE_EXPERT_BANK {
+            return Err(unexpected(
+                "candidate",
+                "neighbour gate",
+                SOURCE_EXPERT_BANK,
+                nc.bank.gate.store_id(),
+            ));
+        }
+        if nb.bank.gate.region.region.bytes().as_ptr()
+            != nc.bank.gate.region.region.bytes().as_ptr()
+        {
+            return Err(Inadmissible::ProtectedOperandChanged {
+                layer: neighbour,
+                projection: "neighbour gate".into(),
+            }
+            .into());
+        }
+        verified.invariant_neighbour_layer = Some(neighbour);
+
+        // The bytes the loader reads must be the bytes the compiler
+        // sealed. Without this, "the candidate" is whatever is on disk
+        // under a path the overlay names.
+        let checked = overlay
+            .verify_reads_match_seals(probe_layer as u32, 16)
+            .map_err(|e| Inadmissible::SealMismatch {
+                layer: probe_layer as u32,
+                detail: e.to_string(),
+            })?;
+        verified.seal_checked_operands += checked;
+        verified.attribution_checked_layers.push(probe_layer);
+    }
+
+    // ── The null arm: BF16 against itself must be EXACTLY zero. ──
+    let t2 = Instant::now();
+    {
+        let mut null_partner = build_stack(&metal, &model, None)?;
+        let mut builder = BankBuilder::new();
+        for seq in 0..NULL_SEQUENCES {
+            let rows = sequence_embeddings(&bank_dir, seq, positions_per_seq, g.hidden)?;
+            let a = run_sequence(&metal, &mut baseline, &rows, g.hidden)?;
+            let b = run_sequence(&metal, &mut null_partner, &rows, g.hidden)?;
+            for (pos, ((la, ta), (lb, tb))) in a.into_iter().zip(b).enumerate() {
+                builder.observe(&observation(seq, pos, &la, &ta, &lb, &tb));
+            }
+        }
+        let null_bank = builder.finish();
+        let want = (NULL_SEQUENCES * positions_per_seq) as u64;
+        if null_bank.positions != want {
+            return Err(Inadmissible::PositionCountMismatch {
+                expected: want,
+                measured: null_bank.positions,
+            }
+            .into());
+        }
+        // **The determinism control.** BF16 against itself must be
+        // exactly zero. If it is not, the device is injecting
+        // nondeterminism and every downstream KL, flip and route
+        // statistic is artifact — while attribution, seals, pointer
+        // identity and position counts all still pass.
+        for (statistic, observed) in [
+            ("kl_p99", null_bank.logits.kl_p99),
+            ("max_logit_delta", null_bank.logits.max_logit_delta),
+            ("top1_flips", null_bank.logits.top1_flips as f64),
+            ("top10_changes", null_bank.logits.top10_changes as f64),
+            ("route_flips", null_bank.routing.route_flips as f64),
+            (
+                "positions_with_route_change",
+                null_bank.routing.positions_with_route_change as f64,
+            ),
+        ] {
+            if observed != 0.0 {
+                return Err(Inadmissible::NullArmNotZero {
+                    statistic: statistic.into(),
+                    observed,
+                }
+                .into());
+            }
+        }
+        eprintln!(
+            "[q2a] null arm: {} positions, everything exactly zero ({:.1}s)",
+            null_bank.positions,
+            t2.elapsed().as_secs_f64()
+        );
+    }
+
+    // ── The measurement: 32 sequences x 32 teacher-forced positions. ──
+    let t3 = Instant::now();
+    let mut builder = BankBuilder::new();
+    let mut candidate_l1_routed: std::collections::BTreeSet<u32> =
+        std::collections::BTreeSet::new();
+    let mut baseline_l1_routed: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
+    for seq in 0..sequences() {
+        let rows = sequence_embeddings(&bank_dir, seq, positions_per_seq, g.hidden)?;
+        let base = run_sequence(&metal, &mut baseline, &rows, g.hidden)?;
+        let cand = run_sequence(&metal, &mut candidate, &rows, g.hidden)?;
+        for (pos, ((lb, tb), (lc, tc))) in base.into_iter().zip(cand).enumerate() {
+            baseline_l1_routed.extend(tb.routes[overlay_layer].iter().copied());
+            candidate_l1_routed.extend(tc.routes[overlay_layer].iter().copied());
+            builder.observe(&observation(seq, pos, &lb, &tb, &lc, &tc));
+        }
+    }
+    let min_covered = builder.min_covered_mass();
+    let bank = builder.finish();
+    let run_s = t3.elapsed().as_secs_f64();
+    let want_positions = (sequences() * positions_per_seq) as u64;
+    if bank.positions != want_positions {
+        return Err(Inadmissible::PositionCountMismatch {
+            expected: want_positions,
+            measured: bank.positions,
+        }
+        .into());
+    }
+    verified.positions = bank.positions;
+
+    // ── The verdicts. v3 is the frozen authority; v1 and v2 are
+    // reported because every earlier claim in this programme cited
+    // them and a reader needs to compare like with like. ──
+    let evidence = QualityEvidence {
+        gate: requested_gate.clone(),
+        bank: bank.clone(),
+    };
+    if evidence.gate.id != request.gate {
+        return Err(Inadmissible::GateMismatch {
+            requested: request.gate.clone(),
+            evaluated: evidence.gate.id.clone(),
+        }
+        .into());
+    }
+    verified.gate_evaluated = evidence.gate.id.clone();
+    let verdict = evidence.verdict();
+    let v1_verdict = kimi_logit_v1().evaluate(&bank);
+    let v2_verdict = kimi_logit_v2().evaluate(&bank);
+
+    // ── The closure report — written BEFORE any verdict assertion, so
+    // a refused run still leaves its evidence on disk. An 8192-position
+    // measurement that panics after the numbers exist and before the
+    // write has destroyed twenty minutes of instrument time; that
+    // happened once and must not happen again. ──
+    //
+    // The bank's identity travels with the report: /tmp has proven
+    // ephemeral, and a verdict whose evidence names no bank cannot be
+    // distinguished from a verdict on a different one.
+    let bank_manifest_sha256 = {
+        use sha2::{Digest, Sha256};
+        let bytes = std::fs::read(&manifest_path)
+            .map_err(|e| unreadable("quality bank manifest", &manifest_path, e.to_string()))?;
+        format!("{:x}", Sha256::digest(&bytes))
+    };
+    let label = request.label.clone();
+    let report = serde_json::json!({
+        "run": label,
+        "gate": evidence.gate,
+        "authority_report": evidence.report(),
+        "verdict_passed": verdict.passed(),
+        "verdict_failures": verdict.failures.iter()
+            .map(|(c, d)| format!("{}: {d}", c.name())).collect::<Vec<_>>(),
+        "verdict_failures_v2": v2_verdict.failures.iter()
+            .map(|(c, d)| format!("{}: {d}", c.name())).collect::<Vec<_>>(),
+        "verdict_failures_v1": v1_verdict.failures.iter()
+            .map(|(c, d)| format!("{}: {d}", c.name())).collect::<Vec<_>>(),
+        "candidate_map": overlay.index.map.name,
+        "candidate_layers": overlay.compiled_layers(),
+        "bank_manifest_sha256": bank_manifest_sha256,
+        "bank": bank,
+        "positions": bank.positions,
+        "sequences": sequences(),
+        "top_n": TOP_N,
+        "min_covered_mass": min_covered,
+        "stores": {
+            "baseline_layer1_routed": "kimi-source-expert-bank (BF16, Table)",
+            "candidate_layer1_routed": format!(
+                "kimi-candidate-bank ({}, Identity)",
+                overlay
+                    .encoding_of(overlay_layer as u32)
+                    .map(|e| e.name())
+                    .unwrap_or("unknown")
+            ),
+            "shared_experts": "kimi-source-decoder-stack (BF16, both arms)",
+        },
+        "layer1_routed_experts": {
+            "baseline_distinct": baseline_l1_routed.len(),
+            "candidate_distinct": candidate_l1_routed.len(),
+            "candidate_only": candidate_l1_routed.difference(&baseline_l1_routed).count(),
+        },
+        "wall_seconds": run_s,
+    });
+    let path = report_path(&label);
+    let rendered = serde_json::to_vec_pretty(&report)
+        .map_err(|e| unreadable("closure report", Path::new(&path), e.to_string()))?;
+    std::fs::write(&path, rendered)
+        .map_err(|e| unreadable("closure report", Path::new(&path), e.to_string()))?;
+
+    Ok(MeasurementReceipt {
+        request: request.clone(),
+        gate: evidence.gate.clone(),
+        verified,
+        bank,
+        min_covered_mass: min_covered,
+        wall_seconds: run_s,
+        report_path: path,
+        verdict_passed: verdict.passed(),
+        verdict_failures: verdict
+            .failures
+            .iter()
+            .map(|(c, d)| format!("{}: {d}", c.name()))
+            .collect(),
+    })
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/measure_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure_tests.rs
@@ -363,10 +363,6 @@ fn every_condition_the_harness_checks_has_a_refusal_to_return() {
             detail: String::new(),
         }
         .into(),
-        Inadmissible::OperandNotSealed {
-            tensor: "w1".into(),
-        }
-        .into(),
         Inadmissible::PositionCountMismatch {
             expected: 1024,
             measured: 512,
@@ -383,11 +379,7 @@ fn every_condition_the_harness_checks_has_a_refusal_to_return() {
         }
         .into(),
     ];
-    assert_eq!(
-        inventory.len(),
-        11,
-        "eleven validity conditions, each named"
-    );
+    assert_eq!(inventory.len(), 10, "ten validity conditions, each named");
     for refusal in &inventory {
         assert!(
             !refusal.nothing_was_measured(),
@@ -512,5 +504,32 @@ fn a_refusal_and_its_verified_facts_survive_json() {
     assert_eq!(
         serde_json::from_value::<VerifiedFacts>(value).expect("from value"),
         facts
+    );
+}
+
+// --------------------------- a build that cannot perform the procedure
+
+#[cfg(not(all(feature = "gpu", target_os = "macos")))]
+#[test]
+fn a_build_that_cannot_run_the_procedure_refuses_rather_than_missing_the_symbol() {
+    // The teacher-forced runner needs Metal and macOS. On any other
+    // build it does not exist, and that absence must reach a caller as
+    // a REFUSAL: `PreparedExperiment` has to decide whether something
+    // is executable on the machine in front of it, and "the symbol is
+    // missing" is not an answer it can act on.
+    let (_dir, request) = artifacts();
+    let refusal = super::measure::run(&request).expect_err("this build cannot perform it");
+
+    assert!(
+        refusal.nothing_was_measured(),
+        "no measurement was attempted, so this is an execution failure"
+    );
+    assert!(
+        refusal.to_string().contains("gpu"),
+        "the refusal must say what the build lacks: {refusal}"
+    );
+    assert!(
+        refusal.to_string().contains(TEACHER_FORCED_TWO_ARM),
+        "and which procedure it could not perform: {refusal}"
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/measure_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure_tests.rs
@@ -16,6 +16,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use super::measure::outcome::{ExecutionFailure, Inadmissible, MeasurementRefusal, VerifiedFacts};
 use super::measure::{
     MeasurementProcedure, TeacherForcedRequest, BANK_ENV, CANDIDATE_ENV, DEFAULT_GATE,
     DEFAULT_LABEL, DEFAULT_SEQUENCES, GATE_ENV, LABEL_ENV, SEQUENCES_ENV, SOURCE_ENV,
@@ -260,5 +261,225 @@ fn a_request_survives_a_round_trip_through_json() {
     assert_eq!(
         serde_json::from_value::<TeacherForcedRequest>(value).expect("from value"),
         request
+    );
+}
+
+// ------------------------------- execution failure vs validity failure
+
+/// A run that checked everything, for tests that move one fact at a
+/// time away from complete.
+fn verified() -> VerifiedFacts {
+    VerifiedFacts {
+        compiled_layers: vec![25],
+        compiled_projections: vec!["w1".into()],
+        attribution_checked_layers: vec![25],
+        seal_checked_operands: 16,
+        invariant_neighbour_layer: Some(26),
+        positions: 1024,
+        gate_evaluated: "kimi-logit-v3".into(),
+    }
+}
+
+#[test]
+fn nothing_measured_and_not_admissible_are_different_answers() {
+    // **The distinction stage 5 needs.** An agent told only "it
+    // failed" would retry an inadmissible run forever; the numbers
+    // would come back identical and still not be evidence.
+    let execution: MeasurementRefusal = ExecutionFailure::BackendUnavailable {
+        detail: "no Metal device".into(),
+    }
+    .into();
+    let validity: MeasurementRefusal = Inadmissible::ProtectedOperandChanged {
+        layer: 25,
+        projection: "w3".into(),
+    }
+    .into();
+
+    assert!(execution.nothing_was_measured());
+    assert!(execution.worth_retrying());
+    assert!(!validity.nothing_was_measured());
+    assert!(
+        !validity.worth_retrying(),
+        "repeating a mis-prepared experiment reproduces the same non-evidence"
+    );
+    assert_ne!(execution, validity);
+}
+
+#[test]
+fn a_refusal_says_which_kind_it_is_in_words() {
+    // The message a caller reads has to carry the distinction too — a
+    // structured variant nobody prints is a distinction that reaches
+    // no one.
+    let execution: MeasurementRefusal = ExecutionFailure::HeadDidNotAttach.into();
+    let validity: MeasurementRefusal = Inadmissible::CandidateCompilesNothing.into();
+    assert!(
+        execution.to_string().contains("could not be performed"),
+        "{execution}"
+    );
+    assert!(
+        validity.to_string().contains("not admissible evidence"),
+        "{validity}"
+    );
+}
+
+#[test]
+fn every_condition_the_harness_checks_has_a_refusal_to_return() {
+    // The inventory. Each of these is an `assert!` in
+    // `q2a_teacher_forced` today, and the move to a callable procedure
+    // must not quietly drop one — a check that becomes nothing is
+    // indistinguishable from a check that passes.
+    let inventory: Vec<MeasurementRefusal> = vec![
+        Inadmissible::ResidencyModeWouldBeMeasured {
+            detail: String::new(),
+        }
+        .into(),
+        Inadmissible::CorpusNotForThisModel {
+            corpus_hidden: 1,
+            model_hidden: 2,
+        }
+        .into(),
+        Inadmissible::CandidateCompilesNothing.into(),
+        Inadmissible::UnexpectedPhysicalRead {
+            arm: "baseline".into(),
+            layer: 25,
+            projection: "gate".into(),
+            expected_store: "kimi-source-expert-bank".into(),
+            actual_store: "kimi-candidate-bank".into(),
+        }
+        .into(),
+        Inadmissible::ProtectedOperandChanged {
+            layer: 25,
+            projection: "up".into(),
+        }
+        .into(),
+        Inadmissible::AddressingMismatch {
+            layer: 25,
+            projection: "down".into(),
+            detail: String::new(),
+        }
+        .into(),
+        Inadmissible::SealMismatch {
+            layer: 25,
+            detail: String::new(),
+        }
+        .into(),
+        Inadmissible::OperandNotSealed {
+            tensor: "w1".into(),
+        }
+        .into(),
+        Inadmissible::PositionCountMismatch {
+            expected: 1024,
+            measured: 512,
+        }
+        .into(),
+        Inadmissible::GateMismatch {
+            requested: "kimi-logit-balanced-v1".into(),
+            evaluated: "kimi-logit-v3".into(),
+        }
+        .into(),
+    ];
+    assert_eq!(inventory.len(), 10, "ten validity conditions, each named");
+    for refusal in &inventory {
+        assert!(
+            !refusal.nothing_was_measured(),
+            "{refusal} measured nothing"
+        );
+    }
+
+    // And the execution class covers the ways a run does not happen.
+    for failure in [
+        ExecutionFailure::BackendUnavailable {
+            detail: String::new(),
+        },
+        ExecutionFailure::ArtifactUnreadable {
+            what: "source".into(),
+            path: "/m/s".into(),
+            detail: String::new(),
+        },
+        ExecutionFailure::LayerIncomplete {
+            layer: 3,
+            detail: String::new(),
+        },
+        ExecutionFailure::HeadDidNotAttach,
+        ExecutionFailure::StepRefused {
+            sequence: 0,
+            position: 0,
+            detail: String::new(),
+        },
+    ] {
+        assert!(MeasurementRefusal::from(failure).nothing_was_measured());
+    }
+}
+
+#[test]
+fn a_run_that_skipped_a_check_is_not_complete() {
+    // `complete()` is explicit and not a count: four conditions out of
+    // five is not eighty per cent of a verified run.
+    assert!(verified().complete());
+
+    let missing: Vec<VerifiedFacts> = vec![
+        VerifiedFacts {
+            compiled_layers: vec![],
+            ..verified()
+        },
+        VerifiedFacts {
+            compiled_projections: vec![],
+            ..verified()
+        },
+        VerifiedFacts {
+            attribution_checked_layers: vec![],
+            ..verified()
+        },
+        VerifiedFacts {
+            seal_checked_operands: 0,
+            ..verified()
+        },
+        VerifiedFacts {
+            invariant_neighbour_layer: None,
+            ..verified()
+        },
+        VerifiedFacts {
+            positions: 0,
+            ..verified()
+        },
+        VerifiedFacts {
+            gate_evaluated: String::new(),
+            ..verified()
+        },
+    ];
+    assert_eq!(missing.len(), 7, "one omission per recorded fact");
+    for facts in missing {
+        assert!(!facts.complete(), "{facts:?} passed with a fact missing");
+    }
+
+    // Attribution must cover EVERY compiled layer, not merely some: a
+    // composed map earns the check per layer, at that layer's own
+    // encoding.
+    assert!(!VerifiedFacts {
+        compiled_layers: vec![25, 26],
+        attribution_checked_layers: vec![25],
+        ..verified()
+    }
+    .complete());
+}
+
+#[test]
+fn a_refusal_and_its_verified_facts_survive_json() {
+    // A receipt that cannot be stored cannot be an observation later.
+    let refusal: MeasurementRefusal = Inadmissible::SealMismatch {
+        layer: 25,
+        detail: "operand 3".into(),
+    }
+    .into();
+    let text = serde_json::to_string(&refusal).expect("serialise");
+    assert_eq!(
+        serde_json::from_str::<MeasurementRefusal>(&text).expect("reload"),
+        refusal
+    );
+    let facts = verified();
+    let value = serde_json::to_value(&facts).expect("to value");
+    assert_eq!(
+        serde_json::from_value::<VerifiedFacts>(value).expect("from value"),
+        facts
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/measure_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure_tests.rs
@@ -1,0 +1,264 @@
+//! **5a-0: every field a prepared experiment will seal is a control the
+//! executor consumes.**
+//!
+//! The runner used to hold `kimi_logit_v3()` as a literal while an
+//! optimiser record declared `kimi-logit-balanced-v1`. Sealing a
+//! "measurement protocol" into a hash while that was true would have
+//! attested to declared intent rather than to caused execution.
+//!
+//! What these tests can establish here is the contract: the controls
+//! exist, they resolve by name, an unknown name is refused, and the
+//! environment form is an ADAPTER onto the same request rather than a
+//! second way to run. What they cannot establish is that the measured
+//! NUMBERS move — that needs the 48 B container and a Metal device, and
+//! saying so beats a test that would pass without one.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use super::measure::{
+    MeasurementProcedure, TeacherForcedRequest, BANK_ENV, CANDIDATE_ENV, DEFAULT_GATE,
+    DEFAULT_LABEL, DEFAULT_SEQUENCES, GATE_ENV, LABEL_ENV, SEQUENCES_ENV, SOURCE_ENV,
+    TEACHER_FORCED_TWO_ARM,
+};
+use super::quality::{gate_by_id, IMPLEMENTED_GATES};
+
+/// Three artifact directories that exist, so `admit` is exercising the
+/// control fields rather than tripping on a missing path.
+fn artifacts() -> (tempfile::TempDir, TeacherForcedRequest) {
+    let dir = tempfile::tempdir().expect("tmp");
+    for name in ["source", "candidate", "bank"] {
+        std::fs::create_dir_all(dir.path().join(name)).expect("dir");
+    }
+    let request = TeacherForcedRequest::new(
+        dir.path().join("source"),
+        dir.path().join("candidate"),
+        dir.path().join("bank"),
+    );
+    (dir, request)
+}
+
+fn vars(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+// ------------------------------------------------- gates resolve by name
+
+#[test]
+fn every_implemented_gate_resolves_and_answers_to_its_own_name() {
+    for id in IMPLEMENTED_GATES {
+        let gate = gate_by_id(id).unwrap_or_else(|e| panic!("{id}: {e}"));
+        assert_eq!(
+            gate.id, id,
+            "a gate must answer to the name it is asked for"
+        );
+    }
+    assert_eq!(IMPLEMENTED_GATES.len(), 4);
+}
+
+#[test]
+fn an_unknown_gate_is_refused_and_never_falls_back() {
+    // **The specific defect.** A run that quietly judged under
+    // `kimi-logit-v3` whatever it was asked for would carry a verdict
+    // nobody requested, and the record naming the other gate would be
+    // describing a judgement that never happened.
+    let err = gate_by_id("kimi-logit-v9").expect_err("must refuse");
+    assert!(format!("{err}").contains("kimi-logit-v9"), "{err}");
+    assert!(format!("{err}").contains("nobody asked for"), "{err}");
+
+    // And the refusal is not a disguised default: nothing this build
+    // can be asked for resolves to a gate of another name.
+    for id in ["", "kimi-logit", "KIMI-LOGIT-V3", "balanced-v1"] {
+        assert!(gate_by_id(id).is_err(), "`{id}` resolved to something");
+    }
+}
+
+#[test]
+fn the_gate_a_request_names_is_the_gate_it_admits_under() {
+    // The load-bearing one. A request naming the optimiser record's own
+    // gate admits under THAT gate, not under the runner's former
+    // literal.
+    let (_dir, request) = artifacts();
+    assert_eq!(
+        request
+            .clone()
+            .with_gate("kimi-logit-balanced-v1")
+            .admit()
+            .expect("a known gate")
+            .id,
+        "kimi-logit-balanced-v1"
+    );
+    assert_eq!(
+        request
+            .clone()
+            .with_gate("kimi-logit-v1")
+            .admit()
+            .expect("known")
+            .id,
+        "kimi-logit-v1"
+    );
+    // Two requests differing only in gate admit differently, which is
+    // what makes the field a control rather than a label.
+    assert_ne!(
+        request
+            .clone()
+            .with_gate("kimi-logit-v1")
+            .admit()
+            .expect("known"),
+        request.with_gate("kimi-logit-v3").admit().expect("known")
+    );
+}
+
+// ------------------------------------------------ procedures resolve too
+
+#[test]
+fn a_procedure_this_build_does_not_perform_is_refused() {
+    assert_eq!(
+        MeasurementProcedure::by_name(TEACHER_FORCED_TWO_ARM).expect("implemented"),
+        MeasurementProcedure::TeacherForcedTwoArm
+    );
+    let err = MeasurementProcedure::by_name("single-arm-perplexity/v1").expect_err("must refuse");
+    assert!(
+        format!("{err}").contains("single-arm-perplexity/v1"),
+        "{err}"
+    );
+    assert_eq!(
+        MeasurementProcedure::TeacherForcedTwoArm.name(),
+        TEACHER_FORCED_TWO_ARM
+    );
+}
+
+// ------------------------------------------- the environment is an adapter
+
+#[test]
+fn the_environment_form_builds_the_request_a_caller_would() {
+    // One procedure, two ways of naming its inputs. The historic
+    // command line keeps meaning what it meant: an unset slice is 32,
+    // an unset gate is the one the runner used to hold.
+    let env = vars(&[
+        (SOURCE_ENV, "/m/source.vindex3"),
+        (CANDIDATE_ENV, "/tmp/candidate.vindex3"),
+        (BANK_ENV, "/tmp/bank"),
+    ]);
+    let request = TeacherForcedRequest::from_vars(|k| env.get(k).cloned()).expect("all three set");
+
+    assert_eq!(
+        request,
+        TeacherForcedRequest::new("/m/source.vindex3", "/tmp/candidate.vindex3", "/tmp/bank")
+    );
+    assert_eq!(request.sequences, DEFAULT_SEQUENCES);
+    assert_eq!(request.gate, DEFAULT_GATE);
+    assert_eq!(request.label, DEFAULT_LABEL);
+    assert_eq!(request.procedure, MeasurementProcedure::TeacherForcedTwoArm);
+    assert_eq!(request.source, PathBuf::from("/m/source.vindex3"));
+}
+
+#[test]
+fn each_environment_control_reaches_the_request() {
+    // Varied one at a time, because a test that moved them together
+    // would pass on any one of them being wired.
+    let base = [
+        (SOURCE_ENV, "/m/s"),
+        (CANDIDATE_ENV, "/m/c"),
+        (BANK_ENV, "/m/b"),
+    ];
+    let build = |extra: &[(&str, &str)]| {
+        let mut pairs = base.to_vec();
+        pairs.extend_from_slice(extra);
+        let env = vars(&pairs);
+        TeacherForcedRequest::from_vars(|k| env.get(k).cloned()).expect("paths set")
+    };
+
+    assert_eq!(build(&[(SEQUENCES_ENV, "8")]).sequences, 8);
+    assert_eq!(
+        build(&[(GATE_ENV, "kimi-logit-balanced-v1")]).gate,
+        "kimi-logit-balanced-v1"
+    );
+    assert_eq!(build(&[(LABEL_ENV, "q80-l25")]).label, "q80-l25");
+
+    // Each leaves the others where they were.
+    let sliced = build(&[(SEQUENCES_ENV, "8")]);
+    assert_eq!(sliced.gate, DEFAULT_GATE);
+    assert_eq!(sliced.label, DEFAULT_LABEL);
+
+    // An unparseable slice is the default rather than a panic — the
+    // historic reader's behaviour, kept deliberately.
+    assert_eq!(
+        build(&[(SEQUENCES_ENV, "many")]).sequences,
+        DEFAULT_SEQUENCES
+    );
+}
+
+#[test]
+fn without_all_three_artifacts_the_environment_names_no_run() {
+    for missing in [SOURCE_ENV, CANDIDATE_ENV, BANK_ENV] {
+        let env: BTreeMap<String, String> = [SOURCE_ENV, CANDIDATE_ENV, BANK_ENV]
+            .into_iter()
+            .filter(|k| *k != missing)
+            .map(|k| (k.to_string(), "/m/x".to_string()))
+            .collect();
+        assert!(
+            TeacherForcedRequest::from_vars(|k| env.get(k).cloned()).is_none(),
+            "a run without {missing} is not a run"
+        );
+    }
+}
+
+// ------------------------------------------------ refused before loading
+
+#[test]
+fn a_request_over_no_sequences_is_refused() {
+    // Zero sequences is zero positions, and a gate that judges on tail
+    // statistics would be reading an empty distribution.
+    let (_dir, request) = artifacts();
+    let err = request.with_sequences(0).admit().expect_err("must refuse");
+    assert!(format!("{err}").contains("zero sequences"), "{err}");
+}
+
+#[test]
+fn an_artifact_that_is_not_there_is_refused_by_name() {
+    let (dir, request) = artifacts();
+    request.admit().expect("all three exist");
+
+    for (what, path) in [
+        ("source", dir.path().join("source")),
+        ("candidate", dir.path().join("candidate")),
+        ("quality bank", dir.path().join("bank")),
+    ] {
+        std::fs::rename(&path, path.with_extension("moved")).expect("move it aside");
+        let err = request.admit().expect_err("must refuse");
+        assert!(format!("{err}").contains(what), "{err}");
+        std::fs::rename(path.with_extension("moved"), &path).expect("put it back");
+    }
+}
+
+#[test]
+fn an_unknown_gate_is_refused_before_anything_is_loaded() {
+    // The refusal that matters most for cost: a 48 B model and twenty
+    // minutes of instrument time must not be spent to discover that the
+    // verdict cannot be drawn.
+    let (_dir, request) = artifacts();
+    assert!(request.with_gate("kimi-logit-v9").admit().is_err());
+}
+
+#[test]
+fn a_request_survives_a_round_trip_through_json() {
+    // A prepared experiment will carry one, and a type that cannot be
+    // stored cannot be sealed — `PhysicalAccountingFacts` derived
+    // `Serialize` and failed at runtime for exactly this reason.
+    let (_dir, request) = artifacts();
+    let request = request.with_sequences(8).with_gate("kimi-logit-v2");
+    let text = serde_json::to_string(&request).expect("serialise");
+    assert_eq!(
+        serde_json::from_str::<TeacherForcedRequest>(&text).expect("reload"),
+        request
+    );
+    let value = serde_json::to_value(&request).expect("to value");
+    assert_eq!(
+        serde_json::from_value::<TeacherForcedRequest>(value).expect("from value"),
+        request
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/measure_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/measure_tests.rs
@@ -372,13 +372,22 @@ fn every_condition_the_harness_checks_has_a_refusal_to_return() {
             measured: 512,
         }
         .into(),
+        Inadmissible::NullArmNotZero {
+            statistic: "kl_p99".into(),
+            observed: 1e-9,
+        }
+        .into(),
         Inadmissible::GateMismatch {
             requested: "kimi-logit-balanced-v1".into(),
             evaluated: "kimi-logit-v3".into(),
         }
         .into(),
     ];
-    assert_eq!(inventory.len(), 10, "ten validity conditions, each named");
+    assert_eq!(
+        inventory.len(),
+        11,
+        "eleven validity conditions, each named"
+    );
     for refusal in &inventory {
         assert!(
             !refusal.nothing_was_measured(),
@@ -409,6 +418,28 @@ fn every_condition_the_harness_checks_has_a_refusal_to_return() {
     ] {
         assert!(MeasurementRefusal::from(failure).nothing_was_measured());
     }
+}
+
+#[test]
+fn the_determinism_control_is_a_validity_condition_and_not_a_pleasantry() {
+    // The variant the first pass of this vocabulary missed, found by
+    // walking the harness assertion by assertion instead of reasoning
+    // about what it ought to check.
+    //
+    // It is the most dangerous condition in the set: a
+    // non-deterministic device produces a plausible KL that is
+    // entirely artifact, and every OTHER check still passes. So it is
+    // inadmissible evidence rather than an execution failure — the
+    // numbers exist, and repeating the run reproduces the same
+    // non-evidence.
+    let refusal: MeasurementRefusal = Inadmissible::NullArmNotZero {
+        statistic: "kl_p99".into(),
+        observed: 1e-9,
+    }
+    .into();
+    assert!(!refusal.nothing_was_measured());
+    assert!(!refusal.worth_retrying());
+    assert!(refusal.to_string().contains("NullArmNotZero"), "{refusal}");
 }
 
 #[test]

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -61,6 +61,9 @@ pub mod gptq;
 pub mod kda_candidate;
 pub mod kquant;
 pub mod map;
+pub mod measure;
+#[cfg(test)]
+mod measure_tests;
 pub mod measurement;
 pub mod nvfp4_pack;
 pub mod participation;

--- a/crates/larql-vindex/src/format/vindex3/represent/quality.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/quality.rs
@@ -30,6 +30,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::error::VindexError;
+
 /// Acceptance criteria, identified so a claim can name what it passed.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QualityGate {
@@ -623,6 +625,47 @@ impl QualityEvidence {
 /// The bar this must clear before it is used on anything: a NULL arm
 /// (BF16 against itself) has to pass it with every count at zero. A gate
 /// its own reference cannot satisfy is measuring the harness.
+/// **Every gate this build implements, by name.**
+///
+/// A record names its gate; this resolves it. The alternative — a
+/// caller choosing the gate and the record merely describing one — is
+/// how `q2a_teacher_forced` came to evaluate `kimi-logit-v3` while the
+/// optimiser record declared `kimi-logit-balanced-v1`: two authorities,
+/// and the stored one was not the one that judged.
+///
+/// **No fallback.** An unknown id is refused, never resolved to
+/// whichever gate this file happens to consider current. A gate decides
+/// what is admissible; silently substituting one re-answers every
+/// verdict drawn under the name that was asked for.
+pub fn gate_by_id(id: &str) -> Result<QualityGate, VindexError> {
+    let gate = match id {
+        "kimi-logit-v1" => kimi_logit_v1(),
+        "kimi-logit-v2" => kimi_logit_v2(),
+        "kimi-logit-v3" => kimi_logit_v3(),
+        "kimi-logit-balanced-v1" => kimi_logit_balanced_v1(),
+        other => {
+            return Err(VindexError::Parse(format!(
+                "no gate named `{other}` is implemented by this build — a run judged under \
+                 another gate would carry a verdict nobody asked for"
+            )))
+        }
+    };
+    debug_assert_eq!(
+        gate.id, id,
+        "a gate must answer to the name it is looked up by"
+    );
+    Ok(gate)
+}
+
+/// The gates [`gate_by_id`] resolves, so a test can assert the registry
+/// and the constructors do not drift apart.
+pub const IMPLEMENTED_GATES: [&str; 4] = [
+    "kimi-logit-v1",
+    "kimi-logit-v2",
+    "kimi-logit-v3",
+    "kimi-logit-balanced-v1",
+];
+
 pub fn kimi_logit_v1() -> QualityGate {
     QualityGate {
         id: "kimi-logit-v1".into(),


### PR DESCRIPTION
> **Status: implementation merged, real Kimi/Metal qualification PENDING.**
> Nothing in this branch has executed a single measurement arm. The
> container and device are not on the machine it was written on. 5a-0 is
> not experimentally closed, and Stage 5a's effect authority must not be
> built on it as though qualification had happened.

Stage 5 is the authority to CAUSE experiments, and it had a precondition
nothing had checked:

> **A prepared experiment must not describe a run more precisely than the
> executor can be instructed to perform.**

The teacher-forced runner violated it. Its gate was a literal —
`kimi_logit_v3()` at the point of verdict — while an optimiser record
declares `kimi-logit-balanced-v1`. Its slice and label were environment
variables read where they were used. Sealing those into a
`PreparedExperimentId` would have attested to declared intent, not to
caused execution: 4b-c's declaration-versus-procedure gap one level up.

## Four commits

**5a-0a — a measurement run is instructed, not configured.**
`TeacherForcedRequest` carries every control as a field. `gate_by_id`
resolves the four gates this build implements and refuses an unknown
name with **no fallback**; `MeasurementProcedure::by_name` does the same
for the procedure — the discipline of 4b-f's `layout_admission` and
`compiled_bytes`. The environment form becomes an ADAPTER onto the same
request, so "the env invocation and the direct invocation agree" is true
by construction rather than by a comparison that needs a 48 B model.
`from_vars` takes a lookup rather than reading process env, so the
adapter is tested without `set_var`, which races every other test in the
binary.

**5a-0b vocabulary — execution failure is not validity failure.**

```text
ExecutionFailure    nothing was measured; retry may help
Inadmissible        numbers may exist and are NOT evidence; retry cannot
```

An agent told only "it failed" would retry the second class forever and
get the same non-evidence back. Every `Inadmissible` variant is a
condition the harness asserted; each one's doc names which.

**5a-0b inventory — the conservation check, frozen before the move.**
Every assertion site mapped to `ExecutionFailure`, `Inadmissible` or
`VerifiedFacts`, so the review question is *where did each one go* rather
than *does this look equivalent*.

**5a-0b body move — the harness becomes callable.**

```text
#[test] fn q2a_teacher_forced_...()
    -> pub fn measure_teacher_forced(&TeacherForcedRequest)
           -> Result<MeasurementReceipt, MeasurementRefusal>
```

`q2a_teacher_forced` is now the thin witness. It keeps only the two
claims that were never about this measurement's validity — the sub-4096
refusal is about `QualityGate::evaluate`, the operand-removal control is
about `verify_complete` — because a check that moves for tidiness is as
lost as one that vanishes.

## What the inventory found that the compiler could not

**Before the move:** `NullArmNotZero` was absent from a vocabulary
written after reading the harness once. It is the determinism control —
the baseline arm against itself must be exactly zero — and the most
dangerous condition in the set, because a non-deterministic device yields
a plausible KL that is entirely artifact while every other check passes.

**After the first transformation pass:** five production sites still
panicked (corpus read, layer load, head attach, teacher-forced step), so
`HeadDidNotAttach` and `StepRefused` were unreachable; and
`OperandNotSealed` was never a production condition at all — the
inventory had assigned it to the line where the operand-removal control
*finds* a seal to delete. Removed, because an unused refusal variant
makes a vocabulary look more authoritative than it is.

Both were in code that compiled, passed the suite, and read correctly in
a diff.

## Evidence semantics

`MeasurementReceipt::qualifies()` is `verified.complete()`, deliberately
not "the candidate passed":

```text
candidate refused + valid measurement    -> admissible evidence
candidate passed  + a skipped check      -> evidence of nothing
```

The verdict travels as a recorded fact. Promotion stays the optimiser's
to derive; execution establishes *experiment X produced observation Y*,
never *therefore Y is preferred*.

A build that cannot perform the procedure REFUSES: the runner needs Metal
and macOS, and on any other build `measure::run` returns
`ExecutionFailure::BackendUnavailable` naming the procedure — because
`PreparedExperiment` must decide whether something is executable on the
machine in front of it, and a missing symbol is not an answer it can act
on.

## The qualification this branch is waiting for

Against the merge SHA, on a machine with the container:

```bash
LARQL_KIMI_VINDEX3=~/chris-models/Kimi-Linear-48B-A3B-Instruct.aligned.vindex3 \
LARQL_KIMI_Q6_CANDIDATE=/tmp/kimi-q80-l25.vindex3 \
LARQL_KIMI_QUALITY_BANK=/tmp/kimi_quality_bank \
LARQL_Q2A_SEQUENCES=8 LARQL_Q2A_LABEL=q80-l25 \
  cargo test -p larql-vindex --features gpu --release --lib q2a_teacher_forced -- --nocapture
```

then four deliberately broken variants — wrong gate, candidate scope
mismatch, seal/read mismatch, and a real execution failure — plus
inspecting the null arm of the positive run for exactly zero. The
question is not whether Kimi performs well. It is whether the callable
path can admit a valid real run, reject invalid ones, and tell an
execution failure from inadmissible evidence.

## Gates

fmt; clippy `-D warnings` workspace-wide and with `--features gpu`;
`cargo check` both ways; 4147 larql-vindex tests; 854 larql-cli; doc
links; coverage policy green at 93.74%, `measure/outcome.rs` 100%.
