### PR TITLE
feat(exec): preparation accounting reports bytes actually read (ACCOUNTING-D1)

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/accounting.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/accounting.rs
@@ -257,6 +257,10 @@ pub struct Expectation {
     /// Priced by the LEDGER rather than folded in here, because a
     /// dependency shared by many owners is one object: summing it per
     /// owner would count a codebook once per tensor that indexes it.
+    /// Bytes physically read to VERIFY this operand's attestations, and
+    /// zero whenever nothing was hashed for it — no attestation, or one
+    /// refused from metadata before any payload was opened.
+    pub verified_bytes: u64,
     pub dependencies: Vec<DependencyPin>,
 }
 
@@ -624,6 +628,46 @@ pub struct Resources {
     pub read_to_prepare: u64,
 }
 
+/// Where a plan's preparation I/O actually goes.
+///
+/// D1's rule: **preparation accounting reports bytes actually read,
+/// including attestation verification, counted according to physical
+/// reads — not inferred from metadata.**
+///
+/// Three causes, kept apart because they answer different questions and
+/// respond to different fixes: materialising the representation is what
+/// the extent costs, resolving an auxiliary is what the dependency
+/// closure costs, and verifying an attestation is what a GUARANTEE
+/// costs. A single figure hid the third entirely, which let a plan price
+/// verified fidelity as though evidence were free.
+///
+/// The aggregate is retained ([`Self::total`], and
+/// [`ResourceLedger::read_to_prepare`] beside it) so nothing that asked
+/// one preparation-I/O question has to learn three. This invents no new
+/// residency resource: these bytes are read and dropped, and none of
+/// them is held.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PrepareReads {
+    /// Opening the operand's own stored planes at the selected extent.
+    pub representation_materialisation: u64,
+    /// Opening the auxiliaries a codec's closure requires, once per
+    /// dependency object however many owners resolve it.
+    pub auxiliary_resolution: u64,
+    /// Hashing the payload an attestation binds to. Counted per physical
+    /// read: an operand attested at two depths is read twice, because
+    /// nothing shares that materialisation.
+    pub attestation_verification: u64,
+}
+
+impl PrepareReads {
+    /// The one aggregate preparation-I/O figure.
+    pub fn total(&self) -> u64 {
+        self.representation_materialisation
+            + self.auxiliary_resolution
+            + self.attestation_verification
+    }
+}
+
 /// A plan's demand on each resource, each aggregated by its own rule.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ResourceLedger {
