### PR TITLE
docs(k3): establish compressed-bank domain and external MXFP4 oracle

### DIFF
--- a/docs/arch-conformance/forecasts/k3-compressed-bank-1-domain-and-oracle.json
+++ b/docs/arch-conformance/forecasts/k3-compressed-bank-1-domain-and-oracle.json
@@ -45,7 +45,7 @@
     "stream_conditionality_from_upstream": "`MXFP4PackedCompressor.compression_param_names` adds `weight_zero_point` when the WEIGHTS are asymmetric, and `input_global_scale` when a non-dynamic INPUT-ACTIVATION scheme requires it \u2014 the latter gated on `getattr_chain(scheme, \"input_activations.dynamic\", True)`, which never consults `weights.dynamic`. K3 is symmetric and declares `input_activations: null`, so the chain falls to its default and neither auxiliary stream is required. **`weights.dynamic: false` is a separate weight-quantization fact and explains neither.** The conclusion the operand plane needs still holds: the two absent streams are absent because the scheme does not require them, not because the checkpoint forgot an operand."
   },
   "THE_FIVE_CLUSTER_AUTHORITY_MAP": {
-    "method": "each cluster answers the same two questions \u2014 what must it REACH, and what must it NOT control \u2014 so that all 14 can eventually retire without pretending they are one authority. One cell is deliberately OPEN: a decomposition that closes every cell on the first attempt has usually forced a leaf into a neighbour.",
+    "method": "each cluster answers the same two questions \u2014 what must it REACH, and what must it NOT control \u2014 so that all 14 can eventually retire without pretending they are one authority. One cell was published OPEN and closed only by tracing the library; a decomposition that closes every cell on the first attempt has usually forced a leaf into a neighbour.",
     "1_codec_identity_and_decode_arithmetic": {
       "leaves": [
         "format (x2)",
@@ -90,19 +90,19 @@
       "must_reach": "artifact/storage lifecycle state \u2014 that the shipped tensors ARE compressed rather than carrying a recipe awaiting application.",
       "must_NOT_control": "FP4 arithmetic. A checkpoint declaring `frozen` or `calibration` with these same config groups is a different artifact and needs a different answer."
     },
-    "3_weights_dynamic_REOPENED": {
+    "3_static_weight_qparam_representation": {
       "leaves": [
         "dynamic"
       ],
       "count": 1,
-      "status": "**REOPENED \u2014 this document originally called it `activation_state` and that was wrong.** See the reconnaissance document's `corrections`.",
-      "must_reach": "NOT YET ESTABLISHED. Upstream defines `dynamic: false` as `the quantization parameters generated are static`, i.e. the weight scales were computed at export and stored. Candidate homes \u2014 static weight-qparam/export state, artifact representation metadata, the `observer` provenance plane, or a precondition on the estate beside `quantization_status` \u2014 are recorded in the reconnaissance and none is selected.",
-      "must_NOT_control": "activation or input representation semantics, which is precisely the authority this document first borrowed for it. `input_activations` is a different leaf and is null here.",
-      "consequence": "the cluster count may be five or six. The map is published with an open cell rather than a tidy one."
+      "status": "reopened, then CLOSED by a trace of the library rather than by its docstring \u2014 see the reconnaissance document.",
+      "must_reach": "representation/storage semantics: the precondition under which a `weight_scale` operand EXISTS. `dynamic: false` means the scales were computed once at export and are stored, which is why the estate carries a scale stream at all.",
+      "must_NOT_control": "activation or input representation semantics (the authority this document first borrowed for it), and not exporter provenance either \u2014 unlike `observer`, changing it changes what the artifact contains and what the forward pass does.",
+      "the_evidence": "`initialize_qparams` returns immediately when `dynamic is True`, so no scale parameter is created and none is persisted; `forward` reads a stored scale only in the static branch; and `MXFP4PackedCompressor.can_compress` never consults `dynamic`, so it is not an admission precondition."
     }
   },
   "COUNT_STILL_NOT_FROZEN": {
-    "position": "unchanged by the oracle, and further from frozen than this document first suggested. The oracle settled cluster 1's arithmetic; it said nothing about clusters 2, 4 and 5, and cluster 3's authority is now reopened. `24 -> N` cannot be stated until that cell closes.",
+    "position": "the map now closes at five authorities, with `weights.dynamic` in the representation/storage cell. That does NOT make `24 -> 10` frozen: it makes it statable. Whether scope, provenance and lifecycle acquire honest homes in this transition is still unmeasured, and the forecast belongs in the freeze.",
     "if_only_the_codec_cluster_and_perhaps_lifecycle_retire": "freeze the smaller movement and leave scope, activation state and provenance to explicit metadata/provenance transitions.",
     "if_all_five_can_be_represented_honestly_in_one_coherent_compressed_artifact_transition": "24 -> 10 becomes earned rather than assumed.",
     "the_outcome_to_avoid": "a 6 -> 0 operand closure and a 24 -> 10 count achieved by making every quantization leaf disappear behind `MXFP4 supported`. The decomposition above exists to make that impossible to do accidentally."
@@ -112,5 +112,11 @@
     "extend the fixture beyond one w1: real w2 and w3, from DIFFERENT experts, at boundary blocks rather than block zero, and a slice crossing a row boundary",
     "decide the binding: how `weight_packed`/`weight_scale` per-expert pairs become planned operands, and whether that is 5,376 operands or 2,688 with an auxiliary stream",
     "then, and only then, the freeze"
-  ]
+  ],
+  "ANTI_CHEAT_CONTROLS_FOR_THE_FREEZE": {
+    "observer_cannot_retire_from_codec_support": "`observer: \"minmax\"` records how the exporter chose the scales and has no decode consequence. It may only retire if it acquires a truthful provenance home.",
+    "weights_dynamic_must_not_be_retired_by_activation_state_handling": "a WITNESSED historical failure mode on this very branch, not a hypothetical mutant \u2014 this decomposition made exactly that error and corrected it. Its home is representation/storage.",
+    "scope_leaves_cannot_select_tensor_representation": "`targets` and `ignore` describe the exporter's selection policy; the stored estate decides an individual operand's representation.",
+    "topk_method_remains_untouched": "fenced out of this rung entirely."
+  }
 }

