### PR TITLE
ci: one piece of evidence, once (CI-E2-0 + E2-A)

### DIFF
--- a/.github/workflows/bench-regress.yml
+++ b/.github/workflows/bench-regress.yml
@@ -65,18 +65,36 @@ name: bench-regress
 #    script advertises. Deliberately left alone here so this change's
 #    effect on the noise floor can be measured on its own.
 
+# ── NOT A PULL-REQUEST GATE (CI-E2-A, 2026-09-07). ──
+#
+# The `pull_request:` trigger is REMOVED, not disabled, and the reason is
+# the contract this file already states above: a gate that reds on a
+# no-op cannot grade a change. That qualification has now run, by
+# accident and then on the numbers.
+#
+#   - PR #446 changed two lines of a JSON coverage-policy file and
+#     nothing else. No Rust, nothing include_str!s it, no build script
+#     reads it — both arms compiled byte-identical artefacts, in one job,
+#     on one runner. It FAILED, swinging -11.4% to +15.3%, most at
+#     p = 0.00.
+#   - PR #449 reported ~+44% in one metal cell and ~-43% in another on a
+#     change that cannot produce that pattern. A run that improves as
+#     much as it regresses is measuring the runner.
+#   - Cost, measured over the 12-attempt window of 2026-09-07:
+#     6 jobs, 137.9 macOS execution-minutes and 61.1 macOS QUEUE-minutes,
+#     on the scarcest runner pool this repository has. #449's bench job
+#     waited 42m01s for a runner to produce a verdict that was not
+#     evidence.
+#
+# `workflow_dispatch` stays, and it is the qualification laboratory: run
+# `noop=true` for the false-positive rate and `noop=true, slowdown=2.0`
+# for the known positive. PERF-QUAL-2 — the order-balanced
+# `B H | H B | B H | H B` shape this file's own header argues for — has
+# to pass BOTH before this workflow is proposed as a PR signal again.
+# Until then a red here grades nobody's pull request.
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'crates/larql-compute/**'
-      - 'crates/larql-compute-metal/**'
-      - 'scripts/bench-regress.sh'
-      - '.github/workflows/bench-regress.yml'
-      - 'Cargo.lock'
-  # Manual trigger so a reviewer can ask for the check on a PR the paths
-  # filter skipped, run it on a branch outside a PR, or QUALIFY THE
-  # INSTRUMENT itself against a no-op.
+  # Manual trigger so a reviewer can ask for the check on a branch, or
+  # QUALIFY THE INSTRUMENT itself against a no-op.
   workflow_dispatch:
     inputs:
       noop:
@@ -148,6 +166,9 @@ jobs:
             # rate rather than a property of any change.
             BASE_REV="$HEAD_REV"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            # UNREACHABLE while the pull_request trigger is off (see the
+            # header). Kept so restoring the trigger, once PERF-QUAL-2
+            # qualifies the gate, stays a one-line change.
             # actions/checkout gives the MERGE commit for pull_request, so
             # ^1 is the base branch tip the PR would land on and HEAD is
             # the merge result itself — exactly the pair worth comparing.

--- a/.github/workflows/larql-compute-metal.yml
+++ b/.github/workflows/larql-compute-metal.yml
@@ -102,19 +102,73 @@ jobs:
         # the same flag for the same reason.
         run: cargo clippy -p larql-compute-metal --all-targets --no-deps -- -D warnings
 
-      # `--test-threads=1` serialises the test runner, matching the Makefile
-      # targets (`larql-compute-metal-test{,-tests}`). Many tests read
-      # process-global state cached at `MetalBackend::new()` (decode flags) and
-      # share the single GPU; cargo's default parallel runner races on them and
-      # intermittently yields NaN/zero pipeline output. Serial execution is the
-      # same fix larql-inference uses for its OpenBLAS global-buffer race.
-      - name: Unit tests
-        run: cargo test -p larql-compute-metal --lib -- --test-threads=1
-
-      - name: Integration tests
-        run: cargo test -p larql-compute-metal --tests -- --test-threads=1
-
-      - name: Coverage policy gate
+      # ── ONE PIECE OF EVIDENCE, ONCE (CI-E2-A, 2026-09-07). ──
+      #
+      # This job used to run:
+      #
+      #     cargo test --lib     -> 1 binary
+      #     cargo test --tests   -> 69 binaries, INCLUDING src/lib.rs again
+      #     cargo llvm-cov       -> the same 69, instrumented
+      #
+      # `--tests` selects every target with `test = true`, and a lib has
+      # that by default, so the 530-test lib suite ran THREE times and the
+      # 68 integration binaries TWICE. Measured on run 34098337888 (#449):
+      # 671.22s + 535.74s + 535.52s for the lib suite alone, in a job that
+      # took 59m25s of a scarce macOS runner. The `--lib` step was already
+      # fully redundant with the `--tests` step before coverage entered
+      # the argument.
+      #
+      # The coverage run is not a report generator bolted onto a test
+      # pass — it IS a test pass: it runs the same 69 binaries under the
+      # same `--test-threads=1`, a failing test fails the step, and
+      # `--fail-under-lines` plus check_coverage_policy.py then hold the
+      # per-file floors. So it is the authoritative execution, and the two
+      # plain passes are deleted rather than reordered.
+      #
+      # What that would lose on its own: the instrumented build is not the
+      # profile anyone develops against (different RUSTFLAGS, a separate
+      # target dir, slower binaries around GPU races). The smoke step below
+      # keeps that witness at a size proportional to the claim — it proves
+      # the ordinary profile executes, not that the estate passes twice.
+      #
+      # `--test-threads=1` throughout, matching the Makefile targets. Many
+      # tests read process-global state cached at `MetalBackend::new()`
+      # (decode flags) and share the single GPU; cargo's default parallel
+      # runner races on them and intermittently yields NaN/zero pipeline
+      # output. Serial execution is the same fix larql-inference uses for
+      # its OpenBLAS global-buffer race.
+      - name: Ordinary-profile execution witness
+        env:
+          # `backend::tests::` constructs a real MetalBackend, populates
+          # the pipeline cache and computes — the smallest subset that
+          # proves the uninstrumented build actually runs on the GPU.
+          SMOKE_FILTER: "backend::tests::"
+          # A cargo test filter that matches nothing exits 0. Without a
+          # floor, renaming the module would turn this witness into a
+          # green that ran no tests. The filter selects 7 today; the floor
+          # is deliberately below that so adding or removing a test does
+          # not break the build, while a typo or a rename still does.
+          SMOKE_MIN_TESTS: "5"
         run: |
-          cargo install --locked cargo-llvm-cov
-          make larql-compute-metal-coverage-summary
+          set -o pipefail
+          cargo test -p larql-compute-metal --lib -- --test-threads=1 "$SMOKE_FILTER" \
+            2>&1 | tee smoke.log
+          ran=$(sed -n 's/^test result: ok\. \([0-9][0-9]*\) passed.*/\1/p' smoke.log | head -1)
+          echo "smoke tests executed: ${ran:-0} (floor ${SMOKE_MIN_TESTS})"
+          if [ "${ran:-0}" -lt "$SMOKE_MIN_TESTS" ]; then
+            echo "::error::the ordinary-profile witness ran ${ran:-0} tests, below the floor of ${SMOKE_MIN_TESTS} — the filter '${SMOKE_FILTER}' no longer selects the intended module"
+            exit 1
+          fi
+
+      - name: Install cargo-llvm-cov
+        # Prebuilt, like every other coverage job in this repository. This
+        # one used to `cargo install --locked` it from source on every
+        # fresh runner: 49.7s on #449, to build a tool that is not under
+        # test.
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      # AUTHORITATIVE. Runs the whole test estate once, instrumented, and
+      # applies the coverage policy to the result. A failing test reds this
+      # step; so does a file dropping below its floor.
+      - name: Test estate + coverage policy (authoritative)
+        run: make larql-compute-metal-coverage-summary

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -231,6 +231,28 @@ jobs:
       - name: Check documentation code references
         run: python3 scripts/check_doc_references.py --strict
 
+  ci-instrument:
+    name: ci throughput instrument
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      # scripts/ci_throughput.py adjudicates the CI experiments that decide
+      # what this repository's CI looks like, and until 2026-09-07 its
+      # `selftest` -- the thing that proves each verdict is reachable and
+      # each metric definition is right -- ran only when someone remembered
+      # to type it. E1 shipped a forecast whose validity gate could not
+      # pass; the selftest now carries the control that catches that class
+      # (an extensive metric scored across samples of different size must
+      # be REFUSED, and must still be scoreable at equal n). A checker
+      # nobody runs is not a check.
+      #
+      # No network: `selftest` builds synthetic runs with known answers and
+      # never calls the API. Seconds on Linux.
+      - name: Instrument selftest
+        run: python3 scripts/ci_throughput.py selftest
+
   proto-lint:
     name: buf lint
     runs-on: ubuntu-latest

--- a/docs/ci-throughput/E1-postmortem.md
+++ b/docs/ci-throughput/E1-postmortem.md
@@ -1,0 +1,117 @@
+# E1 — post-hoc diagnostic
+
+**This document is not a verdict.** E1's verdict is `E1-verdict.json`,
+frozen as delivered:
+
+```
+C1  cancel superseded PR runs        HELD
+C2  macOS scheduling contention      INVALID COMPARISON
+C3  VINDEX benches Linux-only        HELD
+SYSTEM  the tranche as a whole       HELD
+```
+
+Everything below was computed **after** the forecast was scored. It
+explains why C2 could not be adjudicated and what the corrected
+measurement is used for. It does not re-score E1, and none of these
+numbers may be cited as an E1 result.
+
+## What happened
+
+E1 froze five predictions on 2026-09-06. Two of them — P2 and P3, the
+pair that scores C2 — name **extensive** metrics: totals of macOS
+runner-minutes across the sample.
+
+The AFTER window collected **12 attempts** against a 33-attempt
+baseline. For any metric that is flat per attempt, a 12/33 ratio moves
+the total by
+
+```
+12/33 - 1 = -63.6%
+```
+
+before the intervention is considered at all. So:
+
+- **P3 could not have returned HELD.** Its band was "falls by no more
+  than 10%". The sample alone spent 63.6% of it.
+- **P2 could not have returned FALSIFIED.** Its falsifier was "less than
+  20%". The sample alone cleared it three times over.
+
+The adjudicator returned `INVALID COMPARISON` for C2, which is the
+behaviour the forecast designed and the selftest proves reachable. But
+the veto fired on **sample size**, not on the composition change P3 was
+written to detect. C2 is **unadjudicated, not refuted.**
+
+The three predictions that survived are exactly the **intensive** ones:
+P1 is scored on a total but its per-attempt mean moves the same way
+(-92%), and P4 and P5 are percentiles. Only the totals broke.
+
+## The post-hoc numbers
+
+Per-attempt, from the same two snapshots:
+
+| metric | before /attempt | after /attempt | delta |
+|---|---|---|---|
+| `queued.macos` | 137.2 min | 80.1 min | -41.6% |
+| `executed.macos` | 92.0 min | 76.7 min | -16.6% |
+| `queued.linux` | 272.2 min | 129.2 min | -52.5% |
+| `executed.linux` | 152.6 min | 107.1 min | -29.8% |
+| `queued.windows` | 49.5 min | 18.8 min | -62.0% |
+| `executed.windows` | 115.0 min | 69.1 min | -39.9% |
+
+Under P3's own bands, `executed.macos` at -16.6% is neither HELD
+(≥ -10%) nor FALSIFIED (< -20%). **Genuinely inconclusive** — which is
+a different finding from `INVALID COMPARISON`, and it is why this is a
+diagnostic rather than a verdict.
+
+Two further observations that a totals-only reading hides:
+
+- `macos_queue_max` p50 moved the **wrong way**: 20m18s → 21m42s (+7%;
+  +16% with `--require-complete`), while its p95 fell 38%. The tail
+  improved; the median did not.
+- `msrv-metal` — the workflow c2 **created**, by splitting the MSRV Metal
+  leg out of `quality` — is now itself the pathology c2 was written to
+  remove. In the AFTER window: 6 jobs, **63.3 macOS queue-minutes to buy
+  4.3 execution-minutes**. Cheap to run, expensive to schedule.
+
+## What was changed, and what was not
+
+Changed — the **instrument**, so this cannot recur silently:
+
+- every extensive metric gained an intensive companion
+  (`queued_per_attempt.*`, `executed_per_attempt.*`);
+- `score_prediction` **refuses** an extensive metric whose two samples
+  differ in attempt count, returning `UNSCOREABLE` and naming the
+  per-attempt metric to use instead;
+- `workflow_share.*` was added, so composition — the thing P3 was
+  actually reaching for — is a scoreable number rather than a printed
+  line;
+- `workflow_exec_max.*` was added, counting **successful runs only**, so
+  a gate cannot look faster by being cancelled more often;
+- the selftest asserts the guard fires at unequal n and does **not** fire
+  at equal n, and that every forecast frozen from E2 onward names only
+  intensive metrics.
+
+Not changed — **E1**. The forecast, the verdict and both snapshots stand
+exactly as they were. Re-scoring a pre-registered experiment on a metric
+chosen after seeing its data is the failure this whole apparatus exists
+to prevent.
+
+One consequence worth stating plainly: re-running `adjudicate` on E1 with
+today's instrument refuses **C1 as well as C2**, because P1 also names a
+total (`superseded_exec_total`). The frozen verdict read C1 HELD, and
+that finding stands — its intensive companion `superseded_exec_mean`
+moves -92% (28m14s -> 2m15s per attempt), so cancellation is established
+on a metric the guard accepts. The guard refuses a metric by NAME; it
+does not adjudicate the mechanism behind it. For C1 the substance was
+already there in the per-attempt mean; for C2 it was not.
+
+`E1-verdict.json` records the verdict as delivered and is not
+regenerated.
+
+## What C2 still owes
+
+The macOS-occupancy mechanism has never been scored. It is not being
+re-run as E1; it is superseded by CI-E2-D, which proposes the same
+mechanism in a stronger form (tiered Metal triggers) and will be scored
+against `E2-contract.json` on intensive metrics with a composition
+validity gate.

--- a/docs/ci-throughput/E1-verdict.json
+++ b/docs/ci-throughput/E1-verdict.json
@@ -1,0 +1,80 @@
+{
+  "experiment": "E1",
+  "adjudicated_at": "2026-09-07",
+  "status": "FROZEN \u2014 this file records the verdict as delivered and is not regenerated",
+  "provenance": {
+    "instrument": "scripts/ci_throughput.py",
+    "instrument_sha": "beb82d65",
+    "instrument_note": "Produced by the instrument as it stood BEFORE the CI-E2-0 fix. Re-running `adjudicate` against today's instrument returns UNSCOREABLE for BOTH C1 and C2, because P1 and P2/P3 all name extensive totals and the guard added in E2-0 refuses those across samples of different size. C1's finding is unaffected in substance \u2014 its intensive companion superseded_exec_mean moves -92% \u2014 while C2's companion moves only -16.6% and is inconclusive. This file keeps the wording the frozen forecast was actually scored with. Do NOT regenerate it.",
+    "before": "docs/ci-throughput/before-e1.json",
+    "after": "docs/ci-throughput/after-e1.json",
+    "forecast": "docs/ci-throughput/E1-forecast.json",
+    "command": "scripts/ci_throughput.py adjudicate --forecast docs/ci-throughput/E1-forecast.json --before docs/ci-throughput/before-e1.json --after docs/ci-throughput/after-e1.json"
+  },
+  "c2_note": "INVALID COMPARISON \u2014 metric-design defect discovered. The refusal is correct and it is the designed behaviour, but it fired on SAMPLE SIZE (12 attempts against 33, a -63.6% floor on any extensive total) rather than on the composition change P3 was written to catch. C2 is UNADJUDICATED, not refuted. See E1-postmortem.md for the post-hoc diagnostic, which is explicitly not a new E1 verdict.",
+  "mechanisms": {
+    "c1": "HELD",
+    "c2": "INVALID COMPARISON",
+    "c3": "HELD",
+    "system": "HELD"
+  },
+  "predictions": [
+    {
+      "id": "P1",
+      "mechanism": "c1",
+      "kind": "effect",
+      "metric": "superseded_exec_total",
+      "before": 931.65,
+      "after": 26.933333333333334,
+      "delta_pct": -97.10907171863539,
+      "verdict": "HELD",
+      "claim": "superseded_exec_total falls from 931.6 min to <= 300 min"
+    },
+    {
+      "id": "P2",
+      "mechanism": "c2",
+      "kind": "effect",
+      "metric": "queued.macos",
+      "before": 4526.616666666667,
+      "after": 961.75,
+      "delta_pct": -78.75344720302508,
+      "verdict": "HELD",
+      "claim": "total macOS queued runner-minutes fall by 30-55%"
+    },
+    {
+      "id": "P3",
+      "mechanism": "c2",
+      "kind": "validity",
+      "metric": "executed.macos",
+      "before": 3034.9166666666665,
+      "after": 920.6166666666667,
+      "delta_pct": -69.66583376808808,
+      "verdict": "FALSIFIED",
+      "claim": "macOS EXECUTED runner-minutes fall by no more than 10%"
+    },
+    {
+      "id": "P4",
+      "mechanism": "c3",
+      "kind": "effect",
+      "metric": "windows_vindex_exec.p50",
+      "before": 29.683333333333334,
+      "after": 21.766666666666666,
+      "delta_pct": -26.67040988208872,
+      "verdict": "HELD",
+      "claim": "vindex Windows execution p50 falls from 29m41s to 20-24 min"
+    },
+    {
+      "id": "P5",
+      "mechanism": "system",
+      "kind": "effect",
+      "metric": "merge_ready.p50",
+      "before": 61.38333333333333,
+      "after": 40.80833333333333,
+      "delta_pct": -33.51887048601684,
+      "verdict": "HELD",
+      "claim": "merge-ready p50 falls from 61m23s to 30-45 min"
+    }
+  ],
+  "before_attempts": 33,
+  "after_attempts": 12
+}

