### PR TITLE
ci: resolve E2-D's parity review, and add the per-job metric

### DIFF
--- a/crates/larql-compute-metal/parity-obligations.json
+++ b/crates/larql-compute-metal/parity-obligations.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "DESIGN \u2014 declared and checkable, but NOT yet wired to any workflow trigger (CI-E2-D). All five version-1 needs_review entries resolved 2026-09-07.",
   "note": "Which upstream surfaces can invalidate which claim about the Metal backend. This is a DECLARATION, not an inference from directory ancestry. scripts/metal_tier.py checks that it stays COMPLETE with respect to what the Metal crate actually references, so a new parity dependency cannot be added without either declaring it or failing the check.",
   "the_asymmetry": "A file placed in interface_only when it is really behavioural is UNSAFE \u2014 Metal would compile against changed numerics and never re-qualify. A file placed in parity_obligations when it is really structural is merely EXPENSIVE. So anything uncertain belongs in parity_obligations, and entries carrying `needs_review` are there by that default rather than by a positive judgement. Version 2 applies this structurally as well as per-entry: parity subtrees stay WHOLE and exemptions are named files, so a file added to cpu/ or backend/ tomorrow defaults to tier A instead of falling through to tier B.",
@@ -140,6 +140,19 @@
   },
   "known_limits": {
     "file_granularity": "Classification is per FILE, and a module root is one file. crates/larql-compute/src/cpu/mod.rs carries both `pub mod` declarations, which are inert for Metal, and the `pub mod q4 { pub use super::ops::... }` re-export block, which decides WHICH implementation a Metal reference resolves to. A five-line `pub mod` addition therefore costs tier A. That is the safe direction and it is a real floor: #420 stays tier A after every version-2 exemption, not because of kquant_gemv.rs but because it added a line to that module root. Going below file granularity is a different and much harder design; do not paper over it by exempting a module root.",
-    "silent_class_is_unverifiable": "By construction. `metal_tier.py check` lists silent_parity_obligations and cannot verify them \u2014 spin_pool.rs has zero references and is tier A. The class is a standing human commitment, not a derived fact."
+    "silent_class_is_unverifiable": "By construction. `metal_tier.py check` lists silent_parity_obligations and cannot verify them \u2014 spin_pool.rs has zero references and is tier A. The class is a standing human commitment, not a derived fact.",
+    "ordering_is_not_an_invariant": "Recorded because it was nearly a real defect: in version 2, interface_only was tested FIRST, so an interface_only entry overlapping a silent path would have demoted it to tier B \u2014 the one unsafe direction the manifest claims is impossible. No such overlap existed, so nothing was wrong in practice and no test would have caught it. Both the ordering and the invariant now exist, and the invariant is the part that survives a refactor."
+  },
+  "the_precedence": {
+    "order": [
+      "silent_parity_obligations",
+      "the Metal crate and its own workflow",
+      "interface_only",
+      "parity_obligations",
+      "cargo dependency floor"
+    ],
+    "why_silent_is_first": "Its members live INSIDE broad parity subtrees \u2014 spin_pool.rs is under cpu/** \u2014 so testing ordinary parity first would swallow them. The tier would still be A, but the reason would read as ordinary parity and the class would lose the identity it exists to carry.",
+    "why_interface_stays_above_parity": "interface_only is an EXEMPTION from ordinary parity: it is how the named kquant_gemv.rs and backend/{capability,factory}.rs escape their enclosing subtrees. Moving it below parity would make every exemption dead.",
+    "the_invariant": "silent_parity_obligations and interface_only MAY NEVER OVERLAP. Precedence already means an overlap could not demote anything, but an invariant that holds only because of evaluation order is one refactor from not holding. `metal_tier.py check` refuses the overlap outright and calls it malformed authority: a silent obligation is one no static check can rediscover, so exempting it removes the only thing between a changed default or a changed fixture and a Metal backend that never re-qualifies."
   }
 }