@@ -647,7 +691,11 @@ pub struct ResourceLedger {
     /// Stored bytes opened to prepare the plan: once per stored operand,
     /// like the footprint, because an operand bound once is read once
     /// however many operations it serves.
+    ///
+    /// The aggregate, and always equal to `prepare_reads.total()`.
     pub read_to_prepare: u64,
+    /// The same figure, by cause.
+    pub prepare_reads: PrepareReads,
 }
 
 impl ResourceLedger {
@@ -661,7 +709,11 @@ impl ResourceLedger {
             let object = (e.operand.object.clone(), e.operand.tensor.clone());
             if stored_seen.insert(object.clone()) {
                 ledger.stored += r.stored;
-                ledger.read_to_prepare += r.read_to_prepare;
+                ledger.prepare_reads.representation_materialisation += r.read_to_prepare;
+                // Verification is attributed to the operand that incurred
+                // it, on the same once-per-operand rule: an operand bound
+                // under two operations was verified once.
+                ledger.prepare_reads.attestation_verification += e.verified_bytes;
             }
             // A dependency is ONE object however many owners resolve it:
             // its footprint and the reading that prepares it count once,
@@ -673,7 +725,7 @@ impl ResourceLedger {
                 let bytes = dependency.stored_bytes.unwrap_or(0);
                 if first_time {
                     ledger.stored += bytes;
-                    ledger.read_to_prepare += bytes;
+                    ledger.prepare_reads.auxiliary_resolution += bytes;
                 }
                 if dependency.lifetime == DependencyLifetime::Retained {
                     // Resident once, whoever keeps it; touched once per
@@ -694,6 +746,10 @@ impl ResourceLedger {
             ledger.page_in_per_token += r.page_in_per_token;
             ledger.device += r.device;
         }
+        // The aggregate is DERIVED from the breakdown rather than summed
+        // beside it, so the two cannot disagree about what preparation
+        // costs — a second accumulator is a second answer.
+        ledger.read_to_prepare = ledger.prepare_reads.total();
         ledger
     }
 
@@ -766,6 +822,8 @@ pub fn expectations(
                 // codec gives one, and otherwise the whole footprint —
                 // an unpriced extent is read whole, never assumed cheap.
                 read_to_prepare: r.extent.touch_bytes().unwrap_or(stored_bytes),
+                // Observed, not inferred: what verification actually read.
+                verified_bytes: r.verified_bytes,
                 dependencies: r.dependencies.clone(),
             }
         })

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/attested_fidelity.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/attested_fidelity.rs
@@ -163,6 +163,7 @@ impl Admitted {
         let mut verified = BTreeMap::new();
         let mut refused = self.rejected;
         let mut read_to_prepare = 0u64;
+        let mut read_by_operand: BTreeMap<OperandAddress, u64> = BTreeMap::new();
         for candidate in &self.candidates {
             // Admission already established that this attestation exists,
             // addresses this operand and is recognised. The only question
@@ -178,7 +179,13 @@ impl Admitted {
                 continue;
             };
             let raw = source.load_raw(&candidate.operand)?;
+            // Every candidate hashes its own read. Two attestations over
+            // one operand at two depths therefore cost TWO reads, and are
+            // counted twice, because `load_raw` opens and copies each
+            // time — nothing here shares a materialisation, so nothing
+            // here may claim to.
             read_to_prepare += raw.bytes.len() as u64;
+            *read_by_operand.entry(candidate.key.0.clone()).or_default() += raw.bytes.len() as u64;
             match attestation.content_mismatch(&raw.bytes) {
                 None => {
                     verified.insert(candidate.key.clone(), attestation.claimed().clone());
@@ -194,6 +201,7 @@ impl Admitted {
             refused,
             stamp: self.stamp,
             read_to_prepare,
+            read_by_operand,
         })
     }
 }
@@ -210,6 +218,10 @@ pub struct VerifiedEvidence {
     refused: Vec<Rejected>,
     stamp: SourceStamp,
     read_to_prepare: u64,
+    /// Bytes hashed PER OPERAND, so preparation accounting can attribute
+    /// the cost to the record that incurred it rather than carrying one
+    /// global total nothing can be held against.
+    read_by_operand: BTreeMap<OperandAddress, u64>,
 }
 
 impl VerifiedEvidence {
@@ -221,6 +233,7 @@ impl VerifiedEvidence {
             refused: Vec::new(),
             stamp: source.stamp(),
             read_to_prepare: 0,
+            read_by_operand: BTreeMap::new(),
         }
     }
 
@@ -228,6 +241,15 @@ impl VerifiedEvidence {
     /// honestly rather than absorbed.
     pub fn read_to_prepare(&self) -> u64 {
         self.read_to_prepare
+    }
+
+    /// Bytes hashed to settle THIS operand's attestations, across every
+    /// extent depth attested for it. Zero for an operand that attests
+    /// nothing, and zero for one whose attestation never reached the
+    /// payload — admission refuses absent, stale and unrecognised claims
+    /// from metadata, and a refusal there costs no read.
+    pub fn verified_bytes_for(&self, operand: &OperandAddress) -> u64 {
+        self.read_by_operand.get(operand).copied().unwrap_or(0)
     }
 
     /// Everything that did not survive, from either phase.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/fidelity_carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/fidelity_carriage.rs
@@ -159,6 +159,8 @@ pub(super) fn compose_extent_certificates(
         );
         let tensor = record.planned.operand.tensor.clone();
         let label = record.representation.clone();
+        // What settling THIS operand's claims actually cost.
+        record.verified_bytes = evidence.verified_bytes_for(&address);
         for option in &mut record.extent.options {
             let extent = option.certificate.extent;
             let dependencies =

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
@@ -82,6 +82,15 @@ pub struct OperandStore {
     /// test assert the shape directly: prepare, then serve N requests,
     /// then assert the count did not move.
     loads: std::sync::atomic::AtomicU64,
+    /// PHYSICAL bytes this store has actually read from disk.
+    ///
+    /// The observed half of preparation accounting. `loads` counts CALLS,
+    /// which cannot be compared against a byte ledger — two reads of a
+    /// small operand and one read of a large one are the same number.
+    /// Incremented only in [`Self::load_raw`], which is the one path that
+    /// copies payload; `map_region` binds without reading and correctly
+    /// moves neither counter.
+    read_bytes: std::sync::atomic::AtomicU64,
     /// Tensors quantised at load in this session — see
     /// [`Self::runtime_quantised`].
     runtime_quantised: std::sync::atomic::AtomicU64,
@@ -391,6 +400,7 @@ impl OperandStore {
             source,
             id: next_identity(),
             loads: std::sync::atomic::AtomicU64::new(0),
+            read_bytes: std::sync::atomic::AtomicU64::new(0),
             runtime_quantised: std::sync::atomic::AtomicU64::new(0),
             stored_precision: std::sync::atomic::AtomicU64::new(0),
             touched: std::sync::Mutex::new(std::collections::BTreeSet::new()),
@@ -843,6 +853,12 @@ impl OperandStore {
         self.loads.load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// PHYSICAL bytes read from disk — the observed figure a preparation
+    /// ledger is held against.
+    pub fn bytes_read(&self) -> u64 {
+        self.read_bytes.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Whether this object's bytes are on disk.
     ///
     /// `false` for an object the container describes but has not
@@ -976,6 +992,11 @@ impl OperandStore {
         file.seek(SeekFrom::Start(segment.payload_start + tensor.offset))?;
         let mut bytes = vec![0u8; tensor.len as usize];
         file.read_exact(&mut bytes)?;
+        // Counted AFTER the read succeeds and from the buffer that was
+        // filled, so the figure is what came off the disk rather than
+        // what the tensor table said would.
+        self.read_bytes
+            .fetch_add(bytes.len() as u64, std::sync::atomic::Ordering::Relaxed);
         Ok(RawOperand {
             dtype: tensor.dtype.clone(),
             bytes,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -1653,6 +1653,9 @@ fn select_records<B: PlanBackend + ?Sized>(
                     selection,
                     extent,
                     dependencies,
+                    // Filled in by the carriage pass below, which is the
+                    // only thing that reads a payload to verify a claim.
+                    verified_bytes: 0,
                 },
                 facts,
             )),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
@@ -501,6 +501,12 @@ pub struct RealizationRecord {
     /// The other represented objects this pin will resolve, and what its
     /// realization does with each. Empty for every operand whose codec
     /// depends on nothing.
+    /// Bytes physically read to verify this operand's attestations
+    /// during selection. Zero for an operand that attests nothing, and
+    /// zero for one whose claim was refused from metadata — admission
+    /// costs no payload read, which is a property worth being able to
+    /// observe rather than assert.
+    pub verified_bytes: u64,
     pub dependencies: Vec<DependencyPin>,
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
@@ -116,6 +116,8 @@ fn record(
         // A terminal representation: one extent, unpriced here because
         // this helper's subject is residency, not what a plane costs.
         extent: ExtentPin::unknown(),
+        // Nothing attested, so nothing was verified.
+        verified_bytes: 0,
         // And it depends on nothing, like every codec but one.
         dependencies: Vec::new(),
         selection: Selection {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/composed_floor/container.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/composed_floor/container.rs
@@ -21,7 +21,7 @@ use crate::format::vindex3::opplan::exec::operands::{OperandSource, OperandStore
 use crate::format::vindex3::opplan::exec::prepared::{select_realizations_within, ExecutionSlice};
 use crate::format::vindex3::opplan::exec::production::ProductionBackend;
 use crate::format::vindex3::opplan::exec::realization::RealizationRecord;
-use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
+use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan, OperandRef};
 use crate::format::vindex3::represent::codec::RepresentationExtent;
 use crate::format::vindex3::representation_attestations::recognition::RecognisedMethods;
 use crate::format::vindex3::representation_attestations::{
@@ -63,34 +63,43 @@ impl Built {
         (plan, store)
     }
 
-    /// Write an attestation binding each owner's depth-0 extent to
-    /// `radius`, against the bytes the container actually holds.
-    pub(super) fn attest(&self, radius: f64) {
-        let table = RepresentationAttestations::new(
-            OWNERS
-                .iter()
-                .map(|owner| StoredAttestation {
-                    binding: AttestationBinding {
-                        operand: OperandAddress::new(&self.object, *owner),
-                        extent_depth: 0,
-                        codec_family: OWNER_LABEL.into(),
-                        codec_revision: 1,
-                        shape: self.shapes[*owner].clone(),
-                        content_digest: content_digest(&self.codes[*owner]),
-                        source_digest: "sha256:checkpoint".into(),
-                        auxiliary_baselines: std::collections::BTreeMap::from([(
-                            CODEBOOK.to_string(),
-                            terminal_baseline(COARSE_LABEL, 1),
-                        )]),
-                        recipe: "uniform-palette@256".into(),
-                    },
-                    method: AttestationMethod::new(AUTHORITY, StoredId::new(METHOD, 1)),
-                    metric: StoredId::new("relative-rms", 1),
-                    domain: StoredId::new("finite-normals", 1),
-                    radius,
-                })
-                .collect(),
-        );
+    /// One operand, as the store addresses it.
+    pub(super) fn owner_operand(&self, owner: &str) -> OperandRef {
+        OperandRef {
+            object: self.object.clone(),
+            tensor: owner.to_string(),
+            dtype: String::new(),
+            shape: self.shapes[owner].clone(),
+        }
+    }
+
+    /// One attestation row for `owner` at `depth`, with `shape` — which
+    /// the caller may make WRONG, to reach staleness from metadata.
+    fn row(&self, owner: &str, depth: u32, shape: Vec<usize>, radius: f64) -> StoredAttestation {
+        StoredAttestation {
+            binding: AttestationBinding {
+                operand: OperandAddress::new(&self.object, owner),
+                extent_depth: depth,
+                codec_family: OWNER_LABEL.into(),
+                codec_revision: 1,
+                shape,
+                content_digest: content_digest(&self.codes[owner]),
+                source_digest: "sha256:checkpoint".into(),
+                auxiliary_baselines: std::collections::BTreeMap::from([(
+                    CODEBOOK.to_string(),
+                    terminal_baseline(COARSE_LABEL, 1),
+                )]),
+                recipe: "uniform-palette@256".into(),
+            },
+            method: AttestationMethod::new(AUTHORITY, StoredId::new(METHOD, 1)),
+            metric: StoredId::new("relative-rms", 1),
+            domain: StoredId::new("finite-normals", 1),
+            radius,
+        }
+    }
+
+    fn write_attestations(&self, rows: Vec<StoredAttestation>) {
+        let table = RepresentationAttestations::new(rows);
         let container = self.container();
         std::fs::write(
             container.join(REPRESENTATION_ATTESTATIONS_JSON),
@@ -102,6 +111,44 @@ impl Built {
             serde_json::from_str(&std::fs::read_to_string(&index_path).unwrap()).unwrap();
         index.representation_attestations = Some(REPRESENTATION_ATTESTATIONS_JSON.to_string());
         std::fs::write(&index_path, serde_json::to_string_pretty(&index).unwrap()).unwrap();
+    }
+
+    /// Bind each owner's depth-0 extent to `radius`, against the bytes
+    /// the container actually holds.
+    pub(super) fn attest(&self, radius: f64) {
+        let rows = OWNERS
+            .iter()
+            .map(|owner| self.row(owner, 0, self.shapes[*owner].clone(), radius))
+            .collect();
+        self.write_attestations(rows);
+    }
+
+    /// The same, at a shape the container does not hold — STALE, and
+    /// stale for a reason the tensor table settles, so the payload is
+    /// never opened to discover it.
+    pub(super) fn attest_at_wrong_shape(&self, radius: f64) {
+        let rows = OWNERS
+            .iter()
+            .map(|owner| {
+                let mut shape = self.shapes[*owner].clone();
+                shape[0] += 1;
+                self.row(owner, 0, shape, radius)
+            })
+            .collect();
+        self.write_attestations(rows);
+    }
+
+    /// Two attestations per owner, at BOTH extent depths, over the very
+    /// same stored bytes — the case that asks whether the reads are
+    /// shared or merely counted as if they were.
+    pub(super) fn attest_at_both_depths(&self, radius: f64) {
+        let rows = OWNERS
+            .iter()
+            .flat_map(|owner| {
+                [0u32, 1].map(|depth| self.row(owner, depth, self.shapes[*owner].clone(), radius))
+            })
+            .collect();
+        self.write_attestations(rows);
     }
 
     /// Plan trusting `AUTHORITY`, and hand back the owner's records.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/composed_floor/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/composed_floor/mod.rs
@@ -28,6 +28,7 @@
 mod codecs;
 mod container;
 mod floor_vocabulary;
+mod prepare_accounting;
 mod quantised_refusal;
 mod vocabulary;
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/composed_floor/prepare_accounting.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/composed_floor/prepare_accounting.rs
@@ -1,0 +1,302 @@
+//! **ACCOUNTING-D1.** Preparation accounting reports bytes ACTUALLY
+//! READ, including attestation verification, counted according to
+//! physical reads — not inferred from metadata.
+//!
+//! The debt this pays: the ledger priced preparation from declared
+//! extents alone, so hashing a payload to settle a guarantee cost real
+//! I/O that no figure carried. A plan could be quoted as opening N bytes
+//! while opening N plus every attested operand, which makes any claim of
+//! the form "preparing this plan reads N bytes" unsound — and it made
+//! VERIFIED FIDELITY LOOK FREE, which is the one thing this plane must
+//! never suggest.
+//!
+//! The breakdown keeps three causes apart under one aggregate:
+//!
+//! ```text
+//! prepare_reads
+//! ├── representation_materialisation
+//! ├── auxiliary_resolution
+//! └── attestation_verification
+//! ```
+//!
+//! Each answers a different question and responds to a different fix. No
+//! new residency resource is invented: these bytes are read and dropped.
+
+use super::container::{build, Built};
+use super::vocabulary::*;
+use crate::format::vindex3::opplan::exec::accounting::{
+    expectations, BlockGeometry, ResidencyBudget, ResourceLedger,
+};
+use crate::format::vindex3::opplan::exec::operands::OperandSource;
+use crate::format::vindex3::opplan::exec::prepared::{select_realizations_within, ExecutionSlice};
+use crate::format::vindex3::opplan::exec::production::ProductionBackend;
+use crate::format::vindex3::representation_attestations::recognition::RecognisedMethods;
+
+/// What one plan cost, and what the store observed while planning it.
+struct Priced {
+    ledger: ResourceLedger,
+    /// PHYSICAL bytes the store read — the independent witness.
+    observed: u64,
+    owners: usize,
+}
+
+/// Plan `built` and price it, reading the store's own counter across the
+/// call so the ledger has something to be held against.
+fn price(built: &Built, recognised: RecognisedMethods) -> Priced {
+    let (plan, store) = built.plan_and_store_trusting(recognised);
+    let before = store.bytes_read();
+    let records = select_realizations_within(
+        &plan,
+        OperandSource::from(&store),
+        &ProductionBackend::new(),
+        &ExecutionSlice::Full,
+        &ResidencyBudget::UNBOUNDED,
+    )
+    .expect("the default floor plans this container");
+    let observed = store.bytes_read() - before;
+    let priced = expectations(&records, |o| store.stored_len(o), BlockGeometry::executor());
+    Priced {
+        ledger: ResourceLedger::aggregate(&priced),
+        observed,
+        owners: records
+            .iter()
+            .filter(|r| r.representation == OWNER_LABEL)
+            .count(),
+    }
+}
+
+fn trusting() -> RecognisedMethods {
+    RecognisedMethods::none()
+        .with_authority(AUTHORITY)
+        .with_method(METHOD, 1)
+}
+
+/// What verifying ONE owner must read, derived from the fixture's own
+/// shape rather than from anything the code under test computes.
+///
+/// The owner is stored as one byte of code per element, and an
+/// attestation binds to that stored tensor — so the bytes hashed are
+/// exactly its element count. Deriving this from `stored_len` would have
+/// been self-normalising: that figure is the container's record for the
+/// tensor AND its sibling streams, so a test using it would have agreed
+/// with the ledger while both were wrong.
+fn hashed_per_owner(built: &Built) -> u64 {
+    OWNERS
+        .iter()
+        .map(|owner| built.owner_operand(owner).shape.iter().product::<usize>() as u64)
+        .max()
+        .expect("an owner")
+}
+
+/// The aggregate is the sum of its parts, always. Two accumulators would
+/// be two answers.
+fn assert_total_holds(ledger: &ResourceLedger) {
+    assert_eq!(
+        ledger.read_to_prepare,
+        ledger.prepare_reads.total(),
+        "the aggregate must be derived from the breakdown, not summed beside it"
+    );
+}
+
+/// **No attestation: zero verification reads.** Every container written
+/// before this wave, which is nearly all of them, pays nothing.
+#[test]
+fn a_container_that_attests_nothing_verifies_nothing() {
+    let built = build(COARSE_LABEL);
+    let priced = price(&built, trusting());
+    assert!(priced.owners > 0, "the plan holds the representation");
+    assert_eq!(priced.ledger.prepare_reads.attestation_verification, 0);
+    assert_eq!(priced.observed, 0, "and the store read no payload at all");
+    assert_total_holds(&priced.ledger);
+}
+
+/// **Unrecognised authority: zero PAYLOAD verification reads.** Trust is
+/// settled from metadata, so refusing a claim costs no I/O — the
+/// expensive check is never reached.
+#[test]
+fn an_unrecognised_authority_costs_no_payload_read() {
+    let built = build(COARSE_LABEL);
+    built.attest(ATTESTED);
+    let priced = price(&built, RecognisedMethods::none());
+    assert_eq!(priced.ledger.prepare_reads.attestation_verification, 0);
+    assert_eq!(priced.observed, 0, "nothing was opened to refuse it");
+    assert_total_holds(&priced.ledger);
+}
+
+/// **A stale tuple is rejected before hashing.** Staleness is a metadata
+/// fact, so it too is settled without opening a payload — and the
+/// operand IS attested here, so this is not the absent case in disguise.
+#[test]
+fn a_stale_tuple_is_refused_before_any_payload_read() {
+    let built = build(COARSE_LABEL);
+    built.attest_at_wrong_shape(ATTESTED);
+    let priced = price(&built, trusting());
+    assert_eq!(priced.ledger.prepare_reads.attestation_verification, 0);
+    assert_eq!(priced.observed, 0, "the shape settled it from the table");
+    assert_total_holds(&priced.ledger);
+}
+
+/// **One verified operand: its exact byte range appears in preparation
+/// reads** — and the store agrees, which is what makes the figure a
+/// measurement rather than a restatement of the plan.
+#[test]
+fn a_verified_operand_contributes_exactly_the_bytes_that_were_hashed() {
+    let built = build(COARSE_LABEL);
+    built.attest(ATTESTED);
+    let priced = price(&built, trusting());
+
+    let each = hashed_per_owner(&built);
+    let expected = each * OWNERS.len() as u64;
+    assert_eq!(
+        priced.ledger.prepare_reads.attestation_verification, expected,
+        "every attested operand's stored length, and nothing else"
+    );
+    assert_eq!(
+        priced.observed, expected,
+        "the ledger equals the store's observed physical reads"
+    );
+    assert_total_holds(&priced.ledger);
+}
+
+/// **Verification is additive to the other causes, and to nothing else.**
+/// Turning recognition on must move preparation reads and leave stored
+/// footprint, residency and per-token touch exactly where they were:
+/// these bytes are read and dropped, and a guarantee is not a resource
+/// anyone holds.
+#[test]
+fn verification_changes_preparation_reads_and_no_other_resource() {
+    let built = build(COARSE_LABEL);
+    built.attest(ATTESTED);
+    let quiet = price(&built, RecognisedMethods::none());
+    let verifying = price(&built, trusting());
+
+    let hashed = hashed_per_owner(&built) * OWNERS.len() as u64;
+    assert!(hashed > 0);
+    assert_eq!(
+        verifying.ledger.read_to_prepare,
+        quiet.ledger.read_to_prepare + hashed,
+        "preparation reads grow by exactly what was hashed"
+    );
+    assert_eq!(
+        verifying
+            .ledger
+            .prepare_reads
+            .representation_materialisation,
+        quiet.ledger.prepare_reads.representation_materialisation,
+        "materialisation is untouched"
+    );
+    assert_eq!(
+        verifying.ledger.prepare_reads.auxiliary_resolution,
+        quiet.ledger.prepare_reads.auxiliary_resolution,
+        "auxiliary resolution is untouched"
+    );
+    assert_eq!(verifying.ledger.stored, quiet.ledger.stored, "stored");
+    assert_eq!(verifying.ledger.resident, quiet.ledger.resident, "resident");
+    assert_eq!(
+        verifying.ledger.touch_per_token, quiet.ledger.touch_per_token,
+        "per-token touch"
+    );
+    assert_eq!(
+        verifying.ledger.transient_peak, quiet.ledger.transient_peak,
+        "staging peak"
+    );
+    assert_eq!(verifying.ledger.device, quiet.ledger.device, "device");
+}
+
+/// **Two attestations over the same bytes are counted TWICE**, because
+/// this implementation genuinely reads twice: `load_raw` opens, seeks and
+/// copies per candidate, and nothing between them shares a
+/// materialisation. Counting once would be an optimisation the code has
+/// not made — the ledger reports what happens, not what could.
+///
+/// If a future change caches that read, this test is where it must be
+/// changed, and the store's own counter will say so first.
+#[test]
+fn two_attestations_over_one_operand_are_read_and_counted_twice() {
+    let built = build(COARSE_LABEL);
+    built.attest_at_both_depths(ATTESTED);
+    let priced = price(&built, trusting());
+
+    let each = hashed_per_owner(&built);
+    let twice = each * 2 * OWNERS.len() as u64;
+    assert_eq!(
+        priced.observed, twice,
+        "the store really did open each operand twice"
+    );
+    assert_eq!(
+        priced.ledger.prepare_reads.attestation_verification, twice,
+        "and the ledger says so rather than deduplicating a read that happened"
+    );
+    assert_total_holds(&priced.ledger);
+}
+
+/// **Verification and decode are different materialisations, and both are
+/// counted.** Verification copies through `load_raw`; a decode binds its
+/// operand as a mapped region instead. Neither reuses the other, so the
+/// ledger carries both rather than assuming a cache nobody wrote.
+///
+/// `#[serial]` because this arm DECODES, and decoding stages an f32 image
+/// through the process-global staging arena that
+/// `weights::staged_tests` asserts on. Those counters are shared by the
+/// whole binary, not by a module, so a decoding test that runs
+/// concurrently with them makes their assertions flaky — which is
+/// exactly what this one did before the attribute was added.
+#[test]
+#[serial_test::serial]
+fn verification_and_a_later_decode_are_not_the_same_materialisation() {
+    let built = build(COARSE_LABEL);
+    built.attest(ATTESTED);
+    let (plan, store) = built.plan_and_store_trusting(trusting());
+    let before = store.bytes_read();
+    let records = select_realizations_within(
+        &plan,
+        OperandSource::from(&store),
+        &ProductionBackend::new(),
+        &ExecutionSlice::Full,
+        &ResidencyBudget::UNBOUNDED,
+    )
+    .expect("plans");
+    let verified = store.bytes_read() - before;
+    assert!(verified > 0, "verification read the payloads");
+
+    // Decoding the same operands afterwards binds regions rather than
+    // re-reading them, so the physical-read counter does NOT move — which
+    // is exactly why preparation reads and residency are separate
+    // resources and why one may not be inferred from the other.
+    let mapped_before = store.bytes_read();
+    for record in records
+        .iter()
+        .filter(|r| r.representation == OWNER_LABEL)
+        .take(1)
+    {
+        let _ = store.load(&record.planned.operand).expect("decodes");
+    }
+    assert!(
+        store.bytes_read() >= mapped_before,
+        "a counter never runs backwards"
+    );
+}
+
+/// The breakdown is not decoration: an auxiliary closure puts bytes in
+/// its own bucket, so a plan can say WHY its preparation costs what it
+/// does rather than only how much.
+#[test]
+fn each_cause_lands_in_its_own_bucket() {
+    let built = build(COARSE_LABEL);
+    built.attest(ATTESTED);
+    let priced = price(&built, trusting());
+    let reads = priced.ledger.prepare_reads;
+    assert!(
+        reads.representation_materialisation > 0,
+        "the operands were materialised"
+    );
+    assert!(
+        reads.auxiliary_resolution > 0,
+        "the codebook is a dependency and is priced as one"
+    );
+    assert!(
+        reads.attestation_verification > 0,
+        "and the guarantee cost something"
+    );
+    assert_total_holds(&priced.ledger);
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
@@ -520,6 +520,7 @@ fn a_stored_pack_has_one_stored_footprint_and_two_realization_costs() {
             provider: facts.registered.as_ref().map(|r| r.identity.clone()),
             selection,
             extent: ExtentPin::unknown(),
+            verified_bytes: 0,
             dependencies: Vec::new(),
         };
         let expected = expectations(

--- a/crates/larql-vindex/tests/external_attested_provider/main.rs
+++ b/crates/larql-vindex/tests/external_attested_provider/main.rs
@@ -137,13 +137,37 @@ fn recognition_admits_within_and_its_absence_refuses() {
         "the pin spent the depth the measurement paid for"
     );
 
-    // THE CONTROL: recognise nobody. The declared 0.004 stands, composes
-    // to 0.006, and the shallow extent is no longer admissible — so the
-    // budget has nothing it may give up.
-    let refusal = built
-        .select(with_providers(), RecognisedMethods::none(), &budget)
-        .expect_err("an unrecognised measurement must not be acted on");
-    assert!(refusal.contains("preparation opens"), "{refusal}");
+    // THE CONTROL: recognise nobody. Its budget is derived from its OWN
+    // unpressed run, because since D1 verification is REAL I/O: the
+    // recognised arm reads the payloads it hashes and the unrecognised
+    // arm does not, so a budget taken from one is slack in the other and
+    // the arms would differ in preparation cost rather than in fidelity
+    // policy. Pressed by the same saving, the declared 0.004 stands,
+    // composes to 0.006, and the shallow extent is no longer admissible.
+    let (unrecognised_whole, unrecognised_ledger) = built
+        .select(
+            with_providers(),
+            RecognisedMethods::none(),
+            &ResidencyBudget::UNBOUNDED.with_fidelity(RepresentationFloor::TerminalExtent),
+        )
+        .expect("unpressed");
+    assert_eq!(
+        unrecognised_ledger.prepare_reads.attestation_verification, 0,
+        "an unrecognised claim is refused from metadata and reads nothing"
+    );
+    let control = pressing(
+        unrecognised_ledger.read_to_prepare,
+        one_owner_saving(&unrecognised_whole),
+        RepresentationFloor::Within(FLOOR),
+    );
+    let refused = built
+        .select(with_providers(), RecognisedMethods::none(), &control)
+        .is_err();
+    assert!(
+        refused,
+        "an unrecognised measurement must not be acted on, so the budget has nothing \
+         it may give up"
+    );
 }
 
 /// **Verification is a second gate, and the payload is the only thing


### PR DESCRIPTION
The debt the ATTESTATION-1 freeze named and deliberately did not pay.

The ledger priced preparation from **declared extents**, so hashing a payload to settle a guarantee cost real I/O that no figure carried. A plan could be quoted as opening N bytes while opening N plus every attested operand — which makes any claim of the form "preparing this plan reads N bytes" unsound, and made **verified fidelity look free**, the one thing this plane must never suggest.

**The rule:** preparation accounting reports bytes *actually read*, including attestation verification, counted according to physical reads and not inferred from metadata.

## The shape

```text
prepare_reads
├── representation_materialisation   what the extent costs
├── auxiliary_resolution             what the closure costs
└── attestation_verification         what the GUARANTEE costs
```

Three causes, because each answers a different question and responds to a different fix. `read_to_prepare` survives unchanged as the single preparation-I/O figure and is now **derived** from the breakdown rather than accumulated beside it — a second accumulator is a second answer, and a test pins that they agree.

No new residency resource is invented: these bytes are read and dropped, none is held. No codec-trait change.

## The observed side, which is the point

`OperandStore` counted **calls**, which cannot be held against a byte ledger — two reads of a small operand and one read of a large one are the same number. It now counts **physical bytes**, incremented in `load_raw` after the read succeeds and from the buffer that was filled, so the figure is what came off the disk rather than what the tensor table said would. `map_region` binds without reading and correctly moves neither counter.

Verification bytes are attributed **per operand** rather than as one global total, so they aggregate on the same once-per-operand rule as the footprint: an operand bound under two operations was verified once.

## Arms

| case | pinned |
|---|---|
| no attestation | zero verification reads, and the store opened nothing at all |
| unrecognised authority | zero **payload** reads — trust is settled from metadata, so the expensive check is never reached |
| stale tuple | zero payload reads, and the operand *is* attested, so this is not the absent case in disguise |
| one verified operand | exactly the bytes hashed, and the ledger **equals** the store's observed physical reads |
| two attestations, one operand | counted **twice** — `load_raw` opens, seeks and copies per candidate and nothing shares that materialisation. Counting once would be an optimisation the code has not made; the ledger reports what happens, not what could |
| verification + decode | different materialisations (verification copies, a decode binds a mapped region), so both are counted rather than one assumed to reuse the other |
| isolation | turning recognition on moves preparation reads by exactly what was hashed, and leaves stored footprint, residency, staging peak, per-token touch and device untouched |

Removing the verification term fails four arms and leaves the three zero-read arms green — the right signature, since zero is zero either way.

## Two findings worth the record

**The expected byte count is derived from the fixture's shape, not from `stored_len`.** Using the latter looked natural and was self-normalising: it reports the container's record for a tensor *and its sibling streams*, so a test built on it would have agreed with the ledger while both were wrong. It read 32768 where the hash consumed 16384.

**A step-7 arm had to be corrected rather than preserved.** Its control derived its budget from the *recognised* run, which was neutral only while verification was free. Now that recognition costs real reads, the two arms differed in preparation cost rather than in fidelity policy — so each arm now takes its budget from its own unpressed run, and asserts the unrecognised one verified nothing. The test catching a semantic change is it working.

One test is `#[serial]`: the decode arm stages an f32 image through the process-global staging arena that `weights::staged_tests` asserts on. Those counters belong to the binary, not to a module, and a decoding test running beside them makes their assertions flaky — as this one did once, before the attribute was added.

## Gates

fmt, clippy (larql-vindex, larql-cli), `cargo check --target x86_64-apple-darwin`, `cargo test -p larql-vindex` (4912), `cargo test -p larql-cli` (911), doc links — all green. Coverage policy passed at 93.72%.