--- a/docs/ci-throughput/E2-A-execution-notes.md
+++ b/docs/ci-throughput/E2-A-execution-notes.md
@@ -1,0 +1,108 @@
+# E2-A — execution notes
+
+Outcomes, not the forecast. `E2-contract.json` is frozen and is not
+edited by anything here; machine-readable qualification outcomes are in
+`E2-A-qualification.json`.
+
+## The first observation (A1, n=1)
+
+Run `34153296231`, branch `ci-e2` @ `b369d21a`, PR #450 — the pull
+request that makes the change, so it is its own first sample.
+
+```
+                                        baseline        this run
+larql-compute-metal, successful run     56.61 min       24.87 min
+```
+
+Internal split, against the expectation stated before the run:
+
+| | expected | measured |
+|---|---|---|
+| setup / checkout / toolchain / fmt / check / clippy | < 2 min | **65s** |
+| ordinary-profile smoke | well under 1 min | **47s** |
+| install cargo-llvm-cov | — | **1s** (was 49.7s) |
+| authoritative estate + coverage policy | ~23–25 min | **22m54s** |
+| **total** | ~25–28 min | **24m52s** |
+
+The arithmetic said 3565 − 2061 = 1504s. The run measured 1492s, twelve
+seconds away. That agreement is closer than the method earns on one
+sample and should be read as luck, not precision.
+
+**A1 holds at ≤ 27 min on n = 1.** That is not yet an effect estimate.
+The contract asks for `workflow_exec_max.larql-compute-metal.n >= 8`
+before the p50 means anything, and until then the honest statement is
+"the first observation fell in the target band", not "56.61 → 24.87".
+
+Structural qualification and statistical effect estimation are different
+things. The former is complete (below); the latter accumulates.
+
+## Structural qualification
+
+All five controls established — see `E2-A-qualification.json` for run
+IDs, SHAs and exact failing steps.
+
+- **S1** 69 binaries in the authoritative step, matching the pre-change
+  `--tests` count; `unittests src/lib.rs` runs once where it ran three
+  times.
+- **S2** run `34155283543`: smoke green, authoritative step red at 798s
+  on `s2_qualification_this_test_must_fail`.
+- **S3** run `34153560202`: smoke green, **all 70 test binaries passed**,
+  TOTAL 95.46% cleared `--fail-under-lines 90`, and the step went red on
+  `lowering/stack.rs: lines 86.63% below minimum 95.00%`.
+- **S4** `smoke tests executed: 7 (floor 5)`, binary under
+  `target/debug/`, not `target/llvm-cov-target/`.
+- **S5** no `bench-regress` check among PR #450's 13.
+
+S2 and S3 fail the same step for different reasons, which is the point of
+running both: in S2 the tests never finished, so the coverage policy
+never ran, and S2 alone cannot show that coverage can refuse.
+
+## Two runs that established nothing
+
+Recorded because leaving them out would make the qualification look
+cleaner than it was.
+
+| run | died at | after | why it proved nothing |
+|---|---|---|---|
+| `34153558202` | Clippy | 14s | `assert!(false, ..)` trips `clippy::assertions_on_constants` under `-D warnings`; steps 9–11 skipped |
+| `34155142711` | Format check | 9s | the replacement was not rustfmt-clean |
+
+Both went red. Neither reached the gate under test. **A red run at the
+wrong step resembles qualification and is not** — had either run ID been
+filed as "S2 established", the contract would have carried a false
+qualification, which is worse than no qualification at all.
+
+The second was avoidable: `cargo fmt --check` needs no compilation and
+was run locally before the third attempt. Clippy could not be run
+locally — this machine was carrying a peer session's GLM-5 oracle at
+~300% CPU — so the third attempt was checked by CI's clippy instead, at a
+cost of 14s if wrong.
+
+## An incidental finding worth keeping
+
+The early gates are load-bearing, and this is the reverse of what the
+experiment was hunting. Two deliberately broken commits never reached the
+test estate because lint and formatting caught them in 14 and 9 seconds.
+The expensive gate was never asked, because the cheap ones answered
+first.
+
+Total macOS cost of qualification: one full estate run (S3, 24.7 min),
+one partial (S2, 15.4 min, stopping at the failure), and ~2 min of
+early-gate rejections.
+
+## Outstanding
+
+`S4`'s **failure** path is verified only off-runner: the shell logic was
+exercised against synthetic logs (7 → pass, 0 → fail), but no run has
+shown a filter selecting nothing actually redding the step. The floor's
+success path is proven; its failure path is not. That is the same class
+of gap the floor exists to close, and it is worth one dispatch if the
+floor is ever relied on to catch a real rename.
+
+## What this does not license
+
+E2-D — tiered Metal triggers — changes which pull requests enter the
+Metal population, which is A5's validity gate. Landing it before A has
+accumulated observations would hand a freshly-corrected instrument a new
+attribution problem. A answers *how long does the Metal gate take*; D
+answers *how often should we pay it*. They are cleaner apart.

--- a/docs/ci-throughput/E2-A-qualification.json
+++ b/docs/ci-throughput/E2-A-qualification.json
@@ -1,0 +1,95 @@
+{
+  "experiment": "E2-A",
+  "record": "structural qualification (S1-S5)",
+  "qualified_at": "2026-09-07",
+  "scope": "This file records OUTCOMES. It is not the forecast; E2-contract.json is frozen and is not edited by qualification.",
+  "why_this_is_not_optional": "CI-E2-A changes what a green Metal check means. A green run is consistent with a gate that cannot fail at all, so the claim that the cheaper gate still reds needs runs that actually go red, for the stated reason and no other.",
+  "method_note": "The two perturbation runs were dispatched via workflow_dispatch on throwaway branches, NOT opened as pull requests. ci_throughput.py collects on event=pull_request, so a throwaway PR would have injected two deliberately-broken attempts into the very population A1, A3 and A4 are measured over.",
+  "controls": [
+    {
+      "id": "S1",
+      "claim": "the same 69 test binaries are still executed",
+      "established": true,
+      "evidence": {
+        "run_id": 34153296231,
+        "branch": "ci-e2",
+        "sha": "b369d21a",
+        "event": "pull_request",
+        "observation": "69 `Running` lines in the authoritative step, matching the 69 the pre-change `--tests` step executed on run 34098337888. `unittests src/lib.rs` appears ONCE where it previously appeared three times across the job."
+      }
+    },
+    {
+      "id": "S2",
+      "claim": "a deliberately failing test reds the combined gate",
+      "established": true,
+      "evidence": {
+        "run_id": 34155283543,
+        "branch": "ci-e2-qual-s2",
+        "sha": "c26468ba",
+        "event": "workflow_dispatch",
+        "perturbation": "crates/larql-compute-metal/tests/aa_s2_qualification.rs — one integration test asserting on an environment variable that is never set. Deliberately outside backend::tests:: so the ordinary-profile smoke could not be what failed.",
+        "failing_step": "11. Test estate + coverage policy (authoritative)",
+        "step_seconds": 798,
+        "smoke_step": "9. Ordinary-profile execution witness: 57s SUCCESS, `smoke tests executed: 7 (floor 5)`",
+        "observation": "test s2_qualification_this_test_must_fail ... FAILED; test result: FAILED. 0 passed; 1 failed; make: *** [larql-compute-metal-coverage-summary] Error 101",
+        "reverted": "branch deleted; never merged"
+      }
+    },
+    {
+      "id": "S3",
+      "claim": "a deliberately violated coverage policy reds the gate",
+      "established": true,
+      "evidence": {
+        "run_id": 34153560202,
+        "branch": "ci-e2-qual-s3",
+        "sha": "0a7ff7d1",
+        "event": "workflow_dispatch",
+        "perturbation": "coverage-policy.json — lowering/stack.rs raised from its recorded baseline of 86 to 95, above the 86.63 it measures.",
+        "failing_step": "11. Test estate + coverage policy (authoritative)",
+        "step_seconds": 1356,
+        "smoke_step": "9. Ordinary-profile execution witness: 51s SUCCESS, `smoke tests executed: 7 (floor 5)`",
+        "observation": "0 test binaries failed, 70 passed; TOTAL 95.46% cleared --fail-under-lines 90; then `Coverage policy failed: crates/larql-compute-metal/src/lowering/stack.rs: lines 86.63% below minimum 95.00%`, make Error 1 -> Error 2.",
+        "separation": "S2 and S3 fail the SAME step for different reasons. S3 proves the coverage half can refuse on its own, which S2 does not establish: in S2 the tests never finished, so the policy checker never ran.",
+        "reverted": "branch deleted; never merged"
+      }
+    },
+    {
+      "id": "S4",
+      "claim": "the ordinary-profile witness actually runs, in the ordinary profile",
+      "established": true,
+      "evidence": {
+        "run_id": 34153296231,
+        "observation": "`smoke tests executed: 7 (floor 5)`, and the binary path is target/debug/deps/larql_compute_metal-*, NOT target/llvm-cov-target/. Reproduced on both control runs.",
+        "not_yet_established": "That a filter matching nothing FAILS the step has been verified only by running the shell logic against synthetic logs (7 -> pass, 0 -> fail), not on a runner. The floor's success path is proven; its failure path is not."
+      }
+    },
+    {
+      "id": "S5",
+      "claim": "no pull_request benchmark job remains",
+      "established": true,
+      "evidence": {
+        "run_id": 34153296231,
+        "observation": "bench-regress.yml has no pull_request key, and no bench-regress check appears among PR #450's 13 checks."
+      }
+    }
+  ],
+  "attempts_that_established_nothing": [
+    {
+      "run_id": 34153558202,
+      "control": "S2",
+      "failing_step": "8. Clippy (no-deps)",
+      "step_seconds": 14,
+      "why_it_proved_nothing": "The perturbation was `assert!(false, ..)`, which trips clippy::assertions_on_constants under -D warnings. The job died at lint and steps 9-11 were SKIPPED, so the run says nothing about whether the authoritative step can fail. A red run at the wrong step resembles qualification and is not.",
+      "recorded_because": "A qualification record that lists only the run that worked would misrepresent what was tested."
+    },
+    {
+      "run_id": 34155142711,
+      "control": "S2",
+      "failing_step": "6. Format check",
+      "step_seconds": 9,
+      "why_it_proved_nothing": "Same: the replacement perturbation was not rustfmt-clean, so the job died before the step under test. Avoidable — `cargo fmt --check` needs no compilation and was run locally before the third attempt."
+    }
+  ],
+  "incidental_finding": "Both failed attempts were stopped by cheap early gates (14s and 9s) before reaching the expensive one. Two deliberately broken commits never reached the test estate because lint and formatting caught them first. Total macOS cost of the qualification: one full estate run (S3, 24.7 min), one partial (S2, 15.4 min), and ~2 min of early-gate rejections.",
+  "outstanding": "S4's failure path (a smoke filter that selects nothing must red the step) is verified only off-runner. Worth a third dispatch if the floor is ever relied on to catch a real rename."
+}

--- a/docs/ci-throughput/E2-contract.json
+++ b/docs/ci-throughput/E2-contract.json
@@ -1,0 +1,191 @@
+{
+  "experiment": "E2-A",
+  "title": "One piece of evidence, once \u2014 de-duplicated Metal gate, bench-regress off the PR path",
+  "frozen_at": "2026-09-07",
+  "claim": "A Metal-changing pull request executes every required test binary ONCE, under the authoritative coverage profile, plus a deliberately small ordinary-profile execution witness. No complete test suite is executed twice, and no unqualified benchmark job sits on the pull-request critical path.",
+  "measurement_contract": {
+    "rule": "Every prediction frozen from E2 onward names an INTENSIVE metric. The instrument refuses to score an extensive one across samples of different size, and the selftest asserts that refusal fires.",
+    "reason": "E1's C2 froze two extensive totals and collected 12 attempts against 33; a 12/33 ratio contributes -63.6% before any effect exists, so its validity gate could not pass. See E1-postmortem.md.",
+    "intensive_metrics_available": [
+      "merge_ready.p50 / p95",
+      "first_blocking_green.p50 / p95",
+      "macos_queue_max.p50 / p95",
+      "queued_per_attempt.<os>",
+      "executed_per_attempt.<os>",
+      "superseded_exec_mean",
+      "workflow_exec_max.<workflow>.p50 / p95   (successful runs only)",
+      "workflow_share.<workflow>"
+    ]
+  },
+  "baseline": {
+    "primary_snapshot": "docs/ci-throughput/after-e1.json",
+    "primary_window": "2026-09-07, 12 attempts / 6 branches \u2014 the state E1 left behind",
+    "metal_gate_snapshot": "docs/ci-throughput/metal-gate-baseline.json",
+    "metal_gate_window": "2026-08-25 onward, pruned to larql-compute-metal: 40 attempts, 34 SUCCESSFUL runs (durations 47.0-68.7 min)",
+    "why_two": "The primary window holds only 2 successful Metal runs, too thin to freeze a target against. The Metal gate's duration is a property of the job, not of the surrounding mix, and E1's c1/c2/c3 did not change what that job runs \u2014 so a wider window is the honest baseline for it. The two agree: 56.22 min (n=2) and 56.61 min (n=34).",
+    "values": {
+      "workflow_exec_max.larql-compute-metal.p50": 56.61,
+      "workflow_exec_max.larql-compute-metal.p95": 66.05,
+      "merge_ready.p50": 40.81,
+      "merge_ready.p95": 54.47,
+      "macos_queue_max.p50": 21.69,
+      "executed_per_attempt.macos": 76.72,
+      "queued_per_attempt.macos": 80.15,
+      "workflow_share.larql-compute-metal": 0.5,
+      "workflow_share.bench-regress": 0.5,
+      "workflow_share.msrv-metal": 0.5,
+      "workflow_exec_max.msrv-metal.p50": 0.72
+    }
+  },
+  "mechanism_measured_from_the_baseline": {
+    "run_id": 34098337888,
+    "pull_request": 449,
+    "job_seconds": 3565,
+    "duplicate_seconds": 2061,
+    "reading": "`cargo test --tests` selects every target with test = true, and a lib has it by default. Run 34098337888 ran 1 binary under `--lib`, then 69 under `--tests` INCLUDING src/lib.rs again, then the same 69 instrumented. The 530-test lib suite executed three times (671.22s + 535.74s + 535.52s); the 68 integration binaries twice. Deleting both plain steps removes 2061s of a 3565s job. Builds are not the cost: cold `cargo check --all-targets` is 26.1s, the plain test build 21.8s, the instrumented build 35.7s, and `cargo install --locked cargo-llvm-cov` 49.7s."
+  },
+  "predictions": [
+    {
+      "id": "A1",
+      "scores": "metal-dedup",
+      "claim": "the larql-compute-metal gate's successful-run p50 falls from 56.6 min to <= 27 min",
+      "reason": "2061s of 3565s on the measured run is duplicate execution; removing it leaves ~24 min, plus ~1-2 min for the ordinary-profile witness and minus ~50s of cargo install",
+      "falsifier": "> 35 min means the duplication was not the cost, or the coverage run is slower than the plain run by more than instrumentation explains",
+      "mechanism": "metal-dedup",
+      "kind": "effect",
+      "metric": "workflow_exec_max.larql-compute-metal.p50",
+      "held_if": {
+        "after": {
+          "lte": 27
+        }
+      },
+      "falsified_if": {
+        "after": {
+          "gt": 35
+        }
+      },
+      "pass_band_note": "<= 30 min is a pass; 27 is the target. Between 30 and 35 is PARTIAL and must be explained, not rounded."
+    },
+    {
+      "id": "A2",
+      "scores": "bench-removal",
+      "claim": "no pull-request attempt contains a bench-regress run",
+      "reason": "the pull_request trigger is removed from the workflow, not disabled by a paths filter",
+      "falsifier": "any nonzero share means the trigger is still reachable",
+      "mechanism": "bench-removal",
+      "kind": "effect",
+      "metric": "workflow_share.bench-regress",
+      "held_if": {
+        "after": {
+          "lte": 0
+        }
+      },
+      "falsified_if": {
+        "after": {
+          "gt": 0
+        }
+      }
+    },
+    {
+      "id": "A3",
+      "scores": "metal-dedup + bench-removal",
+      "claim": "macOS executed runner-minutes per attempt fall by at least 25%",
+      "reason": "bench-regress contributed 137.9 macOS execution-minutes over 12 attempts (11.5/attempt); Metal de-duplication removes ~34 min on the half of attempts that trigger it (~17/attempt)",
+      "falsifier": "a fall of less than 10% means neither mechanism reached the macOS pool",
+      "mechanism": "system",
+      "kind": "effect",
+      "metric": "executed_per_attempt.macos",
+      "held_if": {
+        "delta_pct": {
+          "lte": -25
+        }
+      },
+      "falsified_if": {
+        "delta_pct": {
+          "gt": -10
+        }
+      }
+    },
+    {
+      "id": "A4",
+      "scores": "system",
+      "claim": "merge-ready p50 falls from 40.8 min to <= 30 min",
+      "reason": "headline; the Metal gate is the tail on the attempts that trigger it, and bench-regress leaves the critical path entirely",
+      "falsifier": "> 38 min means the shortened gates were not on the critical path",
+      "mechanism": "system",
+      "kind": "effect",
+      "metric": "merge_ready.p50",
+      "held_if": {
+        "after": {
+          "lte": 30
+        }
+      },
+      "falsified_if": {
+        "after": {
+          "gt": 38
+        }
+      }
+    },
+    {
+      "id": "A5",
+      "scores": "system",
+      "claim": "VALIDITY \u2014 the AFTER window still triggers the Metal gate on a comparable share of attempts",
+      "reason": "A3 is intensive in sample size but not in MIX: a window that happens to trigger the expensive macOS gate on far fewer pull requests would show macOS minutes falling without anything having been made faster. This is the gate E1's P3 was reaching for and could not express.",
+      "falsifier": "a share below 0.3 means the AFTER window is not comparable and A3 must not be read as an effect",
+      "mechanism": "system",
+      "kind": "validity",
+      "metric": "workflow_share.larql-compute-metal",
+      "held_if": {
+        "after": {
+          "gte": 0.3
+        }
+      },
+      "falsified_if": {
+        "after": {
+          "lt": 0.3
+        }
+      },
+      "one_sided_note": "Only the LOW side falsifies. A higher Metal share would make macOS minutes worse, not flatter, so it cannot manufacture the effect A3 claims."
+    }
+  ],
+  "structural_falsifiers": [
+    {
+      "id": "S1",
+      "claim": "the same 69 test binaries are still executed",
+      "check": "count `Running ` lines in the authoritative step's log; must equal the 69 executed by the pre-change `--tests` step. A binary that stops being built is a silently shrunk estate.",
+      "not_scoreable_by": "ci_throughput.py \u2014 this is a log property, not a timing one"
+    },
+    {
+      "id": "S2",
+      "claim": "a deliberately failing test reds the combined gate",
+      "check": "push a commit with one `assert!(false)` in a lib test and one in an integration test; the authoritative step must fail. Revert before merge."
+    },
+    {
+      "id": "S3",
+      "claim": "a deliberately violated coverage policy reds the gate",
+      "check": "lower a per-file floor in coverage-policy.json above the file's real coverage, or delete a covering test; check_coverage_policy.py must fail. Revert before merge."
+    },
+    {
+      "id": "S4",
+      "claim": "the ordinary-profile witness actually runs, in the ordinary profile",
+      "check": "the step prints `smoke tests executed: N` with N >= SMOKE_MIN_TESTS, and its binary path is under target/debug/, not target/llvm-cov-target/. A filter that matches nothing must fail the step \u2014 verify by dispatching once with a deliberately wrong filter."
+    },
+    {
+      "id": "S5",
+      "claim": "no pull_request benchmark job remains",
+      "check": "`.github/workflows/bench-regress.yml` has no `pull_request:` key, and A2 scores 0 on the AFTER window."
+    }
+  ],
+  "confounds": [
+    "GitHub's hosted macOS pool availability varies independently of this repository; macos_queue_max is not claimed by any E2-A prediction for that reason",
+    "the AFTER window must contain enough SUCCESSFUL Metal runs for A1's p50 to mean anything \u2014 collect until workflow_exec_max.larql-compute-metal.n >= 8",
+    "E2-D (tiered Metal triggers) would change workflow_share.larql-compute-metal deliberately, which is why it must be measured AFTER E2-A is scored, not alongside it"
+  ],
+  "scoring": "scripts/ci_throughput.py adjudicate --forecast docs/ci-throughput/E2-contract.json --before docs/ci-throughput/after-e1.json --after docs/ci-throughput/after-e2a.json",
+  "scoring_note": "A1's baseline comes from metal-gate-baseline.json, not from the primary before-snapshot: pass --before docs/ci-throughput/metal-gate-baseline.json for A1 and read the other four against after-e1.json. The two-baseline split is stated here so the adjudicator cannot be pointed at the thin one by accident.",
+  "mechanisms": {
+    "metal-dedup": "run the Metal test estate once, under coverage, plus a small ordinary-profile witness",
+    "bench-removal": "bench-regress off the pull-request path until PERF-QUAL-2 qualifies it",
+    "system": "the tranche as a whole"
+  }
+}

