### PR TITLE
ci: design E2-D — declare Metal's parity obligations, do not act on them yet

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -253,6 +253,20 @@ jobs:
       - name: Instrument selftest
         run: python3 scripts/ci_throughput.py selftest
 
+      # The Metal tier classifier ships before the trigger change that will
+      # use it (CI-E2-D is designed, not activated). Its completeness check
+      # runs from the moment the manifest exists, not from activation:
+      # `parity-obligations.json` declares which upstream surfaces can
+      # invalidate Metal's behaviour, and its one real weakness is OMISSION.
+      # A new parity dependency added without a declaration would classify
+      # as compile-only once tiering is live, so the gate that notices has
+      # to predate the gate that acts.
+      - name: Metal tier classifier selftest
+        run: python3 scripts/metal_tier.py selftest
+
+      - name: Parity-obligation manifest is complete
+        run: python3 scripts/metal_tier.py check
+
   proto-lint:
     name: buf lint
     runs-on: ubuntu-latest

--- a/crates/larql-compute-metal/parity-obligations.json
+++ b/crates/larql-compute-metal/parity-obligations.json
@@ -1,0 +1,85 @@
+{
+  "version": 1,
+  "status": "DESIGN — declared and checkable, but NOT yet wired to any workflow trigger (CI-E2-D)",
+  "note": "Which upstream surfaces can invalidate which claim about the Metal backend. This is a DECLARATION, not an inference from directory ancestry. scripts/metal_tier.py checks that it stays COMPLETE with respect to what the Metal crate actually references, so a new parity dependency cannot be added without either declaring it or failing the check.",
+  "the_asymmetry": "A file placed in interface_only when it is really behavioural is UNSAFE — Metal would compile against changed numerics and never re-qualify. A file placed in parity_obligations when it is really structural is merely EXPENSIVE. So anything uncertain belongs in parity_obligations, and entries carrying `needs_review` are there by that default rather than by a positive judgement.",
+  "parity_obligations": [
+    {
+      "id": "cpu-quant-kernels",
+      "paths": ["crates/larql-compute/src/cpu/ops/**"],
+      "why": "Metal's kernel tests import these as the NUMERICAL reference — 72 references to cpu::ops::q4_common alone, plus moe, geglu, q8_matvec, outer_combine. A change here changes what the Metal kernels are required to reproduce.",
+      "witnesses": [
+        "tests/test_kernel_q4k_matmul.rs",
+        "tests/test_kernel_q4k_ffn_gate_up.rs",
+        "tests/test_kernel_moe_router.rs",
+        "tests/test_kernel_q6k_geglu_down.rs"
+      ],
+      "confidence": "observed"
+    },
+    {
+      "id": "cpu-other",
+      "paths": ["crates/larql-compute/src/cpu/**"],
+      "why": "Metal references `larql_compute::cpu` through brace and type imports that text extraction truncates, so the subtree is declared whole rather than guessed at leaf level.",
+      "confidence": "needs_review",
+      "review_question": "Which of cpu/{kquant_gemv,nvfp4_gemv,spin_pool}.rs are reachable from an entry point a Metal test uses as a reference? kquant_gemv is currently reached only from cpu/mod.rs and consumed by larql-vindex, not by Metal."
+    },
+    {
+      "id": "attention-math",
+      "paths": ["crates/larql-compute/src/attention/**"],
+      "why": "rope (30 references) and softmax are compared against directly by the Metal kernel tests.",
+      "witnesses": ["tests/test_kernel_rope.rs", "tests/test_kernel_rope_at_pos.rs", "tests/test_lowering_attention_parity.rs"],
+      "confidence": "observed"
+    },
+    {
+      "id": "model-quant-formats",
+      "paths": ["crates/larql-models/src/quant/**"],
+      "why": "ggml, mxfp4, nvfp4, fp4 and half are the on-disk and in-register encodings the Metal kernels decode. A change to an encoder changes what every quant kernel must decode.",
+      "witnesses": ["tests/test_kernel_moe_g_mxfp4.rs", "tests/test_lowering_nvfp4_fusion.rs"],
+      "confidence": "observed"
+    },
+    {
+      "id": "forward-and-ffn",
+      "paths": [
+        "crates/larql-compute/src/forward/**",
+        "crates/larql-compute/src/ffn/**",
+        "crates/larql-compute/src/kquant_forward/**",
+        "crates/larql-compute/src/pipeline/**",
+        "crates/larql-compute/src/pipeline_layer/**",
+        "crates/larql-compute/src/kv_dispatch/**",
+        "crates/larql-compute/src/moe_route_observe.rs"
+      ],
+      "why": "The composition Metal's lowering must reproduce end to end, not merely link against.",
+      "confidence": "needs_review",
+      "review_question": "pipeline and pipeline_layer are referenced 13 times combined but it is not established whether Metal tests compare RESULTS through them or only construct them."
+    },
+    {
+      "id": "backend-traits-with-bodies",
+      "paths": ["crates/larql-compute/src/backend/**"],
+      "why": "Nominally the trait boundary, and matmul.rs is `pub trait MatMul` — but every file here carries arithmetic, including default method bodies a Metal impl can inherit. Declared as parity by the asymmetry above, not by a positive finding.",
+      "confidence": "needs_review",
+      "review_question": "Are capability.rs and factory.rs purely structural? If so they move to interface_only and this obligation narrows to decode/helpers/matmul/quant_matvec."
+    }
+  ],
+  "interface_only": [
+    {
+      "id": "options-and-handles",
+      "paths": [
+        "crates/larql-compute/src/options.rs",
+        "crates/larql-compute/src/state_handle.rs",
+        "crates/larql-compute/src/async_compute_backend/**"
+      ],
+      "why": "Configuration and handle types. A change here breaks the Metal COMPILE, which tier B catches; it does not change a number a Metal kernel must reproduce.",
+      "confidence": "needs_review"
+    },
+    {
+      "id": "test-fixtures",
+      "paths": [
+        "crates/larql-compute/src/test_fixtures.rs",
+        "crates/larql-models/src/test_fixtures.rs"
+      ],
+      "why": "Fixture constructors used by Metal's own tests. A change breaks the test build, which tier B catches by compiling --all-targets.",
+      "confidence": "needs_review",
+      "review_question": "A fixture that silently changes its DATA rather than its signature would change what the Metal tests assert without breaking the compile. That is a parity obligation wearing an interface's clothes, and it is the most likely single hole in this manifest."
+    }
+  ]
+}