--- a/docs/arch-conformance/forecasts/k3-compressed-bank-1-domain-and-oracle.json
+++ b/docs/arch-conformance/forecasts/k3-compressed-bank-1-domain-and-oracle.json
@@ -1,0 +1,100 @@
+{
+  "artifact_kind": "domain decomposition + decode-oracle result (evidence; still NOTHING frozen)",
+  "rung": "K3-COMPRESSED-BANK-1",
+  "written": "2026-09-07",
+  "base": "`1ae057d1`",
+  "follows": "docs/arch-conformance/forecasts/k3-compressed-bank-1-reconnaissance.json",
+
+  "THE_DECODE_ORACLE_RESULT": {
+    "headline": "**LARQL's existing MXFP4 codec and compressed-tensors' `mxfp4-pack-quantized` are the SAME codec arithmetic — bit-identical on real K3 bytes.** What differs is the container/binding dialect, not the decode.",
+    "adjudicator": "compressed-tensors 0.18.0, its own unmodified functions: `compressors.nvfp4.helpers.unpack_fp4_from_uint8` and `compressors.mx_utils.decompress_mx_scale`, with torch 2.14.0 / transformers 5.16.1 in a clean venv built for this purpose.",
+    "subject": "the real checkpoint's bytes, fetched by HTTP range request at the offsets the committed header fixture names: `layers.3.block_sparse_moe.experts.0.w1.weight_packed` rows 0-1 (3,584 bytes) and the matching `weight_scale` rows (224 bytes).",
+    "result": {
+      "elements_compared": 7168,
+      "bit_identical": true,
+      "max_abs_difference": 0.0,
+      "value_range": "-0.093750 .. 0.093750",
+      "first_eight": "0.03125, -0.046875, 0.0, 0.015625, 0.0078125, 0.03125, 0.015625, 0.0078125"
+    },
+    "what_matched": [
+      "E2M1 value table [0, 0.5, 1, 1.5, 2, 3, 4, 6] with the sign in bit 3 — upstream's `kE2M1ToFloat` and LARQL's `MXFP4_TABLE` agree element for element",
+      "adjacent-pair packing, LOW nibble first: upstream `low = a & 0x0F` / `high = (a & 0xF0) >> 4` interleaved as `stack((low, high)).flatten()`; LARQL `output[2b] = TABLE[lo]`, `output[2b+1] = TABLE[hi]`",
+      "group size 32 along K, per row",
+      "E8M0 scale: upstream `2.0 ** (uint8 - 127)`; LARQL `f32::from_bits((byte as u32) << 23)`, which IS 2^(byte-127) for an IEEE-754 f32 with zero mantissa",
+      "the scale MULTIPLIES the dequantised code"
+    ],
+    "controls_every_wrong_reading_is_RED": {
+      "split_half_packing_instead_of_adjacent_pair": "max|delta| 0.140625",
+      "nibble_reversal": "0.125000",
+      "E8M0_read_as_a_linear_uint8": "725.91",
+      "exponent_bias_off_by_one": "0.093750",
+      "group_index_off_by_one": "0.125000",
+      "scale_divided_instead_of_multiplied": "767.95",
+      "note": "six wrong readings, six non-zero deltas, on 7,168 real elements. The bit-identity above is therefore a measurement and not a coincidence of a fixture that could not tell the difference."
+    },
+    "the_consequence": "reuse the codec. Inventing a second `CodecIdentity` because the container says `mxfp4-pack-quantized` would be the wrong abstraction: the codec SEMANTICS are the same and the BINDING dialect is different. What K3 needs is a binding — `weight_packed`/`weight_scale` as two separate per-expert safetensors entries — against the same decode.",
+    "what_the_two_dialects_actually_differ_in": {
+      "GPT-OSS (what LARQL implements today)": "`*_blocks` / `*_scales`, one FUSED tensor per projection over all experts, shaped [experts, rows, k/32, 16] and [experts, rows, k/32]",
+      "K3 / compressed-tensors": "`weight_packed` / `weight_scale`, one tensor per expert per matrix, shaped [rows, k/2] and [rows, k/32]",
+      "so": "same bytes per group, same order within a group, different tensor granularity and different declared shape. That is a binding question, which `bind_packed` and the operand plane already exist to answer."
+    },
+    "TWO_FACTS_THIS_CHECKPOINT_CANNOT_WITNESS": {
+      "the_E8M0_edge_codes": "LARQL's `e8m0_to_f32` returns 0.0 for byte 0x00 and NaN for 0xFF; upstream returns 2^-127 and 2^128 respectively. **A real divergence** — and K3's scales all lie in 120-121, so it is NOT exercised here and must NOT be claimed either way from this checkpoint. It needs its own fixture or an explicit deferral.",
+      "padding": "3584 and 3072 are both divisible by 32 and by 2, so no group is partial and no row is padded. Padding semantics are UNWITNESSED by K3 — marked unwitnessed, never passed. If the existing codec has an independent padded fixture that contract can be borrowed; otherwise this rung makes no padding claim.",
+      "why_recorded_here": "both are the shape of defect that a bit-identical headline invites a reader to assume away."
+    },
+    "stream_conditionality_from_upstream": "`MXFP4PackedCompressor.compression_param_names` declares exactly `('weight_packed', 'weight_scale')`, adding `weight_zero_point` only when `weights.symmetric` is false and `input_global_scale` only when `input_activations.dynamic` is false. K3 declares `symmetric: true` and `dynamic: false` with `input_activations: null`. **So the two absent streams are absent because this scheme does not require them, not because the checkpoint forgot an operand** — a distinction the operand plane would otherwise have to guess at."
+  },
+
+  "THE_FIVE_CLUSTER_AUTHORITY_MAP": {
+    "method": "each cluster answers the same two questions — what must it REACH, and what must it NOT control — so that all 14 can eventually retire without pretending they are one authority.",
+    "1_codec_identity_and_decode_arithmetic": {
+      "leaves": ["format (x2)", "quant_method", "num_bits", "type", "symmetric", "strategy", "group_size", "scale_dtype"],
+      "count": 9,
+      "must_reach": "the operand's representation declaration and its decode validation — the `CodecIdentity` (family, revision, geometry) the container records, and the stored-bytes arithmetic that refuses an operand whose size disagrees with its declared geometry.",
+      "must_NOT_control": "tensor scope. Which operands are compressed is decided elsewhere (cluster 2 does not decide it either — see the estate rule).",
+      "status_after_the_oracle": "the arithmetic is settled and matches an existing codec. This is the cluster a codec earns."
+    },
+    "2_scope": {
+      "leaves": ["ignore", "targets"],
+      "count": 2,
+      "must_reach": "a recorded compression-SCOPE declaration — the exporter's selection policy, carried as provenance.",
+      "must_NOT_control": "which actual tensors are decoded. Reconnaissance falsified the reconstructed predicate: `routed_expert_{down,up}_proj` and the two residual projections are `nn.Linear`, unignored, and uncompressed.",
+      "the_distinction_to_freeze_later": "`targets` and `ignore` describe the exporter's selection POLICY; the **stored estate determines the representation of an individual operand**. This is not `infer architecture from tensor names`: for LatentMoE, tensor presence could not legitimately decide which computation the model means, whereas here the stored object necessarily decides whether a given weight is BF16 or packed+scale — because the declared target language demonstrably does not uniquely determine it.",
+      "explicitly_rejected": "any attempt to turn `targets: [\"Linear\"]` plus the regexes into a reconstructed predicate over tensor names."
+    },
+    "3_activation_state": {
+      "leaves": ["dynamic"],
+      "count": 1,
+      "must_reach": "activation/input representation semantics, if this schema has any. Corroborated by `input_activations: null` and `output_activations: null`, and by upstream's own rule that `input_global_scale` appears only when `dynamic` is false.",
+      "must_NOT_control": "weight decoding. `dynamic` would still mean something under a codec this build did implement, and would still mean something if the weights were not compressed at all."
+    },
+    "4_exporter_provenance": {
+      "leaves": ["observer"],
+      "count": 1,
+      "must_reach": "exporter provenance ONLY — a record of how the scales were chosen at export.",
+      "must_NOT_control": "execution or decode. A checkpoint quantised with a different observer decodes by identical arithmetic.",
+      "the_hazard": "this is the leaf a codec would silence for free. Its honest grade is closer to training-only, like `router_aux_loss_coef`."
+    },
+    "5_lifecycle_state": {
+      "leaves": ["quantization_status"],
+      "count": 1,
+      "must_reach": "artifact/storage lifecycle state — that the shipped tensors ARE compressed rather than carrying a recipe awaiting application.",
+      "must_NOT_control": "FP4 arithmetic. A checkpoint declaring `frozen` or `calibration` with these same config groups is a different artifact and needs a different answer."
+    }
+  },
+
+  "COUNT_STILL_NOT_FROZEN": {
+    "position": "unchanged by the oracle. The oracle settled cluster 1's arithmetic; it said nothing about whether clusters 2-5 acquire homes in this transition.",
+    "if_only_the_codec_cluster_and_perhaps_lifecycle_retire": "freeze the smaller movement and leave scope, activation state and provenance to explicit metadata/provenance transitions.",
+    "if_all_five_can_be_represented_honestly_in_one_coherent_compressed_artifact_transition": "24 -> 10 becomes earned rather than assumed.",
+    "the_outcome_to_avoid": "a 6 -> 0 operand closure and a 24 -> 10 count achieved by making every quantization leaf disappear behind `MXFP4 supported`. The decomposition above exists to make that impossible to do accidentally."
+  },
+
+  "next": [
+    "promote the adjudication venv to a reproducible oracle under `tools/oracles/` — it must not depend on a scratch venv, and this machine's shared environment is provably broken (torchvision/torch/transformers mutually incompatible), which is itself the argument",
+    "extend the fixture beyond one w1: real w2 and w3, from DIFFERENT experts, at boundary blocks rather than block zero, and a slice crossing a row boundary",
+    "decide the binding: how `weight_packed`/`weight_scale` per-expert pairs become planned operands, and whether that is 5,376 operands or 2,688 with an auxiliary stream",
+    "then, and only then, the freeze"
+  ]
+}

--- a/docs/arch-conformance/forecasts/k3-compressed-bank-1-domain-and-oracle.json
+++ b/docs/arch-conformance/forecasts/k3-compressed-bank-1-domain-and-oracle.json
@@ -4,9 +4,8 @@
   "written": "2026-09-07",
   "base": "`1ae057d1`",
   "follows": "docs/arch-conformance/forecasts/k3-compressed-bank-1-reconnaissance.json",
-
   "THE_DECODE_ORACLE_RESULT": {
-    "headline": "**LARQL's existing MXFP4 codec and compressed-tensors' `mxfp4-pack-quantized` are the SAME codec arithmetic — bit-identical on real K3 bytes.** What differs is the container/binding dialect, not the decode.",
+    "headline": "**LARQL's existing MXFP4 codec and compressed-tensors' `mxfp4-pack-quantized` are the SAME codec arithmetic \u2014 bit-identical on real K3 bytes.** What differs is the container/binding dialect, not the decode.",
     "adjudicator": "compressed-tensors 0.18.0, its own unmodified functions: `compressors.nvfp4.helpers.unpack_fp4_from_uint8` and `compressors.mx_utils.decompress_mx_scale`, with torch 2.14.0 / transformers 5.16.1 in a clean venv built for this purpose.",
     "subject": "the real checkpoint's bytes, fetched by HTTP range request at the offsets the committed header fixture names: `layers.3.block_sparse_moe.experts.0.w1.weight_packed` rows 0-1 (3,584 bytes) and the matching `weight_scale` rows (224 bytes).",
     "result": {
@@ -17,7 +16,7 @@
       "first_eight": "0.03125, -0.046875, 0.0, 0.015625, 0.0078125, 0.03125, 0.015625, 0.0078125"
     },
     "what_matched": [
-      "E2M1 value table [0, 0.5, 1, 1.5, 2, 3, 4, 6] with the sign in bit 3 — upstream's `kE2M1ToFloat` and LARQL's `MXFP4_TABLE` agree element for element",
+      "E2M1 value table [0, 0.5, 1, 1.5, 2, 3, 4, 6] with the sign in bit 3 \u2014 upstream's `kE2M1ToFloat` and LARQL's `MXFP4_TABLE` agree element for element",
       "adjacent-pair packing, LOW nibble first: upstream `low = a & 0x0F` / `high = (a & 0xF0) >> 4` interleaved as `stack((low, high)).flatten()`; LARQL `output[2b] = TABLE[lo]`, `output[2b+1] = TABLE[hi]`",
       "group size 32 along K, per row",
       "E8M0 scale: upstream `2.0 ** (uint8 - 127)`; LARQL `f32::from_bits((byte as u32) << 23)`, which IS 2^(byte-127) for an IEEE-754 f32 with zero mantissa",
@@ -32,67 +31,84 @@
       "scale_divided_instead_of_multiplied": "767.95",
       "note": "six wrong readings, six non-zero deltas, on 7,168 real elements. The bit-identity above is therefore a measurement and not a coincidence of a fixture that could not tell the difference."
     },
-    "the_consequence": "reuse the codec. Inventing a second `CodecIdentity` because the container says `mxfp4-pack-quantized` would be the wrong abstraction: the codec SEMANTICS are the same and the BINDING dialect is different. What K3 needs is a binding — `weight_packed`/`weight_scale` as two separate per-expert safetensors entries — against the same decode.",
+    "the_consequence": "reuse the codec. Inventing a second `CodecIdentity` because the container says `mxfp4-pack-quantized` would be the wrong abstraction: the codec SEMANTICS are the same and the BINDING dialect is different. What K3 needs is a binding \u2014 `weight_packed`/`weight_scale` as two separate per-expert safetensors entries \u2014 against the same decode.",
     "what_the_two_dialects_actually_differ_in": {
       "GPT-OSS (what LARQL implements today)": "`*_blocks` / `*_scales`, one FUSED tensor per projection over all experts, shaped [experts, rows, k/32, 16] and [experts, rows, k/32]",
       "K3 / compressed-tensors": "`weight_packed` / `weight_scale`, one tensor per expert per matrix, shaped [rows, k/2] and [rows, k/32]",
       "so": "same bytes per group, same order within a group, different tensor granularity and different declared shape. That is a binding question, which `bind_packed` and the operand plane already exist to answer."
     },
     "TWO_FACTS_THIS_CHECKPOINT_CANNOT_WITNESS": {
-      "the_E8M0_edge_codes": "LARQL's `e8m0_to_f32` returns 0.0 for byte 0x00 and NaN for 0xFF; upstream returns 2^-127 and 2^128 respectively. **A real divergence** — and K3's scales all lie in 120-121, so it is NOT exercised here and must NOT be claimed either way from this checkpoint. It needs its own fixture or an explicit deferral.",
-      "padding": "3584 and 3072 are both divisible by 32 and by 2, so no group is partial and no row is padded. Padding semantics are UNWITNESSED by K3 — marked unwitnessed, never passed. If the existing codec has an independent padded fixture that contract can be borrowed; otherwise this rung makes no padding claim.",
+      "the_E8M0_edge_codes": "LARQL's `e8m0_to_f32` returns 0.0 for byte 0x00 and NaN for 0xFF; upstream returns 2^-127 and 2^128 respectively. **A real divergence** \u2014 and K3's scales all lie in 120-121, so it is NOT exercised here and must NOT be claimed either way from this checkpoint. It needs its own fixture or an explicit deferral.",
+      "padding": "3584 and 3072 are both divisible by 32 and by 2, so no group is partial and no row is padded. Padding semantics are UNWITNESSED by K3 \u2014 marked unwitnessed, never passed. If the existing codec has an independent padded fixture that contract can be borrowed; otherwise this rung makes no padding claim.",
       "why_recorded_here": "both are the shape of defect that a bit-identical headline invites a reader to assume away."
     },
-    "stream_conditionality_from_upstream": "`MXFP4PackedCompressor.compression_param_names` declares exactly `('weight_packed', 'weight_scale')`, adding `weight_zero_point` only when `weights.symmetric` is false and `input_global_scale` only when `input_activations.dynamic` is false. K3 declares `symmetric: true` and `dynamic: false` with `input_activations: null`. **So the two absent streams are absent because this scheme does not require them, not because the checkpoint forgot an operand** — a distinction the operand plane would otherwise have to guess at."
+    "stream_conditionality_from_upstream": "`MXFP4PackedCompressor.compression_param_names` adds `weight_zero_point` when the WEIGHTS are asymmetric, and `input_global_scale` when a non-dynamic INPUT-ACTIVATION scheme requires it \u2014 the latter gated on `getattr_chain(scheme, \"input_activations.dynamic\", True)`, which never consults `weights.dynamic`. K3 is symmetric and declares `input_activations: null`, so the chain falls to its default and neither auxiliary stream is required. **`weights.dynamic: false` is a separate weight-quantization fact and explains neither.** The conclusion the operand plane needs still holds: the two absent streams are absent because the scheme does not require them, not because the checkpoint forgot an operand."
   },
