### PR TITLE
K3 vertical V4: the warm Kimi-Linear token characterised deterministically

### DIFF
--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
@@ -234,6 +234,8 @@ fn run_on<B: PlanBackend>(
                     plan,
                     store,
                     args.repeat,
+                    args.warmup,
+                    args.unquiet_ok,
                 );
             }
             super::generate::run_generate(backend, &engine, tokens, new_tokens, plan, store)

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/generate.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/generate.rs
@@ -471,6 +471,8 @@ pub(super) fn run_residency_curve<B: PlanBackend>(
     plan: &ComponentOpPlan,
     store: &OperandStore,
     repeat: usize,
+    warmup: usize,
+    unquiet_ok: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use larql_vindex::format::vindex3::opplan::exec::accounting::{
         expectations, BlockGeometry, ResourceLedger,
@@ -478,10 +480,41 @@ pub(super) fn run_residency_curve<B: PlanBackend>(
     use larql_vindex::format::vindex3::opplan::exec::kv::RowKvState;
     use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
     use larql_vindex::format::vindex3::opplan::exec::timing::OpClass;
+    use larql_vindex::format::vindex3::opplan::exec::{routing_trace, stages};
 
     if prompt.is_empty() {
         return Err("prompt holds no tokens — nothing to condition on".into());
     }
+    if warmup >= repeat.max(1) {
+        return Err(format!("warmup {warmup} leaves no counted pass out of {repeat}").into());
+    }
+    // Scheduling, declared before anything is timed: the pool the
+    // production backend joins inside every step, and the machine the
+    // probe sees. The boundary is the step's return — the CPU backend
+    // is synchronous and nothing of a token runs past it.
+    println!(
+        "scheduling: cpu pool {} workers of {} available; timing boundary = step return (synchronous CPU backend)",
+        cpu::shared().map(|e| e.workers()).unwrap_or(0),
+        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(0),
+    );
+    let environment = cpu::Environment::read();
+    let disqualifiers = environment.disqualifiers(cpu::environment::Phase::BeforeWork);
+    println!("machine: {}", environment.describe());
+    let qualification = if disqualifiers.is_empty() {
+        "QUALIFIED".to_string()
+    } else {
+        let reasons: Vec<String> = disqualifiers.iter().map(|d| d.to_string()).collect();
+        if !unquiet_ok {
+            return Err(format!(
+                "this machine is not quiet — {} — so the curve would calibrate against whatever \
+                 else is running; pass --unquiet-ok to run anyway, labelled",
+                reasons.join("; ")
+            )
+            .into());
+        }
+        format!("UNQUALIFIED ({})", reasons.join("; "))
+    };
+    println!("qualification: {qualification}");
     let loading = Instant::now();
     let ops = PreparedOperands::load(plan, store, backend, ExecutionSlice::Full)?;
     let load_seconds = loading.elapsed().as_secs_f64();
@@ -543,56 +576,80 @@ pub(super) fn run_residency_curve<B: PlanBackend>(
         base.major_faults
     );
 
-    let classes = [
-        OpClass::Kda,
-        OpClass::Mla,
-        OpClass::AttentionCore,
-        OpClass::MoeRoutedExpert,
-        OpClass::Projection,
-        OpClass::Norm,
-        OpClass::Logits,
-    ];
+    let counted_from = warmup + 1;
+    let mut samples: Vec<PassSample> = Vec::new();
+    let mut first_logits: Option<Vec<f32>> = None;
+    let mut first_generated: Option<Vec<u32>> = None;
     for pass in 1..=repeat.max(1) {
         let mut kv = RowKvState::default();
         let mut session = DecodeSession::over_prepared(plan, &ops, backend, &mut kv)?;
-        let label = if pass == 1 { "cold" } else { "warm" };
-        println!("pass {pass} ({label}):");
+        let label = if pass < counted_from {
+            "warmup"
+        } else if pass == 1 {
+            "cold"
+        } else {
+            "counted"
+        };
         println!(
-            "  {:<8} {:>9} {:>12} {:>12} {:>10} {:>10} {:>9}  time by class (ms)",
+            "pass {pass} ({label}): machine {}",
+            cpu::Environment::read().describe()
+        );
+        println!(
+            "  {:<8} {:>9} {:>12} {:>12} {:>10} {:>10} {:>9}  stages (ms)",
             "step", "ms", "mapped res", "Δ res (GB)", "minor Δ", "major Δ", "rss GB"
         );
         let mut before_res = session.mapped_residency();
         let mut before_proc = process_resources();
         let observe = |name: String,
-                           elapsed: f64,
-                           session: &DecodeSession<'_, B>,
-                           before_res: &mut larql_vindex::format::vindex3::opplan::exec::prepared::MappedResidency,
-                           before_proc: &mut ProcessResources| {
+                       elapsed: f64,
+                       session: &DecodeSession<'_, B>,
+                       before_res: &mut larql_vindex::format::vindex3::opplan::exec::prepared::MappedResidency,
+                       before_proc: &mut ProcessResources|
+         -> StepObservation {
             let now_res = session.mapped_residency();
             let now_proc = process_resources();
-            let ledger = timing::ledger();
-            let by_class: Vec<String> = classes
+            let stage_ledger = stages::ledger();
+            let by_stage: Vec<String> = stage_ledger
+                .all()
                 .iter()
-                .map(|c| (c, ledger.get(*c)))
+                .filter(|(_, t)| t.calls > 0)
+                .map(|(st, t)| format!("{}={:.1}", st.name(), t.nanos as f64 / 1e6))
+                .collect();
+            let leaves = timing::ledger();
+            let leaf_note: Vec<String> = [OpClass::Projection, OpClass::Norm, OpClass::Logits]
+                .iter()
+                .map(|c| (c, leaves.get(*c)))
                 .filter(|(_, t)| t.calls > 0)
                 .map(|(c, t)| format!("{}={:.0}", c.name(), t.nanos as f64 / 1e6))
                 .collect();
+            let obs = StepObservation {
+                elapsed_ms: elapsed * 1e3,
+                resident_delta: now_res.resident_bytes.saturating_sub(before_res.resident_bytes),
+                minor_faults: now_proc.minor_faults.saturating_sub(before_proc.minor_faults),
+                major_faults: now_proc.major_faults.saturating_sub(before_proc.major_faults),
+                stage_ms: stages::Stage::ALL
+                    .map(|st| stage_ledger.get(st).nanos as f64 / 1e6),
+                stages_nested: stage_ledger.nested(),
+            };
             println!(
-                "  {:<8} {:>9.0} {:>9.3} GB {:>12.3} {:>10} {:>10} {:>9.2}  {}",
+                "  {:<8} {:>9.0} {:>9.3} GB {:>12.3} {:>10} {:>10} {:>9.2}  {}  [leaves {}]",
                 name,
-                elapsed * 1e3,
+                obs.elapsed_ms,
                 now_res.resident_bytes as f64 / GB,
-                now_res.resident_bytes.saturating_sub(before_res.resident_bytes) as f64 / GB,
-                now_proc.minor_faults.saturating_sub(before_proc.minor_faults),
-                now_proc.major_faults.saturating_sub(before_proc.major_faults),
+                obs.resident_delta as f64 / GB,
+                obs.minor_faults,
+                obs.major_faults,
                 now_proc.max_rss as f64 / GB,
-                by_class.join(" ")
+                by_stage.join(" "),
+                leaf_note.join(" ")
             );
             *before_res = now_res;
             *before_proc = now_proc;
+            obs
         };
         // Prompt: every position through the stack, timed as one step.
         timing::ledger().reset();
+        stages::ledger().reset();
         let started = Instant::now();
         let mut logits = None;
         for &token in prompt {
@@ -607,6 +664,7 @@ pub(super) fn run_residency_curve<B: PlanBackend>(
         );
         let mut logits = logits.ok_or("plan carries no output head — cannot generate")?;
         let mut generated = Vec::with_capacity(new_tokens);
+        let mut token_sample: Option<PassSample> = None;
         for step in 0..new_tokens {
             let (next, _) = argmax(&logits).ok_or("output head produced no logits")?;
             let id = u32::try_from(next)?;
@@ -615,22 +673,200 @@ pub(super) fn run_residency_curve<B: PlanBackend>(
                 break;
             }
             timing::ledger().reset();
+            stages::ledger().reset();
+            routing_trace::start_capture();
             let started = Instant::now();
             logits = session
                 .step(id)?
                 .logits
                 .ok_or("plan carries no output head — cannot generate")?;
-            observe(
+            let elapsed = started.elapsed().as_secs_f64();
+            let routing = routing_trace::take_capture();
+            let obs = observe(
                 format!("token {}", step + 1),
-                started.elapsed().as_secs_f64(),
+                elapsed,
                 &session,
                 &mut before_res,
                 &mut before_proc,
             );
+            if step == 0 {
+                // The characterised token: the first generated one, whose
+                // state is the prompt's and therefore the same in every pass.
+                let logits_delta = match &first_logits {
+                    Some(first) => first
+                        .iter()
+                        .zip(&logits)
+                        .map(|(a, b)| (a - b).abs())
+                        .fold(0.0f32, f32::max),
+                    None => 0.0,
+                };
+                if first_logits.is_none() {
+                    first_logits = Some(logits.clone());
+                }
+                token_sample = Some(PassSample {
+                    pass,
+                    observation: obs,
+                    routing_fingerprint: routing_trace::fingerprint(&routing),
+                    routed_layers: routing.len(),
+                    first_layer_experts: routing.first().cloned().unwrap_or_default(),
+                    logits_delta,
+                });
+            }
         }
         println!("  generated ids: {}", join_ids(&generated));
+        if let Some(sample) = token_sample {
+            println!(
+                "  token 1: routing {:016x} over {} routed layers, layer-1 experts {:?}, logits max|Δ| vs pass 1 {:.2e}",
+                sample.routing_fingerprint, sample.routed_layers, sample.first_layer_experts, sample.logits_delta
+            );
+            if first_generated.is_none() {
+                first_generated = Some(generated.clone());
+            } else if first_generated.as_deref() != Some(generated.as_slice()) {
+                println!(
+                    "  GENERATED IDS DIFFER from pass 1: {}",
+                    join_ids(&generated)
+                );
+            }
+            if pass >= counted_from {
+                samples.push(sample);
+            }
+        }
     }
+    summarise_passes(&samples, repeat.max(1), warmup, &qualification);
     Ok(())
+}
+
+/// One step's observation, as the curve reads it between tokens.
+#[derive(Debug, Clone, Copy)]
+struct StepObservation {
+    elapsed_ms: f64,
+    resident_delta: u64,
+    minor_faults: u64,
+    major_faults: u64,
+    /// Milliseconds per [`stages::Stage::ALL`] entry, in that order.
+    stage_ms: [f64; 4],
+    stages_nested: u64,
+}
+
+/// The characterised token of one counted pass.
+#[derive(Debug, Clone)]
+struct PassSample {
+    pass: usize,
+    observation: StepObservation,
+    routing_fingerprint: u64,
+    routed_layers: usize,
+    first_layer_experts: Vec<usize>,
+    logits_delta: f32,
+}
+
+/// Nearest-rank percentile of a sorted sample.
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+    let rank = ((p / 100.0) * sorted.len() as f64).ceil().max(1.0) as usize;
+    sorted[rank.min(sorted.len()) - 1]
+}
+
+fn stats(values: impl Iterator<Item = f64>) -> (f64, f64, f64, f64) {
+    let mut v: Vec<f64> = values.collect();
+    v.sort_by(|a, b| a.total_cmp(b));
+    (
+        percentile(&v, 50.0),
+        percentile(&v, 95.0),
+        v.first().copied().unwrap_or(f64::NAN),
+        v.last().copied().unwrap_or(f64::NAN),
+    )
+}
+
+/// The counted passes, reduced: percentiles of the token and of every
+/// stage, and the determinism witnesses — every counted pass routed the
+/// same experts, or the statistics are over different work and say so.
+fn summarise_passes(samples: &[PassSample], repeat: usize, warmup: usize, qualification: &str) {
+    use larql_vindex::format::vindex3::opplan::exec::stages::Stage;
+    println!(
+        "\ncharacterised token over {} counted pass(es) ({} warmup of {}), machine {}:",
+        samples.len(),
+        warmup,
+        repeat,
+        qualification
+    );
+    if samples.is_empty() {
+        println!("  nothing counted");
+        return;
+    }
+    let fingerprints: std::collections::BTreeSet<u64> =
+        samples.iter().map(|s| s.routing_fingerprint).collect();
+    if fingerprints.len() == 1 {
+        println!(
+            "  routing: IDENTICAL in every counted pass ({:016x}, {} routed layers)",
+            samples[0].routing_fingerprint, samples[0].routed_layers
+        );
+    } else {
+        println!(
+            "  routing: DIFFERS across passes — {} distinct selections; the statistics below are over different work",
+            fingerprints.len()
+        );
+        for s in samples {
+            println!("    pass {} {:016x}", s.pass, s.routing_fingerprint);
+        }
+    }
+    let nested: u64 = samples.iter().map(|s| s.observation.stages_nested).sum();
+    if nested > 0 {
+        println!("  REFUSING TO RECONCILE STAGES: {nested} nested stage timers across the counted passes");
+    }
+    let worst_logits = samples
+        .iter()
+        .map(|s| s.logits_delta)
+        .fold(0.0f32, f32::max);
+    println!("  logits max|Δ| vs pass 1 across counted passes: {worst_logits:.2e}");
+    let major: u64 = samples.iter().map(|s| s.observation.major_faults).sum();
+    let minor_max = samples
+        .iter()
+        .map(|s| s.observation.minor_faults)
+        .max()
+        .unwrap_or(0);
+    let resident: u64 = samples.iter().map(|s| s.observation.resident_delta).sum();
+    println!(
+        "  faults: major {major} total, minor ≤ {minor_max} per pass; resident-page delta {} GB total",
+        resident as f64 / GB
+    );
+    println!(
+        "  {:<16} {:>9} {:>9} {:>9} {:>9} {:>8}",
+        "ms", "p50", "p95", "min", "max", "p95/p50"
+    );
+    let (p50, p95, min, max) = stats(samples.iter().map(|s| s.observation.elapsed_ms));
+    println!(
+        "  {:<16} {:>9.1} {:>9.1} {:>9.1} {:>9.1} {:>8.2}",
+        "token",
+        p50,
+        p95,
+        min,
+        max,
+        p95 / p50
+    );
+    let token_p50 = p50;
+    let mut staged = 0.0;
+    for (i, st) in Stage::ALL.iter().enumerate() {
+        let (p50, p95, min, max) = stats(samples.iter().map(|s| s.observation.stage_ms[i]));
+        staged += p50;
+        println!(
+            "  {:<16} {:>9.1} {:>9.1} {:>9.1} {:>9.1} {:>8.2}   {:>5.1}% of token p50",
+            st.name(),
+            p50,
+            p95,
+            min,
+            max,
+            p95 / p50,
+            p50 / token_p50 * 100.0
+        );
+    }
+    println!(
+        "  {:<16} {:>9.1}   ({:.1}% of token p50: norms, residual, embedding, head, glue)",
+        "other",
+        token_p50 - staged,
+        (token_p50 - staged) / token_p50 * 100.0
+    );
 }
 
 fn argmax(v: &[f32]) -> Option<(usize, f32)> {

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -220,6 +220,16 @@ pub struct ExecArgs {
     /// cache kept — the warm number the cold one is compared against.
     #[arg(long, default_value_t = 1, requires = "residency_curve")]
     pub repeat: usize,
+    /// Passes excluded from the residency curve's statistics (they still
+    /// run and print); the counted passes are `repeat - warmup`.
+    #[arg(long, default_value_t = 0, requires = "residency_curve")]
+    pub warmup: usize,
+    /// Run the residency curve even when the machine probe disqualifies
+    /// the machine (battery, load, background CPU); the report is then
+    /// labelled UNQUALIFIED and says why. Without it, a disqualified
+    /// machine is refused before any weight is bound.
+    #[arg(long, requires = "residency_curve")]
+    pub unquiet_ok: bool,
 
     /// Teacher-force a whole quality bank through ONE resident model,
     /// writing `<--dump-dir>/<id>.f32` per entry.

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/generate.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/generate.rs
@@ -60,6 +60,8 @@ fn greedy_decode_runs_end_to_end_on_the_encoded_fixture() {
         generate: Some(2),
         residency_curve: false,
         repeat: 1,
+        warmup: 0,
+        unquiet_ok: true,
         logit_dump: None,
         bank: None,
         dump_dir: None,
@@ -93,7 +95,9 @@ fn the_residency_curve_runs_cold_and_warm_passes_over_one_bound_image() {
         representation_source: "auto".to_string(),
         generate: Some(2),
         residency_curve: true,
-        repeat: 2,
+        repeat: 3,
+        warmup: 1,
+        unquiet_ok: true,
         logit_dump: None,
         bank: None,
         dump_dir: None,
@@ -101,4 +105,40 @@ fn the_residency_curve_runs_cold_and_warm_passes_over_one_bound_image() {
         profile: false,
     }))
     .expect("the residency curve must complete both passes");
+}
+
+/// A warmup that leaves no counted pass is refused by name, before any
+/// weight is bound.
+#[test]
+fn a_warmup_that_leaves_nothing_counted_is_refused() {
+    let dir = fixture_dir(true);
+    let out = dir.path().join("container");
+    run(Vindex3Command::Encode(EncodeArgs {
+        capability: None,
+        artifacts: vec![dir.path().to_path_buf()],
+        output: out.clone(),
+    }))
+    .unwrap();
+    let err = run(Vindex3Command::Exec(ExecArgs {
+        container: out,
+        component: "target".to_string(),
+        tokens: "1,2,3".to_string(),
+        dump_layers: None,
+        resume: false,
+        backend: ExecBackend::Production,
+        representation_source: "auto".to_string(),
+        generate: Some(2),
+        residency_curve: true,
+        repeat: 2,
+        warmup: 2,
+        unquiet_ok: true,
+        logit_dump: None,
+        bank: None,
+        dump_dir: None,
+        draft_depth: None,
+        profile: false,
+    }))
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("no counted pass"), "{err}");
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -488,6 +488,7 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
             // history spans the step boundary, and a single-position call
             // that reconstructed it from the batch would see a window of
             // one. That is the whole point of QW-3.6a.
+            let _attention_stage = super::stages::stage(super::stages::Stage::Attention);
             let raw_attn = match &state.attention {
                 super::prepared::PreparedAttention::GatedDelta(delta) => {
                     let recurrent = self.kv.state_mut().recurrent_state(index)?;
@@ -598,6 +599,7 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
                     out.output
                 }
             };
+            drop(_attention_stage);
             let mut attn_out = match &state.post_attention {
                 Some(norm) => norm.apply(self.backend, &raw_attn),
                 None => raw_attn,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
@@ -564,6 +564,7 @@ impl RoutedOperands {
         // dense FFN over the same input, summed unscaled: composed here,
         // once, for every backend. A gated branch is refused at selection.
         if let Some((ffn, dense)) = &self.shared {
+            let _stage = super::stages::stage(super::stages::Stage::SharedExpert);
             let shared = dense.apply(ffn, backend, x, hidden)?;
             for (acc, v) in routed.iter_mut().zip(&shared) {
                 *acc += v;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -50,9 +50,11 @@ pub mod quantise;
 pub mod realization;
 pub mod reference;
 pub mod requirements;
+pub mod routing_trace;
 pub mod stack;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
 pub mod stack_metal;
+pub mod stages;
 pub mod timing;
 pub mod token;
 pub mod weights;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -52,6 +52,8 @@ use super::realization::{
     class_of, common_selection, cpu_projection_candidates, realization_residency, RealizationForm,
     RealizationId, RefusalKind, RepresentationFacts, Selection, SelectionReason, SelectionRefusal,
 };
+use super::routing_trace;
+use super::stages::{stage, Stage};
 use super::timing::{timed, OpClass};
 use crate::format::vindex3::opplan::planned::PlannedOperand;
 use larql_compute::attention::rope::{
@@ -1050,9 +1052,14 @@ impl PlanBackend for ProductionBackend {
     }
 
     fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError> {
-        let routed_input = router_input(&call)?;
-        let mut logits = matmul_vec(&routed_input, call.router, call.experts, call.hidden);
-        let selected = select_experts(&call, &mut logits)?;
+        let selected = {
+            let _stage = stage(Stage::Router);
+            let routed_input = router_input(&call)?;
+            let mut logits = matmul_vec(&routed_input, call.router, call.experts, call.hidden);
+            select_experts(&call, &mut logits)?
+        };
+        routing_trace::record(&selected);
+        let _stage = stage(Stage::RoutedExperts);
         let mut out = vec![0.0f32; call.hidden];
         match call.weights {
             ExpertSlices::Fused {
@@ -1092,7 +1099,6 @@ impl PlanBackend for ProductionBackend {
                     ));
                 }
                 let rule = MoeGateRule::from_arch(call.gate_policy, call.activation);
-                let _t = timed(OpClass::MoeRoutedExpert);
                 for (expert, weight) in selected {
                     let g = project_matrix(&gate[expert], call.x, call.intermediate, call.hidden)?;
                     let u = project_matrix(&up[expert], call.x, call.intermediate, call.hidden)?;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/routing_trace.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/routing_trace.rs
@@ -1,0 +1,63 @@
+//! A capture of which experts every routed layer selected, in execution
+//! order, for the step under observation. Off unless a caller starts it,
+//! costs one atomic load per routed call when off, and exists so a
+//! latency figure can say what work it timed: two passes over "the same
+//! token" that routed differently measured different things.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+static CAPTURE: Mutex<Option<Vec<Vec<usize>>>> = Mutex::new(None);
+
+/// Begin capturing; any earlier capture is discarded.
+pub fn start_capture() {
+    *CAPTURE.lock().expect("routing capture lock") = Some(Vec::new());
+    ACTIVE.store(true, Ordering::Release);
+}
+
+/// Stop capturing and return every routed call's selected experts, in
+/// the order the calls happened.
+pub fn take_capture() -> Vec<Vec<usize>> {
+    ACTIVE.store(false, Ordering::Release);
+    CAPTURE
+        .lock()
+        .expect("routing capture lock")
+        .take()
+        .unwrap_or_default()
+}
+
+/// Record one routed call's selection. A no-op unless a capture is open.
+pub fn record(selected: &[(usize, f32)]) {
+    if !ACTIVE.load(Ordering::Acquire) {
+        return;
+    }
+    if let Some(capture) = CAPTURE.lock().expect("routing capture lock").as_mut() {
+        capture.push(selected.iter().map(|(e, _)| *e).collect());
+    }
+}
+
+/// A short, order-sensitive fingerprint of a capture, so two passes can
+/// be compared at a glance and a mismatch located by index.
+///
+/// Each expert is hashed as the word (layer, slot, expert) — never the
+/// bare id — so moving a boundary between layers changes the words, not
+/// just their order. (A separator XORed between layers is not enough:
+/// XOR-then-multiply lets `[3, 1 | 0]` and `[3 | 1, 0]` collide.)
+pub fn fingerprint(capture: &[Vec<usize>]) -> u64 {
+    // FNV-1a over position-aware words.
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    const LAYER_SHIFT: u32 = 48;
+    const SLOT_SHIFT: u32 = 32;
+    let mut h = OFFSET;
+    for (layer, selected) in capture.iter().enumerate() {
+        h ^= (selected.len() as u64) << LAYER_SHIFT | 0xffff_ffff;
+        h = h.wrapping_mul(PRIME);
+        for (slot, &expert) in selected.iter().enumerate() {
+            h ^= (layer as u64) << LAYER_SHIFT | (slot as u64) << SLOT_SHIFT | expert as u64;
+            h = h.wrapping_mul(PRIME);
+        }
+    }
+    h
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/stages.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/stages.rs
@@ -1,0 +1,175 @@
+//! The stage ledger: where a token's wall time goes, at the level a
+//! residency decision is priced at — attention, the router, the routed
+//! experts, the shared expert — and nothing finer.
+//!
+//! This is a second instrument beside [`super::timing`], not a
+//! replacement. The leaf ledger refuses to reconcile when timers nest,
+//! because nested leaves double-count; a stage CONTAINS leaves by
+//! definition, so a stage timer must never be a leaf timer. Stages are
+//! disjoint at their own level: one stage starting inside another on the
+//! same thread is counted as a violation and voids the stage sum, the
+//! same discipline the leaf ledger keeps for itself.
+
+use std::cell::Cell;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+/// One stage of a token's execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stage {
+    /// The layer's attention operator, whatever its kind: KDA, MLA,
+    /// softmax, gated delta, Mamba-2, conv-QKV.
+    Attention,
+    /// The router: its projection and the selection it makes.
+    Router,
+    /// The routed experts' projections, over the selected set.
+    RoutedExperts,
+    /// The always-active shared expert.
+    SharedExpert,
+}
+
+impl Stage {
+    pub const ALL: [Stage; 4] = [
+        Stage::Attention,
+        Stage::Router,
+        Stage::RoutedExperts,
+        Stage::SharedExpert,
+    ];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Stage::Attention => "attention",
+            Stage::Router => "router",
+            Stage::RoutedExperts => "routed_experts",
+            Stage::SharedExpert => "shared_expert",
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            Stage::Attention => 0,
+            Stage::Router => 1,
+            Stage::RoutedExperts => 2,
+            Stage::SharedExpert => 3,
+        }
+    }
+}
+
+/// What one stage has accumulated since the last reset.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StageTally {
+    pub calls: u64,
+    pub nanos: u64,
+}
+
+struct Slot {
+    calls: AtomicU64,
+    nanos: AtomicU64,
+}
+
+/// Every stage's tally, and the count of stages that started inside
+/// another on the same thread.
+pub struct StageLedger {
+    slots: [Slot; 4],
+    nested: AtomicU64,
+}
+
+thread_local! {
+    static ACTIVE: Cell<bool> = const { Cell::new(false) };
+}
+
+impl StageLedger {
+    pub(super) const fn new() -> Self {
+        #[allow(clippy::declare_interior_mutable_const)]
+        const ZERO: Slot = Slot {
+            calls: AtomicU64::new(0),
+            nanos: AtomicU64::new(0),
+        };
+        Self {
+            slots: [ZERO; 4],
+            nested: AtomicU64::new(0),
+        }
+    }
+
+    fn record(&self, stage: Stage, nanos: u64) {
+        let slot = &self.slots[stage.index()];
+        slot.calls.fetch_add(1, Ordering::Relaxed);
+        slot.nanos.fetch_add(nanos, Ordering::Relaxed);
+    }
+
+    pub fn get(&self, stage: Stage) -> StageTally {
+        let slot = &self.slots[stage.index()];
+        StageTally {
+            calls: slot.calls.load(Ordering::Relaxed),
+            nanos: slot.nanos.load(Ordering::Relaxed),
+        }
+    }
+
+    pub fn all(&self) -> [(Stage, StageTally); 4] {
+        Stage::ALL.map(|s| (s, self.get(s)))
+    }
+
+    /// Stages that started while another stage was running on the same
+    /// thread. Any value above zero voids the stage sum.
+    pub fn nested(&self) -> u64 {
+        self.nested.load(Ordering::Relaxed)
+    }
+
+    /// The sum of every stage's nanoseconds — meaningful only when
+    /// [`Self::nested`] is zero.
+    pub fn total_nanos(&self) -> u64 {
+        self.slots
+            .iter()
+            .map(|s| s.nanos.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    pub fn reset(&self) {
+        for slot in &self.slots {
+            slot.calls.store(0, Ordering::Relaxed);
+            slot.nanos.store(0, Ordering::Relaxed);
+        }
+        self.nested.store(0, Ordering::Relaxed);
+    }
+}
+
+/// A running stage timer. Records on drop.
+pub struct Staged {
+    stage: Stage,
+    started: Instant,
+    outermost: bool,
+}
+
+impl Drop for Staged {
+    fn drop(&mut self) {
+        let nanos = self.started.elapsed().as_nanos() as u64;
+        ledger().record(self.stage, nanos);
+        if self.outermost {
+            ACTIVE.with(|a| a.set(false));
+        }
+    }
+}
+
+/// Start one stage. Bind the value to a name for the stage's extent.
+pub fn stage(stage: Stage) -> Staged {
+    let outermost = ACTIVE.with(|a| {
+        let was = a.get();
+        a.set(true);
+        !was
+    });
+    if !outermost {
+        ledger().nested.fetch_add(1, Ordering::Relaxed);
+    }
+    Staged {
+        stage,
+        started: Instant::now(),
+        outermost,
+    }
+}
+
+static LEDGER: StageLedger = StageLedger::new();
+
+/// The process's stage ledger.
+pub fn ledger() -> &'static StageLedger {
+    &LEDGER
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -122,6 +122,7 @@ pub(super) use crate::format::vindex3::fixtures::{
     DENSE_Q_HEADS as Q_HEADS, DENSE_VOCAB as VOCAB,
 };
 mod sigmoid_router;
+mod stages_and_routing;
 mod step_many;
 
 /// `step_many`'s gates run on the same encoded hybrid stack the

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/stages_and_routing.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/stages_and_routing.rs
@@ -1,0 +1,88 @@
+//! The stage ledger and the routing trace, on their own terms: a stage
+//! records what it contains, a stage inside a stage is counted and voids
+//! the sum, a capture returns exactly the selections made while it was
+//! open, and a fingerprint tells two selections apart by order.
+
+use super::super::routing_trace;
+use super::super::stages::{ledger, stage, Stage, StageTally};
+
+/// The ledger is process-wide, so these tests hold one lock between them
+/// rather than race each other's counters.
+static SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[test]
+fn a_stage_records_its_extent_and_a_reset_clears_it() {
+    let _serial = SERIAL.lock().unwrap();
+    ledger().reset();
+    {
+        let _s = stage(Stage::Router);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+    let router = ledger().get(Stage::Router);
+    assert_eq!(router.calls, 1);
+    assert!(router.nanos >= 2_000_000, "{router:?}");
+    assert_eq!(ledger().get(Stage::Attention), StageTally::default());
+    assert_eq!(ledger().nested(), 0);
+    assert_eq!(ledger().total_nanos(), router.nanos);
+    ledger().reset();
+    assert_eq!(ledger().get(Stage::Router), StageTally::default());
+}
+
+#[test]
+fn a_stage_inside_a_stage_is_counted_as_nesting() {
+    let _serial = SERIAL.lock().unwrap();
+    ledger().reset();
+    {
+        let _outer = stage(Stage::Attention);
+        let _inner = stage(Stage::Router);
+    }
+    assert_eq!(ledger().nested(), 1);
+    assert_eq!(ledger().get(Stage::Attention).calls, 1);
+    assert_eq!(ledger().get(Stage::Router).calls, 1);
+    // Sequential stages do not nest.
+    ledger().reset();
+    {
+        let _a = stage(Stage::RoutedExperts);
+    }
+    {
+        let _b = stage(Stage::SharedExpert);
+    }
+    assert_eq!(ledger().nested(), 0);
+    assert_eq!(
+        ledger().all().iter().filter(|(_, t)| t.calls == 1).count(),
+        2
+    );
+    ledger().reset();
+}
+
+#[test]
+fn every_stage_has_a_distinct_name() {
+    let names: std::collections::BTreeSet<&str> = Stage::ALL.iter().map(|s| s.name()).collect();
+    assert_eq!(names.len(), Stage::ALL.len());
+}
+
+#[test]
+fn a_capture_returns_the_selections_made_while_it_was_open() {
+    let _serial = SERIAL.lock().unwrap();
+    routing_trace::record(&[(1, 0.5)]);
+    routing_trace::start_capture();
+    routing_trace::record(&[(3, 0.7), (1, 0.3)]);
+    routing_trace::record(&[(0, 1.0)]);
+    let captured = routing_trace::take_capture();
+    assert_eq!(captured, vec![vec![3, 1], vec![0]]);
+    routing_trace::record(&[(9, 1.0)]);
+    assert!(
+        routing_trace::take_capture().is_empty(),
+        "closed captures record nothing"
+    );
+}
+
+#[test]
+fn a_fingerprint_is_order_sensitive_and_layer_aware() {
+    let a = routing_trace::fingerprint(&[vec![3, 1], vec![0]]);
+    let b = routing_trace::fingerprint(&[vec![1, 3], vec![0]]);
+    let c = routing_trace::fingerprint(&[vec![3], vec![1, 0]]);
+    assert_ne!(a, b);
+    assert_ne!(a, c);
+    assert_eq!(a, routing_trace::fingerprint(&[vec![3, 1], vec![0]]));
+}

--- a/docs/represent/forecasts/k3-v4-warm-latency-notes.json
+++ b/docs/represent/forecasts/k3-v4-warm-latency-notes.json
@@ -1,0 +1,119 @@
+{
+  "programme": "residency-into-k3",
+  "wave": "V4 deterministic warm-latency characterisation",
+  "forecast": "k3-v4-warm-latency.json (frozen before implementation; not edited)",
+  "instrument": "`larql vindex3 exec <c> --tokens 1008,10484,318 --backend production --generate 2 --residency-curve --repeat N --warmup K [--unquiet-ok]`: the V3 curve plus a stage ledger (attention / router / routed_experts / shared_expert, disjoint at its level, leaf timers inside it; the V3 leaf timer around the routed loop removed), a routing trace (selected experts per routed layer, fingerprinted), determinism witnesses (generated ids, logits max|Δ| vs pass 1), the CPU pool's worker count and the environment probe at start and per pass, and nearest-rank p50/p95/min/max over the counted passes. A machine the probe disqualifies is refused unless `--unquiet-ok`, and then the report is labelled UNQUALIFIED with the reasons.",
+  "arms": {
+    "A_quiet_attempt_1": {
+      "when": "2026-09-06 ~11:20 local, after waiting for the release build's load to decay (load1 3.92 at start)",
+      "qualification": "UNQUALIFIED — the probe reported POWER = BATTERY (100%, discharging); the arm ran before the refusal existed and is kept as evidence with that label. The forecast's quiet definition named load and background CPU but not power; the codebase's own disqualifier set includes battery, and the instrument now honours it.",
+      "passes": {
+        "repeat": 33,
+        "warmup": 3,
+        "counted": 30
+      },
+      "routing": "IDENTICAL in every counted pass (fingerprint ebe045dc40cce5b1 over 26 routed layers; layer-1 experts [103, 47, 107, 223, 8, 20, 176, 211])",
+      "logits": "bit-identical across all counted passes (max|Δ| 0.00e0)",
+      "faults": "major 0 in every counted pass; resident-page delta 0; minor ≤ 22 (22 on one slow pass, 0–6 otherwise)",
+      "token_ms": {
+        "p50": 79.5,
+        "p95": 760.4,
+        "min": 74.9,
+        "max": 1567.7,
+        "p95_over_p50": 9.57,
+        "all_counted": [
+          76.0,
+          76.0,
+          77.0,
+          76.0,
+          76.0,
+          79.0,
+          76.0,
+          75.0,
+          76.0,
+          83.0,
+          86.0,
+          342.0,
+          102.0,
+          760.0,
+          1568.0,
+          76.0,
+          80.0,
+          80.0,
+          79.0,
+          85.0,
+          82.0,
+          82.0,
+          79.0,
+          83.0,
+          81.0,
+          84.0,
+          79.0,
+          79.0,
+          87.0,
+          75.0
+        ]
+      },
+      "modal_cluster": "25 of 30 counted passes within 74.9–87 ms; the other 5 at 102, 342, 760, 1568 ms (consecutive passes) — in those, EVERY stage scaled by the same factor (attention 25→116→193→365 ms, routed experts 36→194→527→1139 ms) with 0 major faults and 0 resident delta: a whole-process slowdown (frequency or scheduling), not I/O and not the model.",
+      "stage_split_at_p50_ms": {
+        "attention": 26.2,
+        "router": 0.9,
+        "routed_experts": 38.2,
+        "shared_expert": 8.3,
+        "other": 5.9
+      },
+      "stage_share_of_token_p50": {
+        "attention": "32.9%",
+        "router": "1.1%",
+        "routed_experts": "48.0%",
+        "shared_expert": "10.5%",
+        "other": "7.4%"
+      },
+      "scheduling": "cpu pool 6 workers of 16 available; synchronous CPU backend, boundary = step return",
+      "cold_first_pass": "pass 1 (warmup) token: 590 ms, 1.207 GB paged in, 73,516 major faults — the page cache had lost part of the bank since V3's runs."
+    },
+    "B_contended": {
+      "when": "2026-09-06 ~11:45 local, four `yes > /dev/null` processes, `--unquiet-ok`",
+      "qualification": "UNQUALIFIED, as designed — the probe reported: on battery; load average 4.35 > 2.5; background CPU 700% > 40%; `yes` at 100% of a core over the 12% limit. The instrument named the contention.",
+      "passes": {
+        "repeat": 23,
+        "warmup": 3,
+        "counted": 20
+      },
+      "routing": "IDENTICAL (same fingerprint as the quiet arm, ebe045dc40cce5b1)",
+      "logits": "bit-identical (0.00e0)",
+      "faults": "major 0; minor ≤ 6; resident-page delta 0",
+      "token_ms": {
+        "p50": 85.7,
+        "p95": 93.5,
+        "min": 79.7,
+        "max": 99.4,
+        "p95_over_p50": 1.09
+      },
+      "stage_split_at_p50_ms": {
+        "attention": 27.5,
+        "router": 0.9,
+        "routed_experts": 42.7,
+        "shared_expert": 7.9,
+        "other": 6.7
+      },
+      "reading": "Four busy loops on a 16-core machine left the 6-worker pool its cores: p50 moved 79.5 → 85.7 ms (1.08×) and the distribution TIGHTENED (p95/p50 1.09 against the quiet arm's 9.57). The quiet arm's tail was therefore not other processes' CPU demand."
+    }
+  },
+  "predictions_scored": {
+    "P1": "PARTIAL. p50 79.5 ms ≤ 180 ✓ (and below V3's 140 ms floor). p95/p50 9.57 ✗ — but the tail is a labelled, uniform whole-process slowdown on a machine on BATTERY; the prediction stands untested on a QUALIFIED machine.",
+    "P2": "HELD. One routing fingerprint in 30 passes; generated ids identical; logits bit-identical.",
+    "P3": "HELD except the shared expert: routed 48.0% (40–55 ✓), attention 32.9% (25–40 ✓), router 1.1% (<3 ✓), other 7.4% (≤15 ✓), shared expert 10.5% (3–8 ✗ — the 1024-wide shared expert is three dense projections per layer, 26 layers, ≈ one routed expert's cost in every layer; the forecast underpriced it).",
+    "P4": "HELD on major faults (0) and resident delta (0); minor faults ≤ 22 vs ≤ 10 predicted ✗ (the 22 coincided with the 342 ms pass).",
+    "P5": "HELD, stronger than predicted: 0.00e0 — the production CPU path is bit-reproducible pass to pass.",
+    "P6": "FALSIFIED on magnitude, HELD on detection: the probe reported background CPU 700% and named `yes` ✓; but p50 rose 1.08× (≥ 1.5× predicted ✗) and p95/p50 was 1.09 (> 1.3 predicted ✗). CPU-demand contention from four busy loops does not reach a 6-of-16-core pool."
+  },
+  "findings": {
+    "V4-N1": "The warm Kimi-Linear token's floor through the prepared plan is ≈ 75–80 ms on this machine (p50 79.5, min 74.9), with identical routing and bit-identical logits across passes. V3's 140 ms and 430 ms both sit in the slow regime this arm exposed: passes where every stage slows by one factor together, with no page faults — the machine, not the model.",
+    "V4-N2": "The stage denominator for prefetch pricing at p50: routed experts 38 ms (48%), attention 26 ms (33%), shared expert 8 ms (10.5%), router 1 ms, other 6 ms. A prefetch move can only recover cold-path cost; on the WARM token the routed loop is already 48% and compute-bound at these sizes.",
+    "V4-N3": "A measurement's qualification is part of its result. The probe reported BATTERY and the run went ahead because the instrument only printed the probe; it now refuses a disqualified machine unless told to run labelled. [[feedback_a_gate_owns_its_own_state]] again.",
+    "V4-N4": "The tail is episodic and uniform, not load-driven: in the quiet arm four consecutive passes slowed every stage by one common factor (up to 20×) with 0 faults, while a deliberately loaded machine produced a tight 1.09 distribution. What remains as cause is whole-process frequency or scheduling policy — the machine was on BATTERY in both arms, and macOS's frequency policy on battery is exactly the disqualifier the environment probe names. The qualified arm on AC power is the discriminating experiment and has not run."
+  },
+  "not_claimed": "No tokens-per-second. The quiet arm on a QUALIFIED machine (AC power) has not run; 79.5 ms p50 is the modal floor of an unqualified run, and the tail's cause is narrowed to frequency/scheduling policy, not established.",
+  "next": "Run arm A on AC power (the instrument now refuses otherwise). If p95/p50 ≤ 1.3 there, P1 holds and V3's spread is closed as battery frequency policy; if the tail persists on AC, the next tap is per-pass core frequency and QoS class. Then the prefetch arms, priced against V4-N2's denominator."
+}

--- a/docs/represent/forecasts/k3-v4-warm-latency.json
+++ b/docs/represent/forecasts/k3-v4-warm-latency.json
@@ -1,0 +1,33 @@
+{
+  "programme": "residency-into-k3",
+  "wave": "V4 deterministic warm-latency characterisation",
+  "frozen": "2026-09-06, before implementation, on main 43228c97 (PR #428)",
+  "why": "V3 measured the warm Kimi-Linear token at 140 ms and 430 ms in two runs with 0 major faults in both. A 3× spread on identical work is not a throughput figure; 0 major faults rules out cold storage and nothing else. V4 characterises the warm token deterministically before any representation or access move is priced against it.",
+  "subject": "~/chris-models/Kimi-Linear-48B-A3B-Instruct.lift2.vindex3, production backend, prompt [1008, 10484, 318], the first generated token (276) after the prompt, fresh continuation state per pass so the token state is identical by construction",
+  "instrument": {
+    "reuse": "`vindex3 exec … --generate 2 --residency-curve --repeat N` (V3): per pass and step, elapsed, mincore-resident delta, minor/major fault deltas, peak RSS.",
+    "add": [
+      "`--warmup K`: passes excluded from the statistics; the report names how many.",
+      "stage ledger, disjoint at its own level and allowed to contain leaf timers: Attention (the layer's attention operator, KDA/MLA/softmax), Router (router projection + selection), RoutedExperts (the per-expert loop), SharedExpert (the always-on branch); Other = wall − the four. The V3 leaf timer around the routed loop is REMOVED: it nested the projection leaves and voided the leaf ledger's reconciliation.",
+      "routing trace: the selected expert ids of every routed layer for the timed token, captured per pass; a fingerprint and equality across passes are reported.",
+      "determinism: generated ids per pass; max |Δ| of the token's logits against pass 1.",
+      "scheduling: the CPU pool's worker count, available parallelism, and the environment probe (power, load, background CPU, busiest process) at start and per pass.",
+      "boundary: the production CPU backend is synchronous — the pool joins inside the step and nothing runs past the step's return; the report states this and the device backend is out of scope.",
+      "statistics: p50, p95, min, max of the token step and of every stage over the counted passes (nearest-rank)."
+    ]
+  },
+  "arms": {
+    "A_quiet": "n = 30 passes, warmup 3, on a machine the probe calls quiet (background CPU < 10%, load average < 4).",
+    "B_contended": "the same command while four `yes > /dev/null` processes run — a control for the instrument, not a measurement of the model: the probe must NAME the contention and the statistics must move."
+  },
+  "predictions": {
+    "P1": "Quiet arm: token p50 ≤ 180 ms and p95/p50 ≤ 1.3. (The 430 ms V3 run was contention.)",
+    "P2": "Selected experts are identical in every pass (one fingerprint), and so are the generated ids.",
+    "P3": "Quiet-arm stage split of the token p50: RoutedExperts 40–55%, Attention 25–40%, SharedExpert 3–8%, Router < 3%, Other ≤ 15%.",
+    "P4": "Every counted pass: 0 major faults, 0 resident-page delta, ≤ 10 minor faults.",
+    "P5": "Logits max |Δ| against pass 1 ≤ 1e-4 (reduction-order noise only).",
+    "P6": "Contended arm: token p50 ≥ 1.5× the quiet p50 and p95/p50 > 1.3; the probe reports background CPU > 50% and names `yes` as the busiest process."
+  },
+  "falsification": "P1 false → the warm floor is not ~140 ms and the spread is intrinsic (then the stage split says where). P2 false → routing is not deterministic across passes and every latency figure is over different work. P3 false → the stage model is wrong and prefetch is priced against the wrong denominator. P6 false → the instrument cannot see contention and V3's spread stays unexplained.",
+  "not_claimed": "No tokens-per-second figure. No comparison across representations. No prefetch — V4 only fixes the denominator the prefetch arms will be measured against."
+}


### PR DESCRIPTION
V4 of the K3 residency vertical: the warm Kimi-Linear token characterised deterministically, so the prefetch and quantised-residency arms are priced against a fixed denominator rather than V3's 140–430 ms spread.

Forecast frozen before implementation: `docs/represent/forecasts/k3-v4-warm-latency.json`; evidence and verdicts: `…-notes.json`.

## Instrument

- Stage ledger (`exec/stages.rs`): attention / router / routed experts / shared expert, disjoint at its level, leaf timers inside. The V3 leaf timer around the routed loop is removed (it nested the projection leaves).
- Routing trace (`exec/routing_trace.rs`): every routed layer's selected experts for the timed token, fingerprinted position-aware.
- `--residency-curve --repeat N --warmup K [--unquiet-ok]`: per-pass stages, routing fingerprint, generated ids, logits max|Δ| vs pass 1, fault and resident-page deltas, pool workers and the environment probe; p50/p95/min/max over counted passes. A disqualified machine is refused unless overridden, and then labelled.

## Measured (real container; both arms on battery, labelled UNQUALIFIED)

| arm | counted | routing | logits | major faults | token p50 | p95/p50 |
|---|---|---|---|---|---|---|
| quiet | 30 | identical | bit-identical | 0 | 79.5 ms | 9.57 |
| 4 busy loops | 20 | identical | bit-identical | 0 | 85.7 ms | 1.09 |

Quiet arm: 25 of 30 passes in 75–87 ms; five consecutive passes at 102–1568 ms where every stage slowed by one common factor with 0 faults. Stage split at p50: routed experts 48%, attention 33%, shared expert 10.5%, router 1%, other 7%.

## Verdicts

- P2, P5 held (deterministic routing; bit-identical logits). P3 held except the shared expert (10.5% vs 3–8% forecast). P4 held on faults and residency.
- P1 partial: p50 79.5 ms ≤ 180 holds; the p95/p50 half is open because the machine was on battery.
- P6 falsified on magnitude, held on detection: the probe named the busy loops, but four of them do not slow a 6-of-16-core pool.
- Finding: the tail is episodic and uniform, not load-driven. What remains is whole-process frequency or scheduling policy. The discriminating arm is the same run on AC power, which the instrument now requires.

No tokens-per-second figure is claimed.

## Gates

fmt, clippy (both crates), x86_64-apple-darwin check, full larql-vindex and larql-cli suites, per-file coverage ≥ 90% on the new and touched larql-vindex files (policy passes at 93.71%).