--- a/crates/larql-compute-metal/parity-obligations.json
+++ b/crates/larql-compute-metal/parity-obligations.json
@@ -1,13 +1,15 @@
 {
-  "version": 1,
-  "status": "DESIGN — declared and checkable, but NOT yet wired to any workflow trigger (CI-E2-D)",
+  "version": 2,
+  "status": "DESIGN \u2014 declared and checkable, but NOT yet wired to any workflow trigger (CI-E2-D). All five version-1 needs_review entries resolved 2026-09-07.",
   "note": "Which upstream surfaces can invalidate which claim about the Metal backend. This is a DECLARATION, not an inference from directory ancestry. scripts/metal_tier.py checks that it stays COMPLETE with respect to what the Metal crate actually references, so a new parity dependency cannot be added without either declaring it or failing the check.",
-  "the_asymmetry": "A file placed in interface_only when it is really behavioural is UNSAFE — Metal would compile against changed numerics and never re-qualify. A file placed in parity_obligations when it is really structural is merely EXPENSIVE. So anything uncertain belongs in parity_obligations, and entries carrying `needs_review` are there by that default rather than by a positive judgement.",
+  "the_asymmetry": "A file placed in interface_only when it is really behavioural is UNSAFE \u2014 Metal would compile against changed numerics and never re-qualify. A file placed in parity_obligations when it is really structural is merely EXPENSIVE. So anything uncertain belongs in parity_obligations, and entries carrying `needs_review` are there by that default rather than by a positive judgement. Version 2 applies this structurally as well as per-entry: parity subtrees stay WHOLE and exemptions are named files, so a file added to cpu/ or backend/ tomorrow defaults to tier A instead of falling through to tier B.",
   "parity_obligations": [
     {
       "id": "cpu-quant-kernels",
-      "paths": ["crates/larql-compute/src/cpu/ops/**"],
-      "why": "Metal's kernel tests import these as the NUMERICAL reference — 72 references to cpu::ops::q4_common alone, plus moe, geglu, q8_matvec, outer_combine. A change here changes what the Metal kernels are required to reproduce.",
+      "paths": [
+        "crates/larql-compute/src/cpu/ops/**"
+      ],
+      "why": "Metal's kernel tests import these as the NUMERICAL reference \u2014 72 references to cpu::ops::q4_common alone, plus moe, geglu, q8_matvec, outer_combine. A change here changes what the Metal kernels are required to reproduce.",
       "witnesses": [
         "tests/test_kernel_q4k_matmul.rs",
         "tests/test_kernel_q4k_ffn_gate_up.rs",
@@ -18,23 +20,35 @@
     },
     {
       "id": "cpu-other",
-      "paths": ["crates/larql-compute/src/cpu/**"],
-      "why": "Metal references `larql_compute::cpu` through brace and type imports that text extraction truncates, so the subtree is declared whole rather than guessed at leaf level.",
-      "confidence": "needs_review",
-      "review_question": "Which of cpu/{kquant_gemv,nvfp4_gemv,spin_pool}.rs are reachable from an entry point a Metal test uses as a reference? kquant_gemv is currently reached only from cpu/mod.rs and consumed by larql-vindex, not by Metal."
+      "paths": [
+        "crates/larql-compute/src/cpu/**"
+      ],
+      "why": "The cpu subtree stays parity WHOLE, with named exemptions below, so a new file added here defaults to tier A. Resolved from reference counts: nvfp4_gemv has 42 references from the Metal crate including shaders/nvfp4_matvec.rs; cpu::q4 is a re-export of ops::q4_common, ops::q4_matvec and ops::q4_vecmat, already covered; spin_pool has ZERO references but is called from attention/decode/gqa_step.rs as a chunked parallel reduction, so it is declared silent parity below.",
+      "confidence": "observed"
     },
     {
       "id": "attention-math",
-      "paths": ["crates/larql-compute/src/attention/**"],
+      "paths": [
+        "crates/larql-compute/src/attention/**"
+      ],
       "why": "rope (30 references) and softmax are compared against directly by the Metal kernel tests.",
-      "witnesses": ["tests/test_kernel_rope.rs", "tests/test_kernel_rope_at_pos.rs", "tests/test_lowering_attention_parity.rs"],
+      "witnesses": [
+        "tests/test_kernel_rope.rs",
+        "tests/test_kernel_rope_at_pos.rs",
+        "tests/test_lowering_attention_parity.rs"
+      ],
       "confidence": "observed"
     },
     {
       "id": "model-quant-formats",
-      "paths": ["crates/larql-models/src/quant/**"],
+      "paths": [
+        "crates/larql-models/src/quant/**"
+      ],
       "why": "ggml, mxfp4, nvfp4, fp4 and half are the on-disk and in-register encodings the Metal kernels decode. A change to an encoder changes what every quant kernel must decode.",
-      "witnesses": ["tests/test_kernel_moe_g_mxfp4.rs", "tests/test_lowering_nvfp4_fusion.rs"],
+      "witnesses": [
+        "tests/test_kernel_moe_g_mxfp4.rs",
+        "tests/test_lowering_nvfp4_fusion.rs"
+      ],
       "confidence": "observed"
     },
     {
@@ -48,38 +62,84 @@
         "crates/larql-compute/src/kv_dispatch/**",
         "crates/larql-compute/src/moe_route_observe.rs"
       ],
-      "why": "The composition Metal's lowering must reproduce end to end, not merely link against.",
-      "confidence": "needs_review",
-      "review_question": "pipeline and pipeline_layer are referenced 13 times combined but it is not established whether Metal tests compare RESULTS through them or only construct them."
+      "why": "The composition Metal's lowering must reproduce end to end. Resolved: tests/test_pipeline_and_moe.rs constructs FullPipelineLayer from larql_compute::pipeline and calls DecodeBackend::prefill_kquant, exercising the dispatch_full_pipeline + moe_fn callback chain. pipeline defines the layer contract Metal's prefill implements, which is composition semantics rather than a type boundary.",
+      "confidence": "observed"
     },
     {
       "id": "backend-traits-with-bodies",
-      "paths": ["crates/larql-compute/src/backend/**"],
-      "why": "Nominally the trait boundary, and matmul.rs is `pub trait MatMul` — but every file here carries arithmetic, including default method bodies a Metal impl can inherit. Declared as parity by the asymmetry above, not by a positive finding.",
-      "confidence": "needs_review",
-      "review_question": "Are capability.rs and factory.rs purely structural? If so they move to interface_only and this obligation narrows to decode/helpers/matmul/quant_matvec."
+      "paths": [
+        "crates/larql-compute/src/backend/**"
+      ],
+      "why": "Every file here carries arithmetic, including default trait method bodies a Metal impl can inherit. Kept parity WHOLE with capability.rs and factory.rs exempted by name below, so a new file in backend/ defaults to tier A rather than falling through to B.",
+      "confidence": "observed"
     }
   ],
   "interface_only": [
     {
-      "id": "options-and-handles",
+      "id": "cpu-kquant-gemv-not-a-metal-surface",
       "paths": [
-        "crates/larql-compute/src/options.rs",
+        "crates/larql-compute/src/cpu/kquant_gemv.rs",
+        "crates/larql-compute/src/cpu/kquant_gemv_tests.rs"
+      ],
+      "why": "Exemption inside the cpu parity subtree. ZERO references from the Metal crate; its only workspace consumer outside larql-compute is larql-vindex's represent/kquant.rs. Added whole by #420, which this programme twice cited as proof that globs cannot separate the tiers \u2014 it is not that case. Its test module is exempted with it: tests for a file Metal cannot reach are equally unreachable.",
+      "confidence": "observed"
+    },
+    {
+      "id": "backend-structural-files",
+      "paths": [
+        "crates/larql-compute/src/backend/capability.rs",
+        "crates/larql-compute/src/backend/factory.rs"
+      ],
+      "why": "Exemptions inside the backend parity subtree. capability.rs is `pub enum Capability` with a default impl returning false; factory.rs is `pub enum BackendKind` plus a registry, as_str, from_metal_flag and Display. Neither computes anything Metal reproduces.",
+      "confidence": "observed"
+    },
+    {
+      "id": "handles-and-async-surface",
+      "paths": [
         "crates/larql-compute/src/state_handle.rs",
         "crates/larql-compute/src/async_compute_backend/**"
       ],
-      "why": "Configuration and handle types. A change here breaks the Metal COMPILE, which tier B catches; it does not change a number a Metal kernel must reproduce.",
-      "confidence": "needs_review"
+      "why": "Trait surfaces. A change breaks the Metal COMPILE, which is exactly what tier B establishes.",
+      "confidence": "observed"
+    }
+  ],
+  "silent_parity_obligations": [
+    {
+      "id": "path-selection",
+      "paths": [
+        "crates/larql-compute/src/options.rs"
+      ],
+      "why": "Selects WHICH numerical path runs. Its own module docs: 'Decode fast path \u2014 default ON'; 'force the f32/rayon path'; 'Disable fused QK-norm + RoPE'. It exposes decode_options() and spin_pool_enabled(). Changing a DEFAULT here changes the values Metal is compared against while computing nothing itself, adding no reference and breaking no signature.",
+      "confidence": "observed",
+      "moved_from": "interface_only in version 1, where it was wrong"
     },
     {
-      "id": "test-fixtures",
+      "id": "reduction-order",
+      "paths": [
+        "crates/larql-compute/src/cpu/spin_pool.rs"
+      ],
+      "why": "Zero references from the Metal crate, and still tier A: attention/decode/gqa_step.rs calls spin_pool::global().for_each_chunk(). Changing the chunking changes floating-point reduction ORDER inside a declared parity surface. Reachability from a parity surface is an obligation; being referenced by Metal is not the test.",
+      "confidence": "observed"
+    },
+    {
+      "id": "fixture-data-authority",
       "paths": [
         "crates/larql-compute/src/test_fixtures.rs",
         "crates/larql-models/src/test_fixtures.rs"
       ],
-      "why": "Fixture constructors used by Metal's own tests. A change breaks the test build, which tier B catches by compiling --all-targets.",
-      "confidence": "needs_review",
-      "review_question": "A fixture that silently changes its DATA rather than its signature would change what the Metal tests assert without breaking the compile. That is a parity obligation wearing an interface's clothes, and it is the most likely single hole in this manifest."
+      "why": "The INPUTS Metal's tests assert on. A fixture that changes its DATA rather than its signature changes what those tests assert, with no compile break, no new import and nothing for the completeness check to find. Version 1 filed these as interface_only on the argument that a compile catches a fixture change; a compile catches a SIGNATURE change, which is not the hazard.",
+      "confidence": "observed",
+      "moved_from": "interface_only in version 1, where it was wrong",
+      "do_not_simplify": "This entry looks like test scaffolding and will invite reclassification as interface_only. It is not: it is the numerical authority the assertions are written against."
     }
-  ]
+  ],
+  "the_classes": {
+    "parity_obligations": "computes the reference values; discoverable, because Metal names them",
+    "silent_parity_obligations": "changes WHICH values appear without computing any \u2014 path selection, reduction order, fixture data. Tier A on the same terms, but NO static check can find these: they add no reference and break no signature. They exist as a separate class so a future reviewer cannot reason 'nothing imports it, so it is structural' and demote them.",
+    "interface_only": "structural; a compile catches a break here, which is what tier B is"
+  },
+  "known_limits": {
+    "file_granularity": "Classification is per FILE, and a module root is one file. crates/larql-compute/src/cpu/mod.rs carries both `pub mod` declarations, which are inert for Metal, and the `pub mod q4 { pub use super::ops::... }` re-export block, which decides WHICH implementation a Metal reference resolves to. A five-line `pub mod` addition therefore costs tier A. That is the safe direction and it is a real floor: #420 stays tier A after every version-2 exemption, not because of kquant_gemv.rs but because it added a line to that module root. Going below file granularity is a different and much harder design; do not paper over it by exempting a module root.",
+    "silent_class_is_unverifiable": "By construction. `metal_tier.py check` lists silent_parity_obligations and cannot verify them \u2014 spin_pool.rs has zero references and is tier A. The class is a standing human commitment, not a derived fact."
+  }
 }