--- a/docs/ci-throughput/E2-D-classification.json
+++ b/docs/ci-throughput/E2-D-classification.json
@@ -1,0 +1,300 @@
+{
+  "record": "CI-E2-D classification of pull requests #415-#449, replayed against the declared manifest",
+  "classified_at": "2026-09-07",
+  "manifest": "crates/larql-compute-metal/parity-obligations.json",
+  "classifier": "scripts/metal_tier.py",
+  "caveat": "Paths are replayed against TODAY's tree. A file that moved since a pull request landed classifies by where it lives now, not where it lived then. The sample is indicative of the trigger MIX, not an audit of past runs.",
+  "sample": {
+    "pull_requests_with_file_data": 35,
+    "trigger_the_metal_gate_today": 18,
+    "of_those_touch_a_metal_file": 6,
+    "of_those_upstream_only": 12
+  },
+  "under_e2d": {
+    "A": 7,
+    "B": 11,
+    "C": 0
+  },
+  "rows": [
+    {
+      "pr": 449,
+      "files": 2,
+      "triggers_today": true,
+      "touches_metal": true,
+      "tier": "A",
+      "first_reason": "crates/larql-compute-metal/src/moe_dispatch/dispatch/tests.rs: Metal crate or its workflow -> A"
+    },
+    {
+      "pr": 448,
+      "files": 1,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 447,
+      "files": 19,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 446,
+      "files": 1,
+      "triggers_today": true,
+      "touches_metal": true,
+      "tier": "A",
+      "first_reason": "crates/larql-compute-metal/coverage-policy.json: Metal crate or its workflow -> A"
+    },
+    {
+      "pr": 445,
+      "files": 4,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 444,
+      "files": 96,
+      "triggers_today": true,
+      "touches_metal": true,
+      "tier": "A",
+      "first_reason": "crates/larql-compute-metal/src/kernels/ffn.rs: Metal crate or its workflow -> A"
+    },
+    {
+      "pr": 443,
+      "files": 1,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 442,
+      "files": 100,
+      "triggers_today": true,
+      "touches_metal": true,
+      "tier": "A",
+      "first_reason": "crates/larql-compute-metal/coverage-policy.json: Metal crate or its workflow -> A"
+    },
+    {
+      "pr": 441,
+      "files": 44,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 440,
+      "files": 39,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 439,
+      "files": 68,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "crates/larql-models/src/architectures/gemma3.rs: dependency or build input -> B"
+    },
+    {
+      "pr": 438,
+      "files": 7,
+      "triggers_today": true,
+      "touches_metal": true,
+      "tier": "A",
+      "first_reason": "crates/larql-compute-metal/benches/matmul.rs: Metal crate or its workflow -> A"
+    },
+    {
+      "pr": 437,
+      "files": 1,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 436,
+      "files": 1,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 435,
+      "files": 10,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "crates/larql-models/src/config/residual_topology.rs: dependency or build input -> B"
+    },
+    {
+      "pr": 434,
+      "files": 22,
+      "triggers_today": true,
+      "touches_metal": true,
+      "tier": "A",
+      "first_reason": ".github/workflows/larql-compute-metal.yml: Metal crate or its workflow -> A"
+    },
+    {
+      "pr": 433,
+      "files": 23,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 432,
+      "files": 14,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 431,
+      "files": 50,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "crates/larql-models/src/architectures/gemma3.rs: dependency or build input -> B"
+    },
+    {
+      "pr": 430,
+      "files": 23,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "crates/larql-models/src/architectures/gemma3.rs: dependency or build input -> B"
+    },
+    {
+      "pr": 429,
+      "files": 42,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "crates/larql-models/src/architectures/gemma3.rs: dependency or build input -> B"
+    },
+    {
+      "pr": 428,
+      "files": 43,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "Cargo.lock: dependency or build input -> B"
+    },
+    {
+      "pr": 427,
+      "files": 4,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 426,
+      "files": 1,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 425,
+      "files": 36,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "Cargo.lock: dependency or build input -> B"
+    },
+    {
+      "pr": 424,
+      "files": 44,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "crates/larql-models/src/config/residual_topology.rs: dependency or build input -> B"
+    },
+    {
+      "pr": 423,
+      "files": 10,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 422,
+      "files": 24,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "Cargo.lock: dependency or build input -> B"
+    },
+    {
+      "pr": 421,
+      "files": 2,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 420,
+      "files": 38,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "A",
+      "first_reason": "crates/larql-compute/src/cpu/kquant_gemv.rs: declared parity obligation -> A"
+    },
+    {
+      "pr": 419,
+      "files": 36,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 418,
+      "files": 65,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 417,
+      "files": 19,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "crates/larql-models/src/config/residual_topology.rs: dependency or build input -> B"
+    },
+    {
+      "pr": 416,
+      "files": 1,
+      "triggers_today": false,
+      "touches_metal": false,
+      "tier": "C",
+      "first_reason": null
+    },
+    {
+      "pr": 415,
+      "files": 14,
+      "triggers_today": true,
+      "touches_metal": false,
+      "tier": "B",
+      "first_reason": "crates/larql-models/src/architectures/kimi_k3.rs: dependency or build input -> B"
+    }
+  ]
+}