-
   "THE_FIVE_CLUSTER_AUTHORITY_MAP": {
-    "method": "each cluster answers the same two questions — what must it REACH, and what must it NOT control — so that all 14 can eventually retire without pretending they are one authority.",
+    "method": "each cluster answers the same two questions \u2014 what must it REACH, and what must it NOT control \u2014 so that all 14 can eventually retire without pretending they are one authority. One cell is deliberately OPEN: a decomposition that closes every cell on the first attempt has usually forced a leaf into a neighbour.",
     "1_codec_identity_and_decode_arithmetic": {
-      "leaves": ["format (x2)", "quant_method", "num_bits", "type", "symmetric", "strategy", "group_size", "scale_dtype"],
+      "leaves": [
+        "format (x2)",
+        "quant_method",
+        "num_bits",
+        "type",
+        "symmetric",
+        "strategy",
+        "group_size",
+        "scale_dtype"
+      ],
       "count": 9,
-      "must_reach": "the operand's representation declaration and its decode validation — the `CodecIdentity` (family, revision, geometry) the container records, and the stored-bytes arithmetic that refuses an operand whose size disagrees with its declared geometry.",
-      "must_NOT_control": "tensor scope. Which operands are compressed is decided elsewhere (cluster 2 does not decide it either — see the estate rule).",
+      "must_reach": "the operand's representation declaration and its decode validation \u2014 the `CodecIdentity` (family, revision, geometry) the container records, and the stored-bytes arithmetic that refuses an operand whose size disagrees with its declared geometry.",
+      "must_NOT_control": "tensor scope. Which operands are compressed is decided elsewhere (cluster 2 does not decide it either \u2014 see the estate rule).",
       "status_after_the_oracle": "the arithmetic is settled and matches an existing codec. This is the cluster a codec earns."
     },
     "2_scope": {
-      "leaves": ["ignore", "targets"],
+      "leaves": [
+        "ignore",
+        "targets"
+      ],
       "count": 2,
-      "must_reach": "a recorded compression-SCOPE declaration — the exporter's selection policy, carried as provenance.",
+      "must_reach": "a recorded compression-SCOPE declaration \u2014 the exporter's selection policy, carried as provenance.",
       "must_NOT_control": "which actual tensors are decoded. Reconnaissance falsified the reconstructed predicate: `routed_expert_{down,up}_proj` and the two residual projections are `nn.Linear`, unignored, and uncompressed.",
-      "the_distinction_to_freeze_later": "`targets` and `ignore` describe the exporter's selection POLICY; the **stored estate determines the representation of an individual operand**. This is not `infer architecture from tensor names`: for LatentMoE, tensor presence could not legitimately decide which computation the model means, whereas here the stored object necessarily decides whether a given weight is BF16 or packed+scale — because the declared target language demonstrably does not uniquely determine it.",
+      "the_distinction_to_freeze_later": "`targets` and `ignore` describe the exporter's selection POLICY; the **stored estate determines the representation of an individual operand**. This is not `infer architecture from tensor names`: for LatentMoE, tensor presence could not legitimately decide which computation the model means, whereas here the stored object necessarily decides whether a given weight is BF16 or packed+scale \u2014 because the declared target language demonstrably does not uniquely determine it.",
       "explicitly_rejected": "any attempt to turn `targets: [\"Linear\"]` plus the regexes into a reconstructed predicate over tensor names."
     },
-    "3_activation_state": {
-      "leaves": ["dynamic"],
-      "count": 1,
-      "must_reach": "activation/input representation semantics, if this schema has any. Corroborated by `input_activations: null` and `output_activations: null`, and by upstream's own rule that `input_global_scale` appears only when `dynamic` is false.",
-      "must_NOT_control": "weight decoding. `dynamic` would still mean something under a codec this build did implement, and would still mean something if the weights were not compressed at all."
-    },
     "4_exporter_provenance": {
-      "leaves": ["observer"],
+      "leaves": [
+        "observer"
+      ],
       "count": 1,
-      "must_reach": "exporter provenance ONLY — a record of how the scales were chosen at export.",
+      "must_reach": "exporter provenance ONLY \u2014 a record of how the scales were chosen at export.",
       "must_NOT_control": "execution or decode. A checkpoint quantised with a different observer decodes by identical arithmetic.",
       "the_hazard": "this is the leaf a codec would silence for free. Its honest grade is closer to training-only, like `router_aux_loss_coef`."
     },
     "5_lifecycle_state": {
-      "leaves": ["quantization_status"],
+      "leaves": [
+        "quantization_status"
+      ],
       "count": 1,
-      "must_reach": "artifact/storage lifecycle state — that the shipped tensors ARE compressed rather than carrying a recipe awaiting application.",
+      "must_reach": "artifact/storage lifecycle state \u2014 that the shipped tensors ARE compressed rather than carrying a recipe awaiting application.",
       "must_NOT_control": "FP4 arithmetic. A checkpoint declaring `frozen` or `calibration` with these same config groups is a different artifact and needs a different answer."
+    },
+    "3_weights_dynamic_REOPENED": {
+      "leaves": [
+        "dynamic"
+      ],
+      "count": 1,
+      "status": "**REOPENED \u2014 this document originally called it `activation_state` and that was wrong.** See the reconnaissance document's `corrections`.",
+      "must_reach": "NOT YET ESTABLISHED. Upstream defines `dynamic: false` as `the quantization parameters generated are static`, i.e. the weight scales were computed at export and stored. Candidate homes \u2014 static weight-qparam/export state, artifact representation metadata, the `observer` provenance plane, or a precondition on the estate beside `quantization_status` \u2014 are recorded in the reconnaissance and none is selected.",
+      "must_NOT_control": "activation or input representation semantics, which is precisely the authority this document first borrowed for it. `input_activations` is a different leaf and is null here.",
+      "consequence": "the cluster count may be five or six. The map is published with an open cell rather than a tidy one."
     }
   },
-
   "COUNT_STILL_NOT_FROZEN": {
-    "position": "unchanged by the oracle. The oracle settled cluster 1's arithmetic; it said nothing about whether clusters 2-5 acquire homes in this transition.",
+    "position": "unchanged by the oracle, and further from frozen than this document first suggested. The oracle settled cluster 1's arithmetic; it said nothing about clusters 2, 4 and 5, and cluster 3's authority is now reopened. `24 -> N` cannot be stated until that cell closes.",
     "if_only_the_codec_cluster_and_perhaps_lifecycle_retire": "freeze the smaller movement and leave scope, activation state and provenance to explicit metadata/provenance transitions.",
     "if_all_five_can_be_represented_honestly_in_one_coherent_compressed_artifact_transition": "24 -> 10 becomes earned rather than assumed.",
     "the_outcome_to_avoid": "a 6 -> 0 operand closure and a 24 -> 10 count achieved by making every quantization leaf disappear behind `MXFP4 supported`. The decomposition above exists to make that impossible to do accidentally."
   },
