### PR TITLE
test(exec): the Direct pin reconciles against the object it bound

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
@@ -9,16 +9,18 @@ use super::super::accounting::{
 };
 use super::super::backend::{MatrixClass, WeightFormat};
 use super::super::cpu::ledger::{ledger, thread_projection_calls};
-use super::super::cpu::physical::PhysicalProjectionPlan;
+use super::super::cpu::physical::{KQuantExecution, PhysicalProjectionPlan};
 use super::super::operands::OperandStore;
 use super::super::prepared::{ExecutionSlice, PreparedOperands};
-use super::super::production::ProductionBackend;
+use super::super::production::{select_cpu, ProductionBackend};
 use super::super::realization::{
-    ExtentPin, RealizationForm, RealizationId, RealizationRecord, Selection, SelectionReason,
+    ExtentPin, RealizationForm, RealizationId, RealizationRecord, RepresentationFacts, Selection,
+    SelectionReason,
 };
 use super::super::weights::{load_weight, DEVICE_PAGE_ALIGN};
 use super::super::{execute_prepared_streaming, PlaneEvent};
 use super::bf16_zlib_execution::{transcode, Transcode};
+use super::kquant_projection::{a_stored_matrix, compiled, open as open_pack};
 use crate::format::vindex3::fixtures::{
     dense_f32_model, dense_f32_model_with, encode_fixture_container, HeadStorage,
 };