--- a/docs/ci-throughput/E2-D-contract.json
+++ b/docs/ci-throughput/E2-D-contract.json
@@ -1,11 +1,11 @@
 {
   "experiment": "E2-D",
-  "title": "Tiered Metal evidence — declared parity obligation, not directory ancestry",
-  "status": "PREREGISTERED BUT NOT FROZEN — the classification prediction is frozen; numeric baselines are deferred, see baseline.deferred_because",
+  "title": "Tiered Metal evidence \u2014 declared parity obligation, not directory ancestry",
+  "status": "PREREGISTERED BUT NOT FROZEN \u2014 the classification prediction is frozen; numeric baselines are deferred, see baseline.deferred_because",
   "frozen_at": null,
   "claim": "A pull request pays full behavioural Metal qualification only when it changes the Metal crate or a DECLARED parity obligation. An upstream change that can break the compile but not the numbers pays a compile plus the ordinary-profile witness. Everything else pays no macOS time.",
   "measurement_contract": {
-    "inherits": "docs/ci-throughput/E2-contract.json — every prediction names an INTENSIVE metric, and the instrument refuses extensive metrics across samples of different size",
+    "inherits": "docs/ci-throughput/E2-contract.json \u2014 every prediction names an INTENSIVE metric, and the instrument refuses extensive metrics across samples of different size",
     "instrument_change_required_before_freezing": "workflow_exec_max is keyed on WORKFLOW. Under E2-D one workflow emits both a ~24-minute tier-A job and a ~2-minute tier-B job, so its p50 becomes a mixture that hides the per-tier story. E2-D needs job_exec_max.<workflow>.<job> before D1 or D3 can be scored at all."
   },
   "baseline": {
@@ -15,8 +15,20 @@
   "frozen_now": {
     "what": "The classification prediction, which is derivable from data that already exists and must not be re-derived after D runs.",
     "sample": "pull requests #415-#449, 35 with file data, 18 triggering the Metal gate today (6 metal-touching, 12 upstream-only)",
-    "predicted_tiers": { "A": 7, "B": 11, "C": 17 },
-    "predicted_tier_a_pull_requests": [449, 446, 444, 442, 438, 434, 420],
+    "predicted_tiers": {
+      "A": 7,
+      "B": 11,
+      "C": 17
+    },
+    "predicted_tier_a_pull_requests": [
+      449,
+      446,
+      444,
+      442,
+      438,
+      434,
+      420
+    ],
     "record": "docs/ci-throughput/E2-D-classification.json",
     "falsifier": "If the live triage job assigns a different tier to any of these 18 pull requests than the replay did, the classifier and the replay disagree and neither can be cited until that is resolved."
   },
@@ -30,8 +42,16 @@
       "mechanism": "tiering",
       "kind": "effect",
       "metric": "tier_b_share_of_triggering_attempts",
-      "held_if": { "after": { "gte": 0.5 } },
-      "falsified_if": { "after": { "lt": 0.3 } },
+      "held_if": {
+        "after": {
+          "gte": 0.5
+        }
+      },
+      "falsified_if": {
+        "after": {
+          "lt": 0.3
+        }
+      },
       "metric_not_yet_produced": true
     },
     {
@@ -43,33 +63,60 @@
       "mechanism": "tiering",
       "kind": "effect",
       "metric": "executed_per_attempt.macos",
-      "held_if": { "delta_pct": { "lte": -35 } },
-      "falsified_if": { "delta_pct": { "gt": -15 } }
+      "held_if": {
+        "delta_pct": {
+          "lte": -35
+        }
+      },
+      "falsified_if": {
+        "delta_pct": {
+          "gt": -15
+        }
+      }
     },
     {
       "id": "D3",
       "scores": "tiering",
-      "claim": "VALIDITY — the tier-A gate itself is unchanged, within 10%",
+      "claim": "VALIDITY \u2014 the tier-A gate itself is unchanged, within 10%",
       "reason": "D must not appear to work by making the full gate cheaper. If tier-A duration moves, D has changed what full qualification MEANS and D1/D2 are not measuring what they claim.",
-      "falsifier": "a tier-A p50 more than 10% from the E2-A baseline means the full gate was altered and the effect predictions must not be read",
+      "falsifier": "a tier-A p50 more than 10% from the E2-A baseline IN EITHER DIRECTION means the full gate was altered and the effect predictions must not be read. Two-sided deliberately: a tier-A gate that got FASTER has had work removed from it, and one that got SLOWER is no longer the gate A1 measured. Either way D1/D2 are not measuring what they claim.",
       "mechanism": "tiering",
       "kind": "validity",
       "metric": "job_exec_max.larql-compute-metal.full.p50",
-      "held_if": { "delta_pct": { "gte": -10, "lte": 10 } },
-      "falsified_if": { "delta_pct": { "lt": -10 } },
-      "metric_not_yet_produced": true
+      "held_if": {
+        "delta_pct": {
+          "gte": -10,
+          "lte": 10
+        }
+      },
+      "falsified_if": {
+        "abs_delta_pct": {
+          "gt": 10
+        }
+      },
+      "metric_not_yet_produced": true,
+      "condition_note": "Uses abs_delta_pct, not delta_pct. Conditions are ANDed, so a single delta_pct clause cannot express 'more than 10% away in either direction' \u2014 written as {lt: -10} it silently drops the upper half and a +20% slowdown returns PARTIAL rather than FALSIFIED. That is how this entry was first written; ci_throughput.py's selftest now carries the control that catches it."
     },
     {
       "id": "D4",
       "scores": "contention",
       "claim": "macOS queue wait p50 falls by at least 20%",
-      "reason": "E1's c2 established that the macOS win comes from removing scheduling units, not compute: 11 fewer macOS jobs plus msrv-metal folded in. This is c2's mechanism, finally measurable on an intensive metric.",
-      "falsifier": "no movement means the removed jobs were not the ones contending — the same falsifier c2 carried, now scoreable",
+      "reason": "E1's BASELINE analysis identified scheduling units as the hypothesised mechanism: the jobs c2 targeted carried disproportionate queue cost relative to execution \u2014 quality's msrv-macOS leg was 33 jobs, 544 queue-minutes and 22 execution-minutes. E2-D tests that mechanism on an intensive metric. It is NOT inherited from a C2 result: C2 returned INVALID COMPARISON and remains unadjudicated, so the mechanism is a live hypothesis here, not an established finding.",
+      "falsifier": "no movement means the removed jobs were not the ones contending \u2014 the same falsifier c2 carried, now on a metric that can actually be scored",
       "mechanism": "contention",
       "kind": "effect",
       "metric": "macos_queue_max.p50",
-      "held_if": { "delta_pct": { "lte": -20 } },
-      "falsified_if": { "delta_pct": { "gt": -5 } }
+      "held_if": {
+        "delta_pct": {
+          "lte": -20
+        }
+      },
+      "falsified_if": {
+        "delta_pct": {
+          "gt": -5
+        }
+      },
+      "provenance_note": "Wording corrected 2026-09-07. An earlier draft said E1's C2 'established that the macOS win comes from removing scheduling units, not compute'. C2 established no such thing: it was INVALID COMPARISON. What E1 produced was a pre-intervention measurement of the asymmetry plus post-hoc diagnostics in E1-postmortem.md. Citing an unadjudicated mechanism as established is the failure this programme exists to avoid."
     }
   ],
   "structural_falsifiers": [

--- a/docs/ci-throughput/E2-D-contract.json
+++ b/docs/ci-throughput/E2-D-contract.json
@@ -1,0 +1,109 @@
+{
+  "experiment": "E2-D",
+  "title": "Tiered Metal evidence — declared parity obligation, not directory ancestry",
+  "status": "PREREGISTERED BUT NOT FROZEN — the classification prediction is frozen; numeric baselines are deferred, see baseline.deferred_because",
+  "frozen_at": null,
+  "claim": "A pull request pays full behavioural Metal qualification only when it changes the Metal crate or a DECLARED parity obligation. An upstream change that can break the compile but not the numbers pays a compile plus the ordinary-profile witness. Everything else pays no macOS time.",
+  "measurement_contract": {
+    "inherits": "docs/ci-throughput/E2-contract.json — every prediction names an INTENSIVE metric, and the instrument refuses extensive metrics across samples of different size",
+    "instrument_change_required_before_freezing": "workflow_exec_max is keyed on WORKFLOW. Under E2-D one workflow emits both a ~24-minute tier-A job and a ~2-minute tier-B job, so its p50 becomes a mixture that hides the per-tier story. E2-D needs job_exec_max.<workflow>.<job> before D1 or D3 can be scored at all."
+  },
+  "baseline": {
+    "deferred_because": "The post-E2-A steady state does not exist yet: A1 stands at n=2 (24.87 and 23.00 min against a 56.61-minute pre-E2-A baseline) and its contract asks for n>=8. Freezing a numeric baseline now would bake in a two-sample estimate as the thing D is scored against.",
+    "collection_rule": "Freeze when workflow_exec_max.larql-compute-metal.n >= 8 under E2-A, using the same --since windowing discipline as E1: a date strictly after the E2-A merge (2026-09-07), never a window that straddles it."
+  },
+  "frozen_now": {
+    "what": "The classification prediction, which is derivable from data that already exists and must not be re-derived after D runs.",
+    "sample": "pull requests #415-#449, 35 with file data, 18 triggering the Metal gate today (6 metal-touching, 12 upstream-only)",
+    "predicted_tiers": { "A": 7, "B": 11, "C": 17 },
+    "predicted_tier_a_pull_requests": [449, 446, 444, 442, 438, 434, 420],
+    "record": "docs/ci-throughput/E2-D-classification.json",
+    "falsifier": "If the live triage job assigns a different tier to any of these 18 pull requests than the replay did, the classifier and the replay disagree and neither can be cited until that is resolved."
+  },
+  "predictions": [
+    {
+      "id": "D1",
+      "scores": "tiering",
+      "claim": "at least half of Metal-triggering attempts receive tier B",
+      "reason": "the replay puts 11 of 18 at tier B; the band allows for a live mix that differs from a 35-pull-request sample",
+      "falsifier": "below 0.3 means the declared obligations are so broad that tiering buys nothing, and the manifest needs narrowing before the mechanism is worth its complexity",
+      "mechanism": "tiering",
+      "kind": "effect",
+      "metric": "tier_b_share_of_triggering_attempts",
+      "held_if": { "after": { "gte": 0.5 } },
+      "falsified_if": { "after": { "lt": 0.3 } },
+      "metric_not_yet_produced": true
+    },
+    {
+      "id": "D2",
+      "scores": "tiering",
+      "claim": "macOS executed runner-minutes per attempt fall by at least 35% from the post-E2-A baseline",
+      "reason": "11 of 18 triggers move from ~24 min to ~2 min, and msrv-metal folds into the tier-B job",
+      "falsifier": "a fall of less than 15% means the tiering did not reach the macOS pool",
+      "mechanism": "tiering",
+      "kind": "effect",
+      "metric": "executed_per_attempt.macos",
+      "held_if": { "delta_pct": { "lte": -35 } },
+      "falsified_if": { "delta_pct": { "gt": -15 } }
+    },
+    {
+      "id": "D3",
+      "scores": "tiering",
+      "claim": "VALIDITY — the tier-A gate itself is unchanged, within 10%",
+      "reason": "D must not appear to work by making the full gate cheaper. If tier-A duration moves, D has changed what full qualification MEANS and D1/D2 are not measuring what they claim.",
+      "falsifier": "a tier-A p50 more than 10% from the E2-A baseline means the full gate was altered and the effect predictions must not be read",
+      "mechanism": "tiering",
+      "kind": "validity",
+      "metric": "job_exec_max.larql-compute-metal.full.p50",
+      "held_if": { "delta_pct": { "gte": -10, "lte": 10 } },
+      "falsified_if": { "delta_pct": { "lt": -10 } },
+      "metric_not_yet_produced": true
+    },
+    {
+      "id": "D4",
+      "scores": "contention",
+      "claim": "macOS queue wait p50 falls by at least 20%",
+      "reason": "E1's c2 established that the macOS win comes from removing scheduling units, not compute: 11 fewer macOS jobs plus msrv-metal folded in. This is c2's mechanism, finally measurable on an intensive metric.",
+      "falsifier": "no movement means the removed jobs were not the ones contending — the same falsifier c2 carried, now scoreable",
+      "mechanism": "contention",
+      "kind": "effect",
+      "metric": "macos_queue_max.p50",
+      "held_if": { "delta_pct": { "lte": -20 } },
+      "falsified_if": { "delta_pct": { "gt": -5 } }
+    }
+  ],
+  "structural_falsifiers": [
+    {
+      "id": "T1",
+      "claim": "no pull request touching a declared parity path ever receives tier B",
+      "check": "replay every pull request in the live AFTER window through metal_tier.py and assert no attempt whose diff intersects parity_obligations was assigned B. This is the SAFETY property; D1-D4 are throughput and none of them would notice a wrong answer here.",
+      "severity": "blocking"
+    },
+    {
+      "id": "T2",
+      "claim": "the manifest is complete with respect to what the Metal crate references",
+      "check": "scripts/metal_tier.py check exits 0. Must run in CI, not by hand, or it is the vacuous gate this programme keeps finding.",
+      "severity": "blocking"
+    },
+    {
+      "id": "T3",
+      "claim": "the tier-B job actually fails on an upstream API break",
+      "check": "deliberately change a signature in a declared interface_only path so the Metal crate cannot compile; the compat job must red. A green tier B on a real break is the failure mode that makes tiering unsafe. Dispatch on a throwaway branch, as S2/S3 were.",
+      "severity": "blocking"
+    },
+    {
+      "id": "T4",
+      "claim": "the triage job and the offline replay agree",
+      "check": "the tier the live triage assigns equals the tier metal_tier.py assigns to the same diff, for every attempt in the AFTER window."
+    }
+  ],
+  "confounds": [
+    "The replay classifies against TODAY's tree; a file that moved since a pull request landed classifies by where it lives now.",
+    "Five manifest entries carry confidence=needs_review and are tier A by the safety asymmetry rather than by a positive finding. Resolving them can only move pull requests from A to B, so D1 and D2 are conservative as frozen.",
+    "E2-E (reusing a qualification across pushes within one pull request) would also reduce macOS minutes. It must not land inside D's measurement window."
+  ],
+  "mechanisms": {
+    "tiering": "run the evidence proportional to the claim a change can invalidate",
+    "contention": "remove macOS scheduling units, not macOS compute"
+  }
+}

--- a/docs/ci-throughput/E2-D-design.md
+++ b/docs/ci-throughput/E2-D-design.md
@@ -130,9 +130,15 @@ default above).
 
 On the measured tier costs — 24 min and ~2 min — that is 18 × 24 = 432
 macOS execution-minutes today against 7 × 24 + 11 × 2 = 190. It is also
