### PR TITLE
K3-ATTNRES-1 2c: the public readers acknowledge the attention-residual traversal (semantics 18)

### DIFF
--- a/crates/larql-models/src/config/residual_topology.rs
+++ b/crates/larql-models/src/config/residual_topology.rs
@@ -172,60 +172,6 @@ impl ResidualTopology {
     pub fn is_single_stream(&self) -> bool {
         matches!(self, Self::SingleStream)
     }
-
-    /// Why this build cannot EXECUTE this topology, when it cannot.
-    ///
-    /// ONE authority, two readers: the executor's preparation step
-    /// (`larql-vindex`'s `opplan::exec::prepared`), which refuses before a
-    /// single operand is loaded, and the plan report, which must say so.
-    /// Wave 11 established that a refusal only one consumer can see is
-    /// not a refusal, and that two lists of what cannot be lowered drift
-    /// into exactly that state.
-    ///
-    /// **The op plan is deliberately NOT a reader.** Wave 18 settled that
-    /// for hyper-connections and the same argument holds here: the
-    /// topology is a CLOSURE question at that stage — the per-layer site
-    /// operands classify, are required, are checked against the
-    /// topology's own geometry — and refusing there would hide the
-    /// addressability answer behind the traversal gap, which is the
-    /// structural silence a baseline with no `UnclassifiedOperand` at all
-    /// records.
-    ///
-    /// **This function returned `None` for everything between wave 19 and
-    /// K3-ATTNRES-1, and was deleted with its last reader.** Its own
-    /// documentation said a variant that refuses again must bring the
-    /// readers back beside it; that is what this is. Hyper-connections do
-    /// not refuse here — both their traversals were witnessed against the
-    /// reference — and attention residuals do, because no traversal for
-    /// them exists at all.
-    ///
-    /// Saying so precisely matters more than it looks. A stale reason
-    /// sends the next wave to build something that exists; a build that
-    /// lifted the refusal because the operands are addressable would be
-    /// claiming execution from addressing — the same mistake as grading a
-    /// config key representable because a parser read it.
-    pub fn unimplemented_reason(self) -> Option<&'static str> {
-        match self {
-            // Every judged traversal lowers. Hyper-connections joined
-            // them in wave 19, when the decode step and the batch
-            // traversal were each witnessed carrying the bundle against
-            // the reference's own oracle.
-            Self::SingleStream | Self::HyperConnection(_) => None,
-            Self::AttentionResidual { .. } => Some(
-                "the residual is one vector PLUS a history of block-boundary snapshots, and \
-                 every sublayer reads a softmax-weighted mix over that history before it runs \
-                 and adds its result back into the vector; the single-stream residual \
-                 programme cannot lower it without discarding the history, every read of it, \
-                 the periodic snapshot event and the required exit reduction. The declaration \
-                 is represented, the exit pair is owned as one object and the four per-layer \
-                 operands are addressed by role, so neither representation nor addressing is \
-                 what is missing. What is missing is the traversal AND the reference that \
-                 would judge it: this build carries no history in its carrier, and no oracle \
-                 for `_apply_attn_res` exists yet, so there is nothing an implementation could \
-                 be checked against",
-            ),
-        }
-    }
 }
 
 /// One operation in the execution language, named separately rather than
@@ -258,19 +204,30 @@ impl HyperConnectionWeights {
 mod tests {
     use super::*;
 
-    /// The two traversals this build runs lower; the third refuses.
+    /// **Every declared topology now lowers, and this build has no
+    /// `unimplemented_reason` to ask.**
     ///
     /// The refusal that lived here through waves 16-18 was retired in
-    /// wave 19, after the decode and batch traversals were each witnessed
-    /// against the reference's oracle — and returns for attention
-    /// residuals, which have neither a traversal nor an oracle. Both arms
-    /// are pinned: the second is what keeps the first from having been
-    /// implemented as "stop refusing topologies".
+    /// wave 19; it returned for attention residuals in K3-ATTNRES-1's
+    /// first transition, and is retired again here — its readers gone
+    /// with it — now that the decode traversal (2a) and the batch
+    /// traversal (2b) have each been witnessed against a Torch oracle
+    /// transcribed from the reference.
+    ///
+    /// The function is DELETED rather than left returning `None` for
+    /// everything, which is what it did between wave 19 and this rung.
+    /// A dead authority that still answers invites a reader to consult
+    /// it and conclude something; its own documentation asked that a
+    /// variant which refuses again bring the readers back beside it, and
+    /// that remains the contract for the next topology.
+    ///
+    /// What this test can still pin is the part that never depended on
+    /// the refusal: an attention residual carries ONE prefix sum, and is
+    /// still not the ordinary single-stream residual.
     #[test]
-    fn the_witnessed_traversals_lower_and_the_unwitnessed_one_refuses() {
+    fn every_declared_topology_lowers_and_attention_residuals_are_not_single_stream() {
         assert_eq!(ResidualTopology::SingleStream.streams(), 1);
         assert!(ResidualTopology::SingleStream.is_single_stream());
-        assert_eq!(ResidualTopology::SingleStream.unimplemented_reason(), None);
 
         let hc = ResidualTopology::HyperConnection(HyperConnection {
             streams: 4,
@@ -279,7 +236,6 @@ mod tests {
         });
         assert_eq!(hc.streams(), 4);
         assert!(!hc.is_single_stream());
-        assert_eq!(hc.unimplemented_reason(), None);
 
         let attn_res = ResidualTopology::AttentionResidual { block_size: 12 };
         // ONE prefix sum, and a history beside it that no width declares.
@@ -287,9 +243,6 @@ mod tests {
         // ...and still not the ordinary residual: the programme differs,
         // so a plan carrying it must serialise the field.
         assert!(!attn_res.is_single_stream());
-        assert!(attn_res
-            .unimplemented_reason()
-            .is_some_and(|reason| reason.contains("traversal")));
     }
 
     /// The block size is read as declared and never re-derived: two

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -1545,67 +1545,23 @@ impl PreparedOperands {
     ) -> Result<Self, VindexError> {
         let store = store.into();
         slice.validate(plan)?;
-        // **Refuse before any operand is loaded.** The plan may carry a
-        // residual topology this build cannot traverse. Hyper-connections
-        // are not that any more — wave 19 witnessed the bundle on both
-        // the decode step and the batch traversal — but attention
-        // residuals are: the carrier holds one vector and no snapshot
-        // history, so an attention-residual plan prepared here would run
-        // a K3-shaped model as an ordinary one and produce fluent wrong
-        // output rather than a failure.
+        // **Every declared residual topology is traversable here.**
+        // Single-stream always was; hyper-connections joined it in wave
+        // 19 when the bundle was witnessed on both the decode step and
+        // the batch traversal; attention residuals join it now, their
+        // decode (2a) and batch (2b) traversals each witnessed against a
+        // Torch oracle transcribed from the reference. The authority
+        // this used to consult — `ResidualTopology::unimplemented_reason`
+        // — is deleted rather than left answering `None`, so there is no
+        // dead refusal here for a reader to consult and conclude from.
+        // A topology that cannot be traversed again must bring both the
+        // authority and its readers back together.
         //
-        // Read from the same authority the plan report refuses on, so a
-        // plan the report calls not executable can never be prepared
-        // here. The authority lifts only when a traversal exists AND an
-        // oracle has judged it.
-        if let Some(reason) = plan.residual_topology.unimplemented_reason() {
-            return Err(VindexError::Parse(format!(
-                "component `{}`: residual topology {:?} is represented and its operands are \
-                 addressed, but this build cannot execute it — {reason}",
-                plan.component, plan.residual_topology
-            )));
-        }
         // What a hyper-connected image still cannot be is said below by
         // name — a whole-stack image with no declared head reduction, a
         // layer scale under the topology — and the plan report reads the
         // same facts, so a plan it calls executable is one prepared here.
         Self::load_validated(plan, store, backend, slice, budget)
-    }
-
-    /// **The 2a witness seam.** Prepares an attention-residual plan
-    /// WITHOUT the public topology refusal, so the decode traversal can
-    /// be proven against the oracle while [`Self::load`] keeps refusing.
-    ///
-    /// Test-only by construction (`cfg(test)`), crate-internal, and
-    /// attention-residual plans only: a plan of any other topology is
-    /// sent back to the public path, so nothing prepared here is ever
-    /// the thing a caller could have prepared without the seam.
-    /// Everything below the refusal is the production loader — this is
-    /// the refusal removed, not a second loader. Removed at the lift,
-    /// when the authority itself lifts.
-    #[cfg(test)]
-    pub(super) fn load_for_attention_residual_witness<'s, B: PlanBackend + ?Sized>(
-        plan: &ComponentOpPlan,
-        store: impl Into<OperandSource<'s>>,
-        backend: &B,
-        slice: ExecutionSlice,
-    ) -> Result<Self, VindexError> {
-        let store = store.into();
-        slice.validate(plan)?;
-        if !matches!(
-            plan.residual_topology,
-            ResidualTopology::AttentionResidual { .. }
-        ) {
-            return Err(VindexError::Parse(format!(
-                "component `{}` declares {:?}; the witness seam prepares attention-residual \
-                 plans only, and this plan takes the public path",
-                plan.component, plan.residual_topology
-            )));
-        }
-        // The same budget the public `load` passes. This seam is that
-        // loader with the topology refusal removed and nothing else
-        // changed, so it must not acquire a residency policy of its own.
-        Self::load_validated(plan, store, backend, slice, &ResidencyBudget::UNBOUNDED)
     }
 
     /// The loader proper, past slice validation. Every operand the slice

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attn_res_2a_decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attn_res_2a_decode.rs
@@ -539,36 +539,32 @@ fn the_two_numerically_inert_mutations_are_caught_by_the_witness_alone() {
 
 // ── What has NOT lifted ─────────────────────────────────────────────
 
-/// 2a proves the decode traversal and lifts nothing PUBLIC. The loader
-/// every ordinary caller reaches still refuses the topology by name, so
-/// the witness seam that proves the traversal cannot make the component
-/// look supported.
+/// **What 2a and 2b refused, the lift now prepares — through the public
+/// loader, which is the one every witness in this rung reaches.**
 ///
-/// The batch half of this test is GONE, and its absence is the record
-/// of a real change rather than a deletion of inconvenient evidence:
-/// 2a asserted that the batch traversal refused an attention-residual
-/// image by name, and 2b builds the per-position history that refusal
-/// was standing in for. What replaces it lives in `attn_res_2b_batch`,
-/// where the batch path is required to RUN and to be caught by three
-/// positional controls — a stronger obligation than the refusal it
-/// retires. The public refusal here is untouched, and it is the one
-/// that gates the rung.
+/// This test asserted the opposite through both traversal transitions:
+/// the public loader refused the topology by name, and the witnesses
+/// prepared through a test-only seam so that proving the traversal could
+/// not be mistaken for lifting it. At the lift the refusal went and the
+/// seam went with it, so `prepare` in `attn_res_substrate` is now this
+/// same call — every assertion in this file and in `attn_res_2b_batch`
+/// scores the path a real caller takes.
+///
+/// Kept as its own test rather than left implicit in `prepare` because
+/// the claim is about the PUBLIC surface, and a change that reintroduced
+/// a refusal there would otherwise surface as thirteen confusing
+/// failures instead of one clear one.
 #[test]
-fn the_public_loader_still_refuses() {
+fn the_public_loader_prepares_what_it_used_to_refuse() {
     let sub = substrate();
     let store = OperandStore::open(sub.container.path(), &sub.inspection).unwrap();
-
-    let public = match PreparedOperands::load(
+    PreparedOperands::load(
         &sub.plan,
         &store,
         &ReferenceBackend::new(),
         ExecutionSlice::Full,
-    ) {
-        Ok(_) => panic!("the public loader must still refuse an attention-residual plan"),
-        Err(err) => err.to_string(),
-    };
-    assert!(public.contains("cannot execute it"), "{public}");
-    assert!(public.contains("traversal"), "{public}");
+    )
+    .expect("the public loader prepares an attention-residual plan");
 }
 
 /// **Observation is optional, and the traversal must not depend on being

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attn_res_substrate.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/attn_res_substrate.rs
@@ -340,17 +340,26 @@ pub(super) fn substrate() -> Substrate {
     }
 }
 
-/// Prepare through the 2a WITNESS SEAM — the public loader still
-/// refuses, and a test that reached the traversal through it would be
-/// proving the refusal had already lifted.
+/// Prepare through the PUBLIC loader.
+///
+/// Through 2a and 2b this went via a test-only witness seam, because the
+/// public loader refused the topology by name and a test that reached
+/// the traversal through it would have been proving the refusal had
+/// already lifted. At the lift the refusal went and the seam went with
+/// it — its own documentation asked for exactly that — so every witness
+/// in this rung now prepares the way an ordinary caller does.
+///
+/// That is a strengthening of the two witnesses, not a convenience: they
+/// score the traversal a real caller reaches, and there is no longer a
+/// second loader that could drift from the first.
 pub(super) fn prepare(sub: &Substrate) -> (OperandStore, PreparedOperands) {
     let store = OperandStore::open(sub.container.path(), &sub.inspection).unwrap();
-    let ops = PreparedOperands::load_for_attention_residual_witness(
+    let ops = PreparedOperands::load(
         &sub.plan,
         &store,
         &ReferenceBackend::new(),
         ExecutionSlice::Full,
     )
-    .expect("the witness seam prepares an attention-residual plan");
+    .expect("the public loader prepares an attention-residual plan");
     (store, ops)
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/tests/k3_attnres_addressing.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/tests/k3_attnres_addressing.rs
@@ -41,6 +41,7 @@ use crate::format::vindex3::inspect::inspect_container;
 use crate::format::vindex3::opplan::exec::execute_text;
 use crate::format::vindex3::opplan::exec::operands::OperandStore;
 use crate::format::vindex3::opplan::{plan_component_ops, ClosureDefect, OpPlanOutcome};
+use crate::format::vindex3::plan::carriage::Carriage;
 use crate::format::vindex3::plan::plan_system;
 use crate::format::vindex3::plan::tests_support::{custom_artifact, glimmer_shaped_target_with};
 use larql_models::config::ResidualTopology;
@@ -488,21 +489,37 @@ fn a_declaration_with_no_exit_pair_blocks_by_the_exit_s_own_name() {
     );
 }
 
-/// **One authority, two readers.** The report calls a complete
-/// attention-residual surface not executable, and the executor refuses
-/// to prepare the same plan — both from
-/// [`ResidualTopology::unimplemented_reason`], so a plan the report
-/// calls executable can never be one the executor rejects, nor the
-/// reverse.
+/// **One authority, two readers — and at the lift both stop refusing
+/// together.**
 ///
-/// The seam that read this was retired in wave 19 when every judged
-/// topology lowered; its own documentation required that a variant which
-/// refuses again bring the readers back beside it, and this is that
-/// variant. The single-stream control keeps the arm honest: the same
-/// estate minus the topology executes end to end, so what is being
-/// witnessed is the refusal and not a broken fixture.
+/// Through K3-ATTNRES-1's first transition this test asserted the
+/// mirror image: the report called a complete attention-residual surface
+/// not executable and the executor refused the same plan, both reading
+/// `ResidualTopology::unimplemented_reason`. That function is now
+/// deleted, along with both readers, because the decode traversal (2a)
+/// and the batch traversal (2b) were each witnessed against a Torch
+/// oracle transcribed from the reference.
+///
+/// So the test is inverted rather than removed, and it is the same
+/// claim from the other side: what one reader admits, the other must
+/// prepare AND run. A lift that moved the report without the executor
+/// would be exactly the drift the single-authority rule exists to
+/// prevent, and it would be invisible to a test that only checked the
+/// report.
+///
+/// Two arms keep this from having been implemented as "stop refusing
+/// attention residuals":
+///
+///   - the SINGLE-STREAM control, unchanged from the refusing version:
+///     the same estate minus the topology still executes, so what is
+///     being witnessed is the topology and not a fixture that got
+///     easier.
+///   - the EXIT-PAIR arm, in the test immediately above this one: the
+///     same estate without an `attention_residual_exit` object is still
+///     blocked by that object's absence. Capability was granted to a
+///     traversal, not to the declaration.
 #[test]
-fn the_report_and_the_executor_refuse_the_topology_through_one_authority() {
+fn the_report_admits_the_topology_and_the_executor_runs_it() {
     let source = tempfile::tempdir().unwrap();
     let tensors = full_tensors();
     let borrowed: Vec<(&str, &[usize])> = tensors
@@ -511,37 +528,29 @@ fn the_report_and_the_executor_refuse_the_topology_through_one_authority() {
         .collect();
     let inventory = custom_artifact(source.path(), &config(true), &borrowed);
     let system = plan_system(&[(ARTIFACT.to_string(), inventory)]);
-    assert!(!system.admissible, "{:?}", system.summary);
     let blockers: Vec<_> = system
         .artifacts
         .iter()
         .flat_map(|a| &a.findings)
         .filter(|f| f.blocks())
         .collect();
-    assert_eq!(blockers.len(), 1, "{blockers:?}");
     assert!(
-        blockers[0].subject.ends_with("execution_surface")
-            && blockers[0].detail.contains("NOT executable"),
-        "{:?}",
-        blockers[0]
+        blockers.is_empty(),
+        "a complete attention-residual surface must no longer block: {blockers:?}"
     );
-    // The report says the topology is represented and its operands
-    // addressed — the gap is the traversal, not the representation.
-    assert!(
-        blockers[0].detail.contains("traversal"),
-        "{:?}",
-        blockers[0]
-    );
+    assert!(system.admissible, "{:?}", system.summary);
 
-    // The executor, on the very same facts.
+    // The executor, on the very same facts: it prepares, and it runs the
+    // whole stack rather than merely accepting the plan.
     let planned = plan(config(true), full_tensors());
     let attn_res_plan = planned.outcome.plan.as_ref().unwrap();
+    assert!(matches!(
+        attn_res_plan.residual_topology,
+        ResidualTopology::AttentionResidual { .. }
+    ));
     let store = OperandStore::open(planned.container.path(), &planned.inspection).unwrap();
-    let err = execute_text(attn_res_plan, &store, &[1, 2, 3])
-        .expect_err("an attention-residual plan must not prepare")
-        .to_string();
-    assert!(err.contains("cannot execute it"), "{err}");
-    assert!(err.contains("traversal"), "{err}");
+    execute_text(attn_res_plan, &store, &[1, 2, 3])
+        .expect("an attention-residual plan prepares and executes");
 
     // The control: one stream, the same estate minus the topology and
     // its operands, executes.
@@ -642,7 +651,16 @@ fn the_period_is_carried_only_where_the_surface_actually_builds() {
     });
     assert!(!builds.blocks(), "{builds:?}");
     assert_eq!(builds.resolved, Some(serde_json::json!(BLOCK)));
-    assert!(builds.detail.contains("represented"), "{builds:?}");
+    // **`Lowered` since the lift, and the stage is asserted rather than
+    // matched as a substring of the prose.** The period now reaches a
+    // traversal that reads it, so `Represented` would understate what
+    // this build does with the key.
+    //
+    // The key did NOT change whether it blocks, and that half is scored
+    // here too: it was already Representable/ExecutionSemantic and
+    // non-blocking at `Represented`, so a COUNT that moved when the
+    // stage did would mean the stage name was doing work it should not.
+    assert_eq!(builds.carriage, Some(Carriage::Lowered), "{builds:?}");
 
     let refuses = finding_for(|config| {
         config["text_config"]["attn_res_block_size"] = serde_json::json!(BLOCK);

--- a/crates/larql-vindex/src/format/vindex3/plan/carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/carriage.rs
@@ -219,18 +219,25 @@ pub const CARRIAGE_RULES: &[CarriageRule] = &[
         probe: Some(probe_hc_eps),
     },
     // The attention-residual period (K3-ATTNRES-1). ONE declared
-    // component fact, carried to the component's residual topology —
-    // and it stops there ON PURPOSE. `Represented`, not `Lowered`: no
-    // traversal reads a snapshot history, so the executor refuses the
-    // topology by name at preparation and a `Lowered` claim would say a
-    // backend receives this period when nothing does. The probe reads
-    // the BUILT surface, so a checkpoint whose surface does not build
-    // answers nothing here and the row keeps its blocker — the lesson
-    // wave 19 learned when DeepSeek-V4's rows did not move.
+    // component fact, carried to the component's residual topology and
+    // now all the way to a traversal that reads it. `Lowered` since
+    // K3-ATTNRES-1: the executor's history carrier asks this period
+    // which layers take a block-boundary snapshot, on the decode path
+    // (2a) and the batch path (2b), each witnessed against a Torch
+    // oracle transcribed from the reference. Before that it stopped at
+    // `Represented` on purpose, because a `Lowered` claim would have
+    // said a backend receives this period when nothing did.
+    //
+    // The COUNT does not move on this reader — the leaf was already
+    // Representable/ExecutionSemantic and non-blocking — and that is
+    // the point: a count that changed here would mean the stage name was
+    // doing work it should not. The probe still reads the BUILT surface,
+    // so a checkpoint whose surface does not build answers nothing here
+    // and keeps its blocker, the lesson wave 19 learned on DeepSeek-V4.
     CarriageRule {
         leaf: "attn_res_block_size",
-        reaches: Carriage::Represented,
-        site: "Component.execution.residual_topology (ResidualTopology::AttentionResidual.block_size) — and no further: this build has no traversal that carries the snapshot history, so the executor refuses the topology at preparation",
+        reaches: Carriage::Lowered,
+        site: "Component.execution.residual_topology (ResidualTopology::AttentionResidual.block_size) → the executor's attention-residual history carrier, which reads the period to decide which layers take a block-boundary snapshot (opplan::exec::attention_residual::is_block_boundary, on the decode and batch traversals alike)",
         probe: Some(probe_attn_res_block_size),
     },
     // ── Position ────────────────────────────────────────────────────

--- a/crates/larql-vindex/src/format/vindex3/plan/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/mod.rs
@@ -943,15 +943,23 @@ fn execution_surface_findings(artifact: &str, built: &BuiltGraph) -> Vec<Finding
                 o.component == component.id
                     && matches!(o.kind, super::graph::ObjectKind::AttentionResidualExit)
             });
-            // Second: a topology this build represents and cannot
-            // traverse. The seam that read this was retired in wave 19,
-            // when every judged topology lowered and it had nothing left
-            // to read; its own documentation said a variant that refuses
-            // again must bring the reader back beside it, and K3-ATTNRES-1
-            // is that variant. `None` for hyper-connections, whose
-            // traversals were witnessed.
-            let unlowerable = surface.residual_topology.unimplemented_reason();
-            // Third: a hyper-connected component with no head object
+            // **There is no longer a "cannot traverse this topology"
+            // refusal here, and its absence is deliberate.** It read
+            // `ResidualTopology::unimplemented_reason`, which is deleted:
+            // single-stream always lowered, hyper-connections joined it in
+            // wave 19, and attention residuals join it in K3-ATTNRES-1
+            // now that the decode (2a) and batch (2b) traversals have each
+            // been witnessed against a Torch oracle. A topology that
+            // cannot be traversed again brings both the authority and this
+            // reader back together, which is the contract the deleted
+            // function stated for itself twice.
+            //
+            // The two refusals that remain are NOT about traversal, and
+            // retiring the third must not quietly retire them: they are
+            // missing DECLARED objects, and a component that ships no exit
+            // pair or no head is blocked whatever this build can traverse.
+            //
+            // Second: a hyper-connected component with no head object
             // (GLM-5.3-Flash: `mhc` unexplained, no `hc_head_*` shipped)
             // runs layer by layer but has no declared reduction from the
             // bundle to the one vector the final norm reads, and this
@@ -971,11 +979,6 @@ fn execution_surface_findings(artifact: &str, built: &BuiltGraph) -> Vec<Finding
                      component declares no attention_residual_exit object: the topology's own \
                      reduction from the snapshot history to the one vector the final norm \
                      reads is required by the declaration, and this build does not invent one",
-                    surface.residual_topology
-                ))
-            } else if let Some(reason) = unlowerable {
-                Some(format!(
-                    "{:?} is representable but NOT executable by this build — {reason}",
                     surface.residual_topology
                 ))
             } else if headless {

--- a/crates/larql-vindex/src/format/vindex3/plan/report.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/report.rs
@@ -57,6 +57,37 @@ pub const PLAN_SCHEMA: u32 = 6;
 /// `plan/tests/identity.rs` pins fixture verdicts against this value, so
 /// a change that flips one fails there until the version is bumped.
 ///
+/// **18** — attention-residual TRAVERSAL (K3-ATTNRES-1, transition 2).
+/// The topology is executed, not merely addressed: the executor carries
+/// an explicit prefix-plus-snapshots state through the decode traversal
+/// (2a) and one such state PER POSITION through the batch traversal
+/// (2b), each witnessed against a Torch oracle transcribed from
+/// `modeling_kimi_linear.py` before any Rust arithmetic was written.
+///
+/// Two readers move together, as they did at 17 and for the same
+/// reason. `ResidualTopology::unimplemented_reason` is DELETED rather
+/// than left answering `None` — the state it sat in between wave 19 and
+/// this rung — and both the plan report's traversal refusal and the
+/// executor's preparation refusal go with it. A dead authority that
+/// still answers invites a reader to consult it; the contract for the
+/// next topology that cannot be traversed is to bring the authority and
+/// its readers back together.
+///
+/// `attn_res_block_size` moves `Represented` -> `Lowered`, its site now
+/// naming the history carrier that reads the period. That reader's
+/// COUNT does not move: the leaf was already non-blocking, and a count
+/// that changed there would mean the stage name was doing work it
+/// should not.
+///
+/// What does NOT lift: a component declaring the topology and shipping
+/// no `attention_residual_exit` object is still blocked by that object's
+/// absence, which is the arm that keeps this from having been
+/// implemented as "stop refusing attention residuals". Nor does anything
+/// else about K3 — its op plan still does not close on `self_attn.g_proj`
+/// (K3-REP-GATE-1) and the routed-expert bank is its own rung, so the
+/// row moves at the plan level only and the traversal it thereby stops
+/// refusing has never run on it.
+///
 /// **17** — attention residuals are a declared RESIDUAL TOPOLOGY, owned
 /// and addressed, and explicitly not traversable (K3-ATTNRES-1,
 /// transition 1). Read from Kimi-K3's own `modeling_kimi_linear.py`
@@ -287,7 +318,7 @@ pub const PLAN_SCHEMA: u32 = 6;
 /// architectures, now block instead of passing silently into
 /// `GenericArch`'s Llama-shaped defaults. Measured on the conformance
 /// corpus: 15 of 42 declared `model_type` strings, across 30 checkpoints.
-pub const PLANNER_SEMANTICS_VERSION: u32 = 17;
+pub const PLANNER_SEMANTICS_VERSION: u32 = 18;
 
 /// Who judged a plan.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/larql-vindex/src/format/vindex3/plan/tests/identity.rs
+++ b/crates/larql-vindex/src/format/vindex3/plan/tests/identity.rs
@@ -101,7 +101,7 @@ fn identity_survives_a_round_trip_and_parse_refuses_other_schemas_by_name() {
 /// witness is re-recorded.
 #[test]
 fn the_semantics_version_is_pinned_to_known_verdicts() {
-    assert_eq!(PLANNER_SEMANTICS_VERSION, 17);
+    assert_eq!(PLANNER_SEMANTICS_VERSION, 18);
 
     let dir = tempfile::tempdir().unwrap();
     let admissible = plan_system(&one_glimmer(dir.path()));
@@ -300,16 +300,22 @@ fn the_semantics_version_is_pinned_to_known_verdicts() {
         blockers[0]
     );
 
-    // Version 17's verdict (K3-ATTNRES-1, transition 1): an
+    // Version 18's verdict (K3-ATTNRES-1, transition 2): an
     // attention-residual stack with every site operand AND the exit pair
-    // is REPRESENTED — its period is carried, its exit is one placed
-    // object, its four per-layer operands are addressed — and blocked by
-    // ONE finding, the topology's own refusal, because no traversal for
-    // it exists. The same stack without the exit pair is blocked by the
-    // exit's finding instead. Both arms pinned: the second is what keeps
-    // the first from having been implemented as "refuse anything that
-    // declares a period", and a plan that BLOCKED on neither would be
-    // the fail-open this rung exists to make impossible.
+    // is ADMISSIBLE — its period is carried to a traversal that reads
+    // it, its exit is one placed object, its four per-layer operands are
+    // addressed, and the decode (2a) and batch (2b) traversals have each
+    // been witnessed against a Torch oracle. At version 17 this same
+    // estate was blocked by ONE finding, the topology's own refusal,
+    // because no traversal existed; that refusal and both its readers
+    // are now deleted.
+    //
+    // The same stack WITHOUT the exit pair is still blocked, by the
+    // exit's own finding. That arm is what keeps the first from having
+    // been implemented as "stop refusing anything that declares a
+    // period": capability was granted to a traversal, not to the
+    // declaration. A plan that blocked on NEITHER would be the fail-open
+    // this rung exists to make impossible.
     let attn_res_stack = |exit: bool| -> SystemPlan {
         let dir = tempfile::tempdir().unwrap();
         let mut config = serde_json::json!({
@@ -352,23 +358,36 @@ fn the_semantics_version_is_pinned_to_known_verdicts() {
         let inventory = custom_artifact(dir.path(), &config, &tensors);
         plan_system(&[(ARTIFACT.to_string(), inventory)])
     };
-    for (exit, expected) in [(true, "traversal"), (false, "attention_residual_exit")] {
-        let plan = attn_res_stack(exit);
-        assert!(!plan.admissible, "exit={exit}: {:?}", plan.summary);
-        let blockers: Vec<_> = plan
-            .artifacts
-            .iter()
-            .flat_map(|a| &a.findings)
-            .filter(|f| f.blocks())
-            .collect();
-        assert_eq!(blockers.len(), 1, "exit={exit}: {blockers:?}");
-        assert!(
-            blockers[0].subject.ends_with("execution_surface")
-                && blockers[0].detail.contains(expected),
-            "exit={exit}: {:?}",
-            blockers[0]
-        );
-    }
+    let complete = attn_res_stack(true);
+    assert!(
+        complete.admissible,
+        "a complete attention-residual estate is admissible at semantics 18: {:?}",
+        complete.summary
+    );
+    assert_eq!(complete.summary.blocking, 0, "{:?}", complete.summary);
+
+    let no_exit = attn_res_stack(false);
+    assert!(!no_exit.admissible, "{:?}", no_exit.summary);
+    let blockers: Vec<_> = no_exit
+        .artifacts
+        .iter()
+        .flat_map(|a| &a.findings)
+        .filter(|f| f.blocks())
+        .collect();
+    assert_eq!(blockers.len(), 1, "{blockers:?}");
+    assert!(
+        blockers[0].subject.ends_with("execution_surface")
+            && blockers[0].detail.contains("attention_residual_exit"),
+        "{:?}",
+        blockers[0]
+    );
+    // ...and it is blocked by the EXIT, not by a traversal refusal that
+    // should no longer exist anywhere in the report.
+    assert!(
+        !blockers[0].detail.contains("NOT executable"),
+        "the traversal refusal must be gone from the report: {:?}",
+        blockers[0]
+    );
 }
 
 fn pinned(commit: &str) -> ArtifactSource {

--- a/docs/arch-conformance/forecasts/k3-attnres-1-execution-notes.json
+++ b/docs/arch-conformance/forecasts/k3-attnres-1-execution-notes.json
@@ -288,5 +288,68 @@
     "gates": "cargo fmt --check clean; cargo clippy -p larql-vindex --all-targets -D warnings clean; cargo clippy -p larql-cli --bins --tests -D warnings clean in both its default and --no-default-features forms; cargo check --workspace --all-targets clean \u2014 run because `Plane` is a public type and a crate-scoped gate cannot see its readers; the full larql-vindex suite green; larql-vindex coverage measured against its own policy after a clean of stale profdata.",
     "what_this_transition_does_not_claim": "nothing about K3 itself. K3's op plan still does not close, so no assertion here has ever run on the real row; the substrate is synthetic by construction and its branch is an ordinary attention and FFN, not KDA or MLA. This shows the topology traverses correctly around an ordinary branch, per position, in batch \u2014 and that is all it shows.",
     "next": "the lift, as its own step: `unimplemented_reason` returns None for AttentionResidual, its two readers follow, the carriage rule moves from `represented` to `lowered`, and P3 to P10 are scored from a re-plan \u2014 the verdict FORECAST FROM THE CLASSIFIER rather than from blocker arithmetic, which is the lesson transition 1's P8 was falsified by."
+  },
+
+  "transition_2c_the_lift": {
+    "written": "2026-09-06",
+    "scored_against": "docs/arch-conformance/forecasts/k3-attnres-1-traverse.json \u2014 the LIFT half of that freeze's `2b_batch_and_lift` split, taken as its own transition so the batch witness could be shown to fail before any reader moved.",
+    "what_landed": [
+      "`ResidualTopology::unimplemented_reason` DELETED, not left returning `None` for everything \u2014 the state it sat in between wave 19 and this rung. A dead authority that still answers invites a reader to consult it and conclude something.",
+      "both readers deleted with it, together: the plan report's traversal refusal and the executor's preparation refusal. The single-authority rule is what made that a two-line change rather than a search.",
+      "the `#[cfg(test)]` witness seam `load_for_attention_residual_witness` REMOVED. Its own documentation asked for exactly that at the lift. Both witnesses now prepare through the public `PreparedOperands::load`, so they score the path an ordinary caller reaches and there is no second loader that could drift from the first.",
+      "`attn_res_block_size` carriage `Represented` -> `Lowered`, its site naming the history carrier that reads the period.",
+      "semantics 17 -> 18, with the changelog entry stating what lifted and what did not.",
+      "three fixture migrations, each inverted rather than deleted: the models-side topology test, `k3_attnres_addressing`'s one-authority test (now: the report admits AND the executor runs), and the identity pin's version-17 arm (now version 18's verdict pair)."
+    ],
+    "measurement": {
+      "protocol": "release `vindex` built per arm from that arm's sources; `vindex plan hf://<repo> --json` for K3 and the eight controls into two separate caches; scored by importing `scripts/arch_sweep.py` and calling its own `classify`, so the verdict is the classifier's and not arithmetic of mine.",
+      "THE_CANONICAL_CACHE_COULD_NOT_BE_THE_BASELINE": "It sits at semantics 16, and this transition is 17 -> 18. Scoring 18 against 16 would have folded transition 1's movement into the lift's score \u2014 the 'uniform cache before baseline' failure, in its cross-transition form. So BOTH arms were measured here: baseline = merged main (3e6e76f4, semantics 17), candidate = this branch (semantics 18), same nine rows, same protocol, same machine.",
+      "the_baseline_arm_reproduces_transition_1_exactly": "All eight controls came back at the numbers transition 1 recorded \u2014 Kimi-Linear 0/64, GLM-5.3-Flash 28/91, GLM-5.3 19/76, DeepSeek-V4-Flash 31/73, DeepSeek-V4-Pro 31/73, Hy4-preview 32/76, Qwen3-0.6B 0/40, Qwen3.8-Flash-Next 36/80 \u2014 and K3 at 32/152. An independently rebuilt baseline landing on the previously recorded numbers is what makes the candidate arm's single difference readable as this transition's effect."
+    },
+    "predictions_scored": {
+      "P3_execution_surface_finding_178": {
+        "result": "HELD",
+        "evidence": "`target.execution_surface`, finding id 178, unrepresented/unsupported_component in the baseline arm and ABSENT in the candidate. K3 -1 on this reader. The `execution_surface` cluster goes 1 -> 0."
+      },
+      "P4_net_on_the_k3_row": {
+        "result": "HELD",
+        "evidence": "text_generation blocking 32/152 -> 31/152. A reading of 30 was scored in advance as the fail-open; it did not occur. The blocker-subject delta is exactly one REMOVAL and zero additions, so the lift retired the traversal refusal and granted no other capability."
+      },
+      "P5_the_k3_VERDICT": {
+        "result": "HELD",
+        "evidence": "AMBER -> RED, read from `arch_sweep.classify` rather than from blocker arithmetic \u2014 the discipline transition 1's falsified P8 taught. `unsupported_component` findings 1 -> 0, which empties the class and makes the classifier's AMBER arm unreachable for the row. The baseline reason was 'component identified, no implementation'; the candidate's is '31 blocking on text closure'.",
+        "why_this_is_success_not_regression": "AMBER meant 'identified component, no implementation'. Once the component IS implemented that reason must disappear, even though K3 stays blocked on 31 other things. A row that stayed AMBER here would have meant an unaccounted `unsupported_component` was still standing."
+      },
+      "P6_carriage_stage_moves_and_the_count_does_not": {
+        "result": "HELD on both halves",
+        "evidence": "`text_config.attn_res_block_size` carriage `represented` -> `lowered`; class execution_semantic, category representable, blocking False in BOTH arms. The count did not move on this reader, which is what says the stage name is not doing work it should not."
+      },
+      "P7_op_plan_unchanged": {
+        "result": "HELD",
+        "evidence": "K3's text capability is inadmissible in both arms (31 of 152 still blocking), so its executor is never reached and every witness in this rung remains on the synthetic substrate. No finding in the ResidualWiring / LayerRole / ObjectBinding clusters moved."
+      },
+      "P8_controls": {
+        "result": "HELD, and this time on the verdict line too",
+        "evidence": "Zero movement on all eight controls across blockers, unsupported_component count and verdict. Kimi-Linear-48B-A3B-Instruct GREEN 0/64, GLM-5.3-Flash RED 28/91, GLM-5.3 RED 19/76, DeepSeek-V4-Flash AMBER 31/73, DeepSeek-V4-Pro AMBER 31/73, Hy4-preview RED 32/76, Qwen3-0.6B GREEN 0/40, Qwen3.8-Flash-Next RED 36/80.",
+        "the_other_108_rows": "not re-planned, and the argument was CHECKED rather than assumed, the way transition 1 checked it. All 117 cached plans were scanned on two planes: exactly ONE mentions `attn_res_block_size` and exactly ONE binds an `attn_res` operand group \u2014 Kimi-K3 both times. Every rule this transition touches is gated on `ResidualTopology::AttentionResidual`, which only that declaration produces, so no other row can move."
+      },
+      "P9_semantics_version": {
+        "result": "HELD",
+        "evidence": "17 -> 18, stamped on every plan in the candidate arm. The identity pin gained this transition's verdict PAIR: a synthetic attention-residual estate with every operand and the exit pair is now ADMISSIBLE, and the same estate without the exit pair stays blocked by the exit's own finding \u2014 asserted, plus an explicit assertion that the traversal refusal's wording is gone from that report. The second arm is what keeps the first from having been implemented as 'stop refusing attention residuals'."
+      },
+      "P10_fixture_migration_named": {
+        "result": "HELD",
+        "evidence": "Exactly the three the freeze named, and no others: `plan/tests/identity.rs` (version 18, first arm flipped blocked -> admissible), `opplan/tests/k3_attnres_addressing.rs::the_report_and_the_executor_refuse_the_topology_through_one_authority` rewritten as `the_report_admits_the_topology_and_the_executor_runs_it` keeping its single-stream control, and `larql-models`'s topology test. Two tests failed on the first full run and they were these; nothing else in 4363 changed meaning."
+      }
+    },
+    "falsifiers_checked": {
+      "k3_reads_30_or_fewer": "did not occur. 31, the forecast value. 30 was the pre-declared fail-open.",
+      "k3_stays_AMBER": "did not occur. RED, from the classifier. Had it stayed AMBER the instruction was to stop and find the extra `unsupported_component` rather than rationalise it \u2014 there was none to find.",
+      "any_row_other_than_k3_moves": "did not occur, on nine measured rows and on a structural scan of all 117.",
+      "capability_granted_past_the_boundary": "did not occur. The exit-missing refusal and the hyper-connection headless refusal both survive in the report by name; only the traversal refusal was retired. The blocker delta on K3 is one removal, zero additions."
+    },
+    "what_this_transition_does_not_claim": "that K3 runs. Its text closure still names 31 blockers across representation_quantization (14), unclustered (14), ffn_activation, moe_routing and modality_vision. The row moved at the plan level only, and the traversal it thereby stops refusing has never executed on it \u2014 every witness in this rung is on a synthetic substrate whose branch is an ordinary attention and FFN, not KDA or MLA.",
+    "gates": "fmt; clippy on larql-vindex, larql-models and larql-cli; `cargo check --workspace --all-targets`; larql-models 799 + 100, larql-vindex 4363, larql-server 591, all green.",
+    "rung_status": "K3-ATTNRES-1 is CLOSED with this transition. What remains of K3 is not this rung: `self_attn.g_proj` is K3-REP-GATE-1 and the routed-expert bank is K3-LATENTMOE-1."
   }
 }


### PR DESCRIPTION
K3-ATTNRES-1 transition 2c — **the lift, and the rung's last**. Deliberately boring: no attention-residual arithmetic, no traversal semantics. 2a (#429) and 2b (#431) proved the execution; this only makes the public capability readers say what those witnesses established.

## What it does

- `ResidualTopology::unimplemented_reason` **deleted**, not left returning `None` for everything — the state it sat in between wave 19 and this rung. A dead authority that still answers invites a reader to consult it and conclude something.
- **Both readers deleted with it, together**: the plan report's traversal refusal and the executor's preparation refusal. The single-authority rule is what made that a two-line change instead of a search.
- The `#[cfg(test)]` witness seam **removed**, as its own documentation asked at the lift. Both traversal witnesses now prepare through the public `PreparedOperands::load` — the path an ordinary caller reaches, with no second loader that could drift from the first.
- `attn_res_block_size` carriage **Represented → Lowered**, site naming the history carrier that reads the period.
- Semantics **17 → 18**.

## Scored

Both arms measured for this PR rather than against the canonical cache, which sits at **semantics 16** and would have folded transition 1's movement into this transition's score. Baseline = merged main (`3e6e76f4`, sem 17); candidate = this branch (sem 18); same nine rows, same protocol, release build per arm.

| | baseline (17) | candidate (18) |
|---|---|---|
| Kimi-K3 text closure | 32/152 | **31/152** |
| `unsupported_component` | 1 | **0** |
| verdict | AMBER | **RED** |

**AMBER → RED is the success condition, not a regression.** AMBER meant "identified component, no implementation"; once the component *is* implemented that reason must disappear, even though K3 stays blocked on 31 other things. A row that stayed AMBER would have meant an unaccounted `unsupported_component` was still standing. 30 was the pre-declared fail-open and did not occur.

The verdict comes from `arch_sweep.classify` itself, not from blocker arithmetic — the discipline transition 1's falsified P8 taught.

**The blocker delta on K3 is exactly one removal and zero additions**: `target.execution_surface` / unsupported_component, finding 178. The `execution_surface` cluster goes 1 → 0; every other cluster is identical. The exit-missing and headless refusals both survive by name, so capability was granted to a traversal and not to a declaration.

**Eight controls at zero movement**, reproducing transition 1's recorded numbers exactly from an independently rebuilt baseline — Kimi-Linear 0/64, GLM-5.3-Flash 28/91, GLM-5.3 19/76, DeepSeek-V4-Flash 31/73, DeepSeek-V4-Pro 31/73, Hy4-preview 32/76, Qwen3-0.6B 0/40, Qwen3.8-Flash-Next 36/80. The other 108 rows were **checked, not assumed**: across all 117 cached plans, exactly one mentions `attn_res_block_size` and exactly one binds an attn_res operand group — Kimi-K3 both times.

P3–P10 all held; the scoring is in `k3-attnres-1-execution-notes.json` under `transition_2c_the_lift`.

## Fixture migrations

Three, exactly the ones the freeze named, each **inverted rather than deleted**: the models-side topology test; the one-authority test, now `the_report_admits_the_topology_and_the_executor_runs_it` (it runs the plan end to end, keeping its single-stream control); and the identity pin's version-17 arm, now 18's verdict pair — a complete attention-residual estate is admissible, and the same estate *without* the exit pair stays blocked by the exit's own finding. That second arm is what keeps the first from having been implemented as "stop refusing attention residuals".

## What this does not claim

K3 does not run. Its closure still names 31 blockers across representation_quantization (14), unclustered (14), ffn_activation, moe_routing and modality_vision; `self_attn.g_proj` is K3-REP-GATE-1 and the routed-expert bank is K3-LATENTMOE-1. The row moved at the plan level only, and every witness in this rung remains on a synthetic substrate whose branch is an ordinary attention and FFN.

## Gates

fmt; clippy on larql-vindex, larql-models and larql-cli; `cargo check --workspace --all-targets`; larql-models 799 + 100, larql-vindex 4363, larql-server 591; coverage 93.63% with the per-file policy passing.
