### PR TITLE
feat(represent): co-execution — batch execution without batching identity

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/represent/state.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state.rs
@@ -77,6 +77,7 @@ pub mod assess;
 pub mod authority;
 pub mod bind;
 pub mod candidate;
+pub mod coexecution;
 pub mod evidence_bank;
 pub mod footprint;
 pub mod graph;

--- a/crates/larql-vindex/src/format/vindex3/represent/state/coexecution.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/coexecution.rs
@@ -1,0 +1,209 @@
+//! **Measuring several already-identified experiments together.**
+//!
+//! Eight representation candidates traversed a 45-layer MoE and expanded
+//! the materialised expert set by only **1.08x** against a single
+//! candidate, flat across all 42 sparse layers. Scientifically that was
+//! eight experiments; physically it was one traversal. This module is
+//! that separation and nothing else.
+//!
+//! ## Frozen scope
+//!
+//! > **It batches EXECUTION. It does not batch scientific identity, and
+//! > it does not choose which experiments should exist.**
+//!
+//! Three things it deliberately does not do, each because doing it would
+//! damage an abstraction that is already correct:
+//!
+//! - **No population measurement key.** [`MeasurementKey`] is one
+//!   physical state + bank + scale + instrument, and its whole job is to
+//!   say *this observation belongs to this state under these query
+//!   conditions*. A key naming several states would make that sentence
+//!   false. Members keep their own keys, unchanged, and the registry
+//!   records N observations exactly as it would have.
+//! - **No candidate selection.** Deciding that eight candidates should be
+//!   measured *before* any of their results are incorporated is a change
+//!   to SEARCH SEMANTICS, not an execution detail: adaptive best-first
+//!   would have let evidence from A retire B unmeasured. Batch width and
+//!   population policy belong in a registered search policy if evidence
+//!   ever shows population search beats sequential. This module takes the
+//!   set it is given.
+//! - **No sharing assumption.** How much work a batch actually shared is
+//!   recorded by [`SharingLedger`] as an observation. The 1.08x above is
+//!   one model on one prompt; nothing here treats it as a constant.
+//!
+//! ## The falsifier
+//!
+//! > **If co-executing A and B changes either one's key, evidence, or
+//! > registry semantics compared with executing them separately, the
+//! > abstraction is wrong.**
+//!
+//! That is what `coexecution_tests` asserts, rather than asserting that
+//! batching is faster.
+//!
+//! ## One boundary to hold when performance evidence arrives
+//!
+//! Batch context must not affect QUALITY identity — that is the property
+//! above. It may well affect THROUGHPUT: an eight-member batch has
+//! different dispatch and materialisation economics from an isolated
+//! run, and a latency measured inside one is not a latency measured
+//! alone.
+//!
+//! **That difference belongs to the physical/performance observation or
+//! to realization qualification — never to [`MeasurementKey`].** Adding
+//! batch width to the key would make two quality readings of one state
+//! different experiments because of how they were scheduled, which is
+//! exactly the collapse this module exists to prevent. Nothing here
+//! records timing for that reason.
+
+use std::collections::BTreeSet;
+
+use super::key::MeasurementKey;
+
+/// Why a set of requests cannot share one execution.
+///
+/// Co-execution is only sound when the members differ *in the state
+/// being measured* and agree on everything describing the query. Two
+/// requests over different banks are two different bodies of data and
+/// share no traversal; batching them would either measure one against
+/// the other's inputs or silently run twice under one name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BatchRefusal {
+    /// Nothing to execute. Refused rather than returning an empty batch,
+    /// because an empty batch that "succeeds" reads downstream as a
+    /// completed measurement of nothing.
+    Empty,
+    MixedBank,
+    MixedScale,
+    MixedInstrument,
+    /// The same state twice. Its observation would be recorded twice
+    /// under one key, which the registry cannot distinguish from a
+    /// repeated measurement.
+    DuplicateState,
+}
+
+impl std::fmt::Display for BatchRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            BatchRefusal::Empty => "no requests to co-execute",
+            BatchRefusal::MixedBank => {
+                "requests span different evidence banks; they share no traversal"
+            }
+            BatchRefusal::MixedScale => {
+                "requests span diagnostic and authority scales; one run cannot be both"
+            }
+            BatchRefusal::MixedInstrument => {
+                "requests span different instrument semantics; one run cannot answer both"
+            }
+            BatchRefusal::DuplicateState => {
+                "the same representation state appears twice; its observation would be \
+                 recorded twice under one key"
+            }
+        };
+        f.write_str(s)
+    }
+}
+
+/// A set of measurement requests that may share one physical execution.
+///
+/// Holds keys, never states: assembling a batch must be unable to alter
+/// what any member is measuring.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionBatch {
+    members: Vec<MeasurementKey>,
+}
+
+impl ExecutionBatch {
+    /// Decide whether these already-authorised requests are physically
+    /// co-executable. **Does not decide whether they should exist.**
+    pub fn assemble(requests: Vec<MeasurementKey>) -> Result<Self, BatchRefusal> {
+        let first = requests.first().ok_or(BatchRefusal::Empty)?;
+        for r in &requests[1..] {
+            if r.bank() != first.bank() {
+                return Err(BatchRefusal::MixedBank);
+            }
+            if r.scale() != first.scale() {
+                return Err(BatchRefusal::MixedScale);
+            }
+            if r.instrument() != first.instrument() {
+                return Err(BatchRefusal::MixedInstrument);
+            }
+        }
+        let distinct: BTreeSet<_> = requests.iter().map(|r| r.state()).collect();
+        if distinct.len() != requests.len() {
+            return Err(BatchRefusal::DuplicateState);
+        }
+        Ok(Self { members: requests })
+    }
+
+    /// The members, keys unchanged and in the order given.
+    pub fn members(&self) -> &[MeasurementKey] {
+        &self.members
+    }
+
+    pub fn len(&self) -> usize {
+        self.members.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.members.is_empty()
+    }
+}
+
+/// **What a batch actually shared** — measured, never assumed.
+///
+/// `units` is whatever the executor materialises and can count: routed
+/// experts fetched, tensors bound, bytes read. The ledger does not know
+/// which, on purpose, because the saving is the same shape whatever the
+/// unit is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SharingLedger {
+    pub members: usize,
+    /// Units each member would have materialised alone, summed.
+    pub units_if_isolated: u64,
+    /// Units the batch actually materialised.
+    pub units_materialised: u64,
+}
+
+impl SharingLedger {
+    /// Materialised units against what ONE member would have cost.
+    ///
+    /// This is the number worth reporting: 1.0 means the batch was free
+    /// beyond a single member, `members` means it shared nothing. It is
+    /// undefined for an empty batch and for a batch whose members
+    /// materialise nothing, and returns `None` rather than a ratio in
+    /// both cases.
+    pub fn amplification_vs_one(&self) -> Option<f64> {
+        if self.members == 0 || self.units_if_isolated == 0 {
+            return None;
+        }
+        let per_member = self.units_if_isolated as f64 / self.members as f64;
+        Some(self.units_materialised as f64 / per_member)
+    }
+
+    /// Fraction of isolated cost avoided.
+    pub fn saving(&self) -> Option<f64> {
+        if self.units_if_isolated == 0 {
+            return None;
+        }
+        Some(1.0 - self.units_materialised as f64 / self.units_if_isolated as f64)
+    }
+
+    /// One line for a search trace.
+    pub fn describe(&self) -> String {
+        match (self.amplification_vs_one(), self.saving()) {
+            (Some(a), Some(s)) => format!(
+                "{} members: materialised {} of {} isolated units — {a:.2}x one member, \
+                 {:.1}% saved",
+                self.members,
+                self.units_materialised,
+                self.units_if_isolated,
+                s * 100.0
+            ),
+            _ => format!("{} members: nothing materialised", self.members),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "coexecution_tests.rs"]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/state/coexecution_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/coexecution_tests.rs
@@ -1,0 +1,129 @@
+//! **The falsifier: batching must be invisible to identity and evidence.**
+//!
+//! These assert that co-execution changes nothing observable — NOT that
+//! it is faster. Speed is what the ledger reports; soundness is what
+//! makes reporting it legitimate.
+
+use super::super::super::measurement::EvidenceScale;
+use super::super::fixtures;
+use super::*;
+
+fn keys(scale: EvidenceScale) -> Vec<MeasurementKey> {
+    [
+        fixtures::p(),
+        fixtures::t1(),
+        fixtures::s2(),
+        fixtures::s1(),
+    ]
+    .iter()
+    .map(|s| fixtures::key_for(s, scale))
+    .collect()
+}
+
+/// **THE property.** Assembling a batch leaves every member's key
+/// bit-identical to the key it would have had alone, in the same order.
+#[test]
+fn batching_does_not_change_any_members_identity() {
+    let alone = keys(EvidenceScale::Authority);
+    let batch = ExecutionBatch::assemble(alone.clone()).expect("co-executable");
+    assert_eq!(batch.members(), alone.as_slice());
+    assert_eq!(batch.len(), 4);
+    // and each digest individually, so a reordering could not pass
+    for (b, a) in batch.members().iter().zip(&alone) {
+        assert_eq!(b.as_str(), a.as_str());
+        assert_eq!(b.state(), a.state());
+        assert_eq!(b.bank(), a.bank());
+        assert_eq!(b.scale(), a.scale());
+        assert_eq!(b.instrument(), a.instrument());
+    }
+}
+
+/// A batch spanning two evidence SCALES is refused: one run cannot be
+/// both a diagnostic and an authority reading, and the ladder is built
+/// on their being different experiments.
+#[test]
+fn requests_at_different_scales_are_not_co_executable() {
+    let two = vec![
+        fixtures::key_for(&fixtures::p(), EvidenceScale::Authority),
+        fixtures::key_for(&fixtures::t1(), EvidenceScale::Diagnostic),
+    ];
+    assert_eq!(ExecutionBatch::assemble(two), Err(BatchRefusal::MixedScale));
+}
+
+/// The same state twice would be recorded twice under one key, which the
+/// registry cannot tell from a repeated measurement.
+#[test]
+fn a_repeated_state_is_refused() {
+    let p = fixtures::key_for(&fixtures::p(), EvidenceScale::Authority);
+    assert_eq!(
+        ExecutionBatch::assemble(vec![p.clone(), p]),
+        Err(BatchRefusal::DuplicateState)
+    );
+}
+
+/// An empty batch is refused rather than succeeding vacuously — a batch
+/// that "completes" with no members reads downstream as a measurement.
+#[test]
+fn an_empty_batch_is_refused() {
+    assert_eq!(ExecutionBatch::assemble(vec![]), Err(BatchRefusal::Empty));
+    for r in [
+        BatchRefusal::Empty,
+        BatchRefusal::MixedBank,
+        BatchRefusal::MixedScale,
+        BatchRefusal::MixedInstrument,
+        BatchRefusal::DuplicateState,
+    ] {
+        assert!(!r.to_string().is_empty(), "every refusal must say why");
+    }
+}
+
+/// A single request is a legal batch of one. The abstraction must not
+/// require a population to be usable, or the executor grows a second
+/// path for the ordinary case.
+#[test]
+fn one_request_is_a_legal_batch() {
+    let one = vec![fixtures::key_for(&fixtures::p(), EvidenceScale::Authority)];
+    let b = ExecutionBatch::assemble(one.clone()).expect("batch of one");
+    assert_eq!(b.members(), one.as_slice());
+}
+
+/// The ledger reports what was shared, and is undefined rather than
+/// misleading when there is nothing to divide by.
+#[test]
+fn the_sharing_ledger_reports_amplification_against_one_member() {
+    // The GLM shape: 8 arms, 53 experts materialised where 8 isolated
+    // traversals would have touched 8 x 53-ish.
+    let l = SharingLedger {
+        members: 8,
+        units_if_isolated: 8 * 49,
+        units_materialised: 53,
+    };
+    let amp = l.amplification_vs_one().expect("defined");
+    assert!((amp - 53.0 / 49.0).abs() < 1e-12, "{amp}");
+    assert!(amp > 1.0 && amp < 1.2, "expected ~1.08x, got {amp}");
+    let saved = l.saving().expect("defined");
+    assert!(
+        saved > 0.85,
+        "8 arms for 1.08x should save >85%, got {saved}"
+    );
+    assert!(l.describe().contains("8 members"));
+
+    // Shared nothing: amplification equals the member count.
+    let none = SharingLedger {
+        members: 4,
+        units_if_isolated: 40,
+        units_materialised: 40,
+    };
+    assert!((none.amplification_vs_one().expect("defined") - 4.0).abs() < 1e-12);
+    assert_eq!(none.saving(), Some(0.0));
+
+    // Nothing materialised: no ratio is reported rather than 0 or NaN.
+    let empty = SharingLedger {
+        members: 0,
+        units_if_isolated: 0,
+        units_materialised: 0,
+    };
+    assert_eq!(empty.amplification_vs_one(), None);
+    assert_eq!(empty.saving(), None);
+    assert!(empty.describe().contains("nothing materialised"));
+}


### PR DESCRIPTION
## What this is

Eight representation candidates traversed a 45-layer MoE and expanded the materialised expert set by only **1.08x** against a single candidate, flat across all 42 sparse layers. Scientifically that was eight experiments; physically it was one traversal.

This is that separation, and nothing else.

> **It batches EXECUTION. It does not batch scientific identity, and it does not choose which experiments should exist.**

## Three things it deliberately does not do

**No population measurement key.** `MeasurementKey` is one physical state + bank + scale + instrument, and its whole job is to say *this observation belongs to this state under these query conditions*. A key naming several states would make that sentence false. Members keep their own keys, unchanged; the registry records N observations exactly as it would have.

**No candidate selection.** Deciding that eight candidates should be measured *before* any of their results are incorporated is a change to **search semantics**, not an execution detail — adaptive best-first would have let evidence from A retire B unmeasured. Batch width and population policy belong in a registered search policy if evidence ever shows population search beats sequential. This takes the set it is given and cannot enlarge it.

**No sharing assumption.** How much a batch actually shared is recorded by `SharingLedger` as an observation. The 1.08x is one model on one prompt; nothing here treats it as a constant.

## Refusals, each with its reason

| refusal | why |
|---|---|
| mixed banks | different data — they share no traversal |
| **mixed scales** | one run cannot be both a diagnostic and an authority reading, and diagnostic→authority escalation depends on those being different observations |
| mixed instruments | one run cannot answer both |
| duplicate state | its observation would be recorded twice under one key |
| empty | a batch that "completes" with no members reads downstream as a measurement |

A batch of **one** is legal, so the executor does not grow a second path for the ordinary case.

## The falsifier

> If co-executing A and B changes either one's key, evidence, or registry semantics compared with executing them separately, the abstraction is wrong.

That is what the tests assert — not that batching is faster. The load-bearing test checks every member's key is bit-identical (digest, state, bank, scale, instrument, order) to what it would have been alone. Speed is what the ledger reports; soundness is what makes reporting it legitimate.

## One boundary recorded for later

Batch context may well affect **throughput**. That belongs to the physical observation or to realization qualification — **never** to `MeasurementKey`. Batch width in the key would make two quality readings of one state different experiments because of how they were scheduled, which is the collapse this exists to prevent. Nothing here records timing, for that reason.

## Verification

Gates run against **this exact commit** in a clean worktree, and `activation.rs` from #455 is absent from it — so this is independent, not stacked:

- `cargo fmt --all --check` — clean
- `cargo clippy -p larql-vindex --all-targets -- -D warnings` — clean
- `cargo test -p larql-vindex --lib` — 4,525 passed, 0 failed
- coverage policy — 93.56% total; `coexecution.rs` **91.23%**, above the floor with no debt baseline