-11 fewer macOS scheduling units, which on E1's evidence is the larger
-effect: c2's whole finding was that the jobs worth removing are cheap to
-run and expensive to schedule.
+11 fewer macOS scheduling units, which E1 *hypothesised* is the larger
+effect. Be precise about the provenance: E1's **baseline** measurement
+found the asymmetry — `quality`'s msrv-macOS leg was 33 jobs, 544
+queue-minutes and 22 execution-minutes, cheap to run and expensive to
+schedule. E1's **C2**, which would have tested whether removing such jobs
+actually wins, came back `INVALID COMPARISON` and is unadjudicated. So
+scheduling-unit relief is a live hypothesis inherited from a
+pre-intervention measurement, not an established finding, and D4 is the
+first prediction that can score it on an intensive metric.
 
 Treat both as arithmetic on a replayed sample, not as a result. They are
 what `E2-D-contract.json` will be scored against, not evidence for it.

--- a/docs/ci-throughput/E2-D-design.md
+++ b/docs/ci-throughput/E2-D-design.md
@@ -1,0 +1,170 @@
+# CI-E2-D — tiered Metal evidence (DESIGN, not activated)
+
+**Nothing in this document is wired to a trigger.** The manifest and the
+classifier ship; `larql-compute-metal.yml` is untouched. E2-D is held
+until E2-A's A1 sample closes, because D changes *which* pull requests
+enter the Metal population and A measures *how long* the gate takes for
+the ones that do. Landing them together would give a freshly-corrected
+instrument two simultaneous attribution problems — the bill E1's C2
+already paid.
+
+## The question D answers
+
+A asked: how long should the Metal gate take? Answer so far, 24m52s and
+23m00s against a 56.61-minute baseline.
+
+D asks a different one: **how often should we pay that at all?**
+
+Over pull requests #415–#449, 18 triggered the Metal gate and **12 of
+them (67%) touched no Metal file** — three were `Cargo.lock` alone.
+
+## Why not better globs
+
+`crates/larql-compute/**` holds two different kinds of thing:
+
+- the trait boundary Metal **links** against — a change breaks the
+  compile, and a compile catches it;
+- the CPU kernels Metal's tests **compare numbers** against — 72
+  references to `cpu::ops::q4_common` alone. A change here changes what
+  the Metal kernels are required to reproduce, and only running them
+  finds out.
+
+No amount of directory ancestry separates those. So the distinction is
+**declared**, in `crates/larql-compute-metal/parity-obligations.json`.
+
+### The correction that motivated this, corrected again
+
+`larql-compute/src/cpu/kquant_gemv.rs` (#420) was cited twice in the
+design discussion as the case proving globs cannot work. On inspection it
+is not: #420 **added** that file (+113/−0), it is referenced only from
+`cpu/mod.rs`, and its consumer is `larql-vindex`'s opplan executor. The
+Metal crate neither imports it nor reaches it.
+
+It still classifies **tier A** here — because `cpu/**` is declared parity
+under the asymmetry below, and that entry is marked `needs_review` with
+this exact question attached. One review decision moves one pull request
+in the sample. That is the honest size of the uncertainty, stated rather
+than hidden.
+
+## The asymmetry that decides every uncertain call
+
+> A surface wrongly placed in **tier B is unsafe** — Metal compiles
+> against changed numerics and never re-qualifies.
+> A surface wrongly placed in **tier A is merely expensive.**
+
+So uncertain goes to A, and every entry that is there by default rather
+than by a positive finding carries `confidence: needs_review` and the
+question that would settle it. Five of eleven entries currently do.
+
+## The tiers
+
+| tier | when | evidence |
+|---|---|---|
+| **A** | the Metal crate changed, or a declared parity obligation changed | full behavioural qualification (~24 min) |
+| **B** | a crate Metal depends on changed, outside any parity obligation | `cargo check --all-targets` + clippy + the ordinary-profile witness (~2 min) |
+| **C** | neither | no macOS work |
+
+Tier B is not "trust it". It is the evidence proportional to the claim:
+an upstream API change can make the Metal crate **uncompilable**, and a
+compile establishes that it did not. It cannot establish that a number
+changed — which is why anything that could change a number is tier A by
+declaration.
+
+## Architecture
+
+A cheap Linux **triage** job computes the tier and the macOS jobs are
+conditional on it. No generated glob list to drift, and no cargo
+invocation inside a paths filter:
+
+```
+triage (ubuntu, ~30s)  ->  full   (macos-14, if tier == A)
+                       ->  compat (macos-14, if tier == B)
+```
+
+Dependencies come from `larql-compute-metal/Cargo.toml`, read at triage
+time — declared, not inferred. A crate that stops being a dependency
+stops being a tier-B trigger with no glob to edit.
+
+**`msrv-metal` folds into `compat`.** It is a compiler-compatibility
+claim, and in E1's AFTER window it cost **63.3 macOS queue-minutes to buy
+4.3 execution-minutes** — cheap to run, expensive to schedule, which is
+precisely the pathology E1's c2 was written to remove and which c2 itself
+created. Merging it into the tier-B job removes a whole macOS scheduling
+unit.
+
+## The completeness gate
+
+The manifest's weakness is omission: a new parity dependency added
+without a declaration would silently classify as B. So
+`scripts/metal_tier.py check` extracts every `larql_compute::` /
+`larql_models::` path the Metal crate names and fails if any is
+undeclared.
+
+The extraction is **approximate** — brace imports (`cpu::{ops, q4}`) and
+type imports (`cpu::Foo`) truncate. That is why it is a *check on the
+declaration* and never the declaration itself, and the error direction is
+the safe one: truncation reports a shallower path, which is harder to
+satisfy.
+
+**It does not close every hole.** A fixture that changes its DATA rather
+than its signature changes what Metal's tests assert without breaking any
+compile and without adding a reference. That is a parity obligation
+wearing an interface's clothes, it is recorded as the most likely single
+hole in the manifest, and no static check finds it.
+
+## What the sample predicts
+
+Replayed against the manifest (`E2-D-classification.json`):
+
+```
+35 pull requests with file data
+18 trigger the Metal gate today   (6 metal-touching, 12 upstream-only)
+
+under E2-D:   A = 7    B = 11
+```
+
+**11 of 18 triggers (61%) drop from full behavioural qualification to
+compile-plus-witness.** Seven stay tier A: #449, #446, #444, #442, #438,
+#434 (all touch Metal or its workflow) and #420 (the `needs_review`
+default above).
+
+On the measured tier costs — 24 min and ~2 min — that is 18 × 24 = 432
+macOS execution-minutes today against 7 × 24 + 11 × 2 = 190. It is also
+11 fewer macOS scheduling units, which on E1's evidence is the larger
+effect: c2's whole finding was that the jobs worth removing are cheap to
+run and expensive to schedule.
+
+Treat both as arithmetic on a replayed sample, not as a result. They are
+what `E2-D-contract.json` will be scored against, not evidence for it.
+
+## Before activation
+
+1. **A1 closes** (n ≥ 8 successful Metal runs under E2-A).
+2. The five `needs_review` entries get a decision, in particular whether
+   `cpu/{kquant_gemv,nvfp4_gemv,spin_pool}.rs` are reachable from any
+   entry point a Metal test uses as a reference.
+3. The instrument gains a job-scoped metric. `workflow_exec_max` is keyed
+   on workflow, and under D one workflow emits both a 24-minute job and a
+   2-minute one, so its p50 becomes a mixture that hides the per-tier
+   story. D needs `job_exec_max.<workflow>.<job>` before it can be
+   scored.
+4. `E2-D-contract.json` freezes with numeric baselines taken from the
+   post-E2-A steady state, which does not exist yet.
+
+## Later, not now: E2-E
+
+GitHub evaluates a `pull_request` paths filter against the **whole PR
+diff**, not the latest push — observed on #450, where a docs-only commit
+retriggered the full Metal gate because the pull request as a whole edits
+the workflow. So once a pull request contains a tier-A change, every
+later push re-pays tier A, including pushes that only edit prose.
+
+The fix would be to **reuse a successful qualification when the exact set
+of inputs capable of invalidating it has not changed** — which needs a
+relevant-input digest covering base and merge state, not "the latest
+commit touched no Metal files". That is the same ancestry inference this
+document rejects, one layer up.
+
+**Not part of D.** D changes which pull requests enter the population; E
+would change how often an entered one re-pays. Two mechanisms, two
+experiments.

