### PR TITLE
feat(represent): activation authority — a synthetic substrate may not carry a magnitude

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/represent/activation.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/activation.rs
@@ -1,0 +1,183 @@
+//! **Where the activations that produced a magnitude came from.**
+//!
+//! A quality bank is a set of numbers measured while *something* was fed
+//! through the model. What that something was decides whether the numbers
+//! mean anything, and nothing in [`QualityBank`](super::quality::QualityBank)
+//! recorded it. Three failures in one programme, all invisible to every
+//! other field:
+//!
+//! | substrate error | direction | size |
+//! |---|---|---|
+//! | synthetic *weights* instead of trained ones | optimistic | **10.6x** |
+//! | synthetic *input scale* — a scale-sensitive operator in the wrong regime | pessimistic | **2.5x** |
+//! | uniform-random vocabulary ids instead of natural text | optimistic | **1.2-1.3x** |
+//!
+//! **A synthetic substrate does not err in a predictable direction**, so
+//! "synthetic is conservative" is not available as a defence. The two
+//! larger errors also reversed a *conclusion*, not merely a number: the
+//! first made a representation look adequate, the second made one look
+//! RED that passes on real activations.
+//!
+//! The rule this module makes structural:
+//!
+//! > **A synthetic substrate may prove mechanism and fire controls. It may
+//! > never establish a magnitude or an admission.**
+//!
+//! Modelled on [`Provenance::native_kernel`](super::experiment::Provenance),
+//! which already gates throughput claims the same way: a boolean fact about
+//! how a number was produced, checked before the number is allowed to
+//! justify anything.
+//!
+//! ## Absence is not permission
+//!
+//! [`ActivationSource`] is optional on the bank so existing records
+//! deserialize, but a gate that asks for model activations and finds
+//! `None` **fails** — the same contract as
+//! [`Criterion::CoveredMass`](super::quality::Criterion::CoveredMass). An
+//! unstated substrate is indistinguishable from a synthetic one.
+
+use serde::{Deserialize, Serialize};
+
+/// Which population a bank belongs to.
+///
+/// Separated because a search may read calibration as often as it likes
+/// and must read a holdout **once**. Recording the role on the evidence
+/// is what lets a later reader tell a qualification from a selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BankRole {
+    /// May be optimised against. Contaminated as a selection surface by
+    /// construction.
+    Calibration,
+    /// May be read once, to qualify a candidate calibration already
+    /// chose. A holdout read during search is no longer a holdout.
+    Holdout,
+}
+
+/// The activations a magnitude was measured over, captured from the
+/// model's own execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivationAuthority {
+    /// Which checkpoint produced them. A magnitude measured on one
+    /// checkpoint is not evidence about another, however similar.
+    pub checkpoint: String,
+    /// **Where in the operator they were captured**, named exactly.
+    ///
+    /// This field exists because comparing against the wrong boundary is
+    /// a silent error: a layer's *input stream* and the operator's own
+    /// post-norm input differed by 10x on a real model, and reading the
+    /// former as the latter produced a scale claim wrong by an order of
+    /// magnitude. "The layer's input" is not a boundary; `post_input_
+    /// layernorm_post_mhc` is.
+    pub operator_boundary: String,
+    /// `None` when the bank spans layers rather than sampling one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layer: Option<u32>,
+    /// The frozen bank's name and digest. The digest is what makes
+    /// "qualified on holdout-v1" checkable rather than asserted.
+    pub bank: String,
+    pub bank_digest: String,
+    pub role: BankRole,
+}
+
+/// How the activations behind a measurement were obtained.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ActivationSource {
+    /// Generated vectors. Legitimate for proving a mechanism runs and for
+    /// demonstrating that a control fires; never for a magnitude.
+    ///
+    /// The note is required, not decorative — a reader has to be able to
+    /// tell *which* synthetic construction was used, because that is what
+    /// decides which regime the operator was in.
+    Synthetic { note: String },
+    /// Captured from the model executing.
+    ModelExecution(ActivationAuthority),
+}
+
+impl ActivationSource {
+    /// Whether a magnitude or admission may rest on this substrate.
+    ///
+    /// The whole point of the type: this is the only question callers
+    /// ask, and it cannot be answered `true` by a synthetic record.
+    pub fn supports_magnitude_claim(&self) -> bool {
+        matches!(self, ActivationSource::ModelExecution(_))
+    }
+
+    /// The authority, when there is one.
+    pub fn authority(&self) -> Option<&ActivationAuthority> {
+        match self {
+            ActivationSource::ModelExecution(a) => Some(a),
+            ActivationSource::Synthetic { .. } => None,
+        }
+    }
+
+    /// Whether this evidence came from a holdout population.
+    pub fn is_holdout(&self) -> bool {
+        self.authority()
+            .is_some_and(|a| a.role == BankRole::Holdout)
+    }
+
+    /// One line for a promotion report.
+    pub fn describe(&self) -> String {
+        match self {
+            ActivationSource::Synthetic { note } => {
+                format!("SYNTHETIC ({note}) — may not support a magnitude claim")
+            }
+            ActivationSource::ModelExecution(a) => format!(
+                "model execution: {} @ {}{} · bank {} [{}] {:?}",
+                a.checkpoint,
+                a.operator_boundary,
+                a.layer.map(|l| format!(" L{l}")).unwrap_or_default(),
+                a.bank,
+                &a.bank_digest[..a.bank_digest.len().min(16)],
+                a.role,
+            ),
+        }
+    }
+}
+
+/// Why a substrate was refused, for a gate's failure text.
+///
+/// `Unstated` and `Synthetic` are kept apart because they call for
+/// different fixes: one is a record that never said, the other is a
+/// record that said something disqualifying.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActivationRefusal {
+    Unstated,
+    Synthetic(String),
+}
+
+impl std::fmt::Display for ActivationRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ActivationRefusal::Unstated => write!(
+                f,
+                "no activation source recorded; an unstated substrate is \
+                 indistinguishable from a synthetic one"
+            ),
+            ActivationRefusal::Synthetic(note) => write!(
+                f,
+                "synthetic activations ({note}) may prove mechanism and fire \
+                 controls, never a magnitude"
+            ),
+        }
+    }
+}
+
+/// Judge a bank's substrate for a gate that requires model activations.
+pub fn refuse_unless_model_execution(
+    source: Option<&ActivationSource>,
+) -> Option<ActivationRefusal> {
+    match source {
+        None => Some(ActivationRefusal::Unstated),
+        Some(ActivationSource::Synthetic { note }) => {
+            Some(ActivationRefusal::Synthetic(note.clone()))
+        }
+        Some(ActivationSource::ModelExecution(_)) => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "activation_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/activation_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/activation_tests.rs
@@ -1,0 +1,183 @@
+//! The one property that matters: a synthetic substrate cannot promote.
+
+use super::*;
+
+fn authority(role: BankRole) -> ActivationAuthority {
+    ActivationAuthority {
+        checkpoint: "GLM-5.3-Flash".into(),
+        operator_boundary: "post_input_layernorm_post_mhc".into(),
+        layer: Some(0),
+        bank: "calibration-v1".into(),
+        bank_digest: "d639576a334895f8".into(),
+        role,
+    }
+}
+
+#[test]
+fn synthetic_activations_cannot_support_a_magnitude_claim() {
+    let s = ActivationSource::Synthetic {
+        note: "unit-RMS gaussian".into(),
+    };
+    assert!(!s.supports_magnitude_claim());
+    assert!(s.authority().is_none());
+}
+
+#[test]
+fn model_execution_supports_a_magnitude_claim() {
+    let s = ActivationSource::ModelExecution(authority(BankRole::Calibration));
+    assert!(s.supports_magnitude_claim());
+    assert_eq!(s.authority().expect("authority").layer, Some(0));
+}
+
+/// **Absence is not permission.** A record that never stated its
+/// substrate is refused exactly like a synthetic one, and the two
+/// refusals are distinguishable because they call for different fixes.
+#[test]
+fn an_unstated_substrate_is_refused_and_named_apart_from_a_synthetic_one() {
+    assert_eq!(
+        refuse_unless_model_execution(None),
+        Some(ActivationRefusal::Unstated)
+    );
+    let syn = ActivationSource::Synthetic {
+        note: "rtn probe".into(),
+    };
+    assert_eq!(
+        refuse_unless_model_execution(Some(&syn)),
+        Some(ActivationRefusal::Synthetic("rtn probe".into()))
+    );
+    assert!(
+        refuse_unless_model_execution(Some(&ActivationSource::ModelExecution(authority(
+            BankRole::Calibration
+        ))))
+        .is_none()
+    );
+    // Both refusals must say WHY, not merely refuse.
+    assert!(ActivationRefusal::Unstated
+        .to_string()
+        .contains("indistinguishable"));
+    assert!(ActivationRefusal::Synthetic("x".into())
+        .to_string()
+        .contains("never a magnitude"));
+}
+
+#[test]
+fn the_holdout_role_is_visible_on_the_evidence() {
+    let cal = ActivationSource::ModelExecution(authority(BankRole::Calibration));
+    let hold = ActivationSource::ModelExecution(authority(BankRole::Holdout));
+    assert!(!cal.is_holdout());
+    assert!(hold.is_holdout());
+}
+
+/// The operator boundary is carried verbatim, because reading the wrong
+/// boundary is a silent order-of-magnitude error, not a rounding one.
+#[test]
+fn the_describe_line_names_the_boundary_and_the_bank_digest() {
+    let s = ActivationSource::ModelExecution(authority(BankRole::Holdout));
+    let d = s.describe();
+    assert!(d.contains("post_input_layernorm_post_mhc"), "{d}");
+    assert!(d.contains("d639576a334895f8"), "{d}");
+    assert!(d.contains("Holdout"), "{d}");
+    assert!(ActivationSource::Synthetic { note: "n".into() }
+        .describe()
+        .contains("may not support a magnitude claim"));
+}
+
+/// Round-trips, because this travels in serialized experiment records
+/// and a substrate that silently vanishes on reload is worse than none.
+#[test]
+fn an_activation_source_round_trips_through_serde() {
+    for s in [
+        ActivationSource::Synthetic {
+            note: "unit-RMS".into(),
+        },
+        ActivationSource::ModelExecution(authority(BankRole::Holdout)),
+    ] {
+        let json = serde_json::to_string(&s).expect("ser");
+        let back: ActivationSource = serde_json::from_str(&json).expect("de");
+        assert_eq!(back, s);
+        assert_eq!(
+            back.supports_magnitude_claim(),
+            s.supports_magnitude_claim()
+        );
+    }
+}
+
+// ---- the gate integration: the property that makes this structural ----
+
+use super::super::bank::BankBuilder;
+use super::super::quality::{Criterion, QualityGate};
+
+fn magnitude_gate() -> QualityGate {
+    let mut g = super::super::quality::kimi_logit_v1();
+    g.id = "test-magnitude-v1".into();
+    g.positions_min = 0;
+    g.kl_p99_max = 1.0;
+    g.top1_flip_max = None;
+    g.top10_change_max = None;
+    g.route_flip_max = None;
+    g.require_model_activations = Some(true);
+    g
+}
+
+/// A gate that carries a magnitude REFUSES a synthetic bank, refuses an
+/// unstated one, and accepts a model-execution one — with everything
+/// else about the three banks identical.
+#[test]
+fn a_magnitude_gate_refuses_synthetic_and_unstated_substrates() {
+    let gate = magnitude_gate();
+    let build = |src: Option<ActivationSource>| {
+        let mut b = BankBuilder::default();
+        if let Some(s) = src {
+            b = b.activations(s);
+        }
+        b.finish()
+    };
+    let named = |g: &QualityGate, bank: &super::super::quality::QualityBank| {
+        g.evaluate(bank)
+            .failures
+            .iter()
+            .any(|(c, _)| *c == Criterion::ActivationAuthority)
+    };
+
+    let unstated = build(None);
+    let synthetic = build(Some(ActivationSource::Synthetic { note: "rtn".into() }));
+    let real = build(Some(ActivationSource::ModelExecution(authority(
+        BankRole::Calibration,
+    ))));
+    assert!(named(&gate, &unstated), "unstated must fail");
+    assert!(named(&gate, &synthetic), "synthetic must fail");
+    assert!(!named(&gate, &real), "model execution must pass");
+
+    // And the gate can be silent: a MECHANISM gate does not judge the
+    // substrate, so the same synthetic bank passes it. Without this the
+    // criterion would be unavoidable rather than declared.
+    let mut mech = gate.clone();
+    mech.id = "test-mechanism-v1".into();
+    mech.require_model_activations = None;
+    assert!(!named(&mech, &synthetic));
+}
+
+/// The refusal has to SAY which of the two problems it is, because they
+/// call for different fixes.
+#[test]
+fn the_gate_failure_text_distinguishes_unstated_from_synthetic() {
+    let gate = magnitude_gate();
+    let text = |src: Option<ActivationSource>| {
+        let mut b = BankBuilder::default();
+        if let Some(s) = src {
+            b = b.activations(s);
+        }
+        let bank = b.finish();
+        gate.evaluate(&bank)
+            .failures
+            .iter()
+            .find(|(c, _)| *c == Criterion::ActivationAuthority)
+            .map(|(_, m)| m.clone())
+            .expect("refused")
+    };
+    assert!(text(None).contains("indistinguishable"));
+    assert!(text(Some(ActivationSource::Synthetic {
+        note: "unit-RMS".into()
+    }))
+    .contains("unit-RMS"));
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/bank.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/bank.rs
@@ -347,6 +347,8 @@ pub struct BankBuilder {
     top1_margins: Vec<f64>,
     top1_candidate_margins: Vec<f64>,
     top1_masses: Vec<f64>,
+    /// Set by [`BankBuilder::activations`]; `None` until stated.
+    activations: Option<super::activation::ActivationSource>,
 }
 
 impl BankBuilder {
@@ -448,9 +450,20 @@ impl BankBuilder {
         sorted[rank.min(sorted.len()) - 1]
     }
 
+    /// State where this bank's activations came from.
+    ///
+    /// Not defaulted: a builder that never says leaves `None`, and any
+    /// gate carrying a magnitude then refuses the bank by name rather
+    /// than assuming it was real.
+    pub fn activations(mut self, source: super::activation::ActivationSource) -> Self {
+        self.activations = Some(source);
+        self
+    }
+
     pub fn finish(mut self) -> QualityBank {
         self.kls.sort_by(f64::total_cmp);
         QualityBank {
+            activations: self.activations.take(),
             positions: self.kls.len() as u64,
             logits: LogitEvidence {
                 kl_p50: Self::percentile(&self.kls, 0.50),

--- a/crates/larql-vindex/src/format/vindex3/represent/constraint_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/constraint_tests.rs
@@ -31,6 +31,7 @@ fn dist(p99: f64, max: f64) -> Option<Distribution> {
 /// positions. `kimi_full4-selection-8192_report.json`.
 fn four_family_selection() -> QualityBank {
     QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 0.0,
@@ -63,6 +64,7 @@ fn four_family_selection() -> QualityBank {
 /// `kimi_full4-heldout-8192_report.json`.
 fn four_family_heldout() -> QualityBank {
     QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p99: 2.6174e-3,
@@ -88,6 +90,7 @@ fn four_family_heldout() -> QualityBank {
 /// (2048/163840). Every CEILING is perfect. Only a floor catches it.
 fn flat_instrument() -> QualityBank {
     QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 0.0,

--- a/crates/larql-vindex/src/format/vindex3/represent/diagnostic_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/diagnostic_tests.rs
@@ -15,6 +15,7 @@ use super::*;
 /// a maximum wearing a percentile's name.
 pub(in crate::format::vindex3::represent) fn guard_256() -> QualityBank {
     QualityBank {
+        activations: None,
         positions: 256,
         logits: LogitEvidence {
             kl_p50: 6.2998e-5,

--- a/crates/larql-vindex/src/format/vindex3/represent/experiment/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/experiment/tests.rs
@@ -66,6 +66,7 @@ fn component_error_alone_does_not_support_a_quality_claim() {
     assert_eq!(r.quality_proven_by(), None);
 
     let gate = QualityGate {
+        require_model_activations: None,
         id: "kimi-logit-v1".into(),
         positions_min: 512,
         kl_p99_max: 1e-3,
@@ -79,6 +80,7 @@ fn component_error_alone_does_not_support_a_quality_claim() {
         route_mixture_mass_max: None,
     };
     let bank = QualityBank {
+        activations: None,
         positions: 19,
         logits: LogitEvidence {
             kl_p50: 1e-5,
@@ -209,6 +211,7 @@ fn promotable_requires_the_ladder_quality_and_throughput_together() {
     let passing = QualityEvidence {
         gate: kimi_logit_v1(),
         bank: QualityBank {
+            activations: None,
             positions: 8192,
             logits: LogitEvidence {
                 kl_p50: 1e-6,

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -45,6 +45,7 @@
 //! [`super::variants`] already states, and the reason a compiler is needed
 //! at all: a profile cannot turn one encoding's bytes into another's.
 
+pub mod activation;
 pub mod arena;
 pub mod assessment;
 pub mod bank;

--- a/crates/larql-vindex/src/format/vindex3/represent/quality.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/quality.rs
@@ -80,6 +80,16 @@ pub struct QualityGate {
     /// every claim that ever cited it, so it arrives with a new id.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub covered_mass_min: Option<f64>,
+    /// Whether this gate requires the bank's numbers to have been
+    /// measured over the model's OWN activations.
+    ///
+    /// `None` means the gate does not judge the substrate — appropriate
+    /// for a mechanism gate. `Some(true)` means a synthetic or unstated
+    /// substrate fails, which is what any gate carrying a MAGNITUDE must
+    /// set. There is deliberately no `Some(false)`-means-forbidden case:
+    /// a gate never demands a synthetic substrate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_model_activations: Option<bool>,
 }
 
 /// What the bank measured about the output distribution.
@@ -206,6 +216,12 @@ pub struct QualityBank {
     /// by gates that ask for it — see [`kimi_logit_v2`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_covered_mass: Option<f64>,
+    /// **Where the activations behind every number above came from.**
+    ///
+    /// Optional so older records deserialize, but absence is refused by
+    /// any gate that asks — see [`Criterion::ActivationAuthority`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activations: Option<super::activation::ActivationSource>,
     /// **How close the top-10 orderings that changed actually were.**
     ///
     /// The baseline's rank-10-minus-rank-11 logit gap at each position
@@ -269,6 +285,13 @@ pub enum Criterion {
     /// gets `None` must fail rather than assume the truncation was
     /// wide enough.
     CoveredMass,
+    /// The bank did not say where its activations came from, or said
+    /// they were synthetic. A gate that asks for model activations and
+    /// gets either must fail: a synthetic substrate may prove mechanism
+    /// and fire controls, never a magnitude, and an unstated one is
+    /// indistinguishable from a synthetic one. See
+    /// [`super::activation`].
+    ActivationAuthority,
 }
 
 impl Criterion {
@@ -283,6 +306,7 @@ impl Criterion {
             Criterion::TopKDisplacement => "top10_mass_displaced",
             Criterion::RouteDisplacement => "route_mixture_mass",
             Criterion::CoveredMass => "min_covered_mass",
+            Criterion::ActivationAuthority => "activations",
         }
     }
 }
@@ -410,6 +434,13 @@ impl QualityGate {
                 )),
                 Some(got) if got <= limit => {}
                 Some(got) => failures.push((criterion, format!("{what} {got:.4} > {limit:.4}"))),
+            }
+        }
+        if self.require_model_activations == Some(true) {
+            if let Some(refusal) =
+                super::activation::refuse_unless_model_execution(bank.activations.as_ref())
+            {
+                failures.push((Criterion::ActivationAuthority, refusal.to_string()));
             }
         }
         if let Some(required) = self.covered_mass_min {
@@ -676,6 +707,13 @@ pub fn kimi_logit_v1() -> QualityGate {
         route_flip_max: Some(82),
         // v1 does not ask about coverage. See `kimi_logit_v2`.
         covered_mass_min: None,
+        // Nor about the substrate. These gates predate
+        // ACTIVATION-AUTHORITY-1; their banks were real, but the record
+        // does not SAY so, and a gate is not permitted to assume it.
+        // A new gate id is required to start judging it — changing a
+        // threshold under an existing id is what the id exists to
+        // prevent.
+        require_model_activations: None,
         // Nor about consequence. See `kimi_logit_v3`.
         top1_mass_displaced_max: None,
         top10_mass_displaced_p99_max: None,
@@ -710,6 +748,7 @@ pub fn kimi_logit_v2() -> QualityGate {
     QualityGate {
         id: "kimi-logit-v2".into(),
         covered_mass_min: Some(0.60),
+        require_model_activations: None,
         ..kimi_logit_v1()
     }
 }
@@ -807,6 +846,7 @@ pub fn kimi_logit_balanced_v1() -> QualityGate {
         id: "kimi-logit-balanced-v1".into(),
         kl_p99_max: 3.5e-3,
         covered_mass_min: Some(0.55),
+        require_model_activations: None,
         top1_mass_displaced_max: Some(0.12),
         top10_mass_displaced_p99_max: Some(0.12),
         ..kimi_logit_v3()

--- a/crates/larql-vindex/src/format/vindex3/represent/quality_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/quality_tests.rs
@@ -4,6 +4,7 @@ use super::*;
 
 fn gate() -> QualityGate {
     QualityGate {
+        require_model_activations: None,
         id: "kimi-logit-v1".into(),
         positions_min: 512,
         kl_p99_max: 1e-3,
@@ -20,6 +21,7 @@ fn gate() -> QualityGate {
 
 fn clean_bank() -> QualityBank {
     QualityBank {
+        activations: None,
         positions: 512,
         logits: LogitEvidence {
             kl_p50: 4.0e-5,
@@ -67,6 +69,7 @@ fn the_same_bank_passes_one_gate_and_fails_a_tighter_one() {
     let bank = clean_bank();
     assert!(gate().evaluate(&bank).passed());
     let tighter = QualityGate {
+        require_model_activations: None,
         id: "kimi-logit-v2".into(),
         kl_p99_max: 1e-4,
         top10_change_max: Some(0),
@@ -178,6 +181,7 @@ fn kimi_logit_v1_is_frozen() {
 
 fn null_bank() -> QualityBank {
     QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 0.0,
@@ -258,6 +262,7 @@ fn v2_changes_only_the_coverage_criterion() {
 #[test]
 fn v2_refuses_a_bank_whose_kl_is_blind_to_the_distribution() {
     let perfect = QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 0.0,
@@ -353,6 +358,7 @@ fn v3_passes_marginal_churn_and_fails_material_displacement() {
     // probability, 232 top-10 changes moving 0.33 % one rank, no
     // routing change at all.
     let marginal = QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 2.2e-5,
@@ -428,6 +434,7 @@ fn v3_passes_marginal_churn_and_fails_material_displacement() {
 #[test]
 fn v3_refuses_unmeasured_consequence_but_not_an_absent_one() {
     let base = QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 0.0,
@@ -507,6 +514,7 @@ fn the_report_names_authority_and_diagnostics_separately() {
     let evidence = QualityEvidence {
         gate: kimi_logit_v3(),
         bank: QualityBank {
+            activations: None,
             positions: 8192,
             logits: LogitEvidence {
                 kl_p50: 1e-5,
@@ -601,6 +609,7 @@ fn dist(p99: f64, max: f64) -> Distribution {
 /// One calibration anchor's authority-scale evidence.
 fn anchor_bank(kl_p99: f64, top1_max: f64, top10_p99: f64, covered: f64) -> QualityBank {
     QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: kl_p99 / 100.0,

--- a/crates/larql-vindex/src/format/vindex3/represent/selection/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/selection/tests.rs
@@ -48,6 +48,7 @@ fn with_quality_bank(mut c: RepresentationExperiment) -> RepresentationExperimen
     use crate::format::vindex3::represent::quality::*;
     c.quality = Some(QualityEvidence {
         gate: QualityGate {
+            require_model_activations: None,
             id: "kimi-logit-v1".into(),
             positions_min: 512,
             kl_p99_max: 1e-3,
@@ -61,6 +62,7 @@ fn with_quality_bank(mut c: RepresentationExperiment) -> RepresentationExperimen
             route_mixture_mass_max: None,
         },
         bank: QualityBank {
+            activations: None,
             positions: 512,
             logits: LogitEvidence {
                 kl_p50: 1.2e-4,

--- a/crates/larql-vindex/src/format/vindex3/represent/state/candidate_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/candidate_tests.rs
@@ -141,6 +141,7 @@ fn intent(scale: EvidenceScale) -> MeasurementIntent {
 
 fn observation() -> QualityBank {
     QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 0.0,

--- a/crates/larql-vindex/src/format/vindex3/represent/state/fixtures.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/fixtures.rs
@@ -118,6 +118,7 @@ pub fn dist(p99: f64, max: f64) -> Option<Distribution> {
 /// sitting well inside their limits.
 pub fn authority_reading(kl_p99: f64, route_flips: u64) -> QualityBank {
     QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 0.0,

--- a/crates/larql-vindex/src/format/vindex3/represent/state/key_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/key_tests.rs
@@ -102,6 +102,7 @@ fn dist(p99: f64) -> Option<Distribution> {
 
 fn observation(kl_p99: f64) -> QualityBank {
     QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 0.0,

--- a/crates/larql-vindex/src/format/vindex3/represent/state/replay_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/replay_tests.rs
@@ -204,6 +204,7 @@ fn reading(kl_p99: f64) -> QualityBank {
         })
     };
     QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 0.0,

--- a/crates/larql-vindex/src/format/vindex3/represent/state/search_policy_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/search_policy_tests.rs
@@ -676,6 +676,7 @@ fn observation(kl_p99: f64) -> QualityBank {
         })
     };
     QualityBank {
+        activations: None,
         positions: 8192,
         logits: LogitEvidence {
             kl_p50: 0.0,


### PR DESCRIPTION
## What this is

A quality bank is a set of numbers measured while *something* was fed through the model. What that something was decides whether the numbers mean anything — and nothing in `QualityBank` recorded it.

## Why

Three substrate errors in one programme, each invisible to every other field on the record:

| substrate error | direction | size |
|---|---|---|
| synthetic **weights** instead of trained ones | optimistic | **10.6x** |
| synthetic **input scale**, on a scale-sensitive operator | pessimistic | **2.5x** |
| uniform-random vocabulary ids instead of natural text | optimistic | 1.2–1.3x |

They do not err in a predictable direction, so *"synthetic is conservative"* is not available as a defence. Two of them reversed a **conclusion**, not just a number: the first made a representation look adequate; the second made one look RED that passes on real activations.

## The rule, made structural

> A synthetic substrate may prove mechanism and fire controls. It may never establish a magnitude or an admission.

Modelled on `Provenance::native_kernel`, which already gates throughput claims the same way — a fact about *how* a number was produced, checked before the number may justify anything.

```rust
ActivationSource::{ Synthetic { note }, ModelExecution(ActivationAuthority) }
ActivationAuthority { checkpoint, operator_boundary, layer, bank, bank_digest, role }
BankRole::{ Calibration, Holdout }
```

`operator_boundary` is named exactly and is not decoration: comparing against a layer's input stream rather than the operator's own post-norm input differed by **10x** on a real model, and reading one as the other produced a scale claim wrong by an order of magnitude.

## Absence is not permission

`QualityBank.activations` is optional so existing records deserialize, but a gate that asks for model activations and finds `None` **fails** — the same contract as `Criterion::CoveredMass`. An unstated substrate is indistinguishable from a synthetic one, and the two refusals are reported apart because they call for different fixes.

A gate may still decline to judge: `require_model_activations: None` is a mechanism gate, and a synthetic bank passes it. **The authority the claim requires decides what substrate is admissible** — the system does not say "synthetic bad".

## Existing gates are left at `None` deliberately

Their banks were real, but the *record* does not say so, and a gate may not assume it. Starting to judge the substrate requires a new gate id — which is what the id is for.

## Verification

Gates run against **this exact commit** in a clean worktree, not the branch it was extracted from:

- `cargo fmt --all --check` — clean
- `cargo clippy -p larql-vindex --all-targets -- -D warnings` — clean
- `cargo test -p larql-vindex` — 4,527 lib tests, 0 failures
- coverage policy — 93.56% total, 445 files

Per-file: `activation.rs` **100.00%**, `bank.rs` 100.00%, `quality.rs` 97.89%. No debt baseline added.

8 focused tests, including that a mechanism gate still accepts a synthetic bank — without which the criterion would be unavoidable rather than declared.