-
   "next": [
-    "promote the adjudication venv to a reproducible oracle under `tools/oracles/` — it must not depend on a scratch venv, and this machine's shared environment is provably broken (torchvision/torch/transformers mutually incompatible), which is itself the argument",
+    "promote the adjudication venv to a reproducible oracle under `tools/oracles/` \u2014 it must not depend on a scratch venv, and this machine's shared environment is provably broken (torchvision/torch/transformers mutually incompatible), which is itself the argument",
     "extend the fixture beyond one w1: real w2 and w3, from DIFFERENT experts, at boundary blocks rather than block zero, and a slice crossing a row boundary",
     "decide the binding: how `weight_packed`/`weight_scale` per-expert pairs become planned operands, and whether that is 5,376 operands or 2,688 with an auxiliary stream",
     "then, and only then, the freeze"

--- a/docs/arch-conformance/forecasts/k3-compressed-bank-1-reconnaissance.json
+++ b/docs/arch-conformance/forecasts/k3-compressed-bank-1-reconnaissance.json
@@ -5,7 +5,6 @@
   "written": "2026-09-07",
   "base": "`1ae057d1`. The K3 row is read from a fresh sweep at semantics 22 (`_conformance/latentmoe-candidate3`), the estate from the committed two-layer header fixture, and the declarations from the checkpoint's own `config.json` fetched during this reconnaissance.",
   "question_this_answers_first": "What do the 14 `quantization_config` findings actually represent, and how many independent authorities are hiding inside that count? Explicitly NOT starting from `MXFP4 support`.",
-
   "F1_the_14_findings_are_at_least_five_authorities": {
     "verdict": "the count does NOT collapse to one representation dialect. Enumerated individually before any clustering:",
     "codec_identity_and_decode_arithmetic": {
@@ -24,36 +23,51 @@
       "what_it_governs": "how the six stored spellings decode. This is the only cluster whose retirement a codec earns."
     },
     "scope_which_tensors_are_compressed": {
-      "leaves": ["#112 ignore = 6 regexes", "#98 config_groups.group_0.targets = [\"Linear\"]"],
+      "leaves": [
+        "#112 ignore = 6 regexes",
+        "#98 config_groups.group_0.targets = [\"Linear\"]"
+      ],
       "count": 2,
-      "what_it_governs": "which modules were compressed at export. See F2 — it does NOT decide the estate, which is the single most consequential finding here."
-    },
-    "activation_quantisation": {
-      "leaves": ["#101 weights.dynamic = false"],
-      "count": 1,
-      "what_it_governs": "that the WEIGHTS are statically quantised and nothing about activations. Corroborated by `input_activations: null` and `output_activations: null`, which the plan does not surface because a null-valued key already grades as a declared absence (semantics 5).",
-      "note": "a different authority from the codec: `dynamic` would still mean something under a codec this build did implement."
+      "what_it_governs": "which modules were compressed at export. See F2 \u2014 it does NOT decide the estate, which is the single most consequential finding here."
     },
     "exporter_provenance_inert_to_decode": {
-      "leaves": ["#104 weights.observer = \"minmax\""],
+      "leaves": [
+        "#104 weights.observer = \"minmax\""
+      ],
       "count": 1,
-      "what_it_governs": "how the exporter CHOSE the scales. It has no decode consequence whatever — a checkpoint quantised with a different observer decodes by the same arithmetic.",
-      "the_hazard": "this is the leaf most likely to be silenced merely because the six packed tensors became decodable. Retiring it as `representable` on the strength of a codec would be exactly the failure this reconnaissance was told to avoid. Its honest grade is closer to `training_only` — a record of the export procedure, like `router_aux_loss_coef`."
+      "what_it_governs": "how the exporter CHOSE the scales. It has no decode consequence whatever \u2014 a checkpoint quantised with a different observer decodes by the same arithmetic.",
+      "the_hazard": "this is the leaf most likely to be silenced merely because the six packed tensors became decodable. Retiring it as `representable` on the strength of a codec would be exactly the failure this reconnaissance was told to avoid. Its honest grade is closer to `training_only` \u2014 a record of the export procedure, like `router_aux_loss_coef`."
     },
     "lifecycle_state": {
-      "leaves": ["#115 quantization_status = \"compressed\""],
+      "leaves": [
+        "#115 quantization_status = \"compressed\""
+      ],
       "count": 1,
       "what_it_governs": "that the shipped tensors are in compressed form rather than a quantisation recipe awaiting application. It is a PRECONDITION on the estate, not a decode parameter, and a checkpoint declaring `frozen` or `calibration` with the same config groups would need a different answer.",
       "note": "unclear whether this earns a home or an inert grade; it must not be assumed to ride along with the codec."
     },
-    "consequence_for_the_forecast": "9 of the 14 are one authority; the other 5 are four more. Any forecast of `24 -> 10` is a claim that ALL FIVE clusters acquire a home in one transition, which is a much stronger claim than `the bank decodes`. See F8."
+    "consequence_for_the_forecast": "9 of the 14 are one authority; 4 more are three further authorities; and 1 \u2014 `weights.dynamic` \u2014 has no established authority yet. Any forecast of `24 -> 10` is a claim that EVERY cluster acquires a home in one transition, which is a much stronger claim than `the bank decodes`, and it cannot even be stated until the reopened cluster is settled.",
+    "weights_dynamic_AUTHORITY_REOPENED": {
+      "leaves": [
+        "#101 weights.dynamic = false"
+      ],
+      "count": 1,
+      "status": "**REOPENED.** This reconnaissance first filed it as `activation_quantisation` and that was WRONG \u2014 see `corrections`. Its authority is not yet established, and forcing it into one of the other four to keep the count at five would be exactly the error the decomposition exists to prevent.",
+      "what_upstream_says_it_means": "`QuantizationArgs.dynamic`: True = every quantization parameter is generated on the fly; False = the parameters generated are STATIC. So `weights.dynamic: false` says the weight scales were computed once at export and are stored. It says nothing about activations.",
+      "candidate_homes_none_selected": [
+        "static weight-qparam / export-procedure state",
+        "artifact representation metadata",
+        "the same provenance plane as `observer` \u2014 `dynamic` says the scales are static, `observer` says how those static scales were chosen",
+        "a precondition on the ESTATE alongside `quantization_status`: were it true, the scales would not be stored at all and the operand set would differ"
+      ],
+      "why_it_is_left_open": "the cluster count may still be five, or it may become six. That is precisely why 24 -> N is not frozen."
+    }
   },
-
   "F2_THE_DECLARED_SCOPE_DOES_NOT_DECIDE_THE_ESTATE": {
     "verdict": "**`ignore` + `targets` is not a decidable predicate over the tensor names.** Measured against the real two-layer estate (5,421 tensors).",
     "what_was_measured": [
-      "5,376 tensors carry `weight_packed`/`weight_scale`, and ZERO of them sit outside `block_sparse_moe.experts.` — the compressed set is exactly the routed bank.",
-      "the 6 declared `ignore` regexes match 28 names, and none of them is compressed — consistent so far.",
+      "5,376 tensors carry `weight_packed`/`weight_scale`, and ZERO of them sit outside `block_sparse_moe.experts.` \u2014 the compressed set is exactly the routed bank.",
+      "the 6 declared `ignore` regexes match 28 names, and none of them is compressed \u2014 consistent so far.",
       "BUT: seven non-ignored 2-D tensors are NOT compressed, and three of those are `nn.Linear` modules in the checkpoint's own modeling code."
     ],
     "the_three_that_break_it": {
@@ -63,9 +77,8 @@
     },
     "what_is_NOT_known": "why the wrapper and residual projections escaped. Candidates, none verified: the exporter's effective ignore list differed from the serialised one; compressed-tensors resolves `targets` against something other than the module class alone; or those modules postdate the compression pass. Reconnaissance records the fact and does not guess the cause.",
     "the_consequence_that_matters": "LARQL cannot use `ignore`/`targets` to decide which operands are compressed, because on this checkpoint they do not. **The ESTATE (the `weight_packed`/`weight_scale` suffixes) is the operative authority for WHICH tensors are compressed; the config is the authority for HOW they decode.**",
-    "why_this_is_not_a_contradiction_of_the_LatentMoE_rule": "K3-LATENTMOE-1 established that identity is DECLARED and never inferred from operands. That rule is about a fact the declaration determines — the latent form — where a tensor may only confirm. Here the declaration provably does not determine the extent: two `nn.Linear` families satisfy the stated predicate and are not compressed. A rule that insisted on config authority would refuse the real checkpoint. The two facts live on different planes and each takes its authority from the plane that actually decides it — which is the same lesson the GLM FP8 work reached from the other side, where the scale grid and not the global `weight_block_size` was correct."
+    "why_this_is_not_a_contradiction_of_the_LatentMoE_rule": "K3-LATENTMOE-1 established that identity is DECLARED and never inferred from operands. That rule is about a fact the declaration determines \u2014 the latent form \u2014 where a tensor may only confirm. Here the declaration provably does not determine the extent: two `nn.Linear` families satisfy the stated predicate and are not compressed. A rule that insisted on config authority would refuse the real checkpoint. The two facts live on different planes and each takes its authority from the plane that actually decides it \u2014 which is the same lesson the GLM FP8 work reached from the other side, where the scale grid and not the global `weight_block_size` was correct."
   },
-
   "F3_THE_NAME_DOES_NOT_DETERMINE_THE_DECODE": {
     "verdict": "`mxfp4-pack-quantized` and LARQL's existing MXFP4 codec are **shape-indistinguishable**. Nothing measured so far can separate them, and the shapes never will.",
     "the_arithmetic": {
@@ -73,7 +86,7 @@
       "w2": "logical [latent 3584, moe_intermediate 3072]; packed U8 [3584, 1536] = 3072/2; scale U8 [3584, 96] = 3072/32.",
       "so": "two 4-bit elements per byte, one scale per 32 elements along the K axis, per row. Exactly the group geometry `group_size: 32` declares, and exactly LARQL's `MXFP4_GROUP_ELEMS = 32` / `MXFP4_GROUP_BYTES = 16`."
     },
-    "why_that_settles_nothing": "LARQL's codec was transcribed from GPT-OSS's `*_blocks`/`*_scales` dialect, where byte b holds elements 2b (lo nibble) and 2b+1 (hi). A split-half packing — byte j holding elements j and j + 16, which is the convention LARQL's own `WeightSlice::Q4` documents — produces the SAME k/2 bytes and the SAME k/32 scales. The stored shapes are identical under both. Only real bytes compared against the authoritative decoder can separate them.",
+    "why_that_settles_nothing": "LARQL's codec was transcribed from GPT-OSS's `*_blocks`/`*_scales` dialect, where byte b holds elements 2b (lo nibble) and 2b+1 (hi). A split-half packing \u2014 byte j holding elements j and j + 16, which is the convention LARQL's own `WeightSlice::Q4` documents \u2014 produces the SAME k/2 bytes and the SAME k/32 scales. The stored shapes are identical under both. Only real bytes compared against the authoritative decoder can separate them.",
     "the_falsifier_this_rung_must_carry": "**a representation name or metadata string does not determine decode arithmetic.** The GLM `weight_scale_inv` finding is the precedent: a name that meant the reciprocal of what it said. Here the risk is sharper, because LARQL already HAS a codec called MXFP4 and adopting it on the strength of the label would be a one-line change that is either exactly right or silently wrong with every shape closing.",
     "what_is_still_unknown": [
       "nibble order within a byte (adjacent pair vs split half)",
@@ -82,37 +95,33 @@
       "whether `type: \"float\"` + `num_bits: 4` is e2m1 specifically, or another 4-bit float layout"
     ]
   },
-
   "F4_the_geometry_confirmed_against_the_real_header": {
-    "no_padding": "3584 and 3072 are both divisible by 32 and by 2, so no group is partial and no row is padded. A dialect question that would otherwise need answering does not arise on K3 — and therefore CANNOT be witnessed on K3 either, which the fixture design must account for.",
-    "orientation": "w1/w3 and w2 use the SAME storage convention — row-major with groups along the contiguous (K) axis. The transpose between them is in the LOGICAL shape, not in the packing, so one codec serves all three.",
+    "no_padding": "3584 and 3072 are both divisible by 32 and by 2, so no group is partial and no row is padded. A dialect question that would otherwise need answering does not arise on K3 \u2014 and therefore CANNOT be witnessed on K3 either, which the fixture design must account for.",
+    "orientation": "w1/w3 and w2 use the SAME storage convention \u2014 row-major with groups along the contiguous (K) axis. The transpose between them is in the LOGICAL shape, not in the packing, so one codec serves all three.",
     "per_expert": "one packed and one scale tensor per matrix per expert: 896 experts x 3 matrices x 2 streams = 5,376 tensors on the one routed layer of the fixture. The bank is per-expert (`ExpertFormat::PerExpert`), not a fused `[experts, rows, k]` block.",
-    "scales_are_not_linear": "the 224 real scale bytes read for expert 0's w1 all lie in 120-121. Under E8M0 (value = 2^(s-127)) that is 2^-7 and 2^-6, which is the right order for BF16 weights of magnitude ~0.01-0.09. A raw uint8 linear scale would have to be ~1. **Consistent with E8M0 and inconsistent with a linear uint8 scale** — the first decode fact this reconnaissance can actually assert."
+    "scales_are_not_linear": "the 224 real scale bytes read for expert 0's w1 all lie in 120-121. Under E8M0 (value = 2^(s-127)) that is 2^-7 and 2^-6, which is the right order for BF16 weights of magnitude ~0.01-0.09. A raw uint8 linear scale would have to be ~1. **Consistent with E8M0 and inconsistent with a linear uint8 scale** \u2014 the first decode fact this reconnaissance can actually assert."
   },
-
   "F5_the_decode_oracle_is_buildable_without_the_checkpoint": {
     "demonstrated": "HTTP range requests against the real shard return exactly the bytes wanted: the 8-byte safetensors length prefix (header JSON 817,608 bytes, data at 817,616), then 3,584 bytes of `layers.3...experts.0.w1.weight_packed` (two rows) and 224 bytes of its `weight_scale` (the matching two rows). Both HTTP 206.",
-    "why_it_matters": "the oracle needs real bytes and the checkpoint is 96 shards. It does not need the checkpoint — it needs a few kilobytes at chosen offsets, which the committed header fixture already names.",
+    "why_it_matters": "the oracle needs real bytes and the checkpoint is 96 shards. It does not need the checkpoint \u2014 it needs a few kilobytes at chosen offsets, which the committed header fixture already names.",
     "first_bytes_on_the_record": {
       "packed": "d4 20 41 12 1c 40 b0 8a 42 92 19 21 6b 0b b2 83",
       "scale": "79 79 79 79 78 79 79 79 78 78 78 79 78 78 79 79",
-      "nibble_histograms": "lo and hi nibbles have near-identical distributions over the first row, smooth across the sign bit with the extreme codes (7, 15 = +/-6.0) rare. Exactly what a minmax-scaled e2m1 group looks like — and exactly why the histogram cannot discriminate the two packings."
+      "nibble_histograms": "lo and hi nibbles have near-identical distributions over the first row, smooth across the sign bit with the extreme codes (7, 15 = +/-6.0) rare. Exactly what a minmax-scaled e2m1 group looks like \u2014 and exactly why the histogram cannot discriminate the two packings."
     },
     "the_checkpoint_ships_no_decoder": "`modeling_kimi_linear.py` contains no dequantisation, no `weight_packed` reference, no unpacking. compressed-tensors owns the decode, so the oracle must be traced from that library and not from the model repository."
   },
-
   "F6_decode_support_and_direct_execution_are_different_claims": {
     "minimal_semantic_closure": "compressed bank -> codec decodes correctly -> the reference/interpreter executor runs it.",
     "performance_target": "compressed bank -> a direct packed matvec or grouped expert kernel.",
     "position": "these must not be conflated, and K3 closure should not be made to depend on an optimised MXFP4 expert kernel unless the REPRESENT contract genuinely requires one. Correct-on-arrival, fast-later. The existing `RepresentationCapabilities` already distinguishes what a codec can be ASKED for from what a backend implements, which is where the distinction should be carried."
   },
-
   "F7_the_REPRESENT_contract_probably_suffices_and_this_must_be_falsified": {
     "what_the_trait_already_has": [
-      "`streams()` — several streams per operand, which is how the existing MXFP4 codec already carries VALUES + GROUP_SCALES",
-      "`stored_bytes(shape, extent, tensor)` — tensor-local geometry derived from the operand's own shape",
-      "`extents()` / `ExtentCertificate` — extent semantics",
-      "`bind_packed` — streams in one row versus stored apart, which is what `weight_packed`/`weight_scale` as SEPARATE safetensors entries needs"
+      "`streams()` \u2014 several streams per operand, which is how the existing MXFP4 codec already carries VALUES + GROUP_SCALES",
+      "`stored_bytes(shape, extent, tensor)` \u2014 tensor-local geometry derived from the operand's own shape",
+      "`extents()` / `ExtentCertificate` \u2014 extent semantics",
+      "`bind_packed` \u2014 streams in one row versus stored apart, which is what `weight_packed`/`weight_scale` as SEPARATE safetensors entries needs"
     ],
     "the_expectation": "no new contract dimension. The open question is narrower and sharper: **is `mxfp4-pack-quantized` a NEW CodecIdentity, or the existing one under a different label?** `CodecIdentity` already carries family, revision and geometry, so a dialect difference is a distinct identity rather than a missing contract.",
     "what_would_falsify_it": [
@@ -121,31 +130,36 @@
       "auxiliary scales beyond the two streams",
       "direct-kernel optionality that the capabilities type cannot express"
     ],
-    "the_rule": "if the codec trait needs modifying, that is a FINDING of this rung and gets its own transition — not something slipped into the implementation."
+    "the_rule": "if the codec trait needs modifying, that is a FINDING of this rung and gets its own transition \u2014 not something slipped into the implementation."
   },
-
   "F8_what_the_operand_plane_can_and_cannot_promise": {
     "the_durable_claim": "**distinct unaddressed spellings 6 -> 0**, and the remaining K3 unaddressed set exactly EMPTY for the expert bank.",
     "the_claim_to_withhold": "`unclassified 5376 -> N`. Whether the 5,376 tensors become 5,376 represented operands, or 2,688 logical operands each with one auxiliary stream, is a REPRESENT modelling decision this reconnaissance has not made. Freezing the arithmetic before that decision would pin a guess.",
     "the_regression_gate": "if any ordinary architecture operand appears in the unaddressed set while this rung is in flight, the rung FAILS. The set is asserted as a set in `k3_representable::k3_estate_reports_every_unaddressed_spelling`, which is what makes the boundary sharp."
   },
-
   "F9_the_blocker_count_is_not_yet_forecastable": {
     "the_tempting_number": "24 -> 10, on the grounds that 14 findings are `quantization_config`.",
-    "why_it_is_premature": "F1 shows the 14 are at least five authorities. A codec earns the 9 codec leaves. It does NOT earn `observer` (exporter provenance, no decode consequence), and it is not obvious that it earns `quantization_status`, `dynamic`, `ignore` or `targets` — the last two of which describe a scope the config does not in fact decide (F2).",
+    "why_it_is_premature": "F1 shows the 14 are at least five authorities. A codec earns the 9 codec leaves. It does NOT earn `observer` (exporter provenance, no decode consequence), and it is not obvious that it earns `quantization_status`, `dynamic`, `ignore` or `targets` \u2014 the last two of which describe a scope the config does not in fact decide (F2).",
     "the_honest_range": "24 -> 15 if only the codec cluster retires; 24 -> 10 if all five clusters find homes. Both are defensible before measurement and neither should be frozen now.",
     "the_criterion_that_matters": "not `14 blockers disappeared`. It is that **every retired finding acquired a concrete representation or execution authority, and nothing was silenced merely because the six packed tensors became decodable.**",
     "the_other_ten_blockers": "3 multimodal container leaves (`ignore_index`, `image_placeholder`, `media_placeholder_token_id`), 6 HF boilerplate (`add_cross_attention`, `is_decoder`, `tf_legacy_loss`, `tie_encoder_decoder`, `torchscript`, `use_bfloat16`), and `topk_method`. Enumerated so the residue after this rung is known in advance rather than discovered."
   },
-
   "F10_topk_method_is_fenced_out": "`topk_method: \"noaux_tc\"` (#134) is NOT this rung's and K3 keeps it. After compressed-bank closure it should be the only remaining text-side SEMANTIC blocker, which is what makes the subsequent router rung clean.",
-
   "what_this_reconnaissance_did_not_do": [
     "trace compressed-tensors' decoder. That is the next step and the oracle depends on it.",
     "decide the nibble order, the scale direction, or whether the existing MXFP4 codec can be reused. F3 exists to keep those open.",
     "decide how many represented operands the 5,376 tensors become.",
-    "freeze anything. No forecast, no properties, no falsifiers — this artifact is evidence."
+    "freeze anything. No forecast, no properties, no falsifiers \u2014 this artifact is evidence."
   ],
-
-  "next": "domain decomposition of the five clusters into what each would have to reach, then the external decode oracle (compressed-tensors' own implementation, on the real bytes named in F5, with mutants for nibble order, scale direction, block width, scale index, orientation and padding), then the freeze."
+  "next": "domain decomposition of the five clusters into what each would have to reach, then the external decode oracle (compressed-tensors' own implementation, on the real bytes named in F5, with mutants for nibble order, scale direction, block width, scale index, orientation and padding), then the freeze.",
+  "corrections": {
+    "correction_1_the_two_dynamic_fields_are_different_leaves": {
+      "what_was_wrong": "this document originally clustered `#101 weights.dynamic = false` as `activation_quantisation`, and the companion oracle document then explained the absence of upstream's `input_global_scale` stream by it. Both borrowed the authority of a DIFFERENT leaf.",
+      "the_fact": "`MXFP4PackedCompressor.compression_param_names` gates `input_global_scale` on `getattr_chain(scheme, \"input_activations.dynamic\", True)` \u2014 the INPUT-ACTIVATION scheme's `dynamic`, with default True \u2014 and never consults `weights.dynamic` at all. K3 declares `input_activations: null`, so the chain falls to that default and the stream is not required. `weights.dynamic: false` is a separate weight-quantization fact.",
+      "what_survives": "the operand-plane conclusion is unchanged and correct: neither auxiliary stream is required by this scheme, so their absence is not a checkpoint that forgot an operand. Only the reason was wrong.",
+      "what_does_not": "the cluster assignment. `weights.dynamic` is reopened above rather than relabelled.",
+      "how_it_was_caught": "review of the evidence BEFORE the freeze was written, which is the entire reason the oracle and the decomposition are separate artifacts that land before any preregistration. A beautifully preregistered wrong authority is the failure this ordering exists to prevent.",
+      "recorded_not_edited_away": "the wrong clustering is named here rather than quietly replaced, on the same principle the LatentMoE oracle notes used when measurement contradicted its own freeze."
+    }
+  }
 }