--- a/scripts/ci_throughput.py
+++ b/scripts/ci_throughput.py
@@ -738,10 +738,18 @@ def evaluate_conditions(conditions: dict, after: float | None, before: float | N
     for field, tests in conditions.items():
         if field == "after":
             value = after
-        elif field == "delta_pct":
+        elif field in ("delta_pct", "abs_delta_pct"):
             if before in (None, 0) or after is None:
                 return None
             value = (after - before) / before * 100.0
+            # A two-sided claim needs a two-sided condition. Conditions are
+            # ANDed, so `delta_pct` cannot express "more than 10% away in
+            # EITHER direction" — writing `lt: -10` silently drops the
+            # upper half, and a +20% move comes back neither HELD nor
+            # FALSIFIED. E2-D's D3 was written that way and is the reason
+            # this field exists.
+            if field == "abs_delta_pct":
+                value = abs(value)
         else:
             raise ValueError(f"unknown condition field: {field}")
         if value is None:
@@ -1007,6 +1015,27 @@ def selftest(_args: argparse.Namespace) -> int:
           VERDICT_INVALID)
 
     check("missing metric yields NO DATA", score_prediction(p_effect, base, Sample({}, N))["verdict"], VERDICT_NO_DATA)
+
+    # 4f. two-sided validity. `delta_pct` ANDs its operators, so a claim
+    #     of the form "within +/- X%" cannot be falsified on both sides by
+    #     one delta_pct clause; abs_delta_pct exists for exactly that, and
+    #     the control checks BOTH signs and the passing middle.
+    p_two_sided = {"id": "PT", "mechanism": "m", "kind": "validity", "metric": "merge_ready.p50",
+                   "held_if": {"delta_pct": {"gte": -10, "lte": 10}},
+                   "falsified_if": {"abs_delta_pct": {"gt": 10}}}
+    b2 = Sample({"merge_ready.p50": 100.0}, N)
+    check("two-sided validity HOLDS in the middle",
+          score_prediction(p_two_sided, b2, Sample({"merge_ready.p50": 105.0}, N))["verdict"], VERDICT_HELD)
+    check("two-sided validity FALSIFIED below",
+          score_prediction(p_two_sided, b2, Sample({"merge_ready.p50": 85.0}, N))["verdict"], VERDICT_FALSIFIED)
+    check("two-sided validity FALSIFIED above",
+          score_prediction(p_two_sided, b2, Sample({"merge_ready.p50": 120.0}, N))["verdict"], VERDICT_FALSIFIED)
+
+    #     ...and the bug it was written for: a ONE-sided falsifier lets a
+    #     +20% move escape as PARTIAL, which is what D3 originally did.
+    p_one_sided = dict(p_two_sided, id="PO", falsified_if={"delta_pct": {"lt": -10}})
+    check("one-sided falsifier misses the other direction",
+          score_prediction(p_one_sided, b2, Sample({"merge_ready.p50": 120.0}, N))["verdict"], VERDICT_PARTIAL)
 
     # 4a. the E1 C2 defect, as a regression test. The SAME numbers that score
     #     HELD/FALSIFIED above must be refused once the samples differ in

--- a/scripts/metal_tier.py
+++ b/scripts/metal_tier.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Which Metal evidence does this change actually require?
+
+CI-E2-D. The Metal gate costs ~24 minutes of a scarce macOS runner and
+fires whenever `crates/larql-compute/**` or `crates/larql-models/**`
+moves. Over pull requests #415-#449 that was 20 triggers, and 14 of them
+touched no Metal file at all.
+
+The wrong fix is a cleverer set of path globs. `crates/larql-compute/**`
+holds both the trait boundary Metal LINKS against and the CPU kernels
+Metal's tests compare NUMBERS against, and no amount of directory
+ancestry separates those two. So the distinction is DECLARED, in
+crates/larql-compute-metal/parity-obligations.json, and this script
+checks the declaration stays complete.
+
+Three tiers:
+
+    A  full behavioural qualification   the Metal crate itself changed,
+                                        or a declared parity obligation
+    B  compatibility only               a crate Metal depends on changed
+                                        in a way that can break the
+                                        COMPILE but not the numbers
+    C  nothing                          Metal cannot be affected
+
+The asymmetry that sets every uncertain call: a surface wrongly placed
+in tier B is UNSAFE (Metal never re-qualifies against changed numerics);
+wrongly placed in tier A it is merely expensive. Uncertain goes to A.
+
+    metal_tier.py classify --files-from <path>   # one path per line
+    metal_tier.py check                          # manifest completeness
+    metal_tier.py selftest
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+METAL_CRATE = "crates/larql-compute-metal"
+MANIFEST = Path(METAL_CRATE) / "parity-obligations.json"
+
+TIER_A, TIER_B, TIER_C = "A", "B", "C"
+
+# Tier A on their own: the Metal crate, and the workflow that defines the
+# gate (a change to the gate must be qualified by the gate).
+TIER_A_ALWAYS = (
+    f"{METAL_CRATE}/**",
+    ".github/workflows/larql-compute-metal.yml",
+)
+
+# Tier B floor: the workspace crates Metal actually depends on, read from
+# its Cargo.toml rather than assumed, plus the files that can change the
+# build itself.
+BUILD_INPUTS = ("Cargo.toml", "Cargo.lock", "Makefile", "rust-toolchain.toml")
+
+# Where a reference to `larql_compute::foo::bar` is looked for.
+CRATE_DIRS = {"larql_compute": "crates/larql-compute", "larql_models": "crates/larql-models"}
+REFERENCE_RE = re.compile(r"larql_(compute|models)((?:::[a-z_0-9]+)+)")
+
+
+def load_manifest(root: Path = REPO_ROOT) -> dict:
+    return json.loads((root / MANIFEST).read_text())
+
+
+def manifest_paths(manifest: dict, key: str) -> list[str]:
+    return [p for entry in manifest.get(key, []) for p in entry["paths"]]
+
+
+def matches(path: str, pattern: str) -> bool:
+    """Glob match where `**` means 'this subtree'."""
+    if pattern.endswith("/**"):
+        return path == pattern[:-3] or path.startswith(pattern[:-2])
+    return fnmatch.fnmatch(path, pattern)
+
+
+def metal_workspace_deps(root: Path = REPO_ROOT) -> list[str]:
+    """Workspace crates Metal depends on, read from its manifest.
+
+    Declared in Cargo.toml, not inferred from the directory tree: that is
+    the whole point. A crate that stops being a dependency stops being a
+    tier-B trigger without anyone editing a glob.
+    """
+    import tomllib
+
+    cargo = tomllib.loads((root / METAL_CRATE / "Cargo.toml").read_text())
+    out: set[str] = set()
+    for section in ("dependencies", "dev-dependencies", "build-dependencies"):
+        for spec in (cargo.get(section) or {}).values():
+            if isinstance(spec, dict) and "path" in spec:
+                rel = os.path.normpath(os.path.join(METAL_CRATE, spec["path"]))
+                out.add(f"{rel}/**")
+    return sorted(out)
+
+
+def classify(changed: list[str], manifest: dict, deps: list[str]) -> tuple[str, list[str]]:
+    """Highest tier any changed file demands, with the reasons."""
+    reasons: list[str] = []
+    tier = TIER_C
+    parity = manifest_paths(manifest, "parity_obligations")
+    interface = manifest_paths(manifest, "interface_only")
+
+    for path in changed:
+        # interface_only is an EXEMPTION from parity, so it is tested
+        # first — otherwise a file inside a declared parity subtree could
+        # never be exempted.
+        if any(matches(path, p) for p in interface):
+            if tier == TIER_C:
+                tier = TIER_B
+            reasons.append(f"{path}: interface_only -> B")
+            continue
+        if any(matches(path, p) for p in TIER_A_ALWAYS):
+            tier = TIER_A
+            reasons.append(f"{path}: Metal crate or its workflow -> A")
+            continue
+        if any(matches(path, p) for p in parity):
+            tier = TIER_A
+            reasons.append(f"{path}: declared parity obligation -> A")
+            continue
+        if any(matches(path, p) for p in deps) or path in BUILD_INPUTS:
+            if tier == TIER_C:
+                tier = TIER_B
+            reasons.append(f"{path}: dependency or build input -> B")
+    return tier, reasons
+
+
+def referenced_paths(root: Path = REPO_ROOT) -> dict[str, int]:
+    """Upstream paths the Metal crate names, resolved to files/subtrees.
+
+    APPROXIMATE, and deliberately used only as a completeness CHECK on the
+    declaration rather than as the declaration itself: brace imports
+    (`cpu::{ops, q4}`) and type imports (`cpu::Foo`) truncate here, so this
+    under-resolves. Under-resolution makes the check conservative — it
+    reports a shallower path, which is harder to satisfy, not easier.
+    """
+    hits: dict[str, int] = {}
+    for sub in ("src", "tests", "benches"):
+        base = root / METAL_CRATE / sub
+        if not base.is_dir():
+            continue
+        for dirpath, _dirs, files in os.walk(base):
+            for name in files:
+                if not name.endswith(".rs"):
+                    continue
+                text = (Path(dirpath) / name).read_text(errors="replace")
+                for match in REFERENCE_RE.finditer(text):
+                    crate_dir = CRATE_DIRS[f"larql_{match.group(1)}"]
+                    parts = [p for p in match.group(2).split("::") if p]
+                    resolved = _resolve(root, crate_dir, parts)
+                    if resolved:
+                        hits[resolved] = hits.get(resolved, 0) + 1
+    return hits
+
+
+def _resolve(root: Path, crate_dir: str, parts: list[str]) -> str | None:
+    rel = f"{crate_dir}/src"
+    best: str | None = None
+    for seg in parts:
+        as_dir, as_file = f"{rel}/{seg}", f"{rel}/{seg}.rs"
+        if (root / as_dir).is_dir():
+            best, rel = f"{as_dir}/**", as_dir
+        elif (root / as_file).is_file():
+            return as_file
+        else:
+            break
+    return best
+
+
+def check(root: Path = REPO_ROOT) -> tuple[list[str], dict[str, int]]:
+    """Referenced-but-undeclared paths. Empty list means complete."""
+    manifest = load_manifest(root)
+    declared = manifest_paths(manifest, "parity_obligations") + manifest_paths(manifest, "interface_only")
+    undeclared = []
+    hits = referenced_paths(root)
+    for path in sorted(hits):
+        probe = path[:-3] if path.endswith("/**") else path
+        if not any(matches(probe, d) for d in declared):
+            undeclared.append(path)
+    return undeclared, hits
+
+
+# ---------------------------------------------------------------- commands
+
+def cmd_classify(args: argparse.Namespace) -> int:
+    changed = [l.strip() for l in Path(args.files_from).read_text().splitlines() if l.strip()]
+    manifest = load_manifest()
+    tier, reasons = classify(changed, manifest, metal_workspace_deps())
+    if args.quiet:
+        print(tier)
+        return 0
+    print(f"tier: {tier}   ({len(changed)} changed files)")
+    for r in reasons[: args.max_reasons]:
+        print(f"  {r}")
+    if len(reasons) > args.max_reasons:
+        print(f"  ... and {len(reasons) - args.max_reasons} more")
+    return 0
+
+
+def cmd_check(_args: argparse.Namespace) -> int:
+    undeclared, hits = check()
+    print(f"{len(hits)} upstream paths referenced by {METAL_CRATE}")
+    if undeclared:
+        print("\nREFERENCED BUT NOT DECLARED — every one is a surface that could change")
+        print("what Metal must reproduce with nothing in CI noticing:")
+        for path in undeclared:
+            print(f"  {path}  ({hits[path]} references)")
+        return 1
+    print("manifest is complete: every referenced path is declared")
+    return 0
+
+
+def cmd_selftest(_args: argparse.Namespace) -> int:
+    failures: list[str] = []
+
+    def ok(name: str, got, want) -> None:
+        if got != want:
+            failures.append(f"{name}: got {got!r}, want {want!r}")
+        else:
+            print(f"  ok  {name} == {want!r}")
+
+    m = {
+        "parity_obligations": [{"id": "p", "paths": ["crates/larql-compute/src/cpu/ops/**"]}],
+        "interface_only": [{"id": "i", "paths": ["crates/larql-compute/src/options.rs"]}],
+    }
+    deps = ["crates/larql-compute/**", "crates/larql-models/**"]
+
+    ok("metal source is A", classify([f"{METAL_CRATE}/src/lib.rs"], m, deps)[0], TIER_A)
+    ok("the gate's own workflow is A",
+       classify([".github/workflows/larql-compute-metal.yml"], m, deps)[0], TIER_A)
+    ok("declared parity path is A",
+       classify(["crates/larql-compute/src/cpu/ops/q4k_matvec.rs"], m, deps)[0], TIER_A)
+    ok("undeclared dependency path is B",
+       classify(["crates/larql-compute/src/cpu/spin_pool.rs"], m, deps)[0], TIER_B)
+    ok("interface_only inside a dependency is B",
+       classify(["crates/larql-compute/src/options.rs"], m, deps)[0], TIER_B)
+    ok("Cargo.lock alone is B", classify(["Cargo.lock"], m, deps)[0], TIER_B)
+    ok("docs are C", classify(["docs/ci-throughput/README.md"], m, deps)[0], TIER_C)
+    ok("an unrelated crate is C", classify(["crates/larql-lql/src/lib.rs"], m, deps)[0], TIER_C)
+
+    # The tier is the MAXIMUM demand across the diff, never the last file seen.
+    ok("A wins over C regardless of order",
+       classify(["docs/x.md", f"{METAL_CRATE}/src/lib.rs"], m, deps)[0], TIER_A)
+    ok("A wins over C in the other order",
+       classify([f"{METAL_CRATE}/src/lib.rs", "docs/x.md"], m, deps)[0], TIER_A)
+    ok("A wins over B", classify(["Cargo.lock", "crates/larql-compute/src/cpu/ops/q.rs"], m, deps)[0], TIER_A)
+    ok("empty diff is C", classify([], m, deps)[0], TIER_C)
+
+    # An exemption must be able to fire INSIDE a declared parity subtree,
+    # or interface_only would be unreachable wherever it mattered.
+    nested = {
+        "parity_obligations": [{"id": "p", "paths": ["crates/larql-compute/src/**"]}],
+        "interface_only": [{"id": "i", "paths": ["crates/larql-compute/src/options.rs"]}],
+    }
+    ok("interface_only exempts a file inside a parity subtree",
+       classify(["crates/larql-compute/src/options.rs"], nested, deps)[0], TIER_B)
+    ok("its sibling is still A",
+       classify(["crates/larql-compute/src/other.rs"], nested, deps)[0], TIER_A)
+
+    ok("subtree glob matches the directory itself",
+       matches("crates/larql-compute/src/cpu", "crates/larql-compute/src/cpu/**"), True)
+    ok("subtree glob does not match a prefix sibling",
+       matches("crates/larql-compute/src/cpu_extra.rs", "crates/larql-compute/src/cpu/**"), False)
+
+    deps_real = metal_workspace_deps()
+    ok("dependencies are read from Cargo.toml",
+       set(deps_real), {"crates/larql-compute/**", "crates/larql-models/**"})
+
+    undeclared, hits = check()
+    ok("the shipped manifest references something at all", len(hits) > 0, True)
+    ok("the shipped manifest is complete", undeclared, [])
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"  FAIL {f}")
+        print(f"{len(failures)} failing check(s)")
+        return 1
+    print("selftest: all checks passed")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_cl = sub.add_parser("classify", help="tier for a set of changed files")
+    p_cl.add_argument("--files-from", required=True, help="file with one changed path per line")
+    p_cl.add_argument("--quiet", action="store_true", help="print only the tier letter")
+    p_cl.add_argument("--max-reasons", type=int, default=10)
+    p_cl.set_defaults(func=cmd_classify)
+
+    sub.add_parser("check", help="manifest completeness").set_defaults(func=cmd_check)
+    sub.add_parser("selftest", help="classification rules against known answers").set_defaults(func=cmd_selftest)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/metal_tier.py
+++ b/scripts/metal_tier.py
@@ -3,13 +3,14 @@
 
 CI-E2-D. The Metal gate costs ~24 minutes of a scarce macOS runner and
 fires whenever `crates/larql-compute/**` or `crates/larql-models/**`
-moves. Over pull requests #415-#449 that was 20 triggers, and 14 of them
+moves. Over pull requests #415-#449 that was 18 triggers, and 12 of them
 touched no Metal file at all.
 
 The wrong fix is a cleverer set of path globs. `crates/larql-compute/**`
 holds both the trait boundary Metal LINKS against and the CPU kernels
-Metal's tests compare NUMBERS against, and no amount of directory
-ancestry separates those two. So the distinction is DECLARED, in
+Metal's tests compare NUMBERS against -- 72 references to
+`cpu::ops::q4_common` alone -- and no amount of directory ancestry
+separates those two. So the distinction is DECLARED, in
 crates/larql-compute-metal/parity-obligations.json, and this script
 checks the declaration stays complete.
 


### PR DESCRIPTION
**Design only. No trigger changes.** `larql-compute-metal.yml` is
untouched; E2-D waits for E2-A's A1 sample to close.

## The question

A asked how long the Metal gate should take — 24m52s and 23m00s so far
against a 56.61-minute baseline. D asks how often we should pay it.

Over #415–#449: **18 pull requests triggered the Metal gate and 12 of
them (67%) touched no Metal file.** Three were `Cargo.lock` alone.

*(That corrects a figure quoted earlier in this programme as 14 of 20 /
70% — the trigger total was 18 and the upstream-only count 12. The
conclusion is unchanged; the arithmetic was wrong.)*

