### PR TITLE
K3 vertical PREFETCH-1: the selected experts brought in ahead of the routed loop

### DIFF
--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/exec.rs
@@ -236,6 +236,7 @@ fn run_on<B: PlanBackend>(
                     args.repeat,
                     args.warmup,
                     args.unquiet_ok,
+                    &args.expert_access,
                 );
             }
             super::generate::run_generate(backend, &engine, tokens, new_tokens, plan, store)

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/generate.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/generate.rs
@@ -23,6 +23,7 @@ use larql_vindex::format::vindex3::opplan::exec::cpu::{self, PhysicalProjectionP
 use larql_vindex::format::vindex3::opplan::exec::decode::DecodeSession;
 use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
 use larql_vindex::format::vindex3::opplan::exec::prepared::{AllocationCensus, ResidencyCensus};
+use larql_vindex::format::vindex3::opplan::exec::stages;
 use larql_vindex::format::vindex3::opplan::exec::timing;
 use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
 
@@ -473,18 +474,22 @@ pub(super) fn run_residency_curve<B: PlanBackend>(
     repeat: usize,
     warmup: usize,
     unquiet_ok: bool,
+    expert_access: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use larql_vindex::format::vindex3::opplan::exec::accounting::{
         expectations, BlockGeometry, ResourceLedger,
     };
     use larql_vindex::format::vindex3::opplan::exec::kv::RowKvState;
     use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
+    use larql_vindex::format::vindex3::opplan::exec::routing_trace;
     use larql_vindex::format::vindex3::opplan::exec::timing::OpClass;
-    use larql_vindex::format::vindex3::opplan::exec::{routing_trace, stages};
 
     if prompt.is_empty() {
         return Err("prompt holds no tokens — nothing to condition on".into());
     }
+    let access = larql_vindex::format::vindex3::opplan::exec::realization::MappedAccess::parse(
+        expert_access,
+    )?;
     if warmup >= repeat.max(1) {
         return Err(format!("warmup {warmup} leaves no counted pass out of {repeat}").into());
     }
@@ -516,10 +521,16 @@ pub(super) fn run_residency_curve<B: PlanBackend>(
     };
     println!("qualification: {qualification}");
     let loading = Instant::now();
-    let ops = PreparedOperands::load(plan, store, backend, ExecutionSlice::Full)?;
+    let budget =
+        larql_vindex::format::vindex3::opplan::exec::accounting::ResidencyBudget::UNBOUNDED
+            .with_expert_access(access);
+    let ops = PreparedOperands::load_within(plan, store, backend, ExecutionSlice::Full, &budget)?;
     let load_seconds = loading.elapsed().as_secs_f64();
     println!("engine: {engine}");
-    println!("weights bound in {load_seconds:.1} s (once, for {repeat} pass(es))");
+    println!(
+        "weights bound in {load_seconds:.1} s (once, for {repeat} pass(es)); expert access: {}",
+        access.name()
+    );
 
     // PREDICTED, from the pins and the tensor tables.
     let priced = expectations(
@@ -744,7 +755,7 @@ struct StepObservation {
     minor_faults: u64,
     major_faults: u64,
     /// Milliseconds per [`stages::Stage::ALL`] entry, in that order.
-    stage_ms: [f64; 4],
+    stage_ms: [f64; stages::Stage::ALL.len()],
     stages_nested: u64,
 }
 

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -230,6 +230,12 @@ pub struct ExecArgs {
     /// machine is refused before any weight is bound.
     #[arg(long, requires = "residency_curve")]
     pub unquiet_ok: bool,
+    /// How a mapped expert bank's selected experts are brought in per
+    /// token: `demand` (the loop faults each page), `advise` (the kernel
+    /// is told ahead), `touch` (pages are faulted concurrently ahead of
+    /// the loop). The same lossless bytes under every policy.
+    #[arg(long, default_value = "demand", requires = "residency_curve")]
+    pub expert_access: String,
 
     /// Teacher-force a whole quality bank through ONE resident model,
     /// writing `<--dump-dir>/<id>.f32` per entry.

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/generate.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/generate.rs
@@ -62,6 +62,7 @@ fn greedy_decode_runs_end_to_end_on_the_encoded_fixture() {
         repeat: 1,
         warmup: 0,
         unquiet_ok: true,
+        expert_access: "demand".to_string(),
         logit_dump: None,
         bank: None,
         dump_dir: None,
@@ -98,6 +99,7 @@ fn the_residency_curve_runs_cold_and_warm_passes_over_one_bound_image() {
         repeat: 3,
         warmup: 1,
         unquiet_ok: true,
+        expert_access: "touch".to_string(),
         logit_dump: None,
         bank: None,
         dump_dir: None,
@@ -132,6 +134,7 @@ fn a_warmup_that_leaves_nothing_counted_is_refused() {
         repeat: 2,
         warmup: 2,
         unquiet_ok: true,
+        expert_access: "demand".to_string(),
         logit_dump: None,
         bank: None,
         dump_dir: None,
@@ -141,4 +144,41 @@ fn a_warmup_that_leaves_nothing_counted_is_refused() {
     .unwrap_err()
     .to_string();
     assert!(err.contains("no counted pass"), "{err}");
+}
+
+/// An access policy the plan does not know is refused by name, before
+/// any weight is bound.
+#[test]
+fn an_unknown_expert_access_is_refused_by_name() {
+    let dir = fixture_dir(true);
+    let out = dir.path().join("container");
+    run(Vindex3Command::Encode(EncodeArgs {
+        capability: None,
+        artifacts: vec![dir.path().to_path_buf()],
+        output: out.clone(),
+    }))
+    .unwrap();
+    let err = run(Vindex3Command::Exec(ExecArgs {
+        container: out,
+        component: "target".to_string(),
+        tokens: "1,2,3".to_string(),
+        dump_layers: None,
+        resume: false,
+        backend: ExecBackend::Production,
+        representation_source: "auto".to_string(),
+        generate: Some(2),
+        residency_curve: true,
+        repeat: 1,
+        warmup: 0,
+        unquiet_ok: true,
+        expert_access: "prescient".to_string(),
+        logit_dump: None,
+        bank: None,
+        dump_dir: None,
+        draft_depth: None,
+        profile: false,
+    }))
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("prescient"), "{err}");
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/accounting.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/accounting.rs
@@ -289,6 +289,10 @@ pub struct ResidencyBudget {
     pub physical_bytes: Option<u64>,
     /// Bytes the host may stream per token to reach a target rate.
     pub throughput: Option<ThroughputBudget>,
+    /// How a mapped bank's selected experts are brought in per token —
+    /// a policy on the ACCESS realization, stamped on every mapped pin
+    /// the selection makes.
+    pub expert_access: super::realization::MappedAccess,
 }
 
 /// A rate constraint: a plan can fit in memory and still be unusably
@@ -313,6 +317,7 @@ impl ResidencyBudget {
     pub const UNBOUNDED: Self = Self {
         physical_bytes: None,
         throughput: None,
+        expert_access: super::realization::MappedAccess::Demand,
     };
 
     /// This machine's physical memory as the budget, read from the OS;
@@ -321,6 +326,7 @@ impl ResidencyBudget {
         Self {
             physical_bytes: physical_memory_bytes(),
             throughput: None,
+            expert_access: super::realization::MappedAccess::Demand,
         }
     }
 
@@ -328,11 +334,17 @@ impl ResidencyBudget {
         Self {
             physical_bytes: Some(bytes),
             throughput: None,
+            expert_access: super::realization::MappedAccess::Demand,
         }
     }
 
     pub fn with_throughput(mut self, throughput: ThroughputBudget) -> Self {
         self.throughput = Some(throughput);
+        self
+    }
+
+    pub fn with_expert_access(mut self, access: super::realization::MappedAccess) -> Self {
+        self.expert_access = access;
         self
     }
 
@@ -499,7 +511,9 @@ pub fn expectations(
                 RealizationForm::DecodedGather => ResidencyProfile::DECODED_F32,
                 // Mapped as stored: resident exactly as the container
                 // holds it, nothing staged on the way.
-                RealizationForm::MappedStored { format } => resident_profile_with(format, geometry),
+                RealizationForm::MappedStored { format, .. } => {
+                    resident_profile_with(format, geometry)
+                }
             };
             let staging = match realization.form {
                 RealizationForm::Direct(_) | RealizationForm::MappedStored { .. } => 0,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -639,6 +639,8 @@ pub enum ExpertSlices<'a> {
         gate: &'a [WeightSlice<'a>],
         up: &'a [WeightSlice<'a>],
         down: &'a [WeightSlice<'a>],
+        /// How the selected experts' pages are brought in for this call.
+        access: super::realization::MappedAccess,
     },
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/experts.rs
@@ -127,6 +127,8 @@ enum ExpertMatrices {
         gate: Vec<LoadedWeight>,
         up: Vec<LoadedWeight>,
         down: Vec<LoadedWeight>,
+        /// How the selected experts' pages are brought in per token.
+        access: super::realization::MappedAccess,
     },
 }
 
@@ -139,7 +141,7 @@ impl ExpertMatrices {
     fn all(&self) -> Vec<&LoadedWeight> {
         match self {
             Self::Fused { gate_up, down } => gate_up.iter().chain(down).collect(),
-            Self::Separate { gate, up, down } => gate.iter().chain(up).chain(down).collect(),
+            Self::Separate { gate, up, down, .. } => gate.iter().chain(up).chain(down).collect(),
         }
     }
 }
@@ -149,7 +151,7 @@ impl FfnOperands {
         ffn: &LayerFfn,
         store: OperandSource<'_>,
         format: super::prepared::FormatFor<'_>,
-        bank: WeightFormat,
+        bank: super::prepared::BankPin,
         shared: super::prepared::FormatFor<'_>,
     ) -> Result<Self, VindexError> {
         match ffn {
@@ -448,6 +450,7 @@ impl RoutedOperands {
                     gate: g,
                     up: u,
                     down: d,
+                    ..
                 },
             ) => {
                 let bank = Operation::ExpertProject {
@@ -528,6 +531,7 @@ impl RoutedOperands {
                 gate: g,
                 up: u,
                 down: d,
+                access,
             } => {
                 gate = slices(g);
                 up = slices(u);
@@ -536,6 +540,7 @@ impl RoutedOperands {
                     gate: &gate,
                     up: &up,
                     down: &down,
+                    access: *access,
                 }
             }
         };
@@ -576,9 +581,10 @@ impl RoutedOperands {
     fn load(
         op: &RoutedFfnOp,
         store: OperandSource<'_>,
-        format: WeightFormat,
+        bank: super::prepared::BankPin,
         shared_format: super::prepared::FormatFor<'_>,
     ) -> Result<Self, VindexError> {
+        let format = bank.format;
         let hidden = op.router.shape.get(1).copied().unwrap_or(0);
         let inter = op.expert_intermediate_size;
         // The bank first: its geometry is DECLARED — `k` follows from the
@@ -627,6 +633,7 @@ impl RoutedOperands {
                         gate: map(gate, inter, hidden)?,
                         up: map(up, inter, hidden)?,
                         down: map(down, hidden, inter)?,
+                        access: bank.access,
                     },
                     None,
                     None,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -46,6 +46,7 @@ pub mod mla;
 pub mod narrow;
 pub mod observe;
 pub mod operands;
+pub mod prefetch;
 pub mod prepared;
 pub mod production;
 pub mod quantise;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prefetch.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prefetch.rs
@@ -1,0 +1,127 @@
+//! Bringing a mapped bank's selected experts into memory ahead of the
+//! projection loop — the ACCESS realization of the same lossless bytes.
+//!
+//! V3 measured the cold Kimi-Linear token at 1.30 s: 0.976 GB through
+//! 59,670 major faults of one 16 KiB page each, ≈22 µs per fault, taken
+//! one at a time in row order by the loop. Nothing here changes what is
+//! read or stored; only the shape of the request — whether the kernel is
+//! told what is coming, or the pages are faulted concurrently before the
+//! loop needs them.
+
+use super::realization::MappedAccess;
+
+/// One selected expert's matrix, as a range of the mapping: its first
+/// byte's address and its length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Range {
+    pub address: usize,
+    pub bytes: usize,
+}
+
+impl Range {
+    pub fn of<T>(slice: &[T]) -> Self {
+        Self {
+            address: slice.as_ptr() as usize,
+            bytes: std::mem::size_of_val(slice),
+        }
+    }
+}
+
+/// What a prefetch did, for the reconciliation beside it: how many
+/// ranges it covered and how many bytes those spanned once page-aligned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PrefetchReport {
+    pub ranges: usize,
+    pub bytes: usize,
+}
+
+/// The page the OS faults by, read once.
+fn page_size() -> usize {
+    #[cfg(unix)]
+    {
+        // SAFETY: sysconf reads a process-independent constant.
+        let size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if size > 0 {
+            return size as usize;
+        }
+    }
+    // Every platform this runs on pages by at least 4 KiB; a platform
+    // that will not say pages by that.
+    4096
+}
+
+/// `range` rounded out to whole pages.
+fn aligned(range: Range, page: usize) -> Range {
+    let start = range.address / page * page;
+    let end = (range.address + range.bytes).div_ceil(page) * page;
+    Range {
+        address: start,
+        bytes: end - start,
+    }
+}
+
+/// Bring `ranges` in under `access`, ahead of whoever reads them.
+/// `parallelism` bounds the touch arm's concurrency; Demand does nothing
+/// and reports nothing, which is the point of naming it.
+pub fn prefetch(access: MappedAccess, ranges: &[Range], parallelism: usize) -> PrefetchReport {
+    if access == MappedAccess::Demand || ranges.is_empty() {
+        return PrefetchReport::default();
+    }
+    let page = page_size();
+    let mut aligned_ranges: Vec<Range> = ranges.iter().map(|r| aligned(*r, page)).collect();
+    // In address order, so the request follows the file's physical layout.
+    aligned_ranges.sort_by_key(|r| r.address);
+    let bytes = aligned_ranges.iter().map(|r| r.bytes).sum();
+    match access {
+        MappedAccess::Demand => unreachable!("returned above"),
+        MappedAccess::Advise => advise(&aligned_ranges),
+        MappedAccess::Touch => touch(&aligned_ranges, page, parallelism.max(1)),
+    }
+    PrefetchReport {
+        ranges: aligned_ranges.len(),
+        bytes,
+    }
+}
+
+#[cfg(unix)]
+fn advise(ranges: &[Range]) {
+    for r in ranges {
+        // SAFETY: the range is page-aligned and lies inside a mapping this
+        // process owns for the life of the prepared image; WILLNEED is a
+        // hint and cannot change the mapping's contents or protection.
+        unsafe {
+            libc::madvise(r.address as *mut libc::c_void, r.bytes, libc::MADV_WILLNEED);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn advise(_ranges: &[Range]) {}
+
+/// Touch one byte per page of every range, concurrently over up to
+/// `parallelism` threads, each thread taking a contiguous share of the
+/// address-ordered ranges so the device sees sequential runs.
+fn touch(ranges: &[Range], page: usize, parallelism: usize) {
+    let threads = parallelism.min(ranges.len()).max(1);
+    let per_thread = ranges.len().div_ceil(threads);
+    std::thread::scope(|scope| {
+        for share in ranges.chunks(per_thread) {
+            scope.spawn(move || {
+                for r in share {
+                    let mut at = r.address;
+                    let end = r.address + r.bytes;
+                    while at < end {
+                        // SAFETY: `at` lies inside a mapping this process
+                        // owns for the life of the prepared image; a
+                        // volatile read cannot be elided and reads one byte
+                        // the mapping already holds.
+                        unsafe {
+                            std::ptr::read_volatile(at as *const u8);
+                        }
+                        at += page;
+                    }
+                }
+            });
+        }
+    });
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -1241,6 +1241,14 @@ pub fn select_realizations_within<B: PlanBackend + ?Sized>(
     budget: &ResidencyBudget,
 ) -> Result<Vec<RealizationRecord>, VindexError> {
     let mut selected = select_records(plan, store, backend, slice)?;
+    // The access policy is the budget's, not the candidate's: every mapped
+    // pin executes under the one the caller declared.
+    for (record, _) in &mut selected {
+        record.selection.realization = record
+            .selection
+            .realization
+            .with_access(budget.expert_access);
+    }
     let geometry = BlockGeometry::executor();
     let stored_len = |op: &OperandRef| store.stored_len(op);
     let mut switches: Vec<String> = Vec::new();
@@ -1455,7 +1463,27 @@ fn pinned_format(
 /// one slice pin, or the one form every matrix of a per-expert bank was
 /// pinned to — a bank whose experts were pinned differently is a plan
 /// the loader cannot bind, and is refused by name.
-fn bank_pin(records: &[RealizationRecord], index: usize) -> Result<WeightFormat, VindexError> {
+/// What the bank's pins agree on: the resident form, and how a mapped
+/// form is accessed per token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BankPin {
+    pub format: WeightFormat,
+    pub access: super::realization::MappedAccess,
+}
+
+impl From<WeightFormat> for BankPin {
+    /// A format alone is a pin under demand access — the loader's
+    /// behaviour before access was a declared policy, and the one every
+    /// non-mapped form has.
+    fn from(format: WeightFormat) -> Self {
+        Self {
+            format,
+            access: super::realization::MappedAccess::Demand,
+        }
+    }
+}
+
+fn bank_pin(records: &[RealizationRecord], index: usize) -> Result<BankPin, VindexError> {
     let mut pins = records
         .iter()
         .filter(|r| {
@@ -1465,7 +1493,10 @@ fn bank_pin(records: &[RealizationRecord], index: usize) -> Result<WeightFormat,
                     Operation::ExpertBankSlice | Operation::ExpertProject { .. }
                 )
         })
-        .map(|r| r.selection.realization.format());
+        .map(|r| BankPin {
+            format: r.selection.realization.format(),
+            access: r.selection.realization.access(),
+        });
     let Some(first) = pins.next() else {
         return Err(VindexError::Parse(format!(
             "layer {index}: a routed FFN with no pinned bank realization — planned_operands() \
@@ -1671,7 +1702,10 @@ impl PreparedOperands {
             // form so nothing compact is implied.
             let bank_format = match layer.ffn.as_ref().and_then(|f| f.routed()) {
                 Some(_) => bank_pin(&realizations, index)?,
-                None => WeightFormat::F32,
+                None => BankPin {
+                    format: WeightFormat::F32,
+                    access: super::realization::MappedAccess::Demand,
+                },
             };
             layers.push(PreparedLayer {
                 // Absent under post-norm placement: the sublayer reads

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -39,7 +39,7 @@ use super::super::super::graph::policy::AttentionSpan;
 use super::backend::{
     AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, ExpertSlices, FfnCall,
     FfnManyCall, GateCall, NormCall, PlanBackend, ProjectCall, ProjectedQkv, QkNormCall,
-    RoutedFfnCall, WeightFormat,
+    RoutedFfnCall, WeightFormat, WeightSlice,
 };
 use super::cpu::physical::{
     kquant_execution, project_matrix, project_matrix_many, ExecutorProjections, KQuantExecution,
@@ -48,6 +48,7 @@ use super::cpu::PhysicalProjectionPlan;
 use super::kernels::{
     gather_fused_half, mrope_rotate_scaled, rope_rotate, rope_rotate_scaled, sigmoid, FusedHalf,
 };
+use super::prefetch;
 use super::realization::{
     class_of, common_selection, cpu_projection_candidates, realization_residency, RealizationForm,
     RealizationId, RefusalKind, RepresentationFacts, Selection, SelectionReason, SelectionRefusal,
@@ -1059,6 +1060,29 @@ impl PlanBackend for ProductionBackend {
             select_experts(&call, &mut logits)?
         };
         routing_trace::record(&selected);
+        if let ExpertSlices::Separate {
+            gate,
+            up,
+            down,
+            access,
+        } = &call.weights
+        {
+            // The selected experts' pages, ahead of the loop that reads
+            // them — the access realization, timed apart from the loop
+            // so a fault moved is a fault moved, not a fault removed.
+            let _prefetch = stage(Stage::Prefetch);
+            let ranges: Vec<prefetch::Range> = selected
+                .iter()
+                .flat_map(|(e, _)| [&gate[*e], &up[*e], &down[*e]])
+                .filter_map(|w| match w {
+                    WeightSlice::Bf16(rows) => Some(prefetch::Range::of(rows)),
+                    WeightSlice::F32(rows) => Some(prefetch::Range::of(rows)),
+                    _ => None,
+                })
+                .collect();
+            let parallelism = super::cpu::shared().map(|e| e.workers()).unwrap_or(1);
+            prefetch::prefetch(*access, &ranges, parallelism);
+        }
         let _stage = stage(Stage::RoutedExperts);
         let mut out = vec![0.0f32; call.hidden];
         match call.weights {
@@ -1091,7 +1115,7 @@ impl PlanBackend for ProductionBackend {
             // — so the bank stays in its stored form. No bias layout is
             // defined for separate experts, and none is planned; one
             // arriving here is a plan the executor does not know.
-            ExpertSlices::Separate { gate, up, down } => {
+            ExpertSlices::Separate { gate, up, down, .. } => {
                 if call.gate_up_bias.is_some() || call.down_bias.is_some() {
                     return Err(VindexError::Parse(
                         "a per-expert bank carries no expert bias; the call declares one"

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
@@ -18,6 +18,7 @@
 //! bank sliced per expert from stored rows, a decoded table gathered per
 //! token, or a device backend's own resident form.
 
+use serde::Serialize;
 use std::fmt;
 
 use super::backend::{MatrixClass, WeightFormat};
@@ -194,10 +195,62 @@ pub enum RealizationForm {
     /// bound once, never copied or converted — and executed in place in
     /// their stored form. A bank's realization: one physical object
     /// serving every logical expert access, paged in as touched.
-    MappedStored { format: WeightFormat },
+    MappedStored {
+        format: WeightFormat,
+        /// How the selected experts' pages are brought in for a token.
+        access: MappedAccess,
+    },
     /// A device backend's resident form, declared per class by that
     /// backend for its own target.
     DeviceResident(WeightFormat),
+}
+
+/// How a mapped bank's selected experts are brought into memory for one
+/// token — an ACCESS realization of the same lossless bytes. The bytes,
+/// the mapping and the touch are identical across variants; only the
+/// request shape differs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize)]
+pub enum MappedAccess {
+    /// The projection loop faults each page as it reaches it: one page
+    /// per fault, serially, in row order.
+    #[default]
+    Demand,
+    /// `madvise(MADV_WILLNEED)` over the selected experts' regions before
+    /// the loop; the kernel decides how much it reads ahead.
+    Advise,
+    /// The selected experts' pages are touched concurrently, ordered by
+    /// address, before the loop; every fault is taken in parallel and
+    /// the loop then finds resident pages.
+    Touch,
+}
+
+impl MappedAccess {
+    pub const ALL: [MappedAccess; 3] = [
+        MappedAccess::Demand,
+        MappedAccess::Advise,
+        MappedAccess::Touch,
+    ];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            MappedAccess::Demand => "demand",
+            MappedAccess::Advise => "advise",
+            MappedAccess::Touch => "touch",
+        }
+    }
+
+    /// The policy named by a flag, or the names it does accept.
+    pub fn parse(name: &str) -> Result<Self, String> {
+        Self::ALL
+            .into_iter()
+            .find(|a| a.name() == name)
+            .ok_or_else(|| {
+                format!(
+                    "unknown expert access `{name}`; one of {}",
+                    Self::ALL.map(|a| a.name()).join(", ")
+                )
+            })
+    }
 }
 
 /// One realization, named so a plan can pin it and a trace can say it.
@@ -223,8 +276,29 @@ impl RealizationId {
             | RealizationForm::Requantise(plan) => plan.format(),
             RealizationForm::SliceStored { convert } => convert,
             RealizationForm::DecodedGather => WeightFormat::F32,
-            RealizationForm::MappedStored { format } => format,
+            RealizationForm::MappedStored { format, .. } => format,
             RealizationForm::DeviceResident(format) => format,
+        }
+    }
+
+    /// The access realization of a mapped form; every other form is
+    /// brought in whole at binding and has none.
+    pub fn access(self) -> MappedAccess {
+        match self.form {
+            RealizationForm::MappedStored { access, .. } => access,
+            _ => MappedAccess::Demand,
+        }
+    }
+
+    /// The same realization under another access policy — only a mapped
+    /// form changes; every other form is returned as it is.
+    pub fn with_access(self, access: MappedAccess) -> Self {
+        match self.form {
+            RealizationForm::MappedStored { format, .. } => Self {
+                backend: self.backend,
+                form: RealizationForm::MappedStored { format, access },
+            },
+            _ => self,
         }
     }
 
@@ -245,7 +319,9 @@ impl RealizationId {
             RealizationForm::Requantise(plan) => format!("requantise/{plan:?}"),
             RealizationForm::SliceStored { convert } => format!("slice-stored→{convert:?}"),
             RealizationForm::DecodedGather => "decode-f32+gather".to_string(),
-            RealizationForm::MappedStored { format } => format!("mapped-stored/{format:?}"),
+            RealizationForm::MappedStored { format, access } => {
+                format!("mapped-stored/{format:?}/{}", access.name())
+            }
             RealizationForm::DeviceResident(format) => format!("device-resident/{format:?}"),
         };
         match self.backend {
@@ -514,6 +590,7 @@ pub fn common_selection(
             let format = mapped_format(&facts.label);
             let id = RealizationId::cpu(RealizationForm::MappedStored {
                 format: format.unwrap_or(WeightFormat::F32),
+                access: MappedAccess::Demand,
             });
             Some(
                 match (

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
@@ -794,7 +794,7 @@ impl PlanBackend for ReferenceBackend {
             // A per-expert bank, transcribed literally: each matrix
             // widened to f32 exactly (bf16 is the top half of the f32 it
             // denotes), three matvecs, the declared combine.
-            ExpertSlices::Separate { gate, up, down } => {
+            ExpertSlices::Separate { gate, up, down, .. } => {
                 if call.gate_up_bias.is_some() || call.down_bias.is_some() {
                     return Err(VindexError::Parse(
                         "a per-expert bank carries no expert bias; the call declares one"

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/stages.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/stages.rs
@@ -26,14 +26,17 @@ pub enum Stage {
     RoutedExperts,
     /// The always-active shared expert.
     SharedExpert,
+    /// Bringing the selected experts' pages in ahead of the routed loop.
+    Prefetch,
 }
 
 impl Stage {
-    pub const ALL: [Stage; 4] = [
+    pub const ALL: [Stage; 5] = [
         Stage::Attention,
         Stage::Router,
         Stage::RoutedExperts,
         Stage::SharedExpert,
+        Stage::Prefetch,
     ];
 
     pub fn name(self) -> &'static str {
@@ -42,6 +45,7 @@ impl Stage {
             Stage::Router => "router",
             Stage::RoutedExperts => "routed_experts",
             Stage::SharedExpert => "shared_expert",
+            Stage::Prefetch => "prefetch",
         }
     }
 
@@ -51,6 +55,7 @@ impl Stage {
             Stage::Router => 1,
             Stage::RoutedExperts => 2,
             Stage::SharedExpert => 3,
+            Stage::Prefetch => 4,
         }
     }
 }
@@ -70,7 +75,7 @@ struct Slot {
 /// Every stage's tally, and the count of stages that started inside
 /// another on the same thread.
 pub struct StageLedger {
-    slots: [Slot; 4],
+    slots: [Slot; 5],
     nested: AtomicU64,
 }
 
@@ -86,7 +91,7 @@ impl StageLedger {
             nanos: AtomicU64::new(0),
         };
         Self {
-            slots: [ZERO; 4],
+            slots: [ZERO; 5],
             nested: AtomicU64::new(0),
         }
     }
@@ -105,7 +110,7 @@ impl StageLedger {
         }
     }
 
-    pub fn all(&self) -> [(Stage, StageTally); 4] {
+    pub fn all(&self) -> [(Stage, StageTally); 5] {
         Stage::ALL.map(|s| (s, self.get(s)))
     }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production.rs
@@ -311,7 +311,7 @@ fn a_gate_less_dense_op_binds_two_operands_and_runs_ungated() {
         &ffn,
         (&store).into(),
         &|_: &OperandRef| Ok(WeightFormat::F32),
-        WeightFormat::F32,
+        WeightFormat::F32.into(),
         &|_: &OperandRef| Ok(WeightFormat::F32),
     )
     .unwrap();

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/bf16_zlib_bank.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/bf16_zlib_bank.rs
@@ -31,7 +31,7 @@ fn a_sequential_bank_is_refused_by_access_class_before_any_byte_is_read() {
         &ffn,
         (&control).into(),
         &f32_for,
-        WeightFormat::F32,
+        WeightFormat::F32.into(),
         &f32_for,
     )
     .expect("a bf16 bank is row-addressable");
@@ -50,8 +50,13 @@ fn a_sequential_bank_is_refused_by_access_class_before_any_byte_is_read() {
     let store = OperandStore::open(container.path(), &inspection).unwrap();
 
     let before = store.load_count();
-    let Err(err) = FfnOperands::load(&ffn, (&store).into(), &f32_for, WeightFormat::F32, &f32_for)
-    else {
+    let Err(err) = FfnOperands::load(
+        &ffn,
+        (&store).into(),
+        &f32_for,
+        WeightFormat::F32.into(),
+        &f32_for,
+    ) else {
         panic!("a sequential bank cannot be sliced per expert");
     };
     let msg = err.to_string();

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/fixture.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_experts_production/fixture.rs
@@ -354,7 +354,7 @@ pub(super) fn load(op: &RoutedFfnOp, store: &OperandStore, format: WeightFormat)
         &routed(op),
         store.into(),
         &|_: &OperandRef| Ok(format),
-        format,
+        format.into(),
         &|_: &OperandRef| Ok(format),
     )
     .unwrap()
@@ -365,7 +365,7 @@ pub(super) fn load_err(op: &RoutedFfnOp, store: &OperandStore, format: WeightFor
         &routed(op),
         store.into(),
         &|_: &OperandRef| Ok(format),
-        format,
+        format.into(),
         &|_: &OperandRef| Ok(format),
     )
     .err()

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_per_expert_prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kimi_per_expert_prepared.rs
@@ -19,7 +19,7 @@ use super::super::execute_plan;
 use super::super::operands::OperandStore;
 use super::super::prepared::{ExecutionSlice, PreparedOperands};
 use super::super::production::ProductionBackend;
-use super::super::realization::{RealizationForm, SelectionReason};
+use super::super::realization::{MappedAccess, RealizationForm, SelectionReason};
 use super::super::reference::ReferenceBackend;
 use crate::format::vindex3::fixtures::encode_fixture_container;
 use crate::format::vindex3::fixtures_kimi::{
@@ -41,13 +41,13 @@ const ROUTED_LAYERS: usize = MOE_LAYERS - MOE_DENSE_PREFIX;
 const MATRICES_PER_EXPERT: usize = 3;
 const SHARED_PROJECTIONS: usize = 3;
 
-struct Subject {
+pub(super) struct Subject {
     _src: tempfile::TempDir,
     container: tempfile::TempDir,
 }
 
 impl Subject {
-    fn build(write: fn(&Path)) -> Self {
+    pub(super) fn build(write: fn(&Path)) -> Self {
         let src = tempfile::tempdir().unwrap();
         let container = tempfile::tempdir().unwrap();
         encode_fixture_container(write, src.path(), container.path(), "kimi-moe");
@@ -57,7 +57,7 @@ impl Subject {
         }
     }
 
-    fn open(&self) -> (ComponentOpPlan, OperandStore) {
+    pub(super) fn open(&self) -> (ComponentOpPlan, OperandStore) {
         let inspection = inspect_container(self.container.path(), false).unwrap();
         let plan = plan_component_ops(&inspection, self.container.path(), "target")
             .unwrap()
@@ -144,7 +144,8 @@ fn the_bank_is_bound_once_as_a_mapping_and_reconciles_exactly() {
         assert_eq!(
             r.selection.realization.form,
             RealizationForm::MappedStored {
-                format: WeightFormat::F32
+                format: WeightFormat::F32,
+                access: MappedAccess::Demand,
             },
             "{}",
             r.planned.operand.tensor
@@ -483,6 +484,7 @@ fn a_separate_expert_call_is_refused_where_it_cannot_be_executed() {
         gate: &gate,
         up: &gate,
         down: &down,
+        access: MappedAccess::Demand,
     };
     // Executes, on both, once nothing is refusable.
     let production = ProductionBackend::new()
@@ -534,6 +536,7 @@ fn a_separate_expert_call_is_refused_where_it_cannot_be_executed() {
                 gate: &q8,
                 up: &q8,
                 down: &down,
+                access: MappedAccess::Demand,
             },
             None,
             inter,
@@ -569,6 +572,7 @@ fn the_reference_widens_bf16_experts_exactly_and_names_every_other_form() {
         gate: &gate,
         up: &gate,
         down: &down,
+        access: MappedAccess::Demand,
     };
     let production = ProductionBackend::new()
         .routed_ffn(separate_call(&x, &router, bf16(), None, inter, experts))
@@ -628,6 +632,7 @@ fn the_reference_widens_bf16_experts_exactly_and_names_every_other_form() {
                     gate: slices,
                     up: slices,
                     down: &down_f32_slices,
+                    access: MappedAccess::Demand,
                 },
                 None,
                 inter,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -122,6 +122,7 @@ pub(super) use crate::format::vindex3::fixtures::{
     DENSE_HIDDEN as HIDDEN, DENSE_INTERMEDIATE as INTERMEDIATE, DENSE_LAYERS as LAYERS,
     DENSE_Q_HEADS as Q_HEADS, DENSE_VOCAB as VOCAB,
 };
+mod prefetch;
 mod sigmoid_router;
 mod stages_and_routing;
 mod step_many;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/prefetch.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/prefetch.rs
@@ -45,7 +45,9 @@ fn resident_bytes(range: Range) -> usize {
         libc::mincore(
             start as *mut libc::c_void,
             end - start,
-            vec.as_mut_ptr() as *mut libc::c_char,
+            // The vector's element type is the platform's: `c_char` on
+            // macOS, `c_uchar` on Linux. `cast` lets each say which.
+            vec.as_mut_ptr().cast(),
         )
     };
     assert_eq!(rc, 0, "mincore failed");

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/prefetch.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/prefetch.rs
@@ -1,0 +1,187 @@
+//! The access realization on its own terms: Demand does nothing and says
+//! so; Advise and Touch cover exactly the selected ranges, page-rounded,
+//! and leave every byte as it was; a touched range is resident; the
+//! policy is the budget's and lands on every mapped pin; and the three
+//! policies execute the same token to the same bits.
+
+use super::super::accounting::ResidencyBudget;
+use super::super::decode::DecodeSession;
+use super::super::kv::RowKvState;
+use super::super::prefetch::{prefetch, PrefetchReport, Range};
+use super::super::prepared::{select_realizations_within, ExecutionSlice, PreparedOperands};
+use super::super::production::ProductionBackend;
+use super::super::realization::{MappedAccess, RealizationForm};
+use super::kimi_per_expert_prepared::Subject;
+use crate::format::vindex3::fixtures_kimi::kimi_per_expert_moe_f32_model;
+
+const PROMPT: [u32; 4] = [3, 17, 28, 11];
+
+/// A file of `len` bytes with a recognisable pattern, mapped whole. The
+/// prefetch works on address ranges of a mapping, so its witness maps a
+/// plain file and asks the OS about residency the way a region does.
+fn mapped_file(len: usize) -> (tempfile::TempDir, memmap2::Mmap) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bank.bin");
+    let bytes: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+    std::fs::write(&path, &bytes).unwrap();
+    let file = std::fs::File::open(&path).unwrap();
+    // SAFETY: the file is private to this test and never written again
+    // while the mapping lives.
+    let mmap = unsafe { memmap2::Mmap::map(&file) }.unwrap();
+    (dir, mmap)
+}
+
+/// Bytes of `range` the OS reports resident, by page.
+#[cfg(unix)]
+fn resident_bytes(range: Range) -> usize {
+    // SAFETY: sysconf reads a constant; mincore is given a page-aligned
+    // range inside a live mapping and a vector of one byte per page.
+    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
+    let start = range.address / page * page;
+    let end = (range.address + range.bytes).div_ceil(page) * page;
+    let pages = (end - start) / page;
+    let mut vec = vec![0u8; pages];
+    let rc = unsafe {
+        libc::mincore(
+            start as *mut libc::c_void,
+            end - start,
+            vec.as_mut_ptr() as *mut libc::c_char,
+        )
+    };
+    assert_eq!(rc, 0, "mincore failed");
+    vec.iter().filter(|b| **b & 1 == 1).count() * page
+}
+
+#[test]
+fn demand_brings_nothing_in_and_reports_nothing() {
+    let (_dir, mapped) = mapped_file(64 * 1024);
+    let range = Range::of(mapped[..].as_ref());
+    assert_eq!(
+        prefetch(MappedAccess::Demand, &[range], 4),
+        PrefetchReport::default()
+    );
+    assert_eq!(
+        prefetch(MappedAccess::Touch, &[], 4),
+        PrefetchReport::default()
+    );
+}
+
+#[test]
+fn advise_and_touch_cover_the_ranges_page_rounded_and_change_no_byte() {
+    let len = 200 * 1024 + 123;
+    let (_dir, mapped) = mapped_file(len);
+    let before: Vec<u8> = mapped[..].as_ref().to_vec();
+    // Two ranges inside the mapping, deliberately unaligned and out of order.
+    let a = Range::of(&mapped[..].as_ref()[70_000..150_000]);
+    let b = Range::of(&mapped[..].as_ref()[1_000..20_000]);
+    for access in [MappedAccess::Advise, MappedAccess::Touch] {
+        let report = prefetch(access, &[a, b], 3);
+        assert_eq!(report.ranges, 2, "{access:?}");
+        assert!(
+            report.bytes >= (150_000 - 70_000) + (20_000 - 1_000),
+            "{access:?}: page rounding never shrinks a range ({})",
+            report.bytes
+        );
+        assert!(
+            report.bytes <= (150_000 - 70_000) + (20_000 - 1_000) + 4 * 64 * 1024,
+            "{access:?}: rounding is bounded by a page at each end ({})",
+            report.bytes
+        );
+        assert_eq!(mapped[..].as_ref(), &before[..], "{access:?} changed bytes");
+    }
+    // Touched pages are resident, whatever the parallelism.
+    for parallelism in [1, 4, 64] {
+        let whole = Range::of(mapped[..].as_ref());
+        let report = prefetch(MappedAccess::Touch, &[whole], parallelism);
+        assert_eq!(report.ranges, 1);
+        #[cfg(unix)]
+        assert!(
+            resident_bytes(whole) >= len,
+            "parallelism {parallelism}: {} of {len} resident",
+            resident_bytes(whole)
+        );
+    }
+}
+
+#[test]
+fn the_budget_stamps_its_access_on_every_mapped_pin_and_on_nothing_else() {
+    let subject = Subject::build(kimi_per_expert_moe_f32_model);
+    let (plan, store) = subject.open();
+    let budget = ResidencyBudget::UNBOUNDED.with_expert_access(MappedAccess::Touch);
+    let records = select_realizations_within(
+        &plan,
+        (&store).into(),
+        &ProductionBackend::new(),
+        &ExecutionSlice::Full,
+        &budget,
+    )
+    .unwrap();
+    let mut mapped = 0;
+    for record in &records {
+        match record.selection.realization.form {
+            RealizationForm::MappedStored { access, .. } => {
+                assert_eq!(access, MappedAccess::Touch, "{record:?}");
+                mapped += 1;
+            }
+            _ => assert_eq!(record.selection.realization.access(), MappedAccess::Demand),
+        }
+    }
+    assert!(mapped > 0, "the per-expert bank pins as mapped");
+    let named = records
+        .iter()
+        .find(|r| {
+            matches!(
+                r.selection.realization.form,
+                RealizationForm::MappedStored { .. }
+            )
+        })
+        .unwrap();
+    assert!(
+        named.selection.realization.name().contains("touch"),
+        "the realization names its access: {}",
+        named.selection.realization.name()
+    );
+}
+
+/// The same token under every access policy, to the bit: the policy
+/// changes when pages arrive, never what they hold.
+#[test]
+fn every_access_policy_executes_the_same_token_to_the_same_bits() {
+    let subject = Subject::build(kimi_per_expert_moe_f32_model);
+    let (plan, store) = subject.open();
+    let backend = ProductionBackend::new();
+    let mut logits: Vec<Vec<f32>> = Vec::new();
+    for access in MappedAccess::ALL {
+        let budget = ResidencyBudget::UNBOUNDED.with_expert_access(access);
+        let ops =
+            PreparedOperands::load_within(&plan, &store, &backend, ExecutionSlice::Full, &budget)
+                .unwrap();
+        let mut kv = RowKvState::default();
+        let mut session = DecodeSession::over_prepared(&plan, &ops, &backend, &mut kv).unwrap();
+        let mut last = None;
+        for &token in &PROMPT {
+            last = session.step(token).unwrap().logits;
+        }
+        logits.push(last.expect("head"));
+    }
+    for (i, other) in logits.iter().enumerate().skip(1) {
+        assert_eq!(
+            &logits[0],
+            other,
+            "{:?} differs from demand",
+            MappedAccess::ALL[i]
+        );
+    }
+}
+
+#[test]
+fn an_access_policy_is_named_or_refused_by_name() {
+    for access in MappedAccess::ALL {
+        assert_eq!(MappedAccess::parse(access.name()).unwrap(), access);
+    }
+    let err = MappedAccess::parse("prescient").unwrap_err();
+    assert!(
+        err.contains("prescient") && err.contains("demand, advise, touch"),
+        "{err}"
+    );
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/realization.rs
@@ -10,7 +10,7 @@ use super::super::operands::OperandStore;
 use super::super::prepared::{ExecutionSlice, PreparedOperands};
 use super::super::production::{select_cpu, ProductionBackend};
 use super::super::realization::{
-    RealizationForm, RealizationId, RepresentationFacts, SelectionReason,
+    MappedAccess, RealizationForm, RealizationId, RepresentationFacts, SelectionReason,
 };
 use super::super::reference::ReferenceBackend;
 use super::bf16_zlib_execution::{transcode, Transcode};
@@ -667,7 +667,8 @@ fn the_common_selections_cover_the_table_the_bank_and_the_shared_expert() {
     assert_eq!(
         mapped.realization.form,
         RealizationForm::MappedStored {
-            format: WeightFormat::Bf16
+            format: WeightFormat::Bf16,
+            access: MappedAccess::Demand,
         }
     );
     assert_eq!(mapped.reason, SelectionReason::BankMappedAsStored);
@@ -683,7 +684,8 @@ fn the_common_selections_cover_the_table_the_bank_and_the_shared_expert() {
     assert_eq!(
         f32.realization.form,
         RealizationForm::MappedStored {
-            format: WeightFormat::F32
+            format: WeightFormat::F32,
+            access: MappedAccess::Demand,
         }
     );
     for label in ["Q8_0", "BF16_ZLIB"] {

--- a/docs/represent/forecasts/k3-prefetch-notes.json
+++ b/docs/represent/forecasts/k3-prefetch-notes.json
@@ -1,0 +1,66 @@
+{
+  "programme": "residency-into-k3",
+  "wave": "PREFETCH-1: lossless selected-expert prefetch as an access realization",
+  "forecast": "k3-prefetch.json (frozen before implementation; not edited)",
+  "built": "`MappedAccess::{Demand, Advise, Touch}` on `RealizationForm::MappedStored` (part of the realization's identity and name, e.g. `mapped-stored/Bf16/advise`); a policy on `ResidencyBudget.expert_access`, stamped on every mapped pin at selection; carried by `BankPin { format, access }` through the loader to `ExpertSlices::Separate { access }`; `exec/prefetch.rs` (`Range`, `prefetch(access, ranges, parallelism)`: Advise = page-aligned `madvise(MADV_WILLNEED)` per range in address order; Touch = scoped threads touching one byte per page over address-ordered ranges); the hook in the production routed call after routing, in its own `Stage::Prefetch`; CLI `--expert-access demand|advise|touch`.",
+  "witnesses": "exec/tests/prefetch.rs: Demand reports nothing; Advise and Touch cover exactly the ranges, page-rounded, and change no byte; touched pages are mincore-resident at every parallelism; the budget's policy lands on every mapped pin and on nothing else, and the realization names it; ALL THREE policies execute the miniature's token to the same bits; an unknown policy is refused by name. CLI: an unknown `--expert-access` is refused before binding.",
+  "cold_state_protocol": "`evict-bank.sh` streams the HF checkpoint (92 GB) and the .s6 container (92 GB) through the page cache; every arm's binding line then read `94.22 GB address space over 19968 regions, 0.000 GB resident` — cold, witnessed by mincore, three times out of three.",
+  "arms": {
+    "machine": "AC power (plugged in between V4 and this wave), load 5–13 from Spotlight indexing what the eviction stream had just read (`mds_stores`), labelled UNQUALIFIED by the probe; the cold figures are I/O-bound and the warm pass of every arm sits within V4's modal cluster.",
+    "A_demand": {
+      "cold_token_ms": 1253,
+      "prefetch_ms": 0.0,
+      "routed_loop_ms": 1213.6,
+      "major_faults": 73516,
+      "minor_faults": 52,
+      "resident_delta_gb": 1.199,
+      "warm_token_ms": 76,
+      "warm_prefetch_ms": 0.0
+    },
+    "B_advise": {
+      "cold_token_ms": 598,
+      "prefetch_ms": 504.5,
+      "routed_loop_ms": 47.0,
+      "major_faults": 73519,
+      "minor_faults": 1378,
+      "resident_delta_gb": 1.206,
+      "warm_token_ms": 87,
+      "warm_prefetch_ms": 8.0
+    },
+    "C_touch": {
+      "cold_token_ms": 1358,
+      "prefetch_ms": 1279.1,
+      "routed_loop_ms": 36.5,
+      "major_faults": 73518,
+      "minor_faults": 341,
+      "resident_delta_gb": 1.205,
+      "warm_token_ms": 80,
+      "warm_prefetch_ms": 2.8
+    },
+    "D_warm": "pass 2 of each arm: 76 / 87 / 80 ms against V4's p50 79.5 ms",
+    "determinism": "routing fingerprint ebe045dc40cce5b1 (the same as V4) in every arm and pass; logits bit-identical pass to pass; generated ids [276, 6690] in every arm.",
+    "cold_prompt_three_positions": {
+      "demand_ms": 6535,
+      "advise_ms": 3300,
+      "touch_ms": 6394,
+      "resident_delta_gb": "7.72 in every arm",
+      "major_faults": "≈470,500 in every arm",
+      "reading": "the same 2× for advise over three positions and 7.7 GB — the effect is the request shape, not the token."
+    }
+  },
+  "predictions_scored": {
+    "P1": "HELD: demand 1253 ms (1.0–1.6 predicted), 73,516 major faults (55k–65k predicted — MORE, because this run paged 1.199 GB where V3's token paged 0.976 GB; 16.3 KB per fault, one page each, as before), resident delta 1.199 GB ✓.",
+    "P2": "FALSIFIED: touch took 1279 ms in its own stage — the same ≈0.94 GB/s as demand's loop — and the loop then ran at 36.5 ms. Faults were MOVED exactly as predicted (loop 36.5 ms, resident delta unchanged), but concurrency bought nothing: page-ins of one mapping are serialised by the kernel, and six threads faulting in parallel wait on each other. The 'device serialises' clause of the falsification applies; a pread-based pool is the untested alternative.",
+    "P3": "HELD, at the fast end: advise 598 ms — 2.1× faster than demand — with the prefetch stage at 504 ms (2.39 GB/s effective, still under the device's ≈3.8 GB/s) and the loop at 47 ms, within 10 ms of warm. The kernel honours WILLNEED with real read-ahead; the fault count is unchanged (73,519) because the pages still arrive through the fault path, just clustered.",
+    "P4": "HELD for touch (80 ms, +1%) and demand (76 ms); BORDERLINE for advise: 87 ms (+9% vs V4's p50, +14% vs this run's demand) — 24 `madvise` calls over 1.2 GB of already-resident pages cost 8 ms. The falsification clause applies: the advise must be gated on residency (skip ranges mincore reports resident) before it is the default.",
+    "P5": "HELD: predicted mapped / page-in / touch identical across arms (the plan does not change); observed resident delta 1.199 / 1.206 / 1.205 GB (±0.6%); only the fault SPLIT (loop vs prefetch stage) and the wall time moved.",
+    "P6": "HELD: one routing fingerprint, bit-identical logits, the same generated ids in every arm."
+  },
+  "findings": {
+    "PF-N1": "The cold routed-expert cost on this machine is a request-shape cost the kernel can halve when told: `madvise(MADV_WILLNEED)` over the selected experts' 24 regions takes the cold token from 1.25 s to 0.60 s with the same bytes, the same faults and the same bits. The remaining 0.5 s is 2.4 GB/s against a 3.8 GB/s device — the next step on this axis is a read path that issues larger requests (pread into the page cache, or fewer, larger advised ranges), not more threads.",
+    "PF-N2": "Concurrent faulting does not parallelise page-in of one file mapping on macOS: six threads touching disjoint ranges of the bank achieved demand's rate. Parallelism must come from the request size, not the requester count.",
+    "PF-N3": "An access realization has a warm cost: 24 advise calls on resident pages cost 8 ms of an 80 ms token. The realization must be conditioned on the mapping's residency (the instrument's own mincore reader), which is exactly the reconciliation V2 built — the prefetch should consult it, not repeat it."
+  },
+  "next": "(1) Gate the advise on residency and re-measure the warm token (P4 to hold cleanly). (2) One arm of larger requests: advise per contiguous run rather than per tensor, and a pread-into-cache variant, to see whether 2.4 GB/s → 3.8 GB/s. (3) Then the resident quantised expert-bank arms (Q6_K, Q4_K) against these numbers: cold 0.60 s advised vs a resident bank's 0 s cold, priced by resident footprint and HF divergence.",
+  "not_claimed": "No tokens-per-second. The AC-power quiet arm of V4 with 30 passes has still not run under a quiet load (Spotlight was indexing after the eviction stream)."
+}

--- a/docs/represent/forecasts/k3-prefetch.json
+++ b/docs/represent/forecasts/k3-prefetch.json
@@ -1,0 +1,30 @@
+{
+  "programme": "residency-into-k3",
+  "wave": "PREFETCH-1: lossless selected-expert prefetch as an access realization",
+  "frozen": "2026-09-06, before implementation, on k3-v4-warm-latency 2c290c77 (PR #432)",
+  "why": "V3 measured the cold Kimi-Linear token at 1.30 s: 0.976 GB paged in through 59,670 major faults of one 16 KiB page each, ≈22 µs per fault, ≈1.1 GB/s from a device that reads sequentially at ≈3.8 GB/s. That is a request-shape problem before it is a representation problem: the projection loop faults one page at a time, serially, in row order. V4 fixed the warm denominator (p50 79.5 ms, routed experts 38 ms of it). This wave changes only HOW the same lossless bf16 bytes are brought in, never WHAT is stored.",
+  "design": {
+    "when": "After routing names the top-k experts and before the projection loop — inside the production backend's routed call, where the selected experts' gate/up/down slices are in hand.",
+    "what": "The selected experts' three regions each (24 regions for top-8), as (address, length) ranges of the one bank mapping, sorted by address so the request order follows the file's physical layout, then brought in concurrently ahead of the loop.",
+    "how_declared": "`MappedAccess::{Demand, Advise, Touch}` on `ExpertSlices::Separate` — an ACCESS realization of the mapped representation, selected by policy (`--expert-access demand|advise|touch`) and reported with the pins. Demand = today's behaviour (the loop faults). Advise = `madvise(MADV_WILLNEED)` over each range, page-aligned, then the loop. Touch = the CPU pool touches one byte per page of every range concurrently (a major fault per page, in parallel across ranges), then the loop.",
+    "accounting": "Mapped address space, expected page-in per token, execution touch and stored footprint are IDENTICAL across the three access arms — the bytes do not change. Temporary residency is the selected experts' bytes in every arm. The report must say so, and the reconciliation must show the same resident-page delta in every arm with the faults moved out of the loop, not removed.",
+    "boundary": "No new kernel, no new representation, no change to the routing rule; the reference backend is untouched (parity is asserted between arms, not against the reference)."
+  },
+  "cold_state_protocol": "The bank's pages are evicted by reading ≈184 GB of other files (the HF checkpoint and the .s6 container, 92 GB each) through the page cache on a 128 GiB machine; the instrument's binding line (`mapped … 0.000 GB resident`, from mincore) is the witness that the bank is cold before every cold arm. An arm whose binding line shows resident bytes above 0.1 GB does not count as cold.",
+  "arms": {
+    "A_demand_cold": "cold bank, `--expert-access demand`: reproduces V3 (≈1.3 s, ≈60k major faults on the first token).",
+    "B_advise_cold": "cold bank, `--expert-access advise`.",
+    "C_touch_cold": "cold bank, `--expert-access touch`.",
+    "D_warm": "the same command with the bank warm (pass 2 of each arm; and V4's p50 79.5 ms as the reference floor)."
+  },
+  "predictions": {
+    "P1": "A reproduces V3 within noise: first-token wall 1.0–1.6 s, major faults 55k–65k, resident delta 0.9–1.1 GB.",
+    "P2": "C (touch) cuts the cold first token to ≤ 0.45 s — ≥ 2.5 GB/s effective over the same ≈1 GB — with the projection loop's own major faults ≤ 1% of A's (they move into the prefetch) and the SAME resident delta ±5%.",
+    "P3": "B (advise) lands between A and C: macOS honours WILLNEED on a file-backed mapping only partially; predicted 0.6–1.2 s. Either extreme falsifies a different belief: ≈A means the hint is ignored, ≈C means the hint alone suffices and the touch pool is unnecessary.",
+    "P4": "D: the warm token is unchanged by the access policy — p50 within ±10% of V4's 79.5 ms in every arm (the prefetch on a warm bank costs ≤ 3 ms: 24 madvise calls or 24×288 page touches of resident pages).",
+    "P5": "The ledger's mapped / page-in / touch figures are identical across A, B, C; only the observed fault split (prefetch vs loop) and wall time differ.",
+    "P6": "Logits are bit-identical across A, B, C and against V4's run (same fingerprint ebe045dc40cce5b1, same generated ids [276, 6690])."
+  },
+  "falsification": "P2 false → the device or the kernel serialises page-ins for one mapping and concurrency does not help; the next move is a pread-based pool into the page cache or a resident representation. P6 false → the access policy touched values, which it must never do. P4 false → the prefetch has a warm cost and must be gated on residency.",
+  "not_claimed": "No tokens-per-second. No quantised arm yet (Q6_K/Q4_K follow, priced against these numbers). The AC-power quiet arm of V4 remains open."
+}


### PR DESCRIPTION
Stacked on #432 (V4). PREFETCH-1 of the K3 residency vertical: the selected experts of a mapped bank are brought in ahead of the routed loop, as an ACCESS realization of the same lossless bytes, and the three access arms are measured on a mincore-cold bank.

Forecast frozen before implementation: `docs/represent/forecasts/k3-prefetch.json`; evidence and verdicts: `…-notes.json`.

## What it is

- `MappedAccess::{Demand, Advise, Touch}` is a field of `RealizationForm::MappedStored`, part of the realization's identity and name (`mapped-stored/Bf16/advise`).
- Chosen as a policy on `ResidencyBudget.expert_access`, stamped on every mapped pin at selection, carried by `BankPin { format, access }` to `ExpertSlices::Separate { access }`, executed after routing in its own `Stage::Prefetch`.
- Demand: the loop faults each page. Advise: page-aligned `madvise(MADV_WILLNEED)` over the selected experts' regions in address order. Touch: one byte per page touched concurrently over address-ordered ranges.
- Mapped address space, page-in, touch and stored footprint are identical under every policy; only the request shape differs. `--expert-access` names it on the residency curve.

## Measured (real container, bank evicted and `0.000 GB resident` at binding, three times)

| arm | cold token | prefetch stage | routed loop | major faults | paged in | warm token |
|---|---|---|---|---|---|---|
| demand | 1253 ms | 0 | 1214 ms | 73,516 | 1.199 GB | 76 ms |
| advise | 598 ms | 505 ms | 47 ms | 73,519 | 1.206 GB | 87 ms |
| touch | 1358 ms | 1279 ms | 37 ms | 73,518 | 1.205 GB | 80 ms |

Cold prompt of three positions: 6535 / 3300 / 6394 ms for 7.72 GB. Routing fingerprint, logits and generated ids identical in every arm and pass.

## Verdicts

- The kernel's read-ahead halves the cold cost when told: 2.39 GB/s against 0.94, the loop then within 10 ms of warm. Still under the device's ≈3.8 GB/s.
- Concurrent faulting of one mapping does not parallelise on macOS: six threads achieved demand's rate. Parallelism must come from request size, not requester count. Prediction falsified as its own clause anticipated.
- The advise costs 8 ms on a warm token (24 calls over resident pages): it must be gated on residency before it is the default. Not done here; recorded as the next step with larger-request arms, then the Q6_K / Q4_K resident bank arms priced against 0.60 s advised cold.

## Witnesses

`exec/tests/prefetch.rs`: demand reports nothing; advise and touch cover exactly the page-rounded ranges and change no byte; touched pages are resident at every parallelism; the budget's policy lands on every mapped pin and on nothing else, and the realization names it; all three policies execute the miniature's token to the same bits; an unknown policy is refused by name (library and CLI).

## Gates

fmt, clippy (both crates), x86_64-apple-darwin check, full larql-vindex and larql-cli suites, per-file coverage ≥ 90% on every new and touched larql-vindex file (prefetch.rs 95.65%; policy 93.72%).