@@ -29,6 +31,7 @@ use crate::format::vindex3::represent::codec::codecs::{float, kquant, mxfp4, nvf
 use crate::format::vindex3::represent::codec::{
     CodecRegistry, RepresentationExtent, ResidencyProfile,
 };
+use crate::format::vindex3::represent::kquant::Q6_K;
 
 const F32_WIDTH: u64 = std::mem::size_of::<f32>() as u64;
 const BF16_WIDTH: u64 = std::mem::size_of::<u16>() as u64;
@@ -145,6 +148,7 @@ fn an_ffn_projection(plan: &ComponentOpPlan) -> OperandRef {
 /// re-priced under a MUTATED geometry, and the reconciliation must break —
 /// otherwise the comparison would be reading the declaration twice.
 #[test]
+#[serial_test::serial]
 fn every_resident_form_reconciles_with_its_declaration_and_a_mutated_geometry_breaks_it() {
     let f = fixture(dense_f32_model, None);
     let op = an_ffn_projection(&f.plan);
@@ -213,6 +217,121 @@ fn every_resident_form_reconciles_with_its_declaration_and_a_mutated_geometry_br
             "{format:?}: a mutated block geometry must break exactly the forms it prices"
         );
     }
+
+    // ── And one real Direct case, on a container that can hold one ────
+    //
+    // Every form above is either priced from the executor's geometry or
+    // decoded to f32, so none of them reaches the branch that reads
+    // `selection.residency` for a pin that binds the STORED bytes in
+    // place. That branch is the entire reason residency had to become
+    // realization-scoped, so it is witnessed here at the same
+    // declaration-versus-object boundary: a genuinely compiled Q6_K
+    // pack, the pin taken from the production selector rather than
+    // written down, and the object the production loader bound.
+    let tmp = tempfile::tempdir().unwrap();
+    let (_src, pack) = compiled(&tmp, Q6_K);
+    let store = open_pack(&pack, Q6_K);
+    let packed = a_stored_matrix(&pack, Q6_K);
+    let packed_stored = |o: &OperandRef| store.stored_len(o);
+    let operation = Operation::Project(MatrixClass::FfnProjection);
+    let planned = PlannedOperand {
+        operand: packed.clone(),
+        operation,
+        access: operation.access(),
+        extent: RepresentationExtent::BASE,
+        layer: Some(0),
+        declared_representation: None,
+        logical_elements: packed.shape.iter().product(),
+    };
+    let facts = RepresentationFacts::resolve(&packed.dtype);
+
+    // SELECTION: one stored operand, two production answers.
+    let direct = select_cpu(&planned, &facts, KQuantExecution::Direct).unwrap();
+    let widened = select_cpu(&planned, &facts, KQuantExecution::Widen).unwrap();
+    assert_eq!(
+        direct.realization,
+        RealizationId::cpu(RealizationForm::Direct(PhysicalProjectionPlan::FusedKQuant)),
+        "the production selector pins the stored pack in place"
+    );
+    assert_eq!(
+        widened.realization,
+        RealizationId::cpu(RealizationForm::Decode(PhysicalProjectionPlan::BlasF32)),
+        "and widening the same operand decodes it"
+    );
+    // DECLARATION: the two pins do not describe the same residency.
+    assert!(
+        direct.residency.bytes_per_weight < widened.residency.bytes_per_weight,
+        "the pins declare {} and {} bytes per weight over identical stored bytes",
+        direct.residency.bytes_per_weight,
+        widened.residency.bytes_per_weight
+    );
+
+    let pinned = |selection: &Selection| RealizationRecord {
+        planned: planned.clone(),
+        representation: packed.dtype.clone(),
+        provider: None,
+        extent: ExtentPin::unknown(),
+        verified_bytes: 0,
+        dependencies: Vec::new(),
+        selection: selection.clone(),
+    };
+    let bind = |format| {
+        let loaded = load_weight((&store).into(), &packed, format)
+            .unwrap_or_else(|e| panic!("{format:?}: {e}"));
+        let observed = vec![Bound::one(&packed, &loaded)
+            .observed(operation, Some(0))
+            .unwrap()];
+        observed
+    };
+    let on_stored = bind(WeightFormat::KQuant);
+    let on_widened = bind(WeightFormat::F32);
+
+    // OBSERVATION: the genuine Direct declaration against the object the
+    // loader actually bound — the stored blocks, not a derivative.
+    let direct_rec = pinned(&direct);
+    let priced = expectations(std::slice::from_ref(&direct_rec), packed_stored, executor);
+    let ok = reconcile(&priced, &on_stored).expect("the Direct pin reconciles with what it bound");
+    assert_eq!(ok.matched, 1);
+    assert_eq!(ok.padding, 0, "stored blocks are bound exactly");
+    // A Direct pin is priced from its OWN declaration, so the executor's
+    // block geometry is not what holds this arm up.
+    reconcile(
+        &expectations(std::slice::from_ref(&direct_rec), packed_stored, mutated),
+        &on_stored,
+    )
+    .expect("a Direct pin is priced from its declaration, not the executor's geometry");
+
+    // MUTATION: move the Direct pin's residency and nothing else. The
+    // reconciliation must fail, and name the pin it failed for.
+    let mut tampered = direct_rec.clone();
+    tampered.selection.residency.bytes_per_weight *= 2.0;
+    let err = reconcile(
+        &expectations(std::slice::from_ref(&tampered), packed_stored, executor),
+        &on_stored,
+    )
+    .expect_err("a Direct declaration that doubled must not reconcile with the bound object")
+    .to_string();
+    assert!(err.contains(&packed.tensor), "{err}");
+    assert!(err.contains("cpu:direct/FusedKQuant"), "{err}");
+    assert!(
+        err.contains("the declaration and the loader disagree"),
+        "{err}"
+    );
+
+    // CONTROL: the decode pin on the same stored bytes is undisturbed by
+    // that mutation — it was a fact about one pin, not about the operand.
+    let decode_rec = pinned(&widened);
+    let ok = reconcile(
+        &expectations(std::slice::from_ref(&decode_rec), packed_stored, executor),
+        &on_widened,
+    )
+    .expect("the decode pin still reconciles");
+    assert_eq!(ok.matched, 1);
+    reconcile(
+        &expectations(std::slice::from_ref(&direct_rec), packed_stored, executor),
+        &on_stored,
+    )
+    .expect("and so does the un-tampered Direct pin");
 }
 
 #[test]

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
@@ -66,7 +66,10 @@ fn spec(encoding: &str) -> RepresentSpec {
 
 /// The dense fixture, encoded, then compiled to `codec`. Returns the
 /// source and the compiled container.
-fn compiled(tmp: &tempfile::TempDir, codec: KQuant) -> (std::path::PathBuf, std::path::PathBuf) {
+pub(super) fn compiled(
+    tmp: &tempfile::TempDir,
+    codec: KQuant,
+) -> (std::path::PathBuf, std::path::PathBuf) {
     let checkpoint = tmp.path().join("ckpt");
     std::fs::create_dir_all(&checkpoint).unwrap();
     let src = tmp.path().join("src.vindex3");
@@ -79,7 +82,7 @@ fn compiled(tmp: &tempfile::TempDir, codec: KQuant) -> (std::path::PathBuf, std:
 
 /// The first two-dimensional tensor stored as `codec` in the compiled
 /// container, as an operand reference.
-fn a_stored_matrix(out: &std::path::Path, codec: KQuant) -> OperandRef {
+pub(super) fn a_stored_matrix(out: &std::path::Path, codec: KQuant) -> OperandRef {
     let index: Vindex3Index =
         serde_json::from_str(&std::fs::read_to_string(out.join(INDEX_JSON)).unwrap()).unwrap();
     let entry = index
@@ -101,7 +104,7 @@ fn a_stored_matrix(out: &std::path::Path, codec: KQuant) -> OperandRef {
     }
 }
 
-fn open(out: &std::path::Path, codec: KQuant) -> OperandStore {
+pub(super) fn open(out: &std::path::Path, codec: KQuant) -> OperandStore {
     let inspection = inspect_container(out, false).unwrap();
     OperandStore::open_for(
         out,


### PR DESCRIPTION
Closes the final seam in the **realization-scoped residency** guarantee before the v1 representation-contract freeze.

## The gap

`every_resident_form_reconciles_with_its_declaration_and_a_mutated_geometry_breaks_it` covered six forms — `Decode`, `Requantise(×2)` and `DeviceResident(×3)`. Every one of them is priced from the executor's block geometry or decoded to f32, so none reached the branch that reads `selection.residency` for a pin that binds the **stored** bytes in place:

```rust
RealizationForm::Direct(_) | RealizationForm::Decode(_) => r.selection.residency,
```

`Direct` was proven *selected* (`the_policy_answers_the_pack_under_direct_and_f32_under_widen`), *declared* (`realization.rs`), *priced* (`expectations`) and *bound* (`a_stored_matrix_projects_the_same_direct_and_widened`) — but its expectation was never reconciled against its observation. A regression could have made the two disagree with every cited test still green.

## What this adds

One real `Direct` case in that same test, on an actually compiled Q6_K pack:

| link | value carried |
|---|---|
| selection | `select_cpu(…, Direct)` → `cpu:direct/FusedKQuant`; `select_cpu(…, Widen)` → `cpu:decode-f32+BlasF32`, same operand |
| declaration | 0.8203125 vs 4.0 bytes/weight over identical stored bytes |
| observation | `load_weight(KQuant)` binds the stored blocks; declared 13440 == observed 13440, padding 0 |
| mutation | doubling **only** that pin's `residency.bytes_per_weight` refuses, naming the tensor and `cpu:direct/FusedKQuant` |
| control | the decode pin on the same stored bytes still reconciles; the mutated block geometry does **not** re-price `Direct` |

The pin comes from the production selector and the object from the production loader — neither is constructed.

## Both controls checked non-vacuous

- Neutering the mutation (`*= 1.0`) → test fails: `Reconciliation { matched: 1, declared_resident: 13440, observed_resident: 13440 }`.
- Pointing the decode arm at the stored object → fails on `pinned F32 but KQuant is resident`.

## Notes

- The test now decodes, so it takes `#[serial]` — it stages an f32 image through the process-global arena the staged tests assert on.
- Three helpers in `kquant_projection.rs` become `pub(super)` so the compiled-Q6_K machinery has one source rather than a copy.
- Test-only: no production code changed.

`cargo test -p larql-vindex` 4632 passed / 0 failed · `cargo clippy --all-targets -D warnings` clean · `cargo fmt` applied.