### PR TITLE
An exact tally is a claim about the writes you own

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/stages.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/stages.rs
@@ -136,19 +136,43 @@ impl StageLedger {
         }
         self.nested.store(0, Ordering::Relaxed);
     }
+
+    /// Start one stage, recorded into THIS ledger when the guard drops.
+    ///
+    /// Nesting is still judged per thread, because a stage containing
+    /// another stage is a property of the execution, not of the ledger
+    /// the execution reports to.
+    pub fn staged(&self, stage: Stage) -> Staged<'_> {
+        let outermost = ACTIVE.with(|a| {
+            let was = a.get();
+            a.set(true);
+            !was
+        });
+        if !outermost {
+            self.nested.fetch_add(1, Ordering::Relaxed);
+        }
+        Staged {
+            ledger: self,
+            stage,
+            started: Instant::now(),
+            outermost,
+        }
+    }
 }
 
-/// A running stage timer. Records on drop.
-pub struct Staged {
+/// A running stage timer. Records into the ledger it was opened on,
+/// on drop.
+pub struct Staged<'a> {
+    ledger: &'a StageLedger,
     stage: Stage,
     started: Instant,
     outermost: bool,
 }
 
-impl Drop for Staged {
+impl Drop for Staged<'_> {
     fn drop(&mut self) {
         let nanos = self.started.elapsed().as_nanos() as u64;
-        ledger().record(self.stage, nanos);
+        self.ledger.record(self.stage, nanos);
         if self.outermost {
             ACTIVE.with(|a| a.set(false));
         }
@@ -156,20 +180,15 @@ impl Drop for Staged {
 }
 
 /// Start one stage. Bind the value to a name for the stage's extent.
-pub fn stage(stage: Stage) -> Staged {
-    let outermost = ACTIVE.with(|a| {
-        let was = a.get();
-        a.set(true);
-        !was
-    });
-    if !outermost {
-        ledger().nested.fetch_add(1, Ordering::Relaxed);
-    }
-    Staged {
-        stage,
-        started: Instant::now(),
-        outermost,
-    }
+///
+/// This is [`StageLedger::staged`] on the process ledger, which is what
+/// execution wants: one instrument for the whole run. A caller that needs
+/// a tally it alone writes — a test asserting an exact call count, say —
+/// must open its stages on a ledger of its own, because the process
+/// ledger is written by every execution in the binary and a lock over
+/// some of them does not make it exclusive.
+pub fn stage(stage: Stage) -> Staged<'static> {
+    ledger().staged(stage)
 }
 
 static LEDGER: StageLedger = StageLedger::new();

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/stages_and_routing.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/stages_and_routing.rs
@@ -4,55 +4,139 @@
 //! open, and a fingerprint tells two selections apart by order.
 
 use super::super::routing_trace;
-use super::super::stages::{ledger, stage, Stage, StageTally};
+use super::super::stages::{ledger, stage, Stage, StageLedger, StageTally};
 
-/// The ledger is process-wide, so these tests hold one lock between them
-/// rather than race each other's counters.
-static SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+/// An exact tally is a claim about one ledger's own writes, so these
+/// tests open their stages on a ledger they construct.
+///
+/// They used to assert on the process ledger under a module lock, which
+/// is not exclusion: `stage()` is opened by real execution in
+/// `production.rs`, `decode.rs` and `experts.rs`, so every other test in
+/// this binary that executes a layer writes the same counters. The lock
+/// serialised three tests against each other and nothing against the
+/// other four and a half thousand. It read `calls == 11` on a CI runner
+/// where the test had opened one stage.
+fn ledger_of_its_own() -> StageLedger {
+    StageLedger::new()
+}
 
 #[test]
 fn a_stage_records_its_extent_and_a_reset_clears_it() {
-    let _serial = SERIAL.lock().unwrap();
-    ledger().reset();
+    let ledger = ledger_of_its_own();
     {
-        let _s = stage(Stage::Router);
+        let _s = ledger.staged(Stage::Router);
         std::thread::sleep(std::time::Duration::from_millis(2));
     }
-    let router = ledger().get(Stage::Router);
+    let router = ledger.get(Stage::Router);
     assert_eq!(router.calls, 1);
     assert!(router.nanos >= 2_000_000, "{router:?}");
-    assert_eq!(ledger().get(Stage::Attention), StageTally::default());
-    assert_eq!(ledger().nested(), 0);
-    assert_eq!(ledger().total_nanos(), router.nanos);
-    ledger().reset();
-    assert_eq!(ledger().get(Stage::Router), StageTally::default());
+    assert_eq!(ledger.get(Stage::Attention), StageTally::default());
+    assert_eq!(ledger.nested(), 0);
+    assert_eq!(ledger.total_nanos(), router.nanos);
+    ledger.reset();
+    assert_eq!(ledger.get(Stage::Router), StageTally::default());
 }
 
 #[test]
 fn a_stage_inside_a_stage_is_counted_as_nesting() {
-    let _serial = SERIAL.lock().unwrap();
-    ledger().reset();
+    let ledger = ledger_of_its_own();
     {
-        let _outer = stage(Stage::Attention);
-        let _inner = stage(Stage::Router);
+        let _outer = ledger.staged(Stage::Attention);
+        let _inner = ledger.staged(Stage::Router);
     }
-    assert_eq!(ledger().nested(), 1);
-    assert_eq!(ledger().get(Stage::Attention).calls, 1);
-    assert_eq!(ledger().get(Stage::Router).calls, 1);
+    assert_eq!(ledger.nested(), 1);
+    assert_eq!(ledger.get(Stage::Attention).calls, 1);
+    assert_eq!(ledger.get(Stage::Router).calls, 1);
     // Sequential stages do not nest.
-    ledger().reset();
+    ledger.reset();
     {
-        let _a = stage(Stage::RoutedExperts);
+        let _a = ledger.staged(Stage::RoutedExperts);
     }
     {
-        let _b = stage(Stage::SharedExpert);
+        let _b = ledger.staged(Stage::SharedExpert);
     }
-    assert_eq!(ledger().nested(), 0);
-    assert_eq!(
-        ledger().all().iter().filter(|(_, t)| t.calls == 1).count(),
-        2
+    assert_eq!(ledger.nested(), 0);
+    assert_eq!(ledger.all().iter().filter(|(_, t)| t.calls == 1).count(), 2);
+}
+
+#[test]
+fn two_ledgers_do_not_see_each_others_stages() {
+    let mine = ledger_of_its_own();
+    let theirs = ledger_of_its_own();
+    {
+        let _s = mine.staged(Stage::Router);
+    }
+    assert_eq!(mine.get(Stage::Router).calls, 1);
+    assert_eq!(theirs.get(Stage::Router), StageTally::default());
+    assert_eq!(theirs.total_nanos(), 0);
+}
+
+/// The witness that the fix is a fix, rather than a rewrite that happens
+/// to pass. It reproduces the contention the CI failure was made of —
+/// other threads opening the same stage through the ordinary `stage()`
+/// entry point — and asserts an exact tally straight through it.
+///
+/// Before this change the assertion below WAS the failing assertion, and
+/// under this much traffic it fails every run rather than one in fifty:
+/// the counters it read were `LEDGER`'s, and these threads write them.
+#[test]
+fn an_owned_tally_is_exact_while_the_process_ledger_is_hammered() {
+    const FOREIGN: u64 = 32;
+    let mine = ledger_of_its_own();
+    let before = ledger().get(Stage::Router).calls;
+
+    std::thread::scope(|scope| {
+        for _ in 0..4 {
+            scope.spawn(|| {
+                for _ in 0..(FOREIGN / 4) {
+                    let _foreign = stage(Stage::Router);
+                }
+            });
+        }
+        // Opened while the foreign threads are live, not after they join.
+        let _s = mine.staged(Stage::Router);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    });
+
+    let router = mine.get(Stage::Router);
+    assert_eq!(router.calls, 1, "an owned ledger records only its own");
+    assert!(router.nanos >= 2_000_000, "{router:?}");
+    assert_eq!(mine.total_nanos(), router.nanos);
+
+    // And the traffic was real: the shared ledger took every foreign
+    // stage. Without this the test above could pass by nothing happening.
+    let after = ledger().get(Stage::Router).calls;
+    assert!(
+        after >= before + FOREIGN,
+        "the foreign stages must land on the process ledger: {before} -> {after}"
     );
-    ledger().reset();
+}
+
+#[test]
+fn the_free_helper_records_into_the_process_ledger() {
+    // The wiring witness for `stage()`, and the one claim that survives
+    // concurrency: the process ledger is shared, so this asserts that it
+    // MOVED, never what it now reads.
+    //
+    // A delta is only sound while the counters rise monotonically, and
+    // nothing in THIS binary resets them — the reads below are the only
+    // uses of the process ledger left in the crate. `larql-cli` does
+    // reset it between generations, which is right for measuring one
+    // generation and is a different process from this test binary.
+    let before = ledger().get(Stage::Prefetch);
+    {
+        let _s = stage(Stage::Prefetch);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+    let after = ledger().get(Stage::Prefetch);
+    assert!(
+        after.calls > before.calls,
+        "stage() must reach the process ledger: {before:?} -> {after:?}"
+    );
+    assert!(
+        after.nanos >= before.nanos + 2_000_000,
+        "and carry the extent: {before:?} -> {after:?}"
+    );
 }
 
 #[test]
@@ -61,9 +145,21 @@ fn every_stage_has_a_distinct_name() {
     assert_eq!(names.len(), Stage::ALL.len());
 }
 
+/// KNOWN HAZARD, deliberately not fixed here. `routing_trace`'s capture
+/// is a process-global `Mutex<Option<Vec<..>>>`, and `production.rs`
+/// records into it from the same function that opens the router stage —
+/// so a concurrent execution appends foreign selections to an open
+/// capture, in production as well as under test.
+///
+/// The stage ledger above could be fixed without deciding anything,
+/// because execution keeps the process ledger and only the tests moved
+/// off it. This one cannot: making the capture sound means deciding
+/// whether a capture is scoped to an execution or to a thread, and
+/// whether the router always runs on the thread that opened it. That is
+/// a production-semantics question about execution-scoped accounting,
+/// not a test-flake fix, and it is not settled as a drive-by here.
 #[test]
 fn a_capture_returns_the_selections_made_while_it_was_open() {
-    let _serial = SERIAL.lock().unwrap();
     routing_trace::record(&[(1, 0.5)]);
     routing_trace::start_capture();
     routing_trace::record(&[(3, 0.7), (1, 0.3)]);

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged.rs
@@ -127,6 +127,33 @@ pub fn staged_images() -> u64 {
     STAGED_IMAGES.load(Ordering::Relaxed)
 }
 
+thread_local! {
+    /// The same two tallies, for THIS thread's stagings alone.
+    ///
+    /// [`staged_bytes`] and [`staged_images`] answer for the process,
+    /// which is what a residency report wants and what makes them
+    /// useless for a claim about one caller's own writes: any thread
+    /// staging anything moves them.
+    ///
+    /// A thread-scoped tally is sound here for a specific reason, not as
+    /// a general habit. [`StagedF32::stage`] writes and maps on the
+    /// thread that called it and hands nothing to a worker, so the
+    /// stagings attributable to a caller are exactly the stagings its
+    /// own thread performed. If that ever stops being true, this pair
+    /// stops meaning what its name says and must move with it.
+    static STAGED_HERE: std::cell::Cell<(u64, u64)> = const { std::cell::Cell::new((0, 0)) };
+}
+
+/// Bytes staged to the arena by the calling thread.
+pub fn staged_bytes_on_this_thread() -> u64 {
+    STAGED_HERE.with(|c| c.get().0)
+}
+
+/// f32 images staged to the arena by the calling thread.
+pub fn staged_images_on_this_thread() -> u64 {
+    STAGED_HERE.with(|c| c.get().1)
+}
+
 #[derive(Debug)]
 pub(super) struct Arena {
     pub(super) file: std::fs::File,
@@ -264,6 +291,10 @@ impl StagedF32 {
         .map_err(|e| VindexError::Parse(format!("f32 staging map failed: {e}")))?;
         STAGED_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
         STAGED_IMAGES.fetch_add(1, Ordering::Relaxed);
+        STAGED_HERE.with(|c| {
+            let (b, i) = c.get();
+            c.set((b + bytes as u64, i + 1));
+        });
         Ok(Self(Inner::Mapped {
             map,
             elements: values.len(),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/staged_tests.rs
@@ -8,8 +8,8 @@
 //! claim the tests check.
 
 use super::staged::{
-    staged_bytes, staged_images, StagedF32, DEFAULT_STAGE_MIN_BYTES, STAGE_ENV,
-    STAGE_MIN_BYTES_ENV, STAGE_OFF,
+    staged_bytes, staged_bytes_on_this_thread, staged_images, staged_images_on_this_thread,
+    StagedF32, DEFAULT_STAGE_MIN_BYTES, STAGE_ENV, STAGE_MIN_BYTES_ENV, STAGE_OFF,
 };
 use serial_test::serial;
 
@@ -196,23 +196,79 @@ fn an_odd_length_image_keeps_its_last_element() {
     assert_eq!(bits(&staged), bits(&values));
 }
 
+/// "Only" is a claim about writes this caller owns, so it is asserted on
+/// the thread-scoped tally.
+///
+/// It used to be asserted on `staged_bytes()`/`staged_images()`, which
+/// answer for the whole process: every f32 staging anywhere in this
+/// binary moves them, and `#[serial]` orders the `#[serial]` tests
+/// against each other and nothing against the rest. That read 29900
+/// against an expected 28876 — one foreign 1024-byte image — about once
+/// in twenty runs of the suite.
+///
+/// The process counters are still asserted, at the strength they can
+/// carry under concurrency: they must move by AT LEAST this test's own
+/// contribution, never by exactly it.
 #[test]
 #[serial]
 fn the_counters_only_move_for_mapped_images() {
-    let before_bytes = staged_bytes();
-    let before_images = staged_images();
+    let before_bytes = staged_bytes_on_this_thread();
+    let before_images = staged_images_on_this_thread();
+    let before_process = staged_bytes();
+    let before_process_images = staged_images();
+
     let small = with_env(false, Some(DEFAULT_STAGE_MIN_BYTES), || {
         StagedF32::stage(adversarial(4))
     })
     .expect("staging");
     assert!(!small.is_mapped());
-    assert_eq!(staged_bytes(), before_bytes);
-    assert_eq!(staged_images(), before_images);
+    assert_eq!(staged_bytes_on_this_thread(), before_bytes);
+    assert_eq!(staged_images_on_this_thread(), before_images);
 
     let big = with_env(false, Some(1024), || StagedF32::stage(adversarial(1024))).expect("staging");
     assert!(big.is_mapped());
-    assert_eq!(staged_bytes(), before_bytes + 4096);
-    assert_eq!(staged_images(), before_images + 1);
+    assert_eq!(staged_bytes_on_this_thread(), before_bytes + 4096);
+    assert_eq!(staged_images_on_this_thread(), before_images + 1);
+
+    // The thread tally is not a private counter that only this test can
+    // move: the same staging reaches the process report.
+    assert!(staged_bytes() >= before_process + 4096);
+    assert!(staged_images() > before_process_images);
+}
+
+/// The witness that the tally above is scoped rather than merely quiet:
+/// another thread stages while this one does, and only this thread's
+/// images are counted here.
+///
+/// Run against the process counters, the first assertion below reads
+/// 4096 too high — which is the failure the suite was seeing, made
+/// deterministic.
+#[test]
+#[serial]
+fn a_thread_tally_ignores_another_threads_staging() {
+    let before = staged_bytes_on_this_thread();
+    let before_images = staged_images_on_this_thread();
+    let before_process = staged_bytes();
+
+    let foreign = std::thread::spawn(|| {
+        let staged =
+            with_env(false, Some(1024), || StagedF32::stage(adversarial(1024))).expect("staging");
+        assert!(staged.is_mapped());
+        // The foreign thread sees its own staging, and only its own.
+        assert_eq!(staged_bytes_on_this_thread(), 4096);
+        assert_eq!(staged_images_on_this_thread(), 1);
+    });
+    foreign.join().expect("foreign staging thread");
+
+    // Nothing landed on this thread's tally.
+    assert_eq!(staged_bytes_on_this_thread(), before);
+    assert_eq!(staged_images_on_this_thread(), before_images);
+    // And the traffic was real, so this is not passing by nothing having
+    // happened: the process report took the foreign image.
+    assert!(
+        staged_bytes() >= before_process + 4096,
+        "the foreign staging must reach the process report"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Two tests asserted exact counts on process-wide instruments that the whole binary writes. Both have been red on main.

- `a_stage_records_its_extent_and_a_reset_clears_it` failed at `9e2e37d9` with `left: 11, right: 1` after opening a single stage.
- `the_counters_only_move_for_mapped_images` fails about **once in twenty** runs of the suite — reproduced here as `left: 29900, right: 28876`, one foreign 1024-byte image.

## Both were guarded, and neither guard was exclusion

The stage tests held a module lock whose own comment said the quiet part out loud — *"these tests hold one lock between them"*. Between them is the flaw: `stage()` is opened by real execution in `production.rs`, `decode.rs` and `experts.rs`, so every test that runs a layer writes those counters. The lock serialised three tests against each other and nothing against the other four and a half thousand.

The staging test is `#[serial]`, which orders the `#[serial]` tests against each other and nothing against the rest.

A lock over *some* of the writers does not make a counter yours.

## Two instruments, two different seams

**The stage ledger gets an owned instrument.** `StageLedger::staged()` is a stage guard bound to the ledger it was opened on, `Staged` gains the lifetime that needs, and the free `stage()` becomes exactly that method on the process ledger. Execution keeps one ledger for the whole run — which is what a residency decision is priced from — and only the tests move off it, onto ledgers they construct.

**The staging counters get a scoped reader**, because they are free statics inside `StagedF32::stage` with no `&self` to own. `staged_bytes_on_this_thread` and `staged_images_on_this_thread` count the calling thread's stagings beside the unchanged process totals.

That is sound for a specific reason rather than as a general habit: `stage()` writes and maps on the thread that called it and hands nothing to a worker, so a caller's stagings are exactly its thread's. The comment states this, and states what must change if it ever stops being true.

## Claims are now made at the strength each instrument can carry

Exact tallies are asserted on owned or thread-scoped state. The process-wide counters keep their assertions as lower bounds — they must move by *at least* this caller's contribution, never by exactly it.

## Each fix carries a witness that it is a fix

A green test that could not have gone red proves nothing, so both fixes reproduce the contention they claim to survive.

`an_owned_tally_is_exact_while_the_process_ledger_is_hammered` opens 32 foreign stages across four threads through the ordinary `stage()` entry point, asserts the owned tally still reads exactly 1 throughout, and then asserts the process ledger took all 32 — so it cannot pass by no traffic having occurred. Run against the old form, that same assertion reads `left: 33, right: 1`: the CI failure, made deterministic.

`a_thread_tally_ignores_another_threads_staging` does the same for staging — a second thread stages a mapped image, this thread's tally does not move, and the process report does.

## What is deliberately not fixed

`routing_trace`'s capture is the third instrument in this class, annotated where it lives. It is a process-global mutex that `production.rs` records into from the same function that opens the router stage, so a concurrent execution appends foreign selections to an open capture **in production, not only under test**.

Making it sound means deciding whether a capture is scoped to an execution or to a thread, and whether the router always runs on the thread that opened it. That is a change to what the instrument means, and it is not settled as a drive-by inside a test-flake fix.

## Gates

`cargo fmt --all --check`, `cargo clippy -p larql-vindex --all-targets -D warnings`, `cargo test -p larql-vindex`, and a repeated soak of the full lib binary — the suite where both races live — since a single green run is not evidence about a one-in-twenty flake.

Production behaviour is unchanged: `stage()` is `ledger().staged(stage)` on the same process ledger, and the staging path keeps its existing global counters untouched.
