### PR TITLE
ci: cut PR wall clock, with the instrument that proves it

### DIFF
--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -9,6 +9,21 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, edited]
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/larql-boundary.yml
+++ b/.github/workflows/larql-boundary.yml
@@ -25,6 +25,21 @@ on:
       - '.github/workflows/larql-boundary.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: test · ${{ matrix.os }}

--- a/.github/workflows/larql-boundary.yml
+++ b/.github/workflows/larql-boundary.yml
@@ -48,8 +48,22 @@ jobs:
 
     strategy:
       fail-fast: false
+      # macOS runs on pushes to main, not on pull requests.
+      #
+      # This crate has no macOS-specific surface to exercise: no
+      # `cfg(target_os = ...)`, no `cfg(unix)`/`cfg(windows)` split that
+      # Linux and Windows do not already cover between them, and no
+      # `blas-src`/Accelerate linkage (contrast larql-compute, -inference,
+      # -kv, -demos and -cli, which take `features = ["accelerate"]` under
+      # a macOS cfg and therefore keep their macOS PR leg). The macOS leg
+      # here was compiling the same portable code a third time.
+      #
+      # macOS runner availability is what sets this repo's PR wall clock —
+      # queue waits of 19-24 minutes for jobs that run in under a minute —
+      # so the generic cross-platform record is kept on main rather than
+      # paid for on every pull request.
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest", "windows-latest"]' || '["ubuntu-latest", "windows-latest", "macos-14"]') }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -40,6 +40,21 @@ on:
       - '.github/workflows/larql-cli.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: test - ${{ matrix.os }}

--- a/.github/workflows/larql-compute-metal.yml
+++ b/.github/workflows/larql-compute-metal.yml
@@ -30,6 +30,21 @@ on:
       - '.github/workflows/larql-compute-metal.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: test · macos-14

--- a/.github/workflows/larql-compute.yml
+++ b/.github/workflows/larql-compute.yml
@@ -27,6 +27,21 @@ on:
       - '.github/workflows/larql-compute.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Route the ambient decode paths through rayon rather than the spin pool.
 # A spin barrier needs a free core to spin on; a CI runner (2 cores on
 # ubuntu/windows, 3 on macos-14) has none to spare, so the pool's idle

--- a/.github/workflows/larql-core.yml
+++ b/.github/workflows/larql-core.yml
@@ -25,6 +25,21 @@ on:
       - '.github/workflows/larql-core.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: test · ${{ matrix.os }}

--- a/.github/workflows/larql-core.yml
+++ b/.github/workflows/larql-core.yml
@@ -48,8 +48,22 @@ jobs:
 
     strategy:
       fail-fast: false
+      # macOS runs on pushes to main, not on pull requests.
+      #
+      # This crate has no macOS-specific surface to exercise: no
+      # `cfg(target_os = ...)`, no `cfg(unix)`/`cfg(windows)` split that
+      # Linux and Windows do not already cover between them, and no
+      # `blas-src`/Accelerate linkage (contrast larql-compute, -inference,
+      # -kv, -demos and -cli, which take `features = ["accelerate"]` under
+      # a macOS cfg and therefore keep their macOS PR leg). The macOS leg
+      # here was compiling the same portable code a third time.
+      #
+      # macOS runner availability is what sets this repo's PR wall clock —
+      # queue waits of 19-24 minutes for jobs that run in under a minute —
+      # so the generic cross-platform record is kept on main rather than
+      # paid for on every pull request.
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest", "windows-latest"]' || '["ubuntu-latest", "windows-latest", "macos-14"]') }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/larql-demos.yml
+++ b/.github/workflows/larql-demos.yml
@@ -27,6 +27,21 @@ on:
       - '.github/workflows/larql-demos.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: test · ${{ matrix.os }}

--- a/.github/workflows/larql-factory.yml
+++ b/.github/workflows/larql-factory.yml
@@ -54,8 +54,22 @@ jobs:
 
     strategy:
       fail-fast: false
+      # macOS runs on pushes to main, not on pull requests.
+      #
+      # This crate has no macOS-specific surface to exercise: no
+      # `cfg(target_os = ...)`, no `cfg(unix)`/`cfg(windows)` split that
+      # Linux and Windows do not already cover between them, and no
+      # `blas-src`/Accelerate linkage (contrast larql-compute, -inference,
+      # -kv, -demos and -cli, which take `features = ["accelerate"]` under
+      # a macOS cfg and therefore keep their macOS PR leg). The macOS leg
+      # here was compiling the same portable code a third time.
+      #
+      # macOS runner availability is what sets this repo's PR wall clock —
+      # queue waits of 19-24 minutes for jobs that run in under a minute —
+      # so the generic cross-platform record is kept on main rather than
+      # paid for on every pull request.
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest", "windows-latest"]' || '["ubuntu-latest", "windows-latest", "macos-14"]') }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/larql-factory.yml
+++ b/.github/workflows/larql-factory.yml
@@ -31,6 +31,21 @@ on:
       - '.github/workflows/larql-factory.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: test - ${{ matrix.os }}

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -39,6 +39,21 @@ on:
       - '.github/workflows/larql-inference.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: test - ${{ matrix.os }}

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -43,6 +43,21 @@ on:
       - '.github/workflows/larql-kv.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   LARQL_KV_COVERAGE_MIN: 85
 

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -34,6 +34,21 @@ on:
       - '.github/workflows/larql-lql.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: test - ${{ matrix.os }}

--- a/.github/workflows/larql-models.yml
+++ b/.github/workflows/larql-models.yml
@@ -25,6 +25,21 @@ on:
       - '.github/workflows/larql-models.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: test · ${{ matrix.os }}

--- a/.github/workflows/larql-models.yml
+++ b/.github/workflows/larql-models.yml
@@ -48,8 +48,22 @@ jobs:
 
     strategy:
       fail-fast: false
+      # macOS runs on pushes to main, not on pull requests.
+      #
+      # This crate has no macOS-specific surface to exercise: no
+      # `cfg(target_os = ...)`, no `cfg(unix)`/`cfg(windows)` split that
+      # Linux and Windows do not already cover between them, and no
+      # `blas-src`/Accelerate linkage (contrast larql-compute, -inference,
+      # -kv, -demos and -cli, which take `features = ["accelerate"]` under
+      # a macOS cfg and therefore keep their macOS PR leg). The macOS leg
+      # here was compiling the same portable code a third time.
+      #
+      # macOS runner availability is what sets this repo's PR wall clock —
+      # queue waits of 19-24 minutes for jobs that run in under a minute —
+      # so the generic cross-platform record is kept on main rather than
+      # paid for on every pull request.
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest", "windows-latest"]' || '["ubuntu-latest", "windows-latest", "macos-14"]') }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -35,6 +35,21 @@ on:
       - '.github/workflows/larql-server.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # Existing baseline measured 2026-05-10 in Makefile (see
   # `LARQL_SERVER_COVERAGE_MIN`). Keep just under the live value to

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -30,6 +30,21 @@ on:
       - '.github/workflows/larql-vindex.yml'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   LARQL_VINDEX_COVERAGE_MIN: 71
   # Fail extraction on any source tensor no `ModelArchitecture` accessor

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -161,7 +161,18 @@ jobs:
       - name: Tests
         run: cargo test -p larql-vindex
 
+      # Linux only. These are generic criterion targets with no
+      # platform-specific code path, so compiling them a second and third
+      # time buys no correctness evidence — and on Windows it cost 8m43 of
+      # a 31m13 leg on a recent run, on the critical path of every PR that
+      # touches this crate.
+      #
+      # What the other two platforms keep: `cargo check --all-targets`
+      # above type-checks the bench targets on all three. What they give
+      # up is link-and-run evidence for benches specifically, which for
+      # portable criterion harnesses is not a platform-sensitive claim.
       - name: Benchmark compile/tests
+        if: runner.os == 'Linux'
         run: cargo test -p larql-vindex --benches
 
   coverage:

--- a/.github/workflows/msrv-metal.yml
+++ b/.github/workflows/msrv-metal.yml
@@ -1,0 +1,151 @@
+# MSRV gate for `larql-compute-metal` — the one crate the Linux MSRV leg
+# in `quality.yml` cannot check.
+#
+# Why it lives here rather than as a second matrix entry in `quality.yml`:
+# that workflow deliberately carries no `paths:` filter (it has a weekly
+# `schedule:` that must scan an unchanged lockfile), so its macOS leg was
+# requested on EVERY pull request. Measured on a recent run it waited
+# 19m25 for a macos-14 runner to execute a 44-second `cargo check`, and
+# macOS runner availability — not Ubuntu job count — is what sets the
+# wall clock on this repo's PR loop.
+#
+# Split out, the same gate runs only when something can actually change
+# its answer: the crate itself, the dependency graph, or the toolchain
+# pin.
+#
+# KEEP IN SYNC with the `msrv` job in `quality.yml`. The two share the
+# read-rust-version step, the no-restored-target guard and — most
+# importantly — the `RUSTUP_TOOLCHAIN` handling described below. If you
+# change the mechanism in one, change it in the other.
+
+name: msrv-metal
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/larql-compute-metal/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/msrv-metal.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/larql-compute-metal/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/msrv-metal.yml'
+  workflow_dispatch: {}
+
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  msrv-metal:
+    # Named without the version: a job-level `name` cannot reference `steps`,
+    # and hardcoding a number here would be a second place to forget to bump.
+    name: MSRV · larql-compute-metal
+    # macOS because `larql-compute-metal` takes `blas-src` only under
+    # `cfg(target_os = "macos")` while its examples `extern crate blas_src`
+    # unconditionally — on Linux they fail to resolve at *any* toolchain,
+    # which has nothing to do with the MSRV.
+    runs-on: macos-14
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      # Read the declared MSRV out of Cargo.toml rather than hardcoding it
+      # here, so bumping rust-version in one place updates the gate too.
+      - name: Read declared rust-version
+        id: msrv
+        run: |
+          version=$(sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          if [ -z "$version" ]; then
+            echo "::error::no rust-version found in workspace Cargo.toml"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "declared MSRV: $version"
+
+      - name: Install Rust ${{ steps.msrv.outputs.version }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      - name: Cache cargo registry (downloads only, never target/)
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-reg2-msrv-${{ steps.msrv.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-reg2-msrv-${{ steps.msrv.outputs.version }}-
+
+      - name: No compiled workspace artefacts may be restored
+        shell: bash
+        run: |
+          # The cache above carries downloads only. A target/ restored from
+          # another commit can satisfy a link against stale code, so a green
+          # matrix would be evidence about an artefact that is not in this
+          # commit. Fail loudly rather than build on one.
+          if [ -e target ]; then
+            echo "::error::target/ was restored from cache - the cache key or path is wrong"
+            exit 1
+          fi
+
+      # This is `cargo check` at the pinned toolchain rather than
+      # `cargo msrv verify`. cargo-msrv bisects across many toolchains to
+      # *discover* the minimum; we already know what we claim, and the only
+      # question CI needs answered is whether the claim is true. One pinned
+      # check answers it in a fraction of the time.
+      #
+      # `--locked` matters: without it cargo may resolve a newer dependency
+      # than Cargo.lock pins and the job would test a graph nobody ships.
+      #
+      # `RUSTUP_TOOLCHAIN` matters more. `rust-toolchain.toml` pins the
+      # DEVELOPMENT toolchain and rustup honours that file over whatever
+      # `dtolnay/rust-toolchain` installed, so from the day the pin landed
+      # (2026-08-22) this step silently checked at the development version
+      # and the gate was hollow. The env var outranks the file, and the
+      # step before the check refuses to run it under any other compiler.
+      - name: Report the compiler running the gate
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
+        run: |
+          rustc --version
+          cargo --version
+          # `rust-version` may be two components ("1.98"); rustc reports
+          # three ("1.98.0"). The declared version must equal the running
+          # one or be its major.minor prefix.
+          declared="${{ steps.msrv.outputs.version }}"
+          actual=$(rustc --version | awk '{print $2}')
+          case "$actual" in
+            "$declared"|"$declared".*) echo "MSRV gate runs rustc $actual (declared $declared)" ;;
+            *)
+              echo "::error::MSRV gate would run rustc $actual, not the declared $declared"
+              exit 1
+              ;;
+          esac
+
+      - name: Check at declared MSRV
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
+        run: cargo check -p larql-compute-metal --all-targets --locked

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -26,6 +26,21 @@ on:
   pull_request:
     branches: [main]
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -35,6 +35,21 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -97,28 +97,24 @@ jobs:
   msrv:
     # Named without the version: a job-level `name` cannot reference `steps`,
     # and hardcoding a number here would be a second place to forget to bump.
-    name: MSRV · ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: MSRV · workspace
+    runs-on: ubuntu-latest
     timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      # Split by platform because no single runner can build the whole
-      # workspace. `larql-compute-metal` takes `blas-src` only under
-      # `cfg(target_os = "macos")` while its examples `extern crate blas_src`
-      # unconditionally, so on Linux they fail to resolve at *any* toolchain —
-      # nothing to do with the MSRV. Its own workflow is macOS-only for the
-      # same reason.
-      #
-      # So: Linux checks the workspace minus that crate (covering the
-      # cfg(linux) OpenBLAS paths in larql-compute and larql-inference), and
-      # macOS checks the crate Linux cannot. Between them every member crate
-      # is MSRV-gated with no silent hole.
-      matrix:
-        include:
-          - os: ubuntu-latest
-            args: --workspace --all-targets --exclude larql-compute-metal
-          - os: macos-14
-            args: -p larql-compute-metal --all-targets
+    # Split by platform because no single runner can build the whole
+    # workspace. `larql-compute-metal` takes `blas-src` only under
+    # `cfg(target_os = "macos")` while its examples `extern crate blas_src`
+    # unconditionally, so on Linux they fail to resolve at *any* toolchain —
+    # nothing to do with the MSRV.
+    #
+    # So: this job checks the workspace minus that crate (covering the
+    # cfg(linux) OpenBLAS paths in larql-compute and larql-inference), and
+    # `msrv-metal.yml` checks the crate Linux cannot. Between them every
+    # member crate is still MSRV-gated with no silent hole.
+    #
+    # That second leg used to be a macos-14 entry in a matrix here. It was
+    # moved out because this workflow carries no `paths:` filter — the
+    # weekly `schedule:` needs to scan an unchanged lockfile — so a macOS
+    # runner was requested on every pull request, whatever it touched.
     steps:
       - uses: actions/checkout@v7
 
@@ -205,7 +201,7 @@ jobs:
       - name: Check at declared MSRV
         env:
           RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
-        run: cargo check ${{ matrix.args }} --locked
+        run: cargo check --workspace --all-targets --exclude larql-compute-metal --locked
 
   doc-links:
     name: doc links

--- a/.github/workflows/shannon-verify.yml
+++ b/.github/workflows/shannon-verify.yml
@@ -48,6 +48,21 @@ on:
       - 'Cargo.lock'
   workflow_dispatch: {}
 
+# Supersede in-flight pull-request runs: pushing a new commit to a PR
+# cancels the runs still compiling the previous one.
+#
+# Non-PR runs (main pushes, schedules, manual dispatch) are keyed by
+# `run_id`, which is unique per run, so they are each alone in their
+# group. That is deliberate and not the same as `cancel-in-progress:
+# false`: a concurrency group holds at most one running and one pending
+# run, and a newer pending run EVICTS the older pending one. Grouping
+# every main push under `refs/heads/main` would therefore still destroy
+# the CI record for an intermediate main commit when merges land close
+# together, with cancellation disabled or not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/docs/ci-throughput/E1-forecast.json
+++ b/docs/ci-throughput/E1-forecast.json
@@ -1,0 +1,158 @@
+{
+  "experiment": "E1",
+  "title": "PR-run cancellation, macOS PR occupancy, VINDEX bench placement",
+  "frozen_at": "2026-09-06",
+  "frozen_against": {
+    "baseline_snapshot": "docs/ci-throughput/before-e1.json",
+    "workflows_sha": "f7805b66",
+    "note": ".github/workflows at HEAD is identical to origin/main f7805b66"
+  },
+  "instrument": "scripts/ci_throughput.py",
+  "baseline": {
+    "attempts": 33,
+    "branches": 20,
+    "window": "2026-08-15 onward",
+    "merge_ready_p50_s": 3683,
+    "merge_ready_p95_s": 5707,
+    "first_green_p50_s": 130,
+    "first_green_p95_s": 1338,
+    "macos_queue_max_p50_s": 1218,
+    "macos_queue_max_p95_s": 4089,
+    "vindex_windows_exec_p50_s": 1781,
+    "superseded_exec_total_min": 931.6,
+    "superseded_exec_mean_min": 28.2,
+    "queued_min_by_os": {
+      "linux": 8984.0,
+      "windows": 1632.4,
+      "macos": 4526.6
+    },
+    "executed_min_by_os": {
+      "linux": 5037.1,
+      "windows": 3793.8,
+      "macos": 3034.9
+    }
+  },
+  "mechanism_measured_from_baseline": {
+    "c2_macos_jobs_removed_from_prs": 74,
+    "c2_macos_jobs_total": 328,
+    "c2_macos_queue_min_removed_pct": 27.9,
+    "c2_macos_exec_min_removed_pct": 5.2,
+    "reading": "c2 removes jobs that are cheap to RUN and expensive to SCHEDULE (quality's msrv-macOS leg: 33 jobs, 544 queue-min, 22 exec-min). The intended mechanism is relief of contention for a scarce runner pool, NOT a reduction in macOS compute. larql-compute-metal alone is 35.3% of macOS execution and c2 does not touch it."
+  },
+  "predictions": [
+    {
+      "id": "P1",
+      "scores": "c1",
+      "claim": "superseded_exec_total falls from 931.6 min to <= 300 min",
+      "reason": "cancellation fires within seconds of the superseding push, collapsing the overlap window to teardown time",
+      "falsifier": "superseded_exec_total > 600 min means cancellation is not firing as intended",
+      "mechanism": "c1",
+      "kind": "effect",
+      "metric": "superseded_exec_total",
+      "held_if": {
+        "after": {
+          "lte": 300
+        }
+      },
+      "falsified_if": {
+        "after": {
+          "gte": 600
+        }
+      }
+    },
+    {
+      "id": "P2",
+      "scores": "c2",
+      "claim": "total macOS queued runner-minutes fall by 30-55%",
+      "reason": "27.9% is removed directly; the remainder is second-order relief for the macOS jobs that stay",
+      "falsifier": "< 20% means the removed jobs were not the ones contending",
+      "mechanism": "c2",
+      "kind": "effect",
+      "metric": "queued.macos",
+      "held_if": {
+        "delta_pct": {
+          "lte": -30
+        }
+      },
+      "falsified_if": {
+        "delta_pct": {
+          "gt": -20
+        }
+      }
+    },
+    {
+      "id": "P3",
+      "scores": "c2",
+      "claim": "macOS EXECUTED runner-minutes fall by no more than 10%",
+      "reason": "only 5.2% of macOS execution is removed; this prediction exists to catch a composition change masquerading as an effect",
+      "falsifier": "a drop > 20% means the AFTER period is not comparable, and P2 must not be read as an effect",
+      "mechanism": "c2",
+      "kind": "validity",
+      "metric": "executed.macos",
+      "held_if": {
+        "delta_pct": {
+          "gte": -10
+        }
+      },
+      "falsified_if": {
+        "delta_pct": {
+          "lt": -20
+        }
+      }
+    },
+    {
+      "id": "P4",
+      "scores": "c3",
+      "claim": "vindex Windows execution p50 falls from 29m41s to 20-24 min",
+      "reason": "the removed bench step measured 8m43 of a 31m13 leg",
+      "falsifier": "no movement means the bench step was not on the measured path",
+      "mechanism": "c3",
+      "kind": "effect",
+      "metric": "windows_vindex_exec.p50",
+      "held_if": {
+        "after": {
+          "lte": 24
+        }
+      },
+      "falsified_if": {
+        "after": {
+          "gte": 28
+        }
+      }
+    },
+    {
+      "id": "P5",
+      "scores": "c1+c2+c3",
+      "claim": "merge-ready p50 falls from 61m23s to 30-45 min",
+      "reason": "headline; driven mostly by superseded runs releasing runners (c1) and macOS queue relief (c2)",
+      "falsifier": "merge-ready p50 > 55 min means the tranche did not deliver",
+      "mechanism": "system",
+      "kind": "effect",
+      "metric": "merge_ready.p50",
+      "held_if": {
+        "after": {
+          "lte": 45
+        }
+      },
+      "falsified_if": {
+        "after": {
+          "gt": 55
+        }
+      }
+    }
+  ],
+  "confounds": [
+    "GitHub's hosted runner pool availability varies independently of this repository",
+    "AFTER attempts must be comparable in workflow composition; the report prints composition for exactly this reason",
+    "merge-ready is only defined for attempts where every blocking workflow succeeded (21 of 33 in the baseline)",
+    "'blocking' is a stated convention here (everything except mutants); the main ruleset carries no required status checks"
+  ],
+  "scoring": "scripts/ci_throughput.py report --before docs/ci-throughput/before-e1.json --after <after.json>",
+  "adjudication_note": "Thresholds are machine-readable and frozen with the forecast, so scoring cannot reinterpret them once the AFTER data exists. All thresholds are in MINUTES; delta_pct is (after - before) / before * 100, so a reduction is negative. A prediction HOLDS if every held_if condition is true and no falsified_if condition is true. A 'validity' prediction does not score an effect: if it fails, its mechanism is reported as INVALID COMPARISON and its effect predictions are not interpreted.",
+  "mechanisms": {
+    "c1": "cancel superseded pull-request runs",
+    "c2": "reduce macOS PR scheduling contention",
+    "c3": "VINDEX benches Linux-only",
+    "system": "the tranche as a whole"
+  }
+}

--- a/docs/ci-throughput/README.md
+++ b/docs/ci-throughput/README.md
@@ -1,0 +1,121 @@
+# CI throughput — E1
+
+An experiment, not a cleanup. The question is whether three specific CI
+changes move measured wall clock, and by how much, so that afterwards the
+claim is a number rather than "CI feels faster".
+
+## The instrument
+
+`scripts/ci_throughput.py` — `collect` snapshots the Actions API,
+`report` scores a snapshot against a baseline, `selftest` checks the
+metric definitions against synthetic runs with known answers (including
+two negative controls: a failing gate must leave merge-ready undefined,
+and a cancelled run must produce zero superseded execution).
+
+The unit of observation is an **attempt**: one head SHA of one pull
+request, with every workflow run created for it. Every metric separates
+queue from execution, because the two respond to different changes:
+
+```
+queue      job.started_at   - job.created_at
+execution  job.completed_at - job.started_at
+```
+
+## The intervention
+
+| Commit | Change | Scored by |
+|---|---|---|
+| c1 | `concurrency` + `cancel-in-progress` on 17 PR workflows | superseded execution |
+| c2 | macOS PR occupancy: MSRV Metal split out, 4 crates macOS→main-only | macOS queue minutes |
+| c3 | VINDEX benches Linux-only | vindex Windows execution |
+
+`bench-regress.yml` is excluded from c1 until its baseline-restore
+semantics are inspected.
+
+## Baseline (frozen 2026-09-06, before any of c1–c3)
+
+`before-e1.json` — 33 attempts across 20 branches, from 2026-08-15.
+
+```
+merge-ready p50           61m23s
+merge-ready p95           95m07s
+macOS queue max p50       20m18s
+macOS queue max p95       68m09s
+vindex windows exec p50   29m41s
+superseded execution      931.6 runner-min total (28.2 mean/attempt)
+
+executed runner-min       linux 5037  windows 3794  macos 3035
+queued   runner-min       linux 8984  windows 1632  macos 4527
+```
+
+The single most useful number came out of the baseline rather than out of
+the plan: **c2 removes 27.9% of macOS queue-minutes but only 5.2% of
+macOS execution.** The jobs it drops are cheap to run and expensive to
+schedule — `quality`'s msrv-macOS leg is 33 jobs, 544 queue-minutes and
+22 execution-minutes. So c2's mechanism is contention relief for a scarce
+runner pool, not a reduction in macOS compute. `larql-compute-metal`
+alone is 35.3% of macOS execution and c2 deliberately does not touch it.
+
+## Predictions
+
+Pre-registered in `E1-forecast.json`, each with a falsifier. P3 exists
+only to catch a composition change masquerading as an effect.
+
+## Scoring
+
+Collect an AFTER snapshot once 10–20 pull requests have run under the new
+configuration, then:
+
+```
+scripts/ci_throughput.py collect --since <date> --max-prs 20 --out docs/ci-throughput/after-e1.json
+scripts/ci_throughput.py report  --before docs/ci-throughput/before-e1.json \
+                                 --after  docs/ci-throughput/after-e1.json
+```
+
+`report` prints workflow composition for both periods. Read it before
+reading any delta: the two periods must be made of comparable pull
+requests for the comparison to mean anything.
+
+Then adjudicate, which scores the frozen forecast **per mechanism** so the
+headline number cannot swallow the causal information:
+
+```
+scripts/ci_throughput.py adjudicate --forecast docs/ci-throughput/E1-forecast.json \
+                                    --before docs/ci-throughput/before-e1.json \
+                                    --after  docs/ci-throughput/after-e1.json
+```
+
+```
+C1  cancel superseded pull-request runs
+  P1  superseded_exec_total: 931.6 -> X min   HELD / PARTIAL / FALSIFIED
+  VERDICT: ...
+
+C2  reduce macOS PR scheduling contention
+  P2  queued.macos:   4526.6 -> X min
+  P3 (validity)  executed.macos: 3034.9 -> X min
+  VERDICT: ... or INVALID COMPARISON
+```
+
+It is possible for c1 and c3 to work and for GitHub's macOS pool to be
+unusually bad during the AFTER window. Per-mechanism verdicts preserve
+that distinction; a single merge-ready delta would not.
+
+Thresholds live in `E1-forecast.json` as machine-readable conditions,
+frozen with the forecast, so scoring cannot reinterpret them after the
+data exists. `P3` is a **validity** prediction rather than an effect: if
+macOS execution collapses, C2 reports `INVALID COMPARISON` and P2 is not
+interpreted at all.
+
+Two controls back this up. `selftest` proves each verdict is reachable —
+including that a thin AFTER sample makes P2 look `HELD` while P3 vetoes it
+to `INVALID COMPARISON`. And scoring the baseline against itself falsifies
+all four mechanisms, which is the evidence that the forecast is not
+already satisfied by doing nothing.
+
+## Not in E1
+
+vcpkg binary caching and `sccache` are E2, deliberately held back so that
+a change in these numbers is attributable to c1–c3 and nothing else. The
+five remaining ungated `cargo test --benches` steps (`larql-boundary`,
+`larql-core`, `larql-kv`, `larql-lql`, `larql-models`) and an actionlint
+gate are also held back for the same reason.

--- a/docs/ci-throughput/before-e1.json
+++ b/docs/ci-throughput/before-e1.json
@@ -1,0 +1,22084 @@
+{
+  "collected_at": "2026-09-06T11:18:18.083155+00:00",
+  "repo": "chrishayuk/larql",
+  "query": {
+    "since": "2026-08-15",
+    "until": null,
+    "max_prs": 20,
+    "branch": null
+  },
+  "runs": [
+    {
+      "id": 34027856674,
+      "workflow": "larql-inference",
+      "branch": "k3-v4-warm-latency",
+      "sha": "2c290c7717a4399dc7d2f577b2b3d3d5863863cc",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:35:40Z",
+      "run_started_at": "2026-09-06T10:35:40Z",
+      "pr": 432,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:10:36Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:35:41Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:09:58Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:54:32Z",
+          "completed_at": null,
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34027856635,
+      "workflow": "larql-vindex",
+      "branch": "k3-v4-warm-latency",
+      "sha": "2c290c7717a4399dc7d2f577b2b3d3d5863863cc",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:35:40Z",
+      "run_started_at": "2026-09-06T10:35:40Z",
+      "pr": 432,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:36:04Z",
+          "completed_at": "2026-09-06T10:43:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:54:09Z",
+          "completed_at": "2026-09-06T11:12:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:46:14Z",
+          "completed_at": null,
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:35:41Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027856670,
+      "workflow": "larql-lql",
+      "branch": "k3-v4-warm-latency",
+      "sha": "2c290c7717a4399dc7d2f577b2b3d3d5863863cc",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:35:40Z",
+      "run_started_at": "2026-09-06T10:35:40Z",
+      "pr": 432,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:10:34Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:11:04Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:35:41Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:39:31Z",
+          "completed_at": "2026-09-06T11:01:18Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34027856694,
+      "workflow": "quality",
+      "branch": "k3-v4-warm-latency",
+      "sha": "2c290c7717a4399dc7d2f577b2b3d3d5863863cc",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:35:40Z",
+      "run_started_at": "2026-09-06T10:35:40Z",
+      "pr": 432,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:35:41Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:39:19Z",
+          "completed_at": "2026-09-06T10:39:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:35:41Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:09:07Z",
+          "completed_at": "2026-09-06T11:09:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:35:41Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:08:12Z",
+          "completed_at": "2026-09-06T11:09:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:35:41Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:35:41Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:35:41Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027856667,
+      "workflow": "larql-server",
+      "branch": "k3-v4-warm-latency",
+      "sha": "2c290c7717a4399dc7d2f577b2b3d3d5863863cc",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:35:40Z",
+      "run_started_at": "2026-09-06T10:35:40Z",
+      "pr": 432,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:03:53Z",
+          "completed_at": "2026-09-06T11:12:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:35:41Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:06:12Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:04:02Z",
+          "completed_at": null,
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34027856646,
+      "workflow": "commit messages",
+      "branch": "k3-v4-warm-latency",
+      "sha": "2c290c7717a4399dc7d2f577b2b3d3d5863863cc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:35:40Z",
+      "run_started_at": "2026-09-06T10:35:40Z",
+      "pr": 432,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:37:49Z",
+          "completed_at": "2026-09-06T10:37:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027856659,
+      "workflow": "mutants",
+      "branch": "k3-v4-warm-latency",
+      "sha": "2c290c7717a4399dc7d2f577b2b3d3d5863863cc",
+      "attempt": 1,
+      "status": "in_progress",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:35:40Z",
+      "run_started_at": "2026-09-06T10:35:40Z",
+      "pr": 432,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:38:09Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:37:01Z",
+          "completed_at": "2026-09-06T10:37:10Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027856666,
+      "workflow": "shannon-verify",
+      "branch": "k3-v4-warm-latency",
+      "sha": "2c290c7717a4399dc7d2f577b2b3d3d5863863cc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:35:40Z",
+      "run_started_at": "2026-09-06T10:35:40Z",
+      "pr": 432,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:41:32Z",
+          "completed_at": "2026-09-06T10:54:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027856658,
+      "workflow": "larql-cli",
+      "branch": "k3-v4-warm-latency",
+      "sha": "2c290c7717a4399dc7d2f577b2b3d3d5863863cc",
+      "attempt": 1,
+      "status": "in_progress",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:35:40Z",
+      "run_started_at": "2026-09-06T10:35:40Z",
+      "pr": 432,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:42:18Z",
+          "completed_at": "2026-09-06T10:49:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T10:40:57Z",
+          "completed_at": "2026-09-06T11:00:08Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:07:01Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:35:41Z",
+          "started_at": "2026-09-06T11:07:14Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027620922,
+      "workflow": "larql-lql",
+      "branch": "rung5/exchange-search",
+      "sha": "8aa185ad65af8cc8e0005efa4810e72b9228778c",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:30:43Z",
+      "run_started_at": "2026-09-06T10:30:43Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:33:25Z",
+          "completed_at": "2026-09-06T10:51:24Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:56:17Z",
+          "completed_at": "2026-09-06T11:03:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:43Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T11:02:08Z",
+          "completed_at": "2026-09-06T11:10:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027620935,
+      "workflow": "larql-cli",
+      "branch": "rung5/exchange-search",
+      "sha": "8aa185ad65af8cc8e0005efa4810e72b9228778c",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:30:43Z",
+      "run_started_at": "2026-09-06T10:30:43Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T11:05:36Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:53:08Z",
+          "completed_at": null,
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:49:54Z",
+          "completed_at": "2026-09-06T10:56:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:43Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027621026,
+      "workflow": "larql-inference",
+      "branch": "rung5/exchange-search",
+      "sha": "8aa185ad65af8cc8e0005efa4810e72b9228778c",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:30:43Z",
+      "run_started_at": "2026-09-06T10:30:43Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:47:43Z",
+          "completed_at": "2026-09-06T11:07:13Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T11:00:09Z",
+          "completed_at": "2026-09-06T11:06:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:32:39Z",
+          "completed_at": "2026-09-06T10:40:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:43Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027620924,
+      "workflow": "larql-server",
+      "branch": "rung5/exchange-search",
+      "sha": "8aa185ad65af8cc8e0005efa4810e72b9228778c",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:30:43Z",
+      "run_started_at": "2026-09-06T10:30:43Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:33:16Z",
+          "completed_at": "2026-09-06T10:40:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:34:58Z",
+          "completed_at": "2026-09-06T10:44:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:45:30Z",
+          "completed_at": "2026-09-06T11:06:59Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:43Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027620950,
+      "workflow": "quality",
+      "branch": "rung5/exchange-search",
+      "sha": "8aa185ad65af8cc8e0005efa4810e72b9228778c",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:30:43Z",
+      "run_started_at": "2026-09-06T10:30:43Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:41:43Z",
+          "completed_at": "2026-09-06T10:42:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:37:11Z",
+          "completed_at": "2026-09-06T10:38:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:43Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:43Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:43Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T11:07:14Z",
+          "completed_at": "2026-09-06T11:08:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:43Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:43Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:43Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027620936,
+      "workflow": "mutants",
+      "branch": "rung5/exchange-search",
+      "sha": "8aa185ad65af8cc8e0005efa4810e72b9228778c",
+      "attempt": 1,
+      "status": "in_progress",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:30:43Z",
+      "run_started_at": "2026-09-06T10:30:43Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:56:03Z",
+          "completed_at": "2026-09-06T10:56:15Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:47:42Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027620975,
+      "workflow": "larql-vindex",
+      "branch": "rung5/exchange-search",
+      "sha": "8aa185ad65af8cc8e0005efa4810e72b9228778c",
+      "attempt": 1,
+      "status": "in_progress",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:30:43Z",
+      "run_started_at": "2026-09-06T10:30:43Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:46:23Z",
+          "completed_at": "2026-09-06T11:01:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:56:56Z",
+          "completed_at": "2026-09-06T11:06:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:30:58Z",
+          "completed_at": "2026-09-06T10:54:29Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T11:01:43Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027621115,
+      "workflow": "shannon-verify",
+      "branch": "rung5/exchange-search",
+      "sha": "8aa185ad65af8cc8e0005efa4810e72b9228778c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:30:43Z",
+      "run_started_at": "2026-09-06T10:30:43Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T10:51:26Z",
+          "completed_at": "2026-09-06T11:05:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027620931,
+      "workflow": "commit messages",
+      "branch": "rung5/exchange-search",
+      "sha": "8aa185ad65af8cc8e0005efa4810e72b9228778c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:30:43Z",
+      "run_started_at": "2026-09-06T10:30:43Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:30:43Z",
+          "started_at": "2026-09-06T11:10:29Z",
+          "completed_at": "2026-09-06T11:10:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33813111743,
+      "workflow": "shannon-verify",
+      "branch": "rung5/exchange-search",
+      "sha": "c99daffb471ef529a9b10e129052b4a95e21b33a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T22:27:13Z",
+      "run_started_at": "2026-09-03T22:27:13Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:27:18Z",
+          "completed_at": "2026-09-03T22:41:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33813111823,
+      "workflow": "larql-lql",
+      "branch": "rung5/exchange-search",
+      "sha": "c99daffb471ef529a9b10e129052b4a95e21b33a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T22:27:13Z",
+      "run_started_at": "2026-09-03T22:27:13Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:28:26Z",
+          "completed_at": "2026-09-03T22:35:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:35:13Z",
+          "completed_at": "2026-09-03T22:42:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:36:48Z",
+          "completed_at": "2026-09-03T22:45:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:33:19Z",
+          "completed_at": "2026-09-03T22:51:36Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33813111886,
+      "workflow": "larql-inference",
+      "branch": "rung5/exchange-search",
+      "sha": "c99daffb471ef529a9b10e129052b4a95e21b33a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T22:27:13Z",
+      "run_started_at": "2026-09-03T22:27:13Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:27:47Z",
+          "completed_at": "2026-09-03T22:33:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:33:42Z",
+          "completed_at": "2026-09-03T22:52:33Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:36:12Z",
+          "completed_at": "2026-09-03T22:43:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:38:53Z",
+          "completed_at": "2026-09-03T22:47:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33813111829,
+      "workflow": "larql-server",
+      "branch": "rung5/exchange-search",
+      "sha": "c99daffb471ef529a9b10e129052b4a95e21b33a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T22:27:13Z",
+      "run_started_at": "2026-09-03T22:27:13Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:28:06Z",
+          "completed_at": "2026-09-03T22:36:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:37:02Z",
+          "completed_at": "2026-09-03T22:47:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:38:39Z",
+          "completed_at": "2026-09-03T22:46:19Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:34:39Z",
+          "completed_at": "2026-09-03T22:55:53Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33813111728,
+      "workflow": "larql-cli",
+      "branch": "rung5/exchange-search",
+      "sha": "c99daffb471ef529a9b10e129052b4a95e21b33a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T22:27:13Z",
+      "run_started_at": "2026-09-03T22:27:13Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:27:16Z",
+          "completed_at": "2026-09-03T22:33:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:27:16Z",
+          "completed_at": "2026-09-03T22:47:05Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:28:35Z",
+          "completed_at": "2026-09-03T22:40:02Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:27:15Z",
+          "completed_at": "2026-09-03T22:36:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33813111918,
+      "workflow": "quality",
+      "branch": "rung5/exchange-search",
+      "sha": "c99daffb471ef529a9b10e129052b4a95e21b33a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T22:27:13Z",
+      "run_started_at": "2026-09-03T22:27:13Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:34:29Z",
+          "completed_at": "2026-09-03T22:34:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:41:36Z",
+          "completed_at": "2026-09-03T22:41:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:41:08Z",
+          "completed_at": "2026-09-03T22:41:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:40:39Z",
+          "completed_at": "2026-09-03T22:41:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:40:35Z",
+          "completed_at": "2026-09-03T22:41:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:41:37Z",
+          "completed_at": "2026-09-03T22:42:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:42:16Z",
+          "completed_at": "2026-09-03T22:42:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:41:55Z",
+          "completed_at": "2026-09-03T22:42:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:41:47Z",
+          "completed_at": "2026-09-03T22:48:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33813111754,
+      "workflow": "larql-vindex",
+      "branch": "rung5/exchange-search",
+      "sha": "c99daffb471ef529a9b10e129052b4a95e21b33a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T22:27:13Z",
+      "run_started_at": "2026-09-03T22:27:13Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:31:07Z",
+          "completed_at": "2026-09-03T22:40:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:40:04Z",
+          "completed_at": "2026-09-03T22:54:00Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:32:51Z",
+          "completed_at": "2026-09-03T23:02:58Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:33:59Z",
+          "completed_at": "2026-09-03T22:48:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33813111915,
+      "workflow": "commit messages",
+      "branch": "rung5/exchange-search",
+      "sha": "c99daffb471ef529a9b10e129052b4a95e21b33a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T22:27:13Z",
+      "run_started_at": "2026-09-03T22:27:13Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:34:23Z",
+          "completed_at": "2026-09-03T22:34:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33813111775,
+      "workflow": "mutants",
+      "branch": "rung5/exchange-search",
+      "sha": "c99daffb471ef529a9b10e129052b4a95e21b33a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-03T22:27:13Z",
+      "run_started_at": "2026-09-03T22:27:13Z",
+      "pr": 411,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:32:41Z",
+          "completed_at": "2026-09-03T23:18:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T22:27:14Z",
+          "started_at": "2026-09-03T22:35:58Z",
+          "completed_at": "2026-09-03T22:36:09Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027023602,
+      "workflow": "quality",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:17:50Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T11:01:20Z",
+          "completed_at": "2026-09-06T11:02:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:17:50Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:43:48Z",
+          "completed_at": "2026-09-06T10:44:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:27:19Z",
+          "completed_at": "2026-09-06T10:28:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:17:50Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:52:45Z",
+          "completed_at": "2026-09-06T10:52:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:17:50Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:17:50Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027023639,
+      "workflow": "mutants",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:40:34Z",
+          "completed_at": null,
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "queued",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:17:50Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027023657,
+      "workflow": "larql-factory",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:27:15Z",
+          "completed_at": "2026-09-06T10:28:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:30:45Z",
+          "completed_at": "2026-09-06T10:33:14Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:30:47Z",
+          "completed_at": "2026-09-06T10:31:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:18:49Z",
+          "completed_at": "2026-09-06T10:20:02Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027023592,
+      "workflow": "commit messages",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:34:29Z",
+          "completed_at": "2026-09-06T10:34:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027023672,
+      "workflow": "shannon-verify",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:26:54Z",
+          "completed_at": "2026-09-06T10:40:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027023584,
+      "workflow": "larql-models",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:23:56Z",
+          "completed_at": "2026-09-06T10:27:18Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:20:19Z",
+          "completed_at": "2026-09-06T10:22:07Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:28:10Z",
+          "completed_at": "2026-09-06T10:29:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:46:47Z",
+          "completed_at": "2026-09-06T10:47:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027023583,
+      "workflow": "larql-compute",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:33:15Z",
+          "completed_at": "2026-09-06T10:34:57Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:22:14Z",
+          "completed_at": "2026-09-06T10:23:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:26:52Z",
+          "completed_at": "2026-09-06T10:39:03Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:40:06Z",
+          "completed_at": "2026-09-06T10:41:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34027023563,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "in_progress",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:44:35Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027023597,
+      "workflow": "larql-inference",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:19:18Z",
+          "completed_at": "2026-09-06T10:24:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:20:10Z",
+          "completed_at": "2026-09-06T10:30:57Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:37:53Z",
+          "completed_at": "2026-09-06T10:46:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:20:45Z",
+          "completed_at": "2026-09-06T10:40:06Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34027023593,
+      "workflow": "larql-cli",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:46:44Z",
+          "completed_at": "2026-09-06T10:52:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:37:10Z",
+          "completed_at": "2026-09-06T10:47:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:27:20Z",
+          "completed_at": "2026-09-06T10:46:12Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:29:35Z",
+          "completed_at": "2026-09-06T10:39:17Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027023590,
+      "workflow": "larql-vindex",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "in_progress",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:21:48Z",
+          "completed_at": "2026-09-06T10:30:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:47:26Z",
+          "completed_at": null,
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:39:05Z",
+          "completed_at": "2026-09-06T10:53:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:53:41Z",
+          "completed_at": "2026-09-06T11:10:27Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027023570,
+      "workflow": "larql-server",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:28:04Z",
+          "completed_at": "2026-09-06T10:37:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:24:53Z",
+          "completed_at": "2026-09-06T10:46:46Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:36:29Z",
+          "completed_at": "2026-09-06T10:45:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:44:36Z",
+          "completed_at": "2026-09-06T10:55:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027023587,
+      "workflow": "larql-lql",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": 431,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:40:12Z",
+          "completed_at": "2026-09-06T10:47:42Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:20:53Z",
+          "completed_at": "2026-09-06T10:27:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:19:32Z",
+          "completed_at": "2026-09-06T10:38:07Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:56:33Z",
+          "completed_at": "2026-09-06T11:04:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34026734097,
+      "workflow": "commit messages",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:38Z",
+          "started_at": "2026-09-06T10:20:40Z",
+          "completed_at": "2026-09-06T10:20:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34026734106,
+      "workflow": "quality",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "queued",
+      "conclusion": null,
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:52:56Z",
+          "completed_at": "2026-09-06T10:53:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:12:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:40Z",
+          "completed_at": "2026-09-06T10:12:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:30:49Z",
+          "completed_at": "2026-09-06T10:36:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:40Z",
+          "completed_at": "2026-09-06T10:12:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:34:35Z",
+          "completed_at": "2026-09-06T10:35:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T11:06:31Z",
+          "completed_at": "2026-09-06T11:07:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:38Z",
+          "started_at": "2026-09-06T11:12:29Z",
+          "completed_at": "2026-09-06T11:12:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "in_progress",
+          "conclusion": null,
+          "created_at": "2026-09-06T10:11:38Z",
+          "started_at": "2026-09-06T11:12:53Z",
+          "completed_at": null,
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34026734079,
+      "workflow": "shannon-verify",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:40Z",
+          "completed_at": "2026-09-06T10:25:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34026734123,
+      "workflow": "larql-models",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:12:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:15:04Z",
+          "completed_at": "2026-09-06T10:16:34Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:23:45Z",
+          "completed_at": "2026-09-06T10:26:51Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:20:36Z",
+          "completed_at": "2026-09-06T10:21:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34026734099,
+      "workflow": "larql-inference",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:20:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:44Z",
+          "completed_at": "2026-09-06T10:20:10Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:30:46Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:18:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34026734082,
+      "workflow": "larql-lql",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:12:24Z",
+          "completed_at": "2026-09-06T10:30:43Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:13:30Z",
+          "completed_at": "2026-09-06T10:21:58Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:40Z",
+          "completed_at": "2026-09-06T10:19:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:20:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34026734131,
+      "workflow": "larql-cli",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:55Z",
+          "completed_at": "2026-09-06T10:19:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:22:13Z",
+          "completed_at": "2026-09-06T10:33:10Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:12:25Z",
+          "completed_at": "2026-09-06T10:22:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:16:38Z",
+          "completed_at": "2026-09-06T10:32:37Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34026734089,
+      "workflow": "larql-factory",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:32:03Z",
+          "completed_at": "2026-09-06T10:33:23Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:12:24Z",
+          "completed_at": "2026-09-06T10:13:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:13:07Z",
+          "completed_at": "2026-09-06T10:14:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:12:13Z",
+          "completed_at": "2026-09-06T10:14:57Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34026734077,
+      "workflow": "larql-compute",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:13:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:13:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:23:42Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:35:36Z",
+          "completed_at": "2026-09-06T10:37:08Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34026734096,
+      "workflow": "larql-vindex",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:20:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:40Z",
+          "completed_at": "2026-09-06T10:41:42Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:43Z",
+          "completed_at": "2026-09-06T10:26:50Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:27:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34026734112,
+      "workflow": "larql-server",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:14:08Z",
+          "completed_at": "2026-09-06T10:36:28Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:38:08Z",
+          "completed_at": "2026-09-06T10:46:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:25:47Z",
+          "completed_at": "2026-09-06T10:36:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:22:09Z",
+          "completed_at": "2026-09-06T10:34:27Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34026734085,
+      "workflow": "mutants",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:39Z",
+          "completed_at": "2026-09-06T10:56:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:11:44Z",
+          "completed_at": "2026-09-06T10:11:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34026734090,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:13:37Z",
+          "completed_at": "2026-09-06T11:10:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002076179,
+      "workflow": "larql-inference",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:46:52Z",
+          "completed_at": "2026-09-06T00:55:56Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:50:17Z",
+          "completed_at": "2026-09-06T00:58:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:45:48Z",
+          "completed_at": "2026-09-06T01:04:24Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:53:48Z",
+          "completed_at": "2026-09-06T00:59:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002076157,
+      "workflow": "larql-compute",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:54:31Z",
+          "completed_at": "2026-09-06T00:55:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:30:38Z",
+          "completed_at": "2026-09-06T01:32:03Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:54:50Z",
+          "completed_at": "2026-09-06T00:56:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:04:19Z",
+          "completed_at": "2026-09-06T01:15:32Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34002076143,
+      "workflow": "larql-cli",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:56:20Z",
+          "completed_at": "2026-09-06T01:15:59Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:15:55Z",
+          "completed_at": "2026-09-06T01:23:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:21:19Z",
+          "completed_at": "2026-09-06T01:30:21Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:24:56Z",
+          "completed_at": "2026-09-06T01:32:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002076174,
+      "workflow": "larql-server",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:15:56Z",
+          "completed_at": "2026-09-06T01:24:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:18:49Z",
+          "completed_at": "2026-09-06T01:28:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:23:50Z",
+          "completed_at": "2026-09-06T01:34:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:15:33Z",
+          "completed_at": "2026-09-06T01:36:49Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34002076178,
+      "workflow": "quality",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:32:33Z",
+          "completed_at": "2026-09-06T01:33:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:33:01Z",
+          "completed_at": "2026-09-06T01:33:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:38:17Z",
+          "completed_at": "2026-09-06T01:39:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:38:54Z",
+          "completed_at": "2026-09-06T01:39:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:08:17Z",
+          "completed_at": "2026-09-06T01:09:07Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:33:45Z",
+          "completed_at": "2026-09-06T01:41:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:39:52Z",
+          "completed_at": "2026-09-06T01:40:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:39:37Z",
+          "completed_at": "2026-09-06T01:40:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:40:15Z",
+          "completed_at": "2026-09-06T01:40:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002076165,
+      "workflow": "commit messages",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:11:35Z",
+          "completed_at": "2026-09-06T01:11:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002076599,
+      "workflow": "commit messages",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:28Z",
+          "started_at": "2026-09-06T01:19:29Z",
+          "completed_at": "2026-09-06T01:19:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002076136,
+      "workflow": "larql-models",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:59:41Z",
+          "completed_at": "2026-09-06T01:00:50Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:16:15Z",
+          "completed_at": "2026-09-06T01:17:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:07:48Z",
+          "completed_at": "2026-09-06T01:08:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:17:06Z",
+          "completed_at": "2026-09-06T01:20:20Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34002076176,
+      "workflow": "larql-lql",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:58:20Z",
+          "completed_at": "2026-09-06T01:16:15Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:12:25Z",
+          "completed_at": "2026-09-06T01:21:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:16:26Z",
+          "completed_at": "2026-09-06T01:23:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:01:35Z",
+          "completed_at": "2026-09-06T01:07:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002076132,
+      "workflow": "shannon-verify",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:10:41Z",
+          "completed_at": "2026-09-06T01:24:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002076168,
+      "workflow": "larql-factory",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:55:59Z",
+          "completed_at": "2026-09-06T00:58:17Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:17:13Z",
+          "completed_at": "2026-09-06T01:18:43Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:27:24Z",
+          "completed_at": "2026-09-06T01:28:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:17:11Z",
+          "completed_at": "2026-09-06T01:18:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002076134,
+      "workflow": "larql-vindex",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:12:00Z",
+          "completed_at": "2026-09-06T01:21:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:30:23Z",
+          "completed_at": "2026-09-06T01:45:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:14:58Z",
+          "completed_at": "2026-09-06T01:44:53Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:39:08Z",
+          "completed_at": "2026-09-06T01:55:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002076153,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:58:05Z",
+          "completed_at": "2026-09-06T01:59:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002076175,
+      "workflow": "mutants",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:38:10Z",
+          "completed_at": "2026-09-06T01:38:20Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T01:21:21Z",
+          "completed_at": "2026-09-06T02:06:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002001947,
+      "workflow": "commit messages",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:41Z",
+          "completed_at": "2026-09-06T00:42:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002001954,
+      "workflow": "larql-inference",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:41Z",
+          "completed_at": "2026-09-06T00:51:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:41Z",
+          "completed_at": "2026-09-06T00:50:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:42Z",
+          "completed_at": "2026-09-06T01:01:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:45:13Z",
+          "completed_at": "2026-09-06T00:51:51Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002001944,
+      "workflow": "larql-cli",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:43Z",
+          "completed_at": "2026-09-06T00:50:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:46Z",
+          "completed_at": "2026-09-06T00:53:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:41Z",
+          "completed_at": "2026-09-06T01:02:38Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:52:57Z",
+          "completed_at": "2026-09-06T01:02:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002001949,
+      "workflow": "larql-models",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:42Z",
+          "completed_at": "2026-09-06T00:43:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:53:36Z",
+          "completed_at": "2026-09-06T00:55:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:41Z",
+          "completed_at": "2026-09-06T00:45:46Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:03:04Z",
+          "completed_at": "2026-09-06T01:04:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002001979,
+      "workflow": "larql-compute",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:43:41Z",
+          "completed_at": "2026-09-06T00:45:08Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:52:24Z",
+          "completed_at": "2026-09-06T00:53:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:48Z",
+          "completed_at": "2026-09-06T00:54:48Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:52:33Z",
+          "completed_at": "2026-09-06T00:54:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002001977,
+      "workflow": "shannon-verify",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:42Z",
+          "completed_at": "2026-09-06T00:55:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002001965,
+      "workflow": "larql-server",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:42Z",
+          "completed_at": "2026-09-06T00:51:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:43Z",
+          "completed_at": "2026-09-06T00:57:08Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:45Z",
+          "completed_at": "2026-09-06T00:50:22Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:41Z",
+          "completed_at": "2026-09-06T00:52:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002001978,
+      "workflow": "larql-factory",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:44:34Z",
+          "completed_at": "2026-09-06T00:46:45Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:43:39Z",
+          "completed_at": "2026-09-06T00:44:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:51:57Z",
+          "completed_at": "2026-09-06T00:52:56Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:58:10Z",
+          "completed_at": "2026-09-06T00:59:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002001968,
+      "workflow": "larql-lql",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:01:59Z",
+          "completed_at": "2026-09-06T01:07:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:58:22Z",
+          "completed_at": "2026-09-06T01:07:00Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:07:55Z",
+          "completed_at": "2026-09-06T01:16:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:57:10Z",
+          "completed_at": "2026-09-06T01:15:55Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34002001946,
+      "workflow": "larql-vindex",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:42Z",
+          "completed_at": "2026-09-06T00:50:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:43Z",
+          "completed_at": "2026-09-06T01:13:20Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:49Z",
+          "completed_at": "2026-09-06T00:58:08Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:07:03Z",
+          "completed_at": "2026-09-06T01:21:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002002017,
+      "workflow": "quality",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:16:35Z",
+          "completed_at": "2026-09-06T01:17:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:47Z",
+          "completed_at": "2026-09-06T00:43:37Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:42:41Z",
+          "completed_at": "2026-09-06T00:49:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:51:32Z",
+          "completed_at": "2026-09-06T00:52:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:01:22Z",
+          "completed_at": "2026-09-06T01:01:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:16:17Z",
+          "completed_at": "2026-09-06T01:16:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:24:14Z",
+          "completed_at": "2026-09-06T01:24:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:18:46Z",
+          "completed_at": "2026-09-06T01:19:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:29:51Z",
+          "completed_at": "2026-09-06T01:30:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002002035,
+      "workflow": "mutants",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:09:01Z",
+          "completed_at": "2026-09-06T01:54:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T01:14:56Z",
+          "completed_at": "2026-09-06T01:15:06Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002001983,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": 429,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:51:06Z",
+          "completed_at": "2026-09-06T01:55:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34004725844,
+      "workflow": "commit messages",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:46:38Z",
+          "completed_at": "2026-09-06T01:46:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34004725733,
+      "workflow": "larql-models",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:47Z",
+          "completed_at": "2026-09-06T01:46:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:49:39Z",
+          "completed_at": "2026-09-06T01:51:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:46:20Z",
+          "completed_at": "2026-09-06T01:49:18Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:47Z",
+          "completed_at": "2026-09-06T01:46:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34004725858,
+      "workflow": "larql-factory",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:48Z",
+          "completed_at": "2026-09-06T01:46:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:59Z",
+          "completed_at": "2026-09-06T01:48:25Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:55:34Z",
+          "completed_at": "2026-09-06T01:56:40Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:47:43Z",
+          "completed_at": "2026-09-06T01:48:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34004725820,
+      "workflow": "shannon-verify",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:46:47Z",
+          "completed_at": "2026-09-06T01:58:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34004725801,
+      "workflow": "larql-compute",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:48Z",
+          "completed_at": "2026-09-06T01:47:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:47:18Z",
+          "completed_at": "2026-09-06T01:59:34Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:53:39Z",
+          "completed_at": "2026-09-06T01:55:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:59:40Z",
+          "completed_at": "2026-09-06T02:01:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34004725960,
+      "workflow": "larql-server",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:49:20Z",
+          "completed_at": "2026-09-06T01:57:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:55:18Z",
+          "completed_at": "2026-09-06T02:05:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T02:06:01Z",
+          "completed_at": "2026-09-06T02:19:36Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:48:21Z",
+          "completed_at": "2026-09-06T02:05:29Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34004725803,
+      "workflow": "quality",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:48Z",
+          "completed_at": "2026-09-06T01:45:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:47Z",
+          "completed_at": "2026-09-06T01:45:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:47Z",
+          "completed_at": "2026-09-06T01:46:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:48Z",
+          "completed_at": "2026-09-06T01:46:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:48Z",
+          "completed_at": "2026-09-06T01:46:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T02:05:11Z",
+          "completed_at": "2026-09-06T02:05:55Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:47:00Z",
+          "completed_at": "2026-09-06T01:47:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:59Z",
+          "completed_at": "2026-09-06T01:53:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:48:53Z",
+          "completed_at": "2026-09-06T01:49:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34004725884,
+      "workflow": "larql-inference",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:54:52Z",
+          "completed_at": "2026-09-06T02:01:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T02:03:37Z",
+          "completed_at": "2026-09-06T02:11:43Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:56:41Z",
+          "completed_at": "2026-09-06T02:05:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:51:26Z",
+          "completed_at": "2026-09-06T02:08:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34004725802,
+      "workflow": "larql-lql",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T02:11:50Z",
+          "completed_at": "2026-09-06T02:20:55Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:48Z",
+          "completed_at": "2026-09-06T01:53:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:45:48Z",
+          "completed_at": "2026-09-06T01:54:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:46:44Z",
+          "completed_at": "2026-09-06T02:03:24Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34004725845,
+      "workflow": "larql-vindex",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:47:52Z",
+          "completed_at": "2026-09-06T01:56:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:48:02Z",
+          "completed_at": "2026-09-06T02:19:15Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T02:09:39Z",
+          "completed_at": "2026-09-06T02:26:16Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:49:38Z",
+          "completed_at": "2026-09-06T02:01:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34004725816,
+      "workflow": "mutants",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:46:49Z",
+          "completed_at": "2026-09-06T02:28:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:51:16Z",
+          "completed_at": "2026-09-06T01:51:24Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34004725832,
+      "workflow": "larql-cli",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:46:43Z",
+          "completed_at": "2026-09-06T01:53:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T02:19:44Z",
+          "completed_at": "2026-09-06T02:30:46Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:53:13Z",
+          "completed_at": "2026-09-06T02:14:47Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T01:54:19Z",
+          "completed_at": "2026-09-06T02:02:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34004725869,
+      "workflow": "larql-compute-metal",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T02:13:51Z",
+          "completed_at": "2026-09-06T03:05:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002226159,
+      "workflow": "shannon-verify",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:53Z",
+      "run_started_at": "2026-09-06T00:47:53Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:54Z",
+          "started_at": "2026-09-06T01:34:20Z",
+          "completed_at": "2026-09-06T01:47:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002225502,
+      "workflow": "commit messages",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:08:23Z",
+          "completed_at": "2026-09-06T01:08:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002225530,
+      "workflow": "larql-models",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:23:42Z",
+          "completed_at": "2026-09-06T01:24:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:51:30Z",
+          "completed_at": "2026-09-06T00:54:35Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:50:20Z",
+          "completed_at": "2026-09-06T00:51:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:33:09Z",
+          "completed_at": "2026-09-06T01:34:25Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002225521,
+      "workflow": "larql-compute",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:50:01Z",
+          "completed_at": "2026-09-06T00:51:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:56:00Z",
+          "completed_at": "2026-09-06T01:08:21Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:33:15Z",
+          "completed_at": "2026-09-06T01:35:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:13:26Z",
+          "completed_at": "2026-09-06T01:14:56Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002225557,
+      "workflow": "larql-boundary",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:55:38Z",
+          "completed_at": "2026-09-06T00:56:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:02:33Z",
+          "completed_at": "2026-09-06T01:10:38Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:09:11Z",
+          "completed_at": "2026-09-06T01:14:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:28:33Z",
+          "completed_at": "2026-09-06T01:36:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002225515,
+      "workflow": "larql-factory",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:16:05Z",
+          "completed_at": "2026-09-06T01:17:06Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:34:27Z",
+          "completed_at": "2026-09-06T01:35:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:37:09Z",
+          "completed_at": "2026-09-06T01:38:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:55:57Z",
+          "completed_at": "2026-09-06T00:58:14Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34002225503,
+      "workflow": "larql-inference",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:02:45Z",
+          "completed_at": "2026-09-06T01:11:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:11:41Z",
+          "completed_at": "2026-09-06T01:31:31Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:24:32Z",
+          "completed_at": "2026-09-06T01:33:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:33:10Z",
+          "completed_at": "2026-09-06T01:40:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002225532,
+      "workflow": "larql-lql",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:50:23Z",
+          "completed_at": "2026-09-06T00:57:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:07:41Z",
+          "completed_at": "2026-09-06T01:16:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:32:10Z",
+          "completed_at": "2026-09-06T01:38:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:23:29Z",
+          "completed_at": "2026-09-06T01:43:24Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34002225534,
+      "workflow": "larql-demos",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:35:49Z",
+          "completed_at": "2026-09-06T01:43:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:24:36Z",
+          "completed_at": "2026-09-06T01:33:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:51:32Z",
+          "completed_at": "2026-09-06T01:01:21Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34002225513,
+      "workflow": "larql-kv",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:54:37Z",
+          "completed_at": "2026-09-06T01:02:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:28:59Z",
+          "completed_at": "2026-09-06T01:37:47Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:35:05Z",
+          "completed_at": "2026-09-06T01:43:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:21:55Z",
+          "completed_at": "2026-09-06T01:40:11Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34002225523,
+      "workflow": "larql-cli",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:20:22Z",
+          "completed_at": "2026-09-06T01:39:35Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:58:07Z",
+          "completed_at": "2026-09-06T01:07:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:36:15Z",
+          "completed_at": "2026-09-06T01:43:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:38:26Z",
+          "completed_at": "2026-09-06T01:48:19Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002225506,
+      "workflow": "quality",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:55:30Z",
+          "completed_at": "2026-09-06T00:55:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:37:48Z",
+          "completed_at": "2026-09-06T01:38:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:37:26Z",
+          "completed_at": "2026-09-06T01:45:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:01:11Z",
+          "completed_at": "2026-09-06T01:01:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:48:32Z",
+          "completed_at": "2026-09-06T01:49:14Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:39:08Z",
+          "completed_at": "2026-09-06T01:39:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:40:39Z",
+          "completed_at": "2026-09-06T01:40:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:40:13Z",
+          "completed_at": "2026-09-06T01:41:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:40:39Z",
+          "completed_at": "2026-09-06T01:41:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002225511,
+      "workflow": "mutants",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:02:26Z",
+          "completed_at": "2026-09-06T01:47:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:49:21Z",
+          "completed_at": "2026-09-06T01:49:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002225518,
+      "workflow": "larql-server",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:59:19Z",
+          "completed_at": "2026-09-06T01:08:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:56:23Z",
+          "completed_at": "2026-09-06T01:18:04Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:55:39Z",
+          "completed_at": "2026-09-06T02:03:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:16:26Z",
+          "completed_at": "2026-09-06T01:24:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34002225577,
+      "workflow": "larql-core",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:31:32Z",
+          "completed_at": "2026-09-06T01:32:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:08:29Z",
+          "completed_at": "2026-09-06T01:15:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:19:34Z",
+          "completed_at": "2026-09-06T01:27:23Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:56:53Z",
+          "completed_at": "2026-09-06T02:05:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002225588,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:43:55Z",
+          "completed_at": "2026-09-06T02:37:58Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002225507,
+      "workflow": "bench-regress",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 2,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T01:49:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-06T01:49:40Z",
+          "started_at": "2026-09-06T02:01:36Z",
+          "completed_at": "2026-09-06T02:13:45Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002225555,
+      "workflow": "larql-vindex",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:53:07Z",
+          "completed_at": "2026-09-06T02:09:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:04:25Z",
+          "completed_at": "2026-09-06T01:11:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T00:51:30Z",
+          "completed_at": "2026-09-06T01:23:48Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:24:33Z",
+          "completed_at": "2026-09-06T01:37:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34000938799,
+      "workflow": "larql-inference",
+      "branch": "k3-residency-vertical",
+      "sha": "68abfd70d2f636f5e3aa73d719262ac0c6125c65",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:18:26Z",
+      "run_started_at": "2026-09-06T00:18:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:29Z",
+          "completed_at": "2026-09-06T00:27:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:25:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:37:45Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:32Z",
+          "completed_at": "2026-09-06T00:25:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34000938861,
+      "workflow": "larql-lql",
+      "branch": "k3-residency-vertical",
+      "sha": "68abfd70d2f636f5e3aa73d719262ac0c6125c65",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:18:26Z",
+      "run_started_at": "2026-09-06T00:18:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:26:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:26:04Z",
+          "completed_at": "2026-09-06T00:31:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:40Z",
+          "completed_at": "2026-09-06T00:37:36Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:34Z",
+          "completed_at": "2026-09-06T00:30:02Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34000938856,
+      "workflow": "larql-vindex",
+      "branch": "k3-residency-vertical",
+      "sha": "68abfd70d2f636f5e3aa73d719262ac0c6125c65",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-06T00:18:26Z",
+      "run_started_at": "2026-09-06T00:18:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:33:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:33Z",
+          "completed_at": "2026-09-06T00:33:16Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:19:04Z",
+          "completed_at": "2026-09-06T00:40:45Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:27:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34000938830,
+      "workflow": "quality",
+      "branch": "k3-residency-vertical",
+      "sha": "68abfd70d2f636f5e3aa73d719262ac0c6125c65",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:18:26Z",
+      "run_started_at": "2026-09-06T00:18:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:18:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:18:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:35Z",
+          "completed_at": "2026-09-06T00:26:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:19:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:27:06Z",
+          "completed_at": "2026-09-06T00:27:51Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:26:05Z",
+          "completed_at": "2026-09-06T00:27:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:27:36Z",
+          "completed_at": "2026-09-06T00:28:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:27:30Z",
+          "completed_at": "2026-09-06T00:28:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:27:45Z",
+          "completed_at": "2026-09-06T00:28:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34000938839,
+      "workflow": "shannon-verify",
+      "branch": "k3-residency-vertical",
+      "sha": "68abfd70d2f636f5e3aa73d719262ac0c6125c65",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:18:26Z",
+      "run_started_at": "2026-09-06T00:18:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:32:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34000938831,
+      "workflow": "larql-cli",
+      "branch": "k3-residency-vertical",
+      "sha": "68abfd70d2f636f5e3aa73d719262ac0c6125c65",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:18:26Z",
+      "run_started_at": "2026-09-06T00:18:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:33Z",
+          "completed_at": "2026-09-06T00:27:47Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:29Z",
+          "completed_at": "2026-09-06T00:26:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:27:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:36Z",
+          "completed_at": "2026-09-06T00:34:33Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34000938851,
+      "workflow": "larql-server",
+      "branch": "k3-residency-vertical",
+      "sha": "68abfd70d2f636f5e3aa73d719262ac0c6125c65",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-06T00:18:26Z",
+      "run_started_at": "2026-09-06T00:18:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:27:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:34:21Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:34Z",
+          "completed_at": "2026-09-06T00:28:15Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:25:06Z",
+          "completed_at": "2026-09-06T00:35:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34000938899,
+      "workflow": "mutants",
+      "branch": "k3-residency-vertical",
+      "sha": "68abfd70d2f636f5e3aa73d719262ac0c6125c65",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-06T00:18:26Z",
+      "run_started_at": "2026-09-06T00:18:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:25:53Z",
+          "completed_at": "2026-09-06T00:26:03Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:26:41Z",
+          "completed_at": "2026-09-06T01:11:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34000938797,
+      "workflow": "commit messages",
+      "branch": "k3-residency-vertical",
+      "sha": "68abfd70d2f636f5e3aa73d719262ac0c6125c65",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:18:26Z",
+      "run_started_at": "2026-09-06T00:18:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:18:26Z",
+          "started_at": "2026-09-06T00:18:28Z",
+          "completed_at": "2026-09-06T00:18:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33994763622,
+      "workflow": "commit messages",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:41Z",
+          "completed_at": "2026-09-05T22:02:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33994763640,
+      "workflow": "larql-core",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:42Z",
+          "completed_at": "2026-09-05T22:03:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:45Z",
+          "completed_at": "2026-09-05T22:08:56Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:42Z",
+          "completed_at": "2026-09-05T22:12:18Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:03:55Z",
+          "completed_at": "2026-09-05T22:10:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33994763646,
+      "workflow": "bench-regress",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:45Z",
+          "completed_at": "2026-09-05T22:14:15Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33994763631,
+      "workflow": "mutants",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:03:41Z",
+          "completed_at": "2026-09-05T22:49:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:12:26Z",
+          "completed_at": "2026-09-05T22:12:37Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33994763628,
+      "workflow": "larql-compute-metal",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:46Z",
+          "completed_at": "2026-09-05T23:05:12Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33994763648,
+      "workflow": "shannon-verify",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:15:18Z",
+          "completed_at": "2026-09-05T22:29:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33994763653,
+      "workflow": "larql-cli",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:17:49Z",
+          "completed_at": "2026-09-05T22:25:27Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:11:34Z",
+          "completed_at": "2026-09-05T22:19:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:09:52Z",
+          "completed_at": "2026-09-05T22:29:40Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:11:44Z",
+          "completed_at": "2026-09-05T22:19:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33994763651,
+      "workflow": "larql-lql",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:11:47Z",
+          "completed_at": "2026-09-05T22:19:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:12:09Z",
+          "completed_at": "2026-09-05T22:30:23Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:12:44Z",
+          "completed_at": "2026-09-05T22:21:42Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:19:43Z",
+          "completed_at": "2026-09-05T22:28:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33994763679,
+      "workflow": "larql-demos",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:16:47Z",
+          "completed_at": "2026-09-05T22:26:56Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:17:39Z",
+          "completed_at": "2026-09-05T22:26:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:23:23Z",
+          "completed_at": "2026-09-05T22:33:02Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33994763662,
+      "workflow": "larql-server",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:41Z",
+          "completed_at": "2026-09-05T22:09:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:20:06Z",
+          "completed_at": "2026-09-05T22:32:06Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:11:25Z",
+          "completed_at": "2026-09-05T22:21:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:11:33Z",
+          "completed_at": "2026-09-05T22:33:12Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33994763624,
+      "workflow": "larql-boundary",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:41Z",
+          "completed_at": "2026-09-05T22:10:49Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:08:58Z",
+          "completed_at": "2026-09-05T22:16:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:11:30Z",
+          "completed_at": "2026-09-05T22:19:56Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:10:50Z",
+          "completed_at": "2026-09-05T22:11:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33994763632,
+      "workflow": "larql-models",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:10:50Z",
+          "completed_at": "2026-09-05T22:11:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:12:19Z",
+          "completed_at": "2026-09-05T22:15:17Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:10:35Z",
+          "completed_at": "2026-09-05T22:12:07Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:20:18Z",
+          "completed_at": "2026-09-05T22:21:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33994763630,
+      "workflow": "quality",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:21:23Z",
+          "completed_at": "2026-09-05T22:21:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:42Z",
+          "completed_at": "2026-09-05T22:03:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:20:09Z",
+          "completed_at": "2026-09-05T22:20:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:09:47Z",
+          "completed_at": "2026-09-05T22:10:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:19:21Z",
+          "completed_at": "2026-09-05T22:20:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:04:25Z",
+          "completed_at": "2026-09-05T22:11:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:21:24Z",
+          "completed_at": "2026-09-05T22:22:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:21:30Z",
+          "completed_at": "2026-09-05T22:22:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:21:53Z",
+          "completed_at": "2026-09-05T22:22:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33994763626,
+      "workflow": "larql-kv",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:41Z",
+          "completed_at": "2026-09-05T22:11:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:41Z",
+          "completed_at": "2026-09-05T22:20:30Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:14:21Z",
+          "completed_at": "2026-09-05T22:22:36Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:14:54Z",
+          "completed_at": "2026-09-05T22:22:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33994763634,
+      "workflow": "larql-inference",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:42Z",
+          "completed_at": "2026-09-05T22:09:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:42Z",
+          "completed_at": "2026-09-05T22:11:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:50Z",
+          "completed_at": "2026-09-05T22:11:23Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:03:40Z",
+          "completed_at": "2026-09-05T22:23:01Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33994763627,
+      "workflow": "larql-factory",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:20:32Z",
+          "completed_at": "2026-09-05T22:21:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:21:49Z",
+          "completed_at": "2026-09-05T22:23:15Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:21:55Z",
+          "completed_at": "2026-09-05T22:23:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:19:30Z",
+          "completed_at": "2026-09-05T22:21:53Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33994763683,
+      "workflow": "larql-compute",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:41Z",
+          "completed_at": "2026-09-05T22:04:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:45Z",
+          "completed_at": "2026-09-05T22:14:53Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:42Z",
+          "completed_at": "2026-09-05T22:03:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:22:43Z",
+          "completed_at": "2026-09-05T22:24:39Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33994763645,
+      "workflow": "larql-vindex",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:42Z",
+          "completed_at": "2026-09-05T22:33:42Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:45Z",
+          "completed_at": "2026-09-05T22:17:37Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:41Z",
+          "completed_at": "2026-09-05T22:12:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:41Z",
+          "completed_at": "2026-09-05T22:17:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33983292807,
+      "workflow": "bench-regress",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 2,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:59:29Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:59:31Z",
+          "started_at": "2026-09-05T19:02:28Z",
+          "completed_at": "2026-09-05T19:14:12Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33983292863,
+      "workflow": "larql-cli",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:49Z",
+          "started_at": "2026-09-05T18:54:27Z",
+          "completed_at": "2026-09-05T19:06:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:49Z",
+          "started_at": "2026-09-05T18:28:48Z",
+          "completed_at": "2026-09-05T18:36:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:49Z",
+          "started_at": "2026-09-05T18:37:01Z",
+          "completed_at": "2026-09-05T18:46:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:49Z",
+          "started_at": "2026-09-05T18:25:54Z",
+          "completed_at": "2026-09-05T18:45:54Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33983292803,
+      "workflow": "commit messages",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:14:10Z",
+          "completed_at": "2026-09-05T18:14:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33983292820,
+      "workflow": "shannon-verify",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:26:25Z",
+          "completed_at": "2026-09-05T18:40:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33983292810,
+      "workflow": "larql-compute",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 2,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:39:47Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:39:49Z",
+          "started_at": "2026-09-05T18:39:51Z",
+          "completed_at": "2026-09-05T18:41:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:39:49Z",
+          "started_at": "2026-09-05T18:15:07Z",
+          "completed_at": "2026-09-05T18:25:22Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:39:54Z",
+          "started_at": "2026-09-05T18:12:47Z",
+          "completed_at": "2026-09-05T18:14:37Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:39:58Z",
+          "started_at": "2026-09-05T18:30:32Z",
+          "completed_at": "2026-09-05T18:31:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33983292811,
+      "workflow": "larql-server",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:21:27Z",
+          "completed_at": "2026-09-05T18:31:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:26:09Z",
+          "completed_at": "2026-09-05T18:35:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:31:21Z",
+          "completed_at": "2026-09-05T18:41:27Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:49Z",
+          "started_at": "2026-09-05T18:22:01Z",
+          "completed_at": "2026-09-05T18:42:43Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33983292788,
+      "workflow": "larql-demos",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:15:24Z",
+          "completed_at": "2026-09-05T18:24:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:18:13Z",
+          "completed_at": "2026-09-05T18:27:27Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:34:15Z",
+          "completed_at": "2026-09-05T18:43:56Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33983292821,
+      "workflow": "larql-inference",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:32:50Z",
+          "completed_at": "2026-09-05T18:40:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:35:09Z",
+          "completed_at": "2026-09-05T18:44:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:16:50Z",
+          "completed_at": "2026-09-05T18:35:11Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:37:09Z",
+          "completed_at": "2026-09-05T18:45:26Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33983292809,
+      "workflow": "quality",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:36:17Z",
+          "completed_at": "2026-09-05T18:36:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:26:36Z",
+          "completed_at": "2026-09-05T18:27:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:28:01Z",
+          "completed_at": "2026-09-05T18:28:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:35:15Z",
+          "completed_at": "2026-09-05T18:43:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:35:53Z",
+          "completed_at": "2026-09-05T18:36:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:36:04Z",
+          "completed_at": "2026-09-05T18:36:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:36:13Z",
+          "completed_at": "2026-09-05T18:37:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:37:43Z",
+          "completed_at": "2026-09-05T18:38:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:45:02Z",
+          "completed_at": "2026-09-05T18:45:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33983292789,
+      "workflow": "larql-factory",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:14:29Z",
+          "completed_at": "2026-09-05T18:15:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:32:44Z",
+          "completed_at": "2026-09-05T18:35:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:35:46Z",
+          "completed_at": "2026-09-05T18:37:02Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:27:54Z",
+          "completed_at": "2026-09-05T18:28:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33983292808,
+      "workflow": "larql-boundary",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:13:44Z",
+          "completed_at": "2026-09-05T18:14:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:25:21Z",
+          "completed_at": "2026-09-05T18:32:48Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:34:37Z",
+          "completed_at": "2026-09-05T18:40:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:45:32Z",
+          "completed_at": "2026-09-05T18:53:34Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33983292780,
+      "workflow": "larql-models",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:16:13Z",
+          "completed_at": "2026-09-05T18:19:17Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:21:34Z",
+          "completed_at": "2026-09-05T18:22:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:25:37Z",
+          "completed_at": "2026-09-05T18:26:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:53:11Z",
+          "completed_at": "2026-09-05T18:54:19Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33983292793,
+      "workflow": "larql-core",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:25:24Z",
+          "completed_at": "2026-09-05T18:26:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:31:59Z",
+          "completed_at": "2026-09-05T18:40:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:47:48Z",
+          "completed_at": "2026-09-05T18:56:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:12:00Z",
+          "completed_at": "2026-09-05T18:21:21Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33983292856,
+      "workflow": "larql-vindex",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:27:22Z",
+          "completed_at": "2026-09-05T18:58:04Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:28:26Z",
+          "completed_at": "2026-09-05T18:44:17Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:28:42Z",
+          "completed_at": "2026-09-05T18:37:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:49Z",
+          "started_at": "2026-09-05T18:35:34Z",
+          "completed_at": "2026-09-05T18:49:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33983292785,
+      "workflow": "mutants",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:14:17Z",
+          "completed_at": "2026-09-05T18:59:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:14:40Z",
+          "completed_at": "2026-09-05T18:14:50Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33983292784,
+      "workflow": "larql-lql",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:18:19Z",
+          "completed_at": "2026-09-05T18:25:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:27:00Z",
+          "completed_at": "2026-09-05T18:35:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:53:07Z",
+          "completed_at": "2026-09-05T19:01:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:15:44Z",
+          "completed_at": "2026-09-05T18:34:35Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33983292837,
+      "workflow": "larql-kv",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:12:05Z",
+          "completed_at": "2026-09-05T18:18:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:17:45Z",
+          "completed_at": "2026-09-05T18:35:32Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:49Z",
+          "started_at": "2026-09-05T18:35:57Z",
+          "completed_at": "2026-09-05T18:44:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:49Z",
+          "started_at": "2026-09-05T18:56:35Z",
+          "completed_at": "2026-09-05T19:04:02Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33983292853,
+      "workflow": "larql-compute-metal",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:53:40Z",
+          "completed_at": "2026-09-05T19:59:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33981504700,
+      "workflow": "larql-factory",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:37:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:14:56Z",
+          "completed_at": "2026-09-05T18:16:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:37:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:48:43Z",
+          "completed_at": "2026-09-05T17:51:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33981504691,
+      "workflow": "larql-lql",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:13:48Z",
+          "completed_at": "2026-09-05T18:21:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:50:07Z",
+          "completed_at": "2026-09-05T17:58:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:38:48Z",
+          "completed_at": "2026-09-05T17:48:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:54:47Z",
+          "completed_at": "2026-09-05T18:13:46Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33981504690,
+      "workflow": "larql-cli",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:44:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:47:05Z",
+          "completed_at": "2026-09-05T18:03:48Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:04:19Z",
+          "completed_at": "2026-09-05T18:13:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:44:30Z",
+          "completed_at": "2026-09-05T17:53:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33981504736,
+      "workflow": "larql-inference",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:52Z",
+          "completed_at": "2026-09-05T17:44:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:13:59Z",
+          "completed_at": "2026-09-05T18:22:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:00:50Z",
+          "completed_at": "2026-09-05T18:09:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:49:42Z",
+          "completed_at": "2026-09-05T18:08:02Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33981504711,
+      "workflow": "mutants",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:40:32Z",
+          "completed_at": "2026-09-05T18:25:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:54:37Z",
+          "completed_at": "2026-09-05T17:54:45Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33981504697,
+      "workflow": "quality",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:37:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:37:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:55:32Z",
+          "completed_at": "2026-09-05T17:56:18Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:44:19Z",
+          "completed_at": "2026-09-05T17:44:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:38:01Z",
+          "completed_at": "2026-09-05T17:38:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:54:19Z",
+          "completed_at": "2026-09-05T17:55:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:11:56Z",
+          "completed_at": "2026-09-05T18:12:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:19:19Z",
+          "completed_at": "2026-09-05T18:26:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:50Z",
+          "started_at": "2026-09-05T18:21:14Z",
+          "completed_at": "2026-09-05T18:21:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33981504710,
+      "workflow": "larql-kv",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:17:24Z",
+          "completed_at": "2026-09-05T18:26:07Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:41:02Z",
+          "completed_at": "2026-09-05T17:47:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:58:46Z",
+          "completed_at": "2026-09-05T18:17:18Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:03:50Z",
+          "completed_at": "2026-09-05T18:11:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33981504704,
+      "workflow": "larql-compute-metal",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:38:39Z",
+          "completed_at": "2026-09-05T18:35:39Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33981504713,
+      "workflow": "larql-core",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:39:35Z",
+          "completed_at": "2026-09-05T17:40:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:44:19Z",
+          "completed_at": "2026-09-05T17:52:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:55:35Z",
+          "completed_at": "2026-09-05T18:05:35Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:44:03Z",
+          "completed_at": "2026-09-05T18:53:05Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33981504712,
+      "workflow": "larql-vindex",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:37:33Z",
+          "completed_at": "2026-09-05T18:02:18Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:42:11Z",
+          "completed_at": "2026-09-05T17:53:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:52Z",
+          "completed_at": "2026-09-05T17:44:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:52:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33981504703,
+      "workflow": "larql-compute",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:38:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T18:00:23Z",
+          "completed_at": "2026-09-05T18:02:07Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:48:42Z",
+          "completed_at": "2026-09-05T18:00:48Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:38:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33981504701,
+      "workflow": "larql-boundary",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:37:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:46:11Z",
+          "completed_at": "2026-09-05T17:54:30Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:56:25Z",
+          "completed_at": "2026-09-05T18:04:12Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:51:10Z",
+          "completed_at": "2026-09-05T17:58:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33981504716,
+      "workflow": "larql-models",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:37:41Z",
+          "completed_at": "2026-09-05T17:39:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:37:52Z",
+          "completed_at": "2026-09-05T17:41:01Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:37:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:52Z",
+          "completed_at": "2026-09-05T17:38:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33981504738,
+      "workflow": "commit messages",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:46:06Z",
+          "completed_at": "2026-09-05T17:46:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33981504705,
+      "workflow": "larql-demos",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:43:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:38:19Z",
+          "completed_at": "2026-09-05T17:46:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:38:14Z",
+          "completed_at": "2026-09-05T17:46:46Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33981504730,
+      "workflow": "shannon-verify",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:37:38Z",
+          "completed_at": "2026-09-05T17:48:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33981504702,
+      "workflow": "larql-server",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:42:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:36:51Z",
+          "completed_at": "2026-09-05T17:47:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:37:27Z",
+          "completed_at": "2026-09-05T17:49:40Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:37:50Z",
+          "completed_at": "2026-09-05T17:59:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33981504698,
+      "workflow": "bench-regress",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:47:16Z",
+          "completed_at": "2026-09-05T17:59:18Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33980437156,
+      "workflow": "mutants",
+      "branch": "represent-rung3",
+      "sha": "6669d2527072282c010a2dfe491830a46993a4fb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T17:16:19Z",
+      "run_started_at": "2026-09-05T17:16:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T17:16:19Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T18:01:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:26Z",
+          "completed_at": "2026-09-05T17:16:38Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33980437187,
+      "workflow": "larql-inference",
+      "branch": "represent-rung3",
+      "sha": "6669d2527072282c010a2dfe491830a46993a4fb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:16:19Z",
+      "run_started_at": "2026-09-05T17:16:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:19Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T17:25:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:19Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T17:34:44Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:25Z",
+          "completed_at": "2026-09-05T17:24:41Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T17:24:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33980437163,
+      "workflow": "larql-lql",
+      "branch": "represent-rung3",
+      "sha": "6669d2527072282c010a2dfe491830a46993a4fb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:16:19Z",
+      "run_started_at": "2026-09-05T17:16:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T17:23:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:26Z",
+          "completed_at": "2026-09-05T17:25:17Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T17:35:32Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:30Z",
+          "completed_at": "2026-09-05T17:25:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33980437183,
+      "workflow": "larql-server",
+      "branch": "represent-rung3",
+      "sha": "6669d2527072282c010a2dfe491830a46993a4fb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:16:19Z",
+      "run_started_at": "2026-09-05T17:16:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:19Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T17:25:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:25Z",
+          "completed_at": "2026-09-05T17:26:43Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:24:34Z",
+          "completed_at": "2026-09-05T17:34:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:27Z",
+          "completed_at": "2026-09-05T17:37:36Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33980437159,
+      "workflow": "commit messages",
+      "branch": "represent-rung3",
+      "sha": "6669d2527072282c010a2dfe491830a46993a4fb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:16:19Z",
+      "run_started_at": "2026-09-05T17:16:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:22Z",
+          "completed_at": "2026-09-05T17:16:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33980437167,
+      "workflow": "quality",
+      "branch": "represent-rung3",
+      "sha": "6669d2527072282c010a2dfe491830a46993a4fb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T17:16:19Z",
+      "run_started_at": "2026-09-05T17:16:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T17:16:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:40Z",
+          "completed_at": "2026-09-05T17:16:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T17:22:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:24:06Z",
+          "completed_at": "2026-09-05T17:24:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:23:34Z",
+          "completed_at": "2026-09-05T17:24:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:25:22Z",
+          "completed_at": "2026-09-05T17:25:58Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:25:07Z",
+          "completed_at": "2026-09-05T17:25:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:25:11Z",
+          "completed_at": "2026-09-05T17:25:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:25:12Z",
+          "completed_at": "2026-09-05T17:25:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33980437238,
+      "workflow": "shannon-verify",
+      "branch": "represent-rung3",
+      "sha": "6669d2527072282c010a2dfe491830a46993a4fb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:16:19Z",
+      "run_started_at": "2026-09-05T17:16:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:22Z",
+          "completed_at": "2026-09-05T17:29:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33980437201,
+      "workflow": "larql-cli",
+      "branch": "represent-rung3",
+      "sha": "6669d2527072282c010a2dfe491830a46993a4fb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:16:19Z",
+      "run_started_at": "2026-09-05T17:16:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T17:23:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:24:48Z",
+          "completed_at": "2026-09-05T17:33:58Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:22:34Z",
+          "completed_at": "2026-09-05T17:42:06Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:24:23Z",
+          "completed_at": "2026-09-05T17:35:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33980437178,
+      "workflow": "larql-vindex",
+      "branch": "represent-rung3",
+      "sha": "6669d2527072282c010a2dfe491830a46993a4fb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:16:19Z",
+      "run_started_at": "2026-09-05T17:16:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:22Z",
+          "completed_at": "2026-09-05T17:25:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:21Z",
+          "completed_at": "2026-09-05T17:29:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:24:36Z",
+          "completed_at": "2026-09-05T17:54:45Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:16:20Z",
+          "started_at": "2026-09-05T17:16:55Z",
+          "completed_at": "2026-09-05T17:35:47Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33986784633,
+      "workflow": "quality",
+      "branch": "test-isolation-unique-arenas",
+      "sha": "9154f377314e1d651eb1a6ba504918a4e61abd16",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T19:19:54Z",
+      "run_started_at": "2026-09-05T19:19:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:20:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:57Z",
+          "completed_at": "2026-09-05T19:27:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:20:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:20:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:59Z",
+          "completed_at": "2026-09-05T19:20:41Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:20:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:20:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:20:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:04Z",
+          "completed_at": "2026-09-05T19:20:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33986784648,
+      "workflow": "larql-vindex",
+      "branch": "test-isolation-unique-arenas",
+      "sha": "9154f377314e1d651eb1a6ba504918a4e61abd16",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T19:19:54Z",
+      "run_started_at": "2026-09-05T19:19:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:45:08Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:34:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:01Z",
+          "completed_at": "2026-09-05T19:36:40Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:28:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33986784706,
+      "workflow": "larql-cli",
+      "branch": "test-isolation-unique-arenas",
+      "sha": "9154f377314e1d651eb1a6ba504918a4e61abd16",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T19:19:54Z",
+      "run_started_at": "2026-09-05T19:19:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:55Z",
+          "completed_at": "2026-09-05T19:28:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:27:31Z",
+          "completed_at": "2026-09-05T19:47:15Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:28:20Z",
+          "completed_at": "2026-09-05T19:35:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:27:31Z",
+          "completed_at": "2026-09-05T19:37:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33986784651,
+      "workflow": "larql-lql",
+      "branch": "test-isolation-unique-arenas",
+      "sha": "9154f377314e1d651eb1a6ba504918a4e61abd16",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T19:19:54Z",
+      "run_started_at": "2026-09-05T19:19:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:04Z",
+          "completed_at": "2026-09-05T19:27:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:43Z",
+          "completed_at": "2026-09-05T19:29:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:21:05Z",
+          "completed_at": "2026-09-05T19:29:37Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:48Z",
+          "completed_at": "2026-09-05T19:39:21Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33986784600,
+      "workflow": "larql-inference",
+      "branch": "test-isolation-unique-arenas",
+      "sha": "9154f377314e1d651eb1a6ba504918a4e61abd16",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T19:19:54Z",
+      "run_started_at": "2026-09-05T19:19:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:31:47Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:01Z",
+          "completed_at": "2026-09-05T19:28:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:27:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:57Z",
+          "completed_at": "2026-09-05T19:29:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33986784663,
+      "workflow": "larql-server",
+      "branch": "test-isolation-unique-arenas",
+      "sha": "9154f377314e1d651eb1a6ba504918a4e61abd16",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T19:19:54Z",
+      "run_started_at": "2026-09-05T19:19:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:27:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:27Z",
+          "completed_at": "2026-09-05T19:41:32Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:39Z",
+          "completed_at": "2026-09-05T19:30:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:59Z",
+          "completed_at": "2026-09-05T19:28:14Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33986784579,
+      "workflow": "commit messages",
+      "branch": "test-isolation-unique-arenas",
+      "sha": "9154f377314e1d651eb1a6ba504918a4e61abd16",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T19:19:53Z",
+      "run_started_at": "2026-09-05T19:19:53Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:41Z",
+          "completed_at": "2026-09-05T19:20:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33986784597,
+      "workflow": "mutants",
+      "branch": "test-isolation-unique-arenas",
+      "sha": "9154f377314e1d651eb1a6ba504918a4e61abd16",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T19:19:53Z",
+      "run_started_at": "2026-09-05T19:19:53Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:19:56Z",
+          "completed_at": "2026-09-05T19:29:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T19:19:54Z",
+          "started_at": "2026-09-05T19:20:48Z",
+          "completed_at": "2026-09-05T19:20:59Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33982081918,
+      "workflow": "commit messages",
+      "branch": "wave19-notes-canonical-refresh",
+      "sha": "c2880e174a98123e20bb0ec31cad63a84d77bb5b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:48:08Z",
+      "run_started_at": "2026-09-05T17:48:08Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:08Z",
+          "started_at": "2026-09-05T18:11:09Z",
+          "completed_at": "2026-09-05T18:11:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33982082007,
+      "workflow": "mutants",
+      "branch": "wave19-notes-canonical-refresh",
+      "sha": "c2880e174a98123e20bb0ec31cad63a84d77bb5b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:48:08Z",
+      "run_started_at": "2026-09-05T17:48:08Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:08Z",
+          "started_at": "2026-09-05T17:54:05Z",
+          "completed_at": "2026-09-05T17:54:17Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:08Z",
+          "started_at": "2026-09-05T18:11:00Z",
+          "completed_at": "2026-09-05T18:11:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33982082114,
+      "workflow": "quality",
+      "branch": "wave19-notes-canonical-refresh",
+      "sha": "c2880e174a98123e20bb0ec31cad63a84d77bb5b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T17:48:08Z",
+      "run_started_at": "2026-09-05T17:48:08Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:08Z",
+          "started_at": "2026-09-05T18:21:23Z",
+          "completed_at": "2026-09-05T18:21:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:08Z",
+          "started_at": "2026-09-05T18:21:30Z",
+          "completed_at": "2026-09-05T18:21:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:09Z",
+          "started_at": "2026-09-05T18:22:36Z",
+          "completed_at": "2026-09-05T18:30:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:09Z",
+          "started_at": "2026-09-05T18:44:22Z",
+          "completed_at": "2026-09-05T18:44:56Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T17:48:09Z",
+          "started_at": "2026-09-05T18:24:35Z",
+          "completed_at": "2026-09-05T18:25:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:09Z",
+          "started_at": "2026-09-05T18:35:43Z",
+          "completed_at": "2026-09-05T18:35:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:09Z",
+          "started_at": "2026-09-05T18:35:10Z",
+          "completed_at": "2026-09-05T18:35:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:09Z",
+          "started_at": "2026-09-05T18:24:40Z",
+          "completed_at": "2026-09-05T18:25:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:48:09Z",
+          "started_at": "2026-09-05T18:36:50Z",
+          "completed_at": "2026-09-05T18:37:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33978351431,
+      "workflow": "larql-compute",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:37Z",
+      "run_started_at": "2026-09-05T16:35:37Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:55Z",
+          "completed_at": "2026-09-05T16:37:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:44:40Z",
+          "completed_at": "2026-09-05T16:46:05Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:39:29Z",
+          "completed_at": "2026-09-05T16:41:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:42:40Z",
+          "completed_at": "2026-09-05T16:54:44Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33978351417,
+      "workflow": "shannon-verify",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:37Z",
+      "run_started_at": "2026-09-05T16:35:37Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:43:52Z",
+          "completed_at": "2026-09-05T16:57:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33978351460,
+      "workflow": "larql-vindex",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:37Z",
+      "run_started_at": "2026-09-05T16:35:37Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:37:15Z",
+          "completed_at": "2026-09-05T16:44:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:46:13Z",
+          "completed_at": "2026-09-05T17:04:19Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:43:24Z",
+          "completed_at": "2026-09-05T16:58:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:42:59Z",
+          "completed_at": "2026-09-05T17:12:25Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33978351318,
+      "workflow": "larql-lql",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:36Z",
+      "run_started_at": "2026-09-05T16:35:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:43Z",
+          "completed_at": "2026-09-05T16:43:50Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:38Z",
+          "completed_at": "2026-09-05T16:44:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:43:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:40Z",
+          "completed_at": "2026-09-05T16:53:42Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33978351320,
+      "workflow": "larql-inference",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:36Z",
+      "run_started_at": "2026-09-05T16:35:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:43:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:43Z",
+          "completed_at": "2026-09-05T16:44:21Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:44:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:54:40Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33978351315,
+      "workflow": "larql-cli",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:36Z",
+      "run_started_at": "2026-09-05T16:35:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:42Z",
+          "completed_at": "2026-09-05T16:55:16Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:45:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:42:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:37:12Z",
+          "completed_at": "2026-09-05T16:48:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33978351342,
+      "workflow": "larql-server",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:36Z",
+      "run_started_at": "2026-09-05T16:35:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:45:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:50Z",
+          "completed_at": "2026-09-05T16:57:32Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:44:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:44:28Z",
+          "completed_at": "2026-09-05T16:54:21Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33978351345,
+      "workflow": "larql-compute-metal",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:36Z",
+      "run_started_at": "2026-09-05T16:35:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:36:58Z",
+          "completed_at": "2026-09-05T17:34:16Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33978351363,
+      "workflow": "commit messages",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:36Z",
+      "run_started_at": "2026-09-05T16:35:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:43:18Z",
+          "completed_at": "2026-09-05T16:43:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33978351356,
+      "workflow": "quality",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T16:35:36Z",
+      "run_started_at": "2026-09-05T16:35:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:35:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:44:16Z",
+          "completed_at": "2026-09-05T16:44:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:43:56Z",
+          "completed_at": "2026-09-05T16:44:36Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:38:47Z",
+          "completed_at": "2026-09-05T16:39:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:41:19Z",
+          "completed_at": "2026-09-05T16:41:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:36:34Z",
+          "completed_at": "2026-09-05T16:43:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:41:47Z",
+          "completed_at": "2026-09-05T16:42:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:43:26Z",
+          "completed_at": "2026-09-05T16:44:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:44:13Z",
+          "completed_at": "2026-09-05T16:44:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33978351326,
+      "workflow": "larql-models",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:36Z",
+      "run_started_at": "2026-09-05T16:35:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:36:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:39Z",
+          "completed_at": "2026-09-05T16:38:46Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:43Z",
+          "completed_at": "2026-09-05T16:37:05Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:38Z",
+          "completed_at": "2026-09-05T16:36:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33978351309,
+      "workflow": "mutants",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T16:35:36Z",
+      "run_started_at": "2026-09-05T16:35:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:35:43Z",
+          "completed_at": "2026-09-05T16:35:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:44:11Z",
+          "completed_at": "2026-09-05T17:29:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33976559843,
+      "workflow": "larql-models",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:29Z",
+          "completed_at": "2026-09-05T16:02:48Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:24Z",
+          "completed_at": "2026-09-05T16:04:37Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:05:46Z",
+          "completed_at": "2026-09-05T16:06:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:02:05Z",
+          "completed_at": "2026-09-05T16:03:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33976559884,
+      "workflow": "mutants",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:29Z",
+          "completed_at": "2026-09-05T16:01:39Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:30Z",
+          "completed_at": "2026-09-05T16:09:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33976559810,
+      "workflow": "commit messages",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:24Z",
+          "completed_at": "2026-09-05T16:01:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33976559844,
+      "workflow": "larql-compute",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:03:18Z",
+          "completed_at": "2026-09-05T16:04:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:24Z",
+          "completed_at": "2026-09-05T16:13:14Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:02:00Z",
+          "completed_at": "2026-09-05T16:03:16Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:04:55Z",
+          "completed_at": "2026-09-05T16:06:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33976559833,
+      "workflow": "quality",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:25Z",
+          "completed_at": "2026-09-05T16:01:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:24Z",
+          "completed_at": "2026-09-05T16:02:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:04:11Z",
+          "completed_at": "2026-09-05T16:04:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:24Z",
+          "completed_at": "2026-09-05T16:01:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:08:12Z",
+          "completed_at": "2026-09-05T16:08:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:02:00Z",
+          "completed_at": "2026-09-05T16:02:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:25Z",
+          "completed_at": "2026-09-05T16:02:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:03:15Z",
+          "completed_at": "2026-09-05T16:04:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:08:37Z",
+          "completed_at": "2026-09-05T16:15:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33976559813,
+      "workflow": "shannon-verify",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:41Z",
+          "completed_at": "2026-09-05T16:15:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33976559841,
+      "workflow": "larql-vindex",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:24Z",
+          "completed_at": "2026-09-05T16:08:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:26Z",
+          "completed_at": "2026-09-05T16:16:03Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:28Z",
+          "completed_at": "2026-09-05T16:05:44Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:24Z",
+          "completed_at": "2026-09-05T16:08:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33976559829,
+      "workflow": "larql-lql",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:24Z",
+          "completed_at": "2026-09-05T16:20:05Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:02:48Z",
+          "completed_at": "2026-09-05T16:10:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:29Z",
+          "completed_at": "2026-09-05T16:09:08Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:04:39Z",
+          "completed_at": "2026-09-05T16:11:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33976559812,
+      "workflow": "larql-compute-metal",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:02:54Z",
+          "completed_at": "2026-09-05T16:55:42Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33976559828,
+      "workflow": "larql-cli",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:09:10Z",
+          "completed_at": "2026-09-05T16:16:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:06:32Z",
+          "completed_at": "2026-09-05T16:17:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:23Z",
+          "started_at": "2026-09-05T16:09:12Z",
+          "completed_at": "2026-09-05T16:19:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:23Z",
+          "started_at": "2026-09-05T16:02:10Z",
+          "completed_at": "2026-09-05T16:21:38Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33976559831,
+      "workflow": "larql-inference",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:24Z",
+          "completed_at": "2026-09-05T16:09:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:29Z",
+          "completed_at": "2026-09-05T16:09:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:24Z",
+          "completed_at": "2026-09-05T16:21:25Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:08:23Z",
+          "completed_at": "2026-09-05T16:17:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33976559865,
+      "workflow": "larql-server",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:34Z",
+          "completed_at": "2026-09-05T16:10:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:01:26Z",
+          "completed_at": "2026-09-05T16:23:08Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:06:50Z",
+          "completed_at": "2026-09-05T16:20:09Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:04:38Z",
+          "completed_at": "2026-09-05T16:14:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33967497316,
+      "workflow": "larql-inference",
+      "branch": "stage5a0-executor-contract",
+      "sha": "6958489a3ec2d123f4989ce6a872a05286f848fe",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T12:57:17Z",
+      "run_started_at": "2026-09-05T12:57:17Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:24Z",
+          "completed_at": "2026-09-05T13:04:42Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:21Z",
+          "completed_at": "2026-09-05T13:16:04Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:31Z",
+          "completed_at": "2026-09-05T13:06:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:20Z",
+          "completed_at": "2026-09-05T13:03:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33967497320,
+      "workflow": "larql-cli",
+      "branch": "stage5a0-executor-contract",
+      "sha": "6958489a3ec2d123f4989ce6a872a05286f848fe",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T12:57:17Z",
+      "run_started_at": "2026-09-05T12:57:17Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:20Z",
+          "completed_at": "2026-09-05T13:04:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:23Z",
+          "completed_at": "2026-09-05T13:17:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:39Z",
+          "completed_at": "2026-09-05T13:06:59Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:20Z",
+          "completed_at": "2026-09-05T13:07:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33967497311,
+      "workflow": "quality",
+      "branch": "stage5a0-executor-contract",
+      "sha": "6958489a3ec2d123f4989ce6a872a05286f848fe",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T12:57:17Z",
+      "run_started_at": "2026-09-05T12:57:17Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:20Z",
+          "completed_at": "2026-09-05T12:57:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:20Z",
+          "completed_at": "2026-09-05T12:57:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:25Z",
+          "completed_at": "2026-09-05T12:58:18Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T13:07:10Z",
+          "completed_at": "2026-09-05T13:14:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:20Z",
+          "completed_at": "2026-09-05T12:58:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:20Z",
+          "completed_at": "2026-09-05T12:58:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T13:14:27Z",
+          "completed_at": "2026-09-05T13:15:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T13:18:55Z",
+          "completed_at": "2026-09-05T13:19:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T13:13:50Z",
+          "completed_at": "2026-09-05T13:14:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33967497329,
+      "workflow": "commit messages",
+      "branch": "stage5a0-executor-contract",
+      "sha": "6958489a3ec2d123f4989ce6a872a05286f848fe",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T12:57:17Z",
+      "run_started_at": "2026-09-05T12:57:17Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T13:05:13Z",
+          "completed_at": "2026-09-05T13:05:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33967497319,
+      "workflow": "larql-server",
+      "branch": "stage5a0-executor-contract",
+      "sha": "6958489a3ec2d123f4989ce6a872a05286f848fe",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T12:57:17Z",
+      "run_started_at": "2026-09-05T12:57:17Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:20Z",
+          "completed_at": "2026-09-05T13:06:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:51Z",
+          "completed_at": "2026-09-05T13:07:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:58:19Z",
+          "completed_at": "2026-09-05T13:19:18Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:58:29Z",
+          "completed_at": "2026-09-05T13:10:01Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33967497308,
+      "workflow": "larql-vindex",
+      "branch": "stage5a0-executor-contract",
+      "sha": "6958489a3ec2d123f4989ce6a872a05286f848fe",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T12:57:17Z",
+      "run_started_at": "2026-09-05T12:57:17Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:19Z",
+          "completed_at": "2026-09-05T13:26:32Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:20Z",
+          "completed_at": "2026-09-05T13:06:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:25Z",
+          "completed_at": "2026-09-05T13:14:26Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:58:04Z",
+          "completed_at": "2026-09-05T13:12:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33967497315,
+      "workflow": "larql-lql",
+      "branch": "stage5a0-executor-contract",
+      "sha": "6958489a3ec2d123f4989ce6a872a05286f848fe",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T12:57:17Z",
+      "run_started_at": "2026-09-05T12:57:17Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:31Z",
+          "completed_at": "2026-09-05T13:05:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:21Z",
+          "completed_at": "2026-09-05T13:06:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:25Z",
+          "completed_at": "2026-09-05T13:05:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T13:05:12Z",
+          "completed_at": "2026-09-05T13:24:34Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33967497302,
+      "workflow": "mutants",
+      "branch": "stage5a0-executor-contract",
+      "sha": "6958489a3ec2d123f4989ce6a872a05286f848fe",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T12:57:17Z",
+      "run_started_at": "2026-09-05T12:57:17Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:23Z",
+          "completed_at": "2026-09-05T12:57:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T12:57:18Z",
+          "started_at": "2026-09-05T12:57:20Z",
+          "completed_at": "2026-09-05T13:42:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33964736457,
+      "workflow": "mutants",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:12:46Z",
+          "completed_at": "2026-09-05T12:12:55Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T12:43:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33964736439,
+      "workflow": "larql-compute-metal",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:09:21Z",
+          "completed_at": "2026-09-05T12:56:43Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33964736415,
+      "workflow": "quality",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:28Z",
+          "completed_at": "2026-09-05T11:59:05Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T11:58:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:03:55Z",
+          "completed_at": "2026-09-05T12:11:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:08:48Z",
+          "completed_at": "2026-09-05T12:09:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:07:36Z",
+          "completed_at": "2026-09-05T12:08:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:13:24Z",
+          "completed_at": "2026-09-05T12:13:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:13:36Z",
+          "completed_at": "2026-09-05T12:14:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:12:29Z",
+          "completed_at": "2026-09-05T12:13:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:13:20Z",
+          "completed_at": "2026-09-05T12:14:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33964736482,
+      "workflow": "larql-lql",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T12:05:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:59:20Z",
+          "completed_at": "2026-09-05T12:14:14Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:04:48Z",
+          "completed_at": "2026-09-05T12:12:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:08:13Z",
+          "completed_at": "2026-09-05T12:17:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33964736427,
+      "workflow": "bench-regress",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:07:50Z",
+          "completed_at": "2026-09-05T12:19:31Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33964736455,
+      "workflow": "larql-demos",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:59:13Z",
+          "completed_at": "2026-09-05T12:07:43Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:11:50Z",
+          "completed_at": "2026-09-05T12:20:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:05:28Z",
+          "completed_at": "2026-09-05T12:15:14Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33964736436,
+      "workflow": "commit messages",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T11:58:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33964736414,
+      "workflow": "larql-core",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:25Z",
+          "completed_at": "2026-09-05T12:07:50Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:27Z",
+          "completed_at": "2026-09-05T12:06:37Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T12:06:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T11:59:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33964736437,
+      "workflow": "larql-models",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T11:59:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:24Z",
+          "completed_at": "2026-09-05T11:59:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:06:42Z",
+          "completed_at": "2026-09-05T12:08:10Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:59:47Z",
+          "completed_at": "2026-09-05T12:03:20Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33964736491,
+      "workflow": "larql-factory",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:28Z",
+          "completed_at": "2026-09-05T11:59:48Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:59:50Z",
+          "completed_at": "2026-09-05T12:02:05Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:03:31Z",
+          "completed_at": "2026-09-05T12:04:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:07:52Z",
+          "completed_at": "2026-09-05T12:08:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33964736430,
+      "workflow": "larql-compute",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:24Z",
+          "completed_at": "2026-09-05T11:59:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:02:11Z",
+          "completed_at": "2026-09-05T12:03:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T11:59:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:32Z",
+          "completed_at": "2026-09-05T12:10:40Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33964736417,
+      "workflow": "shannon-verify",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T12:12:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33964736461,
+      "workflow": "larql-cli",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:59:21Z",
+          "completed_at": "2026-09-05T12:07:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:12:57Z",
+          "completed_at": "2026-09-05T12:22:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:06:05Z",
+          "completed_at": "2026-09-05T12:14:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:08:17Z",
+          "completed_at": "2026-09-05T12:24:17Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33964736507,
+      "workflow": "larql-server",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:59:46Z",
+          "completed_at": "2026-09-05T12:17:00Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T12:05:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:14:12Z",
+          "completed_at": "2026-09-05T12:24:05Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:12:54Z",
+          "completed_at": "2026-09-05T12:22:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33964736450,
+      "workflow": "larql-inference",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:06:11Z",
+          "completed_at": "2026-09-05T12:13:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:13:59Z",
+          "completed_at": "2026-09-05T12:22:10Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:06:54Z",
+          "completed_at": "2026-09-05T12:25:06Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:12:14Z",
+          "completed_at": "2026-09-05T12:21:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33964736500,
+      "workflow": "larql-boundary",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:14:16Z",
+          "completed_at": "2026-09-05T12:14:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:13:15Z",
+          "completed_at": "2026-09-05T12:20:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:19:36Z",
+          "completed_at": "2026-09-05T12:26:59Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:07:05Z",
+          "completed_at": "2026-09-05T12:13:18Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33964736456,
+      "workflow": "larql-kv",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:28Z",
+          "completed_at": "2026-09-05T12:07:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:59:38Z",
+          "completed_at": "2026-09-05T12:06:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:10:42Z",
+          "completed_at": "2026-09-05T12:27:35Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:14:09Z",
+          "completed_at": "2026-09-05T12:22:06Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33964736412,
+      "workflow": "larql-vindex",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:28Z",
+          "completed_at": "2026-09-05T12:12:27Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T12:13:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T11:58:23Z",
+          "completed_at": "2026-09-05T12:29:30Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:03:22Z",
+          "completed_at": "2026-09-05T12:12:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962691498,
+      "workflow": "commit messages",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:12:11Z",
+      "run_started_at": "2026-09-05T11:12:11Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:12:11Z",
+          "started_at": "2026-09-05T11:15:06Z",
+          "completed_at": "2026-09-05T11:15:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962379947,
+      "workflow": "larql-models",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:20Z",
+      "run_started_at": "2026-09-05T11:05:20Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:06:49Z",
+          "completed_at": "2026-09-05T11:08:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:06:39Z",
+          "completed_at": "2026-09-05T11:10:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:14:08Z",
+          "completed_at": "2026-09-05T11:15:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:23:17Z",
+          "completed_at": "2026-09-05T11:25:01Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33962380022,
+      "workflow": "larql-server",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:20Z",
+      "run_started_at": "2026-09-05T11:05:20Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:08:05Z",
+          "completed_at": "2026-09-05T11:17:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:20:11Z",
+          "completed_at": "2026-09-05T11:30:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:15:05Z",
+          "completed_at": "2026-09-05T11:36:26Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:25:21Z",
+          "completed_at": "2026-09-05T11:35:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33962379969,
+      "workflow": "larql-cli",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:20Z",
+      "run_started_at": "2026-09-05T11:05:20Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:22:06Z",
+          "completed_at": "2026-09-05T11:30:57Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:15:05Z",
+          "completed_at": "2026-09-05T11:35:08Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:15:25Z",
+          "completed_at": "2026-09-05T11:21:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:18:05Z",
+          "completed_at": "2026-09-05T11:27:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962379828,
+      "workflow": "commit messages",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:22Z",
+          "completed_at": "2026-09-05T11:05:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962379797,
+      "workflow": "larql-factory",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:22Z",
+          "completed_at": "2026-09-05T11:06:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:21Z",
+          "completed_at": "2026-09-05T11:07:31Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:26Z",
+          "completed_at": "2026-09-05T11:06:37Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:22Z",
+          "completed_at": "2026-09-05T11:06:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962379849,
+      "workflow": "bench-regress",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:27Z",
+          "completed_at": "2026-09-05T11:16:57Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33962379826,
+      "workflow": "larql-boundary",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:28Z",
+          "completed_at": "2026-09-05T11:14:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:22Z",
+          "completed_at": "2026-09-05T11:11:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:27Z",
+          "completed_at": "2026-09-05T11:06:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:13:48Z",
+          "completed_at": "2026-09-05T11:22:05Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33962379806,
+      "workflow": "larql-compute",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:21:34Z",
+          "completed_at": "2026-09-05T11:22:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:20:14Z",
+          "completed_at": "2026-09-05T11:22:00Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:23Z",
+          "completed_at": "2026-09-05T11:17:23Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:22:07Z",
+          "completed_at": "2026-09-05T11:23:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962379776,
+      "workflow": "larql-kv",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:57Z",
+          "completed_at": "2026-09-05T11:13:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:28Z",
+          "completed_at": "2026-09-05T11:16:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:21Z",
+          "completed_at": "2026-09-05T11:14:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:21Z",
+          "completed_at": "2026-09-05T11:24:26Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33962379821,
+      "workflow": "larql-lql",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:22Z",
+          "completed_at": "2026-09-05T11:14:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:17:12Z",
+          "completed_at": "2026-09-05T11:35:52Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:17:27Z",
+          "completed_at": "2026-09-05T11:25:15Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:16:34Z",
+          "completed_at": "2026-09-05T11:23:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962379770,
+      "workflow": "larql-vindex",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:26Z",
+          "completed_at": "2026-09-05T11:20:06Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:22Z",
+          "completed_at": "2026-09-05T11:20:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:06:11Z",
+          "completed_at": "2026-09-05T11:15:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:22Z",
+          "completed_at": "2026-09-05T11:27:27Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33962379904,
+      "workflow": "larql-core",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:14:05Z",
+          "completed_at": "2026-09-05T11:15:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:20:04Z",
+          "completed_at": "2026-09-05T11:27:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:32Z",
+          "completed_at": "2026-09-05T11:13:45Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:15:55Z",
+          "completed_at": "2026-09-05T11:24:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962379790,
+      "workflow": "shannon-verify",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:14:00Z",
+          "completed_at": "2026-09-05T11:29:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962379847,
+      "workflow": "larql-inference",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:14:58Z",
+          "completed_at": "2026-09-05T11:23:09Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:11:26Z",
+          "completed_at": "2026-09-05T11:18:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:10:44Z",
+          "completed_at": "2026-09-05T11:29:38Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:15:55Z",
+          "completed_at": "2026-09-05T11:25:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962379855,
+      "workflow": "quality",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:22Z",
+          "completed_at": "2026-09-05T11:05:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:06:22Z",
+          "completed_at": "2026-09-05T11:06:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:17:05Z",
+          "completed_at": "2026-09-05T11:18:03Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:15:12Z",
+          "completed_at": "2026-09-05T11:15:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:14:22Z",
+          "completed_at": "2026-09-05T11:15:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:22:50Z",
+          "completed_at": "2026-09-05T11:22:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:23:00Z",
+          "completed_at": "2026-09-05T11:23:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:23:44Z",
+          "completed_at": "2026-09-05T11:29:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:18:59Z",
+          "completed_at": "2026-09-05T11:19:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33962379816,
+      "workflow": "larql-demos",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:22Z",
+          "completed_at": "2026-09-05T11:14:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:05:21Z",
+          "completed_at": "2026-09-05T11:15:53Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:25:06Z",
+          "completed_at": "2026-09-05T11:31:43Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33962379869,
+      "workflow": "mutants",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:06:20Z",
+          "completed_at": "2026-09-05T11:51:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:19:47Z",
+          "completed_at": "2026-09-05T11:19:58Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33962379822,
+      "workflow": "larql-compute-metal",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:07:36Z",
+          "completed_at": "2026-09-05T12:03:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33958557269,
+      "workflow": "larql-vindex",
+      "branch": "wave18-followup-hc-mixer-arm",
+      "sha": "a4dfe5411074bb186a4e2b8a4c1c7bb781fba94c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T09:39:00Z",
+      "run_started_at": "2026-09-05T09:39:00Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:50Z",
+          "completed_at": "2026-09-05T09:47:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:07Z",
+          "completed_at": "2026-09-05T09:55:13Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:57Z",
+          "completed_at": "2026-09-05T10:10:12Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:53:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33958557272,
+      "workflow": "quality",
+      "branch": "wave18-followup-hc-mixer-arm",
+      "sha": "a4dfe5411074bb186a4e2b8a4c1c7bb781fba94c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T09:39:00Z",
+      "run_started_at": "2026-09-05T09:39:00Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:06Z",
+          "completed_at": "2026-09-05T09:39:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:39:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:46:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:39:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:03Z",
+          "completed_at": "2026-09-05T09:39:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:39:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:08Z",
+          "completed_at": "2026-09-05T09:39:57Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:39:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:39:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33958557277,
+      "workflow": "mutants",
+      "branch": "wave18-followup-hc-mixer-arm",
+      "sha": "a4dfe5411074bb186a4e2b8a4c1c7bb781fba94c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T09:39:00Z",
+      "run_started_at": "2026-09-05T09:39:00Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:49:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:46:20Z",
+          "completed_at": "2026-09-05T09:46:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33958557267,
+      "workflow": "commit messages",
+      "branch": "wave18-followup-hc-mixer-arm",
+      "sha": "a4dfe5411074bb186a4e2b8a4c1c7bb781fba94c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T09:39:00Z",
+      "run_started_at": "2026-09-05T09:39:00Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:39:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33958557270,
+      "workflow": "larql-lql",
+      "branch": "wave18-followup-hc-mixer-arm",
+      "sha": "a4dfe5411074bb186a4e2b8a4c1c7bb781fba94c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T09:39:00Z",
+      "run_started_at": "2026-09-05T09:39:00Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:47:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:45:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:08Z",
+          "completed_at": "2026-09-05T09:57:26Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:40:03Z",
+          "completed_at": "2026-09-05T09:48:02Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33958557268,
+      "workflow": "larql-cli",
+      "branch": "wave18-followup-hc-mixer-arm",
+      "sha": "a4dfe5411074bb186a4e2b8a4c1c7bb781fba94c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T09:39:00Z",
+      "run_started_at": "2026-09-05T09:39:00Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:46:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:03Z",
+          "completed_at": "2026-09-05T09:57:52Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:06Z",
+          "completed_at": "2026-09-05T09:46:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:02Z",
+          "completed_at": "2026-09-05T09:48:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33958557281,
+      "workflow": "larql-server",
+      "branch": "wave18-followup-hc-mixer-arm",
+      "sha": "a4dfe5411074bb186a4e2b8a4c1c7bb781fba94c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T09:39:00Z",
+      "run_started_at": "2026-09-05T09:39:00Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:43Z",
+          "completed_at": "2026-09-05T10:00:42Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:07Z",
+          "completed_at": "2026-09-05T09:48:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:45:10Z",
+          "completed_at": "2026-09-05T09:54:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:46:33Z",
+          "completed_at": "2026-09-05T09:56:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33958557294,
+      "workflow": "larql-inference",
+      "branch": "wave18-followup-hc-mixer-arm",
+      "sha": "a4dfe5411074bb186a4e2b8a4c1c7bb781fba94c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T09:39:00Z",
+      "run_started_at": "2026-09-05T09:39:00Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:11Z",
+          "completed_at": "2026-09-05T09:46:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:50Z",
+          "completed_at": "2026-09-05T09:54:31Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:16Z",
+          "completed_at": "2026-09-05T09:47:27Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T09:39:00Z",
+          "started_at": "2026-09-05T09:39:36Z",
+          "completed_at": "2026-09-05T09:48:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33939903892,
+      "workflow": "commit messages",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T02:44:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33939903917,
+      "workflow": "mutants",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:05Z",
+          "completed_at": "2026-09-05T02:44:16Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T03:29:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33939903832,
+      "workflow": "larql-compute-metal",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:06Z",
+          "completed_at": "2026-09-05T03:37:45Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33939903831,
+      "workflow": "larql-inference",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:02Z",
+          "completed_at": "2026-09-05T03:02:40Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:56:46Z",
+          "completed_at": "2026-09-05T03:06:39Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:51:15Z",
+          "completed_at": "2026-09-05T02:59:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:52:49Z",
+          "completed_at": "2026-09-05T03:00:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33939904050,
+      "workflow": "larql-server",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:51:44Z",
+          "completed_at": "2026-09-05T03:00:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:53:31Z",
+          "completed_at": "2026-09-05T03:03:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T03:05:05Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T03:00:46Z",
+          "completed_at": "2026-09-05T03:10:27Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33939903850,
+      "workflow": "bench-regress",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:45:41Z",
+          "completed_at": "2026-09-05T02:57:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33939903830,
+      "workflow": "shannon-verify",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T02:57:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33939903881,
+      "workflow": "larql-cli",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T02:51:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:06Z",
+          "completed_at": "2026-09-05T02:56:39Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T02:53:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T02:59:18Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33939904023,
+      "workflow": "quality",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:58:01Z",
+          "completed_at": "2026-09-05T02:58:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:53:09Z",
+          "completed_at": "2026-09-05T02:59:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:54:59Z",
+          "completed_at": "2026-09-05T02:55:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:55:56Z",
+          "completed_at": "2026-09-05T02:56:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:53:42Z",
+          "completed_at": "2026-09-05T02:54:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:54:28Z",
+          "completed_at": "2026-09-05T02:54:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:55:11Z",
+          "completed_at": "2026-09-05T02:55:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:56:45Z",
+          "completed_at": "2026-09-05T02:56:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:56:06Z",
+          "completed_at": "2026-09-05T02:56:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33939903993,
+      "workflow": "larql-compute",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T02:56:05Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:18Z",
+          "completed_at": "2026-09-05T02:46:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:07Z",
+          "completed_at": "2026-09-05T02:45:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:59:01Z",
+          "completed_at": "2026-09-05T03:00:40Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33939903853,
+      "workflow": "larql-lql",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T02:51:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:05Z",
+          "completed_at": "2026-09-05T02:49:47Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:02Z",
+          "completed_at": "2026-09-05T02:53:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T03:02:22Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33939903905,
+      "workflow": "larql-vindex",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:02Z",
+          "completed_at": "2026-09-05T02:53:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:49:53Z",
+          "completed_at": "2026-09-05T03:07:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:01Z",
+          "completed_at": "2026-09-05T03:12:23Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:46:14Z",
+          "completed_at": "2026-09-05T03:01:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933693431,
+      "workflow": "larql-lql",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:04:20Z",
+          "completed_at": "2026-09-05T01:11:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:46:36Z",
+          "completed_at": "2026-09-05T01:04:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:40:59Z",
+          "completed_at": "2026-09-05T01:49:27Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:29:56Z",
+          "completed_at": "2026-09-05T01:38:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933693457,
+      "workflow": "larql-compute-metal",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:56:02Z",
+          "completed_at": "2026-09-05T01:43:00Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33933693473,
+      "workflow": "larql-compute",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:20:38Z",
+          "completed_at": "2026-09-05T01:32:07Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:43:08Z",
+          "completed_at": "2026-09-05T01:45:09Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:21:59Z",
+          "completed_at": "2026-09-05T01:23:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:23:58Z",
+          "completed_at": "2026-09-05T01:25:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933693507,
+      "workflow": "larql-vindex",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:03:40Z",
+          "completed_at": "2026-09-05T01:11:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:45:14Z",
+          "completed_at": "2026-09-05T01:56:51Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:11:32Z",
+          "completed_at": "2026-09-05T01:25:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:17:28Z",
+          "completed_at": "2026-09-05T01:47:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33933693460,
+      "workflow": "quality",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:20:24Z",
+          "completed_at": "2026-09-05T01:28:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:27:24Z",
+          "completed_at": "2026-09-05T01:28:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:23:51Z",
+          "completed_at": "2026-09-05T01:24:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:32:10Z",
+          "completed_at": "2026-09-05T01:32:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:28:57Z",
+          "completed_at": "2026-09-05T01:29:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:51:20Z",
+          "completed_at": "2026-09-05T01:52:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:56:47Z",
+          "completed_at": "2026-09-05T01:56:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:56:58Z",
+          "completed_at": "2026-09-05T01:57:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:47:30Z",
+          "completed_at": "2026-09-05T01:48:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33933693467,
+      "workflow": "larql-inference",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:09:47Z",
+          "completed_at": "2026-09-05T01:17:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:24:06Z",
+          "completed_at": "2026-09-05T01:30:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:10:23Z",
+          "completed_at": "2026-09-05T01:16:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:12:43Z",
+          "completed_at": "2026-09-05T01:28:27Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33933693496,
+      "workflow": "larql-cli",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:49:51Z",
+          "completed_at": "2026-09-05T00:55:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:12:49Z",
+          "completed_at": "2026-09-05T01:20:36Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:49:34Z",
+          "completed_at": "2026-09-05T00:57:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:46:10Z",
+          "completed_at": "2026-09-05T01:05:08Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33933693506,
+      "workflow": "larql-server",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:57:12Z",
+          "completed_at": "2026-09-05T01:05:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:58:38Z",
+          "completed_at": "2026-09-05T01:19:16Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:50:20Z",
+          "completed_at": "2026-09-05T01:01:31Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T01:14:22Z",
+          "completed_at": "2026-09-05T01:24:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933693428,
+      "workflow": "mutants",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:49:29Z",
+          "completed_at": "2026-09-05T00:49:38Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:42:07Z",
+          "completed_at": "2026-09-05T01:27:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933693498,
+      "workflow": "commit messages",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:45:52Z",
+          "completed_at": "2026-09-05T00:45:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933693430,
+      "workflow": "bench-regress",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:45:40Z",
+          "completed_at": "2026-09-05T00:57:36Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33933693545,
+      "workflow": "shannon-verify",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:45:37Z",
+          "completed_at": "2026-09-05T00:59:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933561639,
+      "workflow": "larql-compute-metal",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:48:07Z",
+          "completed_at": "2026-09-05T01:43:42Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33933561615,
+      "workflow": "mutants",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T00:37:02Z",
+          "started_at": "2026-09-05T00:37:05Z",
+          "completed_at": "2026-09-05T01:22:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:10Z",
+          "completed_at": "2026-09-05T00:37:20Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33933561686,
+      "workflow": "larql-vindex",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:05Z",
+          "completed_at": "2026-09-05T00:46:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:51Z",
+          "completed_at": "2026-09-05T00:49:24Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:38:24Z",
+          "completed_at": "2026-09-05T01:01:55Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:58:23Z",
+          "completed_at": "2026-09-05T01:13:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933561649,
+      "workflow": "larql-compute",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T01:06:31Z",
+          "completed_at": "2026-09-05T01:08:22Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:48:31Z",
+          "completed_at": "2026-09-05T00:50:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T01:01:58Z",
+          "completed_at": "2026-09-05T01:14:20Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T01:08:24Z",
+          "completed_at": "2026-09-05T01:09:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933561632,
+      "workflow": "larql-inference",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:04Z",
+          "completed_at": "2026-09-05T00:44:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:57:25Z",
+          "completed_at": "2026-09-05T01:03:38Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:51:09Z",
+          "completed_at": "2026-09-05T01:00:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:57:40Z",
+          "completed_at": "2026-09-05T01:16:05Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33933561678,
+      "workflow": "bench-regress",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:08Z",
+          "completed_at": "2026-09-05T00:48:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33933561611,
+      "workflow": "shannon-verify",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:05Z",
+          "completed_at": "2026-09-05T00:51:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933561625,
+      "workflow": "commit messages",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:21Z",
+          "completed_at": "2026-09-05T00:37:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933561619,
+      "workflow": "quality",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:05Z",
+          "completed_at": "2026-09-05T00:37:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:05Z",
+          "completed_at": "2026-09-05T00:38:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:06Z",
+          "completed_at": "2026-09-05T00:37:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:45:57Z",
+          "completed_at": "2026-09-05T00:53:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:48:51Z",
+          "completed_at": "2026-09-05T00:49:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T01:03:26Z",
+          "completed_at": "2026-09-05T01:03:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:04Z",
+          "completed_at": "2026-09-05T00:37:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:49:01Z",
+          "completed_at": "2026-09-05T00:49:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T01:03:46Z",
+          "completed_at": "2026-09-05T01:04:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933561614,
+      "workflow": "larql-server",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:13Z",
+          "completed_at": "2026-09-05T00:45:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:04Z",
+          "completed_at": "2026-09-05T00:57:10Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:09Z",
+          "completed_at": "2026-09-05T00:47:59Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:53:41Z",
+          "completed_at": "2026-09-05T01:03:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33933561637,
+      "workflow": "larql-cli",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:09Z",
+          "completed_at": "2026-09-05T00:48:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:26Z",
+          "completed_at": "2026-09-05T00:45:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:27Z",
+          "completed_at": "2026-09-05T00:46:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:44:52Z",
+          "completed_at": "2026-09-05T01:04:19Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33933561650,
+      "workflow": "larql-lql",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:53Z",
+          "completed_at": "2026-09-05T00:45:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T01:01:37Z",
+          "completed_at": "2026-09-05T01:10:17Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:37:04Z",
+          "completed_at": "2026-09-05T00:56:19Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:49:39Z",
+          "completed_at": "2026-09-05T00:58:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33934307404,
+      "workflow": "larql-compute",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:25:44Z",
+          "completed_at": "2026-09-05T01:37:47Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:59:13Z",
+          "completed_at": "2026-09-05T02:00:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T00:56:20Z",
+          "completed_at": "2026-09-05T00:58:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:22:24Z",
+          "completed_at": "2026-09-05T01:23:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33934307332,
+      "workflow": "larql-lql",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:27:27Z",
+          "completed_at": "2026-09-05T01:34:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:04:15Z",
+          "completed_at": "2026-09-05T01:12:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:51:35Z",
+          "completed_at": "2026-09-05T02:01:07Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:07:48Z",
+          "completed_at": "2026-09-05T01:23:56Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33934307311,
+      "workflow": "mutants",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:27:13Z",
+          "completed_at": "2026-09-05T01:27:23Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:16:54Z",
+          "completed_at": "2026-09-05T02:02:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33934307328,
+      "workflow": "larql-compute-metal",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:25:44Z",
+          "completed_at": "2026-09-05T02:17:36Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33934307307,
+      "workflow": "larql-server",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:28:31Z",
+          "completed_at": "2026-09-05T01:39:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:03:36Z",
+          "completed_at": "2026-09-05T01:25:59Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:23:27Z",
+          "completed_at": "2026-09-05T01:34:50Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:42:03Z",
+          "completed_at": "2026-09-05T01:51:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33934307326,
+      "workflow": "larql-vindex",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:24:49Z",
+          "completed_at": "2026-09-05T01:36:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:28:18Z",
+          "completed_at": "2026-09-05T01:39:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:34:51Z",
+          "completed_at": "2026-09-05T01:42:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T00:59:44Z",
+          "completed_at": "2026-09-05T01:24:47Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33934307367,
+      "workflow": "larql-models",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:40:44Z",
+          "completed_at": "2026-09-05T01:41:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:26:01Z",
+          "completed_at": "2026-09-05T01:28:55Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:11:29Z",
+          "completed_at": "2026-09-05T01:12:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:49:34Z",
+          "completed_at": "2026-09-05T01:51:12Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33934307377,
+      "workflow": "larql-cli",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:00:16Z",
+          "completed_at": "2026-09-05T01:07:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:05:24Z",
+          "completed_at": "2026-09-05T01:12:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:49:13Z",
+          "completed_at": "2026-09-05T01:58:38Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:25:59Z",
+          "completed_at": "2026-09-05T01:45:52Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33934307293,
+      "workflow": "larql-inference",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T00:55:43Z",
+          "completed_at": "2026-09-05T01:03:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:03:08Z",
+          "completed_at": "2026-09-05T01:11:27Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:13:12Z",
+          "completed_at": "2026-09-05T01:20:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:39:07Z",
+          "completed_at": "2026-09-05T01:58:17Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33934307355,
+      "workflow": "quality",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:12:08Z",
+          "completed_at": "2026-09-05T01:12:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:05:45Z",
+          "completed_at": "2026-09-05T01:06:23Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:25:51Z",
+          "completed_at": "2026-09-05T01:26:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:37:37Z",
+          "completed_at": "2026-09-05T01:38:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:57:25Z",
+          "completed_at": "2026-09-05T01:58:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:57:27Z",
+          "completed_at": "2026-09-05T01:57:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:45:54Z",
+          "completed_at": "2026-09-05T01:52:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:57:56Z",
+          "completed_at": "2026-09-05T01:58:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:58:19Z",
+          "completed_at": "2026-09-05T01:59:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33934307310,
+      "workflow": "shannon-verify",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:12:19Z",
+          "completed_at": "2026-09-05T01:25:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33934307297,
+      "workflow": "commit messages",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:12:37Z",
+          "completed_at": "2026-09-05T01:12:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33930595037,
+      "workflow": "commit messages",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:44:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33930594987,
+      "workflow": "larql-compute",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:55:53Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:15Z",
+          "completed_at": "2026-09-04T23:45:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:45:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:46:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33930595032,
+      "workflow": "larql-models",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:52:24Z",
+          "completed_at": "2026-09-04T23:53:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:54:45Z",
+          "completed_at": "2026-09-04T23:56:08Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:34Z",
+          "completed_at": "2026-09-04T23:45:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:51:51Z",
+          "completed_at": "2026-09-04T23:54:45Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33930594980,
+      "workflow": "shannon-verify",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:55:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33930595142,
+      "workflow": "mutants",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-05T00:29:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:22Z",
+          "completed_at": "2026-09-04T23:44:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33930595124,
+      "workflow": "quality",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:53:18Z",
+          "completed_at": "2026-09-04T23:53:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:44:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:52:13Z",
+          "completed_at": "2026-09-04T23:52:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:44:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:54:00Z",
+          "completed_at": "2026-09-04T23:54:37Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:52:00Z",
+          "completed_at": "2026-09-04T23:53:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:53:26Z",
+          "completed_at": "2026-09-04T23:54:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:53:44Z",
+          "completed_at": "2026-09-04T23:54:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:54:00Z",
+          "completed_at": "2026-09-05T00:01:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33930595146,
+      "workflow": "larql-lql",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:51:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:46:06Z",
+          "completed_at": "2026-09-04T23:53:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:45:34Z",
+          "completed_at": "2026-09-05T00:02:58Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:53:08Z",
+          "completed_at": "2026-09-05T00:01:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33930595073,
+      "workflow": "larql-cli",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-05T00:03:18Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:51:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:13Z",
+          "completed_at": "2026-09-04T23:52:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:51:44Z",
+          "completed_at": "2026-09-05T00:01:47Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33930595029,
+      "workflow": "larql-inference",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:51:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:45:33Z",
+          "completed_at": "2026-09-04T23:53:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:45:42Z",
+          "completed_at": "2026-09-05T00:04:43Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:51:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33930595018,
+      "workflow": "larql-server",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-05T00:05:52Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:53:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:47Z",
+          "completed_at": "2026-09-04T23:54:41Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:53:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33930595148,
+      "workflow": "larql-vindex",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:55Z",
+          "completed_at": "2026-09-05T00:08:02Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:53:59Z",
+          "completed_at": "2026-09-05T00:07:34Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:12Z",
+          "completed_at": "2026-09-04T23:58:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:51:05Z",
+          "completed_at": "2026-09-05T00:00:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33930594995,
+      "workflow": "larql-compute-metal",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:19Z",
+          "completed_at": "2026-09-05T00:45:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33932073539,
+      "workflow": "quality",
+      "branch": "worktree-represent-codec-contract",
+      "sha": "80911f23deece86f93fcd2a504babf00b3e54f08",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:10:12Z",
+      "run_started_at": "2026-09-05T00:10:12Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:11:07Z",
+          "completed_at": "2026-09-05T00:11:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:23:03Z",
+          "completed_at": "2026-09-05T00:23:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:15:44Z",
+          "completed_at": "2026-09-05T00:16:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:19:01Z",
+          "completed_at": "2026-09-05T00:26:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:21:00Z",
+          "completed_at": "2026-09-05T00:21:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:15:45Z",
+          "completed_at": "2026-09-05T00:16:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:17:22Z",
+          "completed_at": "2026-09-05T00:18:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:28:08Z",
+          "completed_at": "2026-09-05T00:28:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:23:15Z",
+          "completed_at": "2026-09-05T00:24:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33932073637,
+      "workflow": "larql-server",
+      "branch": "worktree-represent-codec-contract",
+      "sha": "80911f23deece86f93fcd2a504babf00b3e54f08",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:10:12Z",
+      "run_started_at": "2026-09-05T00:10:12Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:11:08Z",
+          "completed_at": "2026-09-05T00:19:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:21:37Z",
+          "completed_at": "2026-09-05T00:31:22Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:10:57Z",
+          "completed_at": "2026-09-05T00:32:52Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:18:15Z",
+          "completed_at": "2026-09-05T00:26:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33932073651,
+      "workflow": "commit messages",
+      "branch": "worktree-represent-codec-contract",
+      "sha": "80911f23deece86f93fcd2a504babf00b3e54f08",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:10:12Z",
+      "run_started_at": "2026-09-05T00:10:12Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:11:17Z",
+          "completed_at": "2026-09-05T00:11:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33932073571,
+      "workflow": "larql-vindex",
+      "branch": "worktree-represent-codec-contract",
+      "sha": "80911f23deece86f93fcd2a504babf00b3e54f08",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:10:12Z",
+      "run_started_at": "2026-09-05T00:10:12Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:18:42Z",
+          "completed_at": "2026-09-05T00:27:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:16:17Z",
+          "completed_at": "2026-09-05T00:32:05Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:13:22Z",
+          "completed_at": "2026-09-05T00:28:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:16:30Z",
+          "completed_at": "2026-09-05T00:46:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33932073538,
+      "workflow": "larql-inference",
+      "branch": "worktree-represent-codec-contract",
+      "sha": "80911f23deece86f93fcd2a504babf00b3e54f08",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:10:12Z",
+      "run_started_at": "2026-09-05T00:10:12Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:19:51Z",
+          "completed_at": "2026-09-05T00:30:09Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:17:19Z",
+          "completed_at": "2026-09-05T00:37:23Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:21:49Z",
+          "completed_at": "2026-09-05T00:29:16Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:24:02Z",
+          "completed_at": "2026-09-05T00:33:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33932073613,
+      "workflow": "larql-lql",
+      "branch": "worktree-represent-codec-contract",
+      "sha": "80911f23deece86f93fcd2a504babf00b3e54f08",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:10:12Z",
+      "run_started_at": "2026-09-05T00:10:12Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:11:10Z",
+          "completed_at": "2026-09-05T00:17:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:10:52Z",
+          "completed_at": "2026-09-05T00:18:15Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:18:50Z",
+          "completed_at": "2026-09-05T00:36:01Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:15:56Z",
+          "completed_at": "2026-09-05T00:23:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33932073740,
+      "workflow": "larql-cli",
+      "branch": "worktree-represent-codec-contract",
+      "sha": "80911f23deece86f93fcd2a504babf00b3e54f08",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:10:12Z",
+      "run_started_at": "2026-09-05T00:10:12Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:11:21Z",
+          "completed_at": "2026-09-05T00:18:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:11:43Z",
+          "completed_at": "2026-09-05T00:20:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:16:15Z",
+          "completed_at": "2026-09-05T00:36:11Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:13Z",
+          "started_at": "2026-09-05T00:28:59Z",
+          "completed_at": "2026-09-05T00:36:25Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33932073514,
+      "workflow": "mutants",
+      "branch": "worktree-represent-codec-contract",
+      "sha": "80911f23deece86f93fcd2a504babf00b3e54f08",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-05T00:10:12Z",
+      "run_started_at": "2026-09-05T00:10:12Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:15:30Z",
+          "completed_at": "2026-09-05T00:15:43Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-05T00:10:12Z",
+          "started_at": "2026-09-05T00:10:23Z",
+          "completed_at": "2026-09-05T00:55:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33931309003,
+      "workflow": "commit messages",
+      "branch": "worktree-optimizer-mcp-facade",
+      "sha": "58fdd0348171f2d40fc29b2dfa33344de2aff73e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:56:36Z",
+      "run_started_at": "2026-09-04T23:56:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-04T23:56:38Z",
+          "completed_at": "2026-09-04T23:56:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33931308968,
+      "workflow": "larql-server",
+      "branch": "worktree-optimizer-mcp-facade",
+      "sha": "58fdd0348171f2d40fc29b2dfa33344de2aff73e",
+      "attempt": 2,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:56:36Z",
+      "run_started_at": "2026-09-05T00:45:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:25Z",
+          "started_at": "2026-09-05T01:05:10Z",
+          "completed_at": "2026-09-05T01:21:57Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:25Z",
+          "started_at": "2026-09-04T23:56:38Z",
+          "completed_at": "2026-09-05T00:05:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:26Z",
+          "started_at": "2026-09-05T00:15:25Z",
+          "completed_at": "2026-09-05T00:28:02Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:34Z",
+          "started_at": "2026-09-04T23:56:39Z",
+          "completed_at": "2026-09-05T00:06:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33931308982,
+      "workflow": "quality",
+      "branch": "worktree-optimizer-mcp-facade",
+      "sha": "58fdd0348171f2d40fc29b2dfa33344de2aff73e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:56:36Z",
+      "run_started_at": "2026-09-04T23:56:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:07:40Z",
+          "completed_at": "2026-09-05T00:08:25Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:03:20Z",
+          "completed_at": "2026-09-05T00:03:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:09:20Z",
+          "completed_at": "2026-09-05T00:10:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:06:57Z",
+          "completed_at": "2026-09-05T00:07:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:16:16Z",
+          "completed_at": "2026-09-05T00:21:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:15:47Z",
+          "completed_at": "2026-09-05T00:15:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:07:45Z",
+          "completed_at": "2026-09-05T00:08:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:18:17Z",
+          "completed_at": "2026-09-05T00:18:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:10:09Z",
+          "completed_at": "2026-09-05T00:10:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33931308971,
+      "workflow": "shannon-verify",
+      "branch": "worktree-optimizer-mcp-facade",
+      "sha": "58fdd0348171f2d40fc29b2dfa33344de2aff73e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:56:36Z",
+      "run_started_at": "2026-09-04T23:56:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-04T23:56:38Z",
+          "completed_at": "2026-09-05T00:10:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33931308990,
+      "workflow": "larql-cli",
+      "branch": "worktree-optimizer-mcp-facade",
+      "sha": "58fdd0348171f2d40fc29b2dfa33344de2aff73e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:56:36Z",
+      "run_started_at": "2026-09-04T23:56:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:08:31Z",
+          "completed_at": "2026-09-05T00:18:58Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-04T23:58:42Z",
+          "completed_at": "2026-09-05T00:08:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-04T23:57:00Z",
+          "completed_at": "2026-09-05T00:15:22Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-05T00:05:54Z",
+          "completed_at": "2026-09-05T00:13:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33931308993,
+      "workflow": "larql-vindex",
+      "branch": "worktree-optimizer-mcp-facade",
+      "sha": "58fdd0348171f2d40fc29b2dfa33344de2aff73e",
+      "attempt": 2,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:56:36Z",
+      "run_started_at": "2026-09-05T00:17:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:17:15Z",
+          "started_at": "2026-09-05T00:18:36Z",
+          "completed_at": "2026-09-05T00:48:29Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:17:16Z",
+          "started_at": "2026-09-04T23:56:38Z",
+          "completed_at": "2026-09-05T00:11:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:17:16Z",
+          "started_at": "2026-09-05T00:08:01Z",
+          "completed_at": "2026-09-05T00:15:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:17:16Z",
+          "started_at": "2026-09-04T23:56:42Z",
+          "completed_at": "2026-09-05T00:11:07Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33931309031,
+      "workflow": "mutants",
+      "branch": "worktree-optimizer-mcp-facade",
+      "sha": "58fdd0348171f2d40fc29b2dfa33344de2aff73e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-04T23:56:36Z",
+      "run_started_at": "2026-09-04T23:56:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-04T23:56:45Z",
+          "completed_at": "2026-09-04T23:56:57Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-04T23:56:36Z",
+          "started_at": "2026-09-04T23:56:45Z",
+          "completed_at": "2026-09-05T00:42:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33931309019,
+      "workflow": "larql-lql",
+      "branch": "worktree-optimizer-mcp-facade",
+      "sha": "58fdd0348171f2d40fc29b2dfa33344de2aff73e",
+      "attempt": 2,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:56:36Z",
+      "run_started_at": "2026-09-05T00:45:24Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:26Z",
+          "started_at": "2026-09-05T00:46:07Z",
+          "completed_at": "2026-09-05T01:03:02Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:26Z",
+          "started_at": "2026-09-05T00:01:56Z",
+          "completed_at": "2026-09-05T00:11:05Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:26Z",
+          "started_at": "2026-09-05T00:01:49Z",
+          "completed_at": "2026-09-05T00:09:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:32Z",
+          "started_at": "2026-09-05T00:04:45Z",
+          "completed_at": "2026-09-05T00:11:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33931309025,
+      "workflow": "larql-inference",
+      "branch": "worktree-optimizer-mcp-facade",
+      "sha": "58fdd0348171f2d40fc29b2dfa33344de2aff73e",
+      "attempt": 2,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:56:36Z",
+      "run_started_at": "2026-09-05T00:45:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:24Z",
+          "started_at": "2026-09-05T00:45:55Z",
+          "completed_at": "2026-09-05T01:05:23Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:24Z",
+          "started_at": "2026-09-05T00:00:11Z",
+          "completed_at": "2026-09-05T00:10:46Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:24Z",
+          "started_at": "2026-09-05T00:08:04Z",
+          "completed_at": "2026-09-05T00:17:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:45:31Z",
+          "started_at": "2026-09-05T00:08:48Z",
+          "completed_at": "2026-09-05T00:16:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33904473233,
+      "workflow": "commit messages",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:10:37Z",
+          "completed_at": "2026-09-04T18:10:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33904473112,
+      "workflow": "larql-factory",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:10:50Z",
+          "completed_at": "2026-09-04T18:12:21Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:17:50Z",
+          "completed_at": "2026-09-04T18:18:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:19:30Z",
+          "completed_at": "2026-09-04T18:22:00Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:19:50Z",
+          "completed_at": "2026-09-04T18:20:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33904473161,
+      "workflow": "mutants",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:15:41Z",
+          "completed_at": "2026-09-04T18:15:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:19:44Z",
+          "completed_at": "2026-09-04T18:41:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33904473243,
+      "workflow": "larql-server",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:19:49Z",
+          "completed_at": "2026-09-04T18:28:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:23:02Z",
+          "completed_at": "2026-09-04T18:33:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:19:53Z",
+          "completed_at": "2026-09-04T18:42:21Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:22:01Z",
+          "completed_at": "2026-09-04T18:31:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33904473431,
+      "workflow": "shannon-verify",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:11:38Z",
+          "completed_at": "2026-09-04T18:25:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33904473117,
+      "workflow": "larql-lql",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:10:36Z",
+          "completed_at": "2026-09-04T18:18:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:10:36Z",
+          "completed_at": "2026-09-04T18:18:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:10:37Z",
+          "completed_at": "2026-09-04T18:27:30Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:18:09Z",
+          "completed_at": "2026-09-04T18:26:19Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33904473200,
+      "workflow": "larql-models",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:18:12Z",
+          "completed_at": "2026-09-04T18:19:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:18:35Z",
+          "completed_at": "2026-09-04T18:19:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:22:07Z",
+          "completed_at": "2026-09-04T18:25:01Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:27:19Z",
+          "completed_at": "2026-09-04T18:28:43Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33904473323,
+      "workflow": "quality",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:13:51Z",
+          "completed_at": "2026-09-04T18:13:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:15:02Z",
+          "completed_at": "2026-09-04T18:15:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:20:58Z",
+          "completed_at": "2026-09-04T18:28:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:19:01Z",
+          "completed_at": "2026-09-04T18:19:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:25:03Z",
+          "completed_at": "2026-09-04T18:25:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:25:54Z",
+          "completed_at": "2026-09-04T18:26:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:21:23Z",
+          "completed_at": "2026-09-04T18:22:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:26:26Z",
+          "completed_at": "2026-09-04T18:27:13Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:25:36Z",
+          "completed_at": "2026-09-04T18:27:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33904473340,
+      "workflow": "larql-vindex",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:12:01Z",
+          "completed_at": "2026-09-04T18:21:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:18:12Z",
+          "completed_at": "2026-09-04T18:48:15Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:21:30Z",
+          "completed_at": "2026-09-04T18:37:40Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:15:11Z",
+          "completed_at": "2026-09-04T18:29:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33904473237,
+      "workflow": "larql-compute",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:10:36Z",
+          "completed_at": "2026-09-04T18:11:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:16:00Z",
+          "completed_at": "2026-09-04T18:17:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:15:08Z",
+          "completed_at": "2026-09-04T18:17:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:17:26Z",
+          "completed_at": "2026-09-04T18:29:31Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33904473072,
+      "workflow": "larql-cli",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:34Z",
+          "started_at": "2026-09-04T18:10:36Z",
+          "completed_at": "2026-09-04T18:18:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:34Z",
+          "started_at": "2026-09-04T18:10:36Z",
+          "completed_at": "2026-09-04T18:19:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:34Z",
+          "started_at": "2026-09-04T18:10:36Z",
+          "completed_at": "2026-09-04T18:29:20Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:34Z",
+          "started_at": "2026-09-04T18:10:43Z",
+          "completed_at": "2026-09-04T18:21:21Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33904473339,
+      "workflow": "larql-inference",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:10:36Z",
+          "completed_at": "2026-09-04T18:18:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:14:06Z",
+          "completed_at": "2026-09-04T18:22:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:11:56Z",
+          "completed_at": "2026-09-04T18:30:20Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:10:37Z",
+          "completed_at": "2026-09-04T18:19:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33904473111,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:12:27Z",
+          "completed_at": "2026-09-04T19:06:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33903041714,
+      "workflow": "commit messages",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:26Z",
+          "completed_at": "2026-09-04T17:54:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33903041646,
+      "workflow": "quality",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T17:54:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T17:55:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:26Z",
+          "completed_at": "2026-09-04T17:55:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:55:52Z",
+          "completed_at": "2026-09-04T17:56:34Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T18:01:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T18:04:28Z",
+          "completed_at": "2026-09-04T18:04:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T18:05:20Z",
+          "completed_at": "2026-09-04T18:05:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T18:04:34Z",
+          "completed_at": "2026-09-04T18:05:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T18:04:39Z",
+          "completed_at": "2026-09-04T18:05:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33903041501,
+      "workflow": "larql-compute",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T17:56:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T17:55:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:33Z",
+          "completed_at": "2026-09-04T17:56:45Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T18:06:33Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33903041647,
+      "workflow": "larql-models",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T17:55:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:55:13Z",
+          "completed_at": "2026-09-04T17:56:34Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T18:03:50Z",
+          "completed_at": "2026-09-04T18:06:47Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T18:03:08Z",
+          "completed_at": "2026-09-04T18:04:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33903041660,
+      "workflow": "shannon-verify",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T18:07:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33903041662,
+      "workflow": "larql-inference",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T17:59:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:56:36Z",
+          "completed_at": "2026-09-04T18:05:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:55:27Z",
+          "completed_at": "2026-09-04T18:10:15Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:56:41Z",
+          "completed_at": "2026-09-04T18:03:39Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33903041693,
+      "workflow": "larql-lql",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T18:13:50Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T18:02:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:56:52Z",
+          "completed_at": "2026-09-04T18:04:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T18:02:47Z",
+          "completed_at": "2026-09-04T18:10:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33903041644,
+      "workflow": "larql-cli",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T18:03:48Z",
+          "completed_at": "2026-09-04T18:15:06Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T18:03:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T18:04:18Z",
+          "completed_at": "2026-09-04T18:11:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:55:28Z",
+          "completed_at": "2026-09-04T18:15:00Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33903041651,
+      "workflow": "larql-server",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T18:03:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T18:15:33Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:55Z",
+          "completed_at": "2026-09-04T18:05:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T18:01:41Z",
+          "completed_at": "2026-09-04T18:11:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33903041627,
+      "workflow": "larql-vindex",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:26Z",
+          "completed_at": "2026-09-04T18:07:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:25Z",
+          "completed_at": "2026-09-04T18:03:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:56:14Z",
+          "completed_at": "2026-09-04T18:25:55Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:57Z",
+          "completed_at": "2026-09-04T18:10:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33903041583,
+      "workflow": "larql-compute-metal",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:59:15Z",
+          "completed_at": "2026-09-04T18:58:51Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33903041556,
+      "workflow": "mutants",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:26Z",
+          "completed_at": "2026-09-04T18:39:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:54:38Z",
+          "completed_at": "2026-09-04T17:54:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33826441184,
+      "workflow": "shannon-verify",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "5e530ef8dfc3aa22f8ab64983f1cbcda48a9839b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T01:36:55Z",
+      "run_started_at": "2026-09-04T01:36:55Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:48:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33826441224,
+      "workflow": "mutants",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "5e530ef8dfc3aa22f8ab64983f1cbcda48a9839b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-04T01:36:55Z",
+      "run_started_at": "2026-09-04T01:36:55Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:59Z",
+          "completed_at": "2026-09-04T02:22:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:37:09Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33826441182,
+      "workflow": "larql-server",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "5e530ef8dfc3aa22f8ab64983f1cbcda48a9839b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T01:36:55Z",
+      "run_started_at": "2026-09-04T01:36:55Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:44:17Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:58Z",
+          "completed_at": "2026-09-04T01:45:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:56:25Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:46:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33826441289,
+      "workflow": "larql-inference",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "5e530ef8dfc3aa22f8ab64983f1cbcda48a9839b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T01:36:55Z",
+      "run_started_at": "2026-09-04T01:36:55Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:58Z",
+          "completed_at": "2026-09-04T01:44:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:44:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:37:02Z",
+          "completed_at": "2026-09-04T01:43:09Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:37:41Z",
+          "completed_at": "2026-09-04T01:56:29Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33826441247,
+      "workflow": "larql-cli",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "5e530ef8dfc3aa22f8ab64983f1cbcda48a9839b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T01:36:55Z",
+      "run_started_at": "2026-09-04T01:36:55Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:43:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:46:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:37:02Z",
+          "completed_at": "2026-09-04T01:46:26Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:59Z",
+          "completed_at": "2026-09-04T01:56:12Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33826441274,
+      "workflow": "larql-lql",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "5e530ef8dfc3aa22f8ab64983f1cbcda48a9839b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T01:36:55Z",
+      "run_started_at": "2026-09-04T01:36:55Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:58Z",
+          "completed_at": "2026-09-04T01:44:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:37:51Z",
+          "completed_at": "2026-09-04T01:56:43Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:56Z",
+          "started_at": "2026-09-04T01:42:45Z",
+          "completed_at": "2026-09-04T01:49:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:56Z",
+          "started_at": "2026-09-04T01:43:15Z",
+          "completed_at": "2026-09-04T01:50:55Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33826441422,
+      "workflow": "larql-vindex",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "5e530ef8dfc3aa22f8ab64983f1cbcda48a9839b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T01:36:55Z",
+      "run_started_at": "2026-09-04T01:36:55Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:56Z",
+          "started_at": "2026-09-04T01:37:51Z",
+          "completed_at": "2026-09-04T01:44:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:56Z",
+          "started_at": "2026-09-04T01:38:37Z",
+          "completed_at": "2026-09-04T02:08:26Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:56Z",
+          "started_at": "2026-09-04T01:43:41Z",
+          "completed_at": "2026-09-04T01:58:35Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:56Z",
+          "started_at": "2026-09-04T01:44:19Z",
+          "completed_at": "2026-09-04T01:58:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33826441295,
+      "workflow": "quality",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "5e530ef8dfc3aa22f8ab64983f1cbcda48a9839b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T01:36:55Z",
+      "run_started_at": "2026-09-04T01:36:55Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:37:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:58Z",
+          "completed_at": "2026-09-04T01:37:47Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:58Z",
+          "completed_at": "2026-09-04T01:44:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:37:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:38:05Z",
+          "completed_at": "2026-09-04T01:38:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:37:54Z",
+          "completed_at": "2026-09-04T01:38:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:37:09Z",
+          "completed_at": "2026-09-04T01:37:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:37:11Z",
+          "completed_at": "2026-09-04T01:37:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:44:24Z",
+          "completed_at": "2026-09-04T01:45:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33826441189,
+      "workflow": "commit messages",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "5e530ef8dfc3aa22f8ab64983f1cbcda48a9839b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T01:36:55Z",
+      "run_started_at": "2026-09-04T01:36:55Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T01:36:55Z",
+          "started_at": "2026-09-04T01:36:57Z",
+          "completed_at": "2026-09-04T01:37:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33822801455,
+      "workflow": "commit messages",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "b6b290a815a9fc7dd79deb4af5dec7c7e8926bc6",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T00:41:25Z",
+      "run_started_at": "2026-09-04T00:41:25Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:26Z",
+          "started_at": "2026-09-04T00:55:33Z",
+          "completed_at": "2026-09-04T00:55:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33822800390,
+      "workflow": "mutants",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "b6b290a815a9fc7dd79deb4af5dec7c7e8926bc6",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-04T00:41:24Z",
+      "run_started_at": "2026-09-04T00:41:24Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:57:26Z",
+          "completed_at": "2026-09-04T01:42:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T01:01:43Z",
+          "completed_at": "2026-09-04T01:01:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33822800388,
+      "workflow": "larql-server",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "b6b290a815a9fc7dd79deb4af5dec7c7e8926bc6",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T00:41:24Z",
+      "run_started_at": "2026-09-04T00:41:24Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:50:20Z",
+          "completed_at": "2026-09-04T00:59:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:59:30Z",
+          "completed_at": "2026-09-04T01:10:47Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:50:20Z",
+          "completed_at": "2026-09-04T00:59:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:49:59Z",
+          "completed_at": "2026-09-04T01:10:15Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33822800381,
+      "workflow": "shannon-verify",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "b6b290a815a9fc7dd79deb4af5dec7c7e8926bc6",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T00:41:24Z",
+      "run_started_at": "2026-09-04T00:41:24Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:47:31Z",
+          "completed_at": "2026-09-04T01:00:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33822800380,
+      "workflow": "larql-cli",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "b6b290a815a9fc7dd79deb4af5dec7c7e8926bc6",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T00:41:24Z",
+      "run_started_at": "2026-09-04T00:41:24Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:45:23Z",
+          "completed_at": "2026-09-04T00:54:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:54:36Z",
+          "completed_at": "2026-09-04T01:01:34Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:46:16Z",
+          "completed_at": "2026-09-04T01:00:39Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:55:50Z",
+          "completed_at": "2026-09-04T01:02:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33822800392,
+      "workflow": "larql-lql",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "b6b290a815a9fc7dd79deb4af5dec7c7e8926bc6",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T00:41:24Z",
+      "run_started_at": "2026-09-04T00:41:24Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:50:25Z",
+          "completed_at": "2026-09-04T00:58:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:52:15Z",
+          "completed_at": "2026-09-04T00:59:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:51:27Z",
+          "completed_at": "2026-09-04T00:57:57Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:45:02Z",
+          "completed_at": "2026-09-04T01:03:36Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 33822800500,
+      "workflow": "larql-inference",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "b6b290a815a9fc7dd79deb4af5dec7c7e8926bc6",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T00:41:24Z",
+      "run_started_at": "2026-09-04T00:41:24Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:43:56Z",
+          "completed_at": "2026-09-04T00:51:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:55:30Z",
+          "completed_at": "2026-09-04T01:03:38Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:45:02Z",
+          "completed_at": "2026-09-04T01:04:22Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:50:21Z",
+          "completed_at": "2026-09-04T00:59:10Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33822800431,
+      "workflow": "quality",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "b6b290a815a9fc7dd79deb4af5dec7c7e8926bc6",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T00:41:24Z",
+      "run_started_at": "2026-09-04T00:41:24Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:55:38Z",
+          "completed_at": "2026-09-04T00:55:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:57:59Z",
+          "completed_at": "2026-09-04T00:58:46Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:49:30Z",
+          "completed_at": "2026-09-04T00:49:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:58:47Z",
+          "completed_at": "2026-09-04T00:59:29Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:58:48Z",
+          "completed_at": "2026-09-04T01:05:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:59:11Z",
+          "completed_at": "2026-09-04T00:59:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:59:31Z",
+          "completed_at": "2026-09-04T00:59:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:59:40Z",
+          "completed_at": "2026-09-04T01:00:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:59:41Z",
+          "completed_at": "2026-09-04T01:00:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33822800387,
+      "workflow": "commit messages",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "b6b290a815a9fc7dd79deb4af5dec7c7e8926bc6",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T00:41:24Z",
+      "run_started_at": "2026-09-04T00:41:24Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:43:50Z",
+          "completed_at": "2026-09-04T00:43:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 33822800567,
+      "workflow": "larql-vindex",
+      "branch": "pareto-1/unsloth-headhead",
+      "sha": "b6b290a815a9fc7dd79deb4af5dec7c7e8926bc6",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-04T00:41:24Z",
+      "run_started_at": "2026-09-04T00:41:24Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:46:31Z",
+          "completed_at": "2026-09-04T00:55:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:47:11Z",
+          "completed_at": "2026-09-04T01:01:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:58:27Z",
+          "completed_at": "2026-09-04T01:12:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T00:41:25Z",
+          "started_at": "2026-09-04T00:48:41Z",
+          "completed_at": "2026-09-04T01:18:10Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/ci_throughput.py
+++ b/scripts/ci_throughput.py
@@ -1,0 +1,817 @@
+#!/usr/bin/env python3
+"""CI throughput instrument — what a pull request actually costs in
+wall clock and in runner minutes.
+
+Written to score one specific intervention (E1: PR-run cancellation,
+macOS PR occupancy, VINDEX bench placement) as a before/after, so that
+the claim afterwards is a number and not "CI feels faster".
+
+The unit of observation is an ATTEMPT: one head SHA of one pull request,
+with every workflow run GitHub created for it. t0 for an attempt is the
+earliest job-creation timestamp across those runs, which is the closest
+thing the API offers to "when the push landed".
+
+Every metric separates QUEUE from EXECUTION, because the two respond to
+different changes and mixing them hides which one moved:
+
+  queue      job.started_at   - job.created_at    (waiting for a runner)
+  execution  job.completed_at - job.started_at    (doing the work)
+
+Metrics, and the intervention each one scores:
+
+  first-blocking-green   t0 -> earliest blocking run to succeed
+                         perceived feedback speed
+  merge-ready            t0 -> last blocking run to succeed
+                         actual merge readiness
+  macos-queue            max macOS queue wait in the attempt
+                         scores the macOS-occupancy change
+  superseded-execution   executed minutes spent on runs for a SHA that
+                         a later push had already superseded
+                         scores run cancellation
+  windows-vindex         execution time of larql-vindex's Windows leg
+                         scores bench placement
+  queued/executed by OS  did pressure move, or actually go away
+
+"Blocking" is defined here as every PR-triggered workflow EXCEPT those
+named in --informational (default: mutants, which declares itself
+advisory and runs continue-on-error). The repository ruleset carries no
+required status checks, so this is a stated convention, not something
+read off the branch protection.
+
+    scripts/ci_throughput.py collect --since 2026-08-20 --out before.json
+    scripts/ci_throughput.py report  --before before.json --after after.json
+    scripts/ci_throughput.py selftest
+
+`collect` snapshots the API; `report` never calls the network. Freeze the
+BEFORE snapshot before the change lands — the runs are immutable, but
+retention is not forever.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PER_PAGE = 100
+MAX_PAGES = 50
+DEFAULT_INFORMATIONAL = ("mutants",)
+DEFAULT_PERCENTILES = (50, 95)
+SECONDS_PER_MINUTE = 60.0
+
+# Substring -> canonical OS name. Read off a job's `labels` (the literal
+# `runs-on` values), never off the runner's hostname, which is assigned.
+OS_LABEL_MARKERS = (
+    ("ubuntu", "linux"),
+    ("linux", "linux"),
+    ("windows", "windows"),
+    ("macos", "macos"),
+    ("macOS", "macos"),
+)
+OS_ORDER = ("linux", "windows", "macos", "unknown")
+
+TERMINAL_SUCCESS = "success"
+TERMINAL_CANCELLED = "cancelled"
+
+
+# --------------------------------------------------------------------------
+# time helpers
+# --------------------------------------------------------------------------
+
+def parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def seconds_between(start: datetime | None, end: datetime | None) -> float | None:
+    if start is None or end is None:
+        return None
+    delta = (end - start).total_seconds()
+    # Clock skew between GitHub's queue and runner clocks shows up as small
+    # negatives. Clamp rather than discard: a negative queue wait is a zero
+    # wait, and dropping the row would bias the percentile.
+    return max(0.0, delta)
+
+
+def fmt_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return "-"
+    total = int(round(seconds))
+    return f"{total // 60}m{total % 60:02d}s"
+
+
+def fmt_minutes(seconds: float | None) -> str:
+    if seconds is None:
+        return "-"
+    return f"{seconds / SECONDS_PER_MINUTE:.1f}m"
+
+
+def percentile(values: Sequence[float], pct: float) -> float | None:
+    """Linear-interpolated percentile. Defined for n == 1, unlike
+    statistics.quantiles, because early samples are small."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    return ordered[low] + (ordered[high] - ordered[low]) * (rank - low)
+
+
+# --------------------------------------------------------------------------
+# GitHub API
+# --------------------------------------------------------------------------
+
+def gh_api(path: str, params: dict[str, str] | None = None) -> Any:
+    # `--method GET` is not redundant: `gh api` defaults to POST as soon as
+    # any `-f` parameter is present, which turns a read into a 404.
+    cmd = ["gh", "api", "--method", "GET", "-H", "Accept: application/vnd.github+json", path]
+    for key, value in (params or {}).items():
+        cmd += ["-f", f"{key}={value}"]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh api {path} failed: {proc.stderr.strip()}")
+    return json.loads(proc.stdout)
+
+
+def gh_paginated(path: str, key: str, params: dict[str, str] | None = None) -> list[dict]:
+    out: list[dict] = []
+    for page in range(1, MAX_PAGES + 1):
+        payload = gh_api(path, {**(params or {}), "per_page": str(PER_PAGE), "page": str(page)})
+        batch = payload.get(key, []) if isinstance(payload, dict) else payload
+        if not batch:
+            break
+        out.extend(batch)
+        if len(batch) < PER_PAGE:
+            break
+    return out
+
+
+def repo_slug() -> str:
+    return gh_api("repos/{owner}/{repo}")["full_name"]
+
+
+def classify_os(labels: Iterable[str]) -> str:
+    joined = " ".join(labels).lower()
+    for marker, name in OS_LABEL_MARKERS:
+        if marker.lower() in joined:
+            return name
+    return "unknown"
+
+
+# --------------------------------------------------------------------------
+# collect
+# --------------------------------------------------------------------------
+
+def collect(args: argparse.Namespace) -> int:
+    slug = repo_slug()
+    params = {"event": "pull_request"}
+    if args.since:
+        params["created"] = f">={args.since}"
+    if args.branch:
+        params["branch"] = args.branch
+
+    print(f"collecting pull_request runs for {slug} ...", file=sys.stderr)
+    runs = gh_paginated(f"repos/{slug}/actions/runs", "workflow_runs", params)
+    if args.until:
+        cutoff = parse_ts(f"{args.until}T23:59:59Z")
+        runs = [r for r in runs if (parse_ts(r["created_at"]) or cutoff) <= cutoff]
+    runs.sort(key=lambda r: r["created_at"], reverse=True)
+
+    # Bound by PR, not by run count, so a snapshot is always a whole number
+    # of pull requests and the two periods stay comparable.
+    by_branch: dict[str, list[dict]] = defaultdict(list)
+    for run in runs:
+        by_branch[run.get("head_branch") or "?"].append(run)
+    branches = sorted(by_branch, key=lambda b: max(r["created_at"] for r in by_branch[b]), reverse=True)
+    if args.max_prs:
+        branches = branches[: args.max_prs]
+    selected = [r for b in branches for r in by_branch[b]]
+
+    print(f"  {len(selected)} runs across {len(branches)} branches; fetching jobs", file=sys.stderr)
+    records = []
+    for index, run in enumerate(selected, 1):
+        jobs = gh_paginated(f"repos/{slug}/actions/runs/{run['id']}/jobs", "jobs")
+        records.append(
+            {
+                "id": run["id"],
+                "workflow": run.get("name"),
+                "branch": run.get("head_branch"),
+                "sha": run.get("head_sha"),
+                "attempt": run.get("run_attempt"),
+                "status": run.get("status"),
+                "conclusion": run.get("conclusion"),
+                "created_at": run.get("created_at"),
+                "run_started_at": run.get("run_started_at"),
+                "pr": (run.get("pull_requests") or [{}])[0].get("number"),
+                "jobs": [
+                    {
+                        "name": j.get("name"),
+                        "status": j.get("status"),
+                        "conclusion": j.get("conclusion"),
+                        "created_at": j.get("created_at"),
+                        "started_at": j.get("started_at"),
+                        "completed_at": j.get("completed_at"),
+                        "labels": j.get("labels") or [],
+                        "os": classify_os(j.get("labels") or []),
+                    }
+                    for j in jobs
+                ],
+            }
+        )
+        if index % 20 == 0:
+            print(f"  {index}/{len(selected)}", file=sys.stderr)
+
+    snapshot = {
+        "collected_at": datetime.now(timezone.utc).isoformat(),
+        "repo": slug,
+        "query": {"since": args.since, "until": args.until, "max_prs": args.max_prs, "branch": args.branch},
+        "runs": records,
+    }
+    out = Path(args.out)
+    out.write_text(json.dumps(snapshot, indent=2) + "\n")
+    print(f"wrote {out} — {len(records)} runs, {len(branches)} branches", file=sys.stderr)
+    return 0
+
+
+# --------------------------------------------------------------------------
+# analysis
+# --------------------------------------------------------------------------
+
+@dataclass
+class AttemptMetrics:
+    branch: str
+    sha: str
+    workflows: list[str] = field(default_factory=list)
+    first_blocking_green: float | None = None
+    merge_ready: float | None = None
+    all_blocking_succeeded: bool = False
+    complete: bool = True
+    macos_queue_max: float | None = None
+    windows_vindex_exec: float | None = None
+    superseded_exec: float = 0.0
+    queued_by_os: dict[str, float] = field(default_factory=dict)
+    executed_by_os: dict[str, float] = field(default_factory=dict)
+
+
+def run_bounds(run: dict) -> tuple[datetime | None, datetime | None]:
+    created = [parse_ts(j["created_at"]) for j in run["jobs"]]
+    done = [parse_ts(j["completed_at"]) for j in run["jobs"]]
+    created = [c for c in created if c]
+    done = [d for d in done if d]
+    return (min(created) if created else None, max(done) if done else None)
+
+
+def analyse(
+    snapshot: dict,
+    informational: Sequence[str],
+    workflow_filter: Sequence[str] | None,
+    require_complete: bool,
+) -> list[AttemptMetrics]:
+    runs = snapshot["runs"]
+    if workflow_filter:
+        wanted = set(workflow_filter)
+        runs = [r for r in runs if r["workflow"] in wanted]
+
+    by_attempt: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for run in runs:
+        by_attempt[(run["branch"] or "?", run["sha"] or "?")].append(run)
+
+    # t0 per attempt, and the ordering of attempts within a branch — needed
+    # to decide which runs were superseded by a later push.
+    t0: dict[tuple[str, str], datetime] = {}
+    for key, group in by_attempt.items():
+        starts = [run_bounds(r)[0] for r in group]
+        starts = [s for s in starts if s]
+        if starts:
+            t0[key] = min(starts)
+
+    by_branch: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for key in by_attempt:
+        if key in t0:
+            by_branch[key[0]].append(key)
+    for branch in by_branch:
+        by_branch[branch].sort(key=lambda k: t0[k])
+
+    results: list[AttemptMetrics] = []
+    for key, group in sorted(by_attempt.items(), key=lambda kv: t0.get(kv[0], datetime.max.replace(tzinfo=timezone.utc))):
+        branch, sha = key
+        if key not in t0:
+            continue
+        start = t0[key]
+        metrics = AttemptMetrics(branch=branch, sha=sha, workflows=sorted({r["workflow"] or "?" for r in group}))
+
+        # When did the NEXT push on this branch happen? Anything still
+        # executing after that moment is work on a superseded commit.
+        siblings = by_branch[branch]
+        position = siblings.index(key)
+        next_start = t0[siblings[position + 1]] if position + 1 < len(siblings) else None
+
+        blocking_done: list[float] = []
+        blocking_all_ok = True
+        saw_blocking = False
+
+        for run in group:
+            is_informational = (run["workflow"] or "") in informational
+            _, finished = run_bounds(run)
+            if run["status"] != "completed":
+                metrics.complete = False
+
+            for job in run["jobs"]:
+                created = parse_ts(job["created_at"])
+                started = parse_ts(job["started_at"])
+                completed = parse_ts(job["completed_at"])
+                queued = seconds_between(created, started)
+                executed = seconds_between(started, completed)
+                os_name = job["os"]
+
+                if queued is not None:
+                    metrics.queued_by_os[os_name] = metrics.queued_by_os.get(os_name, 0.0) + queued
+                    if os_name == "macos":
+                        metrics.macos_queue_max = max(metrics.macos_queue_max or 0.0, queued)
+                if executed is not None:
+                    metrics.executed_by_os[os_name] = metrics.executed_by_os.get(os_name, 0.0) + executed
+                    if next_start is not None and completed is not None and completed > next_start:
+                        # Only the portion spent after the superseding push
+                        # is waste; the rest was legitimate work at the time.
+                        overlap = seconds_between(max(started or next_start, next_start), completed)
+                        metrics.superseded_exec += overlap or 0.0
+                    if run["workflow"] == "larql-vindex" and os_name == "windows":
+                        metrics.windows_vindex_exec = max(metrics.windows_vindex_exec or 0.0, executed)
+
+            if is_informational:
+                continue
+            saw_blocking = True
+            if run["conclusion"] == TERMINAL_SUCCESS and finished is not None:
+                blocking_done.append((finished - start).total_seconds())
+            else:
+                blocking_all_ok = False
+
+        if saw_blocking and blocking_done:
+            metrics.first_blocking_green = min(blocking_done)
+        metrics.all_blocking_succeeded = saw_blocking and blocking_all_ok
+        if metrics.all_blocking_succeeded and blocking_done:
+            metrics.merge_ready = max(blocking_done)
+
+        if require_complete and not metrics.complete:
+            continue
+        results.append(metrics)
+
+    return results
+
+
+def aggregate(rows: Sequence[AttemptMetrics], percentiles: Sequence[int]) -> dict[str, Any]:
+    def series(pick) -> list[float]:
+        return [v for v in (pick(r) for r in rows) if v is not None]
+
+    out: dict[str, Any] = {"attempts": len(rows), "merge_ready_attempts": sum(1 for r in rows if r.merge_ready is not None)}
+    for label, pick in (
+        ("first_blocking_green", lambda r: r.first_blocking_green),
+        ("merge_ready", lambda r: r.merge_ready),
+        ("macos_queue_max", lambda r: r.macos_queue_max),
+        ("windows_vindex_exec", lambda r: r.windows_vindex_exec),
+    ):
+        values = series(pick)
+        out[label] = {f"p{p}": percentile(values, p) for p in percentiles}
+        out[label]["n"] = len(values)
+
+    out["superseded_exec_total"] = sum(r.superseded_exec for r in rows)
+    out["superseded_exec_mean"] = statistics.fmean([r.superseded_exec for r in rows]) if rows else None
+    for bucket, attr in (("queued_by_os", "queued_by_os"), ("executed_by_os", "executed_by_os")):
+        totals: dict[str, float] = defaultdict(float)
+        for row in rows:
+            for os_name, value in getattr(row, attr).items():
+                totals[os_name] += value
+        out[bucket] = dict(totals)
+    return out
+
+
+# --------------------------------------------------------------------------
+# report
+# --------------------------------------------------------------------------
+
+def delta_str(before: float | None, after: float | None) -> str:
+    if before is None or after is None or before == 0:
+        return "-"
+    return f"{(after - before) / before * 100:+.0f}%"
+
+
+def print_table(before: dict | None, after: dict, percentiles: Sequence[int]) -> None:
+    header = f"{'metric':<26}{'before':>12}{'after':>12}{'delta':>10}"
+    if before is None:
+        header = f"{'metric':<26}{'value':>12}"
+    print(header)
+    print("-" * len(header))
+
+    def row(label: str, b: float | None, a: float | None, fmt=fmt_duration) -> None:
+        if before is None:
+            print(f"{label:<26}{fmt(a):>12}")
+        else:
+            print(f"{label:<26}{fmt(b):>12}{fmt(a):>12}{delta_str(b, a):>10}")
+
+    for key, label in (
+        ("first_blocking_green", "first green"),
+        ("merge_ready", "merge-ready"),
+        ("macos_queue_max", "macOS queue (max/attempt)"),
+        ("windows_vindex_exec", "vindex windows exec"),
+    ):
+        for p in percentiles:
+            row(f"{label} p{p}", (before or {}).get(key, {}).get(f"p{p}"), after[key].get(f"p{p}"))
+
+    row("superseded exec (mean)", (before or {}).get("superseded_exec_mean"), after.get("superseded_exec_mean"))
+    row("superseded exec (total)", (before or {}).get("superseded_exec_total"), after.get("superseded_exec_total"), fmt_minutes)
+
+    print()
+    for bucket, title in (("queued_by_os", "queued runner-minutes"), ("executed_by_os", "executed runner-minutes")):
+        print(f"{title}:")
+        names = sorted(set((before or {}).get(bucket, {})) | set(after.get(bucket, {})), key=lambda n: OS_ORDER.index(n) if n in OS_ORDER else 99)
+        for name in names:
+            row(f"  {name}", (before or {}).get(bucket, {}).get(name), after.get(bucket, {}).get(name), fmt_minutes)
+        print()
+
+
+def report(args: argparse.Namespace) -> int:
+    percentiles = [int(p) for p in args.percentiles.split(",")]
+    informational = tuple(w.strip() for w in args.informational.split(",") if w.strip())
+    workflows = [w.strip() for w in args.workflow.split(",")] if args.workflow else None
+
+    after_snap = json.loads(Path(args.after).read_text())
+    after_rows = analyse(after_snap, informational, workflows, args.require_complete)
+    after_agg = aggregate(after_rows, percentiles)
+
+    before_agg = None
+    before_rows: list[AttemptMetrics] = []
+    if args.before:
+        before_snap = json.loads(Path(args.before).read_text())
+        before_rows = analyse(before_snap, informational, workflows, args.require_complete)
+        before_agg = aggregate(before_rows, percentiles)
+
+    print(f"informational (non-blocking): {', '.join(informational) or 'none'}")
+    if workflows:
+        print(f"workflow subset: {', '.join(workflows)}")
+    print(f"attempts: before={len(before_rows)} after={len(after_rows)}")
+    print()
+    print_table(before_agg, after_agg, percentiles)
+
+    # Composition, so a delta can never be read without seeing whether the
+    # two periods were made of comparable pull requests.
+    print("workflow composition (attempts containing each workflow):")
+    for label, rows in (("before", before_rows), ("after", after_rows)):
+        if not rows:
+            continue
+        counts: dict[str, int] = defaultdict(int)
+        for r in rows:
+            for w in r.workflows:
+                counts[w] += 1
+        summary = ", ".join(f"{w}:{c}" for w, c in sorted(counts.items(), key=lambda kv: -kv[1]))
+        print(f"  {label}: {summary}")
+
+    if args.rows:
+        print()
+        print(f"{'branch':<34}{'sha':<10}{'first':>9}{'ready':>9}{'macosQ':>9}{'super':>9}")
+        for r in (before_rows + after_rows):
+            print(
+                f"{r.branch[:33]:<34}{(r.sha or '')[:8]:<10}"
+                f"{fmt_duration(r.first_blocking_green):>9}{fmt_duration(r.merge_ready):>9}"
+                f"{fmt_duration(r.macos_queue_max):>9}{fmt_duration(r.superseded_exec):>9}"
+            )
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps({"before": before_agg, "after": after_agg}, indent=2) + "\n")
+    return 0
+
+
+# --------------------------------------------------------------------------
+# adjudication — score a frozen forecast, per mechanism
+# --------------------------------------------------------------------------
+
+# Everything the adjudicator compares is in MINUTES. The aggregates carry
+# seconds internally; converting once, here, keeps the frozen thresholds in
+# one unit and out of reach of a scoring-time reinterpretation.
+VERDICT_HELD = "HELD"
+VERDICT_PARTIAL = "PARTIAL"
+VERDICT_FALSIFIED = "FALSIFIED"
+VERDICT_INVALID = "INVALID COMPARISON"
+VERDICT_NO_DATA = "NO DATA"
+
+OPERATORS = {
+    "lt": lambda a, b: a < b,
+    "lte": lambda a, b: a <= b,
+    "gt": lambda a, b: a > b,
+    "gte": lambda a, b: a >= b,
+}
+
+
+def flatten_metrics(agg: dict) -> dict[str, float | None]:
+    """Aggregate -> flat metric table, all values in minutes."""
+    if not agg:
+        return {}
+    out: dict[str, float | None] = {}
+    for key in ("first_blocking_green", "merge_ready", "macos_queue_max", "windows_vindex_exec"):
+        for stat, value in (agg.get(key) or {}).items():
+            if stat == "n":
+                continue
+            out[f"{key}.{stat}"] = None if value is None else value / SECONDS_PER_MINUTE
+    for key in ("superseded_exec_total", "superseded_exec_mean"):
+        value = agg.get(key)
+        out[key] = None if value is None else value / SECONDS_PER_MINUTE
+    for bucket, prefix in (("queued_by_os", "queued"), ("executed_by_os", "executed")):
+        for os_name, value in (agg.get(bucket) or {}).items():
+            out[f"{prefix}.{os_name}"] = value / SECONDS_PER_MINUTE
+    # merge_ready.p50 is the common shorthand; keep the full path too.
+    return out
+
+
+def evaluate_conditions(conditions: dict, after: float | None, before: float | None) -> bool | None:
+    """True/False, or None when the data cannot answer the question."""
+    if not conditions:
+        return None
+    for field, tests in conditions.items():
+        if field == "after":
+            value = after
+        elif field == "delta_pct":
+            if before in (None, 0) or after is None:
+                return None
+            value = (after - before) / before * 100.0
+        else:
+            raise ValueError(f"unknown condition field: {field}")
+        if value is None:
+            return None
+        for op, threshold in tests.items():
+            if op not in OPERATORS:
+                raise ValueError(f"unknown operator: {op}")
+            if not OPERATORS[op](value, threshold):
+                return False
+    return True
+
+
+def score_prediction(pred: dict, before: dict, after: dict) -> dict:
+    metric = pred["metric"]
+    b, a = before.get(metric), after.get(metric)
+    held = evaluate_conditions(pred.get("held_if", {}), a, b)
+    falsified = evaluate_conditions(pred.get("falsified_if", {}), a, b)
+    if a is None:
+        verdict = VERDICT_NO_DATA
+    elif falsified:
+        verdict = VERDICT_FALSIFIED
+    elif held:
+        verdict = VERDICT_HELD
+    else:
+        verdict = VERDICT_PARTIAL
+    delta = None if (b in (None, 0) or a is None) else (a - b) / b * 100.0
+    return {"id": pred["id"], "mechanism": pred["mechanism"], "kind": pred.get("kind", "effect"),
+            "metric": metric, "before": b, "after": a, "delta_pct": delta,
+            "verdict": verdict, "claim": pred.get("claim", "")}
+
+
+def mechanism_verdict(scored: Sequence[dict]) -> str:
+    validity = [s for s in scored if s["kind"] == "validity"]
+    if any(s["verdict"] in (VERDICT_FALSIFIED, VERDICT_PARTIAL) for s in validity):
+        return VERDICT_INVALID
+    effects = [s for s in scored if s["kind"] == "effect"]
+    if not effects or all(s["verdict"] == VERDICT_NO_DATA for s in effects):
+        return VERDICT_NO_DATA
+    verdicts = {s["verdict"] for s in effects if s["verdict"] != VERDICT_NO_DATA}
+    if verdicts == {VERDICT_HELD}:
+        return VERDICT_HELD
+    if verdicts == {VERDICT_FALSIFIED}:
+        return VERDICT_FALSIFIED
+    return VERDICT_PARTIAL
+
+
+def adjudicate(args: argparse.Namespace) -> int:
+    forecast = json.loads(Path(args.forecast).read_text())
+    percentiles = [int(p) for p in args.percentiles.split(",")]
+    informational = tuple(w.strip() for w in args.informational.split(",") if w.strip())
+
+    before_rows = analyse(json.loads(Path(args.before).read_text()), informational, None, args.require_complete)
+    after_rows = analyse(json.loads(Path(args.after).read_text()), informational, None, args.require_complete)
+    before = flatten_metrics(aggregate(before_rows, percentiles))
+    after = flatten_metrics(aggregate(after_rows, percentiles))
+
+    scored = [score_prediction(p, before, after) for p in forecast["predictions"]]
+    by_mech: dict[str, list[dict]] = defaultdict(list)
+    for s in scored:
+        by_mech[s["mechanism"]].append(s)
+
+    names = forecast.get("mechanisms", {})
+    order = [m for m in ("c1", "c2", "c3", "system") if m in by_mech] +             [m for m in by_mech if m not in ("c1", "c2", "c3", "system")]
+
+    print(f"E1 adjudication — before n={len(before_rows)} attempts, after n={len(after_rows)} attempts")
+    print()
+    results = {}
+    for mech in order:
+        entries = by_mech[mech]
+        verdict = mechanism_verdict(entries)
+        results[mech] = verdict
+        label = "SYSTEM" if mech == "system" else mech.upper()
+        print(f"{label}  {names.get(mech, '')}")
+        for s in entries:
+            delta = "-" if s["delta_pct"] is None else f"{s['delta_pct']:+.0f}%"
+            b = "-" if s["before"] is None else f"{s['before']:.1f}"
+            a = "-" if s["after"] is None else f"{s['after']:.1f}"
+            kind = " (validity)" if s["kind"] == "validity" else ""
+            print(f"  {s['id']}{kind}  {s['metric']}: {b} -> {a} min  ({delta})   {s['verdict']}")
+        print(f"  VERDICT: {verdict}")
+        if verdict == VERDICT_INVALID:
+            print("  the validity gate failed: this mechanism's effect predictions are NOT interpreted")
+        print()
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(
+            {"mechanisms": results, "predictions": scored,
+             "before_attempts": len(before_rows), "after_attempts": len(after_rows)}, indent=2) + "\n")
+    return 0
+
+
+# --------------------------------------------------------------------------
+# selftest — the metric definitions, on synthetic runs with known answers
+# --------------------------------------------------------------------------
+
+def _job(created: str, started: str, completed: str, labels: list[str], conclusion: str = TERMINAL_SUCCESS) -> dict:
+    return {
+        "name": "j", "status": "completed", "conclusion": conclusion,
+        "created_at": created, "started_at": started, "completed_at": completed,
+        "labels": labels, "os": classify_os(labels),
+    }
+
+
+def _run(workflow: str, sha: str, jobs: list[dict], conclusion: str = TERMINAL_SUCCESS, branch: str = "pr-1") -> dict:
+    return {
+        "id": 1, "workflow": workflow, "branch": branch, "sha": sha, "attempt": 1,
+        "status": "completed", "conclusion": conclusion,
+        "created_at": jobs[0]["created_at"], "run_started_at": jobs[0]["started_at"],
+        "pr": 1, "jobs": jobs,
+    }
+
+
+def selftest(_args: argparse.Namespace) -> int:
+    failures: list[str] = []
+
+    def check(name: str, got: Any, want: Any) -> None:
+        if got != want:
+            failures.append(f"{name}: got {got!r}, want {want!r}")
+        else:
+            print(f"  ok  {name} == {want!r}")
+
+    T = "2026-09-06T10:{:02d}:00Z".format
+
+    # 1. queue vs execution are separated, and macOS queue is picked out.
+    snap = {"runs": [_run("quality", "aaa", [
+        _job(T(0), T(20), T(21), ["macos-14"]),      # 20m queue, 1m exec
+        _job(T(0), T(1), T(11), ["ubuntu-latest"]),  # 1m queue, 10m exec
+    ])]}
+    rows = analyse(snap, DEFAULT_INFORMATIONAL, None, True)
+    check("macos queue max", rows[0].macos_queue_max, 20 * 60.0)
+    check("queued linux", rows[0].queued_by_os["linux"], 60.0)
+    check("executed macos", rows[0].executed_by_os["macos"], 60.0)
+
+    # 2. merge-ready spans to the LAST blocking success; the informational
+    #    workflow is excluded even when it finishes last and fails.
+    snap = {"runs": [
+        _run("larql-core", "aaa", [_job(T(0), T(1), T(6), ["ubuntu-latest"])]),
+        _run("quality", "aaa", [_job(T(0), T(1), T(15), ["ubuntu-latest"])]),
+        _run("mutants", "aaa", [_job(T(0), T(1), T(45), ["ubuntu-latest"], "failure")], conclusion="failure"),
+    ]}
+    rows = analyse(snap, DEFAULT_INFORMATIONAL, None, True)
+    check("first blocking green", rows[0].first_blocking_green, 6 * 60.0)
+    check("merge-ready", rows[0].merge_ready, 15 * 60.0)
+    check("all blocking ok", rows[0].all_blocking_succeeded, True)
+
+    # 2b. control: a FAILING blocking run must leave merge-ready undefined.
+    snap["runs"][1] = _run("quality", "aaa", [_job(T(0), T(1), T(15), ["ubuntu-latest"], "failure")], conclusion="failure")
+    rows = analyse(snap, DEFAULT_INFORMATIONAL, None, True)
+    check("merge-ready when a gate fails", rows[0].merge_ready, None)
+
+    # 3. superseded execution counts only the part after the next push.
+    #    sha aaa runs 00:00->00:30; sha bbb is pushed at 00:10 => 20m wasted.
+    snap = {"runs": [
+        _run("larql-core", "aaa", [_job(T(0), T(0), T(30), ["ubuntu-latest"])]),
+        _run("larql-core", "bbb", [_job(T(10), T(10), T(25), ["ubuntu-latest"])]),
+    ]}
+    rows = analyse(snap, DEFAULT_INFORMATIONAL, None, True)
+    by_sha = {r.sha: r for r in rows}
+    check("superseded exec (old sha)", by_sha["aaa"].superseded_exec, 20 * 60.0)
+    check("superseded exec (newest sha)", by_sha["bbb"].superseded_exec, 0.0)
+
+    # 3b. control: cancel the old run at the push and the waste goes to zero.
+    snap["runs"][0] = _run("larql-core", "aaa", [_job(T(0), T(0), T(10), ["ubuntu-latest"], TERMINAL_CANCELLED)], conclusion=TERMINAL_CANCELLED)
+    rows = analyse(snap, DEFAULT_INFORMATIONAL, None, True)
+    check("superseded exec after cancellation", {r.sha: r for r in rows}["aaa"].superseded_exec, 0.0)
+
+    # 4. adjudication: each verdict must be reachable, or the adjudicator is
+    #    not an instrument. Synthetic metric tables, same shape the real
+    #    forecast scores against.
+    p_effect = {"id": "PX", "mechanism": "c2", "kind": "effect", "metric": "queued.macos",
+                "held_if": {"delta_pct": {"lte": -30}}, "falsified_if": {"delta_pct": {"gt": -20}}}
+    p_valid = {"id": "PV", "mechanism": "c2", "kind": "validity", "metric": "executed.macos",
+               "held_if": {"delta_pct": {"gte": -10}}, "falsified_if": {"delta_pct": {"lt": -20}}}
+    base = {"queued.macos": 4526.6, "executed.macos": 3034.9}
+
+    good = {"queued.macos": 2263.3, "executed.macos": 2882.2}   # -50% queue, -5% exec
+    check("effect HELD", score_prediction(p_effect, base, good)["verdict"], VERDICT_HELD)
+    check("validity HELD", score_prediction(p_valid, base, good)["verdict"], VERDICT_HELD)
+    check("c2 verdict when both hold",
+          mechanism_verdict([score_prediction(p_effect, base, good), score_prediction(p_valid, base, good)]),
+          VERDICT_HELD)
+
+    flat = {"queued.macos": 4300.0, "executed.macos": 2950.0}    # -5% queue
+    check("effect FALSIFIED", score_prediction(p_effect, base, flat)["verdict"], VERDICT_FALSIFIED)
+
+    # The control that matters: a spectacular queue drop that is really just a
+    # thinner AFTER sample must NOT be readable as an effect.
+    thin = {"queued.macos": 1000.0, "executed.macos": 1500.0}    # -78% queue, -51% exec
+    check("effect looks HELD on a thin sample", score_prediction(p_effect, base, thin)["verdict"], VERDICT_HELD)
+    check("validity FALSIFIED on a thin sample", score_prediction(p_valid, base, thin)["verdict"], VERDICT_FALSIFIED)
+    check("c2 verdict is vetoed by validity",
+          mechanism_verdict([score_prediction(p_effect, base, thin), score_prediction(p_valid, base, thin)]),
+          VERDICT_INVALID)
+
+    check("missing metric yields NO DATA", score_prediction(p_effect, base, {})["verdict"], VERDICT_NO_DATA)
+
+    # 4b. the shipped forecast must be scoreable: every condition parses and
+    #     every metric name is one flatten_metrics actually produces.
+    forecast_path = REPO_ROOT / "docs" / "ci-throughput" / "E1-forecast.json"
+    if forecast_path.exists():
+        forecast = json.loads(forecast_path.read_text())
+        known = set(flatten_metrics(aggregate([
+            AttemptMetrics(branch="b", sha="s", queued_by_os={"macos": 1.0}, executed_by_os={"macos": 1.0})
+        ], DEFAULT_PERCENTILES)))
+        for pred in forecast["predictions"]:
+            check(f"{pred['id']} metric is produced", pred["metric"] in known, True)
+            for conditions in (pred.get("held_if", {}), pred.get("falsified_if", {})):
+                evaluate_conditions(conditions, 1.0, 2.0)   # raises on an unknown field/operator
+        check("forecast conditions all parse", True, True)
+
+    # 5. percentile is defined at n == 1 and interpolates at n == 2.
+    check("percentile n=1", percentile([7.0], 95), 7.0)
+    check("percentile n=2 p50", percentile([0.0, 10.0], 50), 5.0)
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"  FAIL {f}")
+        print(f"{len(failures)} failing check(s)")
+        return 1
+    print("selftest: all checks passed")
+    return 0
+
+
+# --------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_collect = sub.add_parser("collect", help="snapshot pull_request runs and their jobs")
+    p_collect.add_argument("--out", required=True, help="snapshot path to write")
+    p_collect.add_argument("--since", help="YYYY-MM-DD lower bound on run creation")
+    p_collect.add_argument("--until", help="YYYY-MM-DD upper bound on run creation")
+    p_collect.add_argument("--branch", help="restrict to one head branch")
+    p_collect.add_argument("--max-prs", type=int, default=20, help="most recent N head branches (default 20)")
+    p_collect.set_defaults(func=collect)
+
+    p_report = sub.add_parser("report", help="score a snapshot, optionally against a baseline")
+    p_report.add_argument("--after", required=True, help="snapshot to score")
+    p_report.add_argument("--before", help="baseline snapshot")
+    p_report.add_argument("--informational", default=",".join(DEFAULT_INFORMATIONAL),
+                          help="comma-separated non-blocking workflow names")
+    p_report.add_argument("--workflow", help="comma-separated workflow subset")
+    p_report.add_argument("--percentiles", default=",".join(str(p) for p in DEFAULT_PERCENTILES))
+    p_report.add_argument("--require-complete", action="store_true",
+                          help="drop attempts with a run still in flight")
+    p_report.add_argument("--rows", action="store_true", help="print one row per attempt")
+    p_report.add_argument("--json-out", help="also write the aggregates as JSON")
+    p_report.set_defaults(func=report)
+
+    p_adj = sub.add_parser("adjudicate", help="score a frozen forecast, per mechanism")
+    p_adj.add_argument("--forecast", required=True, help="frozen forecast JSON")
+    p_adj.add_argument("--before", required=True, help="baseline snapshot")
+    p_adj.add_argument("--after", required=True, help="snapshot to score")
+    p_adj.add_argument("--informational", default=",".join(DEFAULT_INFORMATIONAL))
+    p_adj.add_argument("--percentiles", default=",".join(str(p) for p in DEFAULT_PERCENTILES))
+    p_adj.add_argument("--require-complete", action="store_true")
+    p_adj.add_argument("--json-out", help="also write the verdicts as JSON")
+    p_adj.set_defaults(func=adjudicate)
+
+    p_self = sub.add_parser("selftest", help="check the metric definitions against known answers")
+    p_self.set_defaults(func=selftest)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Three CI changes plus the instrument that decides whether they worked.

Not a cleanup — a before/after experiment with a frozen baseline, pre-registered predictions and falsifiers, landed in an order that makes the baseline provably pre-change.

## The commits

| | Change | Files |
|---|---|---|
| **c0** | `scripts/ci_throughput.py` + frozen baseline + pre-registered forecast | 4 |
| **c1** | `concurrency` + `cancel-in-progress` on 17 PR workflows | 17 |
| **c2** | MSRV Metal split out; 4 crates macOS→main-only | 6 |
| **c3** | VINDEX benches Linux-only | 1 |

## The baseline it is measured against

33 attempts across 20 branches, frozen in `docs/ci-throughput/before-e1.json` before any of c1–c3:

```
merge-ready p50           61m23s
merge-ready p95           95m07s
macOS queue max p50       20m18s
macOS queue max p95       68m09s
vindex windows exec p50   29m41s
superseded execution      931.6 runner-min total (28.2 mean/attempt)
```

## What the baseline changed about the plan

`c2` removes **27.9% of macOS queue-minutes for only 5.2% of macOS execution**. The jobs it drops are cheap to run and expensive to schedule — `quality`'s msrv-macOS leg was 33 jobs, 544 queue-minutes, 22 execution-minutes. So the mechanism is contention relief for a scarce runner pool, not less macOS compute. `larql-compute-metal`, 35.3% of all macOS execution, is deliberately untouched.

macOS legs were dropped only on positive evidence of no macOS-specific surface: no `cfg(target_os)`, no `cfg(unix)`/`cfg(windows)` split Linux and Windows don't already cover, no `blas-src`/Accelerate linkage. Crates that do take `features = ["accelerate"]` under a macOS cfg keep their macOS PR leg.

## Concurrency detail worth reviewing

Non-PR runs are keyed by `run_id`, not `github.ref`. A concurrency group holds at most one running and one *pending* run, and a newer pending run evicts the older — so grouping main pushes under `refs/heads/main` could destroy the CI record for an intermediate main commit even with `cancel-in-progress: false`.

`bench-regress.yml` is excluded from c1 until its baseline-restore semantics are inspected.

## Verification

- `actionlint` clean at every one of the four stages; baseline was already clean, so any finding would be new. Negative control fired on the `fromJSON` matrix expression.
- `ci_throughput.py selftest` — 26 checks including negative controls: a failing gate leaves merge-ready undefined; a cancelled run yields zero superseded execution; a thin AFTER sample makes P2 look `HELD` while the P3 validity gate vetoes C2 to `INVALID COMPARISON`.
- Scoring the baseline against itself **falsifies all four mechanisms** — evidence the forecast is not already satisfied by doing nothing.
- Sequence applied from a clean reconstruction and reproduces the reviewed tree byte-for-byte.

## Scoring this later

```
scripts/ci_throughput.py collect --since <date> --max-prs 20 --out docs/ci-throughput/after-e1.json
scripts/ci_throughput.py adjudicate --forecast docs/ci-throughput/E1-forecast.json \
                                    --before docs/ci-throughput/before-e1.json \
                                    --after  docs/ci-throughput/after-e1.json
```

Verdicts are per mechanism, so a good headline can't swallow the causal detail.

## Held back deliberately

vcpkg binary caching and `sccache` are E2. An actionlint gate and the five remaining ungated `cargo test --benches` steps are also held back — nothing else should touch CI until E1 has 10–20 observations, or the deltas stop being attributable.
