### PR TITLE
feat(exec): planned execution realizations — rung 3 of the REPRESENT codec contract (3a–3d)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,9 +1052,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "pem-rfc7468",
  "zeroize",

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/generate.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/generate.rs
@@ -52,6 +52,14 @@ pub(super) fn run_generate<B: PlanBackend>(
     eprintln!("weights resident in {load_seconds:.1} s");
     report_residency(&session.residency_census());
     report_allocations(&session.allocation_census());
+    // What was pinned, from the structured records; the rendering is
+    // presentation only.
+    eprint!(
+        "{}",
+        larql_vindex::format::vindex3::opplan::exec::accounting::render_selection_summary(
+            session.realizations()
+        )
+    );
 
     let mut emitted = 0usize;
     let decoded = greedy_decode(&mut session, prompt, new_tokens, &mut |id, value| {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/accounting.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/accounting.rs
@@ -1,0 +1,454 @@
+//! **Accounting bound AGAINST the census, never into it.**
+//!
+//! Rung 3c of the representation/execution contract. Two instruments,
+//! kept apart on purpose:
+//!
+//! * an [`Expectation`] is what a pinned realization DECLARES — derived from
+//!   the pin, the codec's declared residency, the executor's own block
+//!   geometry and the container's RECORDED operand length. It never reads
+//!   a loaded object.
+//! * an [`Observed`] is what the loader actually made resident — read off
+//!   the bound `LoadedWeight`s, paired with the operand each one binds.
+//!
+//! [`reconcile`] compares the two. If both came from one declaration the
+//! comparison would be circular; because they do not, a wrong block
+//! constant, a wrong codec residency, or a loader that drifted from the
+//! selector shows up as a mismatch. The residency census is a third
+//! reading — the loaded objects summed by site — and the plan-level
+//! witness checks it against the observed pairs.
+//!
+//! Three quantities, each with one definition:
+//!
+//! ```text
+//! stored footprint   Σ recorded length over DISTINCT stored operands
+//!                    (a tied head and its embedding are one object)
+//! execution touch    Σ recorded length over OPERATIONS
+//!                    (the same object read once per operation)
+//! resident / staging what the realization holds, and what it
+//!                    materialises transiently on the way there
+//! ```
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::backend::WeightFormat;
+use super::cpu::integer::weight_index_enabled;
+use super::cpu::ledger::{PlanTally, ProjectionLedger};
+use super::cpu::physical::PhysicalProjectionPlan;
+use super::quantise::{Q4_BLOCK, Q8_BLOCK};
+use super::realization::{RealizationForm, RealizationId, RealizationRecord};
+use super::weights::{LoadedWeight, DEVICE_PAGE_ALIGN};
+use crate::error::VindexError;
+use crate::format::vindex3::opplan::planned::Operation;
+use crate::format::vindex3::opplan::OperandRef;
+use crate::format::vindex3::represent::codec::{ResidencyClass, ResidencyProfile};
+
+/// Width of the canonical decode target.
+const F32_WIDTH: f64 = std::mem::size_of::<f32>() as f64;
+/// Width of a half-precision resident element.
+const HALF_WIDTH: f64 = std::mem::size_of::<u16>() as f64;
+/// Bits in a byte, for the stored-bit pricings below.
+const BITS_PER_BYTE: f64 = 8.0;
+/// NVFP4's stored rate — 4-bit codes and one 8-bit scale per 16 elements.
+const NVFP4_BITS_PER_WEIGHT: f64 = 4.5;
+/// MXFP4's stored rate — 4-bit codes and one 8-bit scale per 32 elements.
+const MXFP4_BITS_PER_WEIGHT: f64 = 4.25;
+/// The widest of the three K-quant codecs; the bound operand carries which.
+const KQUANT_WIDEST_BITS_PER_WEIGHT: f64 = 8.5;
+/// One f32 scale per block of a re-quantised image.
+const SCALE_WIDTH: f64 = F32_WIDTH;
+/// One i16 code sum per block, when the weight-code index is on.
+const SUM_WIDTH: f64 = std::mem::size_of::<i16>() as f64;
+
+/// The executor's own resident geometry: what a re-quantised image costs
+/// per weight depends on these, and they are the executor's declarations,
+/// not the codec's.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockGeometry {
+    pub q8_block: usize,
+    pub q4_block: usize,
+    /// Whether the Q8 image also carries one code sum per block.
+    pub q8_indexed: bool,
+}
+
+impl BlockGeometry {
+    /// The geometry this process's executor uses.
+    pub fn executor() -> Self {
+        Self {
+            q8_block: Q8_BLOCK,
+            q4_block: Q4_BLOCK,
+            q8_indexed: weight_index_enabled(),
+        }
+    }
+}
+
+/// What the executor makes resident for `format`, priced from `geometry`:
+/// a widened image is f32 per weight; a re-quantised image is its codes
+/// plus one f32 scale (and one i16 sum, when indexed) per block; a
+/// device's half-precision image is two bytes per weight and, being
+/// rounded from the source, a re-quantisation; a compact pack bound as
+/// stored is its stored bits.
+pub fn resident_profile_with(format: WeightFormat, geometry: BlockGeometry) -> ResidencyProfile {
+    match format {
+        WeightFormat::F32 => ResidencyProfile::DECODED_F32,
+        WeightFormat::Bf16 => ResidencyProfile::rebound(HALF_WIDTH * BITS_PER_BYTE),
+        WeightFormat::F16 => ResidencyProfile {
+            class: ResidencyClass::TransientRequantised,
+            bytes_per_weight: HALF_WIDTH,
+        },
+        WeightFormat::Q8 => ResidencyProfile {
+            class: ResidencyClass::TransientRequantised,
+            bytes_per_weight: 1.0
+                + (SCALE_WIDTH + if geometry.q8_indexed { SUM_WIDTH } else { 0.0 })
+                    / geometry.q8_block as f64,
+        },
+        WeightFormat::Q4 => ResidencyProfile {
+            class: ResidencyClass::TransientRequantised,
+            bytes_per_weight: 0.5 + SCALE_WIDTH / geometry.q4_block as f64,
+        },
+        WeightFormat::Nvfp4 => ResidencyProfile::rebound(NVFP4_BITS_PER_WEIGHT),
+        WeightFormat::Mxfp4 => ResidencyProfile::stored(MXFP4_BITS_PER_WEIGHT),
+        WeightFormat::KQuant => ResidencyProfile::stored(KQUANT_WIDEST_BITS_PER_WEIGHT),
+    }
+}
+
+/// What one pinned realization declares it will cost. Every field is
+/// derived from the pin and the container's record; none from a loaded
+/// object.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Expectation {
+    pub operand: OperandRef,
+    pub operation: Operation,
+    pub layer: Option<usize>,
+    pub realization: RealizationId,
+    /// The container's recorded length for the stored operand — an
+    /// instance fact, which for an entropy-coded operand is not a
+    /// function of its shape.
+    pub stored_bytes: u64,
+    pub logical_elements: usize,
+    /// The declared resident image: the realization's residency profile
+    /// over the logical elements.
+    pub declared_resident: u64,
+    /// Bytes materialised transiently on the way to residency: the f32
+    /// image a decode or re-quantisation passes through, none for a
+    /// realization that binds the stored bytes.
+    pub staging: u64,
+}
+
+impl Expectation {
+    /// The stored bytes read once for this operation.
+    pub fn touch(&self) -> u64 {
+        self.stored_bytes
+    }
+
+    /// The peak the realization holds while preparing: resident plus
+    /// whatever it staged to get there.
+    pub fn working_set(&self) -> u64 {
+        self.declared_resident + self.staging
+    }
+}
+
+/// Price every record. `stored_len` answers with the container's recorded
+/// length for an operand, or `None` for one the container does not hold.
+pub fn expectations(
+    records: &[RealizationRecord],
+    stored_len: impl Fn(&OperandRef) -> Option<u64>,
+    geometry: BlockGeometry,
+) -> Vec<Expectation> {
+    records
+        .iter()
+        .map(|r| {
+            let logical = r.planned.logical_elements;
+            let realization = r.selection.realization;
+            // Direct and decode carry the codec's own declaration; the
+            // executor's forms are priced from its geometry, so a change
+            // to that geometry re-prices them here and nowhere else.
+            let profile = match realization.form {
+                RealizationForm::Direct(_) | RealizationForm::Decode(_) => r.selection.residency,
+                RealizationForm::Requantise(_)
+                | RealizationForm::SliceStored { .. }
+                | RealizationForm::DeviceResident(_) => {
+                    resident_profile_with(realization.format(), geometry)
+                }
+                RealizationForm::DecodedGather => ResidencyProfile::DECODED_F32,
+            };
+            let staging = match realization.form {
+                RealizationForm::Direct(_) => 0,
+                RealizationForm::Decode(_)
+                | RealizationForm::Requantise(_)
+                | RealizationForm::DecodedGather => (logical as f64 * F32_WIDTH).round() as u64,
+                RealizationForm::SliceStored { convert }
+                | RealizationForm::DeviceResident(convert) => {
+                    if convert == WeightFormat::F32 {
+                        0
+                    } else {
+                        (logical as f64 * F32_WIDTH).round() as u64
+                    }
+                }
+            };
+            Expectation {
+                operand: r.planned.operand.clone(),
+                operation: r.planned.operation,
+                layer: r.planned.layer,
+                realization,
+                stored_bytes: stored_len(&r.planned.operand).unwrap_or(0),
+                logical_elements: logical,
+                declared_resident: (profile.bytes_per_weight * logical as f64).round() as u64,
+                staging,
+            }
+        })
+        .collect()
+}
+
+/// One operand paired with the object(s) the loader bound for it: a
+/// matrix is one object, a packed bank is one per expert. Every loader
+/// names its own pairing, field by field, so the observation cannot be
+/// derived from the plan's order.
+pub struct Bound<'a> {
+    pub operand: &'a OperandRef,
+    pub weights: Vec<&'a LoadedWeight>,
+}
+
+impl<'a> Bound<'a> {
+    pub fn one(operand: &'a OperandRef, weight: &'a LoadedWeight) -> Self {
+        Self {
+            operand,
+            weights: vec![weight],
+        }
+    }
+
+    pub fn observed(
+        &self,
+        operation: Operation,
+        layer: Option<usize>,
+    ) -> Result<Observed, VindexError> {
+        let Some(first) = self.weights.first() else {
+            return Err(VindexError::Parse(format!(
+                "operand `{}`: bound to no object",
+                self.operand.tensor
+            )));
+        };
+        let format = first.format();
+        if let Some(other) = self.weights.iter().find(|w| w.format() != format) {
+            return Err(VindexError::Parse(format!(
+                "operand `{}`: bound objects disagree on their representation ({format:?} vs {:?})",
+                self.operand.tensor,
+                other.format()
+            )));
+        }
+        Ok(Observed {
+            operand: self.operand.clone(),
+            operation,
+            layer,
+            format,
+            resident_bytes: self.weights.iter().map(|w| w.resident_bytes() as u64).sum(),
+            allocations: self.weights.iter().map(|w| w.padded_allocations()).sum(),
+        })
+    }
+}
+
+/// What the loader actually made resident for one planned operand.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Observed {
+    pub operand: OperandRef,
+    pub operation: Operation,
+    pub layer: Option<usize>,
+    pub format: WeightFormat,
+    /// Bytes held, allocation padding included.
+    pub resident_bytes: u64,
+    /// Allocations the bytes live in: one for a matrix, one per expert
+    /// for a bank.
+    pub allocations: usize,
+}
+
+/// The result of a reconciliation that held.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Reconciliation {
+    pub matched: usize,
+    pub declared_resident: u64,
+    pub observed_resident: u64,
+    /// Observed minus declared — allocation padding, bounded per
+    /// allocation by the page.
+    pub padding: u64,
+}
+
+/// Every expectation must meet one observation for its operand and
+/// operation instance, in the pinned representation, holding the declared
+/// bytes plus at most a page of padding per allocation; nothing observed
+/// may be unexpected.
+///
+/// Instances are counted, not deduplicated: the same stored operand bound
+/// twice — a tied head under two operations, Gemma-4's layer that binds
+/// one tensor as both its key and value projection — is two expectations
+/// meeting two objects, and the loader really does hold it twice.
+pub fn reconcile(
+    expected: &[Expectation],
+    observed: &[Observed],
+) -> Result<Reconciliation, VindexError> {
+    let key = |op: &OperandRef, operation: Operation, layer: Option<usize>| {
+        (
+            op.object.clone(),
+            op.tensor.clone(),
+            operation.name(),
+            layer,
+        )
+    };
+    let mut pool: BTreeMap<(String, String, &'static str, Option<usize>), Vec<&Observed>> =
+        BTreeMap::new();
+    for o in observed {
+        pool.entry(key(&o.operand, o.operation, o.layer))
+            .or_default()
+            .push(o);
+    }
+    let mut out = Reconciliation::default();
+    for e in expected {
+        let k = key(&e.operand, e.operation, e.layer);
+        let Some(o) = pool.get_mut(&k).and_then(Vec::pop) else {
+            return Err(VindexError::Parse(format!(
+                "operand `{}` ({}): pinned {} but nothing is resident for it",
+                e.operand.tensor,
+                e.operation.name(),
+                e.realization.name()
+            )));
+        };
+        let pinned = e.realization.format();
+        if o.format != pinned {
+            return Err(VindexError::Parse(format!(
+                "operand `{}` ({}): pinned {pinned:?} but {:?} is resident",
+                e.operand.tensor,
+                e.operation.name(),
+                o.format
+            )));
+        }
+        // Exact for an object held in plain vectors; up to a page of
+        // padding per page-aligned allocation, and never less than declared.
+        let ceiling = e.declared_resident + (o.allocations as u64) * DEVICE_PAGE_ALIGN as u64;
+        let within = if o.allocations == 0 {
+            o.resident_bytes == e.declared_resident
+        } else {
+            o.resident_bytes >= e.declared_resident && o.resident_bytes < ceiling
+        };
+        if !within {
+            return Err(VindexError::Parse(format!(
+                "operand `{}` ({}): {} declares {} resident bytes over {} elements; {} are \
+                 resident in {} allocation(s) — the declaration and the loader disagree",
+                e.operand.tensor,
+                e.operation.name(),
+                e.realization.name(),
+                e.declared_resident,
+                e.logical_elements,
+                o.resident_bytes,
+                o.allocations
+            )));
+        }
+        out.matched += 1;
+        out.declared_resident += e.declared_resident;
+        out.observed_resident += o.resident_bytes;
+        out.padding += o.resident_bytes - e.declared_resident;
+    }
+    if let Some(stray) = pool.values().flatten().next() {
+        return Err(VindexError::Parse(format!(
+            "operand `{}` ({}) is resident but nothing was pinned for it",
+            stray.operand.tensor,
+            stray.operation.name()
+        )));
+    }
+    Ok(out)
+}
+
+/// The stored footprint: each stored operand counted once, however many
+/// operations read it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct StoredFootprint {
+    pub bytes: u64,
+    pub operands: usize,
+}
+
+pub fn stored_footprint(expected: &[Expectation]) -> StoredFootprint {
+    let mut seen = BTreeSet::new();
+    let mut out = StoredFootprint::default();
+    for e in expected {
+        if seen.insert((e.operand.object.clone(), e.operand.tensor.clone())) {
+            out.bytes += e.stored_bytes;
+            out.operands += 1;
+        }
+    }
+    out
+}
+
+/// The execution touch: the stored bytes read, once per operation.
+pub fn execution_touch(expected: &[Expectation]) -> u64 {
+    expected.iter().map(Expectation::touch).sum()
+}
+
+/// The ledger's account of what ran, held against the pins: every CPU
+/// plan the ledger tallied is a pinned realization, and every pinned CPU
+/// realization ran. Returned per plan with the number of operands pinned
+/// to it and its tally, so a caller can hold the tally's POSITIONS against
+/// the operands — calls are not the unit, because the executor batches a
+/// projection's positions differently per site (per position at the
+/// attention, all at once in the FFN), while every position a pinned
+/// operand processed is counted exactly once.
+pub fn ledger_correspondence(
+    records: &[RealizationRecord],
+    ledger: &ProjectionLedger,
+) -> Result<Vec<(PhysicalProjectionPlan, usize, PlanTally)>, VindexError> {
+    let mut pinned: Vec<(PhysicalProjectionPlan, usize)> = Vec::new();
+    for r in records {
+        if let Some(plan) = r.selection.realization.cpu_plan() {
+            match pinned.iter_mut().find(|(p, _)| *p == plan) {
+                Some((_, n)) => *n += 1,
+                None => pinned.push((plan, 1)),
+            }
+        }
+    }
+    let mut out = Vec::new();
+    for (plan, tally) in ledger.all() {
+        let pins = pinned.iter().find(|(p, _)| *p == plan).map(|(_, n)| *n);
+        match (pins, tally.calls) {
+            (None, 0) => {}
+            (None, calls) => {
+                return Err(VindexError::Parse(format!(
+                    "{plan:?} ran {calls} call(s) but no operand was pinned to it"
+                )))
+            }
+            (Some(n), 0) => {
+                return Err(VindexError::Parse(format!(
+                    "{n} operand(s) pinned to {plan:?} but it never ran"
+                )))
+            }
+            (Some(n), _) => out.push((plan, n, tally)),
+        }
+    }
+    Ok(out)
+}
+
+/// A selection summary for a report: presentation over the structured
+/// records, one line per realization with the operands it serves.
+pub fn render_selection_summary(records: &[RealizationRecord]) -> String {
+    let mut groups: Vec<(String, String, String, usize, usize)> = Vec::new();
+    for r in records {
+        let key = (
+            r.representation.clone(),
+            r.selection.realization.name(),
+            r.selection.reason.name().to_string(),
+        );
+        match groups
+            .iter_mut()
+            .find(|g| g.0 == key.0 && g.1 == key.1 && g.2 == key.2)
+        {
+            Some(g) => {
+                g.3 += 1;
+                g.4 += r.planned.logical_elements;
+            }
+            None => groups.push((key.0, key.1, key.2, 1, r.planned.logical_elements)),
+        }
+    }
+    let mut out = String::from("realizations:\n");
+    for (representation, realization, reason, operands, elements) in groups {
+        out.push_str(&format!(
+            "  {representation:<10} → {realization:<32} {operands:>4} operand(s) {:>12} weights  ({reason})\n",
+            elements
+        ));
+    }
+    out
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -29,7 +29,9 @@ use larql_models::config::{
 use super::super::super::graph::policy::AttentionSpan;
 use super::cpu::WeightRows;
 use super::quantise::SUM_BLOCK;
+use super::realization::{RepresentationFacts, Selection, SelectionRefusal};
 use crate::error::VindexError;
+use crate::format::vindex3::opplan::planned::PlannedOperand;
 use crate::format::vindex3::represent::kquant::KQuant;
 
 /// The numerical representation a backend wants matrix operands in.
@@ -143,43 +145,6 @@ pub enum MatrixClass {
     /// question about "how big is this matrix" has no answer here, which
     /// is exactly why answering it as an `FfnProjection` would be wrong.
     RoutedExpertBank,
-}
-
-/// What the interpreter knows about one matrix operand before loading
-/// it: enough to choose a representation, never enough to reinterpret
-/// the tensor.
-///
-/// The class alone stopped being sufficient at Qwen3.8. Its `48 x 5120`
-/// delta gates and its `10240 x 5120` fused projection are both
-/// attention-class operands separated by a factor of 213 in size, and
-/// the measured answer for one is the wrong answer for the other by
-/// 3.8x. A per-class declaration cannot express that; a per-operand one
-/// can.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct MatrixOperand {
-    pub class: MatrixClass,
-    /// The matrix's element count — `out_dim * in_dim`.
-    pub elements: usize,
-    /// Whether the container holds this operand as bf16 AND it can be
-    /// read unwidened. A physical fact about the checkpoint, not a
-    /// preference: a backend that wants compact bytes where there are
-    /// none would have to quantise to get them.
-    pub stored_bf16: bool,
-    /// Whether the container holds this operand as a compiled NVFP4
-    /// pack. The same kind of fact as [`Self::stored_bf16`] — physical,
-    /// not a preference — and it outranks the size policy: a pack exists
-    /// because someone compiled it deliberately, so a backend asking for
-    /// anything else would widen bytes that are already in the shape a
-    /// kernel wants.
-    pub stored_nvfp4: bool,
-    /// Whether the container holds this operand as a compiled K-quant
-    /// pack — Q8_0, Q6_K or Q4_K. The same kind of fact as
-    /// [`Self::stored_nvfp4`], with one difference in how it is acted
-    /// on: a stored K-quant has TWO execution routes, in place or
-    /// widened to f32, and which one runs is the process's
-    /// [`super::cpu::physical::KQuantExecution`] arm rather than a
-    /// consequence of the bytes alone.
-    pub stored_kquant: bool,
 }
 
 /// A backend's declared format per matrix class.
@@ -728,11 +693,21 @@ pub trait PlanBackend: Sync {
         None
     }
 
-    /// The representation this backend wants one matrix operand loaded
-    /// in. A capability, asked per operand at load time — not a per-call
-    /// decision, and not a per-model one.
-    fn weight_format(&self, _operand: MatrixOperand) -> WeightFormat {
-        WeightFormat::F32
+    /// The realization this backend takes for one planned operand, given
+    /// what the registry declares for its stored representation.
+    ///
+    /// Chosen from candidates the backend derives from those declarations,
+    /// or refused naming every candidate considered. Asked per operand at
+    /// preparation, BEFORE any byte is read, and pinned in the prepared
+    /// plan: the executor runs what was pinned or refuses. The default is
+    /// the reference oracle — the literal f32 transcription — so a backend
+    /// that says nothing inherits the arithmetic that defines correctness.
+    fn select(
+        &self,
+        operand: &PlannedOperand,
+        facts: &RepresentationFacts,
+    ) -> Result<Selection, Box<SelectionRefusal>> {
+        super::realization::reference_selection(operand, facts)
     }
 
     /// How this backend performs a Gated DeltaNet layer's dense

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/physical.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/physical.rs
@@ -338,15 +338,18 @@ impl PhysicalProjectionPlan {
     /// and its `10240 x 5120` fused projection are both attention-class
     /// operands, and they want opposite answers.
     ///
-    /// `stored_bf16` is a physical fact about the checkpoint, not a
+    /// `bf16_kernel_declared` was `stored_bf16` until rung 3b: a physical
+    /// fact about the checkpoint, read off a dtype label. It is now the
+    /// codec DECLARING the direct bf16 kernel, resolved by the selector —
+    /// the same fact, from the declaration instead of the label. Not a
     /// preference. A container holding f32 has no compact bytes to keep,
     /// and narrowing them here would ROUND — bf16 residency promises the
     /// stored bytes are the resident bytes, and a policy that quietly
     /// quantised to hit its own threshold would make that a lie.
-    pub fn choose(elements: usize, stored_bf16: bool) -> Self {
+    pub fn choose(elements: usize, bf16_kernel_declared: bool) -> Self {
         // Class-agnostic: every class admitted, which is what a caller
         // asking without one means.
-        Self::choose_for(None, elements, stored_bf16)
+        Self::choose_for(None, elements, bf16_kernel_declared)
     }
 
     /// The same policy, told which class the operand belongs to.
@@ -354,8 +357,12 @@ impl PhysicalProjectionPlan {
     /// The class changes nothing except whether a Q4 arm may reach this
     /// operand — the cache thresholds are physical and identical for
     /// every class.
-    pub fn choose_for(class: Option<MatrixClass>, elements: usize, stored_bf16: bool) -> Self {
-        if !stored_bf16 || elements * F32_BYTES < compact_threshold_bytes() {
+    pub fn choose_for(
+        class: Option<MatrixClass>,
+        elements: usize,
+        bf16_kernel_declared: bool,
+    ) -> Self {
+        if !bf16_kernel_declared || elements * F32_BYTES < compact_threshold_bytes() {
             return Self::BlasF32;
         }
         // **The same cache argument, one format further down.**

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/kquant_plan.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/kquant_plan.rs
@@ -229,6 +229,7 @@ fn planned(operation: Operation) -> PlannedOperand {
         access: operation.access(),
         extent: RepresentationExtent::TERMINAL,
         layer: Some(0),
+        declared_representation: None,
         logical_elements: 17408 * 5120,
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/kquant_plan.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/cpu/tests/kquant_plan.rs
@@ -12,8 +12,14 @@
 use super::super::kernels::ScalarF32;
 use super::super::physical::{KQuantExecution, PhysicalProjectionPlan, KQUANT_EXEC_WIDEN};
 use super::super::projector::{DenseProjector, WeightRows};
-use crate::format::vindex3::opplan::exec::backend::{MatrixClass, MatrixOperand, WeightFormat};
-use crate::format::vindex3::opplan::exec::production::declared_format;
+use crate::format::vindex3::opplan::exec::backend::{MatrixClass, WeightFormat};
+use crate::format::vindex3::opplan::exec::production::select_cpu;
+use crate::format::vindex3::opplan::exec::realization::{
+    RealizationForm, RealizationId, RepresentationFacts, SelectionReason,
+};
+use crate::format::vindex3::opplan::planned::{Operation, PlannedOperand};
+use crate::format::vindex3::opplan::OperandRef;
+use crate::format::vindex3::represent::codec::{RepresentationExtent, RequiredAccess};
 use crate::format::vindex3::represent::kquant::{KQuant, COMPILABLE, Q4_K, Q6_K, Q8_0};
 
 /// Rows and a width every codec's block divides: 512 is 16 Q8_0 blocks
@@ -209,66 +215,99 @@ fn the_env_value_selects_the_arm_exactly() {
     assert_eq!(KQuantExecution::default(), KQuantExecution::Direct);
 }
 
-fn operand(class: MatrixClass, stored_kquant: bool, stored_nvfp4: bool) -> MatrixOperand {
-    MatrixOperand {
-        class,
-        // Large enough to stream, so the size policy would have had an
-        // opinion if it were consulted.
-        elements: 17408 * 5120,
-        stored_bf16: false,
-        stored_nvfp4,
-        stored_kquant,
+/// A planned projection large enough to stream, so the size policy would
+/// have had an opinion if it were consulted.
+fn planned(operation: Operation) -> PlannedOperand {
+    PlannedOperand {
+        operand: OperandRef {
+            object: "target.decoder_stack".into(),
+            tensor: "0.mlp.up_proj.weight".into(),
+            dtype: String::new(),
+            shape: vec![17408, 5120],
+        },
+        operation,
+        access: operation.access(),
+        extent: RepresentationExtent::TERMINAL,
+        layer: Some(0),
+        logical_elements: 17408 * 5120,
     }
 }
 
-/// The production policy binds a stored K-quant in place under the direct
-/// arm and widens it under the other — and answers exactly as it did
-/// before the arm existed for everything that is not a stored K-quant.
+fn facts(label: &str) -> RepresentationFacts {
+    RepresentationFacts::resolve(label)
+}
+
+/// The production selector binds a stored K-quant in place under the
+/// direct arm and widens it under the other — and answers exactly as the
+/// boolean ladder did before it, for everything that is not a stored
+/// K-quant. The candidates come from the codec's declarations: a K-quant
+/// label offers Direct(FusedKQuant) because the codec declares it, and an
+/// F16 label offers no direct realization at all.
 #[test]
 fn the_policy_answers_the_pack_under_direct_and_f32_under_widen() {
-    for class in [
-        MatrixClass::AttentionProjection,
-        MatrixClass::FfnProjection,
-        MatrixClass::OutputHead,
+    for operation in [
+        Operation::Project(MatrixClass::AttentionProjection),
+        Operation::Project(MatrixClass::FfnProjection),
+        Operation::OutputHead,
     ] {
-        assert_eq!(
-            declared_format(operand(class, true, false), KQuantExecution::Direct),
-            WeightFormat::KQuant,
-            "{class:?} direct"
-        );
-        // The widened arm is the v2 authority path: stored_bf16 is false
-        // for a K-quant, so the size policy lands on BLAS f32 exactly as
-        // it did before this arm existed.
-        assert_eq!(
-            declared_format(operand(class, true, false), KQuantExecution::Widen),
-            WeightFormat::F32,
-            "{class:?} widen"
-        );
-        // Not a stored K-quant: the arm is irrelevant and the answer is
-        // the size policy's.
-        for arm in [KQuantExecution::Direct, KQuantExecution::Widen] {
+        for label in ["Q4_K", "Q6_K", "Q8_0"] {
+            let direct =
+                select_cpu(&planned(operation), &facts(label), KQuantExecution::Direct).unwrap();
             assert_eq!(
-                declared_format(operand(class, false, false), arm),
-                WeightFormat::F32,
-                "{class:?} {arm:?} without a pack"
+                direct.realization,
+                RealizationId::cpu(RealizationForm::Direct(PhysicalProjectionPlan::FusedKQuant)),
+                "{operation:?} {label} direct"
             );
+            assert_eq!(direct.realization.format(), WeightFormat::KQuant);
+            assert_eq!(direct.reason, SelectionReason::DirectDeclared);
+            assert!(direct.candidates.contains(&direct.realization));
+            // The widened arm is the v2 authority path: decode, then BLAS.
+            let widened =
+                select_cpu(&planned(operation), &facts(label), KQuantExecution::Widen).unwrap();
+            assert_eq!(
+                widened.realization,
+                RealizationId::cpu(RealizationForm::Decode(PhysicalProjectionPlan::BlasF32)),
+                "{operation:?} {label} widen"
+            );
+            assert_eq!(widened.realization.format(), WeightFormat::F32);
+            assert_eq!(widened.reason, SelectionReason::ArmPrefersDecode);
+            // Both arms saw the same candidates; the arm only orders them.
+            assert_eq!(direct.candidates, widened.candidates);
+        }
+        // Not a stored K-quant: the arm is irrelevant and the answer is
+        // decode, because F16 declares no direct realization.
+        for arm in [KQuantExecution::Direct, KQuantExecution::Widen] {
+            let plain = select_cpu(&planned(operation), &facts("F16"), arm).unwrap();
+            assert_eq!(
+                plain.realization.format(),
+                WeightFormat::F32,
+                "{operation:?} {arm:?}"
+            );
+            assert_eq!(plain.reason, SelectionReason::NoDirectRealization);
         }
     }
-    // The bank is widened on the way in; no pack survives to bind.
+    // The bank is sliced at load; a K-quant bank provides the row access
+    // that slicing needs, and no pack survives to bind.
+    let bank = PlannedOperand {
+        operation: Operation::ExpertBankSlice,
+        access: RequiredAccess::RowRandom,
+        ..planned(Operation::ExpertBankSlice)
+    };
+    let sliced = select_cpu(&bank, &facts("Q4_K"), KQuantExecution::Direct).unwrap();
     assert_eq!(
-        declared_format(
-            operand(MatrixClass::RoutedExpertBank, true, false),
-            KQuantExecution::Direct
-        ),
-        WeightFormat::F32
+        sliced.realization,
+        RealizationId::cpu(RealizationForm::SliceStored {
+            convert: WeightFormat::F32
+        })
     );
-    // A stored NVFP4 pack keeps precedence; the two cannot both be true
-    // of one operand, and the order says which claim would win.
-    assert_eq!(
-        declared_format(
-            operand(MatrixClass::FfnProjection, true, true),
-            KQuantExecution::Direct
-        ),
-        WeightFormat::Nvfp4
-    );
+    // A stored NVFP4 pack keeps precedence over the arm: one label names
+    // one codec, so the two claims cannot meet on one operand any more,
+    // and the ladder's order is what says NVFP4 wins where it is declared.
+    let pack = select_cpu(
+        &planned(Operation::Project(MatrixClass::FfnProjection)),
+        &facts("NVFP4"),
+        KQuantExecution::Direct,
+    )
+    .unwrap();
+    assert_eq!(pack.realization.format(), WeightFormat::Nvfp4);
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -164,6 +164,9 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
         backend: &'a B,
         mut kv: KvSlot<'a>,
     ) -> Result<Self, VindexError> {
+        ops.get().ensure_providers_in(
+            crate::format::vindex3::represent::codec::CodecRegistry::builtin(),
+        )?;
         // The FULL continuation geometry, KV and recurrent alike.
         // `plan_kv_geometry` is the KV-only adapter and refuses a hybrid
         // plan; a session over one needs both forms announced.
@@ -182,6 +185,12 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
     /// representation — see [`PreparedOperands::residency_census`].
     pub fn residency_census(&self) -> super::prepared::ResidencyCensus {
         self.ops.get().residency_census()
+    }
+
+    /// The realization pinned for every operand this session executes,
+    /// with its candidates, reason and declared residency.
+    pub fn realizations(&self) -> &[super::realization::RealizationRecord] {
+        self.ops.get().realizations()
     }
 
     /// Where this session's operand allocations landed.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -164,9 +164,7 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
         backend: &'a B,
         mut kv: KvSlot<'a>,
     ) -> Result<Self, VindexError> {
-        ops.get().ensure_providers_in(
-            crate::format::vindex3::represent::codec::CodecRegistry::builtin(),
-        )?;
+        ops.get().ensure_providers_in(ops.get().registry())?;
         // The FULL continuation geometry, KV and recurrent alike.
         // `plan_kv_geometry` is the KV-only adapter and refuses a hybrid
         // plan; a session over one needs both forms announced.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
@@ -48,7 +48,7 @@ use larql_models::config::{Activation, GateActivation, GateCombine, GatePlacemen
 
 use super::backend::{
     AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, DispatchStats, FfnCall,
-    GateCall, MatrixOperand, NormCall, PlanBackend, ProjectCall, ProjectedQkv, RoutedFfnCall,
+    GateCall, MatrixClass, NormCall, PlanBackend, ProjectCall, ProjectedQkv, RoutedFfnCall,
     WeightFormat, WeightFormats, WeightSlice,
 };
 use super::production::{
@@ -62,6 +62,11 @@ use ndarray::ArrayView2;
 use rayon::prelude::*;
 
 use super::production::unsupported_activation;
+use super::realization::{
+    class_of, common_selection, resident_profile, RealizationBackend, RealizationForm,
+    RealizationId, RefusalKind, RepresentationFacts, Selection, SelectionReason, SelectionRefusal,
+};
+use crate::format::vindex3::opplan::planned::PlannedOperand;
 use larql_compute::ffn::gelu_tanh;
 
 /// One MXFP4 matrix as the device trait consumes it:
@@ -352,8 +357,44 @@ impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
     /// resident in device memory, and neither of those turns on a host
     /// cache boundary. The operand's size is available and ignored on
     /// purpose.
-    fn weight_format(&self, operand: MatrixOperand) -> WeightFormat {
-        self.formats.for_class(operand.class)
+    fn select(
+        &self,
+        operand: &PlannedOperand,
+        facts: &RepresentationFacts,
+    ) -> Result<Selection, Box<SelectionRefusal>> {
+        let bank = self.formats.for_class(MatrixClass::RoutedExpertBank);
+        if let Some(common) = common_selection(operand, facts, bank) {
+            return common;
+        }
+        let refuse = |kind| {
+            Box::new(SelectionRefusal {
+                operand: operand.operand.clone(),
+                operation: operand.operation,
+                representation: facts.label.clone(),
+                requested: operand.access,
+                kind,
+                considered: vec![],
+            })
+        };
+        let Some(class) = class_of(operand.operation) else {
+            return Err(refuse(RefusalKind::MissingRealization));
+        };
+        if facts.registered.is_none() {
+            return Err(refuse(RefusalKind::UnregisteredRepresentation));
+        }
+        // This backend's class table is its own declaration for its own
+        // target: the one candidate it offers, named as such.
+        let format = self.formats.for_class(class);
+        let id = RealizationId {
+            backend: RealizationBackend::Device,
+            form: RealizationForm::DeviceResident(format),
+        };
+        Ok(Selection {
+            realization: id,
+            residency: resident_profile(format),
+            reason: SelectionReason::DeviceClassTable,
+            candidates: vec![id],
+        })
     }
 
     fn prepare(&self, weights: &[WeightSlice<'_>]) {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
@@ -2,32 +2,36 @@
 //! declared format, and building the resolved call.
 //!
 //! The routed case binds a **packed expert bank**: every expert's
-//! projections live in one operand (`[experts, rows, k]`, MXFP4 blocks
-//! plus a scales stream, or unquantised BF16). Per expert, the loader
-//! either binds the stored bytes as they are — an MXFP4 expert for a
-//! backend that declared MXFP4 is a copy into aligned memory and nothing
-//! else — or converts through f32 to the format the backend asked for,
-//! exactly as `load_weight` does for a dense matrix. One resolution path,
-//! so the batch executor and the decode session cannot drift.
+//! projections live in one operand (`[experts, rows, k]`), bound ONCE as
+//! its codec's named streams over the whole `[experts × rows, k]` region.
+//! The codec — the container's label when that names one, else the codec
+//! the plan's declared layout carries (a packed MXFP4 bank is stored as
+//! two `U8` streams) — validates the streams against that geometry and
+//! decodes each expert as a row range of it, which the loader converts to
+//! the format the backend asked for exactly as `load_weight` does for a
+//! dense matrix. A backend that declared the bank's own format gets each
+//! expert's stored rows copied into aligned memory and nothing else. One
+//! resolution path, so the batch executor and the decode session cannot
+//! drift, and no dtype name is judged here: the codec is.
 
-use larql_models::config::ExpertFormat;
-use larql_models::quant::mxfp4::{dequantize_expert, MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS};
+use larql_models::quant::mxfp4::{MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS};
 
 use super::accounting::Bound;
 use super::backend::{FfnCall, NormCall, RoutedFfnCall, WeightFormat, WeightSlice};
-use super::narrow::{bf16_bytes_to_f16, f32_bytes_to_f16};
-use super::operands::{widen, OperandSource};
+use super::narrow::f32_bytes_to_f16;
+use super::operands::OperandSource;
 use super::realization::RepresentationFacts;
 use super::weights::{load_weight, quantize_mxfp4, quantize_nvfp4, AlignedBytes, LoadedWeight};
 use crate::error::VindexError;
+use crate::format::vindex3::opplan::planned::declared_bank_representation;
 use crate::format::vindex3::opplan::{
     ExpertBank, FfnOp, LayerFfn, NormOp, OperandRef, PackedProjection, RoutedFfnOp,
 };
+use crate::format::vindex3::represent::codec::codecs::lyrw2::bind_region;
+use crate::format::vindex3::represent::codec::codecs::mxfp4::DTYPE_MXFP4;
+use crate::format::vindex3::represent::codec::streams::{GROUP_SCALES, VALUES};
+use crate::format::vindex3::represent::codec::RepresentationExtent;
 
-/// Stored dtype of MXFP4 block and scale streams.
-const DTYPE_U8: &str = "U8";
-/// Stored dtype of an unquantised packed bank.
-const DTYPE_BF16: &str = "BF16";
 /// Gate and up: the two branches sharing one fused operand.
 const FUSED_BRANCHES: usize = larql_models::quant::mxfp4::FUSED_HALVES;
 
@@ -467,7 +471,8 @@ impl RoutedOperands {
 }
 
 /// Load one packed projection as `experts` matrices of `[rows, k]` in
-/// `format`.
+/// `format`: the bank bound once through its codec, each expert decoded
+/// as a row range of it.
 fn load_packed(
     store: OperandSource<'_>,
     projection: &PackedProjection,
@@ -477,79 +482,93 @@ fn load_packed(
     format: WeightFormat,
 ) -> Result<Vec<LoadedWeight>, VindexError> {
     let name = projection.weights.tensor.as_str();
-    // Declared geometry before bytes: a `k` the group cannot tile is a
-    // fact about the op, and refusing it costs no read.
-    if op.expert_format == ExpertFormat::PackedMxfp4 && !k.is_multiple_of(MXFP4_GROUP_ELEMS) {
+    let facts = bank_facts(store, op, &projection.weights)?;
+    let Some(registered) = facts.registered.as_ref() else {
         return Err(VindexError::Parse(format!(
-            "`{name}`: k={k} is not a multiple of the MXFP4 group"
+            "`{name}`: `{}` names no registered codec, so the bank cannot be decoded",
+            facts.label
+        )));
+    };
+    // Declared geometry before bytes: a `k` the codec's row alignment
+    // cannot tile is a fact about the op, and refusing it costs no read.
+    if !registered.capabilities.admits_k(k) {
+        return Err(VindexError::Parse(format!(
+            "`{name}`: k={k} is not a whole number of `{}` row alignments of {} elements",
+            facts.label, registered.capabilities.row_align_elems
         )));
     }
-    require_row_access(store, &projection.weights)?;
+    // The same admission the selector made before this loader was
+    // reached — one derivation, so a direct caller gets the same refusal
+    // rather than a read followed by a decode-time one.
+    facts.admit_row_slicing()?;
+    let codec = store.registry().resolve(&facts.label, name)?;
     let raw = store.load_raw(&projection.weights)?;
-    match op.expert_format {
-        ExpertFormat::PackedMxfp4 => {
-            let scales_ref = projection.scales.as_ref().ok_or_else(|| {
-                VindexError::Parse(format!(
-                    "`{name}`: MXFP4 expert projection carries no scales operand"
-                ))
-            })?;
-            let scales = store.load_raw(scales_ref)?;
-            expect_dtype(&raw.dtype, DTYPE_U8, name)?;
-            expect_dtype(&scales.dtype, DTYPE_U8, &scales_ref.tensor)?;
-            let groups = k / MXFP4_GROUP_ELEMS;
-            let block_stride = rows * groups * MXFP4_GROUP_BYTES;
-            let scale_stride = rows * groups;
-            expect_len(raw.bytes.len(), op.experts * block_stride, name)?;
-            expect_len(
-                scales.bytes.len(),
-                op.experts * scale_stride,
-                &scales_ref.tensor,
-            )?;
-            (0..op.experts)
-                .map(|e| {
-                    let packed = &raw.bytes[e * block_stride..(e + 1) * block_stride];
-                    let scale = &scales.bytes[e * scale_stride..(e + 1) * scale_stride];
-                    match format {
-                        // Native: the stored bytes are the operand.
-                        WeightFormat::Mxfp4 => Ok(LoadedWeight::Mxfp4 {
-                            packed: AlignedBytes::from_bytes(packed),
-                            scales: AlignedBytes::from_bytes(scale),
-                        }),
-                        // Everything else converts through f32, exactly as
-                        // a dense matrix would.
-                        other => {
-                            let values = dequantize_expert(packed, scale, rows, groups)
-                                .map_err(|e| VindexError::Parse(format!("`{name}`: {e}")))?;
-                            from_f32(values, rows, k, other, name)
-                        }
-                    }
-                })
-                .collect()
-        }
-        ExpertFormat::PackedBF16 => {
-            expect_dtype(&raw.dtype, DTYPE_BF16, name)?;
-            let stride = rows * k * 2;
-            expect_len(raw.bytes.len(), op.experts * stride, name)?;
-            (0..op.experts)
-                .map(|e| {
-                    let bytes = &raw.bytes[e * stride..(e + 1) * stride];
-                    match format {
-                        WeightFormat::F16 => Ok(LoadedWeight::F16(bf16_bytes_to_f16(bytes, name)?)),
-                        other => from_f32(widen(DTYPE_BF16, bytes, name)?, rows, k, other, name),
-                    }
-                })
-                .collect()
-        }
-        // Unreachable via `RoutedOperands::load` (it refuses `ExpertBank::
-        // PerExpert` before this is called), kept as the function's own
-        // invariant rather than trusting the one caller never to drift.
-        ExpertFormat::PerExpert => Err(VindexError::Parse(format!(
-            "`{name}`: per-expert tensors are not a packed projection"
-        ))),
-    }
+    let scales = projection
+        .scales
+        .as_ref()
+        .map(|scales_ref| store.load_raw(scales_ref))
+        .transpose()?;
+    // The whole bank is one region of `experts × rows` rows: the codec
+    // validates every stream's length against that geometry, and a codec
+    // that declares no scales stream refuses a partner it cannot consume.
+    let bank_shape = [op.experts * rows, k];
+    let operands = bind_region(
+        codec,
+        &bank_shape,
+        &raw.bytes,
+        scales.as_ref().map(|s| s.bytes.as_slice()),
+        name,
+    )?;
+    (0..op.experts)
+        .map(|e| {
+            let expert_rows = e * rows..(e + 1) * rows;
+            match format {
+                // Native: the bank IS MXFP4 — the codec bound it as
+                // MXFP4's two streams — so each expert's rows are one
+                // contiguous slab of each stream, copied as they are.
+                WeightFormat::Mxfp4 if facts.label == DTYPE_MXFP4 => {
+                    let groups = k / MXFP4_GROUP_ELEMS;
+                    let code_row = groups * MXFP4_GROUP_BYTES;
+                    let codes = operands.stream_of_len(
+                        VALUES,
+                        expert_rows.end * code_row,
+                        DTYPE_MXFP4,
+                        name,
+                    )?;
+                    let scales = operands.stream_of_len(
+                        GROUP_SCALES,
+                        expert_rows.end * groups,
+                        DTYPE_MXFP4,
+                        name,
+                    )?;
+                    Ok(LoadedWeight::Mxfp4 {
+                        packed: AlignedBytes::from_bytes(
+                            &codes[expert_rows.start * code_row..expert_rows.end * code_row],
+                        ),
+                        scales: AlignedBytes::from_bytes(
+                            &scales[expert_rows.start * groups..expert_rows.end * groups],
+                        ),
+                    })
+                }
+                // Everything else decodes through the codec and converts
+                // exactly as a dense matrix would.
+                other => {
+                    let mut values = vec![0.0f32; rows * k];
+                    codec.decode_rows(
+                        &operands,
+                        &bank_shape,
+                        expert_rows,
+                        RepresentationExtent::TERMINAL,
+                        &mut values,
+                        name,
+                    )?;
+                    from_f32(values, rows, k, other, name)
+                }
+            }
+        })
+        .collect()
 }
 
-/// One expert's `[rows, k]` f32 matrix, converted to `format`.
 fn from_f32(
     values: Vec<f32>,
     rows: usize,
@@ -591,42 +610,25 @@ fn from_f32(
     }
 }
 
-/// A packed bank is sliced per expert — arbitrary rows of the stored
-/// bytes. Ask the representation whether it can be addressed that way
-/// BEFORE its bytes are read, so a sequential codec is refused by its
-/// access class, which is the planner's question, and not by dtype name
-/// after the read was paid for.
-///
-/// Only a registered codec can answer. The MXFP4 bank's `U8` streams are
-/// a dialect this loader judges itself below, and an unregistered label
-/// keeps taking that path unchanged.
-fn require_row_access(store: OperandSource<'_>, operand: &OperandRef) -> Result<(), VindexError> {
-    let Some(dtype) = store.store().stored_dtype(operand) else {
-        return Ok(());
-    };
-    // The same admission the selector made before this loader was
-    // reached — one derivation, kept here so a direct caller gets the
-    // same refusal rather than a read followed by a dtype-name refusal.
-    RepresentationFacts::resolve(dtype).admit_row_slicing()?;
-    Ok(())
-}
-
-fn expect_dtype(found: &str, expected: &str, name: &str) -> Result<(), VindexError> {
-    if found == expected {
-        Ok(())
-    } else {
-        Err(VindexError::Parse(format!(
-            "`{name}`: expected stored dtype {expected}, found {found}"
-        )))
-    }
-}
-
-fn expect_len(found: usize, expected: usize, name: &str) -> Result<(), VindexError> {
-    if found == expected {
-        Ok(())
-    } else {
-        Err(VindexError::Parse(format!(
-            "`{name}`: {found} stored bytes, expected {expected} for the declared expert geometry"
-        )))
+/// What a packed bank IS: the same resolution the selector made before
+/// this loader was reached — the container's label when it names a codec,
+/// else the codec the plan's declared layout carries — so a direct caller
+/// is refused exactly as the selector would have refused it.
+fn bank_facts(
+    store: OperandSource<'_>,
+    op: &RoutedFfnOp,
+    operand: &OperandRef,
+) -> Result<RepresentationFacts, VindexError> {
+    let registry = store.registry();
+    let declared = declared_bank_representation(op.expert_format);
+    match (store.store().stored_dtype(operand), declared) {
+        (Some(stored), declared) => Ok(RepresentationFacts::resolve_declared(
+            registry, stored, declared,
+        )),
+        (None, Some(declared)) => Ok(RepresentationFacts::resolve_in(registry, declared)),
+        (None, None) => Err(VindexError::Parse(format!(
+            "`{}`: the bank is neither stored under a label nor declared by the plan",
+            operand.tensor
+        ))),
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
@@ -16,12 +16,12 @@ use larql_models::quant::mxfp4::{dequantize_expert, MXFP4_GROUP_BYTES, MXFP4_GRO
 use super::backend::{FfnCall, NormCall, RoutedFfnCall, WeightFormat, WeightSlice};
 use super::narrow::{bf16_bytes_to_f16, f32_bytes_to_f16};
 use super::operands::{widen, OperandSource};
+use super::realization::RepresentationFacts;
 use super::weights::{load_weight, quantize_mxfp4, quantize_nvfp4, AlignedBytes, LoadedWeight};
 use crate::error::VindexError;
 use crate::format::vindex3::opplan::{
     ExpertBank, FfnOp, LayerFfn, NormOp, OperandRef, PackedProjection, RoutedFfnOp,
 };
-use crate::format::vindex3::represent::codec::{CodecRegistry, RequiredAccess};
 
 /// Stored dtype of MXFP4 block and scale streams.
 const DTYPE_U8: &str = "U8";
@@ -112,6 +112,17 @@ impl FfnOperands {
                 post_dense_norm: LoadedNormWeight::load(&op.post_dense_norm, store)?,
                 post_experts_norm: LoadedNormWeight::load(&op.post_experts_norm, store)?,
             }))),
+        }
+    }
+
+    /// The dense projections only — what a pinned projection realization
+    /// is checked against. A bank's per-expert slices are a different
+    /// realization and are not projections of the plan's operands.
+    pub(super) fn dense_matrices(&self) -> Vec<&LoadedWeight> {
+        match self {
+            Self::Dense(d) => d.loaded_matrices(),
+            Self::Routed(_) => Vec::new(),
+            Self::Hybrid(h) => h.dense.loaded_matrices(),
         }
     }
 
@@ -245,15 +256,15 @@ impl DenseOperands {
     ) -> Result<Self, VindexError> {
         Ok(Self {
             gate: match &op.gate {
-                Some(gate) => Some(load_weight(store, gate, format(gate))?),
+                Some(gate) => Some(load_weight(store, gate, format(gate)?)?),
                 None => None,
             },
-            up: load_weight(store, &op.up, format(&op.up))?,
-            down: load_weight(store, &op.down, format(&op.down))?,
+            up: load_weight(store, &op.up, format(&op.up)?)?,
+            down: load_weight(store, &op.down, format(&op.down)?)?,
         })
     }
 
-    fn loaded_matrices(&self) -> Vec<&LoadedWeight> {
+    pub(super) fn loaded_matrices(&self) -> Vec<&LoadedWeight> {
         let mut all = vec![&self.up, &self.down];
         if let Some(gate) = &self.gate {
             all.push(gate);
@@ -546,11 +557,10 @@ fn require_row_access(store: OperandSource<'_>, operand: &OperandRef) -> Result<
     let Some(dtype) = store.store().stored_dtype(operand) else {
         return Ok(());
     };
-    if let Some(codec) = CodecRegistry::builtin().by_label(dtype) {
-        codec
-            .capabilities()
-            .require(RequiredAccess::RowRandom, codec.encoding_label())?;
-    }
+    // The same admission the selector made before this loader was
+    // reached — one derivation, kept here so a direct caller gets the
+    // same refusal rather than a read followed by a dtype-name refusal.
+    RepresentationFacts::resolve(dtype).admit_row_slicing()?;
     Ok(())
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
@@ -13,6 +13,7 @@
 use larql_models::config::ExpertFormat;
 use larql_models::quant::mxfp4::{dequantize_expert, MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS};
 
+use super::accounting::Bound;
 use super::backend::{FfnCall, NormCall, RoutedFfnCall, WeightFormat, WeightSlice};
 use super::narrow::{bf16_bytes_to_f16, f32_bytes_to_f16};
 use super::operands::{widen, OperandSource};
@@ -112,6 +113,23 @@ impl FfnOperands {
                 post_dense_norm: LoadedNormWeight::load(&op.post_dense_norm, store)?,
                 post_experts_norm: LoadedNormWeight::load(&op.post_experts_norm, store)?,
             }))),
+        }
+    }
+
+    /// Every bound operand of this FFN: the dense projections one each,
+    /// a packed bank as one operand over its per-expert objects.
+    pub(super) fn bound<'a>(&'a self, ffn: &'a LayerFfn) -> Result<Vec<Bound<'a>>, VindexError> {
+        match (self, ffn) {
+            (Self::Dense(d), LayerFfn::Dense(op)) => Ok(d.bound(op)),
+            (Self::Routed(r), LayerFfn::Routed(op)) => Ok(r.bound(op)),
+            (Self::Hybrid(h), LayerFfn::Hybrid(op)) => {
+                let mut out = h.dense.bound(&op.dense);
+                out.extend(h.routed.bound(&op.routed));
+                Ok(out)
+            }
+            _ => Err(VindexError::Parse(
+                "the prepared FFN and the plan's FFN are different programs".to_string(),
+            )),
         }
     }
 
@@ -264,6 +282,17 @@ impl DenseOperands {
         })
     }
 
+    /// Each projection paired with the operand it binds.
+    pub(super) fn bound<'a>(&'a self, op: &'a FfnOp) -> Vec<Bound<'a>> {
+        let mut out = Vec::new();
+        if let (Some(gate), Some(weight)) = (&op.gate, &self.gate) {
+            out.push(Bound::one(gate, weight));
+        }
+        out.push(Bound::one(&op.up, &self.up));
+        out.push(Bound::one(&op.down, &self.down));
+        out
+    }
+
     pub(super) fn loaded_matrices(&self) -> Vec<&LoadedWeight> {
         let mut all = vec![&self.up, &self.down];
         if let Some(gate) = &self.gate {
@@ -320,6 +349,24 @@ impl DenseOperands {
 }
 
 impl RoutedOperands {
+    /// The two banks, each one operand over its per-expert objects. A
+    /// per-expert bank is refused before it is loaded, so it binds nothing.
+    pub(super) fn bound<'a>(&'a self, op: &'a RoutedFfnOp) -> Vec<Bound<'a>> {
+        match &op.bank {
+            ExpertBank::Packed { gate_up, down } => vec![
+                Bound {
+                    operand: &gate_up.weights,
+                    weights: self.gate_up.iter().collect(),
+                },
+                Bound {
+                    operand: &down.weights,
+                    weights: self.down.iter().collect(),
+                },
+            ],
+            ExpertBank::PerExpert { .. } => Vec::new(),
+        }
+    }
+
     /// Every expert matrix, for residency accounting. The router itself
     /// is f32 glue and is counted with the norms.
     fn loaded_matrices(&self) -> Vec<&LoadedWeight> {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -60,7 +60,6 @@ pub mod weights;
 #[cfg(test)]
 mod tests;
 
-use crate::format::vindex3::represent::codec::CodecRegistry;
 use larql_models::config::GateSource;
 
 use super::{AttentionOp, ComponentOpPlan, LayerPlan};
@@ -245,8 +244,9 @@ pub fn execute_prepared_streaming<B: PlanBackend + ?Sized>(
     sink: &mut dyn FnMut(PlaneEvent) -> Result<(), VindexError>,
 ) -> Result<FinalOutput, VindexError> {
     // A pin whose provider has gone or changed invalidates the image;
-    // nothing here falls back to another realization.
-    ops.ensure_providers_in(CodecRegistry::builtin())?;
+    // nothing here falls back to another realization. The registry is
+    // the image's own — the store's — never a built-in default.
+    ops.ensure_providers_in(ops.registry())?;
     // A one-shot forward owns whatever continuation state the plan needs.
     //
     // For a wholly-softmax stack that is nothing: `None` keeps the

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -18,6 +18,7 @@
 //! after the FFN residual add) so parity can compare layer by layer
 //! against a checkpoint-driven oracle.
 
+pub mod accounting;
 pub mod backend;
 pub mod continuation;
 pub mod conv_qkv;
@@ -59,6 +60,7 @@ pub mod weights;
 #[cfg(test)]
 mod tests;
 
+use crate::format::vindex3::represent::codec::CodecRegistry;
 use larql_models::config::GateSource;
 
 use super::{AttentionOp, ComponentOpPlan, LayerPlan};
@@ -242,6 +244,9 @@ pub fn execute_prepared_streaming<B: PlanBackend + ?Sized>(
     resume: Option<ResumePoint>,
     sink: &mut dyn FnMut(PlaneEvent) -> Result<(), VindexError>,
 ) -> Result<FinalOutput, VindexError> {
+    // A pin whose provider has gone or changed invalidates the image;
+    // nothing here falls back to another realization.
+    ops.ensure_providers_in(CodecRegistry::builtin())?;
     // A one-shot forward owns whatever continuation state the plan needs.
     //
     // For a wholly-softmax stack that is nothing: `None` keeps the
@@ -989,6 +994,20 @@ impl AttentionOperands {
     /// Every matrix operand this attention holds, for residency
     /// preparation.
     /// Every matrix operand, for residency accounting.
+    /// Each matrix paired with the operand it binds, field by field.
+    pub(super) fn bound<'a>(&'a self, op: &'a AttentionOp) -> Vec<accounting::Bound<'a>> {
+        let mut out = vec![
+            accounting::Bound::one(&op.q, &self.w_q),
+            accounting::Bound::one(&op.k, &self.w_k),
+            accounting::Bound::one(&op.v, &self.w_v),
+            accounting::Bound::one(&op.o, &self.w_o),
+        ];
+        if let (Some(gate), Some(weight)) = (&op.output_gate, &self.gate) {
+            out.push(accounting::Bound::one(&gate.projection, weight));
+        }
+        out
+    }
+
     pub(super) fn loaded_matrices(&self) -> Vec<&LoadedWeight> {
         let mut all = vec![&self.w_q, &self.w_k, &self.w_v, &self.w_o];
         if let Some(gate) = &self.gate {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -46,6 +46,7 @@ pub mod operands;
 pub mod prepared;
 pub mod production;
 pub mod quantise;
+pub mod realization;
 pub mod reference;
 pub mod requirements;
 pub mod stack;
@@ -933,10 +934,10 @@ impl AttentionOperands {
         // V before conditioning Q/K, and apply the parameter-free V norm
         // to it when the op carries one.
         Ok(Self {
-            w_q: load_weight(store, &op.q, format(&op.q))?,
-            w_k: load_weight(store, &op.k, format(&op.k))?,
-            w_v: load_weight(store, &op.v, format(&op.v))?,
-            w_o: load_weight(store, &op.o, format(&op.o))?,
+            w_q: load_weight(store, &op.q, format(&op.q)?)?,
+            w_k: load_weight(store, &op.k, format(&op.k)?)?,
+            w_v: load_weight(store, &op.v, format(&op.v)?)?,
+            w_o: load_weight(store, &op.o, format(&op.o)?)?,
             qk_weights: match &op.qk_norm {
                 Some(qk) => Some((store.load(&qk.q)?, store.load(&qk.k)?)),
                 None => None,
@@ -956,7 +957,7 @@ impl AttentionOperands {
             // unrelated loader change broke the aliasing.
             gate: match &op.output_gate {
                 Some(gate) if gate.spec.source != GateSource::FusedQueryProjection => Some(
-                    load_weight(store, &gate.projection, format(&gate.projection))?,
+                    load_weight(store, &gate.projection, format(&gate.projection)?)?,
                 ),
                 _ => None,
             },

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
@@ -720,51 +720,12 @@ impl<'a> OperandSource<'a> {
         Ok(values)
     }
 
-    /// Whether this operand can be held in the checkpoint's own compact
-    /// bytes.
-    ///
-    /// Two conditions, and the second is easy to forget: the container
-    /// must store bf16, AND no overlay edit may stand in the way. An edit
-    /// is an f32-space fact with no representation in stored bytes, so an
-    /// edited operand has to be widened to be honoured at all — see
-    /// [`Self::load_raw`], which refuses it.
-    ///
-    /// False on anything it cannot establish. This decides how many bytes
-    /// a weight occupies, never what it means, so an unknown answers
-    /// "widen it" and the load path reports any real problem a moment
-    /// later with the tensor's name.
-    pub fn is_stored_bf16(&self, operand: &OperandRef) -> bool {
-        if self.overrides.is_some_and(|o| o.is_overridden(operand)) {
-            return false;
-        }
-        self.base.stored_dtype(operand) == Some(DTYPE_BF16)
-    }
-
-    /// Whether this operand is held as a compiled NVFP4 pack.
-    ///
-    /// Overlay edits are f32-space facts with no compact form, so an
-    /// overridden operand answers `false` and is served widened — the
-    /// same rule [`Self::is_stored_bf16`] follows, for the same reason.
-    pub fn is_stored_nvfp4(&self, operand: &OperandRef) -> bool {
-        if self.overrides.is_some_and(|o| o.is_overridden(operand)) {
-            return false;
-        }
-        self.base.stored_dtype(operand)
-            == Some(crate::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4)
-    }
-
-    /// Whether this operand is held as a compiled K-quant pack — any
-    /// encoding `represent::kquant::lookup` names.
-    ///
-    /// The same overlay rule as [`Self::is_stored_bf16`], for the same
-    /// reason: an edited operand has no compact form and answers `false`.
-    pub fn is_stored_kquant(&self, operand: &OperandRef) -> bool {
-        if self.overrides.is_some_and(|o| o.is_overridden(operand)) {
-            return false;
-        }
-        self.base
-            .stored_dtype(operand)
-            .is_some_and(|d| crate::format::vindex3::represent::kquant::lookup(d).is_some())
+    /// Whether an overlay edit stands on this operand. An edit is an
+    /// f32-space fact with no representation in stored bytes, so the only
+    /// realization that can honour it decodes — the selector reads this
+    /// beside the registry's facts, and [`Self::load_raw`] refuses it.
+    pub fn is_overridden(&self, operand: &OperandRef) -> bool {
+        self.overrides.is_some_and(|o| o.is_overridden(operand))
     }
 
     /// Load one operand's stored bytes unwidened. Overlay edits are

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
@@ -452,6 +452,19 @@ impl OperandStore {
             .map(|t| t.dtype.as_str())
     }
 
+    /// The length the container RECORDS for this operand's stored bytes —
+    /// tensor-table metadata only, no payload read. An instance fact: for
+    /// an entropy-coded operand it is not a function of the shape, which
+    /// is exactly why the stored footprint reads it here and never from
+    /// a codec.
+    pub fn stored_len(&self, operand: &OperandRef) -> Option<u64> {
+        self.segments
+            .get(&operand.object)?
+            .tensors
+            .get(&operand.tensor)
+            .map(|t| t.len)
+    }
+
     /// Load one operand's stored bytes and dtype, unwidened — for a
     /// caller that converts to a representation other than f32 (and for
     /// [`Self::load`] itself, so there is exactly one resolution path).
@@ -726,6 +739,13 @@ impl<'a> OperandSource<'a> {
     /// beside the registry's facts, and [`Self::load_raw`] refuses it.
     pub fn is_overridden(&self, operand: &OperandRef) -> bool {
         self.overrides.is_some_and(|o| o.is_overridden(operand))
+    }
+
+    /// The container's recorded length for an operand's stored bytes —
+    /// the base store's record; an overlay edit changes values, not what
+    /// the container holds.
+    pub fn stored_len(&self, operand: &OperandRef) -> Option<u64> {
+        self.base.stored_len(operand)
     }
 
     /// Load one operand's stored bytes unwidened. Overlay edits are

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
@@ -16,6 +16,7 @@ use super::super::super::encode::REPRESENTATION_ID_SEP;
 use super::super::super::inspect::SystemInspection;
 use super::super::OperandRef;
 use crate::error::VindexError;
+use crate::format::vindex3::represent::codec::CodecRegistry;
 
 /// Safetensors dtype labels this reference executor can widen to f32.
 const DTYPE_F32: &str = "F32";
@@ -31,6 +32,10 @@ struct SegmentMap {
 
 /// Operand store over one container.
 pub struct OperandStore {
+    /// The codecs this store decodes through — the built-in registry
+    /// unless a caller binds another, which is how a representation this
+    /// build does not ship becomes executable through registration alone.
+    registry: &'static CodecRegistry,
     segments: BTreeMap<String, SegmentMap>,
     /// Which representation each object was bound to.
     selected: BTreeMap<String, SelectedRepresentation>,
@@ -246,6 +251,7 @@ impl OperandStore {
             );
         }
         Ok(Self {
+            registry: CodecRegistry::builtin(),
             segments,
             absent,
             selected,
@@ -261,6 +267,20 @@ impl OperandStore {
             stored_precision: std::sync::atomic::AtomicU64::new(0),
             touched: std::sync::Mutex::new(std::collections::BTreeSet::new()),
         })
+    }
+
+    /// The same store, decoding through `registry` instead of the built-in
+    /// one. Selection, provider identity and decode all read this one
+    /// registry, so a codec registered here is executable end to end and a
+    /// codec absent from it is refused everywhere.
+    pub fn with_registry(mut self, registry: &'static CodecRegistry) -> Self {
+        self.registry = registry;
+        self
+    }
+
+    /// The codecs this store decodes through.
+    pub fn registry(&self) -> &'static CodecRegistry {
+        self.registry
     }
 
     /// What each object was bound to.
@@ -390,9 +410,9 @@ impl OperandStore {
     /// That is the point — it is what makes a compact representation
     /// measurable on a stack the device cannot run.
     pub fn load(&self, operand: &OperandRef) -> Result<Vec<f32>, VindexError> {
-        use crate::format::vindex3::represent::codec::{CodecRegistry, RepresentationExtent};
+        use crate::format::vindex3::represent::codec::RepresentationExtent;
         let raw = self.load_raw(operand)?;
-        let codec = CodecRegistry::builtin().resolve(&raw.dtype, &operand.tensor)?;
+        let codec = self.registry.resolve(&raw.dtype, &operand.tensor)?;
         Ok(codec.decode_packed(
             &raw.bytes,
             &operand.shape,
@@ -714,6 +734,11 @@ impl<'a> OperandSource<'a> {
     /// how many tensors were quantised at load.
     pub fn store(&self) -> &OperandStore {
         self.base
+    }
+
+    /// The codecs this source decodes through.
+    pub fn registry(&self) -> &'static CodecRegistry {
+        self.base.registry()
     }
 
     /// This source's identity, for stamping derived artefacts.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -45,6 +45,9 @@
 //! seam the decoupled surfaces grow from, and preparation refuses a
 //! slice the plan cannot satisfy rather than silently preparing less.
 
+use super::accounting::{
+    expectations, reconcile, BlockGeometry, Bound, Expectation, Observed, Reconciliation,
+};
 use super::backend::{MatrixClass, NormCall, PlanBackend, WeightFormat, WeightSlice};
 use super::experts::FfnOperands;
 use super::operands::{OperandSource, SourceStamp};
@@ -53,9 +56,13 @@ use super::weights::{load_weight, LoadedWeight};
 use super::AttentionOperands;
 use crate::error::VindexError;
 use crate::format::vindex3::opplan::planned::Operation;
+use crate::format::vindex3::represent::codec::CodecRegistry;
+use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
 
+use super::super::conv_qkv::ConvQkvOp;
 use super::super::{
-    ComponentOpPlan, GatedDeltaOp, LayerAttention, Mamba2Op, NormOp, OperandRef, OutputOp,
+    ComponentOpPlan, GatedDeltaOp, KdaOp, LayerAttention, LayerFfn, Mamba2Op, MlaOp, NormOp,
+    OperandRef, OutputOp,
 };
 
 /// Which part of a component's program to prepare.
@@ -225,6 +232,28 @@ pub(super) enum PreparedAttention {
 }
 
 impl PreparedAttention {
+    /// Every bound operand, paired by the loader that bound it — refusing
+    /// a plan whose attention is a different program from the prepared one.
+    pub(super) fn bound<'a>(
+        &'a self,
+        attention: &'a LayerAttention,
+    ) -> Result<Vec<Bound<'a>>, VindexError> {
+        Ok(match (self, attention) {
+            (Self::Softmax(ops), LayerAttention::Softmax(op)) => ops.bound(op),
+            (Self::GatedDelta(ops), LayerAttention::GatedDelta(op)) => ops.bound(op),
+            (Self::Mamba2(ops), LayerAttention::Mamba2(op)) => ops.bound(op),
+            (Self::ConvQkv(ops), LayerAttention::ConvQkv(op)) => ops.bound(op),
+            (Self::Kda(ops), LayerAttention::Kda(op)) => ops.bound(op),
+            (Self::Mla(ops), LayerAttention::Mla(op)) => ops.bound(op),
+            _ => {
+                return Err(VindexError::Parse(
+                    "the prepared attention and the plan's attention are different programs"
+                        .to_string(),
+                ))
+            }
+        })
+    }
+
     /// Every matrix this attention holds resident — what a pinned
     /// projection realization is checked against.
     pub(super) fn matrices(&self) -> Vec<&LoadedWeight> {
@@ -276,6 +305,16 @@ pub(super) struct GatedDeltaOperands {
 }
 
 impl GatedDeltaOperands {
+    pub(super) fn bound<'a>(&'a self, op: &'a GatedDeltaOp) -> Vec<Bound<'a>> {
+        vec![
+            Bound::one(&op.in_proj_qkv, &self.in_proj_qkv),
+            Bound::one(&op.in_proj_a, &self.in_proj_a),
+            Bound::one(&op.in_proj_b, &self.in_proj_b),
+            Bound::one(&op.in_proj_z, &self.in_proj_z),
+            Bound::one(&op.out_proj, &self.out_proj),
+        ]
+    }
+
     fn load(
         op: &GatedDeltaOp,
         store: OperandSource<'_>,
@@ -363,6 +402,13 @@ pub(super) struct Mamba2Operands {
 }
 
 impl Mamba2Operands {
+    pub(super) fn bound<'a>(&'a self, op: &'a Mamba2Op) -> Vec<Bound<'a>> {
+        vec![
+            Bound::one(&op.in_proj, &self.in_proj),
+            Bound::one(&op.out_proj, &self.out_proj),
+        ]
+    }
+
     fn load(
         op: &Mamba2Op,
         store: OperandSource<'_>,
@@ -434,6 +480,13 @@ pub(super) struct ConvQkvOperands {
 }
 
 impl ConvQkvOperands {
+    pub(super) fn bound<'a>(&'a self, op: &'a ConvQkvOp) -> Vec<Bound<'a>> {
+        vec![
+            Bound::one(&op.in_proj, &self.in_proj),
+            Bound::one(&op.out_proj, &self.out_proj),
+        ]
+    }
+
     fn load(
         op: &super::super::conv_qkv::ConvQkvOp,
         store: OperandSource<'_>,
@@ -505,6 +558,15 @@ pub(super) struct KdaOperands {
 }
 
 impl KdaOperands {
+    pub(super) fn bound<'a>(&'a self, op: &'a KdaOp) -> Vec<Bound<'a>> {
+        vec![
+            Bound::one(&op.q_proj, &self.q_proj),
+            Bound::one(&op.k_proj, &self.k_proj),
+            Bound::one(&op.v_proj, &self.v_proj),
+            Bound::one(&op.out_proj, &self.o_proj),
+        ]
+    }
+
     fn load(
         op: &super::super::KdaOp,
         store: OperandSource<'_>,
@@ -604,6 +666,15 @@ pub(super) struct MlaOperands {
 }
 
 impl MlaOperands {
+    pub(super) fn bound<'a>(&'a self, op: &'a MlaOp) -> Vec<Bound<'a>> {
+        vec![
+            Bound::one(&op.q_proj, &self.q_proj),
+            Bound::one(&op.kv_a_proj, &self.kv_a_proj),
+            Bound::one(&op.kv_b_proj, &self.kv_b_proj),
+            Bound::one(&op.out_proj, &self.o_proj),
+        ]
+    }
+
     fn load(
         op: &super::super::MlaOp,
         store: OperandSource<'_>,
@@ -701,6 +772,7 @@ pub fn select_realizations<B: PlanBackend + ?Sized>(
     store: OperandSource<'_>,
     backend: &B,
     slice: &ExecutionSlice,
+    registry: &CodecRegistry,
 ) -> Result<Vec<RealizationRecord>, VindexError> {
     let whole = slice.is_whole_stack();
     let range = slice.layers(plan);
@@ -717,13 +789,15 @@ pub fn select_realizations<B: PlanBackend + ?Sized>(
         let Some(label) = store.store().stored_dtype(&planned.operand) else {
             continue;
         };
-        let mut facts = RepresentationFacts::resolve(label);
+        let mut facts = RepresentationFacts::resolve_in(registry, label);
         if store.is_overridden(&planned.operand) {
             facts = facts.overlaid();
         }
+        let provider = facts.registered.as_ref().map(|r| r.identity.clone());
         match backend.select(&planned, &facts) {
             Ok(selection) => records.push(RealizationRecord {
                 representation: label.to_string(),
+                provider,
                 planned,
                 selection,
             }),
@@ -819,6 +893,20 @@ impl PreparedOperands {
         backend: &B,
         slice: ExecutionSlice,
     ) -> Result<Self, VindexError> {
+        Self::load_in(plan, store, backend, slice, CodecRegistry::builtin())
+    }
+
+    /// [`Self::load`] with the codec registry named: the providers the
+    /// selection resolves against. A scratch registry is how a test
+    /// prepares against codecs this build does not ship, and how a
+    /// provider that later disappears is witnessed.
+    pub fn load_in<'s, B: PlanBackend + ?Sized>(
+        plan: &ComponentOpPlan,
+        store: impl Into<OperandSource<'s>>,
+        backend: &B,
+        slice: ExecutionSlice,
+        registry: &CodecRegistry,
+    ) -> Result<Self, VindexError> {
         let store = store.into();
         slice.validate(plan)?;
         // **Refuse before any operand is loaded.** The plan may carry a
@@ -842,7 +930,7 @@ impl PreparedOperands {
         // this slice executes is resolved against the registry, admitted,
         // and pinned to one realization — or the whole plan is refused
         // with every reason — before a byte of any of them is read.
-        let realizations = select_realizations(plan, store, backend, &slice)?;
+        let realizations = select_realizations(plan, store, backend, &slice, registry)?;
         let embedding = plan.embedding.as_ref().ok_or_else(|| {
             VindexError::Parse(format!(
                 "component `{}` has no embedding op — external hidden-state input is a later rung",
@@ -1106,6 +1194,121 @@ impl PreparedOperands {
         let resident = observed(self.output.iter().map(|(_, w)| w).collect());
         if head != resident {
             return Err(mismatch("output head".to_string(), head, resident));
+        }
+        Ok(())
+    }
+
+    /// Every planned operand paired with the object(s) the loader bound
+    /// for it — the OBSERVATION side of the accounting, read off the
+    /// resident objects and never off a declaration.
+    pub fn bound(&self, plan: &ComponentOpPlan) -> Result<Vec<Observed>, VindexError> {
+        let mut out = Vec::new();
+        if let (Some(embedding), Some(table)) = (&plan.embedding, &self.embed_table) {
+            out.push(Observed {
+                operand: embedding.table.clone(),
+                operation: Operation::Embed,
+                layer: None,
+                format: WeightFormat::F32,
+                resident_bytes: std::mem::size_of_val(&table[..]) as u64,
+                allocations: 0,
+            });
+        }
+        for (offset, prepared) in self.layers.iter().enumerate() {
+            let index = self.first_layer + offset;
+            let layer = plan.layers.get(index).ok_or_else(|| {
+                VindexError::Parse(format!("layer {index}: prepared but not in the plan"))
+            })?;
+            for bound in prepared.attention.bound(&layer.attention)? {
+                out.push(bound.observed(
+                    Operation::Project(MatrixClass::AttentionProjection),
+                    Some(index),
+                )?);
+            }
+            if let (Some(ffn), Some(op)) = (&prepared.ffn, &layer.ffn) {
+                for bound in ffn.bound(op)? {
+                    let operation = match op {
+                        LayerFfn::Routed(_) => Operation::ExpertBankSlice,
+                        LayerFfn::Dense(_) => Operation::Project(MatrixClass::FfnProjection),
+                        // A hybrid binds its dense projections one each
+                        // and its banks over their experts; the pairing
+                        // says which by how many objects it holds.
+                        LayerFfn::Hybrid(_) => {
+                            if bound.weights.len() == 1 {
+                                Operation::Project(MatrixClass::FfnProjection)
+                            } else {
+                                Operation::ExpertBankSlice
+                            }
+                        }
+                    };
+                    out.push(bound.observed(operation, Some(index))?);
+                }
+            }
+        }
+        if let Some((op, weight)) = &self.output {
+            out.push(Bound::one(&op.projection, weight).observed(Operation::OutputHead, None)?);
+        }
+        Ok(out)
+    }
+
+    /// What every pinned realization DECLARES it costs, priced from the
+    /// pin, the codec's declared residency, `geometry`, and the container's
+    /// recorded lengths — the EXPECTATION side, which reads no object.
+    pub fn expectations(
+        &self,
+        store: OperandSource<'_>,
+        geometry: BlockGeometry,
+    ) -> Vec<Expectation> {
+        expectations(&self.realizations, |op| store.stored_len(op), geometry)
+    }
+
+    /// Bind the declarations AGAINST the observations: every pin meets
+    /// exactly one resident object in the pinned representation holding
+    /// the declared bytes, and nothing resident is unpinned.
+    pub fn reconcile(
+        &self,
+        plan: &ComponentOpPlan,
+        store: OperandSource<'_>,
+    ) -> Result<Reconciliation, VindexError> {
+        reconcile(
+            &self.expectations(store, BlockGeometry::executor()),
+            &self.bound(plan)?,
+        )
+    }
+
+    /// The providers this image was prepared against, by stored label,
+    /// with the identity each resolved to (`None` for a label no codec
+    /// claims — a dialect the loader judged itself).
+    pub fn providers(&self) -> Vec<(String, Option<CodecIdentity>)> {
+        let mut out: Vec<(String, Option<CodecIdentity>)> = Vec::new();
+        for r in &self.realizations {
+            if !out.iter().any(|(label, _)| *label == r.representation) {
+                out.push((r.representation.clone(), r.provider.clone()));
+            }
+        }
+        out
+    }
+
+    /// Refuse to execute this image against a registry that no longer
+    /// resolves every provider it was prepared with to the same identity
+    /// — a provider that disappeared or changed invalidates the
+    /// preparation; nothing falls back.
+    pub fn ensure_providers_in(&self, registry: &CodecRegistry) -> Result<(), VindexError> {
+        let describe = |identity: &Option<CodecIdentity>| {
+            identity
+                .as_ref()
+                .map(|i| format!("{} r{}", i.family, i.revision))
+                .unwrap_or_else(|| "no registered codec".to_string())
+        };
+        for (label, prepared) in self.providers() {
+            let now = registry.by_label(&label).map(|c| c.identity());
+            if now != prepared {
+                return Err(VindexError::Parse(format!(
+                    "representation `{label}` was prepared against {} and the registry now \
+                     offers {}; re-prepare rather than execute a pin whose provider changed",
+                    describe(&prepared),
+                    describe(&now)
+                )));
+            }
         }
         Ok(())
     }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -45,14 +45,14 @@
 //! seam the decoupled surfaces grow from, and preparation refuses a
 //! slice the plan cannot satisfy rather than silently preparing less.
 
-use super::backend::{
-    MatrixClass, MatrixOperand, NormCall, PlanBackend, WeightFormat, WeightSlice,
-};
+use super::backend::{MatrixClass, NormCall, PlanBackend, WeightFormat, WeightSlice};
 use super::experts::FfnOperands;
 use super::operands::{OperandSource, SourceStamp};
+use super::realization::{RealizationRecord, RepresentationFacts, SelectionRefusals};
 use super::weights::{load_weight, LoadedWeight};
 use super::AttentionOperands;
 use crate::error::VindexError;
+use crate::format::vindex3::opplan::planned::Operation;
 
 use super::super::{
     ComponentOpPlan, GatedDeltaOp, LayerAttention, Mamba2Op, NormOp, OperandRef, OutputOp,
@@ -225,6 +225,19 @@ pub(super) enum PreparedAttention {
 }
 
 impl PreparedAttention {
+    /// Every matrix this attention holds resident — what a pinned
+    /// projection realization is checked against.
+    pub(super) fn matrices(&self) -> Vec<&LoadedWeight> {
+        match self {
+            Self::Softmax(ops) => ops.loaded_matrices(),
+            Self::GatedDelta(ops) => ops.loaded_matrices().to_vec(),
+            Self::Mamba2(ops) => ops.loaded_matrices().to_vec(),
+            Self::ConvQkv(ops) => ops.loaded_matrices().to_vec(),
+            Self::Kda(ops) => ops.loaded_matrices().to_vec(),
+            Self::Mla(ops) => ops.loaded_matrices().to_vec(),
+        }
+    }
+
     /// Matrix operands for device placement.
     ///
     /// A recurrence contributes none: its nine operands are elementwise
@@ -274,7 +287,7 @@ impl GatedDeltaOperands {
         // while `in_proj_a` is 0.5 MB and does not. A single format for
         // the layer could not express that, and the version of this that
         // loaded everything f32 is what left 48 of 64 layers widened.
-        let matrix = |r: &OperandRef| load_weight(store, r, format(r));
+        let matrix = |r: &OperandRef| load_weight(store, r, format(r)?);
         let glue = |r: &OperandRef| store.load(r);
         Ok(Self {
             op: op.clone(),
@@ -355,7 +368,7 @@ impl Mamba2Operands {
         store: OperandSource<'_>,
         format: FormatFor<'_>,
     ) -> Result<Self, VindexError> {
-        let matrix = |r: &OperandRef| load_weight(store, r, format(r));
+        let matrix = |r: &OperandRef| load_weight(store, r, format(r)?);
         let glue = |r: &OperandRef| store.load(r);
         Ok(Self {
             op: op.clone(),
@@ -426,7 +439,7 @@ impl ConvQkvOperands {
         store: OperandSource<'_>,
         format: FormatFor<'_>,
     ) -> Result<Self, VindexError> {
-        let matrix = |r: &OperandRef| load_weight(store, r, format(r));
+        let matrix = |r: &OperandRef| load_weight(store, r, format(r)?);
         let glue = |r: &OperandRef| store.load(r);
         Ok(Self {
             op: op.clone(),
@@ -498,7 +511,7 @@ impl KdaOperands {
         format: FormatFor<'_>,
         norm_eps: f32,
     ) -> Result<Self, VindexError> {
-        let matrix = |r: &OperandRef| load_weight(store, r, format(r));
+        let matrix = |r: &OperandRef| load_weight(store, r, format(r)?);
         let glue = |r: &OperandRef| store.load(r);
         Ok(Self {
             op: op.clone(),
@@ -596,7 +609,7 @@ impl MlaOperands {
         store: OperandSource<'_>,
         format: FormatFor<'_>,
     ) -> Result<Self, VindexError> {
-        let matrix = |r: &OperandRef| load_weight(store, r, format(r));
+        let matrix = |r: &OperandRef| load_weight(store, r, format(r)?);
         let kv_a_norm_eps = op.kv_a_norm_eps.ok_or_else(|| {
             VindexError::Parse(
                 "this MLA layer carries no epsilon for its latent norm (`kv_a_layernorm`), \
@@ -673,27 +686,102 @@ fn two_dims(r: &OperandRef) -> Result<(usize, usize), VindexError> {
 /// projections — to the same resolver and can get different answers, which
 /// is what lets a `48 x 5120` gate stay f32 inside a stack whose `10240 x
 /// 5120` projections do not.
-pub(super) type FormatFor<'a> = &'a dyn Fn(&OperandRef) -> WeightFormat;
+pub(super) type FormatFor<'a> = &'a dyn Fn(&OperandRef) -> Result<WeightFormat, VindexError>;
 
-/// Ask the backend about one operand, with the physical facts attached.
+/// Resolve, admit and select a realization for every planned operand
+/// `slice` of `plan` will load — BEFORE any byte is read.
 ///
-/// The backend still cannot reach the bytes — it is told the element
-/// count and what the checkpoint holds, and answers with a
-/// representation. Handing it the `OperandRef` would let it resolve
-/// operands by name, which is the one thing the seam forbids.
-fn resolve<B: PlanBackend + ?Sized>(
-    backend: &B,
+/// The backend is handed the planned operation and the registry's facts
+/// for the stored dtype, never the bytes and never a label to match on.
+/// Every refusal is collected, so the caller sees the whole problem and
+/// not its first symptom. An operand the container does not hold is
+/// skipped here: the loader refuses it by name, as it always has.
+pub fn select_realizations<B: PlanBackend + ?Sized>(
+    plan: &ComponentOpPlan,
     store: OperandSource<'_>,
-    class: MatrixClass,
+    backend: &B,
+    slice: &ExecutionSlice,
+) -> Result<Vec<RealizationRecord>, VindexError> {
+    let whole = slice.is_whole_stack();
+    let range = slice.layers(plan);
+    let mut records = Vec::new();
+    let mut refusals = Vec::new();
+    for planned in plan.planned_operands() {
+        let in_scope = match planned.layer {
+            Some(layer) => range.contains(&layer),
+            None => whole,
+        };
+        if !in_scope {
+            continue;
+        }
+        let Some(label) = store.store().stored_dtype(&planned.operand) else {
+            continue;
+        };
+        let mut facts = RepresentationFacts::resolve(label);
+        if store.is_overridden(&planned.operand) {
+            facts = facts.overlaid();
+        }
+        match backend.select(&planned, &facts) {
+            Ok(selection) => records.push(RealizationRecord {
+                representation: label.to_string(),
+                planned,
+                selection,
+            }),
+            Err(refusal) => refusals.push(*refusal),
+        }
+    }
+    if refusals.is_empty() {
+        Ok(records)
+    } else {
+        Err(VindexError::Parse(SelectionRefusals(refusals).to_string()))
+    }
+}
+
+/// The representation pinned for `op` under `operation`.
+///
+/// An operand with no record is either absent from the container — the
+/// loader refuses it by name a moment later, so any answer here is
+/// unread — or one the plan's own view failed to list, which is a
+/// disagreement between `planned_operands()` and the loader and is
+/// refused as such rather than defaulted.
+fn pinned_format(
+    records: &[RealizationRecord],
+    store: OperandSource<'_>,
     op: &OperandRef,
-) -> WeightFormat {
-    backend.weight_format(MatrixOperand {
-        class,
-        elements: op.shape.iter().product(),
-        stored_bf16: store.is_stored_bf16(op),
-        stored_nvfp4: store.is_stored_nvfp4(op),
-        stored_kquant: store.is_stored_kquant(op),
-    })
+    operation: Operation,
+) -> Result<WeightFormat, VindexError> {
+    if let Some(record) = records.iter().find(|r| {
+        r.planned.operand.object == op.object
+            && r.planned.operand.tensor == op.tensor
+            && r.planned.operation == operation
+    }) {
+        return Ok(record.selection.realization.format());
+    }
+    if store.store().stored_dtype(op).is_none() {
+        return Ok(WeightFormat::F32);
+    }
+    Err(VindexError::Parse(format!(
+        "tensor `{}` ({}): the loader resolves an operand the plan's own view does not list — \
+         planned_operands() and the loader disagree",
+        op.tensor,
+        operation.name()
+    )))
+}
+
+/// The resident form pinned for layer `index`'s packed bank.
+fn bank_pin(records: &[RealizationRecord], index: usize) -> Result<WeightFormat, VindexError> {
+    records
+        .iter()
+        .find(|r| {
+            r.planned.layer == Some(index) && r.planned.operation == Operation::ExpertBankSlice
+        })
+        .map(|r| r.selection.realization.format())
+        .ok_or_else(|| {
+            VindexError::Parse(format!(
+                "layer {index}: a routed FFN with no pinned bank realization — planned_operands() \
+                 and the loader disagree"
+            ))
+        })
 }
 
 /// A component's operands, lowered once for a given slice and backend.
@@ -715,6 +803,9 @@ pub struct PreparedOperands {
     layers: Vec<PreparedLayer>,
     final_norm: Option<PreparedNorm>,
     output: Option<(OutputOp, LoadedWeight)>,
+    /// One pinned realization per planned operand this image executes,
+    /// in the plan's order — the record the trace reads.
+    realizations: Vec<RealizationRecord>,
 }
 
 impl PreparedOperands {
@@ -747,6 +838,11 @@ impl PreparedOperands {
         }
         let stamp = store.stamp();
         let whole = slice.is_whole_stack();
+        // **Select before any operand is loaded.** Every planned operand
+        // this slice executes is resolved against the registry, admitted,
+        // and pinned to one realization — or the whole plan is refused
+        // with every reason — before a byte of any of them is read.
+        let realizations = select_realizations(plan, store, backend, &slice)?;
         let embedding = plan.embedding.as_ref().ok_or_else(|| {
             VindexError::Parse(format!(
                 "component `{}` has no embedding op — external hidden-state input is a later rung",
@@ -760,29 +856,28 @@ impl PreparedOperands {
             None
         };
 
-        // One resolver per matrix class, each answering per operand.
+        // The loaders ask by operand and class; the answer is the pin.
+        let pinned = |op: &OperandRef, operation: Operation| {
+            pinned_format(&realizations, store, op, operation)
+        };
         let attention_format =
-            |op: &OperandRef| resolve(backend, store, MatrixClass::AttentionProjection, op);
-        let ffn_format = |op: &OperandRef| resolve(backend, store, MatrixClass::FfnProjection, op);
-        // The bank is asked once, for the class: it is one stored tensor
-        // holding every expert's matrix, so there is no per-matrix size to
-        // answer about.
-        let bank_format = backend.weight_format(MatrixOperand {
-            class: MatrixClass::RoutedExpertBank,
-            elements: 0,
-            stored_bf16: false,
-            // The bank is widened and sliced into per-expert matrices on
-            // the way in, so no stored form survives for a format to
-            // apply to — the same reason `elements` is 0 here.
-            stored_nvfp4: false,
-            stored_kquant: false,
-        });
-        let head_format = |op: &OperandRef| resolve(backend, store, MatrixClass::OutputHead, op);
+            |op: &OperandRef| pinned(op, Operation::Project(MatrixClass::AttentionProjection));
+        let ffn_format =
+            |op: &OperandRef| pinned(op, Operation::Project(MatrixClass::FfnProjection));
+        let head_format = |op: &OperandRef| pinned(op, Operation::OutputHead);
 
         let range = slice.layers(plan);
         let first_layer = range.start;
         let mut layers = Vec::with_capacity(range.len());
-        for layer in &plan.layers[range] {
+        for index in range.clone() {
+            let layer = &plan.layers[index];
+            // A packed bank's realization is pinned per layer; a layer
+            // with no bank never reads the value, and gets the widened
+            // form so nothing compact is implied.
+            let bank_format = match layer.ffn.as_ref().and_then(|f| f.routed()) {
+                Some(_) => bank_pin(&realizations, index)?,
+                None => WeightFormat::F32,
+            };
             layers.push(PreparedLayer {
                 // Absent under post-norm placement: the sublayer reads
                 // the raw residual there. `None` is the program, and the
@@ -885,7 +980,7 @@ impl PreparedOperands {
                 .map(|op| {
                     Ok::<_, VindexError>((
                         op.clone(),
-                        load_weight(store, &op.projection, head_format(&op.projection))?,
+                        load_weight(store, &op.projection, head_format(&op.projection)?)?,
                     ))
                 })
                 .transpose()?
@@ -902,7 +997,13 @@ impl PreparedOperands {
             layers,
             final_norm,
             output,
+            realizations,
         };
+        // **The executor runs what was pinned.** Every resident matrix
+        // holds the representation its record named, checked here so a
+        // loader that drifted from the selector cannot hand the executor
+        // bytes the plan never pinned.
+        prepared.verify_pins()?;
         prepared.place(backend);
         Ok(prepared)
     }
@@ -934,6 +1035,81 @@ impl PreparedOperands {
     /// The embedding table is the one f32 population that is EXPECTED:
     /// decode gathers a single row from it per token, so it is residency
     /// without traffic, and no kernel here consumes a compact one.
+    /// One pinned realization per planned operand this image executes:
+    /// the representation resolved, the candidates considered, the one
+    /// selected, its reason and its declared residency.
+    pub fn realizations(&self) -> &[RealizationRecord] {
+        &self.realizations
+    }
+
+    #[cfg(test)]
+    pub(super) fn realizations_mut(&mut self) -> &mut Vec<RealizationRecord> {
+        &mut self.realizations
+    }
+
+    /// Every resident matrix holds the representation its pinned
+    /// realization named — checked per layer and site as a multiset, so
+    /// the executor, which reads its kernel off the resident bytes, can
+    /// run nothing the plan did not pin. A packed bank's per-expert slices
+    /// are a different realization and are checked by the bank loader.
+    pub fn verify_pins(&self) -> Result<(), VindexError> {
+        let pinned =
+            |layer: Option<usize>, want: &dyn Fn(Operation) -> bool| -> Vec<WeightFormat> {
+                let mut out: Vec<WeightFormat> = self
+                    .realizations
+                    .iter()
+                    .filter(|r| r.planned.layer == layer && want(r.planned.operation))
+                    .map(|r| r.selection.realization.format())
+                    .collect();
+                out.sort_by_key(|f| format!("{f:?}"));
+                out
+            };
+        let observed = |weights: Vec<&LoadedWeight>| -> Vec<WeightFormat> {
+            let mut out: Vec<WeightFormat> = weights.iter().map(|w| w.format()).collect();
+            out.sort_by_key(|f| format!("{f:?}"));
+            out
+        };
+        let mismatch = |site: String, pinned: Vec<WeightFormat>, resident: Vec<WeightFormat>| {
+            VindexError::Parse(format!(
+                "{site}: the resident representations {resident:?} are not the pinned \
+                 realizations {pinned:?} — the loader drifted from the selector"
+            ))
+        };
+        for (offset, layer) in self.layers.iter().enumerate() {
+            let index = self.first_layer + offset;
+            let attention = pinned(Some(index), &|o| {
+                o == Operation::Project(MatrixClass::AttentionProjection)
+            });
+            let resident = observed(layer.attention.matrices());
+            if attention != resident {
+                return Err(mismatch(
+                    format!("layer {index} attention"),
+                    attention,
+                    resident,
+                ));
+            }
+            let ffn = pinned(Some(index), &|o| {
+                o == Operation::Project(MatrixClass::FfnProjection)
+            });
+            let resident = observed(
+                layer
+                    .ffn
+                    .as_ref()
+                    .map(|f| f.dense_matrices())
+                    .unwrap_or_default(),
+            );
+            if ffn != resident {
+                return Err(mismatch(format!("layer {index} ffn"), ffn, resident));
+            }
+        }
+        let head = pinned(None, &|o| o == Operation::OutputHead);
+        let resident = observed(self.output.iter().map(|(_, w)| w).collect());
+        if head != resident {
+            return Err(mismatch("output head".to_string(), head, resident));
+        }
+        Ok(())
+    }
+
     pub fn residency_census(&self) -> ResidencyCensus {
         let mut census = ResidencyCensus::default();
         if let Some(table) = &self.embed_table {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -772,8 +772,8 @@ pub fn select_realizations<B: PlanBackend + ?Sized>(
     store: OperandSource<'_>,
     backend: &B,
     slice: &ExecutionSlice,
-    registry: &CodecRegistry,
 ) -> Result<Vec<RealizationRecord>, VindexError> {
+    let registry = store.registry();
     let whole = slice.is_whole_stack();
     let range = slice.layers(plan);
     let mut records = Vec::new();
@@ -786,10 +786,15 @@ pub fn select_realizations<B: PlanBackend + ?Sized>(
         if !in_scope {
             continue;
         }
-        let Some(label) = store.store().stored_dtype(&planned.operand) else {
+        let Some(stored) = store.store().stored_dtype(&planned.operand) else {
             continue;
         };
-        let mut facts = RepresentationFacts::resolve_in(registry, label);
+        let mut facts = RepresentationFacts::resolve_declared(
+            registry,
+            stored,
+            planned.declared_representation,
+        );
+        let label = facts.label.clone();
         if store.is_overridden(&planned.operand) {
             facts = facts.overlaid();
         }
@@ -865,6 +870,9 @@ fn bank_pin(records: &[RealizationRecord], index: usize) -> Result<WeightFormat,
 /// rather than mutating them, so one prepared image can serve every
 /// concurrent request on the model.
 pub struct PreparedOperands {
+    /// The registry this image was prepared through — the store's — and
+    /// the one execution re-checks its providers against.
+    registry: &'static CodecRegistry,
     /// Which effective source this image was compiled from.
     stamp: SourceStamp,
     slice: ExecutionSlice,
@@ -893,20 +901,6 @@ impl PreparedOperands {
         backend: &B,
         slice: ExecutionSlice,
     ) -> Result<Self, VindexError> {
-        Self::load_in(plan, store, backend, slice, CodecRegistry::builtin())
-    }
-
-    /// [`Self::load`] with the codec registry named: the providers the
-    /// selection resolves against. A scratch registry is how a test
-    /// prepares against codecs this build does not ship, and how a
-    /// provider that later disappears is witnessed.
-    pub fn load_in<'s, B: PlanBackend + ?Sized>(
-        plan: &ComponentOpPlan,
-        store: impl Into<OperandSource<'s>>,
-        backend: &B,
-        slice: ExecutionSlice,
-        registry: &CodecRegistry,
-    ) -> Result<Self, VindexError> {
         let store = store.into();
         slice.validate(plan)?;
         // **Refuse before any operand is loaded.** The plan may carry a
@@ -930,7 +924,7 @@ impl PreparedOperands {
         // this slice executes is resolved against the registry, admitted,
         // and pinned to one realization — or the whole plan is refused
         // with every reason — before a byte of any of them is read.
-        let realizations = select_realizations(plan, store, backend, &slice, registry)?;
+        let realizations = select_realizations(plan, store, backend, &slice)?;
         let embedding = plan.embedding.as_ref().ok_or_else(|| {
             VindexError::Parse(format!(
                 "component `{}` has no embedding op — external hidden-state input is a later rung",
@@ -1085,6 +1079,7 @@ impl PreparedOperands {
             layers,
             final_norm,
             output,
+            registry: store.registry(),
             realizations,
         };
         // **The executor runs what was pinned.** Every resident matrix
@@ -1126,6 +1121,11 @@ impl PreparedOperands {
     /// One pinned realization per planned operand this image executes:
     /// the representation resolved, the candidates considered, the one
     /// selected, its reason and its declared residency.
+    /// The registry this image was prepared through.
+    pub fn registry(&self) -> &'static CodecRegistry {
+        self.registry
+    }
+
     pub fn realizations(&self) -> &[RealizationRecord] {
         &self.realizations
     }
@@ -1275,9 +1275,11 @@ impl PreparedOperands {
         )
     }
 
-    /// The providers this image was prepared against, by stored label,
-    /// with the identity each resolved to (`None` for a label no codec
-    /// claims — a dialect the loader judged itself).
+    /// The providers this image was prepared against, by representation
+    /// label, with the identity each resolved to. Since 3d every record
+    /// names a registered codec — a packed bank's carrier label resolves
+    /// to the codec the plan declares — so a `None` here is an overlay
+    /// edit's f32-space fact, never a label a loader judged for itself.
     pub fn providers(&self) -> Vec<(String, Option<CodecIdentity>)> {
         let mut out: Vec<(String, Option<CodecIdentity>)> = Vec::new();
         for r in &self.realizations {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -37,8 +37,8 @@ use larql_compute::MoeGateRule;
 use super::super::super::graph::policy::AttentionSpan;
 use super::backend::{
     AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, FfnCall, FfnManyCall,
-    GateCall, MatrixClass, MatrixOperand, NormCall, PlanBackend, ProjectCall, ProjectedQkv,
-    QkNormCall, RoutedFfnCall, WeightFormat,
+    GateCall, NormCall, PlanBackend, ProjectCall, ProjectedQkv, QkNormCall, RoutedFfnCall,
+    WeightFormat,
 };
 use super::cpu::physical::{
     kquant_execution, project_matrix, project_matrix_many, ExecutorProjections, KQuantExecution,
@@ -47,7 +47,12 @@ use super::cpu::PhysicalProjectionPlan;
 use super::kernels::{
     gather_fused_half, mrope_rotate_scaled, rope_rotate, rope_rotate_scaled, FusedHalf,
 };
+use super::realization::{
+    class_of, common_selection, cpu_projection_candidates, resident_profile, RealizationForm,
+    RealizationId, RefusalKind, RepresentationFacts, Selection, SelectionReason, SelectionRefusal,
+};
 use super::timing::{timed, OpClass};
+use crate::format::vindex3::opplan::planned::PlannedOperand;
 use larql_compute::attention::rope::{
     rope_freq_plan, rope_freq_plan_proportional, RopeFreqScaling,
 };
@@ -697,35 +702,122 @@ impl ProductionBackend {
     }
 }
 
-/// [`ProductionBackend::weight_format`]'s decision, with the K-quant
-/// execution arm passed in rather than read from the environment — so
-/// both arms are testable in one process without touching it.
-pub(crate) fn declared_format(operand: MatrixOperand, kquant: KQuantExecution) -> WeightFormat {
-    match operand.class {
-        // The packed bank is widened to f32 on the way in and sliced
-        // into per-expert matrices; there are no stored bytes left to
-        // keep by the time a format could apply.
-        MatrixClass::RoutedExpertBank => WeightFormat::F32,
-        // A compiled pack outranks the size policy. `choose_for`
-        // decides what to MAKE an operand resident as, from its size;
-        // an operand that is already NVFP4 has had that decision made
-        // for it deliberately, and re-deciding here would widen 4-bit
-        // bytes to f32 to satisfy a policy about bf16.
-        _ if operand.stored_nvfp4 => WeightFormat::Nvfp4,
-        // The same for a stored K-quant, under one condition: the arm.
-        // `Widen` is rung A's authority path (decode to f32, BLAS) and
-        // falls through to the size policy exactly as before this arm
-        // existed — with `stored_bf16` false, that is `BlasF32`.
-        _ if operand.stored_kquant && kquant == KQuantExecution::Direct => WeightFormat::KQuant,
-        MatrixClass::AttentionProjection | MatrixClass::FfnProjection | MatrixClass::OutputHead => {
-            PhysicalProjectionPlan::choose_for(
-                Some(operand.class),
-                operand.elements,
-                operand.stored_bf16,
-            )
-            .format()
-        }
+/// The CPU executor's own re-quantised resident forms, offered as
+/// candidates for a float source it knows how to narrow — which a codec
+/// declares by naming the direct bf16 kernel.
+const REQUANTISE: [PhysicalProjectionPlan; 4] = [
+    PhysicalProjectionPlan::FusedQ8,
+    PhysicalProjectionPlan::Q8xQ8,
+    PhysicalProjectionPlan::Q4xQ8,
+    PhysicalProjectionPlan::FusedQ4,
+];
+
+/// [`ProductionBackend::select`]'s decision, with the K-quant execution
+/// arm passed in rather than read from the environment — so both arms are
+/// testable in one process without touching it.
+///
+/// **The policy, over a derived candidate set.** The candidates come from
+/// the codec's declarations and the executor's own compact forms; the
+/// ladder below only ORDERS them, and can answer nothing that is not a
+/// candidate. A compiled NVFP4 pack outranks everything; a stored K-quant
+/// runs in place or widens by the arm; a float source goes to the size
+/// policy, which keeps a large bf16 image compact and widens a small one;
+/// a codec with no direct realization decodes, and says so.
+pub(crate) fn select_cpu(
+    operand: &PlannedOperand,
+    facts: &RepresentationFacts,
+    kquant: KQuantExecution,
+) -> Result<Selection, Box<SelectionRefusal>> {
+    use RealizationForm::{Decode, Direct, Requantise};
+    if let Some(common) = common_selection(operand, facts, WeightFormat::F32) {
+        return common;
     }
+    let refuse = |kind, considered| {
+        Box::new(SelectionRefusal {
+            operand: operand.operand.clone(),
+            operation: operand.operation,
+            representation: facts.label.clone(),
+            requested: operand.access,
+            kind,
+            considered,
+        })
+    };
+    let Some(class) = class_of(operand.operation) else {
+        return Err(refuse(RefusalKind::MissingRealization, vec![]));
+    };
+    let Some(registered) = &facts.registered else {
+        return Err(refuse(RefusalKind::UnregisteredRepresentation, vec![]));
+    };
+    let candidates = cpu_projection_candidates(facts, PhysicalProjectionPlan::BlasF32, &REQUANTISE);
+    let has = |form: RealizationForm| candidates.iter().any(|c| c.form == form);
+    let decode = RealizationId::cpu(Decode(PhysicalProjectionPlan::BlasF32));
+    let pick = |id: RealizationId, reason: SelectionReason| {
+        let residency = match id.form {
+            Direct(plan) => facts
+                .direct_residency(plan)
+                .unwrap_or(registered.decode_residency),
+            Decode(_) => registered.decode_residency,
+            _ => resident_profile(id.format()),
+        };
+        Ok(Selection {
+            realization: id,
+            residency,
+            reason,
+            candidates: candidates.clone(),
+        })
+    };
+    if has(Direct(PhysicalProjectionPlan::FusedNvfp4)) {
+        return pick(
+            RealizationId::cpu(Direct(PhysicalProjectionPlan::FusedNvfp4)),
+            SelectionReason::DirectDeclared,
+        );
+    }
+    if has(Direct(PhysicalProjectionPlan::FusedKQuant)) {
+        return match kquant {
+            KQuantExecution::Direct => pick(
+                RealizationId::cpu(Direct(PhysicalProjectionPlan::FusedKQuant)),
+                SelectionReason::DirectDeclared,
+            ),
+            KQuantExecution::Widen => pick(decode, SelectionReason::ArmPrefersDecode),
+        };
+    }
+    // The size policy is asked whether a bf16 image is worth keeping
+    // compact — and the fact it is asked about is the codec DECLARING the
+    // direct bf16 kernel, not a dtype the loader compared.
+    let bf16_kernel_declared = has(Direct(PhysicalProjectionPlan::FusedBf16));
+    let plan = PhysicalProjectionPlan::choose_for(
+        Some(class),
+        operand.logical_elements,
+        bf16_kernel_declared,
+    );
+    let form = if has(Direct(plan)) {
+        Direct(plan)
+    } else if plan.format() == WeightFormat::F32 {
+        Decode(plan)
+    } else {
+        Requantise(plan)
+    };
+    if !has(form) {
+        return Err(refuse(
+            RefusalKind::MissingRealization,
+            candidates
+                .iter()
+                .map(|c| {
+                    (
+                        *c,
+                        "not the resident form the size policy chose".to_string(),
+                    )
+                })
+                .collect(),
+        ));
+    }
+    let reason = match form {
+        _ if facts.overlaid => SelectionReason::OverlaidEdit,
+        Direct(_) if !bf16_kernel_declared => SelectionReason::DirectDeclared,
+        Decode(_) if !bf16_kernel_declared => SelectionReason::NoDirectRealization,
+        _ => SelectionReason::SizePolicy,
+    };
+    pick(RealizationId::cpu(form), reason)
 }
 
 impl PlanBackend for ProductionBackend {
@@ -733,11 +825,15 @@ impl PlanBackend for ProductionBackend {
         &ExecutorProjections
     }
 
-    /// **The policy.** One decision per matrix, producing the format here
-    /// and the kernel at [`project_rows`] — see
-    /// [`PhysicalProjectionPlan`].
-    fn weight_format(&self, operand: MatrixOperand) -> WeightFormat {
-        declared_format(operand, kquant_execution())
+    /// **The policy.** One decision per matrix, producing the resident
+    /// form here and the kernel at [`project_rows`] — see
+    /// [`PhysicalProjectionPlan`] and [`select_cpu`].
+    fn select(
+        &self,
+        operand: &PlannedOperand,
+        facts: &RepresentationFacts,
+    ) -> Result<Selection, Box<SelectionRefusal>> {
+        select_cpu(operand, facts, kquant_execution())
     }
 
     fn name(&self) -> &str {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
@@ -35,11 +35,13 @@ use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
 /// representation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RepresentationFacts {
-    /// The label the container stores the operand under.
+    /// The label the facts were resolved from: the container's stored
+    /// label, or the codec the plan declares when the stored label is a
+    /// carrier dialect that names none (see [`Self::resolve_declared`]).
     pub label: String,
     /// The codec's declarations, when the label names a registered codec.
     /// `None` is a fact too: an unregistered label has no decode and no
-    /// capabilities, and only a loader with its own dialect can bind it.
+    /// capabilities, and nothing binds it.
     pub registered: Option<RegisteredFacts>,
     /// Whether an overlay edit stands on the operand. An edit is an
     /// f32-space fact with no stored bytes, so no direct realization can
@@ -59,6 +61,7 @@ pub struct RegisteredFacts {
 
 impl RepresentationFacts {
     /// Resolve `label` through the built-in registry.
+    #[cfg(test)]
     pub fn resolve(label: &str) -> Self {
         Self::resolve_in(CodecRegistry::builtin(), label)
     }
@@ -116,13 +119,34 @@ impl RepresentationFacts {
         })
     }
 
+    /// The facts for an operand whose container label is `stored` and
+    /// whose plan declares `declared`. The STORED representation is
+    /// authoritative: the container's label wins whenever it names a
+    /// codec, because the bytes say what they are. The plan's declaration
+    /// is a legacy default, consulted only for a carrier dialect whose
+    /// label names no codec — a packed MXFP4 bank stored as two `U8`
+    /// streams. These are not two competing truths; the declaration fills
+    /// in where the container says nothing a registry knows. One rule, so
+    /// the selector and the bank loader cannot disagree about what a
+    /// bank is.
+    pub fn resolve_declared(
+        registry: &CodecRegistry,
+        stored: &str,
+        declared: Option<&str>,
+    ) -> Self {
+        let label = match declared {
+            Some(declared) if registry.by_label(stored).is_none() => declared,
+            _ => stored,
+        };
+        Self::resolve_in(registry, label)
+    }
+
     /// Admit slicing the stored bytes per expert — the packed-bank
-    /// realization's requirement, judged BEFORE any byte is read.
-    ///
-    /// A registered codec must provide row access; an unregistered label
-    /// is a dialect the bank loader judges itself (the MXFP4 bank's `U8`
-    /// streams), and is admitted here so that judgement stays where it
-    /// is until 3d moves it into declarations.
+    /// realization's requirement, judged BEFORE any byte is read. A
+    /// registered codec must declare row access. An unregistered label
+    /// has no capabilities to judge; registration itself is refused
+    /// first, by the same rule as every other operation, so this answers
+    /// only for a codec.
     pub fn admit_row_slicing(&self) -> Result<(), CodecError> {
         match &self.registered {
             Some(r) => r
@@ -442,6 +466,9 @@ pub fn common_selection(
             let id = RealizationId::cpu(RealizationForm::SliceStored {
                 convert: bank_convert,
             });
+            if facts.registered.is_none() {
+                return Some(Err(refuse(RefusalKind::UnregisteredRepresentation, vec![])));
+            }
             Some(match facts.admit_row_slicing() {
                 Ok(()) => Ok(Selection {
                     realization: id,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
@@ -22,21 +22,13 @@ use std::fmt;
 
 use super::backend::{MatrixClass, WeightFormat};
 use super::cpu::physical::PhysicalProjectionPlan;
-use super::quantise::{Q4_BLOCK, Q8_BLOCK};
 use crate::format::vindex3::opplan::planned::{Operation, PlannedOperand};
 use crate::format::vindex3::opplan::OperandRef;
 use crate::format::vindex3::represent::codec::{
     Acceleration, AccelerationBackend, CodecCapabilities, CodecError, CodecRegistry,
-    RepresentationCodec, RequiredAccess, ResidencyClass, ResidencyProfile,
+    RepresentationCodec, RequiredAccess, ResidencyProfile,
 };
 use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
-
-/// Width of the canonical decode target.
-const F32_WIDTH: f64 = std::mem::size_of::<f32>() as f64;
-/// Width of a half-precision resident element.
-const HALF_WIDTH: f64 = std::mem::size_of::<u16>() as f64;
-/// Bits in a byte, for the stored-bit pricings below.
-const BITS_PER_BYTE: f64 = 8.0;
 
 /// What the registry declares for one stored dtype — resolved once per
 /// operand at preparation, and the only thing a backend is told about the
@@ -233,36 +225,10 @@ impl RealizationId {
 }
 
 /// What the executor makes resident for `format`, priced from its own
-/// resident forms: a widened image is f32 per weight; a re-quantised image
-/// is its codes plus one f32 scale per block; a device's half-precision
-/// image is two bytes per weight and, being rounded from the source, is a
-/// re-quantisation; a compact pack bound as stored is its stored bits.
-///
-/// Rung 3c binds these into the census and checks them against what the
-/// loader actually holds.
+/// block geometry — see [`super::accounting::resident_profile_with`],
+/// which is the one definition; this is it under the executor's constants.
 pub fn resident_profile(format: WeightFormat) -> ResidencyProfile {
-    match format {
-        WeightFormat::F32 => ResidencyProfile::DECODED_F32,
-        WeightFormat::Bf16 => ResidencyProfile::rebound(HALF_WIDTH * BITS_PER_BYTE),
-        WeightFormat::F16 => ResidencyProfile {
-            class: ResidencyClass::TransientRequantised,
-            bytes_per_weight: HALF_WIDTH,
-        },
-        WeightFormat::Q8 => ResidencyProfile {
-            class: ResidencyClass::TransientRequantised,
-            bytes_per_weight: 1.0 + F32_WIDTH / Q8_BLOCK as f64,
-        },
-        WeightFormat::Q4 => ResidencyProfile {
-            class: ResidencyClass::TransientRequantised,
-            bytes_per_weight: 0.5 + F32_WIDTH / Q4_BLOCK as f64,
-        },
-        WeightFormat::Nvfp4 => ResidencyProfile::rebound(4.5),
-        WeightFormat::Mxfp4 => ResidencyProfile::stored(4.25),
-        // Three codecs share the resident form; the bound operand carries
-        // which, so the profile is the widest of them until 3c reads it
-        // off the record's own codec declaration.
-        WeightFormat::KQuant => ResidencyProfile::stored(8.5),
-    }
+    super::accounting::resident_profile_with(format, super::accounting::BlockGeometry::executor())
 }
 
 /// Why a backend chose what it chose.
@@ -400,6 +366,9 @@ impl fmt::Display for SelectionRefusals {
 pub struct RealizationRecord {
     pub planned: PlannedOperand,
     pub representation: String,
+    /// The identity the stored label resolved to at preparation; `None`
+    /// for a label no codec claims.
+    pub provider: Option<CodecIdentity>,
     pub selection: Selection,
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
@@ -1,0 +1,532 @@
+//! **The realization vocabulary** — what a prepared plan resolves, considers,
+//! selects and pins for each planned operand, and how it refuses.
+//!
+//! Rung 3b of the representation/execution contract
+//! (`docs/represent/forecasts/rung3-planned-realizations.json`). Before this
+//! module the seam between plan and backend was three stored-dtype booleans
+//! and a silent fallback: any dtype the policy did not recognise widened to
+//! f32 with nothing recorded. Now a backend is handed the planned operation
+//! and the REPRESENTATION FACTS the registry declares for the stored dtype,
+//! and answers with one [`RealizationId`] chosen from a candidate set it
+//! derived from those declarations — or refuses, naming every candidate it
+//! considered and why. Nothing here reads a label to decide anything.
+//!
+//! The forms a realization can take are the executor's own, made explicit:
+//! a direct kernel over the stored bytes (declared by the codec), the
+//! universal decode to f32 followed by an f32 projection, a decode followed
+//! by a lossy re-quantisation (the executor's own compact forms), the packed
+//! bank sliced per expert from stored rows, a decoded table gathered per
+//! token, or a device backend's own resident form.
+
+use std::fmt;
+
+use super::backend::{MatrixClass, WeightFormat};
+use super::cpu::physical::PhysicalProjectionPlan;
+use super::quantise::{Q4_BLOCK, Q8_BLOCK};
+use crate::format::vindex3::opplan::planned::{Operation, PlannedOperand};
+use crate::format::vindex3::opplan::OperandRef;
+use crate::format::vindex3::represent::codec::{
+    Acceleration, AccelerationBackend, CodecCapabilities, CodecError, CodecRegistry,
+    RepresentationCodec, RequiredAccess, ResidencyClass, ResidencyProfile,
+};
+use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
+
+/// Width of the canonical decode target.
+const F32_WIDTH: f64 = std::mem::size_of::<f32>() as f64;
+/// Width of a half-precision resident element.
+const HALF_WIDTH: f64 = std::mem::size_of::<u16>() as f64;
+/// Bits in a byte, for the stored-bit pricings below.
+const BITS_PER_BYTE: f64 = 8.0;
+
+/// What the registry declares for one stored dtype — resolved once per
+/// operand at preparation, and the only thing a backend is told about the
+/// representation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RepresentationFacts {
+    /// The label the container stores the operand under.
+    pub label: String,
+    /// The codec's declarations, when the label names a registered codec.
+    /// `None` is a fact too: an unregistered label has no decode and no
+    /// capabilities, and only a loader with its own dialect can bind it.
+    pub registered: Option<RegisteredFacts>,
+    /// Whether an overlay edit stands on the operand. An edit is an
+    /// f32-space fact with no stored bytes, so no direct realization can
+    /// honour it; only decode can.
+    pub overlaid: bool,
+}
+
+/// A registered codec's declarations, copied out so a backend never holds
+/// the codec itself.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RegisteredFacts {
+    pub identity: CodecIdentity,
+    pub capabilities: CodecCapabilities,
+    pub accelerations: Vec<Acceleration>,
+    pub decode_residency: ResidencyProfile,
+}
+
+impl RepresentationFacts {
+    /// Resolve `label` through the built-in registry.
+    pub fn resolve(label: &str) -> Self {
+        Self::resolve_in(CodecRegistry::builtin(), label)
+    }
+
+    /// Resolve `label` through `registry` — a scratch registry in a test is
+    /// how a codec that is not shipped gets facts.
+    pub fn resolve_in(registry: &CodecRegistry, label: &str) -> Self {
+        Self {
+            label: label.to_string(),
+            registered: registry.by_label(label).map(RegisteredFacts::of),
+            overlaid: false,
+        }
+    }
+
+    /// The same facts, with an overlay edit standing on the operand.
+    pub fn overlaid(mut self) -> Self {
+        self.overlaid = true;
+        self
+    }
+
+    /// Whether the STORED bytes can be addressed as `required` asks.
+    pub fn provides(&self, required: RequiredAccess) -> bool {
+        self.registered
+            .as_ref()
+            .is_some_and(|r| r.capabilities.access.provides(required))
+    }
+
+    /// The direct CPU realizations the codec declares — none while an
+    /// overlay edit stands on the operand, because there are no stored
+    /// bytes for a kernel to run over.
+    pub fn direct_cpu_plans(&self) -> Vec<PhysicalProjectionPlan> {
+        if self.overlaid {
+            return Vec::new();
+        }
+        self.registered
+            .as_ref()
+            .map(|r| {
+                r.accelerations
+                    .iter()
+                    .filter(|a| a.backend == AccelerationBackend::Cpu)
+                    .map(|a| a.plan)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// The residency the codec declares for a direct realization over
+    /// `plan`, if it declares one.
+    pub fn direct_residency(&self, plan: PhysicalProjectionPlan) -> Option<ResidencyProfile> {
+        self.registered.as_ref().and_then(|r| {
+            r.accelerations
+                .iter()
+                .find(|a| a.plan == plan)
+                .map(|a| a.residency)
+        })
+    }
+
+    /// Admit slicing the stored bytes per expert — the packed-bank
+    /// realization's requirement, judged BEFORE any byte is read.
+    ///
+    /// A registered codec must provide row access; an unregistered label
+    /// is a dialect the bank loader judges itself (the MXFP4 bank's `U8`
+    /// streams), and is admitted here so that judgement stays where it
+    /// is until 3d moves it into declarations.
+    pub fn admit_row_slicing(&self) -> Result<(), CodecError> {
+        match &self.registered {
+            Some(r) => r
+                .capabilities
+                .require(RequiredAccess::RowRandom, &self.label),
+            None => Ok(()),
+        }
+    }
+}
+
+impl RegisteredFacts {
+    pub fn of(codec: &dyn RepresentationCodec) -> Self {
+        Self {
+            identity: codec.identity(),
+            capabilities: codec.capabilities(),
+            accelerations: codec.accelerations(),
+            decode_residency: codec.decode_residency(),
+        }
+    }
+}
+
+/// Where a realization runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RealizationBackend {
+    /// This crate's CPU executor, including its reference transcription.
+    Cpu,
+    /// A device backend's own resident form.
+    Device,
+}
+
+/// How a planned operand is executed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RealizationForm {
+    /// A kernel the codec declared, over the stored bytes.
+    Direct(PhysicalProjectionPlan),
+    /// The universal decode to f32, then an f32 projection.
+    Decode(PhysicalProjectionPlan),
+    /// Decode, then the executor's own lossy re-quantisation.
+    Requantise(PhysicalProjectionPlan),
+    /// The packed bank, sliced per expert from STORED rows and converted.
+    SliceStored { convert: WeightFormat },
+    /// The whole table decoded, one row gathered per token.
+    DecodedGather,
+    /// A device backend's resident form, declared per class by that
+    /// backend for its own target.
+    DeviceResident(WeightFormat),
+}
+
+/// One realization, named so a plan can pin it and a trace can say it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RealizationId {
+    pub backend: RealizationBackend,
+    pub form: RealizationForm,
+}
+
+impl RealizationId {
+    pub const fn cpu(form: RealizationForm) -> Self {
+        Self {
+            backend: RealizationBackend::Cpu,
+            form,
+        }
+    }
+
+    /// The representation the loader makes resident for this realization.
+    pub fn format(self) -> WeightFormat {
+        match self.form {
+            RealizationForm::Direct(plan)
+            | RealizationForm::Decode(plan)
+            | RealizationForm::Requantise(plan) => plan.format(),
+            RealizationForm::SliceStored { convert } => convert,
+            RealizationForm::DecodedGather => WeightFormat::F32,
+            RealizationForm::DeviceResident(format) => format,
+        }
+    }
+
+    /// The CPU projection plan this realization runs, when it is one.
+    pub fn cpu_plan(self) -> Option<PhysicalProjectionPlan> {
+        match self.form {
+            RealizationForm::Direct(plan)
+            | RealizationForm::Decode(plan)
+            | RealizationForm::Requantise(plan) => Some(plan),
+            _ => None,
+        }
+    }
+
+    pub fn name(self) -> String {
+        let form = match self.form {
+            RealizationForm::Direct(plan) => format!("direct/{plan:?}"),
+            RealizationForm::Decode(plan) => format!("decode-f32+{plan:?}"),
+            RealizationForm::Requantise(plan) => format!("requantise/{plan:?}"),
+            RealizationForm::SliceStored { convert } => format!("slice-stored→{convert:?}"),
+            RealizationForm::DecodedGather => "decode-f32+gather".to_string(),
+            RealizationForm::DeviceResident(format) => format!("device-resident/{format:?}"),
+        };
+        match self.backend {
+            RealizationBackend::Cpu => format!("cpu:{form}"),
+            RealizationBackend::Device => format!("device:{form}"),
+        }
+    }
+}
+
+/// What the executor makes resident for `format`, priced from its own
+/// resident forms: a widened image is f32 per weight; a re-quantised image
+/// is its codes plus one f32 scale per block; a device's half-precision
+/// image is two bytes per weight and, being rounded from the source, is a
+/// re-quantisation; a compact pack bound as stored is its stored bits.
+///
+/// Rung 3c binds these into the census and checks them against what the
+/// loader actually holds.
+pub fn resident_profile(format: WeightFormat) -> ResidencyProfile {
+    match format {
+        WeightFormat::F32 => ResidencyProfile::DECODED_F32,
+        WeightFormat::Bf16 => ResidencyProfile::rebound(HALF_WIDTH * BITS_PER_BYTE),
+        WeightFormat::F16 => ResidencyProfile {
+            class: ResidencyClass::TransientRequantised,
+            bytes_per_weight: HALF_WIDTH,
+        },
+        WeightFormat::Q8 => ResidencyProfile {
+            class: ResidencyClass::TransientRequantised,
+            bytes_per_weight: 1.0 + F32_WIDTH / Q8_BLOCK as f64,
+        },
+        WeightFormat::Q4 => ResidencyProfile {
+            class: ResidencyClass::TransientRequantised,
+            bytes_per_weight: 0.5 + F32_WIDTH / Q4_BLOCK as f64,
+        },
+        WeightFormat::Nvfp4 => ResidencyProfile::rebound(4.5),
+        WeightFormat::Mxfp4 => ResidencyProfile::stored(4.25),
+        // Three codecs share the resident form; the bound operand carries
+        // which, so the profile is the widest of them until 3c reads it
+        // off the record's own codec declaration.
+        WeightFormat::KQuant => ResidencyProfile::stored(8.5),
+    }
+}
+
+/// Why a backend chose what it chose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionReason {
+    /// The codec declares a direct realization and the backend takes it.
+    DirectDeclared,
+    /// The codec declares no direct realization; decode is the only path.
+    NoDirectRealization,
+    /// A direct realization exists and the process arm prefers decoding.
+    ArmPrefersDecode,
+    /// The size policy over a float source chose this resident form.
+    SizePolicy,
+    /// A packed bank is sliced per expert from stored rows at load.
+    BankSlicedAtLoad,
+    /// The device backend's class table names its resident form.
+    DeviceClassTable,
+    /// An embedding table is decoded whole and gathered per token.
+    EmbeddingGather,
+    /// The reference backend takes the literal transcription, always.
+    ReferenceOracle,
+    /// An overlay edit stands on the operand; only decode can honour it.
+    OverlaidEdit,
+}
+
+impl SelectionReason {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::DirectDeclared => "direct realization declared by the codec",
+            Self::NoDirectRealization => "no direct realization registered",
+            Self::ArmPrefersDecode => "the process arm prefers decoding",
+            Self::SizePolicy => "size policy over a float source",
+            Self::BankSlicedAtLoad => "packed bank sliced per expert at load",
+            Self::DeviceClassTable => "device class table",
+            Self::EmbeddingGather => "table decoded whole, gathered per token",
+            Self::ReferenceOracle => "reference oracle",
+            Self::OverlaidEdit => "an overlay edit stands on the operand; only decode honours it",
+        }
+    }
+}
+
+/// The realization a backend pinned for one operand, with everything a
+/// trace needs to say about the choice.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Selection {
+    pub realization: RealizationId,
+    /// What the selected realization makes resident, declared — never
+    /// measured — so the census can be checked against it.
+    pub residency: ResidencyProfile,
+    pub reason: SelectionReason,
+    /// Every realization the backend considered, the selected one
+    /// included. Derived from declarations, never from a label.
+    pub candidates: Vec<RealizationId>,
+}
+
+/// Why no realization could be selected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefusalKind {
+    /// The stored label names no registered codec, so nothing can decode
+    /// it and no capability is declared for it.
+    UnregisteredRepresentation,
+    /// Every candidate needs access the stored representation does not
+    /// provide.
+    AccessRefused,
+    /// The plan executes an operation no realization on this backend can
+    /// bind — a planned operand with nowhere to go.
+    MissingRealization,
+}
+
+impl RefusalKind {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::UnregisteredRepresentation => "unregistered representation",
+            Self::AccessRefused => "access refused",
+            Self::MissingRealization => "missing realization",
+        }
+    }
+}
+
+/// A refusal that names the operand, what it asked for, what the
+/// representation is, and every candidate with the reason it was rejected.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectionRefusal {
+    pub operand: OperandRef,
+    pub operation: Operation,
+    pub representation: String,
+    pub requested: RequiredAccess,
+    pub kind: RefusalKind,
+    pub considered: Vec<(RealizationId, String)>,
+}
+
+impl fmt::Display for SelectionRefusal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "operand `{}` ({}, requires {} access) stored as `{}`: {}",
+            self.operand.tensor,
+            self.operation.name(),
+            self.requested.name(),
+            self.representation,
+            self.kind.name()
+        )?;
+        if self.considered.is_empty() {
+            write!(f, "; no realization to consider")?;
+        }
+        for (candidate, why) in &self.considered {
+            write!(f, "; {} — {why}", candidate.name())?;
+        }
+        Ok(())
+    }
+}
+
+/// Every refusal a plan raised, together, so a caller sees the whole
+/// problem and not its first symptom.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectionRefusals(pub Vec<SelectionRefusal>);
+
+impl fmt::Display for SelectionRefusals {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} planned operand(s) have no admissible realization",
+            self.0.len()
+        )?;
+        for refusal in &self.0 {
+            write!(f, "\n  {refusal}")?;
+        }
+        Ok(())
+    }
+}
+
+/// One planned operand's pinned realization — the record the prepared
+/// plan keeps and the trace reads.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RealizationRecord {
+    pub planned: PlannedOperand,
+    pub representation: String,
+    pub selection: Selection,
+}
+
+// ── The candidate sets, derived from declarations ─────────────────────
+
+/// The candidates the CPU executor has for a projection-class operand:
+/// every direct realization the codec declares, the universal decode
+/// (`decode_plan` is the f32 projection that follows it), and — for a
+/// source whose stored bytes the executor knows how to re-quantise, which
+/// it declares by naming a direct bf16 kernel — the executor's own compact
+/// forms. Nothing is added by label.
+pub fn cpu_projection_candidates(
+    facts: &RepresentationFacts,
+    decode_plan: PhysicalProjectionPlan,
+    requantise: &[PhysicalProjectionPlan],
+) -> Vec<RealizationId> {
+    let mut out: Vec<RealizationId> = facts
+        .direct_cpu_plans()
+        .into_iter()
+        .map(|p| RealizationId::cpu(RealizationForm::Direct(p)))
+        .collect();
+    if facts.registered.is_some() {
+        out.push(RealizationId::cpu(RealizationForm::Decode(decode_plan)));
+        if facts
+            .direct_cpu_plans()
+            .contains(&PhysicalProjectionPlan::FusedBf16)
+        {
+            out.extend(
+                requantise
+                    .iter()
+                    .map(|p| RealizationId::cpu(RealizationForm::Requantise(*p))),
+            );
+        }
+    }
+    out
+}
+
+/// The selection every backend makes for the operations that are not a
+/// projection, given the candidate it offers for them; `None` for the
+/// shared expert, which no backend binds through the prepared plan.
+pub fn common_selection(
+    operand: &PlannedOperand,
+    facts: &RepresentationFacts,
+    bank_convert: WeightFormat,
+) -> Option<Result<Selection, Box<SelectionRefusal>>> {
+    let refuse = |kind, considered: Vec<(RealizationId, String)>| {
+        Box::new(SelectionRefusal {
+            operand: operand.operand.clone(),
+            operation: operand.operation,
+            representation: facts.label.clone(),
+            requested: operand.access,
+            kind,
+            considered,
+        })
+    };
+    match operand.operation {
+        Operation::Embed => {
+            let id = RealizationId::cpu(RealizationForm::DecodedGather);
+            Some(if facts.registered.is_some() {
+                Ok(Selection {
+                    realization: id,
+                    residency: ResidencyProfile::DECODED_F32,
+                    reason: SelectionReason::EmbeddingGather,
+                    candidates: vec![id],
+                })
+            } else {
+                Err(refuse(RefusalKind::UnregisteredRepresentation, vec![]))
+            })
+        }
+        Operation::ExpertBankSlice => {
+            let id = RealizationId::cpu(RealizationForm::SliceStored {
+                convert: bank_convert,
+            });
+            Some(match facts.admit_row_slicing() {
+                Ok(()) => Ok(Selection {
+                    realization: id,
+                    residency: resident_profile(bank_convert),
+                    reason: SelectionReason::BankSlicedAtLoad,
+                    candidates: vec![id],
+                }),
+                Err(e) => Err(refuse(
+                    RefusalKind::AccessRefused,
+                    vec![(id, e.to_string())],
+                )),
+            })
+        }
+        Operation::SharedExpertProject => {
+            Some(Err(refuse(RefusalKind::MissingRealization, vec![])))
+        }
+        Operation::Project(_) | Operation::OutputHead => None,
+    }
+}
+
+/// The reference backend's answer: the literal f32 transcription, always,
+/// for every projection of a registered representation.
+pub fn reference_selection(
+    operand: &PlannedOperand,
+    facts: &RepresentationFacts,
+) -> Result<Selection, Box<SelectionRefusal>> {
+    if let Some(common) = common_selection(operand, facts, WeightFormat::F32) {
+        return common;
+    }
+    let id = RealizationId::cpu(RealizationForm::Decode(PhysicalProjectionPlan::ScalarF32));
+    match &facts.registered {
+        Some(r) => Ok(Selection {
+            realization: id,
+            residency: r.decode_residency,
+            reason: SelectionReason::ReferenceOracle,
+            candidates: vec![id],
+        }),
+        None => Err(Box::new(SelectionRefusal {
+            operand: operand.operand.clone(),
+            operation: operand.operation,
+            representation: facts.label.clone(),
+            requested: operand.access,
+            kind: RefusalKind::UnregisteredRepresentation,
+            considered: vec![],
+        })),
+    }
+}
+
+/// The class a projection-class operation names; the two non-projection
+/// operations never reach a class table.
+pub fn class_of(operation: Operation) -> Option<MatrixClass> {
+    match operation {
+        Operation::Project(class) => Some(class),
+        Operation::OutputHead => Some(MatrixClass::OutputHead),
+        Operation::Embed | Operation::ExpertBankSlice | Operation::SharedExpertProject => None,
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
@@ -1,0 +1,727 @@
+//! Rung 3c: declarations bound AGAINST observations. The expectation side
+//! is priced from the pin, the codec's declared residency, the executor's
+//! block geometry and the container's recorded lengths; the observation
+//! side is read off the objects the loader bound. Neither reads the other.
+
+use super::super::accounting::{
+    execution_touch, expectations, ledger_correspondence, reconcile, render_selection_summary,
+    resident_profile_with, stored_footprint, BlockGeometry, Bound, Observed,
+};
+use super::super::backend::{MatrixClass, WeightFormat};
+use super::super::cpu::ledger::{ledger, thread_projection_calls};
+use super::super::cpu::physical::PhysicalProjectionPlan;
+use super::super::operands::OperandStore;
+use super::super::prepared::{ExecutionSlice, PreparedOperands};
+use super::super::production::ProductionBackend;
+use super::super::realization::{
+    RealizationForm, RealizationId, RealizationRecord, Selection, SelectionReason,
+};
+use super::super::weights::{load_weight, DEVICE_PAGE_ALIGN};
+use super::super::{execute_prepared_streaming, PlaneEvent};
+use super::bf16_zlib_execution::{transcode, Transcode};
+use crate::format::vindex3::fixtures::{
+    dense_f32_model, dense_f32_model_with, encode_fixture_container, HeadStorage,
+};
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::planned::{Operation, PlannedOperand};
+use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan, OperandRef};
+use crate::format::vindex3::represent::codec::codecs::{float, kquant, mxfp4, nvfp4};
+use crate::format::vindex3::represent::codec::{
+    CodecRegistry, RepresentationExtent, ResidencyProfile,
+};
+
+const F32_WIDTH: u64 = std::mem::size_of::<f32>() as u64;
+const BF16_WIDTH: u64 = std::mem::size_of::<u16>() as u64;
+const PROJECTION_SUFFIX: &str = "_proj.weight";
+const TOKENS: [u32; 3] = [3, 17, 28];
+
+struct Fixture {
+    _src: tempfile::TempDir,
+    _container: tempfile::TempDir,
+    plan: ComponentOpPlan,
+    store: OperandStore,
+}
+
+fn fixture(write: fn(&std::path::Path), into: Option<Transcode>) -> Fixture {
+    let src = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(write, src.path(), container.path(), "dense");
+    if let Some(into) = into {
+        let done = transcode(
+            container.path(),
+            |name, shape| shape.len() == 2 && name.ends_with(PROJECTION_SUFFIX),
+            into,
+        );
+        assert!(!done.is_empty());
+    }
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let plan = plan_component_ops(&inspection, container.path(), "target")
+        .unwrap()
+        .plan
+        .unwrap();
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    Fixture {
+        _src: src,
+        _container: container,
+        plan,
+        store,
+    }
+}
+
+fn tied_head() -> Fixture {
+    fixture(|d| dense_f32_model_with(d, HeadStorage::Tied), None)
+}
+
+fn prepared(f: &Fixture) -> PreparedOperands {
+    PreparedOperands::load(
+        &f.plan,
+        &f.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap()
+}
+
+/// A record for one operand under one realization, as the selector would
+/// have pinned it, with the residency a codec would have declared.
+fn record(
+    operand: &OperandRef,
+    realization: RealizationId,
+    residency: ResidencyProfile,
+) -> RealizationRecord {
+    let operation = Operation::Project(MatrixClass::FfnProjection);
+    RealizationRecord {
+        planned: PlannedOperand {
+            operand: operand.clone(),
+            operation,
+            access: operation.access(),
+            extent: RepresentationExtent::TERMINAL,
+            layer: Some(0),
+            logical_elements: operand.shape.iter().product(),
+        },
+        representation: operand.dtype.clone(),
+        provider: None,
+        selection: Selection {
+            realization,
+            residency,
+            reason: SelectionReason::SizePolicy,
+            candidates: vec![realization],
+        },
+    }
+}
+
+/// The first FFN projection of the dense plan.
+fn an_ffn_projection(plan: &ComponentOpPlan) -> OperandRef {
+    plan.planned_operands()
+        .into_iter()
+        .find(|p| p.operation == Operation::Project(MatrixClass::FfnProjection))
+        .map(|p| p.operand)
+        .unwrap()
+}
+
+// ── Every resident form the CPU loader produces, against its declaration ──
+
+/// For each resident form: load the object, price the pin, reconcile.
+/// The pricing that comes from the executor's block geometry is then
+/// re-priced under a MUTATED geometry, and the reconciliation must break —
+/// otherwise the comparison would be reading the declaration twice.
+#[test]
+fn every_resident_form_reconciles_with_its_declaration_and_a_mutated_geometry_breaks_it() {
+    let f = fixture(dense_f32_model, None);
+    let op = an_ffn_projection(&f.plan);
+    let stored = |o: &OperandRef| f.store.stored_len(o);
+    let executor = BlockGeometry::executor();
+    let mutated = BlockGeometry {
+        q8_block: executor.q8_block / 2,
+        q4_block: executor.q4_block / 2,
+        q8_indexed: !executor.q8_indexed,
+    };
+    let cases: [(WeightFormat, RealizationForm, bool); 6] = [
+        (
+            WeightFormat::F32,
+            RealizationForm::Decode(PhysicalProjectionPlan::BlasF32),
+            false,
+        ),
+        (
+            WeightFormat::Q8,
+            RealizationForm::Requantise(PhysicalProjectionPlan::FusedQ8),
+            true,
+        ),
+        (
+            WeightFormat::Q4,
+            RealizationForm::Requantise(PhysicalProjectionPlan::FusedQ4),
+            true,
+        ),
+        (
+            WeightFormat::F16,
+            RealizationForm::DeviceResident(WeightFormat::F16),
+            false,
+        ),
+        (
+            WeightFormat::Nvfp4,
+            RealizationForm::DeviceResident(WeightFormat::Nvfp4),
+            false,
+        ),
+        (
+            WeightFormat::Mxfp4,
+            RealizationForm::DeviceResident(WeightFormat::Mxfp4),
+            false,
+        ),
+    ];
+    for (format, form, geometry_priced) in cases {
+        let loaded = load_weight((&f.store).into(), &op, format)
+            .unwrap_or_else(|e| panic!("{format:?}: {e}"));
+        let rec = record(&op, RealizationId::cpu(form), ResidencyProfile::DECODED_F32);
+        let observed = vec![Bound::one(&op, &loaded)
+            .observed(rec.planned.operation, rec.planned.layer)
+            .unwrap()];
+        let expected = expectations(std::slice::from_ref(&rec), stored, executor);
+        let ok = reconcile(&expected, &observed).unwrap_or_else(|e| panic!("{format:?}: {e}"));
+        assert_eq!(ok.matched, 1);
+        assert!(
+            ok.padding < loaded.padded_allocations() as u64 * DEVICE_PAGE_ALIGN as u64 + 1,
+            "{format:?}: padding {} over {} padded allocation(s)",
+            ok.padding,
+            loaded.padded_allocations()
+        );
+        if loaded.padded_allocations() == 0 {
+            assert_eq!(ok.padding, 0, "{format:?}: an exact form has no padding");
+        }
+        let under_mutation = expectations(std::slice::from_ref(&rec), stored, mutated);
+        let broken = reconcile(&under_mutation, &observed).is_err();
+        assert_eq!(
+            broken, geometry_priced,
+            "{format:?}: a mutated block geometry must break exactly the forms it prices"
+        );
+    }
+}
+
+#[test]
+fn the_q8_pricing_follows_the_executor_s_index_flag_and_block() {
+    let plain = BlockGeometry {
+        q8_block: 64,
+        q4_block: 64,
+        q8_indexed: false,
+    };
+    let indexed = BlockGeometry {
+        q8_indexed: true,
+        ..plain
+    };
+    let p = resident_profile_with(WeightFormat::Q8, plain).bytes_per_weight;
+    let i = resident_profile_with(WeightFormat::Q8, indexed).bytes_per_weight;
+    assert!((p - (1.0 + 4.0 / 64.0)).abs() < 1e-12);
+    assert!(
+        (i - (1.0 + 6.0 / 64.0)).abs() < 1e-12,
+        "one i16 sum per block"
+    );
+    let q4 = resident_profile_with(WeightFormat::Q4, plain).bytes_per_weight;
+    assert!((q4 - (0.5 + 4.0 / 64.0)).abs() < 1e-12);
+}
+
+// ── A prepared plan reconciles, and the census is a third reading ─────
+
+#[test]
+fn a_prepared_dense_plan_reconciles_every_pin_and_the_census_is_the_same_bytes() {
+    let f = fixture(dense_f32_model, None);
+    let ops = prepared(&f);
+    let done = ops.reconcile(&f.plan, (&f.store).into()).unwrap();
+    assert_eq!(done.matched, ops.realizations().len());
+    assert_eq!(done.padding, 0, "f32 images are exact");
+    // The census walks the loaded objects by site; the observation walks
+    // them by operand. Two readings of one resident image must agree.
+    let observed = ops.bound(&f.plan).unwrap();
+    let total: u64 = observed.iter().map(|o| o.resident_bytes).sum();
+    let census = ops.residency_census();
+    assert_eq!(total, (census.total() - census.glue.total()) as u64);
+    assert_eq!(done.observed_resident, total);
+}
+
+#[test]
+fn the_entropy_coded_container_s_stored_bytes_are_the_recorded_length_and_its_staging_is_the_image()
+{
+    let f = fixture(dense_f32_model, Some(Transcode::Bf16Zlib));
+    let ops = prepared(&f);
+    let expected = ops.expectations((&f.store).into(), BlockGeometry::executor());
+    let mut seen = 0;
+    for e in expected
+        .iter()
+        .filter(|e| f.store.stored_dtype(&e.operand) == Some("BF16_ZLIB"))
+    {
+        let recorded = f.store.stored_len(&e.operand).unwrap();
+        assert_eq!(e.stored_bytes, recorded, "{}", e.operand.tensor);
+        assert_ne!(
+            e.stored_bytes,
+            e.logical_elements as u64 * BF16_WIDTH,
+            "instance, not shape"
+        );
+        assert_eq!(
+            e.staging,
+            e.logical_elements as u64 * F32_WIDTH,
+            "decoded through f32"
+        );
+        assert_eq!(e.declared_resident, e.logical_elements as u64 * F32_WIDTH);
+        assert_eq!(e.working_set(), e.staging + e.declared_resident);
+        seen += 1;
+    }
+    assert!(seen > 0);
+    ops.reconcile(&f.plan, (&f.store).into()).unwrap();
+    // Footprint and touch: every operand is read once per operation, and
+    // no operand is shared, so the two agree on this plan.
+    assert_eq!(
+        stored_footprint(&expected).bytes,
+        execution_touch(&expected)
+    );
+}
+
+#[test]
+fn a_tied_head_counts_once_in_the_stored_footprint_and_once_per_operation_in_the_touch() {
+    let f = tied_head();
+    let ops = prepared(&f);
+    let expected = ops.expectations((&f.store).into(), BlockGeometry::executor());
+    let table = f.plan.embedding.as_ref().unwrap().table.clone();
+    let table_bytes = f.store.stored_len(&table).unwrap();
+    let footprint = stored_footprint(&expected);
+    let touch = execution_touch(&expected);
+    let operations = expected.len();
+    assert_eq!(
+        footprint.operands,
+        operations - 1,
+        "the table is one stored operand under two operations"
+    );
+    assert_eq!(
+        touch,
+        footprint.bytes + table_bytes,
+        "the table is read once per operation"
+    );
+    ops.reconcile(&f.plan, (&f.store).into()).unwrap();
+}
+
+// ── Providers: gone or changed invalidates the image ─────────────────
+
+fn rung_one_registry(with_f32: bool) -> CodecRegistry {
+    let mut r = CodecRegistry::new()
+        .register(Box::new(float::BF16))
+        .and_then(|r| r.register(Box::new(float::F16)))
+        .unwrap();
+    if with_f32 {
+        r = r.register(Box::new(float::F32)).unwrap();
+    }
+    r.register(Box::new(kquant::Q4_K))
+        .and_then(|r| r.register(Box::new(kquant::Q6_K)))
+        .and_then(|r| r.register(Box::new(kquant::Q8_0)))
+        .and_then(|r| r.register(Box::new(nvfp4::NVFP4)))
+        .and_then(|r| r.register(Box::new(mxfp4::MXFP4)))
+        .unwrap()
+}
+
+#[test]
+fn a_provider_that_disappears_invalidates_the_preparation_rather_than_falling_back() {
+    let f = fixture(dense_f32_model, None);
+    let with = rung_one_registry(true);
+    let ops = PreparedOperands::load_in(
+        &f.plan,
+        &f.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+        &with,
+    )
+    .unwrap();
+    ops.ensure_providers_in(&with).unwrap();
+    ops.ensure_providers_in(CodecRegistry::builtin())
+        .expect("the built-in registry offers the same F32 identity");
+    let without = rung_one_registry(false);
+    let err = ops.ensure_providers_in(&without).unwrap_err().to_string();
+    assert!(
+        err.contains("`F32`") && err.contains("no registered codec"),
+        "{err}"
+    );
+    assert!(err.contains("re-prepare"), "{err}");
+    // And preparing against the registry that lacks F32 refuses outright.
+    let Err(err) = PreparedOperands::load_in(
+        &f.plan,
+        &f.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+        &without,
+    ) else {
+        panic!("F32 is not registered there");
+    };
+    let err = err.to_string();
+    assert!(err.contains("unregistered representation"), "{err}");
+}
+
+// ── The four-way correspondence ───────────────────────────────────────
+
+/// Planned operands, pins, bound objects and the ledger's account of what
+/// ran describe one execution — EXACTLY, in positions. The projection
+/// ledger is process-global, so the exact reading is only available in a
+/// process that executes nothing else: this test re-launches the test
+/// binary on itself, marked, and the marked run makes the assertions.
+#[test]
+fn planned_operands_pins_bound_objects_and_the_ledger_correspond() {
+    const WITNESS: &str = "LARQL_LEDGER_WITNESS";
+    const NAME: &str = "format::vindex3::opplan::exec::tests::accounting::planned_operands_pins_bound_objects_and_the_ledger_correspond";
+    if std::env::var_os(WITNESS).is_some() {
+        return exact_ledger_correspondence();
+    }
+    let exe = std::env::current_exe().expect("the test binary knows its own path");
+    let output = std::process::Command::new(exe)
+        .args(["--exact", NAME, "--test-threads=1", "--nocapture"])
+        .env(WITNESS, "1")
+        .output()
+        .expect("the test binary re-launches");
+    assert!(
+        output.status.success(),
+        "the exact correspondence did not hold in an isolated process:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn exact_ledger_correspondence() {
+    let f = fixture(dense_f32_model, None);
+    let ops = prepared(&f);
+    let planned = f.plan.planned_operands();
+    let pins = ops.realizations();
+    let bound = ops.bound(&f.plan).unwrap();
+    // One pin per planned operand, one bound object per pin.
+    assert_eq!(pins.len(), planned.len());
+    assert_eq!(bound.len(), pins.len());
+    let projections = pins
+        .iter()
+        .filter(|r| r.selection.realization.cpu_plan().is_some())
+        .count();
+
+    ledger().reset();
+    let backend = ProductionBackend::new();
+    let mut sink = |_: PlaneEvent| Ok(());
+    execute_prepared_streaming(&f.plan, &ops, &TOKENS, &backend, None, &mut sink).unwrap();
+    let account = ledger_correspondence(pins, ledger()).unwrap();
+    assert_eq!(
+        account.len(),
+        1,
+        "one CPU plan on an f32 fixture: {account:?}"
+    );
+    let (plan, pinned, tally) = account[0];
+    assert_eq!(plan, PhysicalProjectionPlan::BlasF32);
+    assert_eq!(pinned, projections);
+    eprintln!(
+        "BlasF32 over {projections} pinned projections: calls {} slabs {} positions {} (this thread: {})",
+        tally.calls,
+        tally.slabs,
+        tally.positions,
+        thread_projection_calls()
+    );
+    // Positions are the unit that corresponds: every layer projection
+    // processed every token, and the head processed the last one. Calls
+    // are batched differently per site and threaded, so they are not.
+    let in_layers = pins
+        .iter()
+        .filter(|r| r.planned.layer.is_some() && r.selection.realization.cpu_plan().is_some())
+        .count() as u64;
+    let heads = projections as u64 - in_layers;
+    assert_eq!(
+        tally.positions,
+        in_layers * TOKENS.len() as u64 + heads,
+        "{tally:?}"
+    );
+}
+
+// ── Presentation over the records ────────────────────────────────────
+
+#[test]
+fn the_summary_renders_the_structured_records_and_adds_nothing() {
+    let f = fixture(dense_f32_model, Some(Transcode::Bf16Zlib));
+    let ops = prepared(&f);
+    let text = render_selection_summary(ops.realizations());
+    assert!(text.starts_with("realizations:\n"), "{text}");
+    for record in ops.realizations() {
+        assert!(text.contains(&record.representation), "{text}");
+        assert!(
+            text.contains(&record.selection.realization.name()),
+            "{text}"
+        );
+        assert!(text.contains(record.selection.reason.name()), "{text}");
+    }
+    let lines = text.lines().count() - 1;
+    let distinct: std::collections::BTreeSet<_> = ops
+        .realizations()
+        .iter()
+        .map(|r| {
+            (
+                r.representation.clone(),
+                r.selection.realization.name(),
+                r.selection.reason.name(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        lines,
+        distinct.len(),
+        "one line per (representation, realization, reason)"
+    );
+}
+
+/// The observation side refuses a pairing that contradicts itself,
+/// and the reconciliation refuses a stray object and a missing one.
+#[test]
+fn reconciliation_refuses_strays_omissions_and_disagreeing_forms() {
+    let f = fixture(dense_f32_model, None);
+    let op = an_ffn_projection(&f.plan);
+    let f32 = load_weight((&f.store).into(), &op, WeightFormat::F32).unwrap();
+    // A different resident form for the same operand: the executor's own
+    // re-quantisation, which any f32 source can take.
+    let q8 = load_weight((&f.store).into(), &op, WeightFormat::Q8).unwrap();
+    let rec = record(
+        &op,
+        RealizationId::cpu(RealizationForm::Decode(PhysicalProjectionPlan::BlasF32)),
+        ResidencyProfile::DECODED_F32,
+    );
+    let expected = expectations(
+        std::slice::from_ref(&rec),
+        |o| f.store.stored_len(o),
+        BlockGeometry::executor(),
+    );
+    let observed = |w| {
+        vec![Bound::one(&op, w)
+            .observed(rec.planned.operation, Some(0))
+            .unwrap()]
+    };
+    reconcile(&expected, &observed(&f32)).unwrap();
+    let err = reconcile(&expected, &observed(&q8))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("pinned F32 but Q8 is resident"), "{err}");
+    let err = reconcile(&expected, &[]).unwrap_err().to_string();
+    assert!(err.contains("nothing is resident for it"), "{err}");
+    let err = reconcile(&[], &observed(&f32)).unwrap_err().to_string();
+    assert!(err.contains("nothing was pinned for it"), "{err}");
+    let mixed = Bound {
+        operand: &op,
+        weights: vec![&f32, &q8],
+    }
+    .observed(rec.planned.operation, Some(0))
+    .unwrap_err()
+    .to_string();
+    assert!(
+        mixed.contains("disagree on their representation"),
+        "{mixed}"
+    );
+    let _: Observed = observed(&f32).remove(0);
+}
+
+// ── The prepared plan's pairing and provider arms ────────────────────
+
+use super::gemma4::{closure as gemma4_closure, encoded as gemma4_encoded, miniature_gemma4};
+use crate::format::vindex3::represent::codec::{
+    AccessGranularity, CodecCapabilities, CodecError, CodecOperands, ExtentCertificate,
+    RepresentationCodec, StreamSpec,
+};
+use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
+
+/// A codec that claims someone else's label under its own identity —
+/// what a provider that CHANGED looks like to a prepared image.
+pub(super) struct ProviderStub {
+    pub label: &'static str,
+}
+
+impl RepresentationCodec for ProviderStub {
+    fn encoding_label(&self) -> &'static str {
+        self.label
+    }
+    fn identity(&self) -> CodecIdentity {
+        CodecIdentity {
+            family: format!("stub-{}", self.label),
+            revision: 7,
+            group_elems: 1,
+            element: "stub".into(),
+            group_scale: "none".into(),
+            tensor_scale: "none".into(),
+            layout: "stub".into(),
+        }
+    }
+    fn streams(&self) -> &'static [StreamSpec] {
+        &[crate::format::vindex3::represent::codec::streams::VALUES]
+    }
+    fn capabilities(&self) -> CodecCapabilities {
+        CodecCapabilities {
+            access: AccessGranularity::ElementRandom,
+            group_elems: 1,
+            row_align_elems: 1,
+            physical_align_bytes: 1,
+        }
+    }
+    fn extents(&self) -> Vec<ExtentCertificate> {
+        vec![ExtentCertificate::terminal(32.0)]
+    }
+    fn stored_bytes(
+        &self,
+        _: &[usize],
+        _: RepresentationExtent,
+        _: &str,
+    ) -> Result<u64, CodecError> {
+        Ok(0)
+    }
+    fn validate(
+        &self,
+        _: &CodecOperands<'_>,
+        _: &[usize],
+        _: RepresentationExtent,
+        _: &str,
+    ) -> Result<(), CodecError> {
+        Ok(())
+    }
+    fn decode_rows(
+        &self,
+        _: &CodecOperands<'_>,
+        _: &[usize],
+        _: std::ops::Range<usize>,
+        _: RepresentationExtent,
+        dst: &mut [f32],
+        _: &str,
+    ) -> Result<(), CodecError> {
+        dst.fill(0.0);
+        Ok(())
+    }
+    fn decode_residency(&self) -> ResidencyProfile {
+        ResidencyProfile::DECODED_F32
+    }
+}
+
+#[test]
+fn a_hybrid_plan_pairs_dense_projections_one_each_and_banks_over_their_experts() {
+    let dir = tempfile::tempdir().unwrap();
+    miniature_gemma4(dir.path(), None);
+    let container = gemma4_encoded(dir.path());
+    let outcome = gemma4_closure(container.path());
+    let plan = outcome.plan.expect("the Gemma-4 miniature plans");
+    // Layer 3 binds one tensor as both its key and value projection: one
+    // stored operand, two operation instances in one layer. The view lists
+    // both, the loader binds both, the pairing matches both, and the
+    // stored footprint counts the object once.
+    let mut counts = std::collections::BTreeMap::new();
+    for p in plan.planned_operands() {
+        *counts
+            .entry((p.operand.tensor.clone(), p.layer))
+            .or_insert(0usize) += 1;
+    }
+    // Two shared objects: the aliased projection within layer 3, and the
+    // head tied to the embedding table (two operations, no layer).
+    let repeated: Vec<_> = counts.iter().filter(|(_, n)| **n > 1).collect();
+    assert_eq!(repeated.len(), 2, "{repeated:?}");
+    assert!(repeated.iter().all(|(_, n)| **n == 2), "{repeated:?}");
+    assert!(repeated
+        .iter()
+        .any(|((t, l), _)| t.ends_with("k_proj.weight") && l.is_some()));
+    assert!(
+        repeated.iter().any(|((_, l), _)| l.is_none()),
+        "the tied head"
+    );
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    let ops = PreparedOperands::load(
+        &plan,
+        &store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let observed = ops.bound(&plan).unwrap();
+    let hybrid_layers = plan
+        .layers
+        .iter()
+        .filter(|l| {
+            matches!(
+                l.ffn,
+                Some(crate::format::vindex3::opplan::LayerFfn::Hybrid(_))
+            )
+        })
+        .count();
+    assert!(hybrid_layers > 0, "the miniature has hybrid layers");
+    let dense: Vec<_> = observed
+        .iter()
+        .filter(|o| o.operation == Operation::Project(MatrixClass::FfnProjection))
+        .collect();
+    let banks: Vec<_> = observed
+        .iter()
+        .filter(|o| o.operation == Operation::ExpertBankSlice)
+        .collect();
+    assert!(
+        dense.len() >= 2 * hybrid_layers,
+        "gate/up and down per hybrid dense branch"
+    );
+    assert_eq!(banks.len(), 2 * hybrid_layers, "two banks per hybrid layer");
+    assert!(banks
+        .iter()
+        .all(|b| b.allocations == 0 && b.format == WeightFormat::F32));
+    let done = ops.reconcile(&plan, (&store).into()).unwrap();
+    assert_eq!(done.matched, ops.realizations().len());
+    let expected = ops.expectations((&store).into(), BlockGeometry::executor());
+    assert_eq!(
+        stored_footprint(&expected).operands,
+        expected.len() - 2,
+        "the aliased projection and the tied table are one stored operand each under two instances"
+    );
+    assert!(execution_touch(&expected) > stored_footprint(&expected).bytes);
+}
+
+#[test]
+fn verify_pins_refuses_a_tampered_ffn_pin_and_a_tampered_head_pin() {
+    let f = fixture(dense_f32_model, None);
+    for (operation, site) in [
+        (Operation::Project(MatrixClass::FfnProjection), "ffn"),
+        (Operation::OutputHead, "output head"),
+    ] {
+        let mut ops = prepared(&f);
+        let index = ops
+            .realizations()
+            .iter()
+            .position(|r| r.planned.operation == operation)
+            .unwrap();
+        ops.realizations_mut()[index].selection.realization =
+            RealizationId::cpu(RealizationForm::Requantise(PhysicalProjectionPlan::FusedQ8));
+        let err = ops.verify_pins().unwrap_err().to_string();
+        assert!(
+            err.contains(site) && err.contains("not the pinned realizations"),
+            "{err}"
+        );
+    }
+}
+
+#[test]
+fn a_provider_whose_identity_changed_invalidates_the_preparation() {
+    let f = fixture(dense_f32_model, None);
+    let ops = prepared(&f);
+    let changed = CodecRegistry::new()
+        .register(Box::new(ProviderStub { label: "F32" }))
+        .unwrap();
+    let err = ops.ensure_providers_in(&changed).unwrap_err().to_string();
+    assert!(
+        err.contains("`F32`") && err.contains("F32 r1") && err.contains("stub-F32 r7"),
+        "{err}"
+    );
+    let providers = ops.providers();
+    assert_eq!(
+        providers.len(),
+        1,
+        "one stored label on the dense fixture: {providers:?}"
+    );
+    assert_eq!(providers[0].0, "F32");
+    assert!(providers[0].1.is_some());
+}
+
+#[test]
+fn bound_refuses_a_plan_that_is_a_different_program_from_the_prepared_one() {
+    let dense = fixture(dense_f32_model, None);
+    let ops = prepared(&dense);
+    let mut headless = dense.plan.clone();
+    headless.layers.clear();
+    let err = ops.bound(&headless).unwrap_err().to_string();
+    assert!(err.contains("prepared but not in the plan"), "{err}");
+    let lllf = fixture(
+        crate::format::vindex3::fixtures::hybrid_lllf_f32_model,
+        None,
+    );
+    let err = ops.bound(&lllf.plan).unwrap_err().to_string();
+    assert!(err.contains("different programs"), "{err}");
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
@@ -22,7 +22,7 @@ use super::bf16_zlib_execution::{transcode, Transcode};
 use crate::format::vindex3::fixtures::{
     dense_f32_model, dense_f32_model_with, encode_fixture_container, HeadStorage,
 };
-use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::inspect::{inspect_container, SystemInspection};
 use crate::format::vindex3::opplan::planned::{Operation, PlannedOperand};
 use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan, OperandRef};
 use crate::format::vindex3::represent::codec::codecs::{float, kquant, mxfp4, nvfp4};
@@ -37,9 +37,19 @@ const TOKENS: [u32; 3] = [3, 17, 28];
 
 struct Fixture {
     _src: tempfile::TempDir,
-    _container: tempfile::TempDir,
+    container: tempfile::TempDir,
+    inspection: SystemInspection,
     plan: ComponentOpPlan,
     store: OperandStore,
+}
+
+impl Fixture {
+    /// The same container, decoding through `registry`.
+    fn store_through(&self, registry: &'static CodecRegistry) -> OperandStore {
+        OperandStore::open(self.container.path(), &self.inspection)
+            .unwrap()
+            .with_registry(registry)
+    }
 }
 
 fn fixture(write: fn(&std::path::Path), into: Option<Transcode>) -> Fixture {
@@ -62,7 +72,8 @@ fn fixture(write: fn(&std::path::Path), into: Option<Transcode>) -> Fixture {
     let store = OperandStore::open(container.path(), &inspection).unwrap();
     Fixture {
         _src: src,
-        _container: container,
+        container,
+        inspection,
         plan,
         store,
     }
@@ -97,6 +108,7 @@ fn record(
             access: operation.access(),
             extent: RepresentationExtent::TERMINAL,
             layer: Some(0),
+            declared_representation: None,
             logical_elements: operand.shape.iter().product(),
         },
         representation: operand.dtype.clone(),
@@ -317,32 +329,33 @@ fn rung_one_registry(with_f32: bool) -> CodecRegistry {
 #[test]
 fn a_provider_that_disappears_invalidates_the_preparation_rather_than_falling_back() {
     let f = fixture(dense_f32_model, None);
-    let with = rung_one_registry(true);
-    let ops = PreparedOperands::load_in(
+    // The store carries the registry it decodes through, so selection,
+    // provider identity and decode all read one registry.
+    let with: &'static CodecRegistry = Box::leak(Box::new(rung_one_registry(true)));
+    let ops = PreparedOperands::load(
         &f.plan,
-        &f.store,
+        &f.store_through(with),
         &ProductionBackend::new(),
         ExecutionSlice::Full,
-        &with,
     )
     .unwrap();
-    ops.ensure_providers_in(&with).unwrap();
+    ops.ensure_providers_in(with).unwrap();
     ops.ensure_providers_in(CodecRegistry::builtin())
         .expect("the built-in registry offers the same F32 identity");
-    let without = rung_one_registry(false);
-    let err = ops.ensure_providers_in(&without).unwrap_err().to_string();
+    let without: &'static CodecRegistry = Box::leak(Box::new(rung_one_registry(false)));
+    let err = ops.ensure_providers_in(without).unwrap_err().to_string();
     assert!(
         err.contains("`F32`") && err.contains("no registered codec"),
         "{err}"
     );
     assert!(err.contains("re-prepare"), "{err}");
-    // And preparing against the registry that lacks F32 refuses outright.
-    let Err(err) = PreparedOperands::load_in(
+    // And preparing through a store whose registry lacks F32 refuses
+    // outright.
+    let Err(err) = PreparedOperands::load(
         &f.plan,
-        &f.store,
+        &f.store_through(without),
         &ProductionBackend::new(),
         ExecutionSlice::Full,
-        &without,
     ) else {
         panic!("F32 is not registered there");
     };

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/bf16_zlib_execution.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/bf16_zlib_execution.rs
@@ -276,18 +276,35 @@ fn without_registration_the_label_is_refused_naming_the_eight_that_are() {
 }
 
 #[test]
-fn the_same_bytes_under_an_unregistered_label_are_refused_at_load_by_name() {
+fn the_same_bytes_under_an_unregistered_label_are_refused_before_any_byte_by_name() {
     let alien = Witness::build(Transcode::Unregistered);
     let (plan, store) = alien.open();
+    // Rung 3b moved the refusal from the load to the preparation: the
+    // selector resolves the label against the registry before any byte
+    // is read, and names every operand it refused.
+    let before = store.load_count();
     let Err(err) = execute_plan(&plan, &store, &TOKENS, &ProductionBackend::new()) else {
         panic!("nothing is registered for the label");
     };
     let msg = err.to_string();
     assert!(
+        msg.contains("unregistered representation") && msg.contains(UNREGISTERED_LABEL),
+        "the refusal names the kind and the label: {msg}"
+    );
+    assert_eq!(
+        store.load_count(),
+        before,
+        "refused before any byte was read"
+    );
+    // The registry's own refusal still stands behind it, listing what IS
+    // registered — reached by asking the store directly.
+    let operand = alien.transcoded[0].operand();
+    let msg = store.load(&operand).unwrap_err().to_string();
+    assert!(
         msg.contains(&format!(
             "representation `{UNREGISTERED_LABEL}` is not registered"
         )) && msg.contains(DTYPE_BF16_ZLIB),
-        "the refusal names the label and lists the registered ones: {msg}"
+        "{msg}"
     );
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_device.rs
@@ -11,7 +11,6 @@
 //! and unsupported-activation FFN arms. Each test here drives one of
 //! those arms directly and asserts what the arm is *for*.
 
-use crate::format::vindex3::opplan::exec::backend::MatrixOperand;
 use std::sync::{Arc, Mutex};
 
 use larql_compute::backend::MatMul;
@@ -667,15 +666,26 @@ fn an_nvfp4_device_backend_executes_and_decodes_the_dense_plan() {
         "nvfp4-loop-dense",
         WeightFormats::uniform(WeightFormat::Nvfp4),
     );
+    // The class table is the device backend's own candidate: an FFN
+    // projection of a registered representation lands on NVFP4 whatever
+    // the container stores it as.
+    let ffn = plan
+        .planned_operands()
+        .into_iter()
+        .find(|p| {
+            p.operation
+                == crate::format::vindex3::opplan::planned::Operation::Project(
+                    MatrixClass::FfnProjection,
+                )
+        })
+        .expect("the dense plan has an FFN projection");
+    let facts =
+        crate::format::vindex3::opplan::exec::realization::RepresentationFacts::resolve("F32");
+    let selection = backend.select(&ffn, &facts).unwrap();
+    assert_eq!(selection.realization.format(), WeightFormat::Nvfp4);
     assert_eq!(
-        backend.weight_format(MatrixOperand {
-            class: MatrixClass::FfnProjection,
-            elements: 0,
-            stored_bf16: false,
-            stored_nvfp4: false,
-            stored_kquant: false,
-        }),
-        WeightFormat::Nvfp4
+        selection.reason,
+        crate::format::vindex3::opplan::exec::realization::SelectionReason::DeviceClassTable
     );
     let on_device: ExecutionTrace = execute_plan(&plan, &store, &DENSE_TOKENS, &backend).unwrap();
     let on_reference =
@@ -697,4 +707,70 @@ fn an_nvfp4_device_backend_executes_and_decodes_the_dense_plan() {
     // Every matrix went through the device: the batch pass and the
     // decode pass both submitted work.
     assert!(backend.dispatch_stats().unwrap().submissions > 0);
+}
+
+/// Rung 3b: the device backend answers the prepared plan's question the
+/// way every backend does — its class table is its own single candidate
+/// for a projection, the table and the bank take the common selections,
+/// and what it cannot bind it refuses by name.
+#[test]
+fn the_device_backend_selects_by_its_class_table_and_refuses_what_it_cannot_bind() {
+    use crate::format::vindex3::opplan::exec::realization::{
+        RealizationBackend, RealizationForm, RefusalKind, RepresentationFacts, SelectionReason,
+    };
+    use crate::format::vindex3::opplan::planned::{Operation, PlannedOperand};
+    use crate::format::vindex3::opplan::OperandRef;
+    use crate::format::vindex3::represent::codec::RepresentationExtent;
+
+    let backend = DevicePlanBackend::with_formats(
+        Nvfp4LoopDevice,
+        "nvfp4-loop-select",
+        WeightFormats::uniform(WeightFormat::Nvfp4),
+    );
+    let planned = |operation: Operation| PlannedOperand {
+        operand: OperandRef {
+            object: "target.decoder_stack".into(),
+            tensor: "0.w".into(),
+            dtype: String::new(),
+            shape: vec![8, 8],
+        },
+        operation,
+        access: operation.access(),
+        extent: RepresentationExtent::TERMINAL,
+        layer: Some(0),
+        logical_elements: 64,
+    };
+    let bf16 = RepresentationFacts::resolve("BF16");
+    let head = backend
+        .select(&planned(Operation::OutputHead), &bf16)
+        .unwrap();
+    assert_eq!(head.realization.backend, RealizationBackend::Device);
+    assert_eq!(
+        head.realization.form,
+        RealizationForm::DeviceResident(WeightFormat::Nvfp4)
+    );
+    assert_eq!(head.reason, SelectionReason::DeviceClassTable);
+    assert_eq!(head.candidates, vec![head.realization]);
+    let table = backend.select(&planned(Operation::Embed), &bf16).unwrap();
+    assert_eq!(table.realization.form, RealizationForm::DecodedGather);
+    let bank = backend
+        .select(&planned(Operation::ExpertBankSlice), &bf16)
+        .unwrap();
+    assert_eq!(
+        bank.realization.form,
+        RealizationForm::SliceStored {
+            convert: WeightFormat::Nvfp4
+        }
+    );
+    let refused = backend
+        .select(
+            &planned(Operation::Project(MatrixClass::FfnProjection)),
+            &RepresentationFacts::resolve("U8"),
+        )
+        .unwrap_err();
+    assert_eq!(refused.kind, RefusalKind::UnregisteredRepresentation);
+    let refused = backend
+        .select(&planned(Operation::SharedExpertProject), &bf16)
+        .unwrap_err();
+    assert_eq!(refused.kind, RefusalKind::MissingRealization);
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_device.rs
@@ -738,6 +738,7 @@ fn the_device_backend_selects_by_its_class_table_and_refuses_what_it_cannot_bind
         access: operation.access(),
         extent: RepresentationExtent::TERMINAL,
         layer: Some(0),
+        declared_representation: None,
         logical_elements: 64,
     };
     let bf16 = RepresentationFacts::resolve("BF16");

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
@@ -20,6 +20,7 @@
 
 mod bf16_zlib_bank;
 mod fixture;
+mod planned_bank;
 
 use crate::format::vindex3::opplan::{ExpertBank, OperandRef, PackedProjection};
 use larql_models::config::{

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
@@ -292,7 +292,7 @@ fn a_gate_less_dense_op_binds_two_operands_and_runs_ungated() {
     let operands = FfnOperands::load(
         &ffn,
         (&store).into(),
-        &|_: &OperandRef| WeightFormat::F32,
+        &|_: &OperandRef| Ok(WeightFormat::F32),
         WeightFormat::F32,
     )
     .unwrap();

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
@@ -97,14 +97,15 @@ fn operands_loaded_for_one_ffn_kind_refuse_the_other_at_apply() {
 }
 
 /// An MXFP4 projection whose op carries no scales operand refuses,
-/// naming the projection — the blocks alone are not a matrix.
+/// naming the projection: the codec stores its streams apart, and the
+/// blocks alone cannot be bound to it.
 #[test]
 fn an_mxfp4_projection_without_scales_refuses() {
     let fx = routed_fixture();
     let mut op = fx.op.clone();
     packed_mut(&mut op.bank).0.scales = None;
     let err = load_err(&op, &fx.store, WeightFormat::F32);
-    assert!(err.contains("no scales operand"), "{err}");
+    assert!(err.contains("stores its streams apart"), "{err}");
     assert!(err.contains(GATE_UP_BLOCKS), "{err}");
 }
 
@@ -119,21 +120,26 @@ fn packed_mut(bank: &mut ExpertBank) -> (&mut PackedProjection, &mut PackedProje
     }
 }
 
-/// An MXFP4 projection whose `k` is not a multiple of the 32-element
-/// group refuses before touching the bytes: `k` follows from the router's
-/// declared width, and a stray width must not be silently grouped.
+/// An MXFP4 projection whose `k` is not a multiple of the codec's
+/// declared 32-element row alignment refuses before touching the bytes:
+/// `k` follows from the router's declared width, and a stray width must
+/// not be silently grouped. The alignment is the codec's declaration,
+/// not a constant the loader knows.
 #[test]
 fn an_mxfp4_projection_with_an_unaligned_k_refuses() {
     let fx = routed_fixture();
     let mut op = fx.op.clone();
     op.router.shape[1] = HIDDEN + 1;
     let err = load_err(&op, &fx.store, WeightFormat::F32);
-    assert!(err.contains("not a multiple of the MXFP4 group"), "{err}");
+    assert!(
+        err.contains("not a whole number of `MXFP4` row alignments of 32 elements"),
+        "{err}"
+    );
 }
 
 /// A scales stream of the wrong length for the declared expert geometry
-/// refuses, naming the scales tensor: here gate_up's scales are pointed
-/// at down's (half the size).
+/// refuses, naming the projection and the stream: here gate_up's scales
+/// are pointed at down's (half the size).
 #[test]
 fn a_scales_stream_of_the_wrong_length_refuses() {
     let fx = routed_fixture();
@@ -141,11 +147,9 @@ fn a_scales_stream_of_the_wrong_length_refuses() {
     let (gate_up, down) = packed_mut(&mut op.bank);
     gate_up.scales = down.scales.clone();
     let err = load_err(&op, &fx.store, WeightFormat::F32);
-    assert!(err.contains("stored bytes, expected"), "{err}");
-    assert!(
-        err.contains(DOWN_BLOCKS.replace(BLOCKS_SUFFIX, SCALES_SUFFIX).as_str()),
-        "{err}"
-    );
+    assert!(err.contains("stream `group_scales`"), "{err}");
+    assert!(err.contains("needed"), "{err}");
+    assert!(err.contains(GATE_UP_BLOCKS), "{err}");
 }
 
 /// A block stream whose byte count disagrees with the declared expert
@@ -157,40 +161,52 @@ fn a_block_stream_disagreeing_with_the_declared_geometry_refuses() {
     let mut op = fx.op.clone();
     op.expert_intermediate_size = INTER + MXFP4_GROUP_ELEMS;
     let err = load_err(&op, &fx.store, WeightFormat::F32);
-    assert!(err.contains("stored bytes, expected"), "{err}");
+    assert!(err.contains("`MXFP4` stream `values`"), "{err}");
+    assert!(err.contains("needed"), "{err}");
     assert!(err.contains(GATE_UP_BLOCKS), "{err}");
 }
 
-/// A stream stored in a dtype other than the one its format demands
-/// refuses, naming both dtypes: an MXFP4 scales operand pointed at the
-/// F32 bias, and a BF16 projection pointed at the U8 blocks.
+/// A bank whose streams disagree with the declared codec refuses on the
+/// codec's own terms, with no dtype name judged: an MXFP4 scales operand
+/// pointed at the F32 bias is a region LONGER than its shape, which the
+/// contract's per-stream minimum alone would accept; and a bank declared
+/// BF16 whose op still carries a scales operand offers a stream the codec
+/// declares no place for.
 #[test]
-fn a_stream_stored_in_the_wrong_dtype_refuses() {
+fn a_bank_disagreeing_with_its_declared_codec_refuses_on_the_codec_s_terms() {
     let fx = routed_fixture();
     let mut op = fx.op.clone();
     let (gate_up, _) = packed_mut(&mut op.bank);
     gate_up.scales = gate_up.bias.clone();
     let err = load_err(&op, &fx.store, WeightFormat::F32);
-    assert!(err.contains("expected stored dtype U8, found F32"), "{err}");
+    assert!(err.contains("streams total"), "{err}");
+    assert!(err.contains("declared geometry disagree"), "{err}");
+    assert!(err.contains(GATE_UP_BLOCKS), "{err}");
 
     let mut op = fx.op.clone();
     op.expert_format = ExpertFormat::PackedBF16;
     let err = load_err(&op, &fx.store, WeightFormat::F32);
     assert!(
-        err.contains("expected stored dtype BF16, found U8"),
+        err.contains("`BF16` declares no stream `group_scales`"),
         "{err}"
     );
+    assert!(err.contains(GATE_UP_BLOCKS), "{err}");
 }
 
-/// `PerExpert` is not a packed projection; closure never plans one, and
-/// the loader refuses rather than guessing a layout.
+/// A packed bank whose op declares `PerExpert` declares no codec for its
+/// streams, and the carrier label `U8` names none: the loader refuses
+/// rather than guessing a layout. Closure never plans this pairing.
 #[test]
-fn a_per_expert_format_is_refused_as_not_packed() {
+fn a_packed_bank_declared_per_expert_is_refused_as_undecodable() {
     let fx = routed_fixture();
     let mut op = fx.op.clone();
     op.expert_format = ExpertFormat::PerExpert;
     let err = load_err(&op, &fx.store, WeightFormat::F32);
-    assert!(err.contains("not a packed projection"), "{err}");
+    assert!(
+        err.contains("`U8` names no registered codec, so the bank cannot be decoded"),
+        "{err}"
+    );
+    assert!(err.contains(GATE_UP_BLOCKS), "{err}");
 }
 
 /// A backend that declares f16 for the FFN class receives the MXFP4 bank
@@ -267,7 +283,8 @@ fn a_bf16_bank_disagreeing_with_the_declared_geometry_refuses() {
     let mut op = bf16_op(&fx.op);
     op.expert_intermediate_size = INTER + 1;
     let err = load_err(&op, &store, WeightFormat::F32);
-    assert!(err.contains("stored bytes, expected"), "{err}");
+    assert!(err.contains("`BF16` stream `values`"), "{err}");
+    assert!(err.contains("needed"), "{err}");
     assert!(err.contains(GATE_UP_BF16), "{err}");
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/bf16_zlib_bank.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/bf16_zlib_bank.rs
@@ -23,7 +23,7 @@ const BANKS_PER_LAYER: usize = 2;
 fn a_sequential_bank_is_refused_by_access_class_before_any_byte_is_read() {
     let op = bf16_op(&routed_fixture().op);
     let ffn = LayerFfn::Routed(Box::new(op));
-    let f32_for = |_: &OperandRef| WeightFormat::F32;
+    let f32_for = |_: &OperandRef| Ok(WeightFormat::F32);
 
     // Control: the raw bf16 carrier loads through the same preflight.
     let (_dir, _container, control) = bf16_carrier_store();

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/fixture.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/fixture.rs
@@ -350,14 +350,25 @@ pub(super) fn routed(op: &RoutedFfnOp) -> LayerFfn {
 }
 
 pub(super) fn load(op: &RoutedFfnOp, store: &OperandStore, format: WeightFormat) -> FfnOperands {
-    FfnOperands::load(&routed(op), store.into(), &|_: &OperandRef| format, format).unwrap()
+    FfnOperands::load(
+        &routed(op),
+        store.into(),
+        &|_: &OperandRef| Ok(format),
+        format,
+    )
+    .unwrap()
 }
 
 pub(super) fn load_err(op: &RoutedFfnOp, store: &OperandStore, format: WeightFormat) -> String {
-    FfnOperands::load(&routed(op), store.into(), &|_: &OperandRef| format, format)
-        .err()
-        .expect("loading must refuse")
-        .to_string()
+    FfnOperands::load(
+        &routed(op),
+        store.into(),
+        &|_: &OperandRef| Ok(format),
+        format,
+    )
+    .err()
+    .expect("loading must refuse")
+    .to_string()
 }
 
 /// A device backend that binds the FFN class in `format` and everything

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/fixture.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/fixture.rs
@@ -292,6 +292,7 @@ pub(super) struct RoutedFixture {
     _container: tempfile::TempDir,
     pub(super) store: OperandStore,
     pub(super) op: RoutedFfnOp,
+    pub(super) plan: ComponentOpPlan,
 }
 
 pub(super) fn routed_fixture() -> RoutedFixture {
@@ -311,6 +312,7 @@ pub(super) fn routed_fixture() -> RoutedFixture {
         _container: container,
         store,
         op,
+        plan,
     }
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/planned_bank.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/planned_bank.rs
@@ -239,16 +239,21 @@ fn a_packed_bank_s_pin_reconciles_with_its_per_expert_objects() {
     }
 }
 
-/// Rung 3c: a bank stored under a dialect no codec claims is prepared
-/// with no provider; a registry that later claims the label is a changed
-/// provider, and the image is invalidated rather than executed. And a
-/// plan whose FFN is a different program from the prepared one is refused
-/// by the pairing.
+/// Rung 3d: a packed MXFP4 bank is stored as two `U8` streams, and its
+/// provider is the MXFP4 codec the plan declares — no dialect, no
+/// provider-less record. A registry without MXFP4 invalidates the image
+/// rather than executing it, and a registry that also claims `U8` changes
+/// nothing: the record names MXFP4, not the carrier label. And a plan
+/// whose FFN is a different program from the prepared one is refused by
+/// the pairing.
 #[test]
-fn an_unregistered_dialect_that_gains_a_provider_invalidates_the_preparation() {
+fn a_packed_bank_s_provider_is_the_declared_codec_and_its_loss_invalidates() {
     use super::super::accounting::ProviderStub;
     use crate::format::vindex3::opplan::exec::operands::OperandStore;
-    use crate::format::vindex3::represent::codec::CodecRegistry;
+    use crate::format::vindex3::represent::codec::codecs::{
+        bf16_zlib, float, kquant, mxfp4, nvfp4,
+    };
+    use crate::format::vindex3::represent::codec::{CodecRegistry, RepresentationCodec};
     let fixture = routed_fixture();
     let ops = PreparedOperands::load(
         &fixture.plan,
@@ -258,18 +263,21 @@ fn an_unregistered_dialect_that_gains_a_provider_invalidates_the_preparation() {
     )
     .unwrap();
     let providers = ops.providers();
-    let u8 = providers
+    assert!(
+        !providers.iter().any(|(label, _)| label == "U8"),
+        "no record names the carrier label: {providers:?}"
+    );
+    let bank = providers
         .iter()
-        .find(|(label, _)| label == "U8")
-        .expect("the MXFP4 bank is stored as U8");
-    assert!(u8.1.is_none(), "no codec claims the dialect");
+        .find(|(label, _)| label == mxfp4::DTYPE_MXFP4)
+        .expect("the bank's record names the declared codec");
+    assert_eq!(bank.1.as_ref(), Some(&mxfp4::MXFP4.identity()));
+    assert!(
+        providers.iter().all(|(_, p)| p.is_some()),
+        "every record has a provider: {providers:?}"
+    );
     ops.ensure_providers_in(CodecRegistry::builtin()).unwrap();
-    // Every shipped codec, so the only change is the dialect gaining a
-    // claimant; a registry with just the stub would mismatch on F32 first.
-    use crate::format::vindex3::represent::codec::codecs::{
-        bf16_zlib, float, kquant, mxfp4, nvfp4,
-    };
-    let claimed = CodecRegistry::new()
+    let mut without_mxfp4 = CodecRegistry::new()
         .register(Box::new(float::BF16))
         .and_then(|r| r.register(Box::new(float::F16)))
         .and_then(|r| r.register(Box::new(float::F32)))
@@ -277,15 +285,23 @@ fn an_unregistered_dialect_that_gains_a_provider_invalidates_the_preparation() {
         .and_then(|r| r.register(Box::new(kquant::Q6_K)))
         .and_then(|r| r.register(Box::new(kquant::Q8_0)))
         .and_then(|r| r.register(Box::new(nvfp4::NVFP4)))
-        .and_then(|r| r.register(Box::new(mxfp4::MXFP4)))
         .and_then(|r| r.register(Box::new(bf16_zlib::BF16_ZLIB)))
-        .and_then(|r| r.register(Box::new(ProviderStub { label: "U8" })))
         .unwrap();
-    let err = ops.ensure_providers_in(&claimed).unwrap_err().to_string();
+    let err = ops
+        .ensure_providers_in(&without_mxfp4)
+        .unwrap_err()
+        .to_string();
     assert!(
-        err.contains("`U8`") && err.contains("no registered codec") && err.contains("stub-U8 r7"),
+        err.contains("`MXFP4`") && err.contains("no registered codec"),
         "{err}"
     );
+    // Claiming the carrier label disturbs nothing: the record's provider
+    // is MXFP4, and MXFP4 is back.
+    without_mxfp4 = without_mxfp4
+        .register(Box::new(mxfp4::MXFP4))
+        .and_then(|r| r.register(Box::new(ProviderStub { label: "U8" })))
+        .unwrap();
+    ops.ensure_providers_in(&without_mxfp4).unwrap();
 
     // The dense fixture's prepared image, held against this routed plan:
     // same attention program, different FFN program.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/planned_bank.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/planned_bank.rs
@@ -1,0 +1,170 @@
+//! Rung 3a over the routed miniature: a packed bank is two expert-slice
+//! operations requiring row access, a per-expert bank is a set of whole
+//! projections, and the production loader's census holds exactly the bytes
+//! the view lists for the FFN site. Lives beside the routed fixture because
+//! that fixture is scoped here.
+
+use super::fixture::{routed_fixture, EXPERTS};
+use crate::format::vindex3::opplan::exec::backend::MatrixClass;
+use crate::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
+use crate::format::vindex3::opplan::exec::production::ProductionBackend;
+use crate::format::vindex3::opplan::planned::Operation;
+use crate::format::vindex3::opplan::{ExpertBank, LayerFfn, OperandRef, SharedExpertOp};
+use crate::format::vindex3::represent::codec::RequiredAccess;
+
+const F32_WIDTH: usize = std::mem::size_of::<f32>();
+
+#[test]
+fn a_packed_bank_is_two_row_random_slices_and_the_census_agrees() {
+    let fixture = routed_fixture();
+    let plan = &fixture.plan;
+    let slices: Vec<_> = plan
+        .planned_operands()
+        .into_iter()
+        .filter(|p| p.operation == Operation::ExpertBankSlice)
+        .collect();
+    let routed_layers = plan
+        .layers
+        .iter()
+        .filter(|l| l.ffn.as_ref().is_some_and(|f| f.routed().is_some()))
+        .count();
+    assert!(routed_layers > 0);
+    assert_eq!(
+        slices.len(),
+        2 * routed_layers,
+        "gate/up and down per routed layer"
+    );
+    assert!(slices.iter().all(|s| s.access == RequiredAccess::RowRandom));
+    // The bank's stored operands, exactly — never the router or a bias.
+    let ExpertBank::Packed { gate_up, down } = &fixture.op.bank else {
+        panic!("the miniature packs its bank");
+    };
+    let named: Vec<&str> = slices.iter().map(|s| s.operand.tensor.as_str()).collect();
+    assert!(named.contains(&gate_up.weights.tensor.as_str()));
+    assert!(named.contains(&down.weights.tensor.as_str()));
+    assert!(!named.contains(&fixture.op.router.tensor.as_str()));
+
+    let census = PreparedOperands::load(
+        plan,
+        &fixture.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap()
+    .residency_census();
+    let ffn_bytes: usize = plan
+        .planned_operands()
+        .iter()
+        .filter(|p| {
+            matches!(
+                p.operation,
+                Operation::ExpertBankSlice | Operation::Project(MatrixClass::FfnProjection)
+            )
+        })
+        .map(|p| p.elements() * F32_WIDTH)
+        .sum();
+    assert_eq!(census.ffn.widened_f32 + census.ffn.compact, ffn_bytes);
+}
+
+#[test]
+fn a_per_expert_bank_is_a_set_of_whole_projections() {
+    let fixture = routed_fixture();
+    let mut plan = fixture.plan.clone();
+    let synthetic = |name: &str| OperandRef {
+        object: fixture.op.router.object.clone(),
+        tensor: name.to_string(),
+        dtype: "F32".into(),
+        shape: vec![8, 4],
+    };
+    let per_expert = ExpertBank::PerExpert {
+        gate: (0..EXPERTS)
+            .map(|e| synthetic(&format!("experts.{e}.gate")))
+            .collect(),
+        up: (0..EXPERTS)
+            .map(|e| synthetic(&format!("experts.{e}.up")))
+            .collect(),
+        down: (0..EXPERTS)
+            .map(|e| synthetic(&format!("experts.{e}.down")))
+            .collect(),
+    };
+    let mut op = fixture.op.clone();
+    op.bank = per_expert;
+    plan.layers[0].ffn = Some(LayerFfn::Routed(Box::new(op)));
+    let listed: Vec<_> = plan
+        .planned_operands()
+        .into_iter()
+        .filter(|p| p.operand.tensor.starts_with("experts."))
+        .collect();
+    assert_eq!(listed.len(), 3 * EXPERTS);
+    assert!(listed.iter().all(
+        |p| p.operation == Operation::Project(MatrixClass::FfnProjection)
+            && p.access == RequiredAccess::Sequential
+    ));
+}
+
+/// The plan executes a shared expert beside the routed ones, so the view
+/// lists its three projections. The CPU loader does not bind them today —
+/// only the Metal stack does — and this test pins that gap in bytes: the
+/// view exceeds the CPU census by exactly the shared expert. When a CPU
+/// loader binds it, this assertion is what changes, deliberately.
+#[test]
+fn a_shared_expert_is_three_projections_the_cpu_loader_does_not_yet_bind() {
+    let fixture = routed_fixture();
+    let mut plan = fixture.plan.clone();
+    let mut op = fixture.op.clone();
+    let synthetic = |name: &str, shape: Vec<usize>| OperandRef {
+        object: op.router.object.clone(),
+        tensor: name.to_string(),
+        dtype: "F32".into(),
+        shape,
+    };
+    let hidden = op.router.shape[1];
+    let inter = 16;
+    op.shared = Some(SharedExpertOp {
+        intermediate_size: inter,
+        activation: op.activation,
+        gate_policy: op.gate_policy,
+        gate: synthetic("shared.gate", vec![inter, hidden]),
+        up: synthetic("shared.up", vec![inter, hidden]),
+        down: synthetic("shared.down", vec![hidden, inter]),
+        branch_gate: None,
+    });
+    plan.layers[0].ffn = Some(LayerFfn::Routed(Box::new(op)));
+    let planned = plan.planned_operands();
+    let shared: Vec<_> = planned
+        .iter()
+        .filter(|p| p.operand.tensor.starts_with("shared."))
+        .collect();
+    assert_eq!(shared.len(), 3);
+    assert!(shared
+        .iter()
+        .all(|p| p.operation == Operation::Project(MatrixClass::FfnProjection)));
+    let shared_bytes: usize = shared.iter().map(|p| p.elements() * F32_WIDTH).sum();
+    assert_eq!(shared_bytes, 3 * inter * hidden * F32_WIDTH);
+
+    // The synthetic operands are not in the container, and the CPU loader
+    // never asks for them: preparation succeeds and the census is short by
+    // exactly the shared expert.
+    let census = PreparedOperands::load(
+        &plan,
+        &fixture.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .expect("the CPU loader ignores the shared expert")
+    .residency_census();
+    let ffn_planned: usize = planned
+        .iter()
+        .filter(|p| {
+            matches!(
+                p.operation,
+                Operation::ExpertBankSlice | Operation::Project(MatrixClass::FfnProjection)
+            )
+        })
+        .map(|p| p.elements() * F32_WIDTH)
+        .sum();
+    assert_eq!(
+        ffn_planned - (census.ffn.widened_f32 + census.ffn.compact),
+        shared_bytes
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/planned_bank.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/planned_bank.rs
@@ -189,3 +189,137 @@ fn a_plan_with_a_shared_expert_is_refused_before_any_byte_is_read() {
         "refused before any byte was read"
     );
 }
+
+/// Rung 3c over the routed miniature: two bank pins reconcile with the
+/// per-expert objects the loader bound (one operand, `EXPERTS` objects),
+/// and the bank's declared residency is the widened image.
+#[test]
+fn a_packed_bank_s_pin_reconciles_with_its_per_expert_objects() {
+    use crate::format::vindex3::opplan::exec::accounting::BlockGeometry;
+    use crate::format::vindex3::opplan::exec::backend::WeightFormat;
+    let fixture = routed_fixture();
+    let ops = PreparedOperands::load(
+        &fixture.plan,
+        &fixture.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let done = ops
+        .reconcile(&fixture.plan, (&fixture.store).into())
+        .unwrap();
+    assert_eq!(done.matched, ops.realizations().len());
+    let observed = ops.bound(&fixture.plan).unwrap();
+    let banks: Vec<_> = observed
+        .iter()
+        .filter(|o| o.operation == Operation::ExpertBankSlice)
+        .collect();
+    assert!(!banks.is_empty());
+    for bank in &banks {
+        assert_eq!(bank.format, WeightFormat::F32);
+        assert_eq!(bank.allocations, 0, "widened experts are exact vectors");
+    }
+    let expected = ops.expectations((&fixture.store).into(), BlockGeometry::executor());
+    for e in expected
+        .iter()
+        .filter(|e| e.operation == Operation::ExpertBankSlice)
+    {
+        assert_eq!(
+            e.declared_resident,
+            e.logical_elements as u64 * F32_WIDTH as u64
+        );
+        assert_eq!(
+            e.staging, 0,
+            "the bank is widened per expert straight into residency"
+        );
+        assert!(
+            e.stored_bytes > 0 && e.stored_bytes < e.declared_resident,
+            "an MXFP4 bank is stored compact"
+        );
+    }
+}
+
+/// Rung 3c: a bank stored under a dialect no codec claims is prepared
+/// with no provider; a registry that later claims the label is a changed
+/// provider, and the image is invalidated rather than executed. And a
+/// plan whose FFN is a different program from the prepared one is refused
+/// by the pairing.
+#[test]
+fn an_unregistered_dialect_that_gains_a_provider_invalidates_the_preparation() {
+    use super::super::accounting::ProviderStub;
+    use crate::format::vindex3::opplan::exec::operands::OperandStore;
+    use crate::format::vindex3::represent::codec::CodecRegistry;
+    let fixture = routed_fixture();
+    let ops = PreparedOperands::load(
+        &fixture.plan,
+        &fixture.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let providers = ops.providers();
+    let u8 = providers
+        .iter()
+        .find(|(label, _)| label == "U8")
+        .expect("the MXFP4 bank is stored as U8");
+    assert!(u8.1.is_none(), "no codec claims the dialect");
+    ops.ensure_providers_in(CodecRegistry::builtin()).unwrap();
+    // Every shipped codec, so the only change is the dialect gaining a
+    // claimant; a registry with just the stub would mismatch on F32 first.
+    use crate::format::vindex3::represent::codec::codecs::{
+        bf16_zlib, float, kquant, mxfp4, nvfp4,
+    };
+    let claimed = CodecRegistry::new()
+        .register(Box::new(float::BF16))
+        .and_then(|r| r.register(Box::new(float::F16)))
+        .and_then(|r| r.register(Box::new(float::F32)))
+        .and_then(|r| r.register(Box::new(kquant::Q4_K)))
+        .and_then(|r| r.register(Box::new(kquant::Q6_K)))
+        .and_then(|r| r.register(Box::new(kquant::Q8_0)))
+        .and_then(|r| r.register(Box::new(nvfp4::NVFP4)))
+        .and_then(|r| r.register(Box::new(mxfp4::MXFP4)))
+        .and_then(|r| r.register(Box::new(bf16_zlib::BF16_ZLIB)))
+        .and_then(|r| r.register(Box::new(ProviderStub { label: "U8" })))
+        .unwrap();
+    let err = ops.ensure_providers_in(&claimed).unwrap_err().to_string();
+    assert!(
+        err.contains("`U8`") && err.contains("no registered codec") && err.contains("stub-U8 r7"),
+        "{err}"
+    );
+
+    // The dense fixture's prepared image, held against this routed plan:
+    // same attention program, different FFN program.
+    let dense = {
+        let src = tempfile::tempdir().unwrap();
+        let container = tempfile::tempdir().unwrap();
+        crate::format::vindex3::fixtures::encode_fixture_container(
+            crate::format::vindex3::fixtures::dense_f32_model,
+            src.path(),
+            container.path(),
+            "dense",
+        );
+        let inspection =
+            crate::format::vindex3::inspect::inspect_container(container.path(), false).unwrap();
+        let plan = crate::format::vindex3::opplan::plan_component_ops(
+            &inspection,
+            container.path(),
+            "target",
+        )
+        .unwrap()
+        .plan
+        .unwrap();
+        let store = OperandStore::open(container.path(), &inspection).unwrap();
+        (src, container, plan, store)
+    };
+    let dense_ops = PreparedOperands::load(
+        &dense.2,
+        &dense.3,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let mut mixed = dense.2.clone();
+    mixed.layers[0].ffn = Some(LayerFfn::Routed(Box::new(fixture.op.clone())));
+    let err = dense_ops.bound(&mixed).unwrap_err().to_string();
+    assert!(err.contains("different programs"), "{err}");
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/planned_bank.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/planned_bank.rs
@@ -4,7 +4,7 @@
 //! the view lists for the FFN site. Lives beside the routed fixture because
 //! that fixture is scoped here.
 
-use super::fixture::{routed_fixture, EXPERTS};
+use super::fixture::{bf16_carrier_store, routed_fixture, BF16_SUFFIX, BLOCKS_SUFFIX, EXPERTS};
 use crate::format::vindex3::opplan::exec::backend::MatrixClass;
 use crate::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
 use crate::format::vindex3::opplan::exec::production::ProductionBackend;
@@ -103,12 +103,13 @@ fn a_per_expert_bank_is_a_set_of_whole_projections() {
 }
 
 /// The plan executes a shared expert beside the routed ones, so the view
-/// lists its three projections. The CPU loader does not bind them today —
-/// only the Metal stack does — and this test pins that gap in bytes: the
-/// view exceeds the CPU census by exactly the shared expert. When a CPU
-/// loader binds it, this assertion is what changes, deliberately.
+/// lists its three projections under their own operation. No backend
+/// binds them through the prepared plan yet, and the plan is REFUSED at
+/// preparation — before any byte is read — rather than prepared without
+/// its shared expert (rung 3b's hard invariant). When a CPU realization
+/// for the shared expert arrives (3d), this is the test that changes.
 #[test]
-fn a_shared_expert_is_three_projections_the_cpu_loader_does_not_yet_bind() {
+fn a_plan_with_a_shared_expert_is_refused_before_any_byte_is_read() {
     let fixture = routed_fixture();
     let mut plan = fixture.plan.clone();
     let mut op = fixture.op.clone();
@@ -138,33 +139,53 @@ fn a_shared_expert_is_three_projections_the_cpu_loader_does_not_yet_bind() {
     assert_eq!(shared.len(), 3);
     assert!(shared
         .iter()
-        .all(|p| p.operation == Operation::Project(MatrixClass::FfnProjection)));
-    let shared_bytes: usize = shared.iter().map(|p| p.elements() * F32_WIDTH).sum();
-    assert_eq!(shared_bytes, 3 * inter * hidden * F32_WIDTH);
+        .all(|p| p.operation == Operation::SharedExpertProject
+            && p.access == RequiredAccess::Sequential));
 
-    // The synthetic operands are not in the container, and the CPU loader
-    // never asks for them: preparation succeeds and the census is short by
-    // exactly the shared expert.
-    let census = PreparedOperands::load(
+    // The synthetic operands are not in the container, so the selector
+    // skips them (the loader would refuse them by name); the refusal has
+    // to come from a shared expert the container DOES hold. Point the
+    // shared projections at the dense-shaped bf16 copies the carrier
+    // stores, which exist and are registered.
+    let (_dir, _container, carrier) = bf16_carrier_store();
+    let mut op = fixture.op.clone();
+    let ExpertBank::Packed { gate_up, down } = &op.bank else {
+        panic!("packed");
+    };
+    let existing = |projection: &crate::format::vindex3::opplan::PackedProjection| OperandRef {
+        object: projection.weights.object.clone(),
+        tensor: projection
+            .weights
+            .tensor
+            .replace(BLOCKS_SUFFIX, BF16_SUFFIX),
+        dtype: "BF16".into(),
+        shape: projection.weights.shape.clone(),
+    };
+    op.shared = Some(SharedExpertOp {
+        intermediate_size: inter,
+        activation: op.activation,
+        gate_policy: op.gate_policy,
+        gate: existing(gate_up),
+        up: existing(gate_up),
+        down: existing(down),
+        branch_gate: None,
+    });
+    plan.layers[0].ffn = Some(LayerFfn::Routed(Box::new(op)));
+    let before = carrier.load_count();
+    let err = PreparedOperands::load(
         &plan,
-        &fixture.store,
+        &carrier,
         &ProductionBackend::new(),
         ExecutionSlice::Full,
     )
-    .expect("the CPU loader ignores the shared expert")
-    .residency_census();
-    let ffn_planned: usize = planned
-        .iter()
-        .filter(|p| {
-            matches!(
-                p.operation,
-                Operation::ExpertBankSlice | Operation::Project(MatrixClass::FfnProjection)
-            )
-        })
-        .map(|p| p.elements() * F32_WIDTH)
-        .sum();
+    .err()
+    .map(|e| e.to_string())
+    .expect("a plan with a shared expert has no realization on the CPU path");
+    assert!(err.contains("missing realization"), "{err}");
+    assert!(err.contains("shared-expert-project"), "{err}");
     assert_eq!(
-        ffn_planned - (census.ffn.widened_f32 + census.ffn.compact),
-        shared_bytes
+        carrier.load_count(),
+        before,
+        "refused before any byte was read"
     );
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/gemma4.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/gemma4.rs
@@ -83,7 +83,7 @@ fn bf16_bytes(values: &[f32]) -> Vec<u8> {
 /// The miniature Gemma 4 checkpoint. `perturb` names one layer-relative
 /// operand (on the full layer for attention, every layer otherwise) whose
 /// values are scaled by [`PERTURB_GAIN`].
-fn miniature_gemma4(dir: &Path, perturb: Option<&str>) {
+pub(super) fn miniature_gemma4(dir: &Path, perturb: Option<&str>) {
     let layer_types: Vec<&str> = (0..LAYERS)
         .map(|i| {
             if i == FULL_LAYER {
@@ -298,14 +298,14 @@ fn miniature_gemma4(dir: &Path, perturb: Option<&str>) {
     shard.write(dir);
 }
 
-fn encoded(dir: &Path) -> tempfile::TempDir {
+pub(super) fn encoded(dir: &Path) -> tempfile::TempDir {
     let inventory = larql_models::inventory::build_inventory(dir).unwrap();
     let container = tempfile::tempdir().unwrap();
     encode_system(&[("mini-gemma4".to_string(), inventory)], container.path()).unwrap();
     container
 }
 
-fn closure(container: &Path) -> OpPlanOutcome {
+pub(super) fn closure(container: &Path) -> OpPlanOutcome {
     let inspection = inspect_container(container, false).unwrap();
     plan_component_ops(&inspection, container, "target").unwrap()
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
@@ -503,6 +503,7 @@ fn a_stored_pack_has_one_stored_footprint_and_two_realization_costs() {
         access: operation.access(),
         extent: RepresentationExtent::TERMINAL,
         layer: Some(0),
+        declared_representation: None,
         logical_elements: op.shape.iter().product(),
     };
     let facts = RepresentationFacts::resolve(Q6_K.name);

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
@@ -471,3 +471,90 @@ fn bytes_under_another_codec_are_refused_not_reinterpreted() {
     };
     assert_eq!(cut.len(), out_dim * Q6_K.row_bytes(in_dim).unwrap());
 }
+
+/// Rung 3c: one stored Q6_K pack, two realizations. The STORED footprint
+/// is the container's recorded length under both — a property of the
+/// representation instance, not of how it runs — while the resident,
+/// staging and working-set accounting differ, and each reconciles with
+/// the object the loader actually binds.
+#[test]
+#[serial]
+fn a_stored_pack_has_one_stored_footprint_and_two_realization_costs() {
+    use crate::format::vindex3::opplan::exec::accounting::{
+        expectations, reconcile, stored_footprint, BlockGeometry, Bound,
+    };
+    use crate::format::vindex3::opplan::exec::backend::MatrixClass;
+    use crate::format::vindex3::opplan::exec::cpu::physical::KQuantExecution;
+    use crate::format::vindex3::opplan::exec::production::select_cpu;
+    use crate::format::vindex3::opplan::exec::realization::{
+        RealizationForm, RealizationRecord, RepresentationFacts,
+    };
+    use crate::format::vindex3::opplan::planned::{Operation, PlannedOperand};
+    use crate::format::vindex3::represent::codec::RepresentationExtent;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let (_src, out) = compiled(&tmp, Q6_K);
+    let op = a_stored_matrix(&out, Q6_K);
+    let store = open(&out, Q6_K);
+    let operation = Operation::Project(MatrixClass::FfnProjection);
+    let planned = PlannedOperand {
+        operand: op.clone(),
+        operation,
+        access: operation.access(),
+        extent: RepresentationExtent::TERMINAL,
+        layer: Some(0),
+        logical_elements: op.shape.iter().product(),
+    };
+    let facts = RepresentationFacts::resolve(Q6_K.name);
+    let mut costs = Vec::new();
+    for (arm, format) in [
+        (KQuantExecution::Direct, WeightFormat::KQuant),
+        (KQuantExecution::Widen, WeightFormat::F32),
+    ] {
+        let selection = select_cpu(&planned, &facts, arm).unwrap();
+        assert_eq!(selection.realization.format(), format);
+        let record = RealizationRecord {
+            planned: planned.clone(),
+            representation: Q6_K.name.to_string(),
+            provider: facts.registered.as_ref().map(|r| r.identity.clone()),
+            selection,
+        };
+        let expected = expectations(
+            std::slice::from_ref(&record),
+            |o| store.stored_len(o),
+            BlockGeometry::executor(),
+        );
+        let loaded = load_weight((&store).into(), &op, format).unwrap();
+        let observed = vec![Bound::one(&op, &loaded)
+            .observed(operation, Some(0))
+            .unwrap()];
+        reconcile(&expected, &observed).unwrap_or_else(|e| panic!("{arm:?}: {e}"));
+        costs.push((
+            arm,
+            stored_footprint(&expected).bytes,
+            expected[0].declared_resident,
+            expected[0].staging,
+            expected[0].working_set(),
+        ));
+    }
+    let (direct, decode) = (&costs[0], &costs[1]);
+    assert_eq!(
+        direct.1, decode.1,
+        "one stored footprint: {direct:?} vs {decode:?}"
+    );
+    assert_eq!(direct.1, store.stored_len(&op).unwrap());
+    assert!(
+        direct.2 < decode.2,
+        "direct holds the pack; decode holds an f32 image"
+    );
+    assert_eq!(direct.3, 0, "direct stages nothing");
+    assert_eq!(decode.3, decode.2, "decode stages the image it then holds");
+    assert!(direct.4 < decode.4);
+    assert!(matches!(
+        select_cpu(&planned, &facts, KQuantExecution::Direct)
+            .unwrap()
+            .realization
+            .form,
+        RealizationForm::Direct(PhysicalProjectionPlan::FusedKQuant)
+    ));
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -58,6 +58,7 @@ mod nvfp4_projection;
 mod output_gate_fused;
 mod plan_fixtures;
 mod projection_bench;
+mod realization;
 // Each module carries its OWN cfg: inserting a bare `mod` line above a
 // gated one hands the attribute to the newcomer and silently un-gates
 // the original — that exact capture broke six CI jobs on PR #346.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -9,6 +9,7 @@
 //! about *semantics* — plan interpretation, operand binding, norm
 //! placement, RoPE convention, residual order — not shared arithmetic.
 
+mod accounting;
 mod attention_kv_parity;
 mod backend_rows;
 mod bf16_gemv_bench;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/output_gate_fused.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/output_gate_fused.rs
@@ -163,7 +163,7 @@ mod mutation_table {
             op,
             (&store).into(),
             &|_: &crate::format::vindex3::opplan::OperandRef| {
-                crate::format::vindex3::opplan::exec::backend::WeightFormat::F32
+                Ok(crate::format::vindex3::opplan::exec::backend::WeightFormat::F32)
             },
         )
         .unwrap();

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/realization.rs
@@ -1,0 +1,714 @@
+//! Rung 3b: the prepared plan resolves every planned operand's
+//! representation, derives the candidates from what the registry declares,
+//! pins one realization with its reason, and refuses — before any byte is
+//! read — when nothing can serve. The old boolean ladder is kept here as
+//! an oracle so the selector's answers are pinned to the pre-rung-3
+//! behaviour, class by class, size by size, arm by arm.
+
+use super::super::cpu::physical::{KQuantExecution, PhysicalProjectionPlan};
+use super::super::operands::OperandStore;
+use super::super::prepared::{ExecutionSlice, PreparedOperands};
+use super::super::production::{select_cpu, ProductionBackend};
+use super::super::realization::{
+    RealizationForm, RealizationId, RepresentationFacts, SelectionReason,
+};
+use super::super::reference::ReferenceBackend;
+use super::bf16_zlib_execution::{transcode, Transcode};
+use crate::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::backend::{MatrixClass, WeightFormat};
+use crate::format::vindex3::opplan::planned::{Operation, PlannedOperand};
+use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan, OperandRef};
+use crate::format::vindex3::represent::codec::{RepresentationExtent, ResidencyProfile};
+
+/// Below and above the size policy's cache threshold.
+const SMALL: usize = 64 * 64;
+const LARGE: usize = 17408 * 5120;
+const PROJECTION_SUFFIX: &str = "_proj.weight";
+
+struct Prepared {
+    _src: tempfile::TempDir,
+    _container: tempfile::TempDir,
+    plan: ComponentOpPlan,
+    store: OperandStore,
+}
+
+fn dense(into: Option<Transcode>) -> Prepared {
+    let src = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(dense_f32_model, src.path(), container.path(), "dense");
+    if let Some(into) = into {
+        let transcoded = transcode(
+            container.path(),
+            |name, shape| shape.len() == 2 && name.ends_with(PROJECTION_SUFFIX),
+            into,
+        );
+        assert!(!transcoded.is_empty());
+    }
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let plan = plan_component_ops(&inspection, container.path(), "target")
+        .unwrap()
+        .plan
+        .unwrap();
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    Prepared {
+        _src: src,
+        _container: container,
+        plan,
+        store,
+    }
+}
+
+fn is_projection(operation: Operation) -> bool {
+    matches!(operation, Operation::Project(_) | Operation::OutputHead)
+}
+
+// ── The selector answers what the boolean ladder answered ────────────
+
+/// The pre-rung-3 policy, copied verbatim as a MIGRATION oracle: three
+/// stored-dtype booleans and a size policy. The selector must land on the
+/// same resident representation for every class, size, label and arm —
+/// today. This ladder is transitional, not the new semantic authority:
+/// once 3c's independent accounting and 3d's provider inventories exist,
+/// new behaviour is allowed to diverge from it deliberately, and this
+/// test is then narrowed or retired rather than preserving old mistakes.
+fn old_ladder(
+    class: MatrixClass,
+    elements: usize,
+    stored_bf16: bool,
+    stored_nvfp4: bool,
+    stored_kquant: bool,
+    kquant: KQuantExecution,
+) -> WeightFormat {
+    match class {
+        MatrixClass::RoutedExpertBank => WeightFormat::F32,
+        _ if stored_nvfp4 => WeightFormat::Nvfp4,
+        _ if stored_kquant && kquant == KQuantExecution::Direct => WeightFormat::KQuant,
+        MatrixClass::AttentionProjection | MatrixClass::FfnProjection | MatrixClass::OutputHead => {
+            PhysicalProjectionPlan::choose_for(Some(class), elements, stored_bf16).format()
+        }
+    }
+}
+
+fn synthetic(operation: Operation, elements: usize) -> PlannedOperand {
+    PlannedOperand {
+        operand: OperandRef {
+            object: "target.decoder_stack".into(),
+            tensor: "0.w".into(),
+            dtype: String::new(),
+            shape: vec![elements, 1],
+        },
+        operation,
+        access: operation.access(),
+        extent: RepresentationExtent::TERMINAL,
+        layer: Some(0),
+        logical_elements: elements,
+    }
+}
+
+#[test]
+fn the_selector_lands_where_the_boolean_ladder_landed_for_every_label_class_size_and_arm() {
+    let labels = [
+        "BF16",
+        "F16",
+        "F32",
+        "Q4_K",
+        "Q6_K",
+        "Q8_0",
+        "NVFP4",
+        "MXFP4",
+        "BF16_ZLIB",
+    ];
+    let mut compared = 0;
+    for label in labels {
+        let facts = RepresentationFacts::resolve(label);
+        assert!(facts.registered.is_some(), "{label} is registered");
+        let stored_bf16 = label == "BF16";
+        let stored_nvfp4 = label == "NVFP4";
+        let stored_kquant = matches!(label, "Q4_K" | "Q6_K" | "Q8_0");
+        for (operation, class) in [
+            (
+                Operation::Project(MatrixClass::AttentionProjection),
+                MatrixClass::AttentionProjection,
+            ),
+            (
+                Operation::Project(MatrixClass::FfnProjection),
+                MatrixClass::FfnProjection,
+            ),
+            (Operation::OutputHead, MatrixClass::OutputHead),
+        ] {
+            for elements in [SMALL, LARGE] {
+                for arm in [KQuantExecution::Direct, KQuantExecution::Widen] {
+                    let selected = select_cpu(&synthetic(operation, elements), &facts, arm)
+                        .unwrap_or_else(|e| panic!("{label} {operation:?} {elements}: {e}"));
+                    let expected = old_ladder(
+                        class,
+                        elements,
+                        stored_bf16,
+                        stored_nvfp4,
+                        stored_kquant,
+                        arm,
+                    );
+                    assert_eq!(
+                        selected.realization.format(),
+                        expected,
+                        "{label} {operation:?} {elements} {arm:?}: {:?}",
+                        selected.realization
+                    );
+                    // The pin is one of the candidates, always.
+                    assert!(selected.candidates.contains(&selected.realization));
+                    compared += 1;
+                }
+            }
+        }
+    }
+    assert_eq!(compared, labels.len() * 3 * 2 * 2);
+}
+
+/// Direct and decode are DISTINCT realizations of the same operand, told
+/// apart by the record and not by the bytes alone.
+#[test]
+fn direct_and_decode_are_distinct_realizations_of_one_stored_kquant() {
+    let facts = RepresentationFacts::resolve("Q6_K");
+    let operand = synthetic(Operation::Project(MatrixClass::FfnProjection), LARGE);
+    let direct = select_cpu(&operand, &facts, KQuantExecution::Direct).unwrap();
+    let decode = select_cpu(&operand, &facts, KQuantExecution::Widen).unwrap();
+    assert_eq!(
+        direct.realization.form,
+        RealizationForm::Direct(PhysicalProjectionPlan::FusedKQuant)
+    );
+    assert_eq!(
+        decode.realization.form,
+        RealizationForm::Decode(PhysicalProjectionPlan::BlasF32)
+    );
+    assert_ne!(
+        direct.residency, decode.residency,
+        "different declared costs"
+    );
+    assert_eq!(decode.residency, ResidencyProfile::DECODED_F32);
+    assert_eq!(
+        direct.candidates, decode.candidates,
+        "one candidate set, two orderings"
+    );
+}
+
+// ── Records on real containers ────────────────────────────────────────
+
+#[test]
+fn a_prepared_plan_pins_one_realization_per_planned_operand_with_its_reason() {
+    let fixture = dense(None);
+    let prepared = PreparedOperands::load(
+        &fixture.plan,
+        &fixture.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let records = prepared.realizations();
+    assert_eq!(records.len(), fixture.plan.planned_operands().len());
+    for record in records {
+        assert_eq!(record.representation, "F32");
+        assert!(record
+            .selection
+            .candidates
+            .contains(&record.selection.realization));
+        match record.planned.operation {
+            Operation::Embed => assert_eq!(
+                record.selection.realization.form,
+                RealizationForm::DecodedGather
+            ),
+            op if is_projection(op) => {
+                // An f32 source's stored bytes ARE the f32 image: the
+                // codec declares BLAS over them as a direct realization.
+                assert_eq!(
+                    record.selection.realization,
+                    RealizationId::cpu(RealizationForm::Direct(PhysicalProjectionPlan::BlasF32))
+                );
+                assert_eq!(record.selection.reason, SelectionReason::DirectDeclared);
+            }
+            other => panic!("the dense plan has no {other:?}"),
+        }
+    }
+    prepared.verify_pins().unwrap();
+}
+
+#[test]
+fn the_reference_backend_pins_the_scalar_oracle_for_every_projection() {
+    let fixture = dense(None);
+    let prepared = PreparedOperands::load(
+        &fixture.plan,
+        &fixture.store,
+        &ReferenceBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    for record in prepared.realizations() {
+        if is_projection(record.planned.operation) {
+            assert_eq!(
+                record.selection.realization,
+                RealizationId::cpu(RealizationForm::Decode(PhysicalProjectionPlan::ScalarF32))
+            );
+            assert_eq!(record.selection.reason, SelectionReason::ReferenceOracle);
+            assert_eq!(
+                record.selection.candidates.len(),
+                1,
+                "the oracle considers nothing else"
+            );
+        }
+    }
+}
+
+#[test]
+fn the_entropy_coded_container_pins_decode_and_says_why() {
+    let fixture = dense(Some(Transcode::Bf16Zlib));
+    let prepared = PreparedOperands::load(
+        &fixture.plan,
+        &fixture.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let mut seen = 0;
+    for record in prepared.realizations() {
+        if record.representation != "BF16_ZLIB" {
+            continue;
+        }
+        assert!(is_projection(record.planned.operation));
+        assert_eq!(
+            record.selection.realization,
+            RealizationId::cpu(RealizationForm::Decode(PhysicalProjectionPlan::BlasF32))
+        );
+        assert_eq!(
+            record.selection.reason,
+            SelectionReason::NoDirectRealization
+        );
+        assert_eq!(
+            record.selection.candidates,
+            vec![RealizationId::cpu(RealizationForm::Decode(
+                PhysicalProjectionPlan::BlasF32
+            ))],
+            "no direct realization is declared, so decode is the only candidate"
+        );
+        assert_eq!(record.selection.residency, ResidencyProfile::DECODED_F32);
+        seen += 1;
+    }
+    assert!(seen > 0);
+}
+
+// ── Refusals, before any byte ─────────────────────────────────────────
+
+#[test]
+fn an_unregistered_representation_is_refused_at_preparation_before_any_byte_is_read() {
+    let fixture = dense(Some(Transcode::Unregistered));
+    let before = fixture.store.load_count();
+    let err = PreparedOperands::load(
+        &fixture.plan,
+        &fixture.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .err()
+    .map(|e| e.to_string())
+    .expect("nothing is registered for the label");
+    assert!(err.contains("unregistered representation"), "{err}");
+    assert!(err.contains("BF16_ZLIB_UNREGISTERED"), "{err}");
+    // Every refused operand is named, not just the first.
+    assert!(
+        err.matches("unregistered representation").count() > 1,
+        "{err}"
+    );
+    assert_eq!(
+        fixture.store.load_count(),
+        before,
+        "refused before any byte was read"
+    );
+}
+
+// ── The pin is checked ────────────────────────────────────────────────
+
+#[test]
+fn a_tampered_pin_is_refused_by_the_prepared_plan() {
+    let fixture = dense(None);
+    let mut prepared = PreparedOperands::load(
+        &fixture.plan,
+        &fixture.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    prepared.verify_pins().unwrap();
+    let index = prepared
+        .realizations()
+        .iter()
+        .position(|r| r.planned.operation == Operation::Project(MatrixClass::AttentionProjection))
+        .unwrap();
+    prepared.realizations_mut()[index].selection.realization =
+        RealizationId::cpu(RealizationForm::Direct(PhysicalProjectionPlan::FusedBf16));
+    let err = prepared.verify_pins().unwrap_err().to_string();
+    assert!(err.contains("not the pinned realizations"), "{err}");
+    assert!(err.contains("Bf16") && err.contains("F32"), "{err}");
+}
+
+/// The plan's own view and the loader agree on every fixture this suite
+/// prepares; a loader asking for an operand the view does not list is a
+/// refusal, not a default.
+#[test]
+fn every_loaded_matrix_has_a_record_and_no_record_is_left_unloaded() {
+    let fixture = dense(None);
+    let prepared = PreparedOperands::load(
+        &fixture.plan,
+        &fixture.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let projections = prepared
+        .realizations()
+        .iter()
+        .filter(|r| is_projection(r.planned.operation))
+        .count();
+    let per_layer = 7;
+    assert_eq!(projections, per_layer * fixture.plan.layers.len() + 1);
+}
+
+// ── The vocabulary itself ─────────────────────────────────────────────
+
+use super::super::quantise::{Q4_BLOCK, Q8_BLOCK};
+use super::super::realization::{
+    class_of, common_selection, cpu_projection_candidates, resident_profile, RealizationBackend,
+    RefusalKind, SelectionRefusal, SelectionRefusals,
+};
+use crate::format::vindex3::represent::codec::codecs::float::BF16;
+use crate::format::vindex3::represent::codec::{CodecRegistry, RequiredAccess, ResidencyClass};
+
+fn every_form() -> Vec<RealizationForm> {
+    vec![
+        RealizationForm::Direct(PhysicalProjectionPlan::FusedBf16),
+        RealizationForm::Decode(PhysicalProjectionPlan::BlasF32),
+        RealizationForm::Requantise(PhysicalProjectionPlan::FusedQ8),
+        RealizationForm::SliceStored {
+            convert: WeightFormat::F16,
+        },
+        RealizationForm::DecodedGather,
+        RealizationForm::DeviceResident(WeightFormat::Nvfp4),
+    ]
+}
+
+#[test]
+fn every_form_names_its_backend_its_form_and_its_resident_representation() {
+    let expected_format = [
+        WeightFormat::Bf16,
+        WeightFormat::F32,
+        WeightFormat::Q8,
+        WeightFormat::F16,
+        WeightFormat::F32,
+        WeightFormat::Nvfp4,
+    ];
+    let expected_plan = [
+        Some(PhysicalProjectionPlan::FusedBf16),
+        Some(PhysicalProjectionPlan::BlasF32),
+        Some(PhysicalProjectionPlan::FusedQ8),
+        None,
+        None,
+        None,
+    ];
+    for ((form, format), plan) in every_form()
+        .into_iter()
+        .zip(expected_format)
+        .zip(expected_plan)
+    {
+        let cpu = RealizationId::cpu(form);
+        assert_eq!(cpu.format(), format, "{form:?}");
+        assert_eq!(cpu.cpu_plan(), plan, "{form:?}");
+        assert!(cpu.name().starts_with("cpu:"), "{}", cpu.name());
+        let device = RealizationId {
+            backend: RealizationBackend::Device,
+            form,
+        };
+        assert!(device.name().starts_with("device:"), "{}", device.name());
+        assert_ne!(cpu, device);
+    }
+    let names: std::collections::BTreeSet<String> = every_form()
+        .into_iter()
+        .map(|f| RealizationId::cpu(f).name())
+        .collect();
+    assert_eq!(
+        names.len(),
+        every_form().len(),
+        "every form renders distinctly"
+    );
+}
+
+#[test]
+fn resident_profiles_are_priced_from_the_executor_s_own_forms() {
+    let f32_width = std::mem::size_of::<f32>() as f64;
+    let cases = [
+        (
+            WeightFormat::F32,
+            ResidencyClass::TransientDecoded,
+            f32_width,
+        ),
+        (WeightFormat::Bf16, ResidencyClass::Rebound, 2.0),
+        (WeightFormat::F16, ResidencyClass::TransientRequantised, 2.0),
+        (
+            WeightFormat::Q8,
+            ResidencyClass::TransientRequantised,
+            1.0 + f32_width / Q8_BLOCK as f64,
+        ),
+        (
+            WeightFormat::Q4,
+            ResidencyClass::TransientRequantised,
+            0.5 + f32_width / Q4_BLOCK as f64,
+        ),
+        (WeightFormat::Nvfp4, ResidencyClass::Rebound, 4.5 / 8.0),
+        (WeightFormat::Mxfp4, ResidencyClass::Stored, 4.25 / 8.0),
+        (WeightFormat::KQuant, ResidencyClass::Stored, 8.5 / 8.0),
+    ];
+    for (format, class, bytes) in cases {
+        let profile = resident_profile(format);
+        assert_eq!(profile.class, class, "{format:?}");
+        assert!(
+            (profile.bytes_per_weight - bytes).abs() < 1e-12,
+            "{format:?}: {profile:?}"
+        );
+    }
+}
+
+#[test]
+fn reasons_and_refusal_kinds_carry_distinct_names() {
+    let reasons = [
+        SelectionReason::DirectDeclared,
+        SelectionReason::NoDirectRealization,
+        SelectionReason::ArmPrefersDecode,
+        SelectionReason::SizePolicy,
+        SelectionReason::BankSlicedAtLoad,
+        SelectionReason::DeviceClassTable,
+        SelectionReason::EmbeddingGather,
+        SelectionReason::ReferenceOracle,
+        SelectionReason::OverlaidEdit,
+    ];
+    let names: std::collections::BTreeSet<&str> = reasons.iter().map(|r| r.name()).collect();
+    assert_eq!(names.len(), reasons.len());
+    let kinds = [
+        RefusalKind::UnregisteredRepresentation,
+        RefusalKind::AccessRefused,
+        RefusalKind::MissingRealization,
+    ];
+    let names: std::collections::BTreeSet<&str> = kinds.iter().map(|k| k.name()).collect();
+    assert_eq!(names.len(), kinds.len());
+}
+
+#[test]
+fn a_refusal_renders_the_operand_the_kind_and_every_candidate_it_considered() {
+    let operand = synthetic(Operation::ExpertBankSlice, SMALL);
+    let slice = RealizationId::cpu(RealizationForm::SliceStored {
+        convert: WeightFormat::F32,
+    });
+    let decode = RealizationId::cpu(RealizationForm::Decode(PhysicalProjectionPlan::BlasF32));
+    let refusal = SelectionRefusal {
+        operand: operand.operand.clone(),
+        operation: operand.operation,
+        representation: "BF16_ZLIB".into(),
+        requested: RequiredAccess::RowRandom,
+        kind: RefusalKind::AccessRefused,
+        considered: vec![
+            (slice, "provides sequential access".into()),
+            (decode, "not offered for a bank".into()),
+        ],
+    };
+    let text = refusal.to_string();
+    for expected in [
+        "`0.w`",
+        "expert-bank-slice",
+        "row-random",
+        "BF16_ZLIB",
+        "access refused",
+        &slice.name(),
+        "provides sequential access",
+        &decode.name(),
+        "not offered for a bank",
+    ] {
+        assert!(text.contains(expected), "{expected} missing from: {text}");
+    }
+    let bare = SelectionRefusal {
+        considered: vec![],
+        kind: RefusalKind::MissingRealization,
+        ..refusal.clone()
+    };
+    assert!(bare.to_string().contains("no realization to consider"));
+    let all = SelectionRefusals(vec![refusal, bare]).to_string();
+    assert!(
+        all.starts_with("2 planned operand(s) have no admissible realization"),
+        "{all}"
+    );
+    assert_eq!(
+        all.matches("\n  ").count(),
+        2,
+        "one line per refusal: {all}"
+    );
+}
+
+#[test]
+fn facts_resolve_through_a_registry_and_an_overlay_empties_the_direct_candidates() {
+    let scratch = CodecRegistry::new().register(Box::new(BF16)).unwrap();
+    let bf16 = RepresentationFacts::resolve_in(&scratch, "BF16");
+    assert_eq!(bf16.label, "BF16");
+    assert!(bf16.registered.is_some());
+    assert_eq!(
+        bf16.direct_cpu_plans(),
+        vec![
+            PhysicalProjectionPlan::FusedBf16,
+            PhysicalProjectionPlan::Bf16xQ8
+        ]
+    );
+    assert!(bf16.provides(RequiredAccess::ElementRandom));
+    assert_eq!(
+        bf16.direct_residency(PhysicalProjectionPlan::FusedBf16),
+        Some(ResidencyProfile::stored(16.0))
+    );
+    assert_eq!(
+        bf16.direct_residency(PhysicalProjectionPlan::FusedNvfp4),
+        None
+    );
+    bf16.admit_row_slicing().unwrap();
+    // An overlay edit: still registered, still row-addressable in storage,
+    // but nothing direct can honour an f32-space edit.
+    let edited = bf16.clone().overlaid();
+    assert!(edited.overlaid);
+    assert!(edited.direct_cpu_plans().is_empty());
+    assert!(edited.provides(RequiredAccess::RowRandom));
+    // A label the scratch registry does not carry: no decode, no
+    // capabilities, and a bank dialect the loader judges itself.
+    let alien = RepresentationFacts::resolve_in(&scratch, "NVFP4");
+    assert!(alien.registered.is_none());
+    assert!(!alien.provides(RequiredAccess::Sequential));
+    assert!(alien.direct_cpu_plans().is_empty());
+    assert_eq!(
+        alien.direct_residency(PhysicalProjectionPlan::FusedNvfp4),
+        None
+    );
+    alien.admit_row_slicing().unwrap();
+    // Candidates follow the facts: a bf16 source offers its kernels, the
+    // decode, and the executor's re-quantised forms; an unregistered
+    // label offers nothing.
+    let requantise = [PhysicalProjectionPlan::FusedQ8];
+    let candidates = cpu_projection_candidates(&bf16, PhysicalProjectionPlan::BlasF32, &requantise);
+    assert_eq!(candidates.len(), 2 + 1 + 1);
+    assert!(
+        cpu_projection_candidates(&alien, PhysicalProjectionPlan::BlasF32, &requantise).is_empty()
+    );
+    let f16 = RepresentationFacts::resolve("F16");
+    assert_eq!(
+        cpu_projection_candidates(&f16, PhysicalProjectionPlan::BlasF32, &requantise),
+        vec![RealizationId::cpu(RealizationForm::Decode(
+            PhysicalProjectionPlan::BlasF32
+        ))]
+    );
+}
+
+#[test]
+fn the_common_selections_cover_the_table_the_bank_and_the_shared_expert() {
+    let registered = RepresentationFacts::resolve("BF16");
+    let unregistered = RepresentationFacts::resolve("U8");
+    let embed = synthetic(Operation::Embed, SMALL);
+    let gathered = common_selection(&embed, &registered, WeightFormat::F32)
+        .unwrap()
+        .unwrap();
+    assert_eq!(gathered.realization.form, RealizationForm::DecodedGather);
+    assert_eq!(gathered.reason, SelectionReason::EmbeddingGather);
+    let refused = common_selection(&embed, &unregistered, WeightFormat::F32)
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(refused.kind, RefusalKind::UnregisteredRepresentation);
+
+    let bank = synthetic(Operation::ExpertBankSlice, SMALL);
+    let sliced = common_selection(&bank, &registered, WeightFormat::F16)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        sliced.realization.form,
+        RealizationForm::SliceStored {
+            convert: WeightFormat::F16
+        }
+    );
+    assert_eq!(sliced.residency, resident_profile(WeightFormat::F16));
+    let sequential = RepresentationFacts::resolve("BF16_ZLIB");
+    let refused = common_selection(&bank, &sequential, WeightFormat::F32)
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(refused.kind, RefusalKind::AccessRefused);
+    assert_eq!(refused.considered.len(), 1);
+
+    let shared = synthetic(Operation::SharedExpertProject, SMALL);
+    let refused = common_selection(&shared, &registered, WeightFormat::F32)
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(refused.kind, RefusalKind::MissingRealization);
+    assert!(refused.considered.is_empty());
+
+    for projection in [
+        Operation::Project(MatrixClass::AttentionProjection),
+        Operation::OutputHead,
+    ] {
+        assert!(common_selection(
+            &synthetic(projection, SMALL),
+            &registered,
+            WeightFormat::F32
+        )
+        .is_none());
+    }
+    assert_eq!(
+        class_of(Operation::OutputHead),
+        Some(MatrixClass::OutputHead)
+    );
+    assert_eq!(class_of(Operation::Embed), None);
+}
+
+#[test]
+fn the_cpu_selector_refuses_an_unregistered_projection_and_a_shared_expert() {
+    let unregistered = RepresentationFacts::resolve("U8");
+    let refused = select_cpu(
+        &synthetic(Operation::Project(MatrixClass::FfnProjection), SMALL),
+        &unregistered,
+        KQuantExecution::Direct,
+    )
+    .unwrap_err();
+    assert_eq!(refused.kind, RefusalKind::UnregisteredRepresentation);
+    let refused = select_cpu(
+        &synthetic(Operation::SharedExpertProject, SMALL),
+        &RepresentationFacts::resolve("BF16"),
+        KQuantExecution::Direct,
+    )
+    .unwrap_err();
+    assert_eq!(refused.kind, RefusalKind::MissingRealization);
+    // An overlay edit on a bf16 operand decodes, and the reason says so.
+    let edited = RepresentationFacts::resolve("BF16").overlaid();
+    let selected = select_cpu(
+        &synthetic(Operation::Project(MatrixClass::FfnProjection), LARGE),
+        &edited,
+        KQuantExecution::Direct,
+    )
+    .unwrap();
+    assert_eq!(
+        selected.realization.form,
+        RealizationForm::Decode(PhysicalProjectionPlan::BlasF32)
+    );
+    assert_eq!(selected.reason, SelectionReason::OverlaidEdit);
+}
+
+#[test]
+fn the_reference_backend_refuses_an_unregistered_representation_before_any_byte() {
+    let fixture = dense(Some(Transcode::Unregistered));
+    let before = fixture.store.load_count();
+    let err = PreparedOperands::load(
+        &fixture.plan,
+        &fixture.store,
+        &ReferenceBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .err()
+    .map(|e| e.to_string())
+    .expect("the oracle cannot decode what nothing decodes");
+    assert!(err.contains("unregistered representation"), "{err}");
+    assert_eq!(fixture.store.load_count(), before);
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/realization.rs
@@ -102,6 +102,7 @@ fn synthetic(operation: Operation, elements: usize) -> PlannedOperand {
         access: operation.access(),
         extent: RepresentationExtent::TERMINAL,
         layer: Some(0),
+        declared_representation: None,
         logical_elements: elements,
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
@@ -259,6 +259,19 @@ impl LoadedWeight {
         matches!(self, LoadedWeight::F32(_))
     }
 
+    /// How many of this operand's allocations are page-padded — the
+    /// `AlignedBytes` buffers, whose length rounds up to the page. A
+    /// reconciliation of declared against resident bytes tolerates one
+    /// page of padding per such allocation and nothing for the rest.
+    pub fn padded_allocations(&self) -> usize {
+        match self {
+            LoadedWeight::F32(_) | LoadedWeight::Q8 { .. } | LoadedWeight::Q4 { .. } => 0,
+            LoadedWeight::Bf16(_) | LoadedWeight::F16(_) => 1,
+            LoadedWeight::Mxfp4 { .. } | LoadedWeight::Nvfp4 { .. } => 2,
+            LoadedWeight::KQuant { .. } => 0,
+        }
+    }
+
     /// The representation these bytes are resident in — what a pinned
     /// realization is checked against.
     pub fn format(&self) -> WeightFormat {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
@@ -259,6 +259,21 @@ impl LoadedWeight {
         matches!(self, LoadedWeight::F32(_))
     }
 
+    /// The representation these bytes are resident in — what a pinned
+    /// realization is checked against.
+    pub fn format(&self) -> WeightFormat {
+        match self {
+            LoadedWeight::F32(_) => WeightFormat::F32,
+            LoadedWeight::Bf16(_) => WeightFormat::Bf16,
+            LoadedWeight::F16(_) => WeightFormat::F16,
+            LoadedWeight::Q8 { .. } => WeightFormat::Q8,
+            LoadedWeight::Q4 { .. } => WeightFormat::Q4,
+            LoadedWeight::Mxfp4 { .. } => WeightFormat::Mxfp4,
+            LoadedWeight::Nvfp4 { .. } => WeightFormat::Nvfp4,
+            LoadedWeight::KQuant { .. } => WeightFormat::KQuant,
+        }
+    }
+
     pub fn slice(&self) -> WeightSlice<'_> {
         match self {
             LoadedWeight::F32(w) => WeightSlice::F32(w),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged.rs
@@ -148,7 +148,16 @@ fn arena() -> Result<&'static Mutex<Arena>, VindexError> {
 /// of the failure path through `arena()` would depend on whether any
 /// other test had staged an image first.
 pub(super) fn open_arena(dir: &std::path::Path) -> Result<Arena, VindexError> {
-    let path = dir.join(format!("larql-f32-stage-{}.bin", std::process::id()));
+    // Unique per OPEN, not per process: two operands widened on two
+    // threads at once would otherwise race to `create_new` one file
+    // (observed as "File exists" under a parallel test run), and a
+    // process id recycled after a crash would find its predecessor's.
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let serial = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let path = dir.join(format!(
+        "larql-f32-stage-{}-{serial}.bin",
+        std::process::id()
+    ));
     let file = std::fs::OpenOptions::new()
         .create_new(true)
         .read(true)

--- a/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/mod.rs
@@ -30,6 +30,7 @@ pub mod gated_delta;
 pub mod kda;
 pub mod mamba2;
 pub mod mla;
+pub mod planned;
 
 #[cfg(test)]
 pub(crate) mod tests;

--- a/crates/larql-vindex/src/format/vindex3/opplan/planned.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/planned.rs
@@ -17,14 +17,19 @@
 //! provide that — a direct kernel over stored rows, a whole decode and then
 //! a gather — is the prepared plan's question (3b), not this one's.
 
-use larql_models::config::GateSource;
+use larql_models::config::{ExpertFormat, GateSource};
 use larql_models::quant::mxfp4::FUSED_HALVES;
 
 use super::exec::backend::MatrixClass;
 use super::{
     ComponentOpPlan, ExpertBank, FfnOp, LayerAttention, LayerFfn, OperandRef, RoutedFfnOp,
 };
+use crate::format::vindex3::represent::codec::codecs::float::FloatDtype;
+use crate::format::vindex3::represent::codec::codecs::mxfp4::DTYPE_MXFP4;
 use crate::format::vindex3::represent::codec::{RepresentationExtent, RequiredAccess};
+
+/// The bf16 codec's label, as the float codec spells it.
+const BF16_LABEL: &str = FloatDtype::Bf16.label();
 
 /// What a plan does with one matrix operand.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,6 +86,14 @@ pub struct PlannedOperand {
     /// The plan layer the operand belongs to; `None` for the embedding and
     /// the head, which sit outside the stack.
     pub layer: Option<usize>,
+    /// A legacy default for the operand's codec, consulted only when the
+    /// container's stored label is a carrier dialect that names no codec:
+    /// a packed MXFP4 bank is stored as two `U8` byte tensors, and only
+    /// the architecture's declaration says they are MXFP4's two streams.
+    /// The STORED representation stays authoritative — a label that names
+    /// a codec is never overridden by this. `None` when the stored label
+    /// is the representation.
+    pub declared_representation: Option<&'static str>,
     /// The weights the operation touches. For every operand but a packed
     /// bank this is the operand's shape; a packed bank's `OperandRef`
     /// carries the STORED tensor's shape — MXFP4 blocks are sixteen bytes
@@ -106,8 +119,14 @@ impl PlannedOperand {
             access: operation.access(),
             extent: RepresentationExtent::TERMINAL,
             layer,
+            declared_representation: None,
             logical_elements,
         }
+    }
+
+    fn declaring(mut self, representation: Option<&'static str>) -> Self {
+        self.declared_representation = representation;
+        self
     }
 
     pub fn elements(&self) -> usize {
@@ -229,18 +248,25 @@ fn routed(op: &RoutedFfnOp, layer: usize, out: &mut Vec<PlannedOperand>) {
         ExpertBank::Packed { gate_up, down } => {
             let hidden = op.router.shape.get(1).copied().unwrap_or(0);
             let inter = op.expert_intermediate_size;
-            out.push(PlannedOperand::sized(
-                &gate_up.weights,
-                Operation::ExpertBankSlice,
-                Some(layer),
-                op.experts * FUSED_HALVES * inter * hidden,
-            ));
-            out.push(PlannedOperand::sized(
-                &down.weights,
-                Operation::ExpertBankSlice,
-                Some(layer),
-                op.experts * hidden * inter,
-            ));
+            let declared = declared_bank_representation(op.expert_format);
+            out.push(
+                PlannedOperand::sized(
+                    &gate_up.weights,
+                    Operation::ExpertBankSlice,
+                    Some(layer),
+                    op.experts * FUSED_HALVES * inter * hidden,
+                )
+                .declaring(declared),
+            );
+            out.push(
+                PlannedOperand::sized(
+                    &down.weights,
+                    Operation::ExpertBankSlice,
+                    Some(layer),
+                    op.experts * hidden * inter,
+                )
+                .declaring(declared),
+            );
         }
         ExpertBank::PerExpert { gate, up, down } => {
             for operand in gate.iter().chain(up).chain(down) {
@@ -261,5 +287,19 @@ fn routed(op: &RoutedFfnOp, layer: usize, out: &mut Vec<PlannedOperand>) {
                 Some(layer),
             ));
         }
+    }
+}
+
+/// The codec a packed bank's declared layout carries — the legacy default
+/// behind [`PlannedOperand::declared_representation`]. A packed MXFP4 bank
+/// is stored as two `U8` tensors that are MXFP4's values and group-scale
+/// streams; a packed bf16 bank is stored as what it is, and its stored
+/// label answers before this does. A per-expert bank is not packed and
+/// declares nothing beyond its tensors' own labels.
+pub fn declared_bank_representation(format: ExpertFormat) -> Option<&'static str> {
+    match format {
+        ExpertFormat::PackedMxfp4 => Some(DTYPE_MXFP4),
+        ExpertFormat::PackedBF16 => Some(BF16_LABEL),
+        ExpertFormat::PerExpert => None,
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/planned.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/planned.rs
@@ -1,0 +1,236 @@
+//! The operands a plan executes through a representation, and what each
+//! operation requires of them — derived from the plan, hardware-independent.
+//!
+//! Rung 3a of the representation/execution contract
+//! (`docs/represent/forecasts/rung3-planned-realizations.json`). Every
+//! matrix operand the prepared-plan loader resolves through the seam
+//! appears here exactly once per operation; every glue operand — norms,
+//! biases, convolution kernels, the recurrences' decay and gate vectors,
+//! the router — does not. The list is a VIEW over the plan, computed on
+//! demand: nothing is added to the plan's wire shape, so a plan serialised
+//! before this rung and after it is the same bytes.
+//!
+//! Access is what the OPERATION needs over the operand as executed, never
+//! what a realization needs over the stored bytes: an embedding lookup
+//! gathers one row per token, a packed expert bank is sliced per expert,
+//! a projection reads its whole matrix front to back. Which realization can
+//! provide that — a direct kernel over stored rows, a whole decode and then
+//! a gather — is the prepared plan's question (3b), not this one's.
+
+use larql_models::config::GateSource;
+use larql_models::quant::mxfp4::FUSED_HALVES;
+
+use super::exec::backend::MatrixClass;
+use super::{
+    ComponentOpPlan, ExpertBank, FfnOp, LayerAttention, LayerFfn, OperandRef, RoutedFfnOp,
+};
+use crate::format::vindex3::represent::codec::{RepresentationExtent, RequiredAccess};
+
+/// What a plan does with one matrix operand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    /// One row of the table per token.
+    Embed,
+    /// The residual through a whole matrix — attention and recurrence
+    /// projections, dense FFN projections.
+    Project(MatrixClass),
+    /// One expert's slice of a packed bank, chosen per token by the router.
+    ExpertBankSlice,
+    /// The vocabulary projection of the final hidden state.
+    OutputHead,
+}
+
+impl Operation {
+    /// The access the operation needs over the operand as executed.
+    pub const fn access(self) -> RequiredAccess {
+        match self {
+            Self::Embed | Self::ExpertBankSlice => RequiredAccess::RowRandom,
+            Self::Project(_) | Self::OutputHead => RequiredAccess::Sequential,
+        }
+    }
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Embed => "embed",
+            Self::Project(MatrixClass::AttentionProjection) => "project/attention",
+            Self::Project(MatrixClass::FfnProjection) => "project/ffn",
+            Self::Project(MatrixClass::OutputHead) => "project/head",
+            Self::Project(MatrixClass::RoutedExpertBank) => "project/bank",
+            Self::ExpertBankSlice => "expert-bank-slice",
+            Self::OutputHead => "output-head",
+        }
+    }
+}
+
+/// One matrix operand the plan will execute, and the requirement its
+/// operation makes of it. Hardware-independent: no representation, no
+/// backend, no realization is named here.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannedOperand {
+    pub operand: OperandRef,
+    pub operation: Operation,
+    pub access: RequiredAccess,
+    pub extent: RepresentationExtent,
+    /// The weights the operation touches. For every operand but a packed
+    /// bank this is the operand's shape; a packed bank's `OperandRef`
+    /// carries the STORED tensor's shape — MXFP4 blocks are sixteen bytes
+    /// per thirty-two weights — so its logical count comes from the op's
+    /// declared geometry, exactly as the bank loader sizes it.
+    pub logical_elements: usize,
+}
+
+impl PlannedOperand {
+    fn new(operand: &OperandRef, operation: Operation) -> Self {
+        Self::sized(operand, operation, operand.shape.iter().product())
+    }
+
+    fn sized(operand: &OperandRef, operation: Operation, logical_elements: usize) -> Self {
+        Self {
+            operand: operand.clone(),
+            operation,
+            access: operation.access(),
+            extent: RepresentationExtent::TERMINAL,
+            logical_elements,
+        }
+    }
+
+    pub fn elements(&self) -> usize {
+        self.logical_elements
+    }
+}
+
+impl ComponentOpPlan {
+    /// Every matrix operand this plan executes through a representation, in
+    /// the order the prepared plan loads them: the embedding, then each
+    /// layer's attention and FFN matrices, then the output head.
+    ///
+    /// Mirrors the loader's own distinction, operand by operand: what
+    /// `load_weight` or the packed-bank loader resolves is listed; what is
+    /// read as f32 glue is not. A tied head lists the embedding operand
+    /// twice, once per operation, because the loader binds it twice.
+    pub fn planned_operands(&self) -> Vec<PlannedOperand> {
+        let mut out = Vec::new();
+        if let Some(embedding) = &self.embedding {
+            out.push(PlannedOperand::new(&embedding.table, Operation::Embed));
+        }
+        for layer in &self.layers {
+            attention(&layer.attention, &mut out);
+            match &layer.ffn {
+                None => {}
+                Some(LayerFfn::Dense(op)) => dense(op, &mut out),
+                Some(LayerFfn::Routed(op)) => routed(op, &mut out),
+                Some(LayerFfn::Hybrid(op)) => {
+                    dense(&op.dense, &mut out);
+                    routed(&op.routed, &mut out);
+                }
+            }
+        }
+        if let Some(output) = &self.output {
+            out.push(PlannedOperand::new(
+                &output.projection,
+                Operation::OutputHead,
+            ));
+        }
+        out
+    }
+}
+
+const ATTENTION: Operation = Operation::Project(MatrixClass::AttentionProjection);
+const FFN: Operation = Operation::Project(MatrixClass::FfnProjection);
+
+fn attention(attention: &LayerAttention, out: &mut Vec<PlannedOperand>) {
+    let mut push = |operand: &OperandRef| out.push(PlannedOperand::new(operand, ATTENTION));
+    match attention {
+        LayerAttention::Softmax(op) => {
+            for operand in [&op.q, &op.k, &op.v, &op.o] {
+                push(operand);
+            }
+            // The one gate that is a matrix of its own: a gate fused into
+            // the query projection has no operand to resolve, exactly as
+            // the loader binds none.
+            if let Some(gate) = &op.output_gate {
+                if gate.spec.source != GateSource::FusedQueryProjection {
+                    push(&gate.projection);
+                }
+            }
+        }
+        LayerAttention::GatedDelta(op) => {
+            for operand in [
+                &op.in_proj_qkv,
+                &op.in_proj_a,
+                &op.in_proj_b,
+                &op.in_proj_z,
+                &op.out_proj,
+            ] {
+                push(operand);
+            }
+        }
+        LayerAttention::Mamba2(op) => {
+            push(&op.in_proj);
+            push(&op.out_proj);
+        }
+        LayerAttention::ConvQkv(op) => {
+            push(&op.in_proj);
+            push(&op.out_proj);
+        }
+        LayerAttention::Kda(op) => {
+            for operand in [&op.q_proj, &op.k_proj, &op.v_proj, &op.out_proj] {
+                push(operand);
+            }
+        }
+        LayerAttention::Mla(op) => {
+            for operand in [&op.q_proj, &op.kv_a_proj, &op.kv_b_proj, &op.out_proj] {
+                push(operand);
+            }
+        }
+    }
+}
+
+fn dense(op: &FfnOp, out: &mut Vec<PlannedOperand>) {
+    if let Some(gate) = &op.gate {
+        out.push(PlannedOperand::new(gate, FFN));
+    }
+    out.push(PlannedOperand::new(&op.up, FFN));
+    out.push(PlannedOperand::new(&op.down, FFN));
+}
+
+/// The router, its biases and scales are glue; the banks are the
+/// operands. A per-expert bank is a set of whole matrices, each projected
+/// on its own when an executor for it exists, and is listed as such.
+///
+/// A packed bank's logical geometry is the loader's: `experts` matrices of
+/// `[FUSED_HALVES * intermediate, hidden]` for gate/up and
+/// `[hidden, intermediate]` for down, with `hidden` read off the router's
+/// declared width — the same three facts `load_packed` is handed.
+fn routed(op: &RoutedFfnOp, out: &mut Vec<PlannedOperand>) {
+    match &op.bank {
+        ExpertBank::Packed { gate_up, down } => {
+            let hidden = op.router.shape.get(1).copied().unwrap_or(0);
+            let inter = op.expert_intermediate_size;
+            out.push(PlannedOperand::sized(
+                &gate_up.weights,
+                Operation::ExpertBankSlice,
+                op.experts * FUSED_HALVES * inter * hidden,
+            ));
+            out.push(PlannedOperand::sized(
+                &down.weights,
+                Operation::ExpertBankSlice,
+                op.experts * hidden * inter,
+            ));
+        }
+        ExpertBank::PerExpert { gate, up, down } => {
+            for operand in gate.iter().chain(up).chain(down) {
+                out.push(PlannedOperand::new(operand, FFN));
+            }
+        }
+    }
+    // The shared expert is three whole projections the plan executes
+    // beside the routed ones. Listed because the PLAN executes them: the
+    // Metal stack binds them, and the CPU loader does not yet — a gap the
+    // census cross-check pins rather than hides.
+    if let Some(shared) = &op.shared {
+        for operand in [&shared.gate, &shared.up, &shared.down] {
+            out.push(PlannedOperand::new(operand, FFN));
+        }
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/planned.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/planned.rs
@@ -38,6 +38,10 @@ pub enum Operation {
     ExpertBankSlice,
     /// The vocabulary projection of the final hidden state.
     OutputHead,
+    /// A shared expert's projection beside the routed ones — its own
+    /// operation, because whether a backend can bind it is a question the
+    /// prepared plan must be able to refuse by name (rung 3b).
+    SharedExpertProject,
 }
 
 impl Operation {
@@ -45,7 +49,9 @@ impl Operation {
     pub const fn access(self) -> RequiredAccess {
         match self {
             Self::Embed | Self::ExpertBankSlice => RequiredAccess::RowRandom,
-            Self::Project(_) | Self::OutputHead => RequiredAccess::Sequential,
+            Self::Project(_) | Self::OutputHead | Self::SharedExpertProject => {
+                RequiredAccess::Sequential
+            }
         }
     }
 
@@ -58,6 +64,7 @@ impl Operation {
             Self::Project(MatrixClass::RoutedExpertBank) => "project/bank",
             Self::ExpertBankSlice => "expert-bank-slice",
             Self::OutputHead => "output-head",
+            Self::SharedExpertProject => "shared-expert-project",
         }
     }
 }
@@ -71,6 +78,9 @@ pub struct PlannedOperand {
     pub operation: Operation,
     pub access: RequiredAccess,
     pub extent: RepresentationExtent,
+    /// The plan layer the operand belongs to; `None` for the embedding and
+    /// the head, which sit outside the stack.
+    pub layer: Option<usize>,
     /// The weights the operation touches. For every operand but a packed
     /// bank this is the operand's shape; a packed bank's `OperandRef`
     /// carries the STORED tensor's shape — MXFP4 blocks are sixteen bytes
@@ -80,16 +90,22 @@ pub struct PlannedOperand {
 }
 
 impl PlannedOperand {
-    fn new(operand: &OperandRef, operation: Operation) -> Self {
-        Self::sized(operand, operation, operand.shape.iter().product())
+    fn new(operand: &OperandRef, operation: Operation, layer: Option<usize>) -> Self {
+        Self::sized(operand, operation, layer, operand.shape.iter().product())
     }
 
-    fn sized(operand: &OperandRef, operation: Operation, logical_elements: usize) -> Self {
+    fn sized(
+        operand: &OperandRef,
+        operation: Operation,
+        layer: Option<usize>,
+        logical_elements: usize,
+    ) -> Self {
         Self {
             operand: operand.clone(),
             operation,
             access: operation.access(),
             extent: RepresentationExtent::TERMINAL,
+            layer,
             logical_elements,
         }
     }
@@ -111,17 +127,21 @@ impl ComponentOpPlan {
     pub fn planned_operands(&self) -> Vec<PlannedOperand> {
         let mut out = Vec::new();
         if let Some(embedding) = &self.embedding {
-            out.push(PlannedOperand::new(&embedding.table, Operation::Embed));
+            out.push(PlannedOperand::new(
+                &embedding.table,
+                Operation::Embed,
+                None,
+            ));
         }
-        for layer in &self.layers {
-            attention(&layer.attention, &mut out);
+        for (index, layer) in self.layers.iter().enumerate() {
+            attention(&layer.attention, index, &mut out);
             match &layer.ffn {
                 None => {}
-                Some(LayerFfn::Dense(op)) => dense(op, &mut out),
-                Some(LayerFfn::Routed(op)) => routed(op, &mut out),
+                Some(LayerFfn::Dense(op)) => dense(op, index, &mut out),
+                Some(LayerFfn::Routed(op)) => routed(op, index, &mut out),
                 Some(LayerFfn::Hybrid(op)) => {
-                    dense(&op.dense, &mut out);
-                    routed(&op.routed, &mut out);
+                    dense(&op.dense, index, &mut out);
+                    routed(&op.routed, index, &mut out);
                 }
             }
         }
@@ -129,6 +149,7 @@ impl ComponentOpPlan {
             out.push(PlannedOperand::new(
                 &output.projection,
                 Operation::OutputHead,
+                None,
             ));
         }
         out
@@ -138,8 +159,9 @@ impl ComponentOpPlan {
 const ATTENTION: Operation = Operation::Project(MatrixClass::AttentionProjection);
 const FFN: Operation = Operation::Project(MatrixClass::FfnProjection);
 
-fn attention(attention: &LayerAttention, out: &mut Vec<PlannedOperand>) {
-    let mut push = |operand: &OperandRef| out.push(PlannedOperand::new(operand, ATTENTION));
+fn attention(attention: &LayerAttention, layer: usize, out: &mut Vec<PlannedOperand>) {
+    let mut push =
+        |operand: &OperandRef| out.push(PlannedOperand::new(operand, ATTENTION, Some(layer)));
     match attention {
         LayerAttention::Softmax(op) => {
             for operand in [&op.q, &op.k, &op.v, &op.o] {
@@ -186,12 +208,12 @@ fn attention(attention: &LayerAttention, out: &mut Vec<PlannedOperand>) {
     }
 }
 
-fn dense(op: &FfnOp, out: &mut Vec<PlannedOperand>) {
+fn dense(op: &FfnOp, layer: usize, out: &mut Vec<PlannedOperand>) {
     if let Some(gate) = &op.gate {
-        out.push(PlannedOperand::new(gate, FFN));
+        out.push(PlannedOperand::new(gate, FFN, Some(layer)));
     }
-    out.push(PlannedOperand::new(&op.up, FFN));
-    out.push(PlannedOperand::new(&op.down, FFN));
+    out.push(PlannedOperand::new(&op.up, FFN, Some(layer)));
+    out.push(PlannedOperand::new(&op.down, FFN, Some(layer)));
 }
 
 /// The router, its biases and scales are glue; the banks are the
@@ -202,7 +224,7 @@ fn dense(op: &FfnOp, out: &mut Vec<PlannedOperand>) {
 /// `[FUSED_HALVES * intermediate, hidden]` for gate/up and
 /// `[hidden, intermediate]` for down, with `hidden` read off the router's
 /// declared width — the same three facts `load_packed` is handed.
-fn routed(op: &RoutedFfnOp, out: &mut Vec<PlannedOperand>) {
+fn routed(op: &RoutedFfnOp, layer: usize, out: &mut Vec<PlannedOperand>) {
     match &op.bank {
         ExpertBank::Packed { gate_up, down } => {
             let hidden = op.router.shape.get(1).copied().unwrap_or(0);
@@ -210,27 +232,34 @@ fn routed(op: &RoutedFfnOp, out: &mut Vec<PlannedOperand>) {
             out.push(PlannedOperand::sized(
                 &gate_up.weights,
                 Operation::ExpertBankSlice,
+                Some(layer),
                 op.experts * FUSED_HALVES * inter * hidden,
             ));
             out.push(PlannedOperand::sized(
                 &down.weights,
                 Operation::ExpertBankSlice,
+                Some(layer),
                 op.experts * hidden * inter,
             ));
         }
         ExpertBank::PerExpert { gate, up, down } => {
             for operand in gate.iter().chain(up).chain(down) {
-                out.push(PlannedOperand::new(operand, FFN));
+                out.push(PlannedOperand::new(operand, FFN, Some(layer)));
             }
         }
     }
     // The shared expert is three whole projections the plan executes
-    // beside the routed ones. Listed because the PLAN executes them: the
-    // Metal stack binds them, and the CPU loader does not yet — a gap the
-    // census cross-check pins rather than hides.
+    // beside the routed ones. Listed under their own operation because the
+    // PLAN executes them and no backend binds them through the prepared
+    // plan yet: the selector refuses them by name (rung 3b) rather than
+    // preparing a model without its shared expert.
     if let Some(shared) = &op.shared {
         for operand in [&shared.gate, &shared.up, &shared.down] {
-            out.push(PlannedOperand::new(operand, FFN));
+            out.push(PlannedOperand::new(
+                operand,
+                Operation::SharedExpertProject,
+                Some(layer),
+            ));
         }
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/mod.rs
@@ -13,6 +13,7 @@ mod kimi_moe_closure;
 pub(crate) mod mamba2;
 mod mla_op;
 mod plan;
+mod planned;
 mod post_norm_placement;
 mod tied_head_realization;
 mod unjudged;

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/planned.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/planned.rs
@@ -102,7 +102,9 @@ fn every_operation_declares_its_access_and_every_extent_is_terminal() {
             assert_eq!(p.extent, RepresentationExtent::TERMINAL, "{name}");
             let expected = match p.operation {
                 Operation::Embed | Operation::ExpertBankSlice => RequiredAccess::RowRandom,
-                Operation::Project(_) | Operation::OutputHead => RequiredAccess::Sequential,
+                Operation::Project(_) | Operation::OutputHead | Operation::SharedExpertProject => {
+                    RequiredAccess::Sequential
+                }
             };
             assert_eq!(p.access, expected, "{name}: {}", p.operation.name());
         }
@@ -159,8 +161,12 @@ fn each_variant_lists_exactly_its_matrices_in_loader_order() {
             let per_ffn = match &layer.ffn {
                 None => 0,
                 Some(LayerFfn::Dense(op)) => 2 + usize::from(op.gate.is_some()),
-                Some(LayerFfn::Routed(_)) => 2,
-                Some(LayerFfn::Hybrid(op)) => 2 + usize::from(op.dense.gate.is_some()) + 2,
+                Some(LayerFfn::Routed(op)) => 2 + 3 * usize::from(op.shared.is_some()),
+                Some(LayerFfn::Hybrid(op)) => {
+                    2 + usize::from(op.dense.gate.is_some())
+                        + 2
+                        + 3 * usize::from(op.routed.shared.is_some())
+                }
             };
             expected += per_attention + per_ffn;
         }

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/planned.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/planned.rs
@@ -1,0 +1,318 @@
+//! Rung 3a: the plan's own statement of what it executes through a
+//! representation, and what each operation requires — checked against the
+//! loader that binds those operands, byte for byte.
+
+use std::collections::BTreeSet;
+
+use super::conv_qkv::miniature_hybrid;
+use super::encoded_fixture;
+use crate::format::vindex3::fixtures::{
+    dense_f32_model_with, encode_fixture_container, hybrid_lllf_f32_model, HeadStorage,
+};
+use crate::format::vindex3::fixtures_kimi::hybrid_kda_mla_f32_model;
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::backend::MatrixClass;
+use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use crate::format::vindex3::opplan::planned::{Operation, PlannedOperand};
+use crate::format::vindex3::opplan::{
+    plan_component_ops, ComponentOpPlan, LayerAttention, LayerFfn,
+};
+use crate::format::vindex3::represent::codec::{RepresentationExtent, RequiredAccess};
+use larql_models::config::GateSource;
+
+const F32_WIDTH: usize = std::mem::size_of::<f32>();
+
+/// A plan and the store it was planned over, sources kept alive.
+struct Planned {
+    _src: tempfile::TempDir,
+    _container: tempfile::TempDir,
+    plan: ComponentOpPlan,
+    store: OperandStore,
+}
+
+fn planned(write: impl FnOnce(&std::path::Path), name: &str, component: &str) -> Planned {
+    let src = tempfile::tempdir().unwrap();
+    let container = tempfile::tempdir().unwrap();
+    encode_fixture_container(write, src.path(), container.path(), name);
+    let inspection = inspect_container(container.path(), false).unwrap();
+    let plan = plan_component_ops(&inspection, container.path(), component)
+        .unwrap()
+        .plan
+        .unwrap_or_else(|| panic!("{name} plans"));
+    let store = OperandStore::open(container.path(), &inspection).unwrap();
+    Planned {
+        _src: src,
+        _container: container,
+        plan,
+        store,
+    }
+}
+
+/// Every fixture whose attention variants together cover the view's arms:
+/// softmax with an output gate (Glimmer), gated delta (LLLF), Mamba2 and
+/// conv-QKV (the OuteAI miniature), KDA and MLA (the Kimi miniature).
+fn every_plan() -> Vec<(&'static str, Planned)> {
+    let glimmer = {
+        let fixture = encoded_fixture();
+        let plan = plan_component_ops(&fixture.inspection, &fixture.root, "target")
+            .unwrap()
+            .plan
+            .unwrap();
+        let store = OperandStore::open(&fixture.root, &fixture.inspection).unwrap();
+        Planned {
+            _src: fixture._target_dir,
+            _container: fixture.container,
+            plan,
+            store,
+        }
+    };
+    vec![
+        ("glimmer", glimmer),
+        ("lllf", planned(hybrid_lllf_f32_model, "hybrid", "target")),
+        ("mamba2attn", planned(miniature_hybrid, "oute", "target")),
+        (
+            "kda-mla",
+            planned(hybrid_kda_mla_f32_model, "kimi", "target"),
+        ),
+    ]
+}
+
+fn key(p: &PlannedOperand) -> (String, String, &'static str) {
+    (
+        p.operand.object.clone(),
+        p.operand.tensor.clone(),
+        p.operation.name(),
+    )
+}
+
+#[test]
+fn every_operation_declares_its_access_and_every_extent_is_terminal() {
+    for (name, fixture) in every_plan() {
+        let planned = fixture.plan.planned_operands();
+        assert!(!planned.is_empty(), "{name}");
+        for p in &planned {
+            assert_eq!(
+                p.access,
+                p.operation.access(),
+                "{name}: {}",
+                p.operand.tensor
+            );
+            assert_eq!(p.extent, RepresentationExtent::TERMINAL, "{name}");
+            let expected = match p.operation {
+                Operation::Embed | Operation::ExpertBankSlice => RequiredAccess::RowRandom,
+                Operation::Project(_) | Operation::OutputHead => RequiredAccess::Sequential,
+            };
+            assert_eq!(p.access, expected, "{name}: {}", p.operation.name());
+        }
+        let distinct: BTreeSet<_> = planned.iter().map(key).collect();
+        assert_eq!(
+            distinct.len(),
+            planned.len(),
+            "{name}: an operand is listed twice for one operation"
+        );
+    }
+}
+
+/// The count is derived from the plan's structure, variant by variant, so
+/// the mapping rule is pinned; the bytes-level check below is what proves
+/// the rule matches the loader.
+#[test]
+fn each_variant_lists_exactly_its_matrices_in_loader_order() {
+    for (name, fixture) in every_plan() {
+        let plan = &fixture.plan;
+        let planned = plan.planned_operands();
+        let mut expected = usize::from(plan.embedding.is_some());
+        let mut seen = BTreeSet::new();
+        for layer in &plan.layers {
+            let per_attention = match &layer.attention {
+                LayerAttention::Softmax(op) => {
+                    seen.insert("softmax");
+                    4 + usize::from(
+                        op.output_gate
+                            .as_ref()
+                            .is_some_and(|g| g.spec.source != GateSource::FusedQueryProjection),
+                    )
+                }
+                LayerAttention::GatedDelta(_) => {
+                    seen.insert("gated-delta");
+                    5
+                }
+                LayerAttention::Mamba2(_) => {
+                    seen.insert("mamba2");
+                    2
+                }
+                LayerAttention::ConvQkv(_) => {
+                    seen.insert("conv-qkv");
+                    2
+                }
+                LayerAttention::Kda(_) => {
+                    seen.insert("kda");
+                    4
+                }
+                LayerAttention::Mla(_) => {
+                    seen.insert("mla");
+                    4
+                }
+            };
+            let per_ffn = match &layer.ffn {
+                None => 0,
+                Some(LayerFfn::Dense(op)) => 2 + usize::from(op.gate.is_some()),
+                Some(LayerFfn::Routed(_)) => 2,
+                Some(LayerFfn::Hybrid(op)) => 2 + usize::from(op.dense.gate.is_some()) + 2,
+            };
+            expected += per_attention + per_ffn;
+        }
+        expected += usize::from(plan.output.is_some());
+        assert_eq!(planned.len(), expected, "{name}");
+        assert_eq!(
+            planned.first().map(|p| p.operation),
+            Some(Operation::Embed),
+            "{name}"
+        );
+        assert_eq!(
+            planned.last().map(|p| p.operation),
+            Some(Operation::OutputHead),
+            "{name}"
+        );
+        eprintln!("{name}: {} planned operands over {:?}", planned.len(), seen);
+    }
+    // Together the fixtures reach every arm, or this test proves less than
+    // it looks like it does.
+    let reached: BTreeSet<&str> = every_plan()
+        .iter()
+        .flat_map(|(_, f)| {
+            f.plan.layers.iter().map(|l| match &l.attention {
+                LayerAttention::Softmax(_) => "softmax",
+                LayerAttention::GatedDelta(_) => "gated-delta",
+                LayerAttention::Mamba2(_) => "mamba2",
+                LayerAttention::ConvQkv(_) => "conv-qkv",
+                LayerAttention::Kda(_) => "kda",
+                LayerAttention::Mla(_) => "mla",
+            })
+        })
+        .collect();
+    assert_eq!(
+        reached,
+        ["softmax", "gated-delta", "mamba2", "conv-qkv", "kda", "mla"]
+            .into_iter()
+            .collect()
+    );
+}
+
+/// The reference loader widens every matrix to f32. So the bytes the census
+/// holds at the matrix sites must be exactly four per planned element —
+/// nothing the loader binds is missing from the view, and nothing in the
+/// view is a matrix the loader does not bind. Glue is the census's own
+/// site and is not planned.
+#[test]
+fn the_view_accounts_for_every_matrix_byte_the_reference_loader_makes_resident() {
+    for (name, fixture) in every_plan() {
+        let planned = fixture.plan.planned_operands();
+        let census = PreparedOperands::load(
+            &fixture.plan,
+            &fixture.store,
+            &ReferenceBackend::new(),
+            ExecutionSlice::Full,
+        )
+        .unwrap_or_else(|e| panic!("{name}: {e}"))
+        .residency_census();
+        let bytes = |op: fn(&PlannedOperand) -> bool| -> usize {
+            planned
+                .iter()
+                .filter(|p| op(p))
+                .map(|p| p.elements() * F32_WIDTH)
+                .sum()
+        };
+        assert_eq!(
+            census.compact(),
+            0,
+            "{name}: the reference backend widens everything"
+        );
+        assert_eq!(
+            census.embedding.widened_f32,
+            bytes(|p| p.operation == Operation::Embed),
+            "{name}: embedding"
+        );
+        assert_eq!(
+            census.head.widened_f32,
+            bytes(|p| p.operation == Operation::OutputHead),
+            "{name}: head"
+        );
+        assert_eq!(
+            census.ffn.widened_f32,
+            bytes(|p| matches!(
+                p.operation,
+                Operation::Project(MatrixClass::FfnProjection) | Operation::ExpertBankSlice
+            )),
+            "{name}: ffn"
+        );
+        // Attention and recurrence projections are one operation class in
+        // the view and two sites in the census (the census separates "the
+        // model attends" from "the model recurs"); together they must match.
+        assert_eq!(
+            census.attention.widened_f32 + census.delta.widened_f32,
+            bytes(|p| p.operation == Operation::Project(MatrixClass::AttentionProjection)),
+            "{name}: attention + delta"
+        );
+    }
+}
+
+#[test]
+fn a_tied_head_is_two_operations_over_one_operand() {
+    let fixture = planned(
+        |d| dense_f32_model_with(d, HeadStorage::Tied),
+        "tied",
+        "target",
+    );
+    let planned = fixture.plan.planned_operands();
+    let embed = planned
+        .iter()
+        .find(|p| p.operation == Operation::Embed)
+        .unwrap();
+    let head = planned
+        .iter()
+        .find(|p| p.operation == Operation::OutputHead)
+        .unwrap();
+    assert_eq!(
+        embed.operand.object, head.operand.object,
+        "one stored object"
+    );
+    assert_ne!(
+        embed.access, head.access,
+        "two operations, two requirements"
+    );
+    // And the loader binds it twice — the census says so in bytes.
+    let census = PreparedOperands::load(
+        &fixture.plan,
+        &fixture.store,
+        &ReferenceBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap()
+    .residency_census();
+    assert_eq!(census.embedding.widened_f32, census.head.widened_f32);
+    assert_eq!(census.head.widened_f32, head.elements() * F32_WIDTH);
+}
+
+/// The view is computed, never serialised: the plan a container carries and
+/// `vindex3 plan` prints is the same bytes it was before this rung.
+#[test]
+fn the_plan_s_wire_shape_carries_none_of_this() {
+    for (name, fixture) in every_plan() {
+        let json = serde_json::to_string(&fixture.plan).unwrap();
+        for absent in [
+            "\"planned_operands\"",
+            "\"operation\":",
+            "\"required_access\"",
+            "\"extent\":",
+        ] {
+            assert!(
+                !json.contains(absent),
+                "{name}: the wire shape grew a `{absent}` field"
+            );
+        }
+        assert!(!fixture.plan.planned_operands().is_empty(), "{name}");
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/lyrw2.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/lyrw2.rs
@@ -70,6 +70,18 @@ pub fn region_binding(packing: Packing) -> Option<RegionBinding> {
 /// codec whose streams are stored apart then refuses by name. With one,
 /// the two regions are the codes and group-scale streams, and a codec
 /// that declares no scales stream refuses a partner it cannot consume.
+///
+/// A region is the WHOLE of a tensor of `shape`, so its streams must
+/// total exactly what the codec declares for that shape. For a fixed-size
+/// codec the rule is: each stream satisfies its declared minimum, all
+/// stream lengths total the declared representation size, therefore no
+/// stream can contain unclaimed bytes. A region longer than its shape is
+/// a container disagreeing with the declared geometry — a scales operand
+/// pointed at some other tensor — not spare bytes. An instance-sized
+/// codec has no shape-derived size (`stored_bytes` refuses with
+/// `InstanceSized`), so it cannot be bound as a region here at all; its
+/// exact length is the bound container record's, read through the
+/// operand store, never a declaration.
 pub fn bind_region<'a>(
     codec: &dyn RepresentationCodec,
     shape: &[usize],
@@ -93,5 +105,18 @@ pub fn bind_region<'a>(
     };
     let operands = CodecOperands::from_streams(streams);
     codec.validate(&operands, shape, RepresentationExtent::TERMINAL, tensor)?;
+    let have = values.len() + scales.map_or(0, <[u8]>::len);
+    let need = codec.stored_bytes(shape, RepresentationExtent::TERMINAL, tensor)?;
+    if have as u64 != need {
+        return Err(CodecError::Geometry {
+            tensor: tensor.into(),
+            label: codec.encoding_label().into(),
+            shape: shape.to_vec(),
+            why: format!(
+                "its streams total {have} bytes and the shape declares {need}; the container \
+                 and the declared geometry disagree"
+            ),
+        });
+    }
     Ok(operands)
 }

--- a/crates/larql-vindex/tests/external_codec_provider.rs
+++ b/crates/larql-vindex/tests/external_codec_provider.rs
@@ -1,0 +1,403 @@
+//! Rung 3d's extensibility proof at the CODEC plane: a crate that is not
+//! `larql-vindex` registers a representation this build does not ship
+//! and executes a container stored in it — bit-exact to the same bytes
+//! under the shipped label — without editing the planner's or the
+//! executor's selection. An integration test is a separate crate in
+//! cargo's model, so this file sees only what `larql-vindex` exports;
+//! anything the proof had needed from the crate's internals would have
+//! been a leak in the contract, and it needed nothing.
+//!
+//! `F32X` is f32 under another name. Its bytes are the fixture's own f32
+//! image, so the candidate container differs from the control ONLY in
+//! the label of its projection tensors, and every difference in what the
+//! executor does is the registry's doing: the same selection, the same
+//! logits, and — with the provider absent — a refusal by name before any
+//! byte, plus the invalidation of an image prepared while it was present.
+//!
+//! The forecast this answers is `docs/represent/forecasts/rung3-planned-realizations.json`.
+
+use std::ops::Range;
+use std::path::Path;
+
+use larql_vindex::error::VindexError;
+use larql_vindex::format::filenames::INDEX_JSON;
+use larql_vindex::format::vindex3::encode::segment::{
+    read_segment_header, write_segment, PlannedTensor,
+};
+use larql_vindex::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
+use larql_vindex::format::vindex3::index::Vindex3Index;
+use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
+use larql_vindex::format::vindex3::opplan::exec::execute_plan;
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
+use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+use larql_vindex::format::vindex3::opplan::exec::realization::RealizationRecord;
+use larql_vindex::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
+use larql_vindex::format::vindex3::represent::codec::codecs::{
+    bf16_zlib, float, kquant, mxfp4, nvfp4,
+};
+use larql_vindex::format::vindex3::represent::codec::streams::VALUES;
+use larql_vindex::format::vindex3::represent::codec::{
+    Acceleration, AccessGranularity, CodecCapabilities, CodecError, CodecOperands, CodecRegistry,
+    ExtentCertificate, RepresentationCodec, RepresentationExtent, ResidencyProfile, StreamSpec,
+};
+use larql_vindex::format::vindex3::represent::nvfp4_pack::CodecIdentity;
+
+/// The label this crate registers and `larql-vindex` does not.
+const LABEL: &str = "F32X";
+/// The shipped label the same bytes carry in the control container.
+const SHIPPED_LABEL: &str = "F32";
+const F32_WIDTH: usize = std::mem::size_of::<f32>();
+const F32_BITS: f64 = 32.0;
+/// Prompt over the dense fixture's 128-token vocabulary — the rung-2
+/// witness's prompt, so the two proofs read the same execution.
+const TOKENS: [u32; 5] = [3, 17, 28, 0, 11];
+/// The projections the candidate relabels.
+const PROJECTION_SUFFIX: &str = "_proj.weight";
+
+// ── The external provider ────────────────────────────────────────────
+
+/// f32 under a label of its own: one row-major little-endian stream,
+/// element-random access, a direct BLAS realization declared exactly as
+/// the shipped f32 codec declares it.
+struct ExternalF32;
+
+impl ExternalF32 {
+    fn rows_and_k(shape: &[usize], tensor: &str) -> Result<(usize, usize), CodecError> {
+        match shape {
+            [rows, rest @ ..] => Ok((*rows, rest.iter().product::<usize>().max(1))),
+            [] => Err(CodecError::Geometry {
+                tensor: tensor.into(),
+                label: LABEL.into(),
+                shape: shape.to_vec(),
+                why: "a scalar has no rows".into(),
+            }),
+        }
+    }
+}
+
+impl RepresentationCodec for ExternalF32 {
+    fn encoding_label(&self) -> &'static str {
+        LABEL
+    }
+
+    fn identity(&self) -> CodecIdentity {
+        CodecIdentity {
+            family: "external-f32x".into(),
+            revision: 1,
+            group_elems: 1,
+            element: "f32".into(),
+            group_scale: "none".into(),
+            tensor_scale: "none".into(),
+            layout: "row-major-le".into(),
+        }
+    }
+
+    fn streams(&self) -> &'static [StreamSpec] {
+        &[VALUES]
+    }
+
+    fn capabilities(&self) -> CodecCapabilities {
+        CodecCapabilities {
+            access: AccessGranularity::ElementRandom,
+            group_elems: 1,
+            row_align_elems: 1,
+            physical_align_bytes: F32_WIDTH,
+        }
+    }
+
+    fn extents(&self) -> Vec<ExtentCertificate> {
+        vec![ExtentCertificate::terminal(F32_BITS)]
+    }
+
+    fn stored_bytes(
+        &self,
+        shape: &[usize],
+        _: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<u64, CodecError> {
+        let (rows, k) = Self::rows_and_k(shape, tensor)?;
+        Ok((rows * k * F32_WIDTH) as u64)
+    }
+
+    fn validate(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        let need = self.stored_bytes(shape, extent, tensor)? as usize;
+        operands.stream_of_len(VALUES, need, LABEL, tensor)?;
+        Ok(())
+    }
+
+    fn decode_rows(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        rows: Range<usize>,
+        _: RepresentationExtent,
+        dst: &mut [f32],
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        let (_, k) = Self::rows_and_k(shape, tensor)?;
+        let bytes = operands.stream_of_len(VALUES, rows.end * k * F32_WIDTH, LABEL, tensor)?;
+        let region = &bytes[rows.start * k * F32_WIDTH..rows.end * k * F32_WIDTH];
+        if dst.len() != rows.len() * k {
+            return Err(CodecError::Destination {
+                tensor: tensor.into(),
+                need: rows.len() * k,
+                have: dst.len(),
+            });
+        }
+        for (out, chunk) in dst.iter_mut().zip(region.chunks_exact(F32_WIDTH)) {
+            *out = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        }
+        Ok(())
+    }
+
+    fn accelerations(&self) -> Vec<Acceleration> {
+        let stored = ResidencyProfile::stored(F32_BITS);
+        vec![
+            Acceleration::cpu(PhysicalProjectionPlan::BlasF32, stored),
+            Acceleration::cpu(PhysicalProjectionPlan::ScalarF32, stored),
+        ]
+    }
+
+    fn decode_residency(&self) -> ResidencyProfile {
+        ResidencyProfile::DECODED_F32
+    }
+}
+
+/// Every shipped codec plus the external one — what a build that linked
+/// this crate as a provider would register.
+fn registry_with_provider() -> &'static CodecRegistry {
+    let registry = CodecRegistry::new()
+        .register(Box::new(float::BF16))
+        .and_then(|r| r.register(Box::new(float::F16)))
+        .and_then(|r| r.register(Box::new(float::F32)))
+        .and_then(|r| r.register(Box::new(kquant::Q4_K)))
+        .and_then(|r| r.register(Box::new(kquant::Q6_K)))
+        .and_then(|r| r.register(Box::new(kquant::Q8_0)))
+        .and_then(|r| r.register(Box::new(nvfp4::NVFP4)))
+        .and_then(|r| r.register(Box::new(mxfp4::MXFP4)))
+        .and_then(|r| r.register(Box::new(bf16_zlib::BF16_ZLIB)))
+        .and_then(|r| r.register(Box::new(ExternalF32)))
+        .expect("nine shipped labels and one new one");
+    Box::leak(Box::new(registry))
+}
+
+// ── Two containers, one image ────────────────────────────────────────
+
+/// Relabel every tensor `select` names from `F32` to `LABEL`, bytes
+/// untouched: the segment is rewritten so its header, lengths and
+/// checksums are what the container records for the new label.
+fn relabel(root: &Path, select: impl Fn(&str, &[usize]) -> bool) -> Vec<(String, String, usize)> {
+    let index_path = root.join(INDEX_JSON);
+    let mut index: Vindex3Index =
+        serde_json::from_str(&std::fs::read_to_string(&index_path).unwrap()).unwrap();
+    let mut out = Vec::new();
+    for entry in index.representations.values_mut() {
+        let path = root.join(&entry.segment);
+        let (header, payload_start) = read_segment_header(&path).unwrap();
+        if !header.tensors.iter().any(|t| select(&t.name, &t.shape)) {
+            continue;
+        }
+        let file = std::fs::read(&path).unwrap();
+        let payload = &file[payload_start as usize..];
+        let mut planned = Vec::new();
+        let mut bytes_by_name = std::collections::BTreeMap::new();
+        for t in &header.tensors {
+            let stored = payload[t.offset as usize..(t.offset + t.len) as usize].to_vec();
+            let dtype = if select(&t.name, &t.shape) {
+                assert_eq!(t.dtype, SHIPPED_LABEL, "the fixture stores f32");
+                out.push((entry.object.clone(), t.name.clone(), stored.len()));
+                LABEL.to_string()
+            } else {
+                t.dtype.clone()
+            };
+            planned.push(PlannedTensor {
+                relative_name: t.name.clone(),
+                source_name: t.name.clone(),
+                dtype,
+                shape: t.shape.clone(),
+                len: stored.len() as u64,
+            });
+            bytes_by_name.insert(t.name.clone(), stored);
+        }
+        let written = write_segment(&path, &header.representation, planned, |name, w, hash| {
+            let bytes = &bytes_by_name[name];
+            w.write_all(bytes).map_err(VindexError::Io)?;
+            hash(bytes);
+            Ok(bytes.len() as u64)
+        })
+        .unwrap();
+        entry.payload_bytes = written.payload_bytes;
+        entry.payload_sha256 = written.payload_sha256;
+        entry.segment_sha256 = written.segment_sha256;
+        entry.tensor_count = written.tensor_count;
+    }
+    std::fs::write(&index_path, serde_json::to_string_pretty(&index).unwrap()).unwrap();
+    out
+}
+
+fn is_projection(name: &str, shape: &[usize]) -> bool {
+    shape.len() == 2 && name.ends_with(PROJECTION_SUFFIX)
+}
+
+struct Container {
+    _src: tempfile::TempDir,
+    dir: tempfile::TempDir,
+    /// (object, tensor, stored bytes) of every relabelled tensor.
+    relabelled: Vec<(String, String, usize)>,
+}
+
+impl Container {
+    fn build(relabelled: bool) -> Self {
+        let src = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        encode_fixture_container(dense_f32_model, src.path(), dir.path(), "dense");
+        let relabelled = if relabelled {
+            let done = relabel(dir.path(), is_projection);
+            assert!(!done.is_empty(), "the dense fixture has projections");
+            done
+        } else {
+            Vec::new()
+        };
+        Self {
+            _src: src,
+            dir,
+            relabelled,
+        }
+    }
+
+    fn open(&self, registry: &'static CodecRegistry) -> (ComponentOpPlan, OperandStore) {
+        let inspection = inspect_container(self.dir.path(), false).unwrap();
+        let plan = plan_component_ops(&inspection, self.dir.path(), "target")
+            .unwrap()
+            .plan
+            .expect("the dense fixture plans");
+        let store = OperandStore::open(self.dir.path(), &inspection)
+            .unwrap()
+            .with_registry(registry);
+        (plan, store)
+    }
+
+    fn logits_and_hidden(&self, registry: &'static CodecRegistry) -> (Vec<u32>, Vec<u32>) {
+        let (plan, store) = self.open(registry);
+        let trace = execute_plan(&plan, &store, &TOKENS, &ProductionBackend::new()).unwrap();
+        let bits = |v: &[f32]| v.iter().map(|x| x.to_bits()).collect::<Vec<u32>>();
+        (
+            bits(&trace.logits.expect("the dense fixture carries a head")),
+            bits(&trace.final_hidden),
+        )
+    }
+
+    fn prepared(&self, registry: &'static CodecRegistry) -> Result<PreparedOperands, VindexError> {
+        let (plan, store) = self.open(registry);
+        PreparedOperands::load(
+            &plan,
+            &store,
+            &ProductionBackend::new(),
+            ExecutionSlice::Full,
+        )
+    }
+}
+
+/// What the selector decided for one operand — everything in the record
+/// except the representation and its provider, which are the two facts
+/// the relabel changes on purpose.
+fn decision(r: &RealizationRecord) -> (String, String, String, String) {
+    (
+        r.planned.operand.tensor.clone(),
+        format!("{:?}", r.planned.operation),
+        format!("{:?}", r.selection.realization),
+        format!("{:?}", r.selection.reason),
+    )
+}
+
+// ── The proof ────────────────────────────────────────────────────────
+
+/// Registration alone: the candidate executes bit-exact to the control,
+/// and every selection the planner made is the one it made for the
+/// shipped label — only the record's representation and provider differ.
+#[test]
+fn an_external_codec_executes_through_registration_alone_with_the_shipped_selection() {
+    let registry = registry_with_provider();
+    let control = Container::build(false);
+    let candidate = Container::build(true);
+    assert_eq!(
+        control.logits_and_hidden(registry),
+        candidate.logits_and_hidden(registry),
+        "the same bytes under the external label compute the same bits"
+    );
+
+    let shipped = control.prepared(registry).unwrap();
+    let external = candidate.prepared(registry).unwrap();
+    let shipped_decisions: Vec<_> = shipped.realizations().iter().map(decision).collect();
+    let external_decisions: Vec<_> = external.realizations().iter().map(decision).collect();
+    assert_eq!(
+        shipped_decisions, external_decisions,
+        "selection is unchanged"
+    );
+
+    let relabelled: std::collections::BTreeSet<&str> = candidate
+        .relabelled
+        .iter()
+        .map(|(_, t, _)| t.as_str())
+        .collect();
+    let external_records: Vec<_> = external
+        .realizations()
+        .iter()
+        .filter(|r| relabelled.contains(r.planned.operand.tensor.as_str()))
+        .collect();
+    assert_eq!(external_records.len(), candidate.relabelled.len());
+    for r in &external_records {
+        assert_eq!(r.representation, LABEL, "{r:?}");
+        assert_eq!(r.provider.as_ref(), Some(&ExternalF32.identity()), "{r:?}");
+    }
+    // And the bytes really are the shipped image: each relabelled tensor
+    // is stored at exactly f32's width.
+    for (_, tensor, stored) in &candidate.relabelled {
+        let r = external_records
+            .iter()
+            .find(|r| &r.planned.operand.tensor == tensor)
+            .unwrap();
+        assert_eq!(*stored, r.planned.logical_elements * F32_WIDTH, "{tensor}");
+    }
+}
+
+/// Without the provider the same container is refused by name before any
+/// byte is read, and an image prepared while the provider was registered
+/// is invalidated — never executed — once it is gone.
+#[test]
+fn without_the_provider_the_candidate_is_refused_by_name_and_a_prepared_image_is_invalidated() {
+    let candidate = Container::build(true);
+    let Err(err) = candidate.prepared(CodecRegistry::builtin()) else {
+        panic!("the built-in registry does not know the label");
+    };
+    let err = err.to_string();
+    assert!(err.contains("unregistered representation"), "{err}");
+    assert!(err.contains(LABEL), "{err}");
+    assert!(
+        err.contains(SHIPPED_LABEL),
+        "the refusal names the registered ones: {err}"
+    );
+
+    let prepared = candidate.prepared(registry_with_provider()).unwrap();
+    let Err(err) = prepared.ensure_providers_in(CodecRegistry::builtin()) else {
+        panic!("the provider is gone");
+    };
+    let err = err.to_string();
+    assert!(err.contains(&format!("`{LABEL}`")), "{err}");
+    assert!(err.contains("no registered codec"), "{err}");
+    assert!(err.contains("re-prepare"), "{err}");
+    // The control never needed the provider, and is untouched by its loss.
+    Container::build(false)
+        .prepared(CodecRegistry::builtin())
+        .unwrap()
+        .ensure_providers_in(CodecRegistry::builtin())
+        .unwrap();
+}

--- a/docs/represent-codec-contract.md
+++ b/docs/represent-codec-contract.md
@@ -164,3 +164,19 @@ representations with different storage and access semantics.
 "Representation-open" waits on VQ and progressive; pluggable *lowering
 targets* are enabled by the seam but not delivered — rung 3 (planner
 admission, realization trace) is their prerequisite.
+
+## Rung 3 — planned execution realizations: preregistered, not yet built
+
+Frozen before any code in
+[`represent/forecasts/rung3-planned-realizations.json`](represent/forecasts/rung3-planned-realizations.json),
+with the baseline measured at the rung-2 merge: the seam between plan and
+backend is three stored-dtype booleans, selection is a boolean ladder over
+them, the kernel is observed from resident bytes rather than pinned, MXFP4
+banks enter through a `U8` label nobody registered, and realization identity
+is a closed enum. The forecast fixes the contract-level design — a
+hardware-independent `PlannedOperand`, a derived candidate set, one pinned
+`RealizationId` with its reason and resource profile — and predicts the
+transition per wave (3a requirements, 3b admission and selection, 3c trace
+and accounting, 3d privileged paths removed), including the blocker an
+external provider is expected to hit. Execution notes go in a sibling
+`rung3-execution-notes.json`; the forecast is immutable once committed.

--- a/docs/represent-codec-contract.md
+++ b/docs/represent-codec-contract.md
@@ -180,3 +180,70 @@ transition per wave (3a requirements, 3b admission and selection, 3c trace
 and accounting, 3d privileged paths removed), including the blocker an
 external provider is expected to hit. Execution notes go in a sibling
 `rung3-execution-notes.json`; the forecast is immutable once committed.
+
+### Rung 3 — built and held, with the falsifier that fired
+
+All four waves ran on branch `represent-rung3`; the execution record, wave by
+wave with every finding the forecast did not contain, is
+[`represent/forecasts/rung3-execution-notes.json`](represent/forecasts/rung3-execution-notes.json).
+What the rung leaves behind:
+
+- **A plan is a set of hardware-independent planned operands** (`PlannedOperand`:
+  operation, required access, logical extent, logical elements, and — since 3d —
+  the codec the plan *declares* when a container's label is a carrier dialect
+  rather than a codec). Nothing in it names a dtype or a kernel.
+- **Admission and selection happen at preparation, before any byte.** The
+  backend derives a candidate set from the codec's declarations, pins one
+  `RealizationId` with its reason, or refuses with every reason. The three
+  stored-dtype booleans, the `U8` bank dialect and every dtype-name judgement
+  under `exec/` are gone; `ExpertFormat` keys exactly one thing, the declared
+  codec of a packed bank.
+- **The declaration is bound against the census, not into it.** An expectation
+  is priced from the pin, the codec's declared residency and the container's
+  recorded length; an observation is read off the bound objects; the two are
+  reconciled, and a mutated declaration breaks the reconciliation of exactly
+  the forms it prices.
+- **The registry is a value, not a default.** The store carries the registry it
+  decodes through, the prepared image records the one it was prepared through,
+  and execution checks its providers against that one. This is the
+  falsifier that fired (F8): the first run of the provider proof was refused at
+  *execution* by three hidden built-in registries that registration could not
+  reach, after selection had already succeeded.
+- **The acceptance test is external.**
+  [`crates/larql-vindex/tests/external_codec_provider.rs`](../crates/larql-vindex/tests/external_codec_provider.rs)
+  is an integration test — a separate crate in cargo's model — that registers a
+  representation this build does not ship and executes a container stored in
+  it: the same selection as the shipped label, bit-exact logits, refusal by name
+  without the provider, invalidation of an image that loses it. It touches only
+  exported API.
+
+**The claim rung 3 earns:** LARQL can accept a representation implementation
+through exported API, carry its registry through preparation and execution,
+select and account for it before I/O, execute it bit-exactly, and invalidate
+prepared state when that provider disappears, without privileged dtype control
+flow.
+
+Two wording boundaries stay explicit:
+
+- The integration test proves *external-crate compatibility*, because Rust
+  integration tests compile as separate crates against exported API. It does
+  not claim runtime discovery or distributed package loading; a plugin here
+  is an external crate linked at compile time.
+- "Stored label wins" makes the **stored representation authoritative**. The
+  expert-format declaration is a legacy default consulted only for a carrier
+  dialect whose label names no codec. They are one rule with a fallback, not
+  two competing semantic truths.
+
+The region exactness rule is correct for fixed-size codecs — each stream
+satisfies its declared minimum, all stream lengths total the declared
+representation size, so no stream can contain unclaimed bytes — and an
+instance-sized codec keeps taking its exact length from the bound container
+record, never from a shape-derived declaration.
+
+What it does not claim: a CPU shared-expert realization (the hard refusal is
+preserved; the missing realizations are inventoried), a provider that brings
+its own *kernel* (the kernel-plane blocker was measured at five closed enums
+across 33 files and is measured debt, not the next task), or any
+performance. The architecture phase has turned K3 failures from
+format-specific surprises into named missing realizations with physical
+costs; the next work binds a real K3 plan through this machinery.

--- a/docs/represent/forecasts/rung3-execution-notes.json
+++ b/docs/represent/forecasts/rung3-execution-notes.json
@@ -1,0 +1,37 @@
+{
+ "programme": "represent-codec-contract",
+ "rung": 3,
+ "forecast": "rung3-planned-realizations.json (frozen at 5007bb77; not edited)",
+ "waves": {
+  "3a_requirements": {
+   "executed": "2026-09-05",
+   "result": "HELD. `ComponentOpPlan::planned_operands()` (opplan/planned.rs) is a derived, hardware-independent view: one `PlannedOperand { operand, operation, access, extent, logical_elements }` per matrix operand per operation, with `Operation ∈ { Embed, Project(MatrixClass), ExpertBankSlice, OutputHead }`. Embed and ExpertBankSlice require RowRandom; Project and OutputHead require Sequential; every extent is TERMINAL. Nothing under exec/ outside tests/ changed; the plan's wire shape is unchanged.",
+   "witnesses": [
+    "bytes-level cross-check: over the Glimmer target (softmax + output gate), the LLLF hybrid (gated delta), the OuteAI miniature (Mamba2 + conv-QKV) and the Kimi miniature (KDA + MLA), the reference loader's census holds exactly four bytes per planned element at the embedding, head and FFN sites, and at attention + delta together; compact is zero — so nothing the loader binds is missing from the view and nothing in the view is a matrix the loader does not bind (opplan/tests/planned.rs)",
+    "per-variant counts pinned against the plan's own structure and the loader's rule for the output gate (a gate fused into the query projection has no operand)",
+    "a tied head is two operations over one operand, and the loader binds it twice — the residency census, which is a BINDING census (execution touch per operation), says so in bytes. The stored physical footprint is a different instrument and counts the shared object once.",
+    "the wire shape carries none of it: the serialised plan has no planned_operands / operation / required_access / extent field",
+    "routed miniature: a packed bank is two RowRandom expert-bank slices per routed layer (never the router or a bias); the production loader's FFN census equals the view's logical bytes; a per-expert bank is a set of Sequential whole projections (exec/tests/coverage_experts_production/planned_bank.rs)"
+   ],
+   "falsifiers_scored": {
+    "F1_behaviour_delta": "NO by construction — no non-test file under exec/ changed; the wire-shape guard passes on every fixture; full-suite and coverage results below",
+    "touch_set_vs_forecast": "the forecast named opplan/mod.rs (+types, +method) and opplan/tests (+1 file). Actual: opplan/planned.rs (a new module — one file per concern, not a larger mod.rs), opplan/mod.rs (+1 mod line), opplan/tests/planned.rs, AND three test-side files under exec/tests/coverage_experts_production/ (planned_bank.rs new; fixture.rs keeps the plan it already built; the mod file +1 line) because the only packed-bank fixture is scoped there. Zero non-test exec changes, as forecast."
+   },
+   "findings_not_in_the_forecast": [
+    {
+     "id": "3a-N1",
+     "finding": "A packed bank's OperandRef shape is the STORED tensor's shape, not the logical matrices: for MXFP4 blocks it is [experts, rows, k/32, 16] (build.rs packed_shape), so its product is half the weight count. The first bytes-level bank check failed at exactly 2× (census 98304 vs view 49152).",
+     "resolution": "PlannedOperand carries `logical_elements`, sized for a packed bank from the op's declared geometry — experts × (FUSED_HALVES × intermediate) × hidden for gate/up, experts × hidden × intermediate for down, hidden from the router's width — the same three facts load_packed is handed. Every other operand's count is its shape.",
+     "for_3b": "the logical extent of an operand is an op-level fact for banks; RepresentationFacts must not derive element counts from OperandRef.shape for them."
+    },
+    {
+     "id": "3a-N2",
+     "finding": "The CPU loader never binds a routed op's SHARED expert: `.shared` is read only by stack_metal.rs (the Metal stack binds it) and kimi_source.rs (which sets it). On the CPU path a plan with a shared expert prepares and runs without it.",
+     "resolution": "The view lists the shared expert's gate/up/down as Project(FfnProjection), because the PLAN executes them; the routed test pins the gap in bytes (view exceeds the CPU binding census by exactly the shared expert) so a CPU loader that binds it changes that assertion deliberately.",
+     "for_3b_3d": "PROMOTED TO A HARD 3b INVARIANT (user, on review of 3a): a planned shared-expert projection with no CPU binding/realization is an explicit MissingRealization refusal at preparation — 3b must not admit such a plan, and a provider claiming generic projection support is insufficient unless preparation can bind the actual shared-expert operand. Until 3d supplies a correct CPU realization the CPU path is semantically incomplete for models with shared experts. Consequence for the record: previous CPU-path measurements of affected Qwen-MoE, Kimi and DeepSeek paths are measurements of a REDUCED computation, not full-model execution — preserved, labelled as such, and not used as parity or final performance evidence."
+    }
+   ],
+   "gates": {"full_crate": "cargo test -p larql-vindex: 4160 lib tests passed, 0 failed, 7 ignored (pre-existing); every integration binary green", "workspace_check": "cargo check --workspace --all-targets: green", "clippy": "clean on rustc 1.98, --all-targets -D warnings", "fmt": "clean, run last", "coverage": "policy passed, total 93.78% over 427 files; opplan/planned.rs 94.44% (119/126), no debt entry", "docs": "check_doc_links.py + check_doc_references.py --strict: green"}
+  }
+ }
+}

--- a/docs/represent/forecasts/rung3-execution-notes.json
+++ b/docs/represent/forecasts/rung3-execution-notes.json
@@ -141,6 +141,93 @@
     "coverage": "policy passed on the final tree: 93.77% total over 429 files; accounting.rs 94.14%, realization.rs 99.16%, prepared.rs 90.69% (back above the floor after the pairing and provider witnesses were added — it had slipped to 89.23% on a debt baseline), weights/staged.rs 91.67%; no debt entry added; the instrumented test phase ran clean with its log kept",
     "docs": "check_doc_links.py + check_doc_references.py --strict: green"
    }
+  },
+  "3d_remove_privileged_paths": {
+   "executed": "2026-09-05",
+   "wording": "Split the inventory by consequence (user): shared expert = correctness gap, implement a CPU realization or preserve the hard refusal; MXFP4 dialect = architectural gap, remove its label/boolean bypass and admit it through registry semantics; external provider = extensibility proof, a separate crate adds a provider without changing planner or executor selection; aliased object = optimisation gap, shared materialization first, projection CSE only with semantic proof, and it must not delay the first three.",
+   "result": "HELD, with one falsifier fired and recorded (F8). (1) Shared expert: the hard refusal is PRESERVED, not replaced — every real shared-expert model (Kimi, DeepSeek, Qwen-MoE) plans `ExpertBank::PerExpert` banks, which the CPU loader refuses before the shared projection is reached, so a CPU shared-expert realization has no executable container to be qualified on yet; the inventory names two missing CPU realizations, the per-expert bank binding and the shared-expert projection (the Metal stack binds both). (2) MXFP4: the packed bank's planned operand DECLARES its codec (`PlannedOperand.declared_representation`, from `ExpertFormat` through one function); the selector and the loader resolve the bank's facts through one rule, `RepresentationFacts::resolve_declared` — the container's label wins whenever it names a codec, the declaration answers only when the label names none — and the loader binds the whole bank ONCE as the codec's named streams over `[experts × rows, k]` through `lyrw2::bind_region`, decodes each expert as a row range through `decode_rows`, and keeps the device's native MXFP4 slab as a copy of the bound streams. `DTYPE_U8`, `DTYPE_BF16`, `expect_dtype`, `expect_len` and `require_row_access` are deleted; the k-alignment refusal reads the codec's `row_align_elems`; the routed parity oracles did not move (the codec's `decode_rows` IS `dequantize_expert`). The prepared image's record for a bank names `MXFP4` with the MXFP4 identity, and a registry without MXFP4 invalidates it. (3) External provider: PROVED at the codec plane by `crates/larql-vindex/tests/external_codec_provider.rs` — an integration test, a separate crate in cargo's model that sees only exported API — which registers `F32X` (f32 under another label, declaring the shipped `BlasF32`/`ScalarF32` plans) into a scratch registry, relabels the dense fixture's projections in place, and executes: bit-exact logits and hidden state against the control, every selection identical to the shipped label's (only the record's representation and provider differ), refusal by name before any byte without the provider, and invalidation of an image prepared with it. The forecast's kernel-plane blocker was MEASURED, not opened (see 3d-N3). (4) Aliased object: noted, not built.",
+   "surfaces": [
+    "`PlannedOperand.declared_representation: Option<&'static str>` and `planned::declared_bank_representation(ExpertFormat)` — the plan's declaration of a packed bank's codec (PackedMxfp4 → MXFP4, PackedBF16 → BF16, PerExpert → none)",
+    "`RepresentationFacts::resolve_declared(registry, stored, declared)` — the one rule the selector and the bank loader share; `RepresentationFacts::resolve` (built-in registry) is now test-only",
+    "`OperandStore::with_registry` / `registry()`, `OperandSource::registry()` — the store carries the registry it decodes through; `OperandStore::load` resolves through it, never through the built-in registry",
+    "`PreparedOperands::registry()` — the image carries the registry it was prepared through; `select_realizations(plan, store, backend, slice)` reads the store's; `execute_prepared_streaming` and `DecodeSession::assemble` check providers against `ops.registry()`; `load_in` is gone",
+    "`experts::load_packed` — bank bound once through `lyrw2::bind_region` over `[experts × rows, k]`, experts decoded as row ranges through the codec, `from_f32` unchanged; `experts::bank_facts` resolves the bank the way the selector did; the selector's bank arm refuses an unregistered label as `UnregisteredRepresentation` like every other operation",
+    "`lyrw2::bind_region` — a region's streams must total exactly `stored_bytes(shape)` (3d-N1)",
+    "`tests/external_codec_provider.rs` (integration) — the acceptance test; `planned_bank::a_packed_bank_s_provider_is_the_declared_codec_and_its_loss_invalidates` replaces the 3c dialect test; the routed refusal witnesses now assert the codec's own terms"
+   ],
+   "forecast_scored": {
+    "P1 DTYPE_U8 leaves experts.rs; bank binds through the MXFP4 codec's two named streams; parity bit-exact": "HELD. The bank binds as one region of `experts × rows` rows rather than expert by expert — one validation, one exactness check, per-expert row ranges.",
+    "P2 KQuantExecution a selector preference; stored_kquant gone; Direct(FusedKQuant) iff declared": "HELD in 3b (recorded there); nothing remained for 3d.",
+    "P3 the predicted blocker (RealizationId closed over PhysicalProjectionPlan; four named files)": "The proof passed WITHOUT opening the enum — the forecast's own 'surprise to record' branch — because it was run at the CODEC plane: a representation provider declaring a SHIPPED plan needs no new kernel identity. The KERNEL-plane blocker stands and was measured, not estimated: see 3d-N3.",
+    "P4 zero edits under exec/ other than registration": "FALSIFIED in letter (F8 fired), see 3d-N2: the executor held three hidden built-in registries that registration could not reach. After they became values carried by the store and the image, the provider needed zero edits, and the acceptance test proves it from outside the crate."
+   },
+   "falsifiers": {
+    "F7 DTYPE_U8 or ExpertFormat-keyed dtype expectations survive": "not fired — both constants and both expect_* helpers are deleted; `ExpertFormat` keys one thing, the DECLARED CODEC of a packed bank, and no dtype name is judged anywhere under exec/",
+    "F8 the provider needs an exec/ edit beyond registration": "FIRED — three `CodecRegistry::builtin()` defaults under exec/ (store decode, selector, execution-time provider check ×2) were edited into explicit registries; recorded as 3d-N2 rather than smoothed over",
+    "F9 a parity oracle moves": "not fired — routed and dense oracles green, external provider bit-exact",
+    "F10 a new file lands under 90% line coverage": "not fired — no new source file; the new file is an integration test outside the policy's scope, and every touched source file above the floor except exec/mod.rs on its pre-existing baseline"
+   },
+   "findings_not_in_the_forecast": [
+    {
+     "id": "3d-N1",
+     "finding": "The contract validates a LOWER BOUND, never an exact length: `validate` proves each stream at least as long as the shape implies (`stream_of_len`), so binding the bank through the codec ACCEPTED a scales operand pointed at the f32 bias (1024 bytes where 256 were needed) that the old loader's exact `expect_len` refused — the routed coverage test caught it on the first codec-driven run. Fixed in `lyrw2::bind_region`, the storage-arrangement helper: a region is the whole of a tensor of `shape`, so its streams must total exactly `stored_bytes(shape)`; with each stream already at least its minimum and the minima summing to the total, every stream is exact. Recorded as a contract finding — a codec validates what it can decode from, a REGION is exact — and left at the helper rather than widened into the trait."
+    },
+    {
+     "id": "3d-N2",
+     "finding": "'Executable through registration alone' held at selection and FAILED at execution on the first run of the provider proof: the image prepared through the scratch registry was refused as 'prepared against external-f32x r1 and the registry now offers no registered codec', because `execute_prepared_streaming` and `DecodeSession::assemble` checked providers against `CodecRegistry::builtin()`, and `OperandStore::load` decoded through it too — three hidden registries no registration could reach. The negative arm (refusal without the provider) had passed, which is exactly the false-green shape a positive arm exists to catch. The registry is now a value: the store carries it, the selector reads the store's, the image records the one it was prepared through, and execution checks against the image's own. With immutable `&'static` registries that execution-time check is a consistency assertion; the meaningful invalidation is the explicit `ensure_providers_in(other)` a caller runs when it switches registries, which the proof exercises."
+    },
+    {
+     "id": "3d-N3",
+     "finding": "The kernel-plane blocker, measured: a provider that brings its OWN plan (not a shipped `PhysicalProjectionPlan`) meets five closed enums — `PhysicalProjectionPlan`, `WeightFormat`, `WeightSlice`, `WeightRows`, `LoadedWeight` — matched exhaustively across the non-test files counted at the end of this wave (see `kernel_plane_blocker`), more than the forecast's four named files. Not opened here: the plugin-planes staging puts it in the ExecutionTargetRegistry stage, and 3d's remit ended at removing privileged paths and proving the codec plane."
+    },
+    {
+     "id": "3d-N4",
+     "finding": "The stored-label-versus-declaration rule has an edge the test pins: a registered codec that CLAIMS the carrier label (`U8`) would claim the bank, because the bytes' own label wins whenever it names a codec. The prepared image's record is immune — it names MXFP4 with MXFP4's identity — so `ensure_providers_in` on a registry that adds a `U8` claimant changes nothing."
+    },
+    {
+     "id": "3d-N5",
+     "finding": "The refusal witnesses changed WHICH refusal fires, not whether: a bank declared BF16 whose op still carries a scales operand is refused as `UnexpectedStream` (BF16 declares no `group_scales`) before any length check; a packed bank declared `PerExpert` is refused as undecodable (its carrier label names no codec and the plan declares none) where it was refused as 'not a packed projection'; an unaligned `k` cites the codec's declared row alignment. None of these read a dtype name."
+    },
+    {
+     "id": "3d-N6",
+     "finding": "Shared expert, inventoried not built: the CPU loader refuses `ExpertBank::PerExpert` before it could reach a shared projection, and every real shared-expert model plans per-expert banks, so the two missing CPU realizations are the per-expert bank binding and the shared-expert projection; the 3b refusal (`MissingRealization`, before any byte) stands and its witness is unchanged."
+    },
+    {
+     "id": "3d-N7",
+     "finding": "Aliased object, noted only: the Gemma-4 miniature binds one tensor as two projections in one layer and ties the head to the embedding; both load twice today. Shared materialization (one bound object, two operation instances) is the safe first step; projection CSE needs a semantic proof that the two operations consume identical inputs, which the plan does not yet carry."
+    }
+   ],
+   "gates": {
+    "run": "2026-09-05, worktree .claude/worktrees/represent-rung3, toolchain 1.98.0 (rust-toolchain.toml)",
+    "cargo test -p larql-vindex": "4500 passed, 0 failed, 7 ignored (lib 4193 + integration tests incl. external_codec_provider 2/2)",
+    "cargo clippy --workspace --all-targets -D warnings": "clean (only the pre-existing future-incompat note on the external `block` crate)",
+    "cargo check --workspace --all-targets --target x86_64-apple-darwin": "clean",
+    "cargo llvm-cov -p larql-vindex + scripts/check_coverage_policy.py": "passed: total 93.77% lines, 429 files checked, 368 at the 90% default, 61 debt baselines; touched files — realization.rs 98.80, planned.rs 98.77, lyrw2.rs 100.00, decode.rs 94.64, experts.rs 91.76, operands.rs 91.74, prepared.rs 90.58; exec/mod.rs 87.31 on its pre-existing debt baseline (the change there is one call and one comment)",
+    "scripts/check_doc_links.py / check_doc_references.py --strict": "855 links resolve; no broken references",
+    "cargo fmt --all -- --check": "clean, run last",
+    "grep gate (non-test exec/)": "no DTYPE_U8, no expect_dtype, no stored_* boolean, no load_in; CodecRegistry::builtin() remains only as the store's documented constructor default and inside the #[cfg(test)] RepresentationFacts::resolve"
+   },
+   "kernel_plane_blocker": {
+    "measured": "2026-09-05, non-test files under opplan/exec/ and represent/ naming a variant of each closed enum",
+    "PhysicalProjectionPlan": 11,
+    "WeightFormat": 11,
+    "WeightSlice": 6,
+    "WeightRows": 13,
+    "LoadedWeight": 7,
+    "files_naming_at_least_one": 33,
+    "exhaustive_matches_over_PhysicalProjectionPlan_by_qualified_path": [
+     "exec/cpu/cost.rs",
+     "exec/cpu/ledger.rs"
+    ],
+    "reading": "The forecast's 'four named files' (ledger, cost, arithmetic, physical) is the set that matches the plan exhaustively; the surface a provider-supplied plan must thread through — the weight-format, slice, rows and loaded-weight enums it would also need a variant in — is 33 files. Opening one enum is not the work; the work is that a kernel identity is five enums wide."
+   },
+   "claim_earned": "LARQL can accept a representation implementation through exported API, carry its registry through preparation and execution, select and account for it before I/O, execute it bit-exactly, and invalidate prepared state when that provider disappears — without privileged dtype control flow. (User's wording, 2026-09-05.)",
+   "wording_boundaries": [
+    "The integration test proves external-crate compatibility (Rust integration tests compile as separate crates against exported API). It does not claim runtime discovery or distributed package loading.",
+    "'Stored label wins' makes the stored representation AUTHORITATIVE; the expert-format declaration is a legacy default consulted only when the stored label names no codec. One rule with a fallback, not two competing semantic truths.",
+    "Region exactness (each stream ≥ its declared minimum, all streams total the declared size, hence no unclaimed bytes) is a rule for FIXED-SIZE codecs; an instance-sized codec takes its exact length from the bound container record, never a shape-derived declaration, and cannot be bound as a region."
+   ],
+   "after_merge": "Stop codec/plugin architecture work. The five closed kernel enums across 33 files are measured debt. Next programme: residency into K3 — bind a real K3 plan through this selection/accounting machinery, let it name every missing realization before bytes are touched, resolve the per-expert-bank/shared-expert CPU refusal as a concrete execution requirement, price direct/decoded/packed-bank paths from observed residency, one-layer → miniature → full K3 parity, feed real costs back into REPRESENT."
   }
  }
 }

--- a/docs/represent/forecasts/rung3-execution-notes.json
+++ b/docs/represent/forecasts/rung3-execution-notes.json
@@ -31,7 +31,69 @@
      "for_3b_3d": "PROMOTED TO A HARD 3b INVARIANT (user, on review of 3a): a planned shared-expert projection with no CPU binding/realization is an explicit MissingRealization refusal at preparation — 3b must not admit such a plan, and a provider claiming generic projection support is insufficient unless preparation can bind the actual shared-expert operand. Until 3d supplies a correct CPU realization the CPU path is semantically incomplete for models with shared experts. Consequence for the record: previous CPU-path measurements of affected Qwen-MoE, Kimi and DeepSeek paths are measurements of a REDUCED computation, not full-model execution — preserved, labelled as such, and not used as parity or final performance evidence."
     }
    ],
-   "gates": {"full_crate": "cargo test -p larql-vindex: 4160 lib tests passed, 0 failed, 7 ignored (pre-existing); every integration binary green", "workspace_check": "cargo check --workspace --all-targets: green", "clippy": "clean on rustc 1.98, --all-targets -D warnings", "fmt": "clean, run last", "coverage": "policy passed, total 93.78% over 427 files; opplan/planned.rs 94.44% (119/126), no debt entry", "docs": "check_doc_links.py + check_doc_references.py --strict: green"}
+   "gates": {
+    "full_crate": "cargo test -p larql-vindex: 4160 lib tests passed, 0 failed, 7 ignored (pre-existing); every integration binary green",
+    "workspace_check": "cargo check --workspace --all-targets: green",
+    "clippy": "clean on rustc 1.98, --all-targets -D warnings",
+    "fmt": "clean, run last",
+    "coverage": "policy passed, total 93.78% over 427 files; opplan/planned.rs 94.44% (119/126), no debt entry",
+    "docs": "check_doc_links.py + check_doc_references.py --strict: green"
+   }
+  },
+  "3b_admission_and_selection": {
+   "executed": "2026-09-05",
+   "result": "HELD, with one refinement to the view. `exec/realization.rs` is the vocabulary: `RepresentationFacts` (resolved from the registry per operand, plus an `overlaid` fact for overlay edits), `RealizationId { backend, form }` with forms Direct / Decode / Requantise / SliceStored / DecodedGather / DeviceResident, `Selection { realization, residency (declared), reason, candidates }`, `SelectionRefusal { operand, operation, representation, requested, kind, considered }`, `RealizationRecord`. `PlanBackend::weight_format(MatrixOperand)` is gone; `PlanBackend::select(&PlannedOperand, &RepresentationFacts)` replaces it, defaulting to the reference oracle. `PreparedOperands::load` selects EVERY planned operand of the slice before reading any byte (`select_realizations`), collects every refusal, pins one realization per operand in `realizations()`, hands the loaders the pinned format through a fallible resolver, and verifies after loading that every resident matrix holds its pinned representation (`verify_pins`, a per-site multiset over formats).",
+   "the_three_booleans": "DELETED, not wrapped: `MatrixOperand { stored_bf16, stored_nvfp4, stored_kquant }` and `OperandSource::is_stored_bf16 / is_stored_nvfp4 / is_stored_kquant` no longer exist; grep for `stored_bf16|stored_nvfp4|stored_kquant|is_stored_|MatrixOperand|declared_format|fn weight_format` under exec/ outside tests returns nothing. The only per-operand physical fact left beside the registry's declarations is `is_overridden` (an overlay edit), which is not a dtype.",
+   "the_selector_is_the_old_policy_over_a_derived_set": "`production::select_cpu` derives candidates from `facts.accelerations()` (Direct), the universal decode (Decode(BlasF32)), and the executor's own re-quantised forms offered only when the codec declares the direct bf16 kernel (Requantise), then orders them with the old ladder: NVFP4 pack first, K-quant by the process arm, then `choose_for` over the float source. An oracle test copies the pre-rung-3 boolean ladder verbatim and compares the selected resident format for every label × class × size × arm (108 cases): identical.",
+   "invariants_witnessed": [
+    "refusal before bytes: an unregistered label is refused at preparation naming every refused operand with load_count unchanged (the rung-2 test moved from the load to the preparation and asserts both layers); a BF16_ZLIB packed bank is refused by access class through the same admission the bank loader still applies",
+    "direct and decode are distinct realizations: a stored Q6_K under the two arms pins Direct(FusedKQuant) vs Decode(BlasF32) with different declared residencies over one candidate set",
+    "the executor cannot silently change the pin: `verify_pins` runs at the end of every preparation, and a tampered record is refused naming both sides",
+    "the shared expert is refused: `Operation::SharedExpertProject` (new in the view) has no realization on any PlanBackend, so a plan whose routed op carries a shared expert the container holds is refused at preparation with `missing realization`, before any byte — the hard invariant from the 3a review",
+    "the reference backend pins Decode(ScalarF32) for every projection with a single-candidate set — the oracle stays the oracle",
+    "the entropy-coded container pins Decode(BlasF32) with reason `no direct realization registered` and a one-element candidate set; its declared residency is DECODED_F32",
+    "an overlay edit pins decode with its own reason (`OverlaidEdit`): facts carry `overlaid`, which empties the direct candidates — the overlay tests are unchanged and green",
+    "the device backend's class table is its own single candidate (`DeviceResident(format)`, reason `device class table`); the NVFP4 device coverage test now asks it through select"
+   ],
+   "refinements_to_the_3a_view": [
+    "`Operation::SharedExpertProject` replaces `Project(FfnProjection)` for a shared expert's three projections, so the missing realization is refusable by name rather than by tensor-name inspection; the 3a bank test that pinned the CPU census as short by the shared expert is replaced by the refusal test",
+    "`PlannedOperand.layer: Option<usize>` — the prepared plan selects only the operands its slice loads, and pins banks per layer"
+   ],
+   "falsifiers_scored": {
+    "F2_label_or_boolean_survives": "NO — see the grep gate above",
+    "F3_selection_changed_without_a_reason": "NO — the 108-case oracle comparison is exact; the full suite (below) is green, every parity oracle included",
+    "F4_pin_mismatch_executes": "NO — verify_pins at preparation; the tampered pin is refused",
+    "F5_contract_change_needed": "NO — `git diff c52497a7 -- represent/codec/` is empty; the rung-1/2 declarations were sufficient",
+    "F9_parity_oracle_moved": "NO — 4168 lib tests green on the final tree, every parity oracle included",
+    "touch_set_vs_forecast": "as forecast, plus: `exec/realization.rs` (new module — the vocabulary lives in one file rather than in backend.rs), `weights/mod.rs` gains `LoadedWeight::format()` for the pin check, `experts.rs` gains `dense_matrices()` for it and its bank preflight now calls the facts' `admit_row_slicing` (one derivation, two call sites), and every `FormatFor` resolver is fallible so a loader asking for an operand the view does not list is refused rather than defaulted (five per-variant loaders, the attention loader, the dense FFN loader and five test closures changed mechanically). opplan/planned.rs changed for the two refinements above. Tests moved off the old API: cpu/tests/kquant_plan.rs, tests/coverage_device.rs.",
+    "F10_new_file_under_floor": "NO after the vocabulary and device-selector tests were added — the first coverage run had realization.rs at 74.90% and device.rs at 89.57%; both are above the floor on the final tree"
+   },
+   "findings_not_in_the_forecast": [
+    {
+     "id": "3b-N1",
+     "finding": "The forecast's W3 said the bank's admission (rung 2's `require_row_access`) would be 'folded into the SliceStored candidate'. It is — the selector calls `RepresentationFacts::admit_row_slicing` — but the bank loader keeps calling the same function, because `FfnOperands::load` is reachable directly (three tests do) and a direct caller must get the same refusal rather than a read followed by a dtype-name refusal. One derivation, two call sites, recorded rather than pretended away."
+    },
+    {
+     "id": "3b-N2",
+     "finding": "`resident_profile(WeightFormat)` prices the executor's re-quantised and device forms from its own block constants (Q8: 1 + 4/Q8_BLOCK bytes per weight; Q4: 0.5 + 4/Q4_BLOCK; F16: 2, requantised; KQuant: the widest of the three codecs). These are DECLARATIONS made by the executor about its own resident forms and are not yet checked against what the loader holds; 3c binds them into the census and will find out where they are wrong."
+    },
+    {
+     "id": "3b-N3",
+     "finding": "Absent operands (partial hydration) are skipped by the selector and refused by the loader by name exactly as before; a resolver asked for such an operand answers the widened form, which the loader never reads because `load_raw` refuses first. Recorded so nobody reads that answer as a selection."
+    }
+   ],
+   "gates": {
+    "affected_suites": "opplan: 636 tests green (the one failure was the rung-2 refusal test, moved); realization + planned + bf16_zlib: 19 green",
+    "full_crate": "cargo test -p larql-vindex on the final tree: 4168 lib tests passed, 0 failed, 7 ignored (pre-existing); every integration binary green",
+    "workspace_check": "cargo check --workspace --all-targets: green (the trait method change reaches every backend and every crate that names one)",
+    "clippy": "clean on rustc 1.98, --all-targets -D warnings (the refusal type is boxed to satisfy result_large_err)",
+    "fmt": "clean, run last",
+    "coverage": "policy passed on the final tree: 93.79% total over 428 files; realization.rs 99.22%, device.rs 91.91%, prepared.rs 93.56%, production.rs 91.35%, planned.rs 98.61%; no debt entry added. The first coverage attempt's instrumented test phase reported one failure whose name my output filter dropped; it did not recur in three subsequent full runs (two instrumented, one plain), so it is recorded as an unnamed flake, not as a pass.",
+    "docs": "check_doc_links.py + check_doc_references.py --strict: green",
+    "grep": "stored_bf16|stored_nvfp4|stored_kquant|is_stored_*|MatrixOperand|declared_format|fn weight_format under exec/ outside tests: none; the size policy's parameter was renamed to bf16_kernel_declared, which is what the selector now feeds it"
+   },
+   "the_oracle_is_transitional": "The copied boolean ladder in exec/tests/realization.rs is a migration oracle, not the new semantic authority (user, on review). Once 3c establishes independent accounting and 3d real provider inventories, new behaviour may diverge from it deliberately; the test is then narrowed or retired rather than preserving old mistakes.",
+   "what_this_closes": "The silent-fallback problem, structurally: all operands selected → all refusals collected → no bytes read unless the complete plan is admissible → exact realization pinned → loaded state verified against the pin. The shared-expert refusal is the operational consequence: LARQL refuses an incomplete CPU computation instead of producing plausible but semantically invalid output."
   }
  }
 }

--- a/docs/represent/forecasts/rung3-execution-notes.json
+++ b/docs/represent/forecasts/rung3-execution-notes.json
@@ -94,6 +94,53 @@
    },
    "the_oracle_is_transitional": "The copied boolean ladder in exec/tests/realization.rs is a migration oracle, not the new semantic authority (user, on review). Once 3c establishes independent accounting and 3d real provider inventories, new behaviour may diverge from it deliberately; the test is then narrowed or retired rather than preserving old mistakes.",
    "what_this_closes": "The silent-fallback problem, structurally: all operands selected → all refusals collected → no bytes read unless the complete plan is admissible → exact realization pinned → loaded state verified against the pin. The shared-expert refusal is the operational consequence: LARQL refuses an incomplete CPU computation instead of producing plausible but semantically invalid output."
+  },
+  "3c_trace_and_accounting": {
+   "executed": "2026-09-05",
+   "wording": "Bind the realization declaration AGAINST the census, not INTO it (user). `exec/accounting.rs` keeps two instruments apart: an Expectation is priced from the pin, the codec's declared residency, the executor's own block geometry and the container's RECORDED operand length, and reads no loaded object; an Observed is read off the objects the loader bound, paired operand-by-operand by each loader naming its own fields. `reconcile` holds one against the other. The residency census is a third reading and is checked against the observed sum.",
+   "result": "HELD. Every decisive test the review named is in place and green: same Q6_K pack → one stored footprint (the recorded length) under direct and decode, with different resident/staging/working-set accounting, each reconciled against the object the loader binds; the entropy-coded container's stored bytes are the recorded instance length (≠ 2 × logical elements) and its staging is the f32 image over `logical_elements`; every pin of a prepared dense plan reconciles with exactly one resident object and the census equals the observed sum; a mutated block geometry breaks the reconciliation of exactly the forms it prices (Q8, Q4) and none of the others; a tied head counts once in the stored footprint and once per operation in the execution touch; the selection summary is presentation over structured records (one line per representation × realization × reason, nothing added); a provider that disappears from the registry invalidates the preparation (`ensure_providers_in`, checked at the streaming executor and at session assembly) and preparing against it refuses outright; planned operands × pins × bound objects × ledger correspond exactly — in POSITIONS.",
+   "surfaces": [
+    "`PreparedOperands::bound(plan)`, `expectations(store, geometry)`, `reconcile(plan, store)`, `providers()`, `ensure_providers_in(registry)`, `load_in(.., registry)`; `select_realizations` takes the registry; `RealizationRecord.provider` carries the identity the label resolved to",
+    "`LoadedWeight::padded_allocations()` — the reconciliation is exact for vector-backed forms and tolerates less than one page per page-aligned allocation, never less than declared",
+    "`OperandStore::stored_len` / `OperandSource::stored_len` — the container's recorded length, tensor-table metadata, no payload read",
+    "`DecodeSession::realizations()`; `vindex3 generate` prints `render_selection_summary` beside the residency report",
+    "`resident_profile` now delegates to `accounting::resident_profile_with(format, BlockGeometry::executor())`; the Q8 pricing includes the i16 code sum per block when the executor's weight index is on — the same predicate the loader reads"
+   ],
+   "findings_not_in_the_forecast": [
+    {
+     "id": "3c-N1",
+     "finding": "The ledger's CALLS are not the unit that corresponds to pins: the executor batches a projection's positions differently per site (per position at the attention, all at once in the FFN), and threads them, so a thread-local count sees only a share. POSITIONS are exact: on the dense fixture over three tokens, 15 pinned BlasF32 projections tallied 31 calls, 31 slabs and 43 positions = 14 layer projections × 3 tokens + the head × 1 (the head processes the last position only). `ledger_correspondence` therefore returns the tally per pinned plan and enforces set equality (every pinned plan ran, no unpinned plan ran); the test asserts the positions identity."
+    },
+    {
+     "id": "3c-N2",
+     "finding": "The first reconciliation refused every exact match: the tolerance was written as `resident < declared + allocations × page` with a strict inequality, which is empty for an object with no padded allocation. Fixed to exact equality for vector-backed forms and a half-open page window per aligned allocation. Recorded because a tolerance rule is itself a declaration that needed its own witness."
+    },
+    {
+     "id": "3c-N3",
+     "finding": "The bf16 loader refuses an f32-stored operand rather than converting, so the disagreeing-form witness uses the executor's own Q8 re-quantisation of an f32 source; the F16 device form is exercised as a narrowing of f32 (the only f16 path there is)."
+    },
+    {
+     "id": "3c-N4",
+     "finding": "The widened-f32 staging arena (exec/weights/staged.rs, from PR #420) is a process singleton initialised through OnceLock::get_or_init behind a bare `get()` check, and its file was named by process id alone: two threads widening at once both found the arena unset, both tried `create_new` on the same `larql-f32-stage-<pid>.bin`, and the second failed with `File exists`. Reproduced in a PLAIN full run (routed::router_and_expert_operands_are_load_bearing), not only under instrumentation — so the earlier unnamed flake almost certainly had this cause. Fixed by a per-open serial in the file name (the loser's file is unlinked on open as before). Recorded because the kept log is what named it; the earlier filtered run could not."
+    },
+    {
+     "id": "3c-N5",
+     "finding": "The projection ledger is process-global, and every test that executes a plan lands in it, so the exact four-way correspondence is only observable in a process that runs nothing else. The witness re-launches the test binary on itself with a marker (`LARQL_LEDGER_WITNESS`, `--exact`, `--test-threads=1`) and asserts in the child; `#[serial]` was insufficient because non-serial tests keep executing. The library check (`ledger_correspondence`) is the production instrument and is unaffected."
+    },
+    {
+     "id": "3c-N6",
+     "finding": "The Gemma-4 miniature binds layer 3's key projection tensor as BOTH its key and its value projection, and ties its head to the embedding table. The first reconciliation refused the repeat as 'expected twice'. The pairing now matches by COUNT per (operand, operation, layer) instance: two expectations meet two objects. Consequence made visible: the CPU loader holds the aliased projection resident TWICE — one stored operand, two operation instances, two f32 images — which the stored footprint counts once and the execution touch and residency count twice, exactly as the tied head is counted. A shared-object realization (bind once, reference twice) is a missing CPU realization for 3d's inventory, beside the shared expert."
+    }
+   ],
+   "gates": {
+    "affected_suites": "accounting + planned_bank + kquant_projection: 38 tests green; opplan: 656 green in the parallel run",
+    "full_crate": "cargo test -p larql-vindex on the final tree: 4193 lib tests passed, 0 failed, 7 ignored (pre-existing); every integration binary green; the log was kept in full",
+    "workspace_check": "cargo check --workspace --all-targets: green",
+    "clippy": "clean on rustc 1.98, --all-targets -D warnings",
+    "fmt": "clean, run last",
+    "coverage": "policy passed on the final tree: 93.77% total over 429 files; accounting.rs 94.14%, realization.rs 99.16%, prepared.rs 90.69% (back above the floor after the pairing and provider witnesses were added — it had slipped to 89.23% on a debt baseline), weights/staged.rs 91.67%; no debt entry added; the instrumented test phase ran clean with its log kept",
+    "docs": "check_doc_links.py + check_doc_references.py --strict: green"
+   }
   }
  }
 }

--- a/docs/represent/forecasts/rung3-planned-realizations.json
+++ b/docs/represent/forecasts/rung3-planned-realizations.json
@@ -1,0 +1,128 @@
+{
+ "programme": "represent-codec-contract",
+ "rung": 3,
+ "name": "planned-execution-realizations",
+ "written": "2026-09-05",
+ "written_before": "any code. Baseline measured by reading origin/main after PR #422 (rung 2) merged — coordinates below are from that tree. Predictions are about the transition only, per wave.",
+ "base_commit": "c52497a7 (merge of PR #422)",
+ "branch": "represent-rung3",
+ "worktree": ".claude/worktrees/represent-rung3",
+ "predecessors": ["rung2-entropy-coded-bf16.json", "rung2-execution-notes.json"],
+
+ "the_claim": "LARQL can discover representations and execution providers, determine whether they satisfy an operation, select an explicit realization, account for it, and execute it without format-specific control flow. Concretely: a hardware-independent OperationPlan states what each operand needs; a PreparedExecutionPlan, bound to registry, device and physical facts, records the representation it resolved, the realizations it considered, the one RealizationId it pinned, that realization's resource profile, and the reason; and the executor runs exactly the pinned realization or refuses.",
+
+ "what_the_entropy_codec_exposed": "Rung 2 executed BF16_ZLIB through registration because the residency policy already routes every non-bf16 dtype to widened f32 — a silent, well-defined fallback with no record. The same silence is why capability admission had to be bolted onto the packed-bank loader (experts.rs require_row_access), why MXFP4 banks enter through a `U8` label nobody registered, and why #420's direct K-quant arrived as a THIRD stored-dtype boolean at the seam rather than as a declared realization. Rung 3 replaces the booleans, the silence and the bypass with candidates, a pin and a trace.",
+
+ "baseline_measured": {
+  "semantic_plan_is_requirement_blind": "opplan/mod.rs: OperandRef { object, tensor, dtype, shape } (mod.rs:54); RoutedFfnOp carries `expert_format: ExpertFormat` (a larql-models config enum: PerExpert | PackedMxfp4 | PackedBF16) and `bank: ExpertBank::{Packed{gate_up, down}, PerExpert}`; PackedProjection { weights, scales: Option, bias }. No op carries a required access, an operation kind, or an extent. Nothing in opplan/build.rs or opplan/mod.rs reads OperandRef.dtype (grep: zero). The plan is serialised by `vindex3 plan` (larql-cli vindex3_cmd/mod.rs:981) and round-tripped by opplan/tests/plan.rs:147, plan/tests/identity.rs:73, plan/tests/system.rs:212.",
+  "the_seam_is_three_booleans": "exec/backend.rs:159 MatrixOperand { class: MatrixClass (AttentionProjection | FfnProjection | OutputHead | RoutedExpertBank), elements, stored_bf16, stored_nvfp4, stored_kquant }. Filled by exec/prepared.rs:684 `resolve` from operands.rs is_stored_bf16 / is_stored_nvfp4 (label compares) / is_stored_kquant (kquant::lookup on the label, operands.rs:761). The bank is asked once with all three false and elements 0 (prepared.rs:770).",
+  "selection_is_a_boolean_ladder": "exec/production.rs:703 declared_format(operand, kquant_execution()): RoutedExpertBank → F32; stored_nvfp4 → Nvfp4; stored_kquant && KQuantExecution::Direct → KQuant; else PhysicalProjectionPlan::choose_for(class, elements, stored_bf16).format() (cpu/physical.rs:329 — BlasF32 unless stored bf16 and the f32 image exceeds compact_threshold_bytes(), then FusedBf16 / FusedQ8 / integer arms by arithmetic_arm() and q8_permitted()). The reference backend uses the trait default: F32 (backend.rs:734). The device backend answers `self.formats.for_class(operand.class)` (exec/device.rs:355) — a class table that reads none of the stored facts.",
+  "process_globals_are_policy_inputs": "KQuantExecution from env LARQL_KQUANT_EXEC, read per operand at load (physical.rs:629, deliberately uncached); ArithmeticArm read once per process; Q4Classes; q8_permitted(). None is recorded in the prepared image.",
+  "the_loader_matches_the_format": "exec/weights/mod.rs load_weight(store, operand, WeightFormat) — 8 formats (F32, Bf16, Q8, Q4, F16, Mxfp4, Nvfp4, KQuant), each arm with its own stored-dtype expectations (the Bf16 arm refuses non-BF16 by name; the F16 arm narrows from BF16/F32 only). Decode-to-f32 realizations go through OperandStore::load → CodecRegistry (rung 1); direct realizations bind bytes per arm.",
+  "the_kernel_is_observed_not_pinned": "cpu/physical.rs for_resident(WeightRows, in_dim) → PhysicalProjectionPlan (10 variants: ScalarF32, FusedQ8, FusedQ4, FusedNvfp4, FusedKQuant, BlasF32, FusedBf16, Q8xQ8, Q4xQ8, Bf16xQ8), read off the resident bytes plus the process arm. There is no pin for the executor to violate, and no record of what was decided at load. cpu/ledger.rs ProjectionLedger tallies calls / bytes / nanos per plan and per site — the only execution-side observation of which realization ran.",
+  "accounting_is_observed_only": "exec/prepared.rs:937 residency_census(): SiteResidency { widened_f32, compact } per site from LoadedWeight::is_widened_f32 and resident_bytes(). No declared profile is bound; no per-operand record exists. Reported by `vindex3 generate` report_residency (larql-cli vindex3_cmd/generate.rs:129) and DecodeSession::residency_census (exec/decode.rs:183).",
+  "declarations_exist_and_have_one_consumer": "Every codec declares capabilities(), accelerations() (backend Cpu, a PhysicalProjectionPlan, a ResidencyProfile, requires RowRandom) and decode_residency(). After rung 2 the ONLY consumer outside represent/codec/ is exec/experts.rs require_row_access. Declared direct realizations today: BF16 → FusedBf16, Bf16xQ8; F32 → BlasF32, ScalarF32; NVFP4 → FusedNvfp4; Q4_K/Q6_K/Q8_0 → FusedKQuant (#420); F16, MXFP4, BF16_ZLIB → none.",
+  "the_mxfp4_bank_bypass": "exec/experts.rs load_packed: ExpertFormat::PackedMxfp4 expects stored dtype `U8` for both the blocks and the scales operand (experts.rs:437-438) — labels outside the registry — then binds natively for a WeightFormat::Mxfp4 backend or dequantises per expert; ExpertFormat::PackedBF16 expects `BF16` (experts.rs:470). RoutedExpertBank is widened to f32 unconditionally on the CPU backend (declared_format). The bank's per-expert slicing is a realization that reads STORED rows — which is why rung 2's require_row_access is a genuine requirement of that realization, not of the operation.",
+  "realization_identity_is_a_closed_enum": "PhysicalProjectionPlan is matched exhaustively in cpu/physical.rs (format, arithmetic, kernel, for_resident), cpu/ledger.rs (tallies), cpu/cost.rs and cpu/arithmetic.rs. A provider outside the crate cannot add a variant; this is the central match an external provider will collide with.",
+  "controls": "4152 lib tests green on the rebased rung-2 tree; every parity oracle under exec/tests is bit-exact against its fixture; rung 2's witnesses (bf16_zlib_execution.rs, bf16_zlib_bank.rs) pin the pre-rung-3 behaviour of the paths this rung rewires."
+ },
+
+ "design_frozen_at_the_contract_level": {
+  "OperationPlan (3a)": "opplan gains a derived, total, hardware-independent view: `PlannedOperand { operand: OperandRef, operation: Operation, access: RequiredAccess, extent: RepresentationExtent }` with `Operation ∈ { Embed, Project(MatrixClass), ExpertBankSlice, OutputHead }`, produced by `ComponentOpPlan::planned_operands()`. Access is what the OPERATION needs over the operand as executed: Embed and ExpertBankSlice need RowRandom (a token's row; an expert's slot), Project and OutputHead need Sequential (the whole matrix). Extent is TERMINAL for every operand this rung. It is derived from the op structure and NOT serialised into the plan JSON; the plan's wire shape is byte-identical.",
+  "RealizationId (3b)": "`RealizationId { backend: AccelerationBackend, form: RealizationForm }` with `RealizationForm ∈ { Direct(PhysicalProjectionPlan), Decode(PhysicalProjectionPlan), Requantise(PhysicalProjectionPlan), SliceStored { convert: WeightFormat } }`. Direct = the codec's declared acceleration; Decode = the universal decode-to-f32 realization then an f32 plan (BlasF32 in production, ScalarF32 under the reference backend); Requantise = decode then a lossy re-quantisation (today's FusedQ8 / integer arms for large bf16); SliceStored = the packed-bank realization that slices stored rows per expert and converts. The candidate set for an operand is DERIVED: the codec's accelerations() filtered to the backend, plus Decode (always, for a codec whose decode is admissible), plus Requantise (policy-gated), plus SliceStored for banks (requires RowRandom over the stored bytes). No candidate may come from a label compare.",
+  "selection (3b)": "The existing policy (`choose_for`, KQuantExecution, ArithmeticArm, Q4Classes) becomes a SELECTOR over the candidate set and may only answer with a member of it. `PlanBackend::weight_format(MatrixOperand)` is replaced by `PlanBackend::select(&PlannedOperand, &RepresentationFacts) -> Result<Selection, SelectionRefusal>` where `RepresentationFacts { label, identity, capabilities, accelerations, decode_residency }` is resolved from the registry by the prepared plan — the three booleans and the three `is_stored_*` queries are deleted. The device backend's class table survives as that backend's own candidate answer (it is a provider for its target) and is not rewired to codec declarations in this rung.",
+  "pin and refusal (3b)": "`PreparedOperands` records one `RealizationRecord { operand, representation: label, requested: RequiredAccess, candidates: Vec<RealizationId>, selected: RealizationId, reason: SelectionReason, residency: ResidencyProfile }` per matrix operand. A refusal is `SelectionRefusal { operand, representation, requested, considered: Vec<(RealizationId, why rejected)> }` raised BEFORE load_raw. At execute time `for_resident` is checked against the pinned plan per operand; disagreement is a refusal, never a fallback.",
+  "trace and accounting (3c)": "`SiteResidency` gains `declared: usize` (Σ selected.residency.bytes_per_weight × elements) beside the observed pair; `ResidencyCensus` exposes agreement per site. `vindex3 generate` and the decode session print a selection summary (per class: representation → selected, reason, candidates). The ProjectionLedger is cross-checked against the pins after a run: every tallied plan for a site must be a pinned realization for that site.",
+  "privileged paths removed (3d)": "The MXFP4 bank enters through the MXFP4 codec's declared streams (blocks = values, scales = group_scales) and its candidates (Decode on CPU; the device backend's grouped kernel as the device provider's own candidate); `DTYPE_U8` leaves experts.rs. The K-quant direct path — the one existing direct codec taken through the mechanism — arrives as Direct(FusedKQuant) from the K-quant codecs' accelerations(), with KQuantExecution now a selector preference between Direct(FusedKQuant) and Decode(BlasF32); `stored_kquant` is deleted. The provider proof: a test-only codec with a test-only acceleration, registered into a scratch CodecRegistry, appears in an operand's candidate set and is selected, with zero edits under exec/ other than registration."
+ },
+
+ "predictions_per_wave": {
+  "3a_requirements": {
+   "intervention": "planned_operands() over the plan; nothing else changes.",
+   "predicted": [
+    "zero behaviour delta: every exec parity test, both rung-2 witnesses, the residency census and the ProjectionLedger tallies are unchanged; the plan JSON emitted by `vindex3 plan` is byte-identical on the dense, routed and hybrid fixtures (a serialisation change is a falsifier)",
+    "every operand the loader touches through load_weight or load_packed appears exactly once in planned_operands(); counts per fixture are pinned (dense: 7 per layer + embed + head; routed: bank operands per layer)",
+    "routed banks are RowRandom; Embed is RowRandom; Project and OutputHead are Sequential; every extent is TERMINAL",
+    "touch set: opplan/mod.rs (+types, +method), opplan/tests (+1 file); nothing under exec/"
+   ]
+  },
+  "3b_admission_and_selection": {
+   "intervention": "RepresentationFacts from the registry; candidates; selector; pin; refusal before bytes; executor pin check.",
+   "predicted": [
+    "the three booleans and is_stored_bf16 / is_stored_nvfp4 / is_stored_kquant are DELETED, not wrapped — grep for `stored_bf16|stored_nvfp4|stored_kquant` under exec/ outside tests/ returns zero",
+    "on every existing fixture the SELECTED realization equals what declared_format + for_resident chose before (the selector is the old policy over a derived set): BF16 small → Decode(BlasF32); BF16 large → Direct(FusedBf16) or Requantise(FusedQ8) by arm; NVFP4 → Direct(FusedNvfp4); K-quant → Direct(FusedKQuant) under Direct, Decode(BlasF32) under Widen; F16 / MXFP4-dense / BF16_ZLIB → Decode(BlasF32) with reason NoDirectRealization; banks → SliceStored; logits bit-exact everywhere",
+    "rung 2's bank refusal is re-issued by the selector: BF16_ZLIB bank → SelectionRefusal considering [SliceStored: needs row-random, codec provides sequential] with load_count unchanged; the rung-2 test is kept and its assertion tightened to the refusal type (a DecodeWholeThenSlice bank realization is a legitimate future candidate and is NOT added in this rung — recorded so its later addition cannot be mistaken for a fallback)",
+    "the executor pin check refuses a prepared image whose resident bytes disagree with its pin (witness: a constructed mismatch); no existing fixture trips it",
+    "the reference backend selects Decode(ScalarF32) for every operand — the oracle stays the oracle",
+    "the device backend is untouched except for the trait method rename; its class table is wrapped as its own candidate answer",
+    "touch set: exec/backend.rs (MatrixOperand → PlannedOperand + RepresentationFacts; PlanBackend::select), exec/prepared.rs (resolve, records, refusal), exec/production.rs (declared_format → selector), exec/reference.rs (default), exec/device.rs (rename), exec/weights/mod.rs (load by RealizationId → WeightFormat mapping, arms unchanged), exec/experts.rs (require_row_access folded into the SliceStored candidate), cpu/physical.rs (pin check beside for_resident), operands.rs (−3 queries), tests. NOT touched: opplan/ (3a's view is consumed, not changed), represent/codec/ (declarations are sufficient — any change there is a contract finding)"
+   ]
+  },
+  "3c_trace_and_accounting": {
+   "intervention": "declared residency bound into the census; selection summary printed; ledger cross-check.",
+   "predicted": [
+    "declared == observed for every site on every fixture (bf16, f32, nvfp4, kquant direct and widened, bf16_zlib); the F16 and MXFP4-dense sites agree through Decode's DECODED_F32",
+    "mutation: a scratch-registry codec whose selected realization declares ResidencyProfile::stored(16.0) while the loader widens it makes declared ≠ observed for its site, and the witness fails as it should",
+    "the ProjectionLedger after a run over the bf16_zlib container shows BlasF32 (and nothing else) at the transcoded sites, matching the pins; over a K-quant container under Direct it shows FusedKQuant only",
+    "touch set: exec/prepared.rs (census fields, summary), larql-cli generate.rs (print), cpu/ledger.rs (read-only cross-check helper), tests"
+   ]
+  },
+  "3d_remove_privileged_paths": {
+   "intervention": "MXFP4 bank via declared streams; K-quant via declared acceleration; external provider proof.",
+   "predicted": [
+    "DTYPE_U8 leaves experts.rs; the MXFP4 bank's operands bind through the MXFP4 codec (two named streams) and its candidates; the routed parity oracles are bit-exact",
+    "KQuantExecution survives as a selector preference; `stored_kquant` is gone; the #420 gate that admits a stored K-quant becomes 'Direct(FusedKQuant) is a candidate iff the codec declares it' — the K-quant codecs already do",
+    "THE PREDICTED BLOCKER: an external provider cannot be selected without opening RealizationId beyond the closed PhysicalProjectionPlan enum, because ledger.rs, cost.rs, arithmetic.rs and physical.rs match it exhaustively. The minimal opening is `RealizationForm::Provider { id: ProviderRealizationId, projector: &'static dyn DenseProjector, residency, requires }` registered in an ExecutionProviderRegistry beside the CodecRegistry, with the ledger tallying unknown providers under their id. If the proof passes WITHOUT opening the enum, that is the surprise to record; if opening it takes more than the four named files, that is the finding.",
+    "the proof: a test-only codec + test-only provider registered in scratch registries appear in the candidate set, are selected under a test policy, execute (the provider's projector runs — witnessed by its own counter), and disappear from the candidate set when unregistered; zero edits under exec/ other than registration for the proof itself"
+   ]
+  }
+ },
+
+ "invariants_and_their_witnesses": [
+  {"invariant": "Capability refusal occurs before operand bytes are read", "witness": "SelectionRefusal raised with store.load_count() unchanged (3b), on the BF16_ZLIB bank and on a constructed operand whose only candidates require row access"},
+  {"invariant": "Direct and decode-reference paths are distinct realizations", "witness": "RealizationId::Direct(FusedKQuant) vs Decode(BlasF32) for the same K-quant operand under the two KQuantExecution arms; the record names which (3b)"},
+  {"invariant": "The executor cannot silently change the pinned realization", "witness": "for_resident checked against the pin; a constructed mismatch refuses (3b)"},
+  {"invariant": "Runtime disappearance causes refusal/replanning, never fallback", "witness": "a provider unregistered between prepare and execute → refusal naming the pin (3d); a KQuantExecution arm changed between prepare and execute → the pin wins or refuses, never re-decides (3b)"},
+  {"invariant": "Stored Footprint remains representation-state-specific", "witness": "stored bytes read from the container's record per operand are unchanged by selection; BF16_ZLIB's InstanceSized refusal is unchanged (3b)"},
+  {"invariant": "Working set and touch accounting come from the selected realization", "witness": "declared residency bound from selected.residency (3c)"},
+  {"invariant": "Mutating the selected realization's resource declaration breaks the census witness", "witness": "the scratch-registry mutation (3c)"},
+  {"invariant": "MXFP4 enters through declared capabilities instead of hardcoded dtype booleans", "witness": "grep gates: no DTYPE_U8, no stored_* booleans (3d)"},
+  {"invariant": "Adding a provider changes the candidate set without modifying planner or executor matches", "witness": "the external-provider proof (3d)"}
+ ],
+
+ "falsifiers": [
+  "F1 3a changes any logits, census, ledger tally or plan JSON byte",
+  "F2 after 3b a label compare or a stored_* boolean remains under exec/ outside tests/",
+  "F3 any fixture's selected realization differs from its pre-rung-3 behaviour without a recorded reason",
+  "F4 an operand loads in a form other than its pin, or a pin mismatch executes",
+  "F5 represent/codec/ needs a change to serve 3b or 3c (the declarations rung 1–2 froze are insufficient — a contract finding)",
+  "F6 declared ≠ observed residency on any fixture, or the mutation fails to break the agreement",
+  "F7 DTYPE_U8 or ExpertFormat-keyed dtype expectations survive 3d",
+  "F8 the external provider needs an edit under exec/ beyond registration and the predicted enum opening",
+  "F9 any parity oracle moves",
+  "F10 a new file lands under 90% line coverage"
+ ],
+
+ "explicitly_not_claimed": [
+  "no plan-BUILD-time admission: the OperationPlan stays portable and registry-free; admission happens at preparation, bound to registry and device",
+  "no new realizations: DecodeWholeThenSlice for banks, a fused BF16_ZLIB kernel, device declarations from codecs — all later",
+  "no rewiring of the Metal backend's class table to codec declarations; it is wrapped as its own candidate answer",
+  "no runtime plugin loading; the provider proof is a compile-time-linked, test-only crate-internal provider",
+  "no performance claim; the selector is the old policy over a derived set",
+  "the artifact-target registry (GGUF, MLX packages) is not started"
+ ],
+
+ "coordination_risks_measured": [
+  "worktree `optimizer-mcp-facade` / branch `stage5a0-executor-contract` (stage 5, PreparedExperiment as the unit of execution authority) sits on the same prepared-plan seam. Rung 3's RealizationRecord is the identity stage 5 should consume as 'the plan that RAN' — the two must agree on who owns PreparedOperands' record fields before 3b lands; raised at freeze, not discovered at merge",
+  "PR #420's KQuantExecution and the `larql-exec-v3-2e5ce84b` PARETO-1 campaign binary read LARQL_KQUANT_EXEC; 3b keeps the env variable's meaning (selector preference) so the running campaign's arms stay identifiable"
+ ],
+
+ "gates_before_each_push": [
+  "cargo fmt --all --check last", "cargo clippy -p larql-vindex --all-targets -- -D warnings on CI's stable, plus --target x86_64-apple-darwin",
+  "cargo test -p larql-vindex (every suite; count the lib line)", "cargo check --workspace --all-targets (a trait method rename reaches every backend)",
+  "cargo llvm-cov one crate per run + check_coverage_policy.py", "check_doc_links.py + check_doc_references.py --strict",
+  "the grep gates named above, run from the base commit"
+ ],
+
+ "immutability": "Frozen at its commit. Per-wave falsifications go in rung3-execution-notes.json; if the design above must change during a wave, the change is written there with the reason and this file is not edited."
+}


### PR DESCRIPTION
## Rung 3 — planned execution realizations (3a–3d)

The third rung of the REPRESENT codec contract, preregistered in
`docs/represent/forecasts/rung3-planned-realizations.json` (frozen at `5007bb77`, base = the rung-2 merge `c52497a7`) and executed wave by wave with every finding recorded in `docs/represent/forecasts/rung3-execution-notes.json`.

**The claim this rung earns:** LARQL can accept a representation implementation through exported API, carry its registry through preparation and execution, select and account for it before I/O, execute it bit-exactly, and invalidate prepared state when that provider disappears — without privileged dtype control flow.

### What each wave leaves behind

- **3a requirements** — a plan is a set of hardware-independent `PlannedOperand`s (operation, required access, logical extent, logical elements). Nothing in it names a dtype or a kernel.
- **3b admission and selection** — at preparation, before any byte, the backend derives a candidate set from the codec's declarations and pins one `RealizationId` with its reason, or refuses with every reason. The three stored-dtype booleans are deleted; a plan with a shared expert the CPU cannot bind is refused as `MissingRealization`.
- **3c trace and accounting** — the realization declaration is bound *against* the census, not into it: an expectation is priced from the pin, the codec's declared residency and the container's recorded length; an observation is read off the bound objects; the two are reconciled. Planned operands × pins × bound objects × ledger correspond exactly, in positions.
- **3d privileged paths removed** — a packed bank's planned operand declares its codec; the selector and the loader share one resolution rule; the loader binds the bank once as the codec's named streams and decodes each expert as a row range. `DTYPE_U8`, `expect_dtype`, `expect_len` and every dtype-name judgement under `exec/` are gone. The acceptance test is an integration test (`crates/larql-vindex/tests/external_codec_provider.rs`) that registers a representation this build does not ship and executes it bit-exact to the shipped label through exported API only.

### The falsifier that fired (F8)

The first run of the provider proof passed selection and was refused at execution: the store's decode, the selector and both execution-time provider checks read `CodecRegistry::builtin()`. Dependency injection at selection, hidden globals afterwards. The registry is now a carried value — the store holds it, the prepared image records the one it was prepared through, execution checks against the image's own.

### Wording boundaries

- The integration test proves external-crate compatibility (Rust integration tests compile as separate crates against exported API). It does not claim runtime discovery or package loading.
- "Stored label wins": the stored representation is authoritative; the expert-format declaration is a legacy default consulted only when the stored label names no codec.
- Region exactness (each stream ≥ its declared minimum, all streams total the declared size, so no unclaimed bytes) is a rule for fixed-size codecs; an instance-sized codec takes its exact length from the bound container record.

### Not claimed

A CPU shared-expert realization (the hard refusal is preserved; the two missing CPU realizations are inventoried). A provider that brings its own kernel (the kernel-plane blocker is measured at five closed enums across 33 non-test files — measured debt, not this PR). Any performance.

### Gates (local, toolchain 1.98.0)

| Gate | Result |
|---|---|
| `cargo test -p larql-vindex` | 4500 passed, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo check --workspace --all-targets --target x86_64-apple-darwin` | clean |
| `cargo llvm-cov -p larql-vindex` + `scripts/check_coverage_policy.py` | passed, 93.77% total; touched files ≥ 90% except `exec/mod.rs` at 87.31 on its 86.5 baseline |
| doc links, doc references `--strict`, `cargo fmt --check` | clean |

After merge, codec/plugin architecture work stops; the next programme binds a real K3 plan through this machinery.