--- a/docs/ci-throughput/E2-D-classification.json
+++ b/docs/ci-throughput/E2-D-classification.json
@@ -1,5 +1,5 @@
 {
-  "record": "CI-E2-D classification of pull requests #415-#449, replayed against the declared manifest",
+  "record": "CI-E2-D classification of pull requests #415-#449, replayed against the declared manifest (version 2)",
   "classified_at": "2026-09-07",
   "manifest": "crates/larql-compute-metal/parity-obligations.json",
   "classifier": "scripts/metal_tier.py",
@@ -254,7 +254,7 @@
       "triggers_today": true,
       "touches_metal": false,
       "tier": "A",
-      "first_reason": "crates/larql-compute/src/cpu/kquant_gemv.rs: declared parity obligation -> A"
+      "first_reason": "crates/larql-compute/src/cpu/kquant_gemv.rs: interface_only -> B"
     },
     {
       "pr": 419,
@@ -296,5 +296,8 @@
       "tier": "B",
       "first_reason": "crates/larql-models/src/architectures/kimi_k3.rs: dependency or build input -> B"
     }
-  ]
+  ],
+  "manifest_version": 2,
+  "reclassified_at": "2026-09-07",
+  "moved_since_version_1": []
 }

--- a/docs/ci-throughput/E2-D-contract.json
+++ b/docs/ci-throughput/E2-D-contract.json
@@ -6,7 +6,7 @@
   "claim": "A pull request pays full behavioural Metal qualification only when it changes the Metal crate or a DECLARED parity obligation. An upstream change that can break the compile but not the numbers pays a compile plus the ordinary-profile witness. Everything else pays no macOS time.",
   "measurement_contract": {
     "inherits": "docs/ci-throughput/E2-contract.json \u2014 every prediction names an INTENSIVE metric, and the instrument refuses extensive metrics across samples of different size",
-    "instrument_change_required_before_freezing": "workflow_exec_max is keyed on WORKFLOW. Under E2-D one workflow emits both a ~24-minute tier-A job and a ~2-minute tier-B job, so its p50 becomes a mixture that hides the per-tier story. E2-D needs job_exec_max.<workflow>.<job> before D1 or D3 can be scored at all."
+    "instrument_change_required_before_freezing": "DONE 2026-09-07. job_exec_max.<workflow>.<job> is in the instrument, counting SUCCESSFUL jobs only so cancellation cannot manufacture a faster job, returning NO DATA (not PARTIAL) when the job is absent from either sample, and validated against a baseline snapshot for any FROZEN forecast. selftest demonstrates the mixture it prevents: a 24-minute and a 2-minute job in one workflow read as 24 and 2 per job, where the workflow-level p50 would have read 13."
   },
   "baseline": {
     "deferred_because": "The post-E2-A steady state does not exist yet: A1 stands at n=2 (24.87 and 23.00 min against a 56.61-minute pre-E2-A baseline) and its contract asks for n>=8. Freezing a numeric baseline now would bake in a two-sample estimate as the thing D is scored against.",
@@ -94,8 +94,8 @@
           "gt": 10
         }
       },