--- a/docs/arch-conformance/forecasts/k3-compressed-bank-1-reconnaissance.json
+++ b/docs/arch-conformance/forecasts/k3-compressed-bank-1-reconnaissance.json
@@ -1,0 +1,151 @@
+{
+  "artifact_kind": "reconnaissance (evidence only; NOTHING here is frozen)",
+  "rung": "K3-COMPRESSED-BANK-1",
+  "name": "compressed-expert-bank",
+  "written": "2026-09-07",
+  "base": "`1ae057d1`. The K3 row is read from a fresh sweep at semantics 22 (`_conformance/latentmoe-candidate3`), the estate from the committed two-layer header fixture, and the declarations from the checkpoint's own `config.json` fetched during this reconnaissance.",
+  "question_this_answers_first": "What do the 14 `quantization_config` findings actually represent, and how many independent authorities are hiding inside that count? Explicitly NOT starting from `MXFP4 support`.",
+
+  "F1_the_14_findings_are_at_least_five_authorities": {
+    "verdict": "the count does NOT collapse to one representation dialect. Enumerated individually before any clustering:",
+    "codec_identity_and_decode_arithmetic": {
+      "leaves": [
+        "#95  config_groups.group_0.format = \"mxfp4-pack-quantized\"",
+        "#110 format = \"mxfp4-pack-quantized\"  (the same fact at the top level)",
+        "#114 quant_method = \"compressed-tensors\"  (already graded tensor_semantic)",
+        "#103 weights.num_bits = 4",
+        "#108 weights.type = \"float\"  (already graded execution_semantic)",
+        "#107 weights.symmetric = true",
+        "#106 weights.strategy = \"group\"",
+        "#102 weights.group_size = 32",
+        "#105 weights.scale_dtype = \"torch.uint8\""
+      ],
+      "count": 9,
+      "what_it_governs": "how the six stored spellings decode. This is the only cluster whose retirement a codec earns."
+    },
+    "scope_which_tensors_are_compressed": {
+      "leaves": ["#112 ignore = 6 regexes", "#98 config_groups.group_0.targets = [\"Linear\"]"],
+      "count": 2,
+      "what_it_governs": "which modules were compressed at export. See F2 — it does NOT decide the estate, which is the single most consequential finding here."
+    },
+    "activation_quantisation": {
+      "leaves": ["#101 weights.dynamic = false"],
+      "count": 1,
+      "what_it_governs": "that the WEIGHTS are statically quantised and nothing about activations. Corroborated by `input_activations: null` and `output_activations: null`, which the plan does not surface because a null-valued key already grades as a declared absence (semantics 5).",
+      "note": "a different authority from the codec: `dynamic` would still mean something under a codec this build did implement."
+    },
+    "exporter_provenance_inert_to_decode": {
+      "leaves": ["#104 weights.observer = \"minmax\""],
+      "count": 1,
+      "what_it_governs": "how the exporter CHOSE the scales. It has no decode consequence whatever — a checkpoint quantised with a different observer decodes by the same arithmetic.",
+      "the_hazard": "this is the leaf most likely to be silenced merely because the six packed tensors became decodable. Retiring it as `representable` on the strength of a codec would be exactly the failure this reconnaissance was told to avoid. Its honest grade is closer to `training_only` — a record of the export procedure, like `router_aux_loss_coef`."
+    },
+    "lifecycle_state": {
+      "leaves": ["#115 quantization_status = \"compressed\""],
+      "count": 1,
+      "what_it_governs": "that the shipped tensors are in compressed form rather than a quantisation recipe awaiting application. It is a PRECONDITION on the estate, not a decode parameter, and a checkpoint declaring `frozen` or `calibration` with the same config groups would need a different answer.",
+      "note": "unclear whether this earns a home or an inert grade; it must not be assumed to ride along with the codec."
+    },
+    "consequence_for_the_forecast": "9 of the 14 are one authority; the other 5 are four more. Any forecast of `24 -> 10` is a claim that ALL FIVE clusters acquire a home in one transition, which is a much stronger claim than `the bank decodes`. See F8."
+  },
+
+  "F2_THE_DECLARED_SCOPE_DOES_NOT_DECIDE_THE_ESTATE": {
+    "verdict": "**`ignore` + `targets` is not a decidable predicate over the tensor names.** Measured against the real two-layer estate (5,421 tensors).",
+    "what_was_measured": [
+      "5,376 tensors carry `weight_packed`/`weight_scale`, and ZERO of them sit outside `block_sparse_moe.experts.` — the compressed set is exactly the routed bank.",
+      "the 6 declared `ignore` regexes match 28 names, and none of them is compressed — consistent so far.",
+      "BUT: seven non-ignored 2-D tensors are NOT compressed, and three of those are `nn.Linear` modules in the checkpoint's own modeling code."
+    ],
+    "the_three_that_break_it": {
+      "routed_expert_down_proj / routed_expert_up_proj": "`nn.Linear` (modeling_kimi_linear.py L804, L807), not matched by any ignore regex, shipped uncompressed BF16.",
+      "self_attention_res_proj / mlp_res_proj": "`nn.Linear` (L914, L916), not ignored, shipped uncompressed BF16.",
+      "block_sparse_moe.gate.weight": "correctly NOT compressed, and correctly not a counterexample: `KimiMoEGate.weight` is an `nn.Parameter` (L689), not an `nn.Linear`, so `targets: [\"Linear\"]` never matched it. Recorded because it looks like a violation and is not."
+    },
+    "what_is_NOT_known": "why the wrapper and residual projections escaped. Candidates, none verified: the exporter's effective ignore list differed from the serialised one; compressed-tensors resolves `targets` against something other than the module class alone; or those modules postdate the compression pass. Reconnaissance records the fact and does not guess the cause.",
+    "the_consequence_that_matters": "LARQL cannot use `ignore`/`targets` to decide which operands are compressed, because on this checkpoint they do not. **The ESTATE (the `weight_packed`/`weight_scale` suffixes) is the operative authority for WHICH tensors are compressed; the config is the authority for HOW they decode.**",
+    "why_this_is_not_a_contradiction_of_the_LatentMoE_rule": "K3-LATENTMOE-1 established that identity is DECLARED and never inferred from operands. That rule is about a fact the declaration determines — the latent form — where a tensor may only confirm. Here the declaration provably does not determine the extent: two `nn.Linear` families satisfy the stated predicate and are not compressed. A rule that insisted on config authority would refuse the real checkpoint. The two facts live on different planes and each takes its authority from the plane that actually decides it — which is the same lesson the GLM FP8 work reached from the other side, where the scale grid and not the global `weight_block_size` was correct."
+  },
+
+  "F3_THE_NAME_DOES_NOT_DETERMINE_THE_DECODE": {
+    "verdict": "`mxfp4-pack-quantized` and LARQL's existing MXFP4 codec are **shape-indistinguishable**. Nothing measured so far can separate them, and the shapes never will.",
+    "the_arithmetic": {
+      "w1_and_w3": "logical [moe_intermediate 3072, latent 3584]; packed U8 [3072, 1792] = 3584/2 bytes per row; scale U8 [3072, 112] = 3584/32 groups per row.",
+      "w2": "logical [latent 3584, moe_intermediate 3072]; packed U8 [3584, 1536] = 3072/2; scale U8 [3584, 96] = 3072/32.",
+      "so": "two 4-bit elements per byte, one scale per 32 elements along the K axis, per row. Exactly the group geometry `group_size: 32` declares, and exactly LARQL's `MXFP4_GROUP_ELEMS = 32` / `MXFP4_GROUP_BYTES = 16`."
+    },
+    "why_that_settles_nothing": "LARQL's codec was transcribed from GPT-OSS's `*_blocks`/`*_scales` dialect, where byte b holds elements 2b (lo nibble) and 2b+1 (hi). A split-half packing — byte j holding elements j and j + 16, which is the convention LARQL's own `WeightSlice::Q4` documents — produces the SAME k/2 bytes and the SAME k/32 scales. The stored shapes are identical under both. Only real bytes compared against the authoritative decoder can separate them.",
+    "the_falsifier_this_rung_must_carry": "**a representation name or metadata string does not determine decode arithmetic.** The GLM `weight_scale_inv` finding is the precedent: a name that meant the reciprocal of what it said. Here the risk is sharper, because LARQL already HAS a codec called MXFP4 and adopting it on the strength of the label would be a one-line change that is either exactly right or silently wrong with every shape closing.",
+    "what_is_still_unknown": [
+      "nibble order within a byte (adjacent pair vs split half)",
+      "whether the E8M0 scale multiplies or divides",
+      "element order within a group, and group order within a row",
+      "whether `type: \"float\"` + `num_bits: 4` is e2m1 specifically, or another 4-bit float layout"
+    ]
+  },
+
+  "F4_the_geometry_confirmed_against_the_real_header": {
+    "no_padding": "3584 and 3072 are both divisible by 32 and by 2, so no group is partial and no row is padded. A dialect question that would otherwise need answering does not arise on K3 — and therefore CANNOT be witnessed on K3 either, which the fixture design must account for.",
+    "orientation": "w1/w3 and w2 use the SAME storage convention — row-major with groups along the contiguous (K) axis. The transpose between them is in the LOGICAL shape, not in the packing, so one codec serves all three.",
+    "per_expert": "one packed and one scale tensor per matrix per expert: 896 experts x 3 matrices x 2 streams = 5,376 tensors on the one routed layer of the fixture. The bank is per-expert (`ExpertFormat::PerExpert`), not a fused `[experts, rows, k]` block.",
+    "scales_are_not_linear": "the 224 real scale bytes read for expert 0's w1 all lie in 120-121. Under E8M0 (value = 2^(s-127)) that is 2^-7 and 2^-6, which is the right order for BF16 weights of magnitude ~0.01-0.09. A raw uint8 linear scale would have to be ~1. **Consistent with E8M0 and inconsistent with a linear uint8 scale** — the first decode fact this reconnaissance can actually assert."
+  },
+
+  "F5_the_decode_oracle_is_buildable_without_the_checkpoint": {
+    "demonstrated": "HTTP range requests against the real shard return exactly the bytes wanted: the 8-byte safetensors length prefix (header JSON 817,608 bytes, data at 817,616), then 3,584 bytes of `layers.3...experts.0.w1.weight_packed` (two rows) and 224 bytes of its `weight_scale` (the matching two rows). Both HTTP 206.",
+    "why_it_matters": "the oracle needs real bytes and the checkpoint is 96 shards. It does not need the checkpoint — it needs a few kilobytes at chosen offsets, which the committed header fixture already names.",
+    "first_bytes_on_the_record": {
+      "packed": "d4 20 41 12 1c 40 b0 8a 42 92 19 21 6b 0b b2 83",
+      "scale": "79 79 79 79 78 79 79 79 78 78 78 79 78 78 79 79",
+      "nibble_histograms": "lo and hi nibbles have near-identical distributions over the first row, smooth across the sign bit with the extreme codes (7, 15 = +/-6.0) rare. Exactly what a minmax-scaled e2m1 group looks like — and exactly why the histogram cannot discriminate the two packings."
+    },
+    "the_checkpoint_ships_no_decoder": "`modeling_kimi_linear.py` contains no dequantisation, no `weight_packed` reference, no unpacking. compressed-tensors owns the decode, so the oracle must be traced from that library and not from the model repository."
+  },
+
+  "F6_decode_support_and_direct_execution_are_different_claims": {
+    "minimal_semantic_closure": "compressed bank -> codec decodes correctly -> the reference/interpreter executor runs it.",
+    "performance_target": "compressed bank -> a direct packed matvec or grouped expert kernel.",
+    "position": "these must not be conflated, and K3 closure should not be made to depend on an optimised MXFP4 expert kernel unless the REPRESENT contract genuinely requires one. Correct-on-arrival, fast-later. The existing `RepresentationCapabilities` already distinguishes what a codec can be ASKED for from what a backend implements, which is where the distinction should be carried."
+  },
+
+  "F7_the_REPRESENT_contract_probably_suffices_and_this_must_be_falsified": {
+    "what_the_trait_already_has": [
+      "`streams()` — several streams per operand, which is how the existing MXFP4 codec already carries VALUES + GROUP_SCALES",
+      "`stored_bytes(shape, extent, tensor)` — tensor-local geometry derived from the operand's own shape",
+      "`extents()` / `ExtentCertificate` — extent semantics",
+      "`bind_packed` — streams in one row versus stored apart, which is what `weight_packed`/`weight_scale` as SEPARATE safetensors entries needs"
+    ],
+    "the_expectation": "no new contract dimension. The open question is narrower and sharper: **is `mxfp4-pack-quantized` a NEW CodecIdentity, or the existing one under a different label?** `CodecIdentity` already carries family, revision and geometry, so a dialect difference is a distinct identity rather than a missing contract.",
+    "what_would_falsify_it": [
+      "per-expert SHARED metadata that is not derivable from one operand's shape",
+      "a physical residency that differs from the canonical decoded image in a way `extents()` cannot state",
+      "auxiliary scales beyond the two streams",
+      "direct-kernel optionality that the capabilities type cannot express"
+    ],
+    "the_rule": "if the codec trait needs modifying, that is a FINDING of this rung and gets its own transition — not something slipped into the implementation."
+  },
+
+  "F8_what_the_operand_plane_can_and_cannot_promise": {
+    "the_durable_claim": "**distinct unaddressed spellings 6 -> 0**, and the remaining K3 unaddressed set exactly EMPTY for the expert bank.",
+    "the_claim_to_withhold": "`unclassified 5376 -> N`. Whether the 5,376 tensors become 5,376 represented operands, or 2,688 logical operands each with one auxiliary stream, is a REPRESENT modelling decision this reconnaissance has not made. Freezing the arithmetic before that decision would pin a guess.",
+    "the_regression_gate": "if any ordinary architecture operand appears in the unaddressed set while this rung is in flight, the rung FAILS. The set is asserted as a set in `k3_representable::k3_estate_reports_every_unaddressed_spelling`, which is what makes the boundary sharp."
+  },
+
+  "F9_the_blocker_count_is_not_yet_forecastable": {
+    "the_tempting_number": "24 -> 10, on the grounds that 14 findings are `quantization_config`.",
+    "why_it_is_premature": "F1 shows the 14 are at least five authorities. A codec earns the 9 codec leaves. It does NOT earn `observer` (exporter provenance, no decode consequence), and it is not obvious that it earns `quantization_status`, `dynamic`, `ignore` or `targets` — the last two of which describe a scope the config does not in fact decide (F2).",
+    "the_honest_range": "24 -> 15 if only the codec cluster retires; 24 -> 10 if all five clusters find homes. Both are defensible before measurement and neither should be frozen now.",
+    "the_criterion_that_matters": "not `14 blockers disappeared`. It is that **every retired finding acquired a concrete representation or execution authority, and nothing was silenced merely because the six packed tensors became decodable.**",
+    "the_other_ten_blockers": "3 multimodal container leaves (`ignore_index`, `image_placeholder`, `media_placeholder_token_id`), 6 HF boilerplate (`add_cross_attention`, `is_decoder`, `tf_legacy_loss`, `tie_encoder_decoder`, `torchscript`, `use_bfloat16`), and `topk_method`. Enumerated so the residue after this rung is known in advance rather than discovered."
+  },
+
+  "F10_topk_method_is_fenced_out": "`topk_method: \"noaux_tc\"` (#134) is NOT this rung's and K3 keeps it. After compressed-bank closure it should be the only remaining text-side SEMANTIC blocker, which is what makes the subsequent router rung clean.",
+
+  "what_this_reconnaissance_did_not_do": [
+    "trace compressed-tensors' decoder. That is the next step and the oracle depends on it.",
+    "decide the nibble order, the scale direction, or whether the existing MXFP4 codec can be reused. F3 exists to keep those open.",
+    "decide how many represented operands the 5,376 tensors become.",
+    "freeze anything. No forecast, no properties, no falsifiers — this artifact is evidence."
+  ],
+
+  "next": "domain decomposition of the five clusters into what each would have to reach, then the external decode oracle (compressed-tensors' own implementation, on the real bytes named in F5, with mutants for nibble order, scale direction, block width, scale index, orientation and padding), then the freeze."
+}

