### PR TITLE
test(vindex3): give every staging arena and test temp dir a name of its own

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged.rs
@@ -34,6 +34,15 @@
 //! the file is removed the moment it is created, so the bytes live
 //! exactly as long as the process holds the handle, including if it is
 //! killed.
+//!
+//! The file's NAME is unique per arena, not per process. Two callers
+//! can race the process-wide initialisation and each open an arena
+//! before either wins it, and a process can inherit the pid of one that
+//! died inside the create-to-unlink window; a pid-only name made both
+//! collide on `create_new` ("File exists"), which a test suite running
+//! two stagings at once reproduced. A per-process counter beside the
+//! pid keeps every arena's name its own, and the loser of the race is
+//! simply dropped — its file was already unlinked.
 
 use std::io::{Seek, SeekFrom, Write};
 use std::ops::Deref;
@@ -126,6 +135,22 @@ pub(super) struct Arena {
 
 static ARENA: OnceLock<Mutex<Arena>> = OnceLock::new();
 
+/// Distinguishes arenas opened by ONE process: the pid alone named two
+/// concurrent opens the same file.
+static ARENA_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// The path the next arena under `dir` is created at — unique per call
+/// within this process (pid plus a counter), and distinct from any
+/// other process's by the pid. Separate from [`open_arena`] so the
+/// naming contract is testable without touching the file system.
+pub(super) fn arena_path(dir: &std::path::Path) -> std::path::PathBuf {
+    let sequence = ARENA_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    dir.join(format!(
+        "larql-f32-stage-{}-{sequence}.bin",
+        std::process::id()
+    ))
+}
+
 fn arena() -> Result<&'static Mutex<Arena>, VindexError> {
     // `OnceLock::get_or_init` cannot fail, so the fallible open happens
     // first and its error is reported rather than swallowed into a
@@ -148,7 +173,7 @@ fn arena() -> Result<&'static Mutex<Arena>, VindexError> {
 /// of the failure path through `arena()` would depend on whether any
 /// other test had staged an image first.
 pub(super) fn open_arena(dir: &std::path::Path) -> Result<Arena, VindexError> {
-    let path = dir.join(format!("larql-f32-stage-{}.bin", std::process::id()));
+    let path = arena_path(dir);
     let file = std::fs::OpenOptions::new()
         .create_new(true)
         .read(true)

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged_tests.rs
@@ -306,3 +306,67 @@ fn debug_names_the_residency_and_the_count_not_the_values() {
     assert!(mapped.is_mapped());
     assert_eq!(format!("{mapped:?}"), "StagedF32(Mapped(4 f32))");
 }
+
+/// Two arenas opened by ONE process have their own names: the pid is
+/// shared, the counter is not. This is the naming contract that stops
+/// concurrent opens colliding on `create_new`.
+#[test]
+fn arena_names_are_unique_within_one_process() {
+    use super::staged::arena_path;
+    let dir = tempfile::tempdir().unwrap();
+    let first = arena_path(dir.path());
+    let second = arena_path(dir.path());
+    assert_ne!(
+        first, second,
+        "two arenas in one process must not share a file"
+    );
+    let pid = std::process::id().to_string();
+    for path in [&first, &second] {
+        let name = path.file_name().unwrap().to_string_lossy();
+        assert!(name.starts_with("larql-f32-stage-"), "{name}");
+        assert!(
+            name.contains(&pid),
+            "{name} names the process it belongs to"
+        );
+        assert!(name.ends_with(".bin"), "{name}");
+    }
+}
+
+/// Eight opens released at once in one process all succeed and coexist,
+/// each on its own unlinked inode. With a pid-only name most of these
+/// found the sibling's file inside its create-to-unlink window and
+/// refused with "File exists" — the failure two test suites running at
+/// once reproduced on 2026-09-05.
+#[test]
+fn concurrent_arenas_in_one_process_coexist() {
+    use super::staged::open_arena;
+    use std::sync::{Arc, Barrier};
+    const OPENS: usize = 8;
+    let dir = Arc::new(tempfile::tempdir().unwrap());
+    let go = Arc::new(Barrier::new(OPENS));
+    let handles: Vec<_> = (0..OPENS)
+        .map(|_| {
+            let dir = Arc::clone(&dir);
+            let go = Arc::clone(&go);
+            std::thread::spawn(move || {
+                go.wait();
+                open_arena(dir.path()).map(|arena| arena.file.metadata().is_ok())
+            })
+        })
+        .collect();
+    let mut opened = 0;
+    for handle in handles {
+        match handle.join().expect("the thread ran") {
+            Ok(alive) => {
+                assert!(alive, "an opened arena keeps a live descriptor");
+                opened += 1;
+            }
+            Err(e) => panic!("a concurrent open must not collide: {e}"),
+        }
+    }
+    assert_eq!(opened, OPENS);
+    // Every one unlinked itself: nothing named after this process is
+    // left behind for a later process to trip on.
+    let leftovers = std::fs::read_dir(dir.path()).unwrap().count();
+    assert_eq!(leftovers, 0, "arenas leave no file behind");
+}

--- a/crates/larql-vindex/src/format/weights/write_kquant/tests/moe_layers_per_expert.rs
+++ b/crates/larql-vindex/src/format/weights/write_kquant/tests/moe_layers_per_expert.rs
@@ -115,11 +115,31 @@ impl WeightSource for MapSource {
     }
 }
 
+/// A directory of its own for every call, however many callers share a
+/// `name` — within this process (a counter) and across processes (the
+/// pid). A fixed name per label let two test processes running at once
+/// remove each other's files mid-read.
 fn temp_dir(name: &str) -> std::path::PathBuf {
-    let dir = std::env::temp_dir().join("moe-per-expert-tests").join(name);
-    let _ = std::fs::remove_dir_all(&dir);
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static SEQUENCE: AtomicUsize = AtomicUsize::new(0);
+    let dir = std::env::temp_dir()
+        .join("moe-per-expert-tests")
+        .join(format!(
+            "{name}-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
     std::fs::create_dir_all(&dir).unwrap();
     dir
+}
+
+/// Two calls under one label are two directories, both present.
+#[test]
+fn temp_dirs_are_unique_per_invocation() {
+    let first = temp_dir("shared-label");
+    let second = temp_dir("shared-label");
+    assert_ne!(first, second);
+    assert!(first.is_dir() && second.is_dir());
 }
 
 fn layer_file(dir: &Path, layer: usize) -> std::path::PathBuf {

--- a/crates/larql-vindex/src/format/weights/write_kquant/tests/norms.rs
+++ b/crates/larql-vindex/src/format/weights/write_kquant/tests/norms.rs
@@ -95,13 +95,31 @@ impl WeightSource for BiasSource {
     }
 }
 
+/// A directory of its own for every call, however many callers share a
+/// `name` — within this process (a counter) and across processes (the
+/// pid). A fixed name per label let two test processes running at once
+/// remove each other's files mid-read.
 fn temp_dir(name: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static SEQUENCE: AtomicUsize = AtomicUsize::new(0);
     let dir = std::env::temp_dir()
         .join("write-kquant-norms-tests")
-        .join(name);
-    let _ = std::fs::remove_dir_all(&dir);
+        .join(format!(
+            "{name}-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
     std::fs::create_dir_all(&dir).unwrap();
     dir
+}
+
+/// Two calls under one label are two directories, both present.
+#[test]
+fn temp_dirs_are_unique_per_invocation() {
+    let first = temp_dir("shared-label");
+    let second = temp_dir("shared-label");
+    assert_ne!(first, second);
+    assert!(first.is_dir() && second.is_dir());
 }
 
 #[test]


### PR DESCRIPTION
Two deterministic test-environment hazards, both reproduced this week, fixed before the next research rung opens. No architecture, no semantics change.

**Staging arena.** `larql-f32-stage-<pid>.bin` was opened with `create_new`. Two callers racing the process-wide initialisation each reach the open before either wins it, and a process can inherit the pid of one that died inside the create-to-unlink window; both collided with "File exists" (seen in `staged_tests`, `gemma4`, and an instrumented run). Names now carry a per-process counter beside the pid. Regression: `concurrent_arenas_in_one_process_coexist` releases eight opens on a barrier and requires all to succeed and leave no file behind — it fails 3/3 under the old naming; `arena_names_are_unique_within_one_process` pins the naming contract.

**Fixed-name temp dirs.** Two `write_kquant` test helpers built one directory per label and `remove_dir_all`'d it on entry, so two test processes running at once deleted each other's files mid-read (seen in `moe_layers_per_expert`). Each call now gets its own directory (label, pid, counter); `temp_dirs_are_unique_per_invocation` pins it in both files.

Gates: fmt, clippy `--all-targets -D warnings`, workspace check, larql-vindex suite 4218 passed / 0 failed, coverage policy passed.