-      "metric_not_yet_produced": true,
-      "condition_note": "Uses abs_delta_pct, not delta_pct. Conditions are ANDed, so a single delta_pct clause cannot express 'more than 10% away in either direction' \u2014 written as {lt: -10} it silently drops the upper half and a +20% slowdown returns PARTIAL rather than FALSIFIED. That is how this entry was first written; ci_throughput.py's selftest now carries the control that catches it."
+      "condition_note": "Uses abs_delta_pct, not delta_pct. Conditions are ANDed, so a single delta_pct clause cannot express 'more than 10% away in either direction' \u2014 written as {lt: -10} it silently drops the upper half and a +20% slowdown returns PARTIAL rather than FALSIFIED. That is how this entry was first written; ci_throughput.py's selftest now carries the control that catches it.",
+      "metric_note": "job_exec_max.<workflow>.<job> now EXISTS in the instrument (added 2026-09-07). The job name `full` does not exist until the trigger change lands, which is why selftest checks job existence only for FROZEN forecasts."
     },
     {
       "id": "D4",

--- a/docs/ci-throughput/E2-D-design.md
+++ b/docs/ci-throughput/E2-D-design.md
@@ -143,17 +143,77 @@ first prediction that can score it on an intensive metric.
 Treat both as arithmetic on a replayed sample, not as a result. They are
 what `E2-D-contract.json` will be scored against, not evidence for it.
 
+## The review, resolved (manifest version 2)
+
+All five `needs_review` entries are decided, and two of them were
+**wrong**, in the unsafe direction.
+
+| question | answer | evidence |
+|---|---|---|
+| `cpu/kquant_gemv.rs` | **exempt, tier B** | 0 references from the Metal crate; its only consumer outside `larql-compute` is `larql-vindex` |
+| `cpu/nvfp4_gemv.rs` | parity | 42 references, including `shaders/nvfp4_matvec.rs` |
+| `cpu/spin_pool.rs` | **silent parity** | 0 references, and `attention/decode/gqa_step.rs:125` calls `spin_pool::global().for_each_chunk()` — reduction ORDER inside a parity surface |
+| `cpu::q4` | already covered | a re-export of `ops::q4_common`, `ops::q4_matvec`, `ops::q4_vecmat` |
+| `backend/{capability,factory}.rs` | exempt, tier B | `pub enum Capability` with a false-returning default impl; `pub enum BackendKind` plus registry, `as_str`, Display |
+| `pipeline`, `pipeline_layer` | parity | `test_pipeline_and_moe.rs` builds `FullPipelineLayer` and calls `prefill_kquant`, exercising the `dispatch_full_pipeline` + `moe_fn` chain |
+| `options.rs` | **silent parity** | exposes `decode_options()` and `spin_pool_enabled()`; its own docs say "decode fast path — default ON", "force the f32/rayon path" |
+| `test_fixtures.rs` (both crates) | **silent parity** | the input DATA the assertions are written against |
+
+### A third class, not a reassignment
+
+`options.rs` and the fixtures were filed as `interface_only` in version 1
+on the argument that a compile catches a change. A compile catches a
+**signature** change, which is not the hazard. Both belong to a class the
+version-1 taxonomy had no room for:
+
+> **`silent_parity_obligations`** — changes WHICH values appear without
+> computing any. Path selection, reduction order, fixture data. Tier A on
+> the same terms as parity, but **no static check can find them**: they
+> add no reference and break no signature.
+
+`metal_tier.py check` therefore *lists* them on every run and says it
+cannot verify them. `spin_pool.rs` prints as `NOT referenced — either way
+it stays tier A`, which is the class stating its own nature.
+
+They exist as a separate class for one reason: a future reviewer looking
+at `test_fixtures.rs` will reason "nothing imports it, it is test
+scaffolding, it is structural" and demote it. The class name and its
+`do_not_simplify` note exist to stop that.
+
+### The asymmetry, applied structurally
+
+Parity subtrees stay **whole** and exemptions are **named files**. A file
+added to `cpu/` or `backend/` tomorrow defaults to tier A rather than
+falling through to tier B. Two selftest controls hold that.
+
+### A limit the review did not remove
+
+**#420 is still tier A**, and not because of `kquant_gemv.rs` — that is
+now exempt, along with its test module. It is tier A because it added
+five lines to `crates/larql-compute/src/cpu/mod.rs`, and that module root
+carries both inert `pub mod` declarations and the `pub mod q4 { pub use
+super::ops::... }` re-export block that decides which implementation a
+Metal reference resolves to. Classification is per file; a module root is
+one file.
+
+So the review moved **zero** pull requests in the sample — A=7, B=11,
+unchanged. An earlier draft of this document predicted it would move one.
+That prediction was wrong, and the reason is worth more than the
+prediction: exempting a leaf does not help when the diff also touches the
+root that re-exports it. Do not paper over this by exempting a module
+root; going below file granularity is a different and much harder design.
+
 ## Before activation
 
 1. **A1 closes** (n ≥ 8 successful Metal runs under E2-A).
-2. The five `needs_review` entries get a decision, in particular whether
-   `cpu/{kquant_gemv,nvfp4_gemv,spin_pool}.rs` are reachable from any
-   entry point a Metal test uses as a reference.
-3. The instrument gains a job-scoped metric. `workflow_exec_max` is keyed
-   on workflow, and under D one workflow emits both a 24-minute job and a
-   2-minute one, so its p50 becomes a mixture that hides the per-tier
-   story. D needs `job_exec_max.<workflow>.<job>` before it can be
-   scored.
+2. ~~The five `needs_review` entries~~ — **done**, manifest version 2.
+3. ~~The instrument gains a job-scoped metric~~ — **done**.
+   `job_exec_max.<workflow>.<job>` counts successful jobs only, returns
+   `NO DATA` rather than `PARTIAL` when the job is absent from either
+   sample, and is validated against a baseline snapshot for any frozen
+   forecast. A selftest control demonstrates the mixture it prevents: a
+   24-minute and a 2-minute job in one workflow read as 24 and 2, where
+   the workflow-level p50 reads 13.
 4. `E2-D-contract.json` freezes with numeric baselines taken from the
    post-E2-A steady state, which does not exist yet.
 

--- a/docs/ci-throughput/E2-D-design.md
+++ b/docs/ci-throughput/E2-D-design.md
@@ -180,6 +180,28 @@ at `test_fixtures.rs` will reason "nothing imports it, it is test
 scaffolding, it is structural" and demote it. The class name and its
 `do_not_simplify` note exist to stop that.
 
+### Precedence, and an invariant that does not depend on it
+
+Classification order is: **silent parity → the Metal crate and its
+workflow → `interface_only` → ordinary parity → the dependency floor.**
+
+Silent parity is first because its members live *inside* broad parity
+subtrees — `spin_pool.rs` is under `cpu/**` — so testing ordinary parity
+first would swallow them. The tier would still be A, but the reason would
+read as ordinary parity and the class would lose the identity it exists
+to carry. `interface_only` stays above ordinary parity because that is
+how the named exemptions escape their enclosing subtrees.
+
+**Ordering is not the safety property.** In version 2 `interface_only`
+was tested first, so an entry overlapping a silent path would have
+demoted it to tier B — the one unsafe direction. No such overlap existed,
+so nothing was wrong in practice and no test would have caught it. An
+invariant that holds only because of evaluation order is one refactor
+from not holding, so `metal_tier.py check` now **refuses the overlap
+outright** and calls it malformed authority. Four controls cover it,
+including one on the shipped manifest and one asserting the demotion is
+impossible even when the overlap is constructed deliberately.
+
 ### The asymmetry, applied structurally
 
 Parity subtrees stay **whole** and exemptions are **named files**. A file

--- a/scripts/ci_throughput.py
+++ b/scripts/ci_throughput.py
@@ -115,7 +115,8 @@ PER_ATTEMPT_SUFFIX = "_per_attempt"
 # `workflow_exec_max.larql-compute-metal.p50`. Their names only exist once
 # that workflow appears in a snapshot, so a forecast that mentions one has
 # to be validated by SHAPE plus a separate check that the workflow is real.
-WORKFLOW_SCOPED_FAMILIES = ("workflow_exec_max", "workflow_share")
+WORKFLOW_SCOPED_FAMILIES = ("workflow_exec_max", "workflow_share", "job_exec_max")
+PROBE_JOB = "<job>"
 PROBE_WORKFLOW = "<workflow>"
 
 
@@ -135,6 +136,10 @@ def metric_shape(name: str) -> str:
         remainder = name[len(prefix):]
         if family == "workflow_share":
             return f"{family}.{PROBE_WORKFLOW}"
+        if family == "job_exec_max":
+            rest, _, stat = remainder.rpartition(".")
+            workflow, _, _job = rest.rpartition(".")
+            return f"{family}.{PROBE_WORKFLOW}.{PROBE_JOB}.{stat}" if workflow else name
         workflow, _, stat = remainder.rpartition(".")
         return f"{family}.{PROBE_WORKFLOW}.{stat}" if workflow else name
     return name
@@ -158,6 +163,10 @@ def metric_workflow(name: str) -> str | None:
         remainder = name[len(prefix):]
         if family == "workflow_share":
             return remainder
+        if family == "job_exec_max":
+            rest, _, _stat = remainder.rpartition(".")
+            workflow, _, _job = rest.rpartition(".")
+            return workflow or None
         workflow, _, _stat = remainder.rpartition(".")
         return workflow or None
     return None
@@ -376,6 +385,10 @@ class AttemptMetrics:
     # clock for the workflow, not its runner-minute cost, because the claims
     # it scores are about how long a gate makes a pull request wait.
     workflow_exec_max: dict[str, float] = field(default_factory=dict)
+    # Same, keyed on (workflow, job). E2-D puts a ~24-minute tier-A job and
+    # a ~2-minute tier-B job in ONE workflow, so a workflow-keyed p50
+    # becomes a mixture that hides exactly the per-tier story D is about.
+    job_exec_max: dict[tuple[str, str], float] = field(default_factory=dict)
     superseded_exec: float = 0.0
     queued_by_os: dict[str, float] = field(default_factory=dict)
     executed_by_os: dict[str, float] = field(default_factory=dict)
@@ -471,6 +484,14 @@ def analyse(
                         workflow = run["workflow"] or "?"
                         metrics.workflow_exec_max[workflow] = max(
                             metrics.workflow_exec_max.get(workflow, 0.0), executed)
+                        # A job cancelled mid-flight is not a completed
+                        # gate; counting it would let more cancellation
+                        # read as a faster job, the same trap the
+                        # workflow-level metric avoids.
+                        if job["conclusion"] == TERMINAL_SUCCESS:
+                            key = (workflow, job["name"] or "?")
+                            metrics.job_exec_max[key] = max(
+                                metrics.job_exec_max.get(key, 0.0), executed)
                     # E1's forecast names this OS-scoped special case, so it
                     # stays; workflow_exec_max is the general form and the one
                     # new forecasts should use.
@@ -534,6 +555,14 @@ def aggregate(rows: Sequence[AttemptMetrics], percentiles: Sequence[int]) -> dic
         entry = {f"p{p}": percentile(values, p) for p in percentiles}
         entry["n"] = len(values)
         out["workflow_exec_max"][workflow] = entry
+
+    job_keys = sorted({k for r in rows for k in r.job_exec_max})
+    out["job_exec_max"] = {}
+    for workflow, job in job_keys:
+        values = [r.job_exec_max[(workflow, job)] for r in rows if (workflow, job) in r.job_exec_max]
+        entry = {f"p{p}": percentile(values, p) for p in percentiles}
+        entry["n"] = len(values)
+        out["job_exec_max"].setdefault(workflow, {})[job] = entry
 
     out["superseded_exec_total"] = sum(r.superseded_exec for r in rows)
     out["superseded_exec_mean"] = statistics.fmean([r.superseded_exec for r in rows]) if rows else None
@@ -714,6 +743,12 @@ def flatten_metrics(agg: dict) -> dict[str, float | None]:
     # SECONDS_PER_MINUTE, so a threshold on it reads as a share.
     for workflow, share in (agg.get("workflow_share") or {}).items():
         out[f"workflow_share.{workflow}"] = share
+    for workflow, jobs in (agg.get("job_exec_max") or {}).items():
+        for job, stats in jobs.items():
+            for stat, value in stats.items():
+                if stat == "n":
+                    continue
+                out[f"job_exec_max.{workflow}.{job}.{stat}"] = None if value is None else value / SECONDS_PER_MINUTE
     for workflow, stats in (agg.get("workflow_exec_max") or {}).items():
         for stat, value in stats.items():
             if stat == "n":
@@ -782,7 +817,18 @@ def score_prediction(pred: dict, before: Sample, after: Sample) -> dict:
     falsified = evaluate_conditions(pred.get("falsified_if", {}), a, b)
     bias = sample_size_bias_pct(before, after)
     unequal = before.attempts != after.attempts
+    uses_delta = any(
+        field in ("delta_pct", "abs_delta_pct")
+        for conditions in (pred.get("held_if", {}), pred.get("falsified_if", {}))
+        for field in conditions
+    )
     if a is None:
+        verdict = VERDICT_NO_DATA
+    elif uses_delta and b is None:
+        # The job or workflow exists in the AFTER sample and not in the
+        # BEFORE one — renamed, or newly added. A delta against nothing is
+        # not a small delta, and PARTIAL would read as "measured, did not
+        # hold". NO DATA is the honest answer.
         verdict = VERDICT_NO_DATA
     elif kind == METRIC_EXTENSIVE and unequal:
         # Refuse rather than report. See METRIC_EXTENSIVE above: this is the
@@ -1074,7 +1120,8 @@ def selftest(_args: argparse.Namespace) -> int:
     produced = set(flatten_metrics(aggregate([
         AttemptMetrics(branch="b", sha="s", workflows=[PROBE_WORKFLOW],
                        queued_by_os={"macos": 1.0}, executed_by_os={"macos": 1.0},
-                       workflow_exec_max={PROBE_WORKFLOW: 60.0})
+                       workflow_exec_max={PROBE_WORKFLOW: 60.0},
+                       job_exec_max={(PROBE_WORKFLOW, PROBE_JOB): 60.0})
     ], DEFAULT_PERCENTILES)))
     check("every extensive metric has a per-attempt companion",
           all(f"{b}{PER_ATTEMPT_SUFFIX}.macos" in produced
@@ -1101,6 +1148,49 @@ def selftest(_args: argparse.Namespace) -> int:
           metric_kind("superseded_exec_total"), METRIC_EXTENSIVE)
     check("superseded_exec_mean is intensive",
           metric_kind("superseded_exec_mean"), METRIC_INTENSIVE)
+    # 4g. job_exec_max — the metric E2-D needs, with the three protections
+    #     a workflow-keyed metric already carries plus one of its own.
+    jm = {"id": "PJ", "mechanism": "m", "kind": "effect",
+          "metric": "job_exec_max.wf.full.p50",
+          "held_if": {"delta_pct": {"lte": -30}}, "falsified_if": {"delta_pct": {"gt": -10}}}
+    check("a job metric present in BOTH samples scores",
+          score_prediction(jm, Sample({"job_exec_max.wf.full.p50": 50.0}, 10),
+                           Sample({"job_exec_max.wf.full.p50": 25.0}, 10))["verdict"], VERDICT_HELD)
+    check("a job missing from AFTER is NO DATA",
+          score_prediction(jm, Sample({"job_exec_max.wf.full.p50": 50.0}, 10),
+                           Sample({}, 10))["verdict"], VERDICT_NO_DATA)
+    check("a job missing from BEFORE is NO DATA, not PARTIAL",
+          score_prediction(jm, Sample({}, 10),
+                           Sample({"job_exec_max.wf.full.p50": 25.0}, 10))["verdict"], VERDICT_NO_DATA)
+    check("job_exec_max is intensive", metric_kind("job_exec_max.wf.full.p50"), METRIC_INTENSIVE)
+    check("metric_shape abstracts workflow AND job",
+          metric_shape("job_exec_max.larql-compute-metal.test · macos-14.p50"),
+          f"job_exec_max.{PROBE_WORKFLOW}.{PROBE_JOB}.p50")
+    check("metric_workflow recovers the workflow from a job metric",
+          metric_workflow("job_exec_max.larql-compute-metal.test.p95"), "larql-compute-metal")
+
+    #     Two jobs in ONE workflow must not blur: this is the mixture E2-D
+    #     would otherwise be scored on.
+    mix = {"runs": [
+        _run("wf", "aaa", [_job(T(0), T(1), T(25), ["macos-14"])], branch="pr-1"),
+        _run("wf", "bbb", [_job(T(0), T(1), T(3), ["macos-14"])], branch="pr-2"),
+    ]}
+    mix["runs"][0]["jobs"][0]["name"] = "full"
+    mix["runs"][1]["jobs"][0]["name"] = "compat"
+    ja = aggregate(analyse(mix, DEFAULT_INFORMATIONAL, None, True), DEFAULT_PERCENTILES)
+    jf = flatten_metrics(ja)
+    check("the expensive job keeps its own number", jf["job_exec_max.wf.full.p50"], 24.0)
+    check("the cheap job keeps its own number", jf["job_exec_max.wf.compat.p50"], 2.0)
+    check("the workflow-level metric is the mixture they would have hidden in",
+          jf["workflow_exec_max.wf.p50"], 13.0)
+
+    #     A cancelled JOB must not enter, or cancelling more would read as
+    #     a faster job.
+    mix["runs"][0]["jobs"][0]["conclusion"] = TERMINAL_CANCELLED
+    jc = aggregate(analyse(mix, DEFAULT_INFORMATIONAL, None, True), DEFAULT_PERCENTILES)
+    check("a cancelled job is excluded from job_exec_max",
+          "full" not in jc["job_exec_max"].get("wf", {}), True)
+
     check("workflow_exec_max is intensive",
           metric_kind("workflow_exec_max.larql-compute-metal.p50"), METRIC_INTENSIVE)
     check("workflow_share is intensive",
@@ -1159,22 +1249,43 @@ def selftest(_args: argparse.Namespace) -> int:
     #     and every metric name is one flatten_metrics actually produces.
     #     Forecasts frozen from E2 onward must additionally name only
     #     INTENSIVE metrics, so the E1 C2 defect cannot recur by copy-paste.
+    def _snapshot_jobs(snapshot: dict) -> set[tuple[str, str]]:
+        return {(r.get("workflow"), j.get("name")) for r in snapshot.get("runs", []) for j in r.get("jobs", [])}
+
+    # A FROZEN forecast must name metrics that exist. An unfrozen one may
+    # name a job the workflow does not have yet -- E2-D's `full` job comes
+    # into being with the trigger change it preregisters -- so existence is
+    # checked at freeze time, while shape, kind and conditions are checked
+    # always. Recording the rule here rather than skipping the file keeps
+    # the unfrozen contract under some check instead of none.
     for forecast_path, intensive_only in (
         (FORECAST_DIR / "E1-forecast.json", False),
         (FORECAST_DIR / "E2-contract.json", True),
+        (FORECAST_DIR / "E2-D-contract.json", True),
     ):
         if not forecast_path.exists():
             continue
         forecast = json.loads(forecast_path.read_text())
         label = forecast.get("experiment", forecast_path.stem)
         snapshot_workflows: set[str] = set()
+        snapshot_jobs: set[tuple[str, str]] = set()
         for snapshot_key in ("primary_snapshot", "metal_gate_snapshot", "baseline_snapshot"):
             snapshot_path = forecast.get("baseline", {}).get(snapshot_key) or forecast.get(
                 "frozen_against", {}).get(snapshot_key)
             if snapshot_path and (REPO_ROOT / snapshot_path).exists():
                 snap = json.loads((REPO_ROOT / snapshot_path).read_text())
                 snapshot_workflows |= {r.get("workflow") for r in snap.get("runs", [])}
+                snapshot_jobs |= _snapshot_jobs(snap)
         for pred in forecast["predictions"]:
+            # A prediction may declare that its metric does not exist yet —
+            # E2-D's tier share is computed by the triage job the same
+            # contract preregisters. Allowed ONLY while unfrozen: freezing
+            # a forecast against a metric nothing produces is how a
+            # prediction quietly becomes unscoreable.
+            if pred.get("metric_not_yet_produced"):
+                check(f"{label} {pred['id']} may defer its metric only while unfrozen",
+                      bool(forecast.get("frozen_at")), False)
+                continue
             # SHAPE, because a workflow-scoped name exists only once that
             # workflow is in a snapshot...
             check(f"{label} {pred['id']} metric is produced",
@@ -1182,15 +1293,33 @@ def selftest(_args: argparse.Namespace) -> int:
             # ...and then the workflow itself must be one the baseline
             # actually contains, or the prediction is unscoreable by name.
             workflow = metric_workflow(pred["metric"])
-            if workflow is not None and snapshot_workflows:
+            frozen = bool(forecast.get("frozen_at"))
+            if workflow is not None and snapshot_workflows and frozen:
                 check(f"{label} {pred['id']} names a workflow the baseline contains",
                       workflow in snapshot_workflows, True)
+            if frozen and pred["metric"].startswith("job_exec_max.") and snapshot_jobs:
+                rest = pred["metric"][len("job_exec_max."):]
+                head, _, _stat = rest.rpartition(".")
+                wf, _, jb = head.rpartition(".")
+                check(f"{label} {pred['id']} names a job the baseline contains",
+                      (wf, jb) in snapshot_jobs, True)
             if intensive_only:
                 check(f"{label} {pred['id']} names an intensive metric",
                       metric_kind(pred["metric"]), METRIC_INTENSIVE)
             for conditions in (pred.get("held_if", {}), pred.get("falsified_if", {})):
                 evaluate_conditions(conditions, 1.0, 2.0)   # raises on an unknown field/operator
         check(f"{label} conditions all parse", True, True)
+
+    # 4h. the job-existence rule can FAIL, not just pass. A frozen forecast
+    #     naming a job no snapshot contains must be caught rather than
+    #     scoring NO DATA forever.
+    real_jobs = _snapshot_jobs(json.loads((FORECAST_DIR / "after-e1.json").read_text())) \
+        if (FORECAST_DIR / "after-e1.json").exists() else set()
+    if real_jobs:
+        check("a real workflow/job pair is recognised",
+              ("larql-compute-metal", "test · macos-14") in real_jobs, True)
+        check("an impossible workflow/job pair is NOT recognised",
+              ("larql-compute-metal", "no-such-job") in real_jobs, False)
 
     # 5. percentile is defined at n == 1 and interpolates at n == 2.
     check("percentile n=1", percentile([7.0], 95), 7.0)

--- a/scripts/metal_tier.py
+++ b/scripts/metal_tier.py
@@ -14,6 +14,17 @@ separates those two. So the distinction is DECLARED, in
 crates/larql-compute-metal/parity-obligations.json, and this script
 checks the declaration stays complete.
 
+Three declaration classes, two of which are tier A:
+
+    parity_obligations         code that COMPUTES the reference values
+    silent_parity_obligations  code that changes WHICH values appear
+                               without computing any: path selection,
+                               reduction order, fixture data. No import
+                               and no signature reveals these, so the
+                               completeness check below cannot discover
+                               them and they must be declared by hand.
+    interface_only             genuinely structural; a compile catches it
+
 Three tiers:
 
     A  full behavioural qualification   the Metal crate itself changed,
@@ -104,6 +115,7 @@ def classify(changed: list[str], manifest: dict, deps: list[str]) -> tuple[str, 
     reasons: list[str] = []
     tier = TIER_C
     parity = manifest_paths(manifest, "parity_obligations")
+    silent = manifest_paths(manifest, "silent_parity_obligations")
     interface = manifest_paths(manifest, "interface_only")
 
     for path in changed:
@@ -122,6 +134,10 @@ def classify(changed: list[str], manifest: dict, deps: list[str]) -> tuple[str, 
         if any(matches(path, p) for p in parity):
             tier = TIER_A
             reasons.append(f"{path}: declared parity obligation -> A")
+            continue
+        if any(matches(path, p) for p in silent):
+            tier = TIER_A
+            reasons.append(f"{path}: SILENT parity obligation -> A")
             continue
         if any(matches(path, p) for p in deps) or path in BUILD_INPUTS:
             if tier == TIER_C:
@@ -175,7 +191,11 @@ def _resolve(root: Path, crate_dir: str, parts: list[str]) -> str | None:
 def check(root: Path = REPO_ROOT) -> tuple[list[str], dict[str, int]]:
     """Referenced-but-undeclared paths. Empty list means complete."""
     manifest = load_manifest(root)
-    declared = manifest_paths(manifest, "parity_obligations") + manifest_paths(manifest, "interface_only")
+    declared = (
+        manifest_paths(manifest, "parity_obligations")
+        + manifest_paths(manifest, "silent_parity_obligations")
+        + manifest_paths(manifest, "interface_only")
+    )
     undeclared = []
     hits = referenced_paths(root)
     for path in sorted(hits):
@@ -205,6 +225,19 @@ def cmd_classify(args: argparse.Namespace) -> int:
 def cmd_check(_args: argparse.Namespace) -> int:
     undeclared, hits = check()
     print(f"{len(hits)} upstream paths referenced by {METAL_CRATE}")
+
+    # Print the silent class every time. Its members are invisible to the
+    # derivation BY DEFINITION -- spin_pool.rs has zero references from the
+    # Metal crate and is still tier A -- so a check that only printed
+    # "complete" would imply a coverage it does not have.
+    silent = manifest_paths(load_manifest(), "silent_parity_obligations")
+    if silent:
+        print(f"\n{len(silent)} SILENT parity paths, declared by hand because no import or")
+        print("signature reveals them. This check lists them; it cannot verify them:")
+        for path in silent:
+            probe = path[:-3] if path.endswith("/**") else path
+            seen = "referenced" if any(h.startswith(probe) for h in hits) else "NOT referenced"
+            print(f"  {path}  ({seen} -- either way it stays tier A)")
     if undeclared:
         print("\nREFERENCED BUT NOT DECLARED — every one is a surface that could change")
         print("what Metal must reproduce with nothing in CI noticing:")
@@ -266,6 +299,45 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
        matches("crates/larql-compute/src/cpu", "crates/larql-compute/src/cpu/**"), True)
     ok("subtree glob does not match a prefix sibling",
        matches("crates/larql-compute/src/cpu_extra.rs", "crates/larql-compute/src/cpu/**"), False)
+
+    # Silent parity: tier A on the same terms as parity, and crucially
+    #     still tier A when NOTHING references it. That is the whole class.
+    sil = {
+        "parity_obligations": [{"id": "p", "paths": ["crates/larql-compute/src/cpu/ops/**"]}],
+        "silent_parity_obligations": [{"id": "s", "paths": ["crates/larql-compute/src/cpu/spin_pool.rs"]}],
+        "interface_only": [],
+    }
+    ok("silent parity path is A",
+       classify(["crates/larql-compute/src/cpu/spin_pool.rs"], sil, deps)[0], TIER_A)
+    ok("silent parity is named as such in the reason",
+       "SILENT" in classify(["crates/larql-compute/src/cpu/spin_pool.rs"], sil, deps)[1][0], True)
+
+    #     Regression controls on the SHIPPED manifest, for the two entries
+    #     version 1 got wrong and the one it cited as its hard case.
+    real, rdeps = load_manifest(), metal_workspace_deps()
+    for path, want, note in (
+        ("crates/larql-compute/src/options.rs", TIER_A, "selects the numerical path; was interface_only in v1"),
+        ("crates/larql-models/src/test_fixtures.rs", TIER_A, "fixture DATA authority; was interface_only in v1"),
+        ("crates/larql-compute/src/cpu/spin_pool.rs", TIER_A, "reduction order, zero Metal references"),
+        ("crates/larql-compute/src/cpu/kquant_gemv.rs", TIER_B, "#420's file: no Metal reference or reach"),
+        ("crates/larql-compute/src/cpu/nvfp4_gemv.rs", TIER_A, "42 Metal references"),
+        ("crates/larql-compute/src/backend/capability.rs", TIER_B, "enum + default impl"),
+        ("crates/larql-compute/src/backend/decode.rs", TIER_A, "arithmetic in default bodies"),
+    ):
+        ok(f"{path.split('/')[-1]} is {want} ({note})", classify([path], real, rdeps)[0], want)
+
+    #     The structural half of the asymmetry: a file that does not exist
+    #     yet, added inside a parity subtree, must default to A rather than
+    #     fall through to the tier-B dependency rule.
+    ok("a NEW file in a parity subtree defaults to A",
+       classify(["crates/larql-compute/src/cpu/ops/brand_new_kernel.rs"], real, rdeps)[0], TIER_A)
+    ok("a NEW file in backend/ defaults to A",
+       classify(["crates/larql-compute/src/backend/brand_new.rs"], real, rdeps)[0], TIER_A)
+
+    #     ...and the exemptions are files, not subtrees, so they cannot
+    #     accidentally exempt a sibling.
+    ok("an exemption does not cover its siblings",
+       classify(["crates/larql-compute/src/backend/helpers.rs"], real, rdeps)[0], TIER_A)
 
     deps_real = metal_workspace_deps()
     ok("dependencies are read from Cargo.toml",

--- a/scripts/metal_tier.py
+++ b/scripts/metal_tier.py
@@ -118,26 +118,38 @@ def classify(changed: list[str], manifest: dict, deps: list[str]) -> tuple[str, 
     silent = manifest_paths(manifest, "silent_parity_obligations")
     interface = manifest_paths(manifest, "interface_only")
 
+    # PRECEDENCE, and each step is load-bearing:
+    #
+    #   1. silent parity      -- FIRST, and NOT exemptable. Two reasons.
+    #      Its members sit inside broad parity subtrees (spin_pool.rs is
+    #      under cpu/**), so testing parity first would swallow them and
+    #      their reason would read as ordinary parity, losing the identity
+    #      the class exists to preserve. And an interface_only entry that
+    #      overlapped one would DEMOTE it to B -- the unsafe direction the
+    #      manifest says is impossible. Ordering alone does not make that
+    #      impossible, so `check` also refuses the overlap outright.
+    #   2. the Metal crate and its own workflow.
+    #   3. interface_only     -- an EXEMPTION from ORDINARY parity only.
+    #      This is how the named kquant_gemv.rs and backend/ exemptions
+    #      escape their enclosing subtree, so it must stay above parity.
+    #   4. ordinary parity, then the dependency floor.
     for path in changed:
-        # interface_only is an EXEMPTION from parity, so it is tested
-        # first — otherwise a file inside a declared parity subtree could
-        # never be exempted.
-        if any(matches(path, p) for p in interface):
-            if tier == TIER_C:
-                tier = TIER_B
-            reasons.append(f"{path}: interface_only -> B")
+        if any(matches(path, p) for p in silent):
+            tier = TIER_A
+            reasons.append(f"{path}: SILENT parity obligation -> A")
             continue
         if any(matches(path, p) for p in TIER_A_ALWAYS):
             tier = TIER_A
             reasons.append(f"{path}: Metal crate or its workflow -> A")
             continue
+        if any(matches(path, p) for p in interface):
+            if tier == TIER_C:
+                tier = TIER_B
+            reasons.append(f"{path}: interface_only -> B")
+            continue
         if any(matches(path, p) for p in parity):
             tier = TIER_A
             reasons.append(f"{path}: declared parity obligation -> A")
-            continue
-        if any(matches(path, p) for p in silent):
-            tier = TIER_A
-            reasons.append(f"{path}: SILENT parity obligation -> A")
             continue
         if any(matches(path, p) for p in deps) or path in BUILD_INPUTS:
             if tier == TIER_C:
@@ -188,6 +200,26 @@ def _resolve(root: Path, crate_dir: str, parts: list[str]) -> str | None:
     return best
 
 
+def overlapping_silent_exemptions(manifest: dict) -> list[tuple[str, str]]:
+    """silent_parity paths that an interface_only entry would exempt.
+
+    MALFORMED AUTHORITY, not something precedence resolves. A silent
+    obligation is one no static check can rediscover, so demoting it to
+    tier B removes the only thing standing between a changed default or a
+    changed fixture and a Metal backend that never re-qualifies. Ordering
+    makes the demotion not HAPPEN; this makes it not be EXPRESSIBLE.
+    """
+    silent = manifest_paths(manifest, "silent_parity_obligations")
+    interface = manifest_paths(manifest, "interface_only")
+    clashes = []
+    for s_path in silent:
+        probe = s_path[:-3] if s_path.endswith("/**") else s_path
+        for i_path in interface:
+            if matches(probe, i_path) or (i_path.endswith("/**") and matches(i_path[:-3], s_path)):
+                clashes.append((s_path, i_path))
+    return clashes
+
+
 def check(root: Path = REPO_ROOT) -> tuple[list[str], dict[str, int]]:
     """Referenced-but-undeclared paths. Empty list means complete."""
     manifest = load_manifest(root)
@@ -224,6 +256,14 @@ def cmd_classify(args: argparse.Namespace) -> int:
 
 def cmd_check(_args: argparse.Namespace) -> int:
     undeclared, hits = check()
+    clashes = overlapping_silent_exemptions(load_manifest())
+    if clashes:
+        print("MALFORMED MANIFEST: a silent parity obligation is also declared interface_only.")
+        print("A silent obligation is one no static check can rediscover; exempting it is the")
+        print("one error direction this manifest exists to make impossible.")
+        for s_path, i_path in clashes:
+            print(f"  {s_path}  exempted by  {i_path}")
+        return 1
     print(f"{len(hits)} upstream paths referenced by {METAL_CRATE}")
 
     # Print the silent class every time. Its members are invisible to the
@@ -312,6 +352,42 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
     ok("silent parity is named as such in the reason",
        "SILENT" in classify(["crates/larql-compute/src/cpu/spin_pool.rs"], sil, deps)[1][0], True)
 
+    #     ...and the same path SHADOWED by a broad parity subtree, which
+    #     is the real manifest's shape: spin_pool.rs lives under cpu/**.
+    #     The synthetic case above cannot catch a precedence regression
+    #     because nothing there shadows it.
+    shadowed = {
+        "parity_obligations": [{"id": "p", "paths": ["crates/larql-compute/src/cpu/**"]}],
+        "silent_parity_obligations": [{"id": "s", "paths": ["crates/larql-compute/src/cpu/spin_pool.rs"]}],
+        "interface_only": [],
+    }
+    sh = classify(["crates/larql-compute/src/cpu/spin_pool.rs"], shadowed, deps)
+    ok("a shadowed silent path is still A", sh[0], TIER_A)
+    ok("a shadowed silent path keeps its SILENT identity", "SILENT" in sh[1][0], True)
+
+    #     Silent parity must NOT be exemptable, or a mis-edit demotes it
+    #     to B -- the one unsafe direction. Ordering makes that not
+    #     happen; overlapping_silent_exemptions makes it not expressible.
+    exempted = {
+        "parity_obligations": [{"id": "p", "paths": ["crates/larql-compute/src/cpu/**"]}],
+        "silent_parity_obligations": [{"id": "s", "paths": ["crates/larql-compute/src/cpu/spin_pool.rs"]}],
+        "interface_only": [{"id": "i", "paths": ["crates/larql-compute/src/cpu/spin_pool.rs"]}],
+    }
+    ok("interface_only cannot demote a silent obligation",
+       classify(["crates/larql-compute/src/cpu/spin_pool.rs"], exempted, deps)[0], TIER_A)
+    ok("...and the overlap is reported as malformed authority",
+       len(overlapping_silent_exemptions(exempted)), 1)
+    ok("a subtree exemption swallowing a silent file is also malformed",
+       len(overlapping_silent_exemptions({
+           "silent_parity_obligations": [{"id": "s", "paths": ["crates/larql-compute/src/cpu/spin_pool.rs"]}],
+           "interface_only": [{"id": "i", "paths": ["crates/larql-compute/src/cpu/**"]}]})), 1)
+    ok("an ordinary parity exemption is still legal",
+       len(overlapping_silent_exemptions({
+           "silent_parity_obligations": [{"id": "s", "paths": ["crates/larql-compute/src/options.rs"]}],
+           "interface_only": [{"id": "i", "paths": ["crates/larql-compute/src/cpu/kquant_gemv.rs"]}]})), 0)
+    ok("the SHIPPED manifest has no silent/interface overlap",
+       overlapping_silent_exemptions(load_manifest()), [])
+
     #     Regression controls on the SHIPPED manifest, for the two entries
     #     version 1 got wrong and the one it cited as its hard case.
     real, rdeps = load_manifest(), metal_workspace_deps()
@@ -329,6 +405,12 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
     #     The structural half of the asymmetry: a file that does not exist
     #     yet, added inside a parity subtree, must default to A rather than
     #     fall through to the tier-B dependency rule.
+    real_spin = classify(["crates/larql-compute/src/cpu/spin_pool.rs"], real, rdeps)
+    ok("SHIPPED manifest: spin_pool.rs reason says SILENT, not ordinary parity",
+       "SILENT" in real_spin[1][0], True)
+    real_opts = classify(["crates/larql-compute/src/options.rs"], real, rdeps)
+    ok("SHIPPED manifest: options.rs reason says SILENT", "SILENT" in real_opts[1][0], True)
+
     ok("a NEW file in a parity subtree defaults to A",
        classify(["crates/larql-compute/src/cpu/ops/brand_new_kernel.rs"], real, rdeps)[0], TIER_A)
     ok("a NEW file in backend/ defaults to A",


### PR DESCRIPTION
Still **not activated** — `larql-compute-metal.yml` is untouched. This
closes the two pre-activation items that did not need A1 to move.

## The five `needs_review` entries are decided, and two were wrong

`options.rs` and the test fixtures were filed as `interface_only` on the
argument that a compile catches a change. **A compile catches a
*signature* change, which is not the hazard.** Both were wrong in the
unsafe direction.

That produced a third class rather than a reassignment:

> **`silent_parity_obligations`** — changes *which* values appear without
> computing any. **No static check can find them**: they add no reference
> and break no signature.

| member | why |
|---|---|
| `options.rs` | exposes `decode_options()` and `spin_pool_enabled()`; its own docs say "decode fast path — default ON" and "force the f32/rayon path" |
| `cpu/spin_pool.rs` | **zero** Metal references, and `attention/decode/gqa_step.rs:125` calls `spin_pool::global().for_each_chunk()` — float reduction *order* inside a parity surface |
| `test_fixtures.rs` ×2 | the input **data** the assertions are written against |

`metal_tier.py check` now lists them every run and states it cannot
verify them. `spin_pool.rs` prints as `NOT referenced — either way it
stays tier A`, which is the class describing its own nature. They are
separate so a future reviewer cannot reason "nothing imports it, so it is
structural" and demote them; the entry carries a `do_not_simplify` note
for the same reason.

Resolved by evidence: `kquant_gemv` 0 Metal references (exempt, with its
test module); `nvfp4_gemv` **42**, including `shaders/nvfp4_matvec.rs`
(parity); `backend/{capability,factory}.rs` are an enum and a registry
(exempt); `cpu::q4` is a re-export of paths already covered; `pipeline`
is the layer contract `prefill_kquant` implements (parity).

The asymmetry now applies structurally too: **parity subtrees stay whole,
exemptions are named files**, so a file added to `cpu/` or `backend/`
tomorrow defaults to tier A. Two controls hold that.

## The review moved zero pull requests

A=7, B=11 — unchanged. **#420 is still tier A**, and not for
`kquant_gemv.rs`, which is now exempt. It added five lines to
`cpu/mod.rs`, and that module root carries both inert `pub mod`
declarations *and* the `pub mod q4 { pub use super::ops::... }` block
that decides which implementation a Metal reference resolves to.
Classification is per file; a module root is one file.

An earlier draft of the design predicted the review would move one pull
request. It was wrong. The limit is now recorded as a known limit rather
than papered over by exempting a module root — going below file
granularity is a different and much harder design.

## `job_exec_max.<workflow>.<job>`

With the three protections requested, plus one of its own:

- **successful jobs only** — cancellation cannot manufacture a faster job;
- **`NO DATA`, not `PARTIAL`, when the job is absent from *either*
  sample** — a delta against nothing is not a small delta, and `PARTIAL`
  would read as "measured, did not hold";
- **job existence validated against a baseline snapshot for any *frozen*
  forecast**, while an unfrozen one may name a job that arrives with the
  change it preregisters — E2-D's `full` job does not exist yet, and the
  rule is recorded rather than the file being skipped;
- a control demonstrating the mixture it prevents: a 24-minute and a
  2-minute job in one workflow read as **24 and 2**, where the
  workflow-level p50 reads **13**.

D3 now names `job_exec_max.larql-compute-metal.full.p50`.

## Not done, deliberately

**Nothing was done to produce A1 samples.** This PR touches the Metal
crate (the manifest lives there), so it will produce one incidentally —
that is a side effect of real work, not a manufactured run.