## Why not better globs

`crates/larql-compute/**` contains two different things:

- the trait boundary Metal **links** against — a compile catches a break;
- the CPU kernels Metal's tests compare **numbers** against — 72
  references to `cpu::ops::q4_common` alone.

Directory ancestry cannot separate them. So the distinction is
**declared** in `crates/larql-compute-metal/parity-obligations.json`, and
`scripts/metal_tier.py check` verifies the declaration stays complete
against what the crate actually references.

### The asymmetry

> Wrongly in **tier B is unsafe** — Metal compiles against changed
> numerics and never re-qualifies.
> Wrongly in **tier A is merely expensive.**

Uncertain goes to A. Five of eleven manifest entries are there by that
default, each carrying `confidence: needs_review` and the question that
would settle it.

### A correction, twice over

`cpu/kquant_gemv.rs` (#420) was cited twice in design discussion as the
case proving globs cannot work. It is not: #420 **added** that file, it
is referenced only from `cpu/mod.rs`, and its consumer is
`larql-vindex`. Metal neither imports it nor reaches it.

It still classifies tier A — by the safety default on `cpu/**`, which is
one of the `needs_review` entries, with this exact question attached. One
review decision moves one pull request in the sample. That is the honest
size of the uncertainty.

## What the replay predicts

```
35 pull requests with file data
18 trigger the Metal gate today   (6 metal-touching, 12 upstream-only)

under E2-D:   A = 7    B = 11    -> 61% drop to compile-plus-witness
tier A stays: #449 #446 #444 #442 #438 #434 #420
```

Arithmetic on the measured tier costs: 18 × 24 = 432 macOS
execution-minutes today against 7 × 24 + 11 × 2 = 190. Also **11 fewer
macOS scheduling units**, which on E1's evidence is the larger effect —
c2's finding was that the jobs worth removing are cheap to run and
expensive to schedule. `msrv-metal` folds into the tier-B job for exactly
that reason: 63.3 macOS queue-minutes to buy 4.3 execution-minutes.

Both figures are arithmetic on a replayed sample. They are what the
contract will be **scored against**, not evidence for it.

## What ships live

The **completeness gate**, in `quality.yml`'s `ci-instrument` job:
`metal_tier.py selftest` (19 controls) and `metal_tier.py check`.

The manifest's one real weakness is omission — an undeclared parity
dependency would classify as compile-only once tiering is active — so the
check that notices has to predate the mechanism that acts on it.

The extraction behind `check` is deliberately approximate: brace imports
(`cpu::{ops, q4}`) truncate. That is why it checks a declaration rather
than replacing one, and the error direction is safe (truncation reports a
shallower path, which is harder to satisfy). It does **not** close every
hole: a fixture that changes its DATA rather than its signature would
change what Metal's tests assert with no compile break and no new
reference. That is recorded as the most likely single hole, and no static
check finds it.

## Before activation

1. A1 closes (n ≥ 8 under E2-A).
2. The five `needs_review` entries get decisions.
3. The instrument gains `job_exec_max.<workflow>.<job>` — `workflow_exec_max`
   is workflow-keyed, and under D one workflow emits both a 24-minute and
   a 2-minute job, so its p50 becomes a mixture that hides the per-tier
   story.
4. `E2-D-contract.json` freezes numeric baselines from the post-E2-A
   steady state, which does not exist yet.

The contract preregisters what *can* be frozen now — the classification,
derivable from existing data — plus four predictions and four structural
falsifiers. **T1 is the one that matters**: no pull request touching a
declared parity path may receive tier B. D1–D4 are throughput and none of
them would notice a wrong answer there.

## Note on cost

This PR adds `parity-obligations.json` inside `crates/larql-compute-metal/`,
which is in the Metal paths filter, so it triggers a full Metal run. That
is a deliberate placement — the manifest is a property of the crate, not
of CI — and the run is a legitimate third A1 observation rather than a
manufactured one.