--- a/docs/ci-throughput/README.md
+++ b/docs/ci-throughput/README.md
@@ -183,6 +183,10 @@ are deleted, and a small ordinary-profile witness keeps the one signal
 that would otherwise be lost. `bench-regress` leaves the pull-request
 path until PERF-QUAL-2 qualifies it.
 
+Outcomes live in `E2-A-qualification.json` (machine-readable) and
+`E2-A-execution-notes.md` (the reading). The contract itself is frozen
+and is not edited by qualification.
+
 Five predictions (A1–A5) plus five **structural** falsifiers (S1–S5) that
 this instrument cannot score and which are checked by hand: the same 69
 binaries still execute, a deliberately failing test reds the gate, a

--- a/docs/ci-throughput/README.md
+++ b/docs/ci-throughput/README.md
@@ -1,4 +1,4 @@
-# CI throughput — E1
+# CI throughput — E1, E2
 
 An experiment, not a cleanup. The question is whether three specific CI
 changes move measured wall clock, and by how much, so that afterwards the
@@ -112,10 +112,96 @@ to `INVALID COMPARISON`. And scoring the baseline against itself falsifies
 all four mechanisms, which is the evidence that the forecast is not
 already satisfied by doing nothing.
 
-## Not in E1
+## E1's verdict (2026-09-07)
 