--- a/docs/arch-conformance/forecasts/k3-compressed-bank-1-reconnaissance.json
+++ b/docs/arch-conformance/forecasts/k3-compressed-bank-1-reconnaissance.json
@@ -52,7 +52,7 @@
         "#101 weights.dynamic = false"
       ],
       "count": 1,
-      "status": "**REOPENED.** This reconnaissance first filed it as `activation_quantisation` and that was WRONG \u2014 see `corrections`. Its authority is not yet established, and forcing it into one of the other four to keep the count at five would be exactly the error the decomposition exists to prevent.",
+      "status": "**REOPENED, then CLOSED by a trace of compressed-tensors 0.18.0 \u2014 not by the docstring.** The question asked was narrow: if an otherwise equivalent scheme had `weights.dynamic=true`, what changes in initialization, admission, persistent streams, decompression and forward execution?",
       "what_upstream_says_it_means": "`QuantizationArgs.dynamic`: True = every quantization parameter is generated on the fly; False = the parameters generated are STATIC. So `weights.dynamic: false` says the weight scales were computed once at export and are stored. It says nothing about activations.",
       "candidate_homes_none_selected": [
         "static weight-qparam / export-procedure state",
@@ -60,7 +60,23 @@
         "the same provenance plane as `observer` \u2014 `dynamic` says the scales are static, `observer` says how those static scales were chosen",
         "a precondition on the ESTATE alongside `quantization_status`: were it true, the scales would not be stored at all and the operand set would differ"
       ],