-vcpkg binary caching and `sccache` are E2, deliberately held back so that
-a change in these numbers is attributable to c1–c3 and nothing else. The
+`E1-verdict.json`, frozen as delivered, against `after-e1.json`
+(12 attempts / 6 branches, `--since 2026-09-07`):
+
+```
+C1  cancel superseded PR runs    P1  931.6 -> 26.9 min  (-97%)        HELD
+C2  macOS scheduling contention  P2  queued.macos      (-79%)         HELD
+                                 P3  executed.macos    (-70%)    FALSIFIED
+                                 VERDICT: INVALID COMPARISON
+C3  VINDEX benches Linux-only    P4  29.7 -> 21.8 min p50            HELD
+SYSTEM                           P5  merge-ready 61.4 -> 40.8 p50    HELD
+```
+
+C2's refusal was correct behaviour and fired for the wrong reason: P2 and
+P3 name **extensive** totals, and 12 attempts against 33 contributes
+-63.6% before any effect exists, so P3 could not have held. C2 is
+**unadjudicated, not refuted**. `E1-postmortem.md` carries the post-hoc
+diagnostic and is explicitly not a new verdict; E1 itself is not
+re-scored.
+
+## E2-0 — what the instrument learned
+
+The defect was in the measurement, so the measurement was fixed:
+
+- every extensive metric gained an intensive companion —
+  `queued_per_attempt.<os>`, `executed_per_attempt.<os>`;
+- `score_prediction` **refuses** an extensive metric whose two samples
+  differ in attempt count, returning `UNSCOREABLE` and naming the
+  per-attempt metric to use instead;
+- `workflow_share.<workflow>` makes composition scoreable, which is what
+  P3 was reaching for;
+- `workflow_exec_max.<workflow>` measures a gate's wall clock over
+  **successful runs only**, so cancelling more runs cannot read as a
+  faster gate;
+- `selftest` asserts the guard fires at unequal n, does **not** fire at
+  equal n, and that every forecast frozen from E2 onward names only
+  intensive metrics.
+
+Re-running `adjudicate` on E1 today returns `UNSCOREABLE` for **both C1
+and C2** — P1 also names a total (`superseded_exec_total`) — where the
+frozen verdict read HELD and INVALID COMPARISON. That is not a retraction
+of C1: its intensive companion `superseded_exec_mean` moves -92%
+(28m14s -> 2m15s per attempt), so cancellation is established on a metric
+the guard accepts. C2's companion moves only -16.6%, which is
+inconclusive. The guard refuses by NAME, not by substance, and the
+substance differs between the two.
+
+`E1-verdict.json` is not regenerated; it records the verdict as
+delivered.
+
+## E2-A — one piece of evidence, once
+
+`E2-contract.json`, frozen 2026-09-07. Baseline: `after-e1.json` for the
+system metrics, `metal-gate-baseline.json` (40 attempts, 34
+successful Metal runs spanning 47.0-68.7 min, p50 56.6) for the Metal
+gate itself.
+
+The mechanism, measured on run 34098337888 (#449): `cargo test --tests`
+selects every target with `test = true`, and a lib has it by default, so
+the job ran 1 binary under `--lib`, then 69 under `--tests` **including
+`src/lib.rs` again**, then the same 69 instrumented. The 530-test lib
+suite executed three times; the 68 integration binaries twice; 2061s of a
+3565s job was duplicate execution.
+
+So the coverage run — which already runs the same 69 binaries serially
+and fails on a failing test — becomes authoritative, the two plain passes
+are deleted, and a small ordinary-profile witness keeps the one signal
+that would otherwise be lost. `bench-regress` leaves the pull-request
+path until PERF-QUAL-2 qualifies it.
+
+Five predictions (A1–A5) plus five **structural** falsifiers (S1–S5) that
+this instrument cannot score and which are checked by hand: the same 69
+binaries still execute, a deliberately failing test reds the gate, a
+deliberately violated coverage policy reds the gate, the smoke witness
+runs in the ordinary profile, and no `pull_request` benchmark job
+remains.
+
+## Still not done
+
+`sccache` and vcpkg binary caching are deliberately later than they were
+in the original plan: measurement says compilation here is tens of
+seconds (cold `cargo check --all-targets` 26.1s, plain test build 21.8s)
+against tens of minutes of test execution. Caching a 22-second build
+before removing a 34-minute duplicate execution optimises the wrong
+denominator.
+
+E2-D — tiered Metal triggers — is next after E2-A is scored, not
+alongside it: it deliberately changes
+`workflow_share.larql-compute-metal`, which is A5's validity gate. The
 five remaining ungated `cargo test --benches` steps (`larql-boundary`,
 `larql-core`, `larql-kv`, `larql-lql`, `larql-models`) and an actionlint
-gate are also held back for the same reason.
+gate stay held back.

--- a/docs/ci-throughput/after-e1.json
+++ b/docs/ci-throughput/after-e1.json
@@ -1,0 +1,6384 @@
+{
+  "collected_at": "2026-09-07T18:08:11.694965+00:00",
+  "repo": "chrishayuk/larql",
+  "query": {
+    "since": "2026-09-07",
+    "until": null,
+    "max_prs": 20,
+    "branch": null
+  },
+  "runs": [
+    {
+      "id": 34099227214,
+      "workflow": "larql-lql",
+      "branch": "represent-attestation-1",
+      "sha": "0d251dc05b9ed8ad86e676cea2adac22e3f02b15",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:10:56Z",
+      "run_started_at": "2026-09-07T08:10:56Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:59Z",
+          "completed_at": "2026-09-07T08:18:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:43:30Z",
+          "completed_at": "2026-09-07T08:53:38Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:59Z",
+          "completed_at": "2026-09-07T08:20:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:11:00Z",
+          "completed_at": "2026-09-07T08:29:20Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34099227094,
+      "workflow": "mutants",
+      "branch": "represent-attestation-1",
+      "sha": "0d251dc05b9ed8ad86e676cea2adac22e3f02b15",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T08:10:56Z",
+      "run_started_at": "2026-09-07T08:10:56Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:59Z",
+          "completed_at": "2026-09-07T08:56:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:40:50Z",
+          "completed_at": "2026-09-07T08:41:00Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34099227245,
+      "workflow": "larql-vindex",
+      "branch": "represent-attestation-1",
+      "sha": "0d251dc05b9ed8ad86e676cea2adac22e3f02b15",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:10:56Z",
+      "run_started_at": "2026-09-07T08:10:56Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:11:05Z",
+          "completed_at": "2026-09-07T08:26:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:12:14Z",
+          "completed_at": "2026-09-07T08:20:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:53:47Z",
+          "completed_at": "2026-09-07T09:07:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:11:00Z",
+          "completed_at": "2026-09-07T08:33:34Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34099227192,
+      "workflow": "quality",
+      "branch": "represent-attestation-1",
+      "sha": "0d251dc05b9ed8ad86e676cea2adac22e3f02b15",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:10:56Z",
+      "run_started_at": "2026-09-07T08:10:56Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:17:00Z",
+          "completed_at": "2026-09-07T08:17:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:18:30Z",
+          "completed_at": "2026-09-07T08:19:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:18:50Z",
+          "completed_at": "2026-09-07T08:19:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:18:52Z",
+          "completed_at": "2026-09-07T08:18:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:19:02Z",
+          "completed_at": "2026-09-07T08:19:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:19:13Z",
+          "completed_at": "2026-09-07T08:20:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:19:16Z",
+          "completed_at": "2026-09-07T08:26:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:57Z",
+          "started_at": "2026-09-07T08:19:35Z",
+          "completed_at": "2026-09-07T08:20:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34099227121,
+      "workflow": "commit messages",
+      "branch": "represent-attestation-1",
+      "sha": "0d251dc05b9ed8ad86e676cea2adac22e3f02b15",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:10:56Z",
+      "run_started_at": "2026-09-07T08:10:56Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:58Z",
+          "completed_at": "2026-09-07T08:11:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34099227087,
+      "workflow": "larql-server",
+      "branch": "represent-attestation-1",
+      "sha": "0d251dc05b9ed8ad86e676cea2adac22e3f02b15",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:10:56Z",
+      "run_started_at": "2026-09-07T08:10:56Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:59Z",
+          "completed_at": "2026-09-07T08:21:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:58Z",
+          "completed_at": "2026-09-07T08:32:36Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:58Z",
+          "completed_at": "2026-09-07T08:20:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:17:10Z",
+          "completed_at": "2026-09-07T08:28:25Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34099227088,
+      "workflow": "larql-inference",
+      "branch": "represent-attestation-1",
+      "sha": "0d251dc05b9ed8ad86e676cea2adac22e3f02b15",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:10:56Z",
+      "run_started_at": "2026-09-07T08:10:56Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:58Z",
+          "completed_at": "2026-09-07T08:29:28Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:30:58Z",
+          "completed_at": "2026-09-07T08:40:17Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:58Z",
+          "completed_at": "2026-09-07T08:17:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:59Z",
+          "completed_at": "2026-09-07T08:18:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34099227229,
+      "workflow": "larql-cli",
+      "branch": "represent-attestation-1",
+      "sha": "0d251dc05b9ed8ad86e676cea2adac22e3f02b15",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:10:56Z",
+      "run_started_at": "2026-09-07T08:10:56Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:58Z",
+          "completed_at": "2026-09-07T08:18:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:58Z",
+          "completed_at": "2026-09-07T08:30:53Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:56Z",
+          "started_at": "2026-09-07T08:10:59Z",
+          "completed_at": "2026-09-07T08:21:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:10:57Z",
+          "started_at": "2026-09-07T08:30:49Z",
+          "completed_at": "2026-09-07T08:42:46Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071944456,
+      "workflow": "commit messages",
+      "branch": "represent-attestation-1",
+      "sha": "9048e9222c8c722db7bc8e575e5b1a938e33dcdb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T01:06:54Z",
+      "run_started_at": "2026-09-07T01:06:54Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:07:02Z",
+          "completed_at": "2026-09-07T01:07:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071944487,
+      "workflow": "larql-server",
+      "branch": "represent-attestation-1",
+      "sha": "9048e9222c8c722db7bc8e575e5b1a938e33dcdb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T01:06:54Z",
+      "run_started_at": "2026-09-07T01:06:54Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:21:28Z",
+          "completed_at": "2026-09-07T01:31:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:08:22Z",
+          "completed_at": "2026-09-07T01:17:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:17:14Z",
+          "completed_at": "2026-09-07T01:39:08Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:21:32Z",
+          "completed_at": "2026-09-07T01:31:46Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071944442,
+      "workflow": "quality",
+      "branch": "represent-attestation-1",
+      "sha": "9048e9222c8c722db7bc8e575e5b1a938e33dcdb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T01:06:54Z",
+      "run_started_at": "2026-09-07T01:06:54Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:09:47Z",
+          "completed_at": "2026-09-07T01:09:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:36:30Z",
+          "completed_at": "2026-09-07T01:36:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:33:05Z",
+          "completed_at": "2026-09-07T01:33:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:13:53Z",
+          "completed_at": "2026-09-07T01:14:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:18:56Z",
+          "completed_at": "2026-09-07T01:26:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:20:59Z",
+          "completed_at": "2026-09-07T01:21:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:38:27Z",
+          "completed_at": "2026-09-07T01:39:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:39:49Z",
+          "completed_at": "2026-09-07T01:40:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071944459,
+      "workflow": "larql-vindex",
+      "branch": "represent-attestation-1",
+      "sha": "9048e9222c8c722db7bc8e575e5b1a938e33dcdb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T01:06:54Z",
+      "run_started_at": "2026-09-07T01:06:54Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:59Z",
+          "started_at": "2026-09-07T01:16:54Z",
+          "completed_at": "2026-09-07T01:26:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:59Z",
+          "started_at": "2026-09-07T01:09:34Z",
+          "completed_at": "2026-09-07T01:24:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:59Z",
+          "started_at": "2026-09-07T01:22:00Z",
+          "completed_at": "2026-09-07T01:32:23Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:59Z",
+          "started_at": "2026-09-07T01:17:56Z",
+          "completed_at": "2026-09-07T01:40:26Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34071944455,
+      "workflow": "mutants",
+      "branch": "represent-attestation-1",
+      "sha": "9048e9222c8c722db7bc8e575e5b1a938e33dcdb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T01:06:54Z",
+      "run_started_at": "2026-09-07T01:06:54Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:46:30Z",
+          "completed_at": "2026-09-07T01:46:39Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:07:42Z",
+          "completed_at": "2026-09-07T01:52:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071944443,
+      "workflow": "larql-cli",
+      "branch": "represent-attestation-1",
+      "sha": "9048e9222c8c722db7bc8e575e5b1a938e33dcdb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T01:06:54Z",
+      "run_started_at": "2026-09-07T01:06:54Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:07:01Z",
+          "started_at": "2026-09-07T01:21:54Z",
+          "completed_at": "2026-09-07T01:27:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:07:01Z",
+          "started_at": "2026-09-07T01:36:38Z",
+          "completed_at": "2026-09-07T01:46:40Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:07:01Z",
+          "started_at": "2026-09-07T01:37:28Z",
+          "completed_at": "2026-09-07T01:47:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:07:01Z",
+          "started_at": "2026-09-07T01:19:11Z",
+          "completed_at": "2026-09-07T01:39:54Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34071944453,
+      "workflow": "larql-inference",
+      "branch": "represent-attestation-1",
+      "sha": "9048e9222c8c722db7bc8e575e5b1a938e33dcdb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T01:06:54Z",
+      "run_started_at": "2026-09-07T01:06:54Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:07:00Z",
+          "started_at": "2026-09-07T01:32:04Z",
+          "completed_at": "2026-09-07T01:49:19Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:07:00Z",
+          "started_at": "2026-09-07T01:25:42Z",
+          "completed_at": "2026-09-07T01:32:13Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:07:00Z",
+          "started_at": "2026-09-07T01:39:10Z",
+          "completed_at": "2026-09-07T01:48:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:07:00Z",
+          "started_at": "2026-09-07T01:33:15Z",
+          "completed_at": "2026-09-07T01:40:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071944445,
+      "workflow": "larql-lql",
+      "branch": "represent-attestation-1",
+      "sha": "9048e9222c8c722db7bc8e575e5b1a938e33dcdb",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T01:06:54Z",
+      "run_started_at": "2026-09-07T01:06:54Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:12:27Z",
+          "completed_at": "2026-09-07T01:20:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:10:15Z",
+          "completed_at": "2026-09-07T01:19:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:17:40Z",
+          "completed_at": "2026-09-07T01:25:35Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T01:06:55Z",
+          "started_at": "2026-09-07T01:18:40Z",
+          "completed_at": "2026-09-07T01:37:26Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34071401558,
+      "workflow": "commit messages",
+      "branch": "represent-attestation-1",
+      "sha": "5c0043d218270a709c987fc4a3d4d450e46b7f8c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:56:46Z",
+      "run_started_at": "2026-09-07T00:56:46Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:56:46Z",
+          "started_at": "2026-09-07T00:59:22Z",
+          "completed_at": "2026-09-07T00:59:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071401597,
+      "workflow": "larql-lql",
+      "branch": "represent-attestation-1",
+      "sha": "5c0043d218270a709c987fc4a3d4d450e46b7f8c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:56:46Z",
+      "run_started_at": "2026-09-07T00:56:46Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:56:51Z",
+          "started_at": "2026-09-07T00:57:05Z",
+          "completed_at": "2026-09-07T01:03:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:51Z",
+          "started_at": "2026-09-07T00:56:51Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:51Z",
+          "started_at": "2026-09-07T00:56:51Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:51Z",
+          "started_at": "2026-09-07T00:56:51Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071401573,
+      "workflow": "mutants",
+      "branch": "represent-attestation-1",
+      "sha": "5c0043d218270a709c987fc4a3d4d450e46b7f8c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:56:46Z",
+      "run_started_at": "2026-09-07T00:56:46Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:57:04Z",
+          "started_at": "2026-09-07T00:57:04Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:57:04Z",
+          "started_at": "2026-09-07T00:57:04Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071401501,
+      "workflow": "quality",
+      "branch": "represent-attestation-1",
+      "sha": "5c0043d218270a709c987fc4a3d4d450e46b7f8c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:56:46Z",
+      "run_started_at": "2026-09-07T00:56:46Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:46Z",
+          "started_at": "2026-09-07T00:56:46Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:46Z",
+          "started_at": "2026-09-07T00:56:46Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:46Z",
+          "started_at": "2026-09-07T00:56:46Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:46Z",
+          "started_at": "2026-09-07T00:56:46Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:46Z",
+          "started_at": "2026-09-07T00:56:46Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:46Z",
+          "started_at": "2026-09-07T00:56:46Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:46Z",
+          "started_at": "2026-09-07T00:56:46Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:46Z",
+          "started_at": "2026-09-07T00:56:46Z",
+          "completed_at": "2026-09-07T01:06:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071401515,
+      "workflow": "larql-server",
+      "branch": "represent-attestation-1",
+      "sha": "5c0043d218270a709c987fc4a3d4d450e46b7f8c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:56:46Z",
+      "run_started_at": "2026-09-07T00:56:46Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:51Z",
+          "started_at": "2026-09-07T00:56:51Z",
+          "completed_at": "2026-09-07T01:06:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:51Z",
+          "started_at": "2026-09-07T00:56:51Z",
+          "completed_at": "2026-09-07T01:06:55Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:51Z",
+          "started_at": "2026-09-07T00:56:51Z",
+          "completed_at": "2026-09-07T01:06:55Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:51Z",
+          "started_at": "2026-09-07T00:56:51Z",
+          "completed_at": "2026-09-07T01:06:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071401550,
+      "workflow": "larql-inference",
+      "branch": "represent-attestation-1",
+      "sha": "5c0043d218270a709c987fc4a3d4d450e46b7f8c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:56:46Z",
+      "run_started_at": "2026-09-07T00:56:46Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:50Z",
+          "started_at": "2026-09-07T00:56:50Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:50Z",
+          "started_at": "2026-09-07T00:56:50Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:50Z",
+          "started_at": "2026-09-07T00:56:53Z",
+          "completed_at": "2026-09-07T01:07:00Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:50Z",
+          "started_at": "2026-09-07T00:56:50Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071401474,
+      "workflow": "larql-cli",
+      "branch": "represent-attestation-1",
+      "sha": "5c0043d218270a709c987fc4a3d4d450e46b7f8c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:56:46Z",
+      "run_started_at": "2026-09-07T00:56:46Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:52Z",
+          "started_at": "2026-09-07T01:00:15Z",
+          "completed_at": "2026-09-07T01:07:00Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:52Z",
+          "started_at": "2026-09-07T00:56:52Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:52Z",
+          "started_at": "2026-09-07T00:56:52Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:56:52Z",
+          "started_at": "2026-09-07T00:56:52Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071401493,
+      "workflow": "larql-vindex",
+      "branch": "represent-attestation-1",
+      "sha": "5c0043d218270a709c987fc4a3d4d450e46b7f8c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:56:46Z",
+      "run_started_at": "2026-09-07T00:56:46Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:57:05Z",
+          "started_at": "2026-09-07T00:57:05Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:57:05Z",
+          "started_at": "2026-09-07T00:57:05Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:57:05Z",
+          "started_at": "2026-09-07T00:57:05Z",
+          "completed_at": "2026-09-07T01:06:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:57:05Z",
+          "started_at": "2026-09-07T01:02:29Z",
+          "completed_at": "2026-09-07T01:06:59Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34070402341,
+      "workflow": "commit messages",
+      "branch": "represent-attestation-1",
+      "sha": "949a18df508c7284be43f78455adcb4c5642e372",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:37:29Z",
+      "run_started_at": "2026-09-07T00:37:29Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:41:36Z",
+          "completed_at": "2026-09-07T00:41:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34070402343,
+      "workflow": "quality",
+      "branch": "represent-attestation-1",
+      "sha": "949a18df508c7284be43f78455adcb4c5642e372",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:37:29Z",
+      "run_started_at": "2026-09-07T00:37:29Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:33Z",
+          "completed_at": "2026-09-07T00:38:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:52Z",
+          "completed_at": "2026-09-07T00:38:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:46:26Z",
+          "completed_at": "2026-09-07T00:47:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:47:14Z",
+          "completed_at": "2026-09-07T00:47:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:47:16Z",
+          "completed_at": "2026-09-07T00:47:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:47:29Z",
+          "completed_at": "2026-09-07T00:47:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:47:38Z",
+          "completed_at": "2026-09-07T00:55:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:47:40Z",
+          "completed_at": "2026-09-07T00:48:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34070402388,
+      "workflow": "larql-inference",
+      "branch": "represent-attestation-1",
+      "sha": "949a18df508c7284be43f78455adcb4c5642e372",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:37:29Z",
+      "run_started_at": "2026-09-07T00:37:29Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:31Z",
+          "completed_at": "2026-09-07T00:44:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:44:37Z",
+          "completed_at": "2026-09-07T00:56:50Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:38:06Z",
+          "completed_at": "2026-09-07T00:47:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:30Z",
+          "completed_at": "2026-09-07T00:56:46Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34070402346,
+      "workflow": "larql-lql",
+      "branch": "represent-attestation-1",
+      "sha": "949a18df508c7284be43f78455adcb4c5642e372",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:37:29Z",
+      "run_started_at": "2026-09-07T00:37:29Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:32Z",
+          "completed_at": "2026-09-07T00:44:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:45:01Z",
+          "completed_at": "2026-09-07T00:56:51Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:39:33Z",
+          "completed_at": "2026-09-07T00:46:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:30Z",
+          "completed_at": "2026-09-07T00:56:46Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34070402326,
+      "workflow": "larql-server",
+      "branch": "represent-attestation-1",
+      "sha": "949a18df508c7284be43f78455adcb4c5642e372",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:37:29Z",
+      "run_started_at": "2026-09-07T00:37:29Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:45:56Z",
+          "completed_at": "2026-09-07T00:53:11Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:41:42Z",
+          "completed_at": "2026-09-07T00:56:51Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:46:07Z",
+          "completed_at": "2026-09-07T00:54:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:30Z",
+          "completed_at": "2026-09-07T00:56:46Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34070402315,
+      "workflow": "larql-cli",
+      "branch": "represent-attestation-1",
+      "sha": "949a18df508c7284be43f78455adcb4c5642e372",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:37:29Z",
+      "run_started_at": "2026-09-07T00:37:29Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:30Z",
+          "completed_at": "2026-09-07T00:56:46Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:31Z",
+          "completed_at": "2026-09-07T00:47:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:32Z",
+          "completed_at": "2026-09-07T00:56:51Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:38:03Z",
+          "completed_at": "2026-09-07T00:45:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34070402359,
+      "workflow": "mutants",
+      "branch": "represent-attestation-1",
+      "sha": "949a18df508c7284be43f78455adcb4c5642e372",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:37:29Z",
+      "run_started_at": "2026-09-07T00:37:29Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:41:28Z",
+          "completed_at": "2026-09-07T00:57:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:52:30Z",
+          "completed_at": "2026-09-07T00:52:40Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34070402328,
+      "workflow": "larql-vindex",
+      "branch": "represent-attestation-1",
+      "sha": "949a18df508c7284be43f78455adcb4c5642e372",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:37:29Z",
+      "run_started_at": "2026-09-07T00:37:29Z",
+      "pr": 447,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:37:32Z",
+          "completed_at": "2026-09-07T00:52:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:39:26Z",
+          "completed_at": "2026-09-07T00:56:51Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:54:01Z",
+          "completed_at": "2026-09-07T00:57:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:37:30Z",
+          "started_at": "2026-09-07T00:46:05Z",
+          "completed_at": "2026-09-07T00:55:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34098337888,
+      "workflow": "larql-compute-metal",
+      "branch": "ci-gates-mean-what-they-say",
+      "sha": "d0c0c816992ab43c2b86ae8864d7acfdef2a3ec4",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:00:51Z",
+      "run_started_at": "2026-09-07T08:00:51Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:03:03Z",
+          "completed_at": "2026-09-07T09:02:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34098337967,
+      "workflow": "bench-regress",
+      "branch": "ci-gates-mean-what-they-say",
+      "sha": "d0c0c816992ab43c2b86ae8864d7acfdef2a3ec4",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T08:00:51Z",
+      "run_started_at": "2026-09-07T08:00:51Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:42:53Z",
+          "completed_at": "2026-09-07T09:05:15Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34098337999,
+      "workflow": "quality",
+      "branch": "ci-gates-mean-what-they-say",
+      "sha": "d0c0c816992ab43c2b86ae8864d7acfdef2a3ec4",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:00:51Z",
+      "run_started_at": "2026-09-07T08:00:51Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:00:53Z",
+          "completed_at": "2026-09-07T08:01:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:00:54Z",
+          "completed_at": "2026-09-07T08:01:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:00:53Z",
+          "completed_at": "2026-09-07T08:08:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:00:53Z",
+          "completed_at": "2026-09-07T08:01:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:00:53Z",
+          "completed_at": "2026-09-07T08:01:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:00:53Z",
+          "completed_at": "2026-09-07T08:01:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:00:56Z",
+          "completed_at": "2026-09-07T08:01:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:01:01Z",
+          "completed_at": "2026-09-07T08:01:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34098337949,
+      "workflow": "commit messages",
+      "branch": "ci-gates-mean-what-they-say",
+      "sha": "d0c0c816992ab43c2b86ae8864d7acfdef2a3ec4",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:00:51Z",
+      "run_started_at": "2026-09-07T08:00:51Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:00:53Z",
+          "completed_at": "2026-09-07T08:00:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34098337894,
+      "workflow": "mutants",
+      "branch": "ci-gates-mean-what-they-say",
+      "sha": "d0c0c816992ab43c2b86ae8864d7acfdef2a3ec4",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:00:51Z",
+      "run_started_at": "2026-09-07T08:00:51Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:28:31Z",
+          "completed_at": "2026-09-07T08:28:58Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:00:58Z",
+          "completed_at": "2026-09-07T08:01:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34098337970,
+      "workflow": "msrv-metal",
+      "branch": "ci-gates-mean-what-they-say",
+      "sha": "d0c0c816992ab43c2b86ae8864d7acfdef2a3ec4",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:00:51Z",
+      "run_started_at": "2026-09-07T08:00:51Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 larql-compute-metal",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:29:59Z",
+          "completed_at": "2026-09-07T08:30:51Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34089976116,
+      "workflow": "quality",
+      "branch": "dependabot/github_actions/github-actions-556be15a16",
+      "sha": "84f5fb42e0b9afd7920467a1170b8fdde6e46cce",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T06:14:53Z",
+      "run_started_at": "2026-09-07T06:14:53Z",
+      "pr": 448,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:14:56Z",
+          "completed_at": "2026-09-07T06:15:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:14:56Z",
+          "completed_at": "2026-09-07T06:15:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:14:56Z",
+          "completed_at": "2026-09-07T06:22:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:14:56Z",
+          "completed_at": "2026-09-07T06:15:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:14:55Z",
+          "completed_at": "2026-09-07T06:15:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:14:56Z",
+          "completed_at": "2026-09-07T06:15:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:14:55Z",
+          "completed_at": "2026-09-07T06:15:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:14:55Z",
+          "completed_at": "2026-09-07T06:15:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34089976416,
+      "workflow": "commit messages",
+      "branch": "dependabot/github_actions/github-actions-556be15a16",
+      "sha": "84f5fb42e0b9afd7920467a1170b8fdde6e46cce",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T06:14:53Z",
+      "run_started_at": "2026-09-07T06:14:53Z",
+      "pr": 448,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:14:55Z",
+          "completed_at": "2026-09-07T06:14:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34089976195,
+      "workflow": "mutants",
+      "branch": "dependabot/github_actions/github-actions-556be15a16",
+      "sha": "84f5fb42e0b9afd7920467a1170b8fdde6e46cce",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T06:14:53Z",
+      "run_started_at": "2026-09-07T06:14:53Z",
+      "pr": 448,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:15:00Z",
+          "completed_at": "2026-09-07T06:15:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T06:14:54Z",
+          "started_at": "2026-09-07T06:14:55Z",
+          "completed_at": "2026-09-07T06:15:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077813242,
+      "workflow": "commit messages",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:04Z",
+          "started_at": "2026-09-07T02:54:10Z",
+          "completed_at": "2026-09-07T02:54:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077813295,
+      "workflow": "msrv-metal",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 larql-compute-metal",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:04Z",
+          "started_at": "2026-09-07T02:54:29Z",
+          "completed_at": "2026-09-07T02:55:15Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077813309,
+      "workflow": "larql-compute-metal",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T02:54:22Z",
+          "started_at": "2026-09-07T02:54:39Z",
+          "completed_at": "2026-09-07T03:53:22Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077813214,
+      "workflow": "larql-vindex",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:24Z",
+          "started_at": "2026-09-07T03:04:11Z",
+          "completed_at": "2026-09-07T03:13:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:24Z",
+          "started_at": "2026-09-07T03:01:31Z",
+          "completed_at": "2026-09-07T03:12:15Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:24Z",
+          "started_at": "2026-09-07T03:03:54Z",
+          "completed_at": "2026-09-07T03:26:15Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:24Z",
+          "started_at": "2026-09-07T02:57:14Z",
+          "completed_at": "2026-09-07T03:13:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077813358,
+      "workflow": "bench-regress",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T02:54:04Z",
+          "started_at": "2026-09-07T03:05:40Z",
+          "completed_at": "2026-09-07T03:28:19Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077813245,
+      "workflow": "larql-lql",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:21Z",
+          "started_at": "2026-09-07T02:54:24Z",
+          "completed_at": "2026-09-07T03:09:10Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:21Z",
+          "started_at": "2026-09-07T02:57:52Z",
+          "completed_at": "2026-09-07T03:05:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:21Z",
+          "started_at": "2026-09-07T02:55:55Z",
+          "completed_at": "2026-09-07T03:05:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:21Z",
+          "started_at": "2026-09-07T03:04:06Z",
+          "completed_at": "2026-09-07T03:12:50Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077813432,
+      "workflow": "larql-kv",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T03:01:26Z",
+          "completed_at": "2026-09-07T03:07:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:54:28Z",
+          "completed_at": "2026-09-07T03:01:25Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:55:14Z",
+          "completed_at": "2026-09-07T03:03:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:54:21Z",
+          "completed_at": "2026-09-07T03:13:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34077813294,
+      "workflow": "larql-inference",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:09Z",
+          "started_at": "2026-09-07T02:54:21Z",
+          "completed_at": "2026-09-07T03:01:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:09Z",
+          "started_at": "2026-09-07T02:54:20Z",
+          "completed_at": "2026-09-07T03:03:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:09Z",
+          "started_at": "2026-09-07T02:54:22Z",
+          "completed_at": "2026-09-07T03:13:37Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:09Z",
+          "started_at": "2026-09-07T02:54:26Z",
+          "completed_at": "2026-09-07T03:03:59Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077813380,
+      "workflow": "larql-server",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:55:23Z",
+          "completed_at": "2026-09-07T03:03:59Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:54:21Z",
+          "completed_at": "2026-09-07T03:02:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:54:21Z",
+          "completed_at": "2026-09-07T03:15:43Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:54:21Z",
+          "completed_at": "2026-09-07T03:02:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077813238,
+      "workflow": "mutants",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:22Z",
+          "started_at": "2026-09-07T03:01:59Z",
+          "completed_at": "2026-09-07T03:07:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:22Z",
+          "started_at": "2026-09-07T03:12:22Z",
+          "completed_at": "2026-09-07T03:17:44Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077813356,
+      "workflow": "larql-factory",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:04Z",
+          "started_at": "2026-09-07T02:54:10Z",
+          "completed_at": "2026-09-07T02:55:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:04Z",
+          "started_at": "2026-09-07T02:54:15Z",
+          "completed_at": "2026-09-07T02:55:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:04Z",
+          "started_at": "2026-09-07T02:54:20Z",
+          "completed_at": "2026-09-07T02:56:37Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34077813343,
+      "workflow": "larql-compute",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:20Z",
+          "started_at": "2026-09-07T02:54:33Z",
+          "completed_at": "2026-09-07T03:04:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:20Z",
+          "started_at": "2026-09-07T03:02:45Z",
+          "completed_at": "2026-09-07T03:04:23Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:20Z",
+          "started_at": "2026-09-07T03:04:06Z",
+          "completed_at": "2026-09-07T03:05:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:20Z",
+          "started_at": "2026-09-07T02:55:13Z",
+          "completed_at": "2026-09-07T02:57:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077813330,
+      "workflow": "quality",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:54:21Z",
+          "completed_at": "2026-09-07T03:01:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:54:22Z",
+          "completed_at": "2026-09-07T02:54:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:54:22Z",
+          "completed_at": "2026-09-07T02:54:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:54:22Z",
+          "completed_at": "2026-09-07T02:55:12Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T03:02:54Z",
+          "completed_at": "2026-09-07T03:03:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T03:05:50Z",
+          "completed_at": "2026-09-07T03:06:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T02:55:11Z",
+          "completed_at": "2026-09-07T02:55:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:19Z",
+          "started_at": "2026-09-07T03:06:11Z",
+          "completed_at": "2026-09-07T03:07:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077813346,
+      "workflow": "larql-models",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:23Z",
+          "started_at": "2026-09-07T03:05:14Z",
+          "completed_at": "2026-09-07T03:06:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:23Z",
+          "started_at": "2026-09-07T02:56:39Z",
+          "completed_at": "2026-09-07T02:57:50Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:23Z",
+          "started_at": "2026-09-07T02:54:25Z",
+          "completed_at": "2026-09-07T02:57:12Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34077813292,
+      "workflow": "shannon-verify",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:21Z",
+          "started_at": "2026-09-07T02:57:02Z",
+          "completed_at": "2026-09-07T03:08:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077813262,
+      "workflow": "larql-cli",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:23Z",
+          "started_at": "2026-09-07T03:12:55Z",
+          "completed_at": "2026-09-07T03:22:26Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:23Z",
+          "started_at": "2026-09-07T03:03:33Z",
+          "completed_at": "2026-09-07T03:11:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:23Z",
+          "started_at": "2026-09-07T03:03:59Z",
+          "completed_at": "2026-09-07T03:21:13Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:54:23Z",
+          "started_at": "2026-09-07T03:04:25Z",
+          "completed_at": "2026-09-07T03:13:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077634508,
+      "workflow": "commit messages",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:47Z",
+      "run_started_at": "2026-09-07T02:50:47Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:47Z",
+          "started_at": "2026-09-07T02:50:47Z",
+          "completed_at": "2026-09-07T02:54:03Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077623192,
+      "workflow": "commit messages",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:37Z",
+          "completed_at": "2026-09-07T02:50:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077623097,
+      "workflow": "msrv-metal",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 larql-compute-metal",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:42Z",
+          "completed_at": "2026-09-07T02:51:30Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077623093,
+      "workflow": "larql-inference",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:38Z",
+          "completed_at": "2026-09-07T02:54:08Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077623213,
+      "workflow": "larql-server",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:09Z",
+          "completed_at": "2026-09-07T02:54:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077623157,
+      "workflow": "larql-compute",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:53:30Z",
+          "completed_at": "2026-09-07T02:54:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34077623236,
+      "workflow": "larql-kv",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:54Z",
+          "completed_at": "2026-09-07T02:54:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077623135,
+      "workflow": "larql-factory",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:36Z",
+          "completed_at": "2026-09-07T02:51:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:21Z",
+          "completed_at": "2026-09-07T02:53:29Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077623216,
+      "workflow": "larql-lql",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:56Z",
+          "completed_at": "2026-09-07T02:54:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:32Z",
+          "completed_at": "2026-09-07T02:54:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077623086,
+      "workflow": "larql-compute-metal",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:42Z",
+          "completed_at": "2026-09-07T02:54:21Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077623117,
+      "workflow": "quality",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:38Z",
+          "completed_at": "2026-09-07T02:50:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:41Z",
+          "completed_at": "2026-09-07T02:51:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:37Z",
+          "completed_at": "2026-09-07T02:51:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:36Z",
+          "completed_at": "2026-09-07T02:54:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:36Z",
+          "completed_at": "2026-09-07T02:51:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:36Z",
+          "completed_at": "2026-09-07T02:50:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:36Z",
+          "completed_at": "2026-09-07T02:51:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:36Z",
+          "completed_at": "2026-09-07T02:51:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077623090,
+      "workflow": "mutants",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:41Z",
+          "completed_at": "2026-09-07T02:54:22Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:19Z",
+          "completed_at": "2026-09-07T02:54:21Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077623126,
+      "workflow": "larql-cli",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:12Z",
+          "completed_at": "2026-09-07T02:54:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:40Z",
+          "completed_at": "2026-09-07T02:54:22Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:36Z",
+          "completed_at": "2026-09-07T02:54:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:33Z",
+          "completed_at": "2026-09-07T02:54:08Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34077623155,
+      "workflow": "larql-models",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:38Z",
+          "completed_at": "2026-09-07T02:51:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:32Z",
+          "completed_at": "2026-09-07T02:54:23Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:45Z",
+          "completed_at": "2026-09-07T02:51:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077623074,
+      "workflow": "shannon-verify",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:37Z",
+          "completed_at": "2026-09-07T02:54:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077623107,
+      "workflow": "larql-vindex",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:51:47Z",
+          "completed_at": "2026-09-07T02:54:24Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:36Z",
+          "completed_at": "2026-09-07T02:54:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:34Z",
+          "completed_at": "2026-09-07T02:54:04Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:49Z",
+          "completed_at": "2026-09-07T02:54:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34077623208,
+      "workflow": "bench-regress",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:42Z",
+          "completed_at": "2026-09-07T03:14:40Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071113361,
+      "workflow": "msrv-metal",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 larql-compute-metal",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:55:47Z",
+          "completed_at": "2026-09-07T00:56:22Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071113352,
+      "workflow": "commit messages",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:06:36Z",
+          "completed_at": "2026-09-07T01:06:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071113369,
+      "workflow": "larql-factory",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:51:16Z",
+          "completed_at": "2026-09-07T00:52:24Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:51:36Z",
+          "completed_at": "2026-09-07T00:53:51Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:06:40Z",
+          "completed_at": "2026-09-07T01:07:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071113383,
+      "workflow": "larql-models",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:51:16Z",
+          "completed_at": "2026-09-07T00:52:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:08:17Z",
+          "completed_at": "2026-09-07T01:09:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:52:40Z",
+          "completed_at": "2026-09-07T00:55:36Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34071113404,
+      "workflow": "shannon-verify",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:55:40Z",
+          "completed_at": "2026-09-07T01:09:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071113348,
+      "workflow": "larql-inference",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:04:27Z",
+          "completed_at": "2026-09-07T01:10:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:55:06Z",
+          "completed_at": "2026-09-07T01:13:37Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:07:00Z",
+          "completed_at": "2026-09-07T01:15:57Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:09:11Z",
+          "completed_at": "2026-09-07T01:15:57Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071113407,
+      "workflow": "larql-lql",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:59:40Z",
+          "completed_at": "2026-09-07T01:05:54Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:05:03Z",
+          "completed_at": "2026-09-07T01:12:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:04:44Z",
+          "completed_at": "2026-09-07T01:10:51Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:57:07Z",
+          "completed_at": "2026-09-07T01:17:12Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34071113357,
+      "workflow": "larql-server",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:56:56Z",
+          "completed_at": "2026-09-07T01:08:20Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:51:16Z",
+          "completed_at": "2026-09-07T01:00:13Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:54:25Z",
+          "completed_at": "2026-09-07T01:16:52Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:52:41Z",
+          "completed_at": "2026-09-07T01:02:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071113431,
+      "workflow": "bench-regress",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:53:59Z",
+          "completed_at": "2026-09-07T01:17:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071113420,
+      "workflow": "larql-compute",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:06:53Z",
+          "completed_at": "2026-09-07T01:08:15Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:08:50Z",
+          "completed_at": "2026-09-07T01:20:58Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:07:08Z",
+          "completed_at": "2026-09-07T01:08:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:12:13Z",
+          "completed_at": "2026-09-07T01:13:36Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071113435,
+      "workflow": "mutants",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:56:53Z",
+          "completed_at": "2026-09-07T01:04:25Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:16:06Z",
+          "completed_at": "2026-09-07T01:21:25Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071113354,
+      "workflow": "larql-kv",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:52:05Z",
+          "completed_at": "2026-09-07T00:59:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:20:34Z",
+          "completed_at": "2026-09-07T01:39:03Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:03:10Z",
+          "completed_at": "2026-09-07T01:10:12Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:56:24Z",
+          "completed_at": "2026-09-07T01:04:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071113414,
+      "workflow": "larql-cli",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:53:14Z",
+          "completed_at": "2026-09-07T01:13:09Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:55:38Z",
+          "completed_at": "2026-09-07T01:05:02Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:07:28Z",
+          "completed_at": "2026-09-07T01:15:04Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:31:29Z",
+          "completed_at": "2026-09-07T01:42:08Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071113470,
+      "workflow": "quality",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:02:17Z",
+          "completed_at": "2026-09-07T01:02:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:06:58Z",
+          "completed_at": "2026-09-07T01:07:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:31:48Z",
+          "completed_at": "2026-09-07T01:32:43Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:20:20Z",
+          "completed_at": "2026-09-07T01:20:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:36:58Z",
+          "completed_at": "2026-09-07T01:37:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:26:56Z",
+          "completed_at": "2026-09-07T01:27:40Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:37:55Z",
+          "completed_at": "2026-09-07T01:38:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:37:40Z",
+          "completed_at": "2026-09-07T01:45:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34071113371,
+      "workflow": "larql-compute-metal",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T00:51:35Z",
+          "started_at": "2026-09-07T01:13:16Z",
+          "completed_at": "2026-09-07T02:08:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071113372,
+      "workflow": "larql-vindex",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:56:52Z",
+          "completed_at": "2026-09-07T01:06:35Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:56:52Z",
+          "completed_at": "2026-09-07T01:18:38Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T00:59:27Z",
+          "completed_at": "2026-09-07T01:12:08Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:51:14Z",
+          "started_at": "2026-09-07T01:32:20Z",
+          "completed_at": "2026-09-07T01:46:23Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34068751707,
+      "workflow": "mutants",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:13:27Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:31:32Z",
+          "completed_at": "2026-09-07T00:37:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34068751693,
+      "workflow": "larql-cli",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:07:19Z",
+          "completed_at": "2026-09-07T00:14:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:27:38Z",
+          "completed_at": "2026-09-07T00:36:57Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:25:02Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:20:21Z",
+          "completed_at": "2026-09-07T00:30:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34068751713,
+      "workflow": "larql-compute-metal",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:07:21Z",
+          "completed_at": "2026-09-07T00:51:35Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34068751715,
+      "workflow": "larql-inference",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:13:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:49Z",
+          "completed_at": "2026-09-07T00:16:30Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:45Z",
+          "completed_at": "2026-09-07T00:16:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:44Z",
+          "completed_at": "2026-09-07T00:18:32Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34068751681,
+      "workflow": "larql-vindex",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:47Z",
+          "completed_at": "2026-09-07T00:15:57Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:22:06Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:19:57Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:07:31Z",
+          "completed_at": "2026-09-07T00:16:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34068751711,
+      "workflow": "larql-kv",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:09:57Z",
+          "completed_at": "2026-09-07T00:17:20Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:16:03Z",
+          "completed_at": "2026-09-07T00:22:36Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:24:26Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:13:01Z",
+          "completed_at": "2026-09-07T00:20:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34068751671,
+      "workflow": "larql-factory",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:18:45Z",
+          "completed_at": "2026-09-07T00:19:58Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:23:32Z",
+          "completed_at": "2026-09-07T00:24:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:08:58Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34068751733,
+      "workflow": "commit messages",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:25:29Z",
+          "completed_at": "2026-09-07T00:25:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34068751678,
+      "workflow": "larql-models",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:13:02Z",
+          "completed_at": "2026-09-07T00:13:55Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:07:52Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:09:56Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34068751726,
+      "workflow": "larql-server",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:13:29Z",
+          "completed_at": "2026-09-07T00:22:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:28:17Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:14:59Z",
+          "completed_at": "2026-09-07T00:24:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:16:37Z",
+          "completed_at": "2026-09-07T00:26:27Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34068751710,
+      "workflow": "shannon-verify",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "verify",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:14:04Z",
+          "completed_at": "2026-09-07T00:29:00Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34068751705,
+      "workflow": "bench-regress",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:48Z",
+          "completed_at": "2026-09-07T00:29:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34068751697,
+      "workflow": "quality",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:18:34Z",
+          "completed_at": "2026-09-07T00:18:42Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:22:46Z",
+          "completed_at": "2026-09-07T00:30:37Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:28:20Z",
+          "completed_at": "2026-09-07T00:28:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:25:03Z",
+          "completed_at": "2026-09-07T00:25:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:29:02Z",
+          "completed_at": "2026-09-07T00:29:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:27:37Z",
+          "completed_at": "2026-09-07T00:28:18Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:26:46Z",
+          "completed_at": "2026-09-07T00:27:33Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:26:40Z",
+          "completed_at": "2026-09-07T00:27:36Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34068751695,
+      "workflow": "larql-lql",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:06:43Z",
+          "completed_at": "2026-09-07T00:12:59Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:24:32Z",
+          "completed_at": "2026-09-07T00:30:35Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:16:22Z",
+          "completed_at": "2026-09-07T00:25:22Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:07:54Z",
+          "completed_at": "2026-09-07T00:25:58Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34068751708,
+      "workflow": "msrv-metal",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 larql-compute-metal",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:30:43Z",
+          "completed_at": "2026-09-07T00:31:23Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34068751712,
+      "workflow": "larql-compute",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:10:43Z",
+          "completed_at": "2026-09-07T00:22:36Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test \u00b7 ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:09:00Z",
+          "completed_at": "2026-09-07T00:10:41Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "coverage \u00b7 ubuntu",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:24:35Z",
+          "completed_at": "2026-09-07T00:25:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:29:58Z",
+          "completed_at": "2026-09-07T00:31:38Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34070137279,
+      "workflow": "msrv-metal",
+      "branch": "metal-coverage-floor-90",
+      "sha": "0c19c518a89005a6fb401f6712ff3e617aa26490",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:32:32Z",
+      "run_started_at": "2026-09-07T00:32:32Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "MSRV \u00b7 larql-compute-metal",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:37:35Z",
+          "completed_at": "2026-09-07T00:38:14Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34070137268,
+      "workflow": "quality",
+      "branch": "metal-coverage-floor-90",
+      "sha": "0c19c518a89005a6fb401f6712ff3e617aa26490",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:32:32Z",
+      "run_started_at": "2026-09-07T00:32:32Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:32Z",
+          "started_at": "2026-09-07T00:33:06Z",
+          "completed_at": "2026-09-07T00:33:14Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:33:17Z",
+          "completed_at": "2026-09-07T00:33:48Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:33:49Z",
+          "completed_at": "2026-09-07T00:41:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:33:48Z",
+          "completed_at": "2026-09-07T00:34:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:34:30Z",
+          "completed_at": "2026-09-07T00:34:39Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:34:34Z",
+          "completed_at": "2026-09-07T00:35:17Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:35:19Z",
+          "completed_at": "2026-09-07T00:36:09Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:34:41Z",
+          "completed_at": "2026-09-07T00:35:26Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34070137276,
+      "workflow": "mutants",
+      "branch": "metal-coverage-floor-90",
+      "sha": "0c19c518a89005a6fb401f6712ff3e617aa26490",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:32:32Z",
+      "run_started_at": "2026-09-07T00:32:32Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:32:51Z",
+          "completed_at": "2026-09-07T00:33:46Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:44:06Z",
+          "completed_at": "2026-09-07T00:44:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34070137265,
+      "workflow": "bench-regress",
+      "branch": "metal-coverage-floor-90",
+      "sha": "0c19c518a89005a6fb401f6712ff3e617aa26490",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T00:32:32Z",
+      "run_started_at": "2026-09-07T00:32:32Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "bench",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T00:32:32Z",
+          "started_at": "2026-09-07T00:37:04Z",
+          "completed_at": "2026-09-07T00:59:20Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34070137280,
+      "workflow": "commit messages",
+      "branch": "metal-coverage-floor-90",
+      "sha": "0c19c518a89005a6fb401f6712ff3e617aa26490",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:32:32Z",
+      "run_started_at": "2026-09-07T00:32:32Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:33Z",
+          "started_at": "2026-09-07T00:32:47Z",
+          "completed_at": "2026-09-07T00:32:49Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34070137270,
+      "workflow": "larql-compute-metal",
+      "branch": "metal-coverage-floor-90",
+      "sha": "0c19c518a89005a6fb401f6712ff3e617aa26490",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:32:32Z",
+      "run_started_at": "2026-09-07T00:32:32Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:32Z",
+          "started_at": "2026-09-07T00:38:21Z",
+          "completed_at": "2026-09-07T01:31:22Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34069286003,
+      "workflow": "larql-lql",
+      "branch": "fix-stage-ledger-race",
+      "sha": "53d089bde3a6467673bb764975ecd3aa4e5f093f",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:16:28Z",
+      "run_started_at": "2026-09-07T00:16:28Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:25:34Z",
+          "completed_at": "2026-09-07T00:34:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:19:59Z",
+          "completed_at": "2026-09-07T00:37:50Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:25:33Z",
+          "completed_at": "2026-09-07T00:34:02Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:28:19Z",
+          "completed_at": "2026-09-07T00:35:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34069286033,
+      "workflow": "larql-cli",
+      "branch": "fix-stage-ledger-race",
+      "sha": "53d089bde3a6467673bb764975ecd3aa4e5f093f",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:16:28Z",
+      "run_started_at": "2026-09-07T00:16:28Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:34:07Z",
+          "completed_at": "2026-09-07T00:44:00Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:25:57Z",
+          "completed_at": "2026-09-07T00:33:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:18:15Z",
+          "completed_at": "2026-09-07T00:28:44Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:22:38Z",
+          "completed_at": "2026-09-07T00:39:25Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34069286056,
+      "workflow": "larql-server",
+      "branch": "fix-stage-ledger-race",
+      "sha": "53d089bde3a6467673bb764975ecd3aa4e5f093f",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:16:28Z",
+      "run_started_at": "2026-09-07T00:16:28Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:25:59Z",
+          "completed_at": "2026-09-07T00:34:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:22:38Z",
+          "completed_at": "2026-09-07T00:46:04Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:29:11Z",
+          "completed_at": "2026-09-07T00:39:31Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:31:45Z",
+          "completed_at": "2026-09-07T00:43:06Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34069285994,
+      "workflow": "larql-inference",
+      "branch": "fix-stage-ledger-race",
+      "sha": "53d089bde3a6467673bb764975ecd3aa4e5f093f",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:16:28Z",
+      "run_started_at": "2026-09-07T00:16:28Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:16:41Z",
+          "completed_at": "2026-09-07T00:24:07Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:44:53Z",
+          "completed_at": "2026-09-07T00:53:53Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:24:36Z",
+          "completed_at": "2026-09-07T00:31:53Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:19:58Z",
+          "completed_at": "2026-09-07T00:35:45Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34069285973,
+      "workflow": "larql-vindex",
+      "branch": "fix-stage-ledger-race",
+      "sha": "53d089bde3a6467673bb764975ecd3aa4e5f093f",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:16:28Z",
+      "run_started_at": "2026-09-07T00:16:28Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "coverage - ubuntu",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:32:21Z",
+          "completed_at": "2026-09-07T00:41:34Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - ubuntu-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:30:37Z",
+          "completed_at": "2026-09-07T00:46:05Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "test - macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:43:12Z",
+          "completed_at": "2026-09-07T00:55:42Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "test - windows-latest",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:24:09Z",
+          "completed_at": "2026-09-07T00:47:27Z",
+          "labels": [
+            "windows-latest"
+          ],
+          "os": "windows"
+        }
+      ]
+    },
+    {
+      "id": 34069286004,
+      "workflow": "commit messages",
+      "branch": "fix-stage-ledger-race",
+      "sha": "53d089bde3a6467673bb764975ecd3aa4e5f093f",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:16:28Z",
+      "run_started_at": "2026-09-07T00:16:28Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "no generated attribution",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:25:23Z",
+          "completed_at": "2026-09-07T00:25:28Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34069285993,
+      "workflow": "mutants",
+      "branch": "fix-stage-ledger-race",
+      "sha": "53d089bde3a6467673bb764975ecd3aa4e5f093f",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:16:28Z",
+      "run_started_at": "2026-09-07T00:16:28Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-mutants \u00b7 larql-compute-metal (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:26:33Z",
+          "completed_at": "2026-09-07T00:26:45Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        },
+        {
+          "name": "cargo-mutants (informational)",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:28:46Z",
+          "completed_at": "2026-09-07T01:06:56Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": 34069285978,
+      "workflow": "quality",
+      "branch": "fix-stage-ledger-race",
+      "sha": "53d089bde3a6467673bb764975ecd3aa4e5f093f",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:16:28Z",
+      "run_started_at": "2026-09-07T00:16:28Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "cargo-audit",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:30:19Z",
+          "completed_at": "2026-09-07T00:30:51Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "doc links",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:23:22Z",
+          "completed_at": "2026-09-07T00:23:30Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "MSRV \u00b7 workspace",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:29:02Z",
+          "completed_at": "2026-09-07T00:36:47Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 licenses",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:25:55Z",
+          "completed_at": "2026-09-07T00:26:38Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "buf lint",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:31:54Z",
+          "completed_at": "2026-09-07T00:32:01Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 sources",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:30:52Z",
+          "completed_at": "2026-09-07T00:31:32Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 advisories",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:31:33Z",
+          "completed_at": "2026-09-07T00:32:19Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        },
+        {
+          "name": "cargo-deny \u00b7 bans",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:16:29Z",
+          "started_at": "2026-09-07T00:32:02Z",
+          "completed_at": "2026-09-07T00:32:45Z",
+          "labels": [
+            "ubuntu-latest"
+          ],
+          "os": "linux"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/ci-throughput/metal-gate-baseline.json
+++ b/docs/ci-throughput/metal-gate-baseline.json
@@ -1,0 +1,1054 @@
+{
+  "collected_at": "2026-09-07T18:34:43.286241+00:00",
+  "repo": "chrishayuk/larql",
+  "query": {
+    "since": "2026-08-25",
+    "until": null,
+    "max_prs": 40,
+    "branch": null,
+    "pruned_to_workflow": "larql-compute-metal",
+    "pruning_note": "Collected as a full snapshot, then pruned to larql-compute-metal runs. This file exists to baseline ONE metric \u2014 workflow_exec_max.larql-compute-metal.p50 \u2014 and the other workflows' jobs are 1MB of bytes no prediction reads. Pruning is lossless for that metric: attempts drop from 65 to 40 because an attempt with no Metal run contributes nothing to it, and the value is unchanged. Do not read any OTHER metric out of this file; use after-e1.json."
+  },
+  "runs": [
+    {
+      "id": 34098337888,
+      "workflow": "larql-compute-metal",
+      "branch": "ci-gates-mean-what-they-say",
+      "sha": "d0c0c816992ab43c2b86ae8864d7acfdef2a3ec4",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T08:00:51Z",
+      "run_started_at": "2026-09-07T08:00:51Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T08:00:52Z",
+          "started_at": "2026-09-07T08:03:03Z",
+          "completed_at": "2026-09-07T09:02:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077813309,
+      "workflow": "larql-compute-metal",
+      "branch": "drive-models-1",
+      "sha": "6874285f4f589be8788e4d0db6d2b99e72abb016",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T02:54:03Z",
+      "run_started_at": "2026-09-07T02:54:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T02:54:22Z",
+          "started_at": "2026-09-07T02:54:39Z",
+          "completed_at": "2026-09-07T03:53:22Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34077623086,
+      "workflow": "larql-compute-metal",
+      "branch": "drive-models-1",
+      "sha": "665b471054d7e6de4567c388f76326557fc46b1e",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T02:50:34Z",
+      "run_started_at": "2026-09-07T02:50:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T02:50:34Z",
+          "started_at": "2026-09-07T02:50:42Z",
+          "completed_at": "2026-09-07T02:54:21Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34071113371,
+      "workflow": "larql-compute-metal",
+      "branch": "drive-models-1",
+      "sha": "9f7725e1acc4fa607e5bc6dd587cf4adde9c2940",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-07T00:51:14Z",
+      "run_started_at": "2026-09-07T00:51:14Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-07T00:51:35Z",
+          "started_at": "2026-09-07T01:13:16Z",
+          "completed_at": "2026-09-07T02:08:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34068751713,
+      "workflow": "larql-compute-metal",
+      "branch": "drive-models-1",
+      "sha": "081b212461286433e2ff688966dff0519f3e3fd2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-07T00:06:41Z",
+      "run_started_at": "2026-09-07T00:06:41Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-07T00:06:41Z",
+          "started_at": "2026-09-07T00:07:21Z",
+          "completed_at": "2026-09-07T00:51:35Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34070137270,
+      "workflow": "larql-compute-metal",
+      "branch": "metal-coverage-floor-90",
+      "sha": "0c19c518a89005a6fb401f6712ff3e617aa26490",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-07T00:32:32Z",
+      "run_started_at": "2026-09-07T00:32:32Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-07T00:32:32Z",
+          "started_at": "2026-09-07T00:38:21Z",
+          "completed_at": "2026-09-07T01:31:22Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34065240055,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-latentmoe-1",
+      "sha": "3c79e2044116588882436ae2c2d2586c1258687a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-09-06T22:51:51Z",
+      "run_started_at": "2026-09-06T22:51:51Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "failure",
+          "created_at": "2026-09-06T22:51:52Z",
+          "started_at": "2026-09-06T23:02:35Z",
+          "completed_at": "2026-09-06T23:59:12Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34040777310,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-rep-gate-1",
+      "sha": "2ddb7476ce6372e8cb05e8b7e00fdd99d3ed8010",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T14:57:29Z",
+      "run_started_at": "2026-09-06T14:57:29Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T14:57:29Z",
+          "started_at": "2026-09-06T16:07:00Z",
+          "completed_at": "2026-09-06T17:15:41Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34040694520,
+      "workflow": "larql-compute-metal",
+      "branch": "ci/bench-same-runner-qualification",
+      "sha": "f42f6852f12ed0cd596cb5094af852c6a7453d08",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T14:55:47Z",
+      "run_started_at": "2026-09-06T14:55:47Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T14:55:47Z",
+          "started_at": "2026-09-06T15:28:29Z",
+          "completed_at": "2026-09-06T16:23:25Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34034845098,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-attnres-1-lift",
+      "sha": "515e2a77dc04a98e9ae3f0a235615bdece7df75a",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T13:01:44Z",
+      "run_started_at": "2026-09-06T13:01:44Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T13:01:45Z",
+          "started_at": "2026-09-06T13:11:37Z",
+          "completed_at": "2026-09-06T14:18:00Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34032689240,
+      "workflow": "larql-compute-metal",
+      "branch": "ci-pr-throughput",
+      "sha": "dd6a6fe854a9c78431e57852bf2c698e4436c27f",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T12:18:03Z",
+      "run_started_at": "2026-09-06T12:18:03Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T12:18:04Z",
+          "started_at": "2026-09-06T12:33:09Z",
+          "completed_at": "2026-09-06T13:30:09Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34032593979,
+      "workflow": "larql-compute-metal",
+      "branch": "ci-pr-throughput",
+      "sha": "4a583ed12c26fdf39d6e4fe3c2a69a84b7fafe81",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "cancelled",
+      "created_at": "2026-09-06T12:16:01Z",
+      "run_started_at": "2026-09-06T12:16:01Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "created_at": "2026-09-06T12:16:02Z",
+          "started_at": "2026-09-06T12:16:02Z",
+          "completed_at": "2026-09-06T12:18:03Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34027023563,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-attnres-1-2b",
+      "sha": "4409cee22d515e6ade2f3faa8820b16e067bd637",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:17:49Z",
+      "run_started_at": "2026-09-06T10:17:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:17:50Z",
+          "started_at": "2026-09-06T10:44:35Z",
+          "completed_at": "2026-09-06T11:42:18Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34026734090,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-attnres-1",
+      "sha": "26b661da81836d6ac5833e830e26cd36b5811262",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T10:11:37Z",
+      "run_started_at": "2026-09-06T10:11:37Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T10:11:37Z",
+          "started_at": "2026-09-06T10:13:37Z",
+          "completed_at": "2026-09-06T11:10:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002076153,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-attnres-1",
+      "sha": "5f4eda0316d1aeb983af2f72dcc6586f4cfaae7c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:44:27Z",
+      "run_started_at": "2026-09-06T00:44:27Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:44:27Z",
+          "started_at": "2026-09-06T00:58:05Z",
+          "completed_at": "2026-09-06T01:59:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002001983,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-attnres-1",
+      "sha": "5f2792a5e07cb149f8f98e90f0f2641b3e9b2508",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:42:39Z",
+      "run_started_at": "2026-09-06T00:42:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:42:40Z",
+          "started_at": "2026-09-06T00:51:06Z",
+          "completed_at": "2026-09-06T01:55:28Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34004725869,
+      "workflow": "larql-compute-metal",
+      "branch": "e30-static-shard-runtime",
+      "sha": "edd01b3a0074393e1b569c13ef7783e988fd0bb2",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T01:45:45Z",
+      "run_started_at": "2026-09-06T01:45:45Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T01:45:46Z",
+          "started_at": "2026-09-06T02:13:51Z",
+          "completed_at": "2026-09-06T03:05:52Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 34002225588,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-residency-vertical",
+      "sha": "1a7d668656c90c5eae789b55ee1792d4d2ab883d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-06T00:47:52Z",
+      "run_started_at": "2026-09-06T00:47:52Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-06T00:47:53Z",
+          "started_at": "2026-09-06T01:43:55Z",
+          "completed_at": "2026-09-06T02:37:58Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33994763628,
+      "workflow": "larql-compute-metal",
+      "branch": "represent-rung3",
+      "sha": "82888431e556ede77e9cb5ba2c2556b3bd0836fc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T22:02:39Z",
+      "run_started_at": "2026-09-05T22:02:39Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T22:02:40Z",
+          "started_at": "2026-09-05T22:02:46Z",
+          "completed_at": "2026-09-05T23:05:12Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33983292853,
+      "workflow": "larql-compute-metal",
+      "branch": "represent-rung3",
+      "sha": "a97283d95195a797c63c227a641badf6dba16648",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T18:11:48Z",
+      "run_started_at": "2026-09-05T18:11:48Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T18:11:48Z",
+          "started_at": "2026-09-05T18:53:40Z",
+          "completed_at": "2026-09-05T19:59:32Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33981504704,
+      "workflow": "larql-compute-metal",
+      "branch": "represent-rung3",
+      "sha": "58bfaa8f63bd336936df2e7ad863855a068320af",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T17:36:49Z",
+      "run_started_at": "2026-09-05T17:36:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T17:36:49Z",
+          "started_at": "2026-09-05T17:38:39Z",
+          "completed_at": "2026-09-05T18:35:39Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33978351345,
+      "workflow": "larql-compute-metal",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "f12a611d6d817c030f5ffa81ccf05e31329eeafa",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:35:36Z",
+      "run_started_at": "2026-09-05T16:35:36Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:35:37Z",
+          "started_at": "2026-09-05T16:36:58Z",
+          "completed_at": "2026-09-05T17:34:16Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33976559812,
+      "workflow": "larql-compute-metal",
+      "branch": "wave19-sinkhorn-traversal",
+      "sha": "406df4f18a9f5a65c55595dda39b4c6e4cac7427",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T16:01:22Z",
+      "run_started_at": "2026-09-05T16:01:22Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T16:01:22Z",
+          "started_at": "2026-09-05T16:02:54Z",
+          "completed_at": "2026-09-05T16:55:42Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33964736439,
+      "workflow": "larql-compute-metal",
+      "branch": "represent-entropy-bf16",
+      "sha": "ee08b35e2fa73ab7b5c3d0ccdd43fb726e1625ed",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:58:21Z",
+      "run_started_at": "2026-09-05T11:58:21Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:58:21Z",
+          "started_at": "2026-09-05T12:09:21Z",
+          "completed_at": "2026-09-05T12:56:43Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33962379822,
+      "workflow": "larql-compute-metal",
+      "branch": "represent-entropy-bf16",
+      "sha": "49d264c3d7f6d2f7d96456678565525c33759e88",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T11:05:19Z",
+      "run_started_at": "2026-09-05T11:05:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T11:05:20Z",
+          "started_at": "2026-09-05T11:07:36Z",
+          "completed_at": "2026-09-05T12:03:29Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33939903832,
+      "workflow": "larql-compute-metal",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "25c9d7157debf151b19c25d8a8dd265f4ca3fa91",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T02:43:59Z",
+      "run_started_at": "2026-09-05T02:43:59Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T02:43:59Z",
+          "started_at": "2026-09-05T02:44:06Z",
+          "completed_at": "2026-09-05T03:37:45Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33933693457,
+      "workflow": "larql-compute-metal",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "915202fbc32e33fd4467d0adadd0e29f039d2dbc",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:39:26Z",
+      "run_started_at": "2026-09-05T00:39:26Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:39:27Z",
+          "started_at": "2026-09-05T00:56:02Z",
+          "completed_at": "2026-09-05T01:43:00Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33933561639,
+      "workflow": "larql-compute-metal",
+      "branch": "pareto-1/instrument-v2",
+      "sha": "7d142b8cc5aa36c724280b83beff0eaf90a14b0d",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:37:02Z",
+      "run_started_at": "2026-09-05T00:37:02Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:37:03Z",
+          "started_at": "2026-09-05T00:48:07Z",
+          "completed_at": "2026-09-05T01:43:42Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33934307328,
+      "workflow": "larql-compute-metal",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "db66f01b8bac2019d6024b70813453bb5c939d99",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-05T00:50:54Z",
+      "run_started_at": "2026-09-05T00:50:54Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-05T00:50:54Z",
+          "started_at": "2026-09-05T01:25:44Z",
+          "completed_at": "2026-09-05T02:17:36Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33930594995,
+      "workflow": "larql-compute-metal",
+      "branch": "wave18-hyper-connection-addressability",
+      "sha": "4b8d52e1a1f4324cabba9b470024fbb353c8c768",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T23:44:10Z",
+      "run_started_at": "2026-09-04T23:44:10Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T23:44:10Z",
+          "started_at": "2026-09-04T23:44:19Z",
+          "completed_at": "2026-09-05T00:45:33Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33904473111,
+      "workflow": "larql-compute-metal",
+      "branch": "k3-arch-1",
+      "sha": "028bfc7826ac1f464dab7b812c0e08d023acd233",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T18:10:34Z",
+      "run_started_at": "2026-09-04T18:10:34Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T18:10:35Z",
+          "started_at": "2026-09-04T18:12:27Z",
+          "completed_at": "2026-09-04T19:06:49Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33903041583,
+      "workflow": "larql-compute-metal",
+      "branch": "wave17-hyper-connection-execution",
+      "sha": "446197d5be82f8635c5e59a6dac52d53863ce02c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-04T17:54:23Z",
+      "run_started_at": "2026-09-04T17:54:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-04T17:54:23Z",
+          "started_at": "2026-09-04T17:59:15Z",
+          "completed_at": "2026-09-04T18:58:51Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33818318776,
+      "workflow": "larql-compute-metal",
+      "branch": "fix/ggml-type-ids",
+      "sha": "5c90d6cbdb3170dd1a1336bae010a00d28ca92b5",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T23:36:23Z",
+      "run_started_at": "2026-09-03T23:36:23Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T23:36:23Z",
+          "started_at": "2026-09-03T23:36:26Z",
+          "completed_at": "2026-09-04T00:37:05Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33808025616,
+      "workflow": "larql-compute-metal",
+      "branch": "wave10-qwen-moe-shared-expert",
+      "sha": "6348b81f2c109d2f003ee5e5337583e230ee902c",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T21:27:16Z",
+      "run_started_at": "2026-09-03T21:27:16Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T21:27:17Z",
+          "started_at": "2026-09-03T21:27:18Z",
+          "completed_at": "2026-09-03T22:16:11Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33798047145,
+      "workflow": "larql-compute-metal",
+      "branch": "wave10-qwen-moe-shared-expert",
+      "sha": "d5d1e4bf2895219b2b6c9923c3e362c8aa79ff37",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T19:42:56Z",
+      "run_started_at": "2026-09-03T19:42:56Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T19:42:57Z",
+          "started_at": "2026-09-03T19:43:03Z",
+          "completed_at": "2026-09-03T20:46:36Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33762767315,
+      "workflow": "larql-compute-metal",
+      "branch": "fix/ci-no-stale-target-cache",
+      "sha": "a20916bb9d7e3a31d4ebb653dc7e80be82f4119f",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T13:43:51Z",
+      "run_started_at": "2026-09-03T13:43:51Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T13:43:52Z",
+          "started_at": "2026-09-03T13:43:59Z",
+          "completed_at": "2026-09-03T14:34:41Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33756780551,
+      "workflow": "larql-compute-metal",
+      "branch": "fix/ci-no-stale-target-cache",
+      "sha": "7cff6a3303da42722eb8a3880297af55dacaaadd",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T12:42:49Z",
+      "run_started_at": "2026-09-03T12:42:49Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T12:42:51Z",
+          "started_at": "2026-09-03T12:43:34Z",
+          "completed_at": "2026-09-03T13:32:24Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33745737639,
+      "workflow": "larql-compute-metal",
+      "branch": "wave9-vestigial-pair",
+      "sha": "5077bf1a9f92d52225c7e893f4cc5772f4042d4b",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T10:42:19Z",
+      "run_started_at": "2026-09-03T10:42:19Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T10:42:19Z",
+          "started_at": "2026-09-03T10:46:21Z",
+          "completed_at": "2026-09-03T11:35:30Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33738473638,
+      "workflow": "larql-compute-metal",
+      "branch": "wave8-partial-rotary-factor",
+      "sha": "4ab796fc71b4b0a0b6a8e6b4dd86cf771bae7d58",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T09:22:29Z",
+      "run_started_at": "2026-09-03T09:22:29Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T09:22:29Z",
+          "started_at": "2026-09-03T09:30:37Z",
+          "completed_at": "2026-09-03T10:32:58Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    },
+    {
+      "id": 33736336384,
+      "workflow": "larql-compute-metal",
+      "branch": "wave8-partial-rotary-factor",
+      "sha": "b40c322cf06382ea037392d0861209e6a0dbdb20",
+      "attempt": 1,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-03T08:59:16Z",
+      "run_started_at": "2026-09-03T08:59:16Z",
+      "pr": null,
+      "jobs": [
+        {
+          "name": "test \u00b7 macos-14",
+          "status": "completed",
+          "conclusion": "success",
+          "created_at": "2026-09-03T08:59:17Z",
+          "started_at": "2026-09-03T09:16:48Z",
+          "completed_at": "2026-09-03T10:13:09Z",
+          "labels": [
+            "macos-14"
+          ],
+          "os": "macos"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/ci_throughput.py
+++ b/scripts/ci_throughput.py
@@ -61,6 +61,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+FORECAST_DIR = REPO_ROOT / "docs" / "ci-throughput"
 
 PER_PAGE = 100
 MAX_PAGES = 50
@@ -78,6 +79,116 @@ OS_LABEL_MARKERS = (
     ("macOS", "macos"),
 )
 OS_ORDER = ("linux", "windows", "macos", "unknown")
+
+# Metric KIND, declared once here rather than inferred at scoring time.
+#
+# An EXTENSIVE metric's value scales with how many attempts are in the
+# sample: totals of runner-minutes, counts of jobs. An INTENSIVE one does
+# not: percentiles, per-attempt means.
+#
+# This distinction is not decoration. E1 froze two extensive metrics
+# (`queued.macos`, `executed.macos`) and collected 12 attempts against a
+# 33-attempt baseline. A 12/33 ratio moves any per-attempt-flat total by
+# -63.6% BEFORE any effect exists, so E1's P3 could not have returned
+# HELD and its P2 could not have returned FALSIFIED. The adjudicator
+# reported `INVALID COMPARISON` for the mechanism, which was the designed
+# refusal — but it fired on sample size, not on the composition change P3
+# was written to catch, and the mechanism came back unadjudicated rather
+# than refuted.
+#
+# So: every extensive metric gets an intensive companion (`*_per_attempt`),
+# and `score_prediction` REFUSES an extensive metric whose two samples
+# differ in attempt count. A forecast that wants to score runner-minutes
+# across unlike samples must name the per-attempt metric.
+METRIC_EXTENSIVE = "extensive"
+METRIC_INTENSIVE = "intensive"
+
+# Prefixes/names that flatten_metrics() emits in extensive form. The
+# per-attempt companions are derived from these, so the two can never
+# drift apart.
+EXTENSIVE_OS_BUCKETS = ("queued", "executed")
+EXTENSIVE_SCALAR_METRICS = ("superseded_exec_total",)
+PER_ATTEMPT_SUFFIX = "_per_attempt"
+
+
+# Metric families whose name carries a workflow, e.g.
+# `workflow_exec_max.larql-compute-metal.p50`. Their names only exist once
+# that workflow appears in a snapshot, so a forecast that mentions one has
+# to be validated by SHAPE plus a separate check that the workflow is real.
+WORKFLOW_SCOPED_FAMILIES = ("workflow_exec_max", "workflow_share")
+PROBE_WORKFLOW = "<workflow>"
+
+
+def metric_shape(name: str) -> str:
+    """A workflow-scoped metric name with the workflow replaced by a probe.
+
+    `workflow_exec_max.larql-compute-metal.p50` -> `workflow_exec_max.<workflow>.p50`
+    `workflow_share.bench-regress`              -> `workflow_share.<workflow>`
+
+    Anything else is returned unchanged. rsplit, not split, because a
+    workflow name may contain a dot; the STAT never does.
+    """
+    for family in WORKFLOW_SCOPED_FAMILIES:
+        prefix = f"{family}."
+        if not name.startswith(prefix):
+            continue
+        remainder = name[len(prefix):]
+        if family == "workflow_share":
+            return f"{family}.{PROBE_WORKFLOW}"
+        workflow, _, stat = remainder.rpartition(".")
+        return f"{family}.{PROBE_WORKFLOW}.{stat}" if workflow else name
+    return name
+
+
+# Metric families that are NOT durations. Printing a share as "0.5 min"
+# is the unit error this whole programme exists to avoid making.
+DIMENSIONLESS_FAMILIES = ("workflow_share",)
+
+
+def metric_unit(name: str) -> str:
+    return "" if name.split(".", 1)[0] in DIMENSIONLESS_FAMILIES else " min"
+
+
+def metric_workflow(name: str) -> str | None:
+    """The workflow a workflow-scoped metric names, or None."""
+    for family in WORKFLOW_SCOPED_FAMILIES:
+        prefix = f"{family}."
+        if not name.startswith(prefix):
+            continue
+        remainder = name[len(prefix):]
+        if family == "workflow_share":
+            return remainder
+        workflow, _, _stat = remainder.rpartition(".")
+        return workflow or None
+    return None
+
+
+# The intensive companion of each extensive SCALAR. The OS buckets derive
+# theirs by suffix; this table covers the ones that do not, so a refusal can
+# never point at a metric the instrument does not produce. `selftest`
+# asserts every extensive metric has a companion and that the companion is
+# itself produced and intensive.
+INTENSIVE_COMPANIONS = {"superseded_exec_total": "superseded_exec_mean"}
+
+
+def intensive_companion(name: str) -> str | None:
+    """The metric to score instead, when `name` is extensive."""
+    if name in INTENSIVE_COMPANIONS:
+        return INTENSIVE_COMPANIONS[name]
+    stem, dot, rest = name.partition(".")
+    if stem in EXTENSIVE_OS_BUCKETS and dot:
+        return f"{stem}{PER_ATTEMPT_SUFFIX}.{rest}"
+    return None
+
+
+def metric_kind(name: str) -> str:
+    """extensive | intensive, for any name flatten_metrics() produces."""
+    stem = name.split(".", 1)[0]
+    if stem.endswith(PER_ATTEMPT_SUFFIX):
+        return METRIC_INTENSIVE
+    if stem in EXTENSIVE_OS_BUCKETS or name in EXTENSIVE_SCALAR_METRICS:
+        return METRIC_EXTENSIVE
+    return METRIC_INTENSIVE
 
 TERMINAL_SUCCESS = "success"
 TERMINAL_CANCELLED = "cancelled"
@@ -261,6 +372,10 @@ class AttemptMetrics:
     complete: bool = True
     macos_queue_max: float | None = None
     windows_vindex_exec: float | None = None
+    # Longest single job execution per workflow, within this attempt. Wall
+    # clock for the workflow, not its runner-minute cost, because the claims
+    # it scores are about how long a gate makes a pull request wait.
+    workflow_exec_max: dict[str, float] = field(default_factory=dict)
     superseded_exec: float = 0.0
     queued_by_os: dict[str, float] = field(default_factory=dict)
     executed_by_os: dict[str, float] = field(default_factory=dict)
@@ -348,6 +463,17 @@ def analyse(
                         # is waste; the rest was legitimate work at the time.
                         overlap = seconds_between(max(started or next_start, next_start), completed)
                         metrics.superseded_exec += overlap or 0.0
+                    # SUCCEEDED runs only. A run cancelled by the
+                    # supersede rule stops mid-suite, so counting it would
+                    # let more cancellation masquerade as a faster gate —
+                    # the metric would be measuring c1, not the gate.
+                    if run["conclusion"] == TERMINAL_SUCCESS:
+                        workflow = run["workflow"] or "?"
+                        metrics.workflow_exec_max[workflow] = max(
+                            metrics.workflow_exec_max.get(workflow, 0.0), executed)
+                    # E1's forecast names this OS-scoped special case, so it
+                    # stays; workflow_exec_max is the general form and the one
+                    # new forecasts should use.
                     if run["workflow"] == "larql-vindex" and os_name == "windows":
                         metrics.windows_vindex_exec = max(metrics.windows_vindex_exec or 0.0, executed)
 
@@ -387,6 +513,28 @@ def aggregate(rows: Sequence[AttemptMetrics], percentiles: Sequence[int]) -> dic
         out[label] = {f"p{p}": percentile(values, p) for p in percentiles}
         out[label]["n"] = len(values)
 
+    # Composition, as a scoreable number rather than only a printed line.
+    # A per-attempt runner-minute figure is intensive in the SAMPLE SIZE but
+    # not in the MIX: if a later window triggers the expensive macOS gate on
+    # half as many pull requests, macOS minutes fall without anything having
+    # been made faster. E1's P3 tried to catch that with an extensive total
+    # and could not. This is the metric that can.
+    out["workflow_share"] = {}
+    if rows:
+        present: dict[str, int] = defaultdict(int)
+        for row in rows:
+            for workflow in row.workflows:
+                present[workflow] += 1
+        out["workflow_share"] = {w: c / len(rows) for w, c in present.items()}
+
+    workflows = sorted({w for r in rows for w in r.workflow_exec_max})
+    out["workflow_exec_max"] = {}
+    for workflow in workflows:
+        values = [r.workflow_exec_max[workflow] for r in rows if workflow in r.workflow_exec_max]
+        entry = {f"p{p}": percentile(values, p) for p in percentiles}
+        entry["n"] = len(values)
+        out["workflow_exec_max"][workflow] = entry
+
     out["superseded_exec_total"] = sum(r.superseded_exec for r in rows)
     out["superseded_exec_mean"] = statistics.fmean([r.superseded_exec for r in rows]) if rows else None
     for bucket, attr in (("queued_by_os", "queued_by_os"), ("executed_by_os", "executed_by_os")):
@@ -395,6 +543,12 @@ def aggregate(rows: Sequence[AttemptMetrics], percentiles: Sequence[int]) -> dic
             for os_name, value in getattr(row, attr).items():
                 totals[os_name] += value
         out[bucket] = dict(totals)
+        # The intensive companion. Derived from the same totals so the two
+        # cannot disagree, and defined only when there is a sample to
+        # divide by.
+        out[f"{bucket}_per_attempt"] = (
+            {os_name: value / len(rows) for os_name, value in totals.items()} if rows else {}
+        )
     return out
 
 
@@ -434,12 +588,21 @@ def print_table(before: dict | None, after: dict, percentiles: Sequence[int]) ->
     row("superseded exec (total)", (before or {}).get("superseded_exec_total"), after.get("superseded_exec_total"), fmt_minutes)
 
     print()
-    for bucket, title in (("queued_by_os", "queued runner-minutes"), ("executed_by_os", "executed runner-minutes")):
-        print(f"{title}:")
-        names = sorted(set((before or {}).get(bucket, {})) | set(after.get(bucket, {})), key=lambda n: OS_ORDER.index(n) if n in OS_ORDER else 99)
-        for name in names:
-            row(f"  {name}", (before or {}).get(bucket, {}).get(name), after.get(bucket, {}).get(name), fmt_minutes)
-        print()
+    # Totals first, then the same quantities per attempt. Only the second
+    # block is comparable when the two periods hold different numbers of
+    # pull requests, which is why both are printed side by side and never
+    # one without the other.
+    for suffix, title_suffix in (("", " (TOTAL — comparable only at equal n)"),
+                                 (PER_ATTEMPT_SUFFIX, " per attempt")):
+        for bucket, title in (("queued_by_os", "queued runner-minutes"),
+                              ("executed_by_os", "executed runner-minutes")):
+            key = f"{bucket}{suffix}"
+            print(f"{title}{title_suffix}:")
+            names = sorted(set((before or {}).get(key, {})) | set(after.get(key, {})),
+                           key=lambda n: OS_ORDER.index(n) if n in OS_ORDER else 99)
+            for name in names:
+                row(f"  {name}", (before or {}).get(key, {}).get(name), after.get(key, {}).get(name), fmt_minutes)
+            print()
 
 
 def report(args: argparse.Namespace) -> int:
@@ -500,11 +663,34 @@ def report(args: argparse.Namespace) -> int:
 # Everything the adjudicator compares is in MINUTES. The aggregates carry
 # seconds internally; converting once, here, keeps the frozen thresholds in
 # one unit and out of reach of a scoring-time reinterpretation.
+# The mechanism name reserved for "the tranche as a whole".
+SYSTEM_MECHANISM = "system"
+
 VERDICT_HELD = "HELD"
 VERDICT_PARTIAL = "PARTIAL"
 VERDICT_FALSIFIED = "FALSIFIED"
 VERDICT_INVALID = "INVALID COMPARISON"
 VERDICT_NO_DATA = "NO DATA"
+# Distinct from NO DATA: the metric exists on both sides and is perfectly
+# well defined, but comparing it across samples of different size answers a
+# question about sample size rather than about the intervention.
+VERDICT_UNSCOREABLE = "UNSCOREABLE"
+
+
+@dataclass(frozen=True)
+class Sample:
+    """A flat metric table plus the sample size that produced it.
+
+    The attempt count travels WITH the metrics because the parity check is
+    not optional: a scorer that has to remember to look it up separately is
+    a scorer that will one day forget.
+    """
+
+    metrics: dict[str, float | None]
+    attempts: int
+
+    def get(self, name: str) -> float | None:
+        return self.metrics.get(name)
 
 OPERATORS = {
     "lt": lambda a, b: a < b,
@@ -524,12 +710,23 @@ def flatten_metrics(agg: dict) -> dict[str, float | None]:
             if stat == "n":
                 continue
             out[f"{key}.{stat}"] = None if value is None else value / SECONDS_PER_MINUTE
+    # A share is a fraction, not a duration: it is NOT divided by
+    # SECONDS_PER_MINUTE, so a threshold on it reads as a share.
+    for workflow, share in (agg.get("workflow_share") or {}).items():
+        out[f"workflow_share.{workflow}"] = share
+    for workflow, stats in (agg.get("workflow_exec_max") or {}).items():
+        for stat, value in stats.items():
+            if stat == "n":
+                continue
+            out[f"workflow_exec_max.{workflow}.{stat}"] = None if value is None else value / SECONDS_PER_MINUTE
     for key in ("superseded_exec_total", "superseded_exec_mean"):
         value = agg.get(key)
         out[key] = None if value is None else value / SECONDS_PER_MINUTE
-    for bucket, prefix in (("queued_by_os", "queued"), ("executed_by_os", "executed")):
-        for os_name, value in (agg.get(bucket) or {}).items():
-            out[f"{prefix}.{os_name}"] = value / SECONDS_PER_MINUTE
+    for bucket in EXTENSIVE_OS_BUCKETS:
+        for os_name, value in (agg.get(f"{bucket}_by_os") or {}).items():
+            out[f"{bucket}.{os_name}"] = value / SECONDS_PER_MINUTE
+        for os_name, value in (agg.get(f"{bucket}_by_os_per_attempt") or {}).items():
+            out[f"{bucket}{PER_ATTEMPT_SUFFIX}.{os_name}"] = value / SECONDS_PER_MINUTE
     # merge_ready.p50 is the common shorthand; keep the full path too.
     return out
 
@@ -557,13 +754,32 @@ def evaluate_conditions(conditions: dict, after: float | None, before: float | N
     return True
 
 
-def score_prediction(pred: dict, before: dict, after: dict) -> dict:
+def sample_size_bias_pct(before: Sample, after: Sample) -> float | None:
+    """The movement an EXTENSIVE metric shows from sample size alone.
+
+    Exactly (n_after / n_before - 1) for a metric that is flat per attempt.
+    Reported so a reader can see how much of a delta was bought and paid
+    for before the intervention was considered.
+    """
+    if not before.attempts:
+        return None
+    return (after.attempts - before.attempts) / before.attempts * 100.0
+
+
+def score_prediction(pred: dict, before: Sample, after: Sample) -> dict:
     metric = pred["metric"]
+    kind = metric_kind(metric)
     b, a = before.get(metric), after.get(metric)
     held = evaluate_conditions(pred.get("held_if", {}), a, b)
     falsified = evaluate_conditions(pred.get("falsified_if", {}), a, b)
+    bias = sample_size_bias_pct(before, after)
+    unequal = before.attempts != after.attempts
     if a is None:
         verdict = VERDICT_NO_DATA
+    elif kind == METRIC_EXTENSIVE and unequal:
+        # Refuse rather than report. See METRIC_EXTENSIVE above: this is the
+        # E1 C2 defect, and the only correct answer is to name it.
+        verdict = VERDICT_UNSCOREABLE
     elif falsified:
         verdict = VERDICT_FALSIFIED
     elif held:
@@ -571,12 +787,27 @@ def score_prediction(pred: dict, before: dict, after: dict) -> dict:
     else:
         verdict = VERDICT_PARTIAL
     delta = None if (b in (None, 0) or a is None) else (a - b) / b * 100.0
-    return {"id": pred["id"], "mechanism": pred["mechanism"], "kind": pred.get("kind", "effect"),
-            "metric": metric, "before": b, "after": a, "delta_pct": delta,
-            "verdict": verdict, "claim": pred.get("claim", "")}
+    scored = {"id": pred["id"], "mechanism": pred["mechanism"], "kind": pred.get("kind", "effect"),
+              "metric": metric, "metric_kind": kind, "before": b, "after": a, "delta_pct": delta,
+              "verdict": verdict, "claim": pred.get("claim", "")}
+    if verdict == VERDICT_UNSCOREABLE:
+        companion = intensive_companion(metric)
+        remedy = f"Score {companion} instead." if companion else (
+            "This metric has no intensive companion; compare equal-sized samples.")
+        scored["unscoreable_because"] = (
+            f"{metric} is {METRIC_EXTENSIVE}; n_before={before.attempts} n_after={after.attempts} "
+            f"contributes {bias:+.1f}% before any effect. {remedy}"
+        )
+        scored["intensive_companion"] = companion
+    return scored
 
 
 def mechanism_verdict(scored: Sequence[dict]) -> str:
+    # An unscoreable prediction is not a failed one. If the mechanism's
+    # validity gate cannot be evaluated, nothing downstream of it can be
+    # either, and saying so beats inventing a verdict.
+    if any(s["verdict"] == VERDICT_UNSCOREABLE for s in scored):
+        return VERDICT_UNSCOREABLE
     validity = [s for s in scored if s["kind"] == "validity"]
     if any(s["verdict"] in (VERDICT_FALSIFIED, VERDICT_PARTIAL) for s in validity):
         return VERDICT_INVALID
@@ -598,8 +829,8 @@ def adjudicate(args: argparse.Namespace) -> int:
 
     before_rows = analyse(json.loads(Path(args.before).read_text()), informational, None, args.require_complete)
     after_rows = analyse(json.loads(Path(args.after).read_text()), informational, None, args.require_complete)
-    before = flatten_metrics(aggregate(before_rows, percentiles))
-    after = flatten_metrics(aggregate(after_rows, percentiles))
+    before = Sample(flatten_metrics(aggregate(before_rows, percentiles)), len(before_rows))
+    after = Sample(flatten_metrics(aggregate(after_rows, percentiles)), len(after_rows))
 
     scored = [score_prediction(p, before, after) for p in forecast["predictions"]]
     by_mech: dict[str, list[dict]] = defaultdict(list)
@@ -607,32 +838,52 @@ def adjudicate(args: argparse.Namespace) -> int:
         by_mech[s["mechanism"]].append(s)
 
     names = forecast.get("mechanisms", {})
-    order = [m for m in ("c1", "c2", "c3", "system") if m in by_mech] +             [m for m in by_mech if m not in ("c1", "c2", "c3", "system")]
+    # Forecast order, with the whole-tranche mechanism last: a system
+    # verdict reads as a summary, and a summary printed first invites
+    # skipping the per-mechanism causal information underneath it.
+    declared = list(forecast.get("mechanisms", {}))
+    ranked = [m for m in declared if m in by_mech and m != SYSTEM_MECHANISM]
+    ranked += [m for m in by_mech if m not in declared and m != SYSTEM_MECHANISM]
+    if SYSTEM_MECHANISM in by_mech:
+        ranked.append(SYSTEM_MECHANISM)
+    order = ranked
 
-    print(f"E1 adjudication — before n={len(before_rows)} attempts, after n={len(after_rows)} attempts")
+    experiment = forecast.get("experiment", "?")
+    print(f"{experiment} adjudication — before n={before.attempts} attempts, after n={after.attempts} attempts")
+    bias = sample_size_bias_pct(before, after)
+    if bias is not None and before.attempts != after.attempts:
+        print(f"  sample sizes differ: any EXTENSIVE metric carries {bias:+.1f}% from that alone,")
+        print(f"  so extensive predictions are refused rather than scored")
     print()
     results = {}
     for mech in order:
         entries = by_mech[mech]
         verdict = mechanism_verdict(entries)
         results[mech] = verdict
-        label = "SYSTEM" if mech == "system" else mech.upper()
+        label = "SYSTEM" if mech == SYSTEM_MECHANISM else mech.upper()
         print(f"{label}  {names.get(mech, '')}")
         for s in entries:
             delta = "-" if s["delta_pct"] is None else f"{s['delta_pct']:+.0f}%"
-            b = "-" if s["before"] is None else f"{s['before']:.1f}"
-            a = "-" if s["after"] is None else f"{s['after']:.1f}"
+            places = 1 if metric_unit(s["metric"]) else 3
+            b = "-" if s["before"] is None else f"{s['before']:.{places}f}"
+            a = "-" if s["after"] is None else f"{s['after']:.{places}f}"
             kind = " (validity)" if s["kind"] == "validity" else ""
-            print(f"  {s['id']}{kind}  {s['metric']}: {b} -> {a} min  ({delta})   {s['verdict']}")
+            unit = metric_unit(s["metric"])
+            print(f"  {s['id']}{kind}  {s['metric']}: {b} -> {a}{unit}  ({delta})   {s['verdict']}")
+            if s.get("unscoreable_because"):
+                print(f"       {s['unscoreable_because']}")
         print(f"  VERDICT: {verdict}")
         if verdict == VERDICT_INVALID:
             print("  the validity gate failed: this mechanism's effect predictions are NOT interpreted")
+        if verdict == VERDICT_UNSCOREABLE:
+            print("  this mechanism's forecast names a metric these two samples cannot compare")
         print()
 
     if args.json_out:
         Path(args.json_out).write_text(json.dumps(
-            {"mechanisms": results, "predictions": scored,
-             "before_attempts": len(before_rows), "after_attempts": len(after_rows)}, indent=2) + "\n")
+            {"experiment": experiment, "mechanisms": results, "predictions": scored,
+             "before_attempts": before.attempts, "after_attempts": after.attempts,
+             "sample_size_bias_pct": bias}, indent=2) + "\n")
     return 0
 
 
@@ -678,6 +929,19 @@ def selftest(_args: argparse.Namespace) -> int:
     check("queued linux", rows[0].queued_by_os["linux"], 60.0)
     check("executed macos", rows[0].executed_by_os["macos"], 60.0)
 
+    # 1b. the per-attempt companion is the total divided by the attempt
+    #     count — checked on two attempts so the divisor is not 1.
+    two = {"runs": [
+        _run("quality", "aaa", [_job(T(0), T(20), T(21), ["macos-14"])], branch="pr-1"),
+        _run("quality", "bbb", [_job(T(30), T(40), T(50), ["macos-14"])], branch="pr-2"),
+    ]}
+    agg2 = aggregate(analyse(two, DEFAULT_INFORMATIONAL, None, True), DEFAULT_PERCENTILES)
+    check("two attempts aggregated", agg2["attempts"], 2)
+    check("queued macos total", agg2["queued_by_os"]["macos"], 30 * 60.0)
+    check("queued macos per attempt", agg2["queued_by_os_per_attempt"]["macos"], 15 * 60.0)
+    check("per-attempt is empty with no attempts",
+          aggregate([], DEFAULT_PERCENTILES)["queued_by_os_per_attempt"], {})
+
     # 2. merge-ready spans to the LAST blocking success; the informational
     #    workflow is excluded even when it finishes last and fails.
     snap = {"runs": [
@@ -718,42 +982,186 @@ def selftest(_args: argparse.Namespace) -> int:
                 "held_if": {"delta_pct": {"lte": -30}}, "falsified_if": {"delta_pct": {"gt": -20}}}
     p_valid = {"id": "PV", "mechanism": "c2", "kind": "validity", "metric": "executed.macos",
                "held_if": {"delta_pct": {"gte": -10}}, "falsified_if": {"delta_pct": {"lt": -20}}}
-    base = {"queued.macos": 4526.6, "executed.macos": 3034.9}
+    N = 20      # equal sample sizes, so the parity guard stays out of the way
+    base = Sample({"queued.macos": 4526.6, "executed.macos": 3034.9}, N)
 
-    good = {"queued.macos": 2263.3, "executed.macos": 2882.2}   # -50% queue, -5% exec
+    good = Sample({"queued.macos": 2263.3, "executed.macos": 2882.2}, N)   # -50% queue, -5% exec
     check("effect HELD", score_prediction(p_effect, base, good)["verdict"], VERDICT_HELD)
     check("validity HELD", score_prediction(p_valid, base, good)["verdict"], VERDICT_HELD)
     check("c2 verdict when both hold",
           mechanism_verdict([score_prediction(p_effect, base, good), score_prediction(p_valid, base, good)]),
           VERDICT_HELD)
 
-    flat = {"queued.macos": 4300.0, "executed.macos": 2950.0}    # -5% queue
+    flat = Sample({"queued.macos": 4300.0, "executed.macos": 2950.0}, N)   # -5% queue
     check("effect FALSIFIED", score_prediction(p_effect, base, flat)["verdict"], VERDICT_FALSIFIED)
 
-    # The control that matters: a spectacular queue drop that is really just a
-    # thinner AFTER sample must NOT be readable as an effect.
-    thin = {"queued.macos": 1000.0, "executed.macos": 1500.0}    # -78% queue, -51% exec
-    check("effect looks HELD on a thin sample", score_prediction(p_effect, base, thin)["verdict"], VERDICT_HELD)
-    check("validity FALSIFIED on a thin sample", score_prediction(p_valid, base, thin)["verdict"], VERDICT_FALSIFIED)
+    # At EQUAL n, a queue drop alongside an execution collapse is a real
+    # composition change, and the validity gate must veto the effect.
+    shifted = Sample({"queued.macos": 1000.0, "executed.macos": 1500.0}, N)  # -78% queue, -51% exec
+    check("effect looks HELD under a composition shift",
+          score_prediction(p_effect, base, shifted)["verdict"], VERDICT_HELD)
+    check("validity FALSIFIED under a composition shift",
+          score_prediction(p_valid, base, shifted)["verdict"], VERDICT_FALSIFIED)
     check("c2 verdict is vetoed by validity",
-          mechanism_verdict([score_prediction(p_effect, base, thin), score_prediction(p_valid, base, thin)]),
+          mechanism_verdict([score_prediction(p_effect, base, shifted), score_prediction(p_valid, base, shifted)]),
           VERDICT_INVALID)
 
-    check("missing metric yields NO DATA", score_prediction(p_effect, base, {})["verdict"], VERDICT_NO_DATA)
+    check("missing metric yields NO DATA", score_prediction(p_effect, base, Sample({}, N))["verdict"], VERDICT_NO_DATA)
 
-    # 4b. the shipped forecast must be scoreable: every condition parses and
-    #     every metric name is one flatten_metrics actually produces.
-    forecast_path = REPO_ROOT / "docs" / "ci-throughput" / "E1-forecast.json"
-    if forecast_path.exists():
+    # 4a. the E1 C2 defect, as a regression test. The SAME numbers that score
+    #     HELD/FALSIFIED above must be refused once the samples differ in
+    #     size, because then they are a statement about n and not about the
+    #     intervention. Both directions are checked: the guard must fire
+    #     here and must NOT fire at equal n (above), or it is not a gate.
+    thin = Sample({"queued.macos": 1000.0, "executed.macos": 1500.0}, N // 2)
+    check("extensive effect is UNSCOREABLE at unequal n",
+          score_prediction(p_effect, base, thin)["verdict"], VERDICT_UNSCOREABLE)
+    check("extensive validity is UNSCOREABLE at unequal n",
+          score_prediction(p_valid, base, thin)["verdict"], VERDICT_UNSCOREABLE)
+    check("mechanism is UNSCOREABLE, not INVALID, when the metric is the problem",
+          mechanism_verdict([score_prediction(p_effect, base, thin), score_prediction(p_valid, base, thin)]),
+          VERDICT_UNSCOREABLE)
+    check("the refusal names the per-attempt metric to use instead",
+          "queued_per_attempt.macos" in score_prediction(p_effect, base, thin)["unscoreable_because"], True)
+    check("the refusal names superseded_exec_MEAN, which exists",
+          intensive_companion("superseded_exec_total"), "superseded_exec_mean")
+
+    # E1's real numbers: 12 attempts against 33 is -63.6% before any effect.
+    check("E1's sample-size bias is reported",
+          round(sample_size_bias_pct(Sample({}, 33), Sample({}, 12)), 1), -63.6)
+
+    # 4c. an INTENSIVE metric is scoreable across unlike samples — that is
+    #     the whole point of having the companion.
+    p_intensive = {"id": "PI", "mechanism": "c2", "kind": "effect",
+                   "metric": "queued_per_attempt.macos",
+                   "held_if": {"delta_pct": {"lte": -30}}, "falsified_if": {"delta_pct": {"gt": -20}}}
+    b_int = Sample({"queued_per_attempt.macos": 137.2}, 33)
+    a_int = Sample({"queued_per_attempt.macos": 80.1}, 12)
+    check("intensive metric scores across unlike samples",
+          score_prediction(p_intensive, b_int, a_int)["verdict"], VERDICT_HELD)
+
+    # 4d. declaration fate: every metric the instrument produces has a kind,
+    #     and the per-attempt companions exist for every extensive bucket.
+    produced = set(flatten_metrics(aggregate([
+        AttemptMetrics(branch="b", sha="s", workflows=[PROBE_WORKFLOW],
+                       queued_by_os={"macos": 1.0}, executed_by_os={"macos": 1.0},
+                       workflow_exec_max={PROBE_WORKFLOW: 60.0})
+    ], DEFAULT_PERCENTILES)))
+    check("every extensive metric has a per-attempt companion",
+          all(f"{b}{PER_ATTEMPT_SUFFIX}.macos" in produced
+              for b in EXTENSIVE_OS_BUCKETS), True)
+    check("metric_kind classifies every produced metric",
+          {metric_kind(m) for m in produced} <= {METRIC_EXTENSIVE, METRIC_INTENSIVE}, True)
+    #     Declaration fate: every extensive metric the instrument produces
+    #     must have a companion, that companion must itself be produced, and
+    #     it must be intensive. Without this a refusal can name a metric
+    #     that does not exist — as it did for superseded_exec_total.
+    extensive_produced = [m for m in produced if metric_kind(m) == METRIC_EXTENSIVE]
+    check("there are extensive metrics to check", len(extensive_produced) > 0, True)
+    check("every extensive metric has a companion",
+          all(intensive_companion(m) for m in extensive_produced), True)
+    check("every companion is itself produced",
+          all(intensive_companion(m) in produced for m in extensive_produced), True)
+    check("every companion is intensive",
+          {metric_kind(intensive_companion(m)) for m in extensive_produced}, {METRIC_INTENSIVE})
+    check("queued.macos is extensive", metric_kind("queued.macos"), METRIC_EXTENSIVE)
+    check("queued_per_attempt.macos is intensive",
+          metric_kind("queued_per_attempt.macos"), METRIC_INTENSIVE)
+    check("merge_ready.p50 is intensive", metric_kind("merge_ready.p50"), METRIC_INTENSIVE)
+    check("superseded_exec_total is extensive",
+          metric_kind("superseded_exec_total"), METRIC_EXTENSIVE)
+    check("superseded_exec_mean is intensive",
+          metric_kind("superseded_exec_mean"), METRIC_INTENSIVE)
+    check("workflow_exec_max is intensive",
+          metric_kind("workflow_exec_max.larql-compute-metal.p50"), METRIC_INTENSIVE)
+    check("workflow_share is intensive",
+          metric_kind("workflow_share.larql-compute-metal"), METRIC_INTENSIVE)
+    check("metric_shape abstracts the workflow out of an exec metric",
+          metric_shape("workflow_exec_max.larql-compute-metal.p50"),
+          f"workflow_exec_max.{PROBE_WORKFLOW}.p50")
+    check("metric_shape abstracts the workflow out of a share",
+          metric_shape("workflow_share.bench-regress"), f"workflow_share.{PROBE_WORKFLOW}")
+    check("metric_shape survives a dot in a workflow name",
+          metric_shape("workflow_exec_max.a.b.p95"), f"workflow_exec_max.{PROBE_WORKFLOW}.p95")
+    check("metric_workflow recovers the name", metric_workflow("workflow_exec_max.a.b.p95"), "a.b")
+    check("metric_shape leaves an unscoped metric alone",
+          metric_shape("merge_ready.p50"), "merge_ready.p50")
+    check("metric_workflow is None for an unscoped metric",
+          metric_workflow("merge_ready.p50"), None)
+
+    # 4e. workflow_exec_max picks the LONGEST job in the workflow, per
+    #     attempt, and is a percentile across attempts — so it survives a
+    #     change in how many pull requests the window holds.
+    wf_snap = {"runs": [
+        _run("larql-compute-metal", "aaa", [
+            _job(T(0), T(1), T(11), ["macos-14"]),
+            _job(T(0), T(1), T(31), ["macos-14"]),
+        ], branch="pr-1"),
+        _run("larql-compute-metal", "bbb", [_job(T(0), T(1), T(21), ["macos-14"])], branch="pr-2"),
+    ]}
+    wf_agg = aggregate(analyse(wf_snap, DEFAULT_INFORMATIONAL, None, True), DEFAULT_PERCENTILES)
+    check("workflow_exec_max takes the longest job",
+          wf_agg["workflow_exec_max"]["larql-compute-metal"]["p50"], 25 * 60.0)
+    check("workflow_exec_max is flattened in minutes",
+          flatten_metrics(wf_agg)["workflow_exec_max.larql-compute-metal.p50"], 25.0)
+
+    #     Share counts attempts the workflow RAN on, success or not, because
+    #     it describes what triggered, not what passed.
+    share_snap = {"runs": wf_snap["runs"] + [
+        _run("quality", "ccc", [_job(T(0), T(1), T(6), ["ubuntu-latest"])], branch="pr-3")]}
+    share_agg = aggregate(analyse(share_snap, DEFAULT_INFORMATIONAL, None, True), DEFAULT_PERCENTILES)
+    check("workflow_share counts attempts, not runs",
+          round(share_agg["workflow_share"]["larql-compute-metal"], 4), round(2 / 3, 4))
+    check("workflow_share is a fraction, not minutes",
+          round(flatten_metrics(share_agg)["workflow_share.larql-compute-metal"], 4), round(2 / 3, 4))
+
+    #     Control: a CANCELLED run must not enter the metric, or cancelling
+    #     more runs would read as a faster gate.
+    wf_snap["runs"][1] = _run("larql-compute-metal", "bbb",
+                              [_job(T(0), T(1), T(4), ["macos-14"], TERMINAL_CANCELLED)],
+                              conclusion=TERMINAL_CANCELLED, branch="pr-2")
+    wf_agg2 = aggregate(analyse(wf_snap, DEFAULT_INFORMATIONAL, None, True), DEFAULT_PERCENTILES)
+    check("a cancelled run is excluded from workflow_exec_max",
+          wf_agg2["workflow_exec_max"]["larql-compute-metal"]["n"], 1)
+    check("the surviving successful attempt sets the value",
+          wf_agg2["workflow_exec_max"]["larql-compute-metal"]["p50"], 30 * 60.0)
+
+    # 4b. every shipped forecast must be scoreable: every condition parses
+    #     and every metric name is one flatten_metrics actually produces.
+    #     Forecasts frozen from E2 onward must additionally name only
+    #     INTENSIVE metrics, so the E1 C2 defect cannot recur by copy-paste.
+    for forecast_path, intensive_only in (
+        (FORECAST_DIR / "E1-forecast.json", False),
+        (FORECAST_DIR / "E2-contract.json", True),
+    ):
+        if not forecast_path.exists():
+            continue
         forecast = json.loads(forecast_path.read_text())
-        known = set(flatten_metrics(aggregate([
-            AttemptMetrics(branch="b", sha="s", queued_by_os={"macos": 1.0}, executed_by_os={"macos": 1.0})
-        ], DEFAULT_PERCENTILES)))
+        label = forecast.get("experiment", forecast_path.stem)
+        snapshot_workflows: set[str] = set()
+        for snapshot_key in ("primary_snapshot", "metal_gate_snapshot", "baseline_snapshot"):
+            snapshot_path = forecast.get("baseline", {}).get(snapshot_key) or forecast.get(
+                "frozen_against", {}).get(snapshot_key)
+            if snapshot_path and (REPO_ROOT / snapshot_path).exists():
+                snap = json.loads((REPO_ROOT / snapshot_path).read_text())
+                snapshot_workflows |= {r.get("workflow") for r in snap.get("runs", [])}
         for pred in forecast["predictions"]:
-            check(f"{pred['id']} metric is produced", pred["metric"] in known, True)
+            # SHAPE, because a workflow-scoped name exists only once that
+            # workflow is in a snapshot...
+            check(f"{label} {pred['id']} metric is produced",
+                  metric_shape(pred["metric"]) in produced, True)
+            # ...and then the workflow itself must be one the baseline
+            # actually contains, or the prediction is unscoreable by name.
+            workflow = metric_workflow(pred["metric"])
+            if workflow is not None and snapshot_workflows:
+                check(f"{label} {pred['id']} names a workflow the baseline contains",
+                      workflow in snapshot_workflows, True)
+            if intensive_only:
+                check(f"{label} {pred['id']} names an intensive metric",
+                      metric_kind(pred["metric"]), METRIC_INTENSIVE)
             for conditions in (pred.get("held_if", {}), pred.get("falsified_if", {})):
                 evaluate_conditions(conditions, 1.0, 2.0)   # raises on an unknown field/operator
-        check("forecast conditions all parse", True, True)
+        check(f"{label} conditions all parse", True, True)
 
     # 5. percentile is defined at n == 1 and interpolates at n == 2.
     check("percentile n=1", percentile([7.0], 95), 7.0)


### PR DESCRIPTION
Lands **CI-E2-0** (the measurement) and **CI-E2-A** (the change it will
score). E2-D — tiered Metal triggers — is deliberately **not** here: it
changes which pull requests enter the Metal population, and mixing a
trigger-selection intervention into this sample would hand a
freshly-corrected instrument a new attribution problem.

## E1 is adjudicated, and not re-scored

`docs/ci-throughput/E1-verdict.json`, frozen as delivered:

```
C1  cancel superseded PR runs    P1  931.6 -> 26.9 min  (-97%)        HELD
C2  macOS scheduling contention  P2  queued.macos      (-79%)         HELD
                                 P3  executed.macos    (-70%)    FALSIFIED
                                 VERDICT: INVALID COMPARISON
C3  VINDEX benches Linux-only    P4  29.7 -> 21.8 min p50            HELD
SYSTEM                           P5  merge-ready 61.4 -> 40.8 p50    HELD
```

C2's refusal was the designed behaviour and it fired for the wrong
reason. P2 and P3 name **extensive** totals; the AFTER window holds 12
attempts against a 33-attempt baseline, and 12/33 contributes **-63.6%
before any effect exists**. P3 could not have returned HELD. **C2 is
unadjudicated, not refuted.**

E1 itself is untouched. The per-attempt analysis lives in
`E1-postmortem.md`, which opens by saying it is not a verdict and that
none of its numbers may be cited as an E1 result.

## E2-0 — fix the instrument, not the experiment

- every extensive metric gains an intensive companion
  (`queued_per_attempt.<os>`, `executed_per_attempt.<os>`);
- a `Sample` type carries the attempt count alongside the metrics, so
  the parity check cannot be forgotten, and `score_prediction` returns
  `UNSCOREABLE` for an extensive metric at unequal n — naming the
  companion to score instead;
- `workflow_share.<wf>` makes composition scoreable, which is what P3
  was reaching for;
- `workflow_exec_max.<wf>` measures a gate's wall clock over
  **successful runs only**, so cancelling more runs cannot read as a
  faster gate;
- `selftest` is wired into `quality.yml` as job `ci-instrument`. The
  script that adjudicates this repository's CI experiments had a
  selftest that only ran when someone remembered to type it.

**The defect was a class, not a C2 patch.** P1 names a total too, so the
new guard refuses C1 as well. C1's finding survives on its companion
(`superseded_exec_mean`, -92%); C2's moves -16.6% and is inconclusive.
The guard refuses a metric by name; it does not adjudicate the mechanism
behind it.

Controls, all in `selftest`: the guard fires at unequal n and **does
not** at equal n; every extensive metric has a companion that is itself
produced and intensive (the first version of the refusal suggested
`superseded_exec_total_per_attempt`, which does not exist); a forecast
naming a nonexistent workflow or an extensive metric fails.

## E2-A — one piece of evidence, once

`cargo test --tests` selects every target with `test = true`, and a lib
has it by default. Resolved from the log of run 34098337888 (#449):

| step | binaries | lib suite |
|---|---|---|
| Unit tests (11m33s) | **1** — `unittests src/lib.rs` | 530 tests, 671.22s |
| Integration tests (22m48s) | **69** — including `src/lib.rs` again | 530 tests, 535.74s |
| Coverage policy gate (23m52s) | the same **69**, instrumented | 530 tests, 535.52s |

**2061 seconds of a 3565-second job were executions of test estates that
were then executed again.** The `--lib` step was already fully redundant
with the `--tests` step before coverage entered the argument.

So the coverage run — which already executes the same 69 binaries under
the same `--test-threads=1`, fails on a failing test, and then applies
`--fail-under-lines` and the per-file policy — becomes authoritative,
and both plain passes are deleted rather than reordered. A 7-test
`backend::tests::` ordinary-profile witness keeps the one signal that
would otherwise be lost: the instrumented build is not the profile
anyone develops against. It carries a floor, because a cargo filter that
matches nothing exits 0.

`cargo install --locked cargo-llvm-cov` (49.7s of compiling a tool that
is not under test) becomes `taiki-e/install-action@cargo-llvm-cov`, as in
the nine other coverage jobs here.

`bench-regress` loses its `pull_request` trigger. Its own header
pre-registers the criterion and the criterion is unmet: #446 changed two
lines of a JSON file, compiled byte-identical artefacts in one job on one
runner, and **failed** at -11.4% to +15.3%. #449 reported ~+44% in one
metal cell and ~-43% in another. It cost 199 macOS runner-minutes over 6
jobs in the E1 window. `workflow_dispatch` stays as the qualification
laboratory; PERF-QUAL-2 has to pass before it grades a pull request
again.

## What this PR is

**Sample A1.** It touches `larql-compute-metal.yml`, so it triggers the
new Metal job and produces the first observation against the frozen
contract in `docs/ci-throughput/E2-contract.json`:

| | claim | held | falsified |
|---|---|---|---|
| A1 | Metal gate p50, 56.61 min baseline (n=34) | ≤ 27 min | > 35 min |
| A2 | `workflow_share.bench-regress` | 0 | > 0 |
| A3 | `executed_per_attempt.macos` | ≤ -25% | > -10% |
| A4 | merge-ready p50, 40.81 baseline | ≤ 30 min | > 38 min |
| A5 | **validity** — Metal share of attempts | ≥ 0.3 | < 0.3 |

Plus five **structural** falsifiers the instrument cannot score (S1–S5 in
the contract): the same 69 binaries still execute, a deliberately failing
test reds the gate, a deliberately violated coverage policy reds it, the
smoke witness runs in the ordinary profile, and no `pull_request`
benchmark job remains.

Read the internal split of this run, not only the total. Expected:
setup/check/clippy under 2 min, smoke well under 1 min after its build,
authoritative estate ~23–25 min. Coverage landing at 35–40 min instead
would be evidence that #449 was unrepresentative or that instrumented
execution behaves differently under the new arrangement — to be scored
against the frozen contract, not fixed on sight.

## Verification

`selftest` passes (including the new controls); both doc gates pass;
every workflow parses. The doc-reference gate had to be run on a copy of
the tree **outside** `.claude/worktrees/` — `SKIP_DIRS` in
`scripts/check_doc_references.py` contains `/.claude/`, so `os.walk`
skips the whole tree and it reports "0 documents". Run there it checks
720 path + 155 example + 146 env + 96 make references with nothing
broken. That vacuous-pass is worth fixing separately.

The Metal smoke filter is verified statically (`pub mod backend`, 7
tests, none `#[ignore]`d) rather than by a local build: this machine is
carrying a peer session's GLM-5 oracle run.

`metal-gate-baseline.json` was collected as a full snapshot and pruned to
Metal runs — 1.2 MB to 30 KB, with the metric it baselines bit-identical
before and after.