-      "why_it_is_left_open": "the cluster count may still be five, or it may become six. That is precisely why 24 -> N is not frozen."
+      "why_it_is_left_open": "the cluster count may still be five, or it may become six. That is precisely why 24 -> N is not frozen.",
+      "the_trace": {
+        "initialization": "`quantization/lifecycle/initialize.py::initialize_qparams` opens with `if dynamic is True: return` \u2014 **no `weight_scale` parameter is created at all**. The scale does not exist to be compressed.",
+        "admission": "`MXFP4PackedCompressor.can_compress` checks the module type, `num_bits == 4`, `type == float` and `group_size == 32`. It does **NOT** consult `dynamic`. So MXFP4 does not reject a dynamic weight scheme at admission \u2014 the first of the three candidate answers is FALSIFIED.",
+        "legality": "`QuantizationArgs`'s validator permits dynamic quantisation for the TOKEN, TENSOR, TENSOR_GROUP and GROUP strategies. K3 declares GROUP, so `dynamic=true` would have been legal here. This leaf is a real choice, not a constant.",
+        "persistent_streams": "follows from initialization: with no `weight_scale` parameter there is no scale stream to persist. **The stored representation differs** \u2014 the second candidate answer is CONFIRMED.",
+        "forward_execution": "`lifecycle/forward.py`: `if args.dynamic in (True, LOCAL): scale, zero_point = compute_dynamic_scales_and_zp(...)` else `scale = getattr(module, f\"{base_name}_scale\")`. Execution reads a STORED scale only in the static case.",
+        "the_third_candidate_answer": "FALSIFIED. It is not the case that only calibration or forward behaviour changes while the persisted representation stays identical. The persisted representation is exactly what changes."
+      },
+      "verdict": "**`weights.dynamic` belongs to REPRESENTATION / STORAGE semantics.** It is the precondition under which a `weight_scale` operand exists at all: `false` means the scales were computed once and are stored, and the estate carries them; `true` means no scale is ever created, nothing is persisted, and the forward pass derives them per call. That is a fact about what the artifact CONTAINS, which is the operand plane's own business.",
+      "what_it_is_therefore_NOT": {
+        "not_exporter_provenance": "unlike `observer`, changing it changes what the checkpoint contains and what the forward pass does.",
+        "not_lifecycle_state": "`quantization_status: compressed` says where the artifact sits in the quantisation lifecycle; `dynamic: false` says whether the qparams are fixed or recomputed. Adjacent, not the same.",
+        "not_activation_state": "the error this document made and corrected. `input_activations` is a different leaf and is null here."
+      },
+      "a_coupling_worth_recording": "upstream FORCES `observer = None` when `dynamic is True` (with a warning), and defaults it to `memoryless_minmax` otherwise. So `observer: \"minmax\"` on K3 is itself corroborating evidence that the weights are static. The two leaves are related and still distinct: `dynamic` decides WHETHER static qparams exist, `observer` decides HOW they were chosen given that they do. A decomposition that merged them would lose the first question.",
+      "consequence_for_the_count": "the cluster map closes at FIVE authorities after all \u2014 but with `weights.dynamic` in the representation/storage cell rather than an activation one, which is a different retirement path and a different anti-cheat control. It may legitimately retire under this rung, because the representation plane genuinely governs it; it must never retire via activation-state handling."
     }
   },
   "F2_THE_DECLARED_SCOPE_DOES_NOT_DECIDE_THE_ESTATE": {


### PR DESCRIPTION
> **Evidence only. No forecast, no implementation, no blocker movement claimed.**
>
> Two documents, no code. The freeze comes after this lands, and lands separately, so the repository history shows that **the oracle preceded the freeze and the implementation**.

Reconnaissance for K3-COMPRESSED-BANK-1, plus the external decode oracle it earned. The question it was told to answer first was not "how do we support MXFP4" but **what the 14 `quantization_config` findings actually represent, and how many independent authorities are hiding inside that count**.

## The 14 findings are five authorities

```
9  codec identity / decode arithmetic   format ×2, quant_method, num_bits, type,
                                        symmetric, strategy, group_size, scale_dtype
2  scope — which tensors                ignore, targets
1  OPEN — authority not established     weights.dynamic
1  exporter provenance, inert to decode observer: "minmax"
1  lifecycle state                      quantization_status: "compressed"
```

**One cell is deliberately open.** The third commit on this branch corrects an error this branch made: `weights.dynamic = false` was first clustered as *activation quantisation*, and the oracle document then explained the absence of upstream's `input_global_scale` stream by it. Both borrowed a different leaf's authority — `compression_param_names` gates that stream on `input_activations.dynamic` (default `True`) and never consults `weights.dynamic`. The operand-plane conclusion survives; the reason did not. `weights.dynamic` is **reopened rather than relabelled**, so the count may be five authorities or six, and `24 → N` cannot be stated until it closes.

A decomposition that closes every cell on the first attempt has usually forced a leaf into a neighbour.

Each cluster is given what it must **reach** and what it must **not control**, so all 14 can eventually retire without pretending they are one authority.

`observer` is the anti-cheat control for the blocker accounting. It records how the exporter *chose* the scales and has no decode consequence whatever — a checkpoint quantised with a different observer decodes by identical arithmetic. **If it disappears merely because MXFP4 becomes decodable, the transition is overclaiming.** It may only retire if it acquires a truthful provenance home.

## The scope inversion

Measured against the real two-layer header fixture: 5,376 tensors carry `weight_packed`/`weight_scale`, none outside the routed bank; the six `ignore` regexes match 28 names and none is compressed. And yet `routed_expert_{down,up}_proj` and `self_attention_res_proj`/`mlp_res_proj` are `nn.Linear` modules in the checkpoint's own modeling code, matched by no ignore regex, shipped uncompressed BF16. (`block_sparse_moe.gate.weight` looks like a fourth counterexample and is not — `KimiMoEGate.weight` is an `nn.Parameter`, so `targets: ["Linear"]` never matched it.)

So `ignore` + `targets` is not a decidable predicate over the tensor names:

> **Configuration determines decode semantics; the stored estate determines whether an individual operand is compressed.**

This is not architecture inference from tensor names. For LatentMoE, tensor presence could not legitimately decide *which computation the model means*. Here the stored object necessarily decides whether a weight is BF16 or packed+scale, because the exporter's declared target language provably does not decide the actual estate. Reconstructing a predicate from `targets` plus the regexes is explicitly rejected — reconnaissance falsified it.

## The oracle: the codecs are the same

compressed-tensors 0.18.0, its own unmodified `unpack_fp4_from_uint8` and `decompress_mx_scale`, against real K3 bytes fetched by HTTP range request at the offsets the committed header fixture names:

```
elements compared   7168
BIT-IDENTICAL       True
max |Δ|             0.0
```

Matching on every axis: the E2M1 table element for element, adjacent-pair packing with the **low** nibble first, group size 32 along K per row, E8M0 as `2^(byte−127)` — which is exactly what LARQL's `f32::from_bits(byte << 23)` constructs — and the scale multiplying rather than dividing.

Six wrong readings, six non-zero deltas, so the bit-identity is a measurement rather than a fixture that could not tell the difference:

| control | max \|Δ\| |
|---|---|
| split-half instead of adjacent-pair | 0.140625 |
| nibble reversal | 0.125000 |
| E8M0 read as a linear uint8 | 725.91 |
| exponent bias off by one | 0.093750 |
| group index off by one | 0.125000 |
| scale divided instead of multiplied | 767.95 |

**Consequence: reuse the codec.** A second `CodecIdentity` because the container says `mxfp4-pack-quantized` would be the wrong abstraction — the codec *semantics* are the same and only the *binding* dialect differs. GPT-OSS ships `*_blocks`/`*_scales` fused over all experts; K3 ships `weight_packed`/`weight_scale` per expert per matrix.

## Two facts this checkpoint cannot witness

Recorded rather than assumed away by a bit-identical headline:

- **The E8M0 edge codes genuinely diverge.** LARQL returns `0.0` at `0x00` and `NaN` at `0xFF`; upstream returns `2⁻¹²⁷` and `2¹²⁸`. K3's scales all lie in 120–121, so it is not exercised here and is claimed neither way.
- **Padding is unwitnessed, not passed.** 3584 and 3072 are both divisible by 32, so no group is partial and no row is padded.

One upstream detail that saves the operand plane a guess: `MXFP4PackedCompressor.compression_param_names` adds `weight_zero_point` when the **weights** are asymmetric, and `input_global_scale` when a non-dynamic **input-activation** scheme requires it — gated on `getattr_chain(scheme, "input_activations.dynamic", True)`, which never consults `weights.dynamic`. K3 is symmetric and declares `input_activations: null`, so the chain falls to its default and neither auxiliary stream is required: they are absent **because the scheme does not require them**, not because the checkpoint forgot an operand.

## What is deliberately not here

No forecast. The count stays open: the oracle settled cluster 1's arithmetic and said nothing about whether scope, activation state, provenance and lifecycle acquire homes in this transition. `24 → 15` if only the codec cluster retires; `24 → 10` only if all five find honest homes. The durable operand claim is **spellings 6 → 0**, not an unclassified count, because whether 5,376 tensors become 5,376 operands or 2,688 with an auxiliary stream is a REPRESENT modelling decision not yet made.

Because the oracle precedes the freeze, the freeze must not present oracle-discovered facts as predictions. Nibble order and E8M0 semantics are now settled design inputs. What the freeze can still preregister: which clusters acquire which homes, whether the existing `CodecIdentity` is reused, exact blocker movement, spellings 6 → 0, closure and refusal behaviour, executor behaviour, estate blast radius, and controls for implementation errors the oracle has not already adjudicated.

This correction is a third commit rather than a rewrite, on the same principle the LatentMoE oracle notes used when measurement contradicted their own freeze: the wrong clustering is named, not quietly replaced. Catching it here is what the evidence-before-freeze ordering is for — a beautifully preregistered wrong authority is the failure it exists to prevent.

The `base` field in each document records the tree the **evidence was gathered against** (`1ae057d1`), which a rebase does not change. The K3 row itself was read from a fresh sweep at semantics 22.
