### PR TITLE
feat(represent): close the registry over its consumers — FP8 as a codec, Q5_K/Q3_K, the admission seam

### DIFF
--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/mod.rs
@@ -28,6 +28,12 @@ pub enum Vindex3Command {
     /// Reconstruct and check a container solely from its own contents —
     /// no source checkpoint, no architecture registry (the G3 gate).
     Inspect(InspectArgs),
+    /// The dependencies a container declares between its own tensors —
+    /// today, the `scales` grid of every fine-grained FP8 weight. With
+    /// `--declare`, derive them from the segment headers and write the
+    /// table, for a container encoded before the encoder declared them;
+    /// the rule is the encoder's own, applied late.
+    References(ReferencesArgs),
     /// Prove source ≡ encoded (the G4 gate): four-authority semantic
     /// comparison plus per-representation byte equivalence, both ends
     /// re-hashed now. Exits non-zero on any disagreement.
@@ -489,6 +495,17 @@ pub struct InspectArgs {
 }
 
 #[derive(Args)]
+pub struct ReferencesArgs {
+    /// Container directory.
+    pub container: PathBuf,
+
+    /// Derive the table from the segment headers and write it. Refuses a
+    /// container that already declares one.
+    #[arg(long)]
+    pub declare: bool,
+}
+
+#[derive(Args)]
 pub struct PlanArgs {
     /// Checkpoint directories, inventory JSON files, or `hf://` repos
     /// (one per artifact).
@@ -509,6 +526,7 @@ pub fn run(cmd: Vindex3Command) -> Result<(), Box<dyn std::error::Error>> {
         Vindex3Command::Plan(args) => run_plan(args),
         Vindex3Command::Encode(args) => run_encode(args),
         Vindex3Command::Inspect(args) => run_inspect(args),
+        Vindex3Command::References(args) => run_references(args),
         Vindex3Command::Verify(args) => run_verify(args),
         Vindex3Command::Ops(args) => run_ops(args),
         Vindex3Command::Exec(args) => run_exec(args),
@@ -866,6 +884,34 @@ fn human_bytes(bytes: u64) -> String {
     } else {
         format!("{bytes} B")
     }
+}
+
+fn run_references(args: ReferencesArgs) -> Result<(), Box<dyn std::error::Error>> {
+    use larql_vindex::format::vindex3::auxiliary_references::AuxiliaryReferences;
+    if args.declare {
+        let declared = larql_vindex::format::vindex3::encode::declare_references(&args.container)?;
+        if declared == 0 {
+            println!("no dependency to declare; nothing written");
+        } else {
+            println!("declared {declared} reference(s)");
+        }
+        return Ok(());
+    }
+    let inspection =
+        larql_vindex::format::vindex3::inspect::inspect_container(&args.container, false)?;
+    let Some(name) = &inspection.index.auxiliary_references else {
+        println!("the container declares no dependencies");
+        return Ok(());
+    };
+    let table = AuxiliaryReferences::read(&args.container, name)?;
+    println!("{} reference(s) in {name}:", table.len());
+    for row in table.stored().references {
+        println!(
+            "  {}/{}  --{}-->  {}/{}",
+            row.owner.object, row.owner.tensor, row.auxiliary, row.target.object, row.target.tensor
+        );
+    }
+    Ok(())
 }
 
 fn run_inspect(args: InspectArgs) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/realizations.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/realizations.rs
@@ -110,7 +110,8 @@ fn a_registry_without_the_representation_refuses_before_io() {
     let empty: &'static CodecRegistry = Box::leak(Box::new(CodecRegistry::new()));
     let store = OperandStore::open(&out, &inspection)
         .unwrap()
-        .with_registry(empty);
+        .with_registry(empty)
+        .unwrap();
     let budget = larql_vindex::format::vindex3::opplan::exec::accounting::ResidencyBudget::physical(
         1024 * 1024 * 1024 * 1024,
     );

--- a/crates/larql-models/src/quant/fp8_finegrained.rs
+++ b/crates/larql-models/src/quant/fp8_finegrained.rs
@@ -286,6 +286,20 @@ pub fn is_scale_sibling(name: &str) -> bool {
     name.ends_with("_scale_inv")
 }
 
+/// The weight a scale sibling belongs to — [`scale_sibling_name`]
+/// inverted — or `None` for a name that is not a sibling at all.
+///
+/// This is the checkpoint's convention consumed ONCE, by the encoder
+/// that turns it into a declared reference in the container; nothing
+/// downstream of the container spells it. Like its inverse it decides
+/// only the name, never whether the weight exists.
+pub fn weight_of_scale_sibling(name: &str) -> Option<String> {
+    if let Some(stem) = name.strip_suffix(".weight_scale_inv") {
+        return Some(format!("{stem}.weight"));
+    }
+    name.strip_suffix("_scale_inv").map(str::to_string)
+}
+
 #[cfg(test)]
 #[path = "tests/fp8_finegrained.rs"]
 mod tests;

--- a/crates/larql-vindex/src/format/vindex3/encode/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/encode/mod.rs
@@ -34,11 +34,12 @@ use std::path::{Path, PathBuf};
 
 use larql_models::inventory::ArchitectureInventory;
 
+use super::auxiliary_references::{AuxiliaryReference, AuxiliaryReferences, OperandAddress};
 use super::graph::{most_specific_owner, LogicalObject, SystemGraph};
 use super::index::{RepresentationEntry, Vindex3Index};
 use super::plan::plan_system;
 use crate::error::VindexError;
-use crate::format::filenames::INDEX_JSON;
+use crate::format::filenames::{AUXILIARY_REFERENCES_JSON, INDEX_JSON};
 use segment::PlannedTensor;
 use source::{ArtifactSource, TensorSource};
 
@@ -261,6 +262,7 @@ pub fn encode_graph_with_sources(
     let mut directory: BTreeMap<String, RepresentationEntry> = BTreeMap::new();
     let mut segment_keys: BTreeMap<String, u32> = BTreeMap::new();
     let mut total_payload_bytes = 0u64;
+    let mut references: Vec<AuxiliaryReference> = Vec::new();
 
     for object in &graph.objects {
         let Some(representation) = object.representations.first() else {
@@ -276,6 +278,12 @@ pub fn encode_graph_with_sources(
         let segment_key = format!("{SEGMENTS_DIR}/{}", object.id);
         let segment_rel = format!("{segment_key}.{SEGMENT_BIN_EXT}");
         let planned = plan_object_tensors(object, &inventories, &graph.objects)?;
+        references.extend(declared_references(
+            &object.id,
+            planned
+                .iter()
+                .map(|t| (t.relative_name.as_str(), t.dtype.as_str())),
+        ));
 
         let written = segment::write_segment(
             &out.join(&segment_rel),
@@ -324,7 +332,18 @@ pub fn encode_graph_with_sources(
         .map_err(|e| VindexError::Parse(format!("serialise system graph: {e}")))?;
     std::fs::write(out.join(SYSTEM_GRAPH_JSON), graph_json)?;
 
-    let index = system_index(graph, named, directory, segment_keys)?;
+    let mut index = system_index(graph, named, directory, segment_keys)?;
+    // The dependencies the container DECLARES, written before the index
+    // that names the table: a reader that finds the index finds the
+    // table. Absent when nothing depends on anything — absence means "no
+    // dependency is declared", never "look somewhere else".
+    if !references.is_empty() {
+        let table = AuxiliaryReferences::new(references);
+        let table_json = serde_json::to_string_pretty(&table)
+            .map_err(|e| VindexError::Parse(format!("serialise auxiliary references: {e}")))?;
+        std::fs::write(out.join(AUXILIARY_REFERENCES_JSON), table_json)?;
+        index.auxiliary_references = Some(AUXILIARY_REFERENCES_JSON.to_string());
+    }
     let index_json = serde_json::to_string_pretty(&index)
         .map_err(|e| VindexError::Parse(format!("serialise index.json: {e}")))?;
     std::fs::write(out.join(INDEX_JSON), index_json)?;
@@ -334,6 +353,98 @@ pub fn encode_graph_with_sources(
         representations: index.representations.len(),
         total_payload_bytes,
     })
+}
+
+/// The dependencies one object's tensors declare on each other, as the
+/// container will address them.
+///
+/// This is where a checkpoint's naming convention becomes a declared
+/// reference, and the only place that convention is consumed: fine-grained
+/// FP8 ships a `*.weight_scale_inv` grid beside every E4M3 `*.weight`, and
+/// the FP8 codec requires that grid under the name it declares. A sibling
+/// beside a weight stored under any OTHER label declares nothing — the
+/// pairing is the FP8 representation's, not a rule about names — and a
+/// stray grid whose weight is absent is left for closure to report.
+fn declared_references<'a>(
+    object: &str,
+    tensors: impl IntoIterator<Item = (&'a str, &'a str)>,
+) -> Vec<AuxiliaryReference> {
+    use super::represent::codec::codecs::fp8_block::{DTYPE_FP8_BLOCK, SCALES};
+    use larql_models::quant::fp8_finegrained::weight_of_scale_sibling;
+    let tensors: Vec<(&str, &str)> = tensors.into_iter().collect();
+    let fp8_weights: std::collections::BTreeSet<&str> = tensors
+        .iter()
+        .filter(|(_, dtype)| *dtype == DTYPE_FP8_BLOCK)
+        .map(|(name, _)| *name)
+        .collect();
+    tensors
+        .iter()
+        .filter_map(|(name, _)| {
+            let weight = weight_of_scale_sibling(name)?;
+            fp8_weights
+                .contains(weight.as_str())
+                .then(|| AuxiliaryReference {
+                    owner: OperandAddress::new(object, &weight),
+                    auxiliary: SCALES.to_string(),
+                    target: OperandAddress::new(object, *name),
+                })
+        })
+        .collect()
+}
+
+/// Declare the dependencies a container's tensors imply, for a container
+/// encoded before the encoder declared them.
+///
+/// The rule is [`declared_references`] — the encoder's own, applied late
+/// to the segment headers already on disk — so a container migrated here
+/// carries exactly the table a fresh encode would have written, and the
+/// convention it consumes stays consumed in one place. Writes the table
+/// and names it in the index; returns how many references were declared,
+/// and writes nothing when there are none (absence means "no dependency
+/// is declared"). A container that already declares a table is refused
+/// rather than merged with: which of two tables an encoder meant has no
+/// answer, and the table that is there was written on purpose.
+pub fn declare_references(root: &Path) -> Result<usize, VindexError> {
+    let index_path = root.join(INDEX_JSON);
+    let mut index: Vindex3Index = serde_json::from_str(&std::fs::read_to_string(&index_path)?)
+        .map_err(|e| VindexError::Parse(format!("parse {INDEX_JSON}: {e}")))?;
+    if let Some(name) = &index.auxiliary_references {
+        return Err(VindexError::Parse(format!(
+            "the container already declares its dependencies in `{name}`; refusing to \
+             rewrite a table that was written on purpose"
+        )));
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    let mut references = Vec::new();
+    for entry in index.representations.values() {
+        let (header, _) = segment::read_segment_header(&root.join(&entry.segment))?;
+        let tensors = header
+            .tensors
+            .iter()
+            .map(|t| (t.name.as_str(), t.dtype.as_str()));
+        // Two representations of one object — its canonical bytes and a
+        // compiled pack — may both hold the pair; one dependency, declared
+        // once, is what the table admits.
+        for reference in declared_references(&entry.object, tensors) {
+            if seen.insert((reference.owner.clone(), reference.auxiliary.clone())) {
+                references.push(reference);
+            }
+        }
+    }
+    let declared = references.len();
+    if declared == 0 {
+        return Ok(0);
+    }
+    let table = AuxiliaryReferences::new(references);
+    table.judge()?;
+    let table_json = serde_json::to_string_pretty(&table)
+        .map_err(|e| VindexError::Parse(format!("serialise auxiliary references: {e}")))?;
+    std::fs::write(root.join(AUXILIARY_REFERENCES_JSON), table_json)?;
+    index.auxiliary_references = Some(AUXILIARY_REFERENCES_JSON.to_string());
+    let index_json = serde_json::to_string_pretty(&index)
+        .map_err(|e| VindexError::Parse(format!("serialise {INDEX_JSON}: {e}")))?;
+    std::fs::write(&index_path, index_json)?;
+    Ok(declared)
 }
 
 /// Refuse a graph that does not validate, naming its defects.

--- a/crates/larql-vindex/src/format/vindex3/opplan/build.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/build.rs
@@ -546,39 +546,16 @@ pub fn plan_component_ops(
             if auxiliary_stream_of(&tensor.name, &names).is_some() {
                 continue;
             }
-            // A quantisation SCALE is part of the operand it accompanies
-            // rather than an operand of its own: fine-grained FP8 stores
-            // a matrix as `*.weight` plus `*.weight_scale_inv`, and
-            // `load_weight` binds the pair. This is a different
-            // relationship from `auxiliary_stream_of` above, which asks
-            // whether the base before the last `.` is itself a tensor —
-            // for `…gate_proj.weight_scale_inv` that base is
-            // `…gate_proj`, and the tensor is `…gate_proj.weight`.
-            //
-            // Skipped only when its weight is HERE. An orphaned scale is
-            // still a defect: a split pair leaves neither half bindable.
-            if larql_models::quant::fp8_finegrained::is_scale_sibling(&tensor.name) {
-                let base = tensor
-                    .name
-                    .strip_suffix(".weight_scale_inv")
-                    .map(|stem| format!("{stem}.weight"))
-                    .or_else(|| {
-                        tensor
-                            .name
-                            .strip_suffix("_scale_inv")
-                            .map(|stem| stem.to_string())
-                    })
-                    .filter(|w| names.contains(w.as_str()));
-                if base.is_some() {
-                    continue;
-                }
-                defects.push(ClosureDefect::UnclassifiedOperand {
-                    object: object.id.clone(),
-                    tensor: tensor.name.clone(),
-                });
-                continue;
-            }
             // Referenced by something: its fate is its owner's requirement.
+            //
+            // A fine-grained FP8 scale grid is the case this rule was
+            // first paid for in production: the encoder declares the
+            // `scales` dependency of every E4M3 weight, so the grid is
+            // referenced here and nothing about its NAME is judged. A
+            // grid nothing references — an orphan, or a container written
+            // before the encoder declared dependencies — falls through to
+            // classification and is reported unclassified, which is the
+            // defect it is: a split pair leaves neither half bindable.
             if references.is_referenced(&object.id, &tensor.name) {
                 continue;
             }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/operands.rs
@@ -241,6 +241,10 @@ pub struct SelectedRepresentation {
     pub encoding: String,
     /// Whether those bytes came from a compiled pack.
     pub stored: bool,
+    /// The decode ABI the pack declares, when it declares one — kept so
+    /// the admission that ran at open can run again against another
+    /// registry ([`OperandStore::with_registry`]).
+    pub codec: Option<crate::format::vindex3::represent::nvfp4_pack::CodecIdentity>,
 }
 
 impl OperandStore {
@@ -260,6 +264,25 @@ impl OperandStore {
         inspection: &SystemInspection,
         want: Option<&str>,
         source: RepresentationSource,
+    ) -> Result<Self, VindexError> {
+        Self::open_in(root, inspection, want, source, CodecRegistry::builtin())
+    }
+
+    /// [`Self::open_for`], decoding through `registry` from the first
+    /// byte: the pack admission at open, selection, provider identity and
+    /// decode all read this one registry.
+    ///
+    /// This is the constructor an external provider needs. A pack whose
+    /// identity names a family only that provider registers is admitted
+    /// here, and would have been refused by name — before the provider's
+    /// registry was ever consulted — had the store been opened through the
+    /// built-in one and re-pointed afterwards.
+    pub fn open_in(
+        root: &Path,
+        inspection: &SystemInspection,
+        want: Option<&str>,
+        source: RepresentationSource,
+        registry: &'static CodecRegistry,
     ) -> Result<Self, VindexError> {
         let mut segments = BTreeMap::new();
         let mut absent: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
@@ -307,7 +330,7 @@ impl OperandStore {
                     // contract this one may not implement must be refused
                     // here, before anything reads them.
                     if let Some(codec) = &entry.codec {
-                        codec.admit()?;
+                        codec.admit_in(registry)?;
                     }
                     (id.clone(), entry, true)
                 }
@@ -327,6 +350,7 @@ impl OperandStore {
             selected.insert(
                 object.id.clone(),
                 SelectedRepresentation {
+                    codec: entry.codec.clone(),
                     encoding: entry.encoding.clone(),
                     stored: is_stored,
                 },
@@ -382,7 +406,7 @@ impl OperandStore {
             None => crate::format::vindex3::representation_attestations::AttestationTable::empty(),
         };
         Ok(Self {
-            registry: CodecRegistry::builtin(),
+            registry,
             references,
             attestations,
             recognised:
@@ -407,13 +431,24 @@ impl OperandStore {
         })
     }
 
-    /// The same store, decoding through `registry` instead of the built-in
-    /// one. Selection, provider identity and decode all read this one
-    /// registry, so a codec registered here is executable end to end and a
-    /// codec absent from it is refused everywhere.
-    pub fn with_registry(mut self, registry: &'static CodecRegistry) -> Self {
+    /// The same store, decoding through `registry` instead of the one it
+    /// was opened with. Selection, provider identity and decode all read
+    /// this one registry, so a codec registered here is executable end to
+    /// end and a codec absent from it is refused everywhere.
+    ///
+    /// Every pack the open admitted is admitted AGAIN, against the new
+    /// registry: a store cannot be re-pointed at a registry that does not
+    /// implement the contract its bytes were written under. A pack the
+    /// open could not admit never reaches here — open the store through
+    /// [`Self::open_in`] with the registry that knows it.
+    pub fn with_registry(mut self, registry: &'static CodecRegistry) -> Result<Self, VindexError> {
+        for selected in self.selected.values() {
+            if let (true, Some(codec)) = (selected.stored, &selected.codec) {
+                codec.admit_in(registry)?;
+            }
+        }
         self.registry = registry;
-        self
+        Ok(self)
     }
 
     /// The same store, acting on measurements from these authorities and
@@ -925,46 +960,6 @@ impl OperandStore {
         Some(total)
     }
 
-    /// A companion tensor of `operand`, from the SAME logical object:
-    /// its declared shape and its stored bytes.
-    ///
-    /// Exists for the one format whose operand is not one tensor.
-    /// Fine-grained FP8 stores a matrix as `*.weight` plus a sibling
-    /// `*.weight_scale_inv`, and an [`OperandRef`] names one tensor —
-    /// so the pair can only be bound if the second can be reached from
-    /// the first.
-    ///
-    /// Deliberately scoped to the same object rather than taking a free
-    /// `(object, tensor)` pair: a scale that came from somewhere else
-    /// would be a different matrix's, and the type should not be able to
-    /// express that.
-    pub fn companion(
-        &self,
-        operand: &OperandRef,
-        tensor: &str,
-    ) -> Result<(Vec<usize>, RawOperand), VindexError> {
-        let companion = OperandRef {
-            object: operand.object.clone(),
-            tensor: tensor.to_string(),
-            // The container's own record is the authority for both; these
-            // are placeholders that `load_raw` never reads.
-            dtype: String::new(),
-            shape: Vec::new(),
-        };
-        let shape = self
-            .segments
-            .get(&operand.object)
-            .and_then(|s| s.tensors.get(tensor))
-            .map(|t| t.shape.clone())
-            .ok_or_else(|| {
-                VindexError::Parse(format!(
-                    "operand `{}` names no companion `{tensor}` in `{}`'s segment",
-                    operand.tensor, operand.object
-                ))
-            })?;
-        Ok((shape, self.load_raw(&companion)?))
-    }
-
     /// Load one operand's stored bytes and dtype, unwidened — for a
     /// caller that converts to a representation other than f32 (and for
     /// [`Self::load`] itself, so there is exactly one resolution path).
@@ -1312,29 +1307,6 @@ impl<'a> OperandSource<'a> {
     /// f32-space facts and cannot be represented in raw stored bytes,
     /// so an overridden operand refuses here rather than serving stale
     /// base bytes.
-    /// A companion tensor of `operand` from the same object — see
-    /// [`OperandStore::companion`].
-    ///
-    /// Refuses an overridden operand for the same reason [`Self::load_raw`]
-    /// does: an overlay edit is an f32-space fact, and serving the base
-    /// scales beside edited codes would silently mix the two.
-    pub fn companion(
-        &self,
-        operand: &OperandRef,
-        tensor: &str,
-    ) -> Result<(Vec<usize>, RawOperand), VindexError> {
-        if let Some(overrides) = self.overrides {
-            if overrides.is_overridden(operand) {
-                return Err(VindexError::Parse(format!(
-                    "operand `{}/{}` carries overlay edits — its companion `{tensor}` \
-                     cannot be bound beside edited values",
-                    operand.object, operand.tensor
-                )));
-            }
-        }
-        self.base.companion(operand, tensor)
-    }
-
     pub fn load_raw(&self, operand: &OperandRef) -> Result<RawOperand, VindexError> {
         if let Some(overrides) = self.overrides {
             if overrides.is_overridden(operand) {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -1418,10 +1418,11 @@ pub fn select_realizations_within<B: PlanBackend + ?Sized>(
     // The access policy is the budget's, not the candidate's: every mapped
     // pin executes under the one the caller declared.
     for (record, _) in &mut selected {
-        record.selection.realization = record
+        let under_policy = record
             .selection
             .realization
             .with_access(budget.expert_access);
+        record.repin(under_policy);
     }
     // The floor gates SELECTION, so it is asked about what was selected
     // — here, before any budget pressure — and not only about the
@@ -1518,7 +1519,7 @@ pub fn select_realizations_within<B: PlanBackend + ?Sized>(
             saving as f64 / 1e9
         ));
         record.selection.residency = realization_residency(facts, candidate);
-        record.selection.realization = candidate;
+        record.repin(candidate);
         record.selection.reason = SelectionReason::BudgetPolicy;
     }
 }
@@ -1643,22 +1644,38 @@ fn select_records<B: PlanBackend + ?Sized>(
         // declaration. The pin starts on the whole of it; a budget may
         // move it shallower, and nothing else may.
         let extent = extent_pin(registry, &label, &planned);
-        let dependencies = dependency_pins(registry, &label, &planned, extent.selected, store);
+        let mut dependencies = dependency_pins(registry, &label, &planned, extent.selected, store);
         match backend.select(&planned, &facts) {
-            Ok(selection) => records.push((
-                RealizationRecord {
-                    representation: label.to_string(),
-                    provider,
-                    planned,
-                    selection,
-                    extent,
-                    dependencies,
-                    // Filled in by the carriage pass below, which is the
-                    // only thing that reads a payload to verify a claim.
-                    verified_bytes: 0,
-                },
-                facts,
-            )),
+            Ok(selection) => {
+                // The lifetime is the REALIZATION's: a decode is finished
+                // with its dependency once it has an f32 image, and a
+                // direct kernel over the stored codes keeps it for every
+                // token. Decided here, after the pin, because nothing
+                // before the pin knows which.
+                let lifetime = if selection.realization.retains_dependencies() {
+                    DependencyLifetime::Retained
+                } else {
+                    DependencyLifetime::PreparationOnly
+                };
+                for dependency in &mut dependencies {
+                    dependency.lifetime = lifetime;
+                }
+                records.push((
+                    RealizationRecord {
+                        representation: label.to_string(),
+                        provider,
+                        planned,
+                        selection,
+                        extent,
+                        dependencies,
+                        // Filled in by the carriage pass below, which is
+                        // the only thing that reads a payload to verify a
+                        // claim.
+                        verified_bytes: 0,
+                    },
+                    facts,
+                ))
+            }
             Err(refusal) => refusals.push(*refusal),
         }
     }
@@ -1718,11 +1735,11 @@ fn shallowest_saving(
 /// What `planned`'s codec depends on at `extent`, as the container's
 /// reference table addresses it, priced from the container's record.
 ///
-/// The LIFETIME is the realization's: every realization this build ships
-/// decodes, and a decode is finished with its dependency once it has an
-/// f32 image, so every pin here is `PreparationOnly`. A direct kernel
-/// over codes would declare `Retained`, and the ledger already knows what
-/// that costs — which is the point of pricing it before anyone builds one.
+/// The LIFETIME is the realization's and is not known here: every pin
+/// starts `PreparationOnly` and [`select_records`] sets it from the
+/// realization the backend pinned. A direct kernel over codes — the FP8
+/// codes with their scale grid — retains its dependency, and the ledger
+/// prices exactly that.
 fn dependency_pins(
     registry: &CodecRegistry,
     label: &str,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -865,6 +865,18 @@ pub(crate) fn select_cpu(
             KQuantExecution::Widen => pick(decode, SelectionReason::ArmPrefersDecode),
         };
     }
+    // The checkpoint's own fine-grained FP8 bytes, executed in place with
+    // their scale grid retained. Ranked with the compiled packs above and
+    // for the same reason: the stored bytes are the compact form, and the
+    // only alternative is a widened image — 612 GB of a 306 GB checkpoint
+    // on GLM-5.3-Flash — which stays a candidate for the oracle and is
+    // never the policy's choice.
+    if has(Direct(PhysicalProjectionPlan::FusedFp8Block)) {
+        return pick(
+            RealizationId::cpu(Direct(PhysicalProjectionPlan::FusedFp8Block)),
+            SelectionReason::DirectDeclared,
+        );
+    }
     // The size policy is asked whether a bf16 image is worth keeping
     // compact — and the fact it is asked about is the codec DECLARING the
     // direct bf16 kernel, not a dtype the loader compared.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
@@ -286,6 +286,25 @@ impl RealizationId {
         }
     }
 
+    /// Whether this realization keeps its codec's DEPENDENCIES resident
+    /// while serving — the fact a dependency pin's lifetime is set from.
+    ///
+    /// A realization over the STORED bytes reads what those bytes need on
+    /// every token: a direct kernel over FP8 codes multiplies by the scale
+    /// grid, a mapped bank executes in place. A realization that decodes
+    /// — to f32, to a re-quantised image, to a device's own form — is
+    /// finished with the dependency once the image exists.
+    pub fn retains_dependencies(self) -> bool {
+        match self.form {
+            RealizationForm::Direct(_) | RealizationForm::MappedStored { .. } => true,
+            RealizationForm::Decode(_)
+            | RealizationForm::Requantise(_)
+            | RealizationForm::SliceStored { .. }
+            | RealizationForm::DecodedGather
+            | RealizationForm::DeviceResident(_) => false,
+        }
+    }
+
     /// The access realization of a mapped form; every other form is
     /// brought in whole at binding and has none.
     pub fn access(self) -> MappedAccess {
@@ -508,6 +527,24 @@ pub struct RealizationRecord {
     /// observe rather than assert.
     pub verified_bytes: u64,
     pub dependencies: Vec<DependencyPin>,
+}
+
+impl RealizationRecord {
+    /// Pin another realization on this record, and let every dependency's
+    /// lifetime follow it: the lifetime is the realization's, so a re-pin
+    /// that left it standing would price the old realization's retention
+    /// against the new one's bytes.
+    pub fn repin(&mut self, realization: RealizationId) {
+        self.selection.realization = realization;
+        let lifetime = if realization.retains_dependencies() {
+            DependencyLifetime::Retained
+        } else {
+            DependencyLifetime::PreparationOnly
+        };
+        for dependency in &mut self.dependencies {
+            dependency.lifetime = lifetime;
+        }
+    }
 }
 
 /// What a realization does with a dependency once it has read it.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
@@ -52,6 +52,7 @@ impl Fixture {
         OperandStore::open(self.container.path(), &self.inspection)
             .unwrap()
             .with_registry(registry)
+            .unwrap()
     }
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/composed_floor/container.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/composed_floor/container.rs
@@ -59,6 +59,7 @@ impl Built {
         let store = OperandStore::open(&self.container(), &inspection)
             .unwrap()
             .with_registry(registry())
+            .unwrap()
             .with_recognised(recognised);
         (plan, store)
     }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/fp8_carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/fp8_carriage.rs
@@ -10,8 +10,10 @@
 //!
 //! ```text
 //! checkpoint (F8_E4M3 + F32 grid)
-//!   -> encode_system -> OperandStore -> load_weight(Fp8Block)
-//!   -> WeightSlice -> WeightRows -> FusedFp8Block          the candidate
+//!   -> encode_system (declares `scales`) -> OperandStore
+//!   -> select: cpu:direct/FusedFp8Block, grid RETAINED
+//!   -> load_weight(Fp8Block) -> WeightSlice -> WeightRows -> FusedFp8Block
+//!                                                          the candidate
 //!
 //! the SAME source bytes -> fp8_finegrained::dequantize -> scalar dot
 //!                                                        the authority
@@ -19,24 +21,43 @@
 //!
 //! The authority reads the CHECKPOINT's bytes, not the container's, so
 //! the two arms share nothing downstream of the source file. A carriage
-//! defect — a dropped sibling, a transposed grid, a tile read off the
+//! defect — a dropped grid, a transposed grid, a tile read off the
 //! config — moves one and not the other.
+//!
+//! Since the format became a codec (`F8_E4M3`, family `fp8-block`), the
+//! grid is a DECLARED dependency the encoder writes into the reference
+//! table, the canonical decode is the registry's, and the kernel is
+//! reached by selection rather than by a caller that knew the answer.
+//! The tests below hold each of those.
 
+use crate::format::vindex3::auxiliary_references::OperandAddress;
 use crate::format::vindex3::encode::segment::read_segment_header;
 use crate::format::vindex3::fixtures::{dense_fp8_model, encode_fixture_container};
 use crate::format::vindex3::index::Vindex3Index;
 use crate::format::vindex3::inspect::inspect_container;
-use crate::format::vindex3::opplan::exec::backend::{WeightFormat, WeightSlice};
+use crate::format::vindex3::opplan::exec::backend::{PlanBackend, WeightFormat, WeightSlice};
 use crate::format::vindex3::opplan::exec::cpu::kernels::FusedFp8Block;
+use crate::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
 use crate::format::vindex3::opplan::exec::cpu::projector::DenseProjector;
+use crate::format::vindex3::opplan::exec::execute_plan;
 use crate::format::vindex3::opplan::exec::operands::{
     OperandSource, OperandStore, RepresentationSource,
 };
+use crate::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
+use crate::format::vindex3::opplan::exec::production::ProductionBackend;
+use crate::format::vindex3::opplan::exec::realization::{
+    DependencyLifetime, RealizationForm, RealizationId, SelectionReason,
+};
+use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
 use crate::format::vindex3::opplan::exec::weights::{load_weight, LoadedWeight};
-use crate::format::vindex3::opplan::OperandRef;
+use crate::format::vindex3::opplan::{plan_component_ops, OperandRef};
+use crate::format::vindex3::represent::codec::codecs::fp8_block::{DTYPE_FP8_BLOCK, SCALES};
 use larql_models::quant::fp8_finegrained::{dequantize, Fp8Grid};
 
 const TARGET: &str = "0.mlp.gate_proj.weight";
+const COMPONENT: &str = "target";
+/// A prompt over the dense fixture's 128-token vocabulary.
+const TOKENS: [u32; 5] = [3, 17, 28, 0, 11];
 
 /// The container, and the checkpoint it came from.
 fn encoded(tmp: &tempfile::TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
@@ -58,7 +79,7 @@ fn fp8_operand(container: &std::path::Path) -> OperandRef {
         let Ok((header, _)) = read_segment_header(&container.join(&entry.segment)) else {
             continue;
         };
-        if let Some(t) = header.tensors.iter().find(|t| t.dtype == "F8_E4M3") {
+        if let Some(t) = header.tensors.iter().find(|t| t.dtype == DTYPE_FP8_BLOCK) {
             return OperandRef {
                 object: entry.object.clone(),
                 tensor: t.name.clone(),
@@ -77,6 +98,21 @@ fn open(container: &std::path::Path) -> OperandStore {
 
 /// The authority: the CHECKPOINT's own bytes, dequantised and dotted.
 fn from_the_checkpoint(checkpoint: &std::path::Path, x: &[f32]) -> Vec<f32> {
+    let (grid, w) = dequantised_from_the_checkpoint(checkpoint);
+    (0..grid.rows)
+        .map(|r| {
+            w[r * grid.cols..(r + 1) * grid.cols]
+                .iter()
+                .zip(x)
+                .map(|(a, b)| a * b)
+                .sum()
+        })
+        .collect()
+}
+
+/// The CHECKPOINT's own bytes, dequantised by the reference and nothing
+/// of this crate's — the values every container-side reading must equal.
+fn dequantised_from_the_checkpoint(checkpoint: &std::path::Path) -> (Fp8Grid, Vec<f32>) {
     let raw = std::fs::read(checkpoint.join("model-fp8.safetensors")).unwrap();
     let hlen = u64::from_le_bytes(raw[..8].try_into().unwrap()) as usize;
     let header: serde_json::Value = serde_json::from_slice(&raw[8..8 + hlen]).unwrap();
@@ -109,19 +145,14 @@ fn from_the_checkpoint(checkpoint: &std::path::Path, x: &[f32]) -> Vec<f32> {
         scale_cols: sshape[1],
     };
     let w = dequantize(codes, &scales, grid).unwrap();
-    (0..grid.rows)
-        .map(|r| {
-            w[r * grid.cols..(r + 1) * grid.cols]
-                .iter()
-                .zip(x)
-                .map(|(a, b)| a * b)
-                .sum()
-        })
-        .collect()
+    (grid, w)
 }
 
+/// The container DECLARES the grid as the codes' dependency: the encoder
+/// consumed the checkpoint's naming convention once and wrote a reference,
+/// and nothing downstream spells `weight_scale_inv`.
 #[test]
-fn the_encoder_carries_the_scale_sibling_beside_its_codes() {
+fn the_encoder_declares_the_scale_grid_as_the_codes_dependency() {
     let tmp = tempfile::tempdir().unwrap();
     let (_, container) = encoded(&tmp);
     let operand = fp8_operand(&container);
@@ -132,17 +163,172 @@ fn the_encoder_carries_the_scale_sibling_beside_its_codes() {
     );
 
     let store = open(&container);
-    let sibling = larql_models::quant::fp8_finegrained::scale_sibling_name(&operand.tensor);
-    let (shape, raw) = OperandSource::from(&store)
-        .companion(&operand, &sibling)
-        .expect("the scale sibling is in the same object as its codes");
-    assert_eq!(raw.dtype, "F32");
+    let owner = OperandAddress::new(&operand.object, &operand.tensor);
+    let grid = store
+        .references()
+        .target(&owner, SCALES)
+        .expect("the encoder declared the grid under the codec's name")
+        .clone();
+    assert_eq!(
+        grid.object, operand.object,
+        "the grid is in the codes' object"
+    );
+    assert!(
+        grid.tensor.ends_with("weight_scale_inv"),
+        "the reference addresses the checkpoint's grid, found `{}`",
+        grid.tensor
+    );
+    let shape = store
+        .stored_shape(&grid)
+        .expect("the container holds the grid");
     assert_eq!(shape.len(), 2, "the grid is two-dimensional");
+    let raw = store
+        .load_raw(&OperandRef {
+            object: grid.object.clone(),
+            tensor: grid.tensor.clone(),
+            dtype: String::new(),
+            shape: shape.clone(),
+        })
+        .unwrap();
+    assert_eq!(raw.dtype, "F32");
     assert_eq!(
         raw.bytes.len(),
         shape.iter().product::<usize>() * 4,
         "the grid's bytes match its declared shape"
     );
+    // And the only dependency: the codec requires one, the table declares one.
+    assert_eq!(store.references().auxiliaries_of(&owner).len(), 1);
+}
+
+/// The registry's canonical decode of the container's bytes IS the
+/// reference dequantisation of the checkpoint's — bit for bit.
+#[test]
+fn the_canonical_decode_is_the_reference_dequantisation_bit_for_bit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (checkpoint, container) = encoded(&tmp);
+    let operand = fp8_operand(&container);
+    let store = open(&container);
+    let decoded = store
+        .load(&operand)
+        .expect("the codec decodes through its dependency");
+    let (grid, want) = dequantised_from_the_checkpoint(&checkpoint);
+    assert_eq!(decoded.len(), grid.elements());
+    let bits = |v: &[f32]| v.iter().map(|x| x.to_bits()).collect::<Vec<u32>>();
+    assert_eq!(bits(&decoded), bits(&want));
+}
+
+fn with_prepared<B: PlanBackend>(
+    container: &std::path::Path,
+    backend: &B,
+    check: impl FnOnce(&PreparedOperands),
+) {
+    let inspection = inspect_container(container, false).unwrap();
+    let plan = plan_component_ops(&inspection, container, COMPONENT)
+        .unwrap()
+        .plan
+        .expect("the FP8 fixture plans");
+    let store = open(container);
+    let prepared = PreparedOperands::load(&plan, &store, backend, ExecutionSlice::Full)
+        .expect("the FP8 operand has an admissible realization");
+    check(&prepared);
+}
+
+/// Selection reaches the FP8 kernel from the codec's declaration — no
+/// privileged caller — and the pin RETAINS the grid, which is the
+/// dependency lifetime a direct kernel over codes has and the ledger
+/// prices. The reference oracle decodes the same operand and is finished
+/// with the grid once it has its image.
+#[test]
+fn selection_pins_the_fp8_kernel_and_retains_its_grid() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_, container) = encoded(&tmp);
+    let operand = fp8_operand(&container);
+    let record_for = |prepared: &PreparedOperands| {
+        prepared
+            .realizations()
+            .iter()
+            .find(|r| r.planned.operand.tensor == operand.tensor)
+            .cloned()
+            .expect("the FP8 projection is planned")
+    };
+
+    with_prepared(&container, &ProductionBackend::new(), |prepared| {
+        let record = record_for(prepared);
+        assert_eq!(record.representation, DTYPE_FP8_BLOCK);
+        assert_eq!(
+            record.provider.as_ref().map(|p| p.family.as_str()),
+            Some("fp8-block")
+        );
+        assert_eq!(
+            record.selection.realization,
+            RealizationId::cpu(RealizationForm::Direct(
+                PhysicalProjectionPlan::FusedFp8Block
+            ))
+        );
+        assert_eq!(record.selection.reason, SelectionReason::DirectDeclared);
+        assert_eq!(record.dependencies.len(), 1, "one dependency: the grid");
+        let grid = &record.dependencies[0];
+        assert_eq!(grid.name, SCALES);
+        assert_eq!(grid.lifetime, DependencyLifetime::Retained);
+        assert_eq!(grid.label, "F32");
+        assert!(grid.elements > 1, "the grid is priced by its elements");
+    });
+
+    with_prepared(&container, &ReferenceBackend::new(), |prepared| {
+        let record = record_for(prepared);
+        assert_eq!(
+            record.selection.realization,
+            RealizationId::cpu(RealizationForm::Decode(PhysicalProjectionPlan::ScalarF32))
+        );
+        assert_eq!(record.selection.reason, SelectionReason::ReferenceOracle);
+        assert_eq!(
+            record.dependencies[0].lifetime,
+            DependencyLifetime::PreparationOnly,
+            "a decode is finished with the grid once it has an f32 image"
+        );
+    });
+}
+
+/// The whole forward through selection: the production backend runs the
+/// FP8 kernel over the stored codes, the reference decodes them, and the
+/// two agree on the same container — which neither could execute at all
+/// before the format was a codec.
+#[test]
+fn production_and_reference_agree_on_the_fp8_container_through_selection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_, container) = encoded(&tmp);
+    let inspection = inspect_container(&container, false).unwrap();
+    let plan = plan_component_ops(&inspection, &container, COMPONENT)
+        .unwrap()
+        .plan
+        .unwrap();
+    let store = open(&container);
+    let logits = |backend: &dyn PlanBackend| {
+        execute_plan(&plan, &store, &TOKENS, backend)
+            .expect("executes")
+            .logits
+            .expect("the dense fixture carries a head")
+    };
+    let production = logits(&ProductionBackend::new());
+    let reference = logits(&ReferenceBackend::new());
+    assert_eq!(production.len(), reference.len());
+    let scale = reference.iter().fold(0.0f32, |m, v| m.max(v.abs()));
+    let worst = production
+        .iter()
+        .zip(&reference)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    assert!(
+        worst <= scale * 1e-4,
+        "production and reference disagree on the FP8 container: worst {worst:e} of {scale:e}"
+    );
+    let argmax = |v: &[f32]| {
+        v.iter()
+            .enumerate()
+            .max_by(|a, b| a.1.total_cmp(b.1))
+            .map(|(i, _)| i)
+    };
+    assert_eq!(argmax(&production), argmax(&reference));
 }
 
 /// The whole path, against an authority that shares nothing with it below
@@ -304,4 +490,64 @@ fn declaring_an_fp8_activation_scheme_is_refused() {
         msg.contains("inadmissible"),
         "the refusal should name the plan, got: {msg}"
     );
+}
+
+/// A container encoded before the encoder declared dependencies holds the
+/// FP8 pair and no table. It is refused LOUDLY — the grid is an
+/// unclassified operand, so the plan does not close — and it migrates
+/// with the encoder's own rule applied late, after which it plans and
+/// executes exactly as a fresh encode does. The rule is never applied by
+/// a reader: a container that declares nothing depends on nothing.
+#[test]
+fn a_container_encoded_before_dependencies_were_declared_refuses_and_then_migrates() {
+    use crate::format::filenames::{AUXILIARY_REFERENCES_JSON, INDEX_JSON};
+    use crate::format::vindex3::encode::declare_references;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let (_, container) = encoded(&tmp);
+    let operand = fp8_operand(&container);
+
+    // Undeclare: drop the table and the index's name for it, which is
+    // exactly what an older encoder left behind.
+    let index_path = container.join(INDEX_JSON);
+    let mut index: Vindex3Index =
+        serde_json::from_str(&std::fs::read_to_string(&index_path).unwrap()).unwrap();
+    assert!(
+        index.auxiliary_references.is_some(),
+        "a fresh encode declares"
+    );
+    index.auxiliary_references = None;
+    std::fs::write(&index_path, serde_json::to_string_pretty(&index).unwrap()).unwrap();
+    std::fs::remove_file(container.join(AUXILIARY_REFERENCES_JSON)).unwrap();
+
+    let inspection = inspect_container(&container, false).unwrap();
+    let outcome = plan_component_ops(&inspection, &container, COMPONENT).unwrap();
+    assert!(
+        outcome.plan.is_none() && !outcome.defects.is_empty(),
+        "an undeclared grid must not plan: {:?}",
+        outcome.defects
+    );
+    let listed: Vec<String> = outcome.defects.iter().map(|d| d.to_string()).collect();
+    assert!(
+        listed.iter().any(|d| d.contains("weight_scale_inv")),
+        "the defect names the orphaned grid: {listed:?}"
+    );
+    // And the decode has no dependency to resolve through.
+    let store = open(&container);
+    let err = store.load(&operand).unwrap_err().to_string();
+    assert!(err.contains(SCALES), "{err}");
+
+    // Migrate: the encoder's rule, applied to the headers on disk.
+    assert_eq!(declare_references(&container).unwrap(), 1);
+    let again = declare_references(&container).unwrap_err().to_string();
+    assert!(again.contains("already declares"), "{again}");
+
+    let inspection = inspect_container(&container, false).unwrap();
+    assert!(inspection.index.auxiliary_references.is_some());
+    let outcome = plan_component_ops(&inspection, &container, COMPONENT).unwrap();
+    assert!(outcome.plan.is_some(), "{:?}", outcome.defects);
+    let store = open(&container);
+    let (_, want) = dequantised_from_the_checkpoint(&tmp.path().join("ckpt"));
+    let bits = |v: &[f32]| v.iter().map(|x| x.to_bits()).collect::<Vec<u32>>();
+    assert_eq!(bits(&store.load(&operand).unwrap()), bits(&want));
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/weights/mod.rs
@@ -22,6 +22,7 @@ use super::operands::{OperandSource, RawOperand, RepresentationSource};
 use super::quantise::{quantise_q4, quantise_q8, Q4_BLOCK, Q8_BLOCK};
 use crate::error::VindexError;
 use crate::format::vindex3::opplan::OperandRef;
+use crate::format::vindex3::represent::codec::codecs::fp8_block::SCALES as FP8_SCALES;
 use crate::format::vindex3::represent::kquant::{self, KQuant};
 use crate::format::vindex3::represent::nvfp4_pack::DTYPE_NVFP4;
 use crate::format::vindex3::represent::physical::WeightRegion;
@@ -476,39 +477,31 @@ impl LoadedWeight {
     }
 }
 
-/// Bind a fine-grained FP8 pair, with every disagreement between the two
-/// tensors refused rather than reconciled.
+/// Bind a fine-grained FP8 pair: the codes byte-for-byte, the scale grid
+/// as its own codec decoded it, and the tile DERIVED from the two shapes.
 ///
-/// The tile is DERIVED here, from the two shapes, and carried on the
-/// loaded weight. `quantization_config.weight_block_size` is not
-/// consulted: it is a whole-checkpoint summary, and the scheme permits
-/// per-tensor grids that contradict it.
+/// `quantization_config.weight_block_size` is not consulted: it is a
+/// whole-checkpoint summary, and the scheme permits per-tensor grids that
+/// contradict it. Nothing here reads a dtype name either — the grid
+/// arrives as values through the registry, so a grid stored under any
+/// registered representation binds, and one under none was refused by
+/// name before this ran.
 fn load_fp8_block(
     operand: &OperandRef,
     codes: RawOperand,
-    sibling: &str,
+    grid_tensor: &str,
     scale_shape: &[usize],
-    scales: RawOperand,
+    scales: Vec<f32>,
 ) -> Result<LoadedWeight, VindexError> {
     use larql_models::quant::fp8_finegrained::Fp8Grid;
 
     let refuse = |what: String| VindexError::Parse(what);
-    if scales.dtype != DTYPE_F32 {
-        // E8M0 scales (`float8_e8m0fnu`, stored as `U8`) are a real
-        // variant of this scheme and decode as `2^(byte-127)`. Refused
-        // rather than guessed: reading those bytes as f32 would not even
-        // have the right length, and reading them as scalars would be
-        // silently wrong by many orders of magnitude.
-        return Err(refuse(format!(
-            "operand `{}`: scale sibling `{sibling}` is `{}`, and this build reads only              F32 fine-grained FP8 scales",
-            operand.tensor, scales.dtype
-        )));
-    }
     let (rows, cols) = match operand.shape.as_slice() {
         [r, c] => (*r, *c),
         other => {
             return Err(refuse(format!(
-                "operand `{}` has shape {other:?}; fine-grained FP8 tiles a `[out, in]`                  matrix and has no reading of any other rank",
+                "operand `{}` has shape {other:?}; fine-grained FP8 tiles a `[out, in]` \
+                 matrix and has no reading of any other rank",
                 operand.tensor
             )))
         }
@@ -517,7 +510,8 @@ fn load_fp8_block(
         [r, c] => (*r, *c),
         other => {
             return Err(refuse(format!(
-                "operand `{}`: scale sibling `{sibling}` has shape {other:?}, which is not                  a two-dimensional grid",
+                "operand `{}`: scale grid `{grid_tensor}` has shape {other:?}, which is not \
+                 a two-dimensional grid",
                 operand.tensor
             )))
         }
@@ -539,21 +533,17 @@ fn load_fp8_block(
             codes.bytes.len()
         )));
     }
-    let values: Vec<f32> = scales
-        .bytes
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-        .collect();
-    if values.len() != grid.scales() {
+    if scales.len() != grid.scales() {
         return Err(refuse(format!(
-            "operand `{}`: scale sibling `{sibling}` declares {scale_rows}x{scale_cols} but              its segment holds {} f32 values",
+            "operand `{}`: scale grid `{grid_tensor}` declares {scale_rows}x{scale_cols} but \
+             decodes to {} values",
             operand.tensor,
-            values.len()
+            scales.len()
         )));
     }
     Ok(LoadedWeight::Fp8Block {
         codes: AlignedBytes::from_bytes(&codes.bytes),
-        scales: values,
+        scales,
         block_rows,
         block_cols,
         scale_cols,
@@ -569,16 +559,47 @@ pub fn load_weight(
 ) -> Result<LoadedWeight, VindexError> {
     match format {
         WeightFormat::F32 => Ok(LoadedWeight::F32(StagedF32::stage(store.load(operand)?)?)),
-        // Fine-grained FP8 binds TWO container tensors: the E4M3 codes
-        // and the `weight_scale_inv` grid the checkpoint shipped beside
-        // them. Neither is widened — that is the point of the format on
-        // this programme, since a widened GLM-5.3-Flash would be 612 GB
-        // of a 306 GB checkpoint.
+        // Fine-grained FP8 binds TWO container objects: the E4M3 codes,
+        // and the scale grid the codec DECLARES as its dependency and the
+        // container's reference table ADDRESSES — never a name this
+        // loader spells. The codes are not widened — that is the point of
+        // the format on this programme, since a widened GLM-5.3-Flash
+        // would be 612 GB of a 306 GB checkpoint. The grid is decoded
+        // through its own codec: it is retained beside the codes, and
+        // its bytes are its own representation's business.
         WeightFormat::Fp8Block => {
             let raw = store.load_raw(operand)?;
-            let sibling = larql_models::quant::fp8_finegrained::scale_sibling_name(&operand.tensor);
-            let (scale_shape, scale_raw) = store.companion(operand, &sibling)?;
-            load_fp8_block(operand, raw, &sibling, &scale_shape, scale_raw)
+            let owner = crate::format::vindex3::auxiliary_references::OperandAddress::new(
+                &operand.object,
+                &operand.tensor,
+            );
+            let grid = store
+                .store()
+                .references()
+                .target(&owner, FP8_SCALES)
+                .cloned()
+                .ok_or_else(|| {
+                    VindexError::Parse(format!(
+                        "operand `{}`: the container declares no `{FP8_SCALES}` dependency for \
+                         it, and fine-grained FP8 codes mean nothing without their grid",
+                        operand.tensor
+                    ))
+                })?;
+            let scale_shape = store.store().stored_shape(&grid).ok_or_else(|| {
+                VindexError::Parse(format!(
+                    "operand `{}`: its `{FP8_SCALES}` dependency {} is referenced and the \
+                     container holds no such tensor",
+                    operand.tensor,
+                    grid.describe()
+                ))
+            })?;
+            let scales = store.load(&OperandRef {
+                object: grid.object.clone(),
+                tensor: grid.tensor.clone(),
+                dtype: String::new(),
+                shape: scale_shape.clone(),
+            })?;
+            load_fp8_block(operand, raw, &grid.tensor, &scale_shape, scales)
         }
         WeightFormat::Q8 => {
             let in_dim = operand.shape.get(1).copied().ok_or_else(|| {

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/fp8_block.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/fp8_block.rs
@@ -1,0 +1,328 @@
+//! Fine-grained (block-wise) FP8 as frontier checkpoints ship it: E4M3
+//! codes with a two-dimensional grid of f32 scales — GLM-5.3-Flash's own
+//! bytes (95.8 % of a 306 GiB checkpoint) and the DeepSeek-V3 lineage's.
+//!
+//! The first PRODUCTION codec whose bytes do not mean anything on their
+//! own. The codes are one stream; the scales are ANOTHER REPRESENTED
+//! OBJECT — the `*.weight_scale_inv` tensor the checkpoint shipped beside
+//! them, stored under its own label, addressed by the container's
+//! reference table under the name [`SCALES`], and decoded through its own
+//! codec before this one is called. The tile is DERIVED from the two
+//! shapes, per tensor, never read from a config: one checkpoint legally
+//! ships `[128, 128]` grids beside `[1, 32]` ones, so no identity could
+//! state it and no stream could carry it — a stream is bytes, and the
+//! grid's SHAPE is what the tile needs. That is what makes the scales a
+//! dependency rather than a second stream, and it is the same rule the
+//! `VQ8_SHARED` codebook follows.
+//!
+//! ```text
+//! values     [rows, cols] u8 E4M3        one code per weight
+//! scales     [rows/br, cols/bc] f32      ANOTHER OPERAND, named `scales`
+//! decode     w[r, c] = e4m3(code[r, c]) * scales[r / br, c / bc]
+//! ```
+//!
+//! Before this codec the format was an execution-side special case: a
+//! loader that spelled the sibling's name, a `companion` accessor that
+//! existed for one format, and a kernel reachable only by a caller that
+//! already knew the answer. Selection could not offer it, the reference
+//! oracle could not decode it, and an external provider could not have
+//! done what it did. Now it is one registration, and the direct kernel
+//! it declares is the same `FusedFp8Block` — reached by selection.
+//!
+//! What it does NOT declare is a reconstruction radius. Fine-grained FP8
+//! is lossy against its bf16 source, and the error is the encoder's and
+//! the data's rather than the format's — the same reason `VQ8_SHARED`
+//! declares none. An attestation supplies a measured radius per artifact.
+
+use std::ops::Range;
+
+use larql_models::quant::fp8::e4m3_to_f32;
+use larql_models::quant::fp8_finegrained::Fp8Grid;
+
+use super::super::auxiliary::{AuxiliaryMetadata, AuxiliarySpec};
+use super::super::capability::{AccessGranularity, CodecCapabilities};
+use super::super::error::CodecError;
+use super::super::extent::{ExtentCertificate, RepresentationExtent, BITS_PER_BYTE};
+use super::super::geometry::RowGeometry;
+use super::super::residency::{Acceleration, ResidencyProfile};
+use super::super::streams::{CodecOperands, StreamSpec, VALUES};
+use super::super::RepresentationCodec;
+use super::vocabulary::{BYTE_ALIGN, SCALE_NONE, UNGROUPED};
+use crate::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
+use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
+
+/// The segment label: the safetensors dtype the encoder carries through
+/// unchanged, because the bytes ARE the checkpoint's. A container tensor
+/// under this label with no `scales` reference is refused by name — a
+/// bare E4M3 tensor is not this representation, and this build ships no
+/// other reading of one.
+pub const DTYPE_FP8_BLOCK: &str = "F8_E4M3";
+/// The ABI family.
+pub const FP8_BLOCK_FAMILY: &str = "fp8-block";
+/// ABI revision. Revision 1 is: row-major E4M3 codes, one per weight, and
+/// a row-major f32 scale grid named `scales` whose shape tiles the codes'
+/// evenly; the value is code times scale, multiplied, in f32. The
+/// REQUIREMENT's name is part of this revision, because a stored
+/// container's references are keyed by it.
+pub const FP8_BLOCK_REVISION: u32 = 1;
+/// The name this codec gives its dependency.
+pub const SCALES: &str = "scales";
+
+/// E4M3 is one byte, exactly. The scale grid is the SCALES operand's own
+/// footprint — another object, priced as one — so the rate here is the
+/// codes' alone, as `VQ8_SHARED` prices its codes without its codebook.
+const FP8_BITS_PER_WEIGHT: f64 = BITS_PER_BYTE;
+
+const ELEMENT_E4M3: &str = "e4m3";
+const GROUP_SCALE_TILE_GRID: &str = "f32-le/tile-derived";
+const LAYOUT_ROW_MAJOR_CODES: &str = "row-major-codes;scales-by-reference";
+
+const FP8_STREAMS: [StreamSpec; 1] = [VALUES];
+const FP8_AUXILIARIES: [AuxiliarySpec; 1] = [AuxiliarySpec::new(SCALES)];
+
+/// Fine-grained FP8: E4M3 codes scaled by a referenced f32 tile grid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fp8BlockCodec;
+
+/// The scale grid as a decode reads it: its geometry, the tile it implies,
+/// and its values.
+struct ResolvedGrid<'a> {
+    grid: Fp8Grid,
+    block_rows: usize,
+    block_cols: usize,
+    values: &'a [f32],
+}
+
+pub const FP8_BLOCK: Fp8BlockCodec = Fp8BlockCodec;
+
+impl Fp8BlockCodec {
+    pub const fn bits_per_weight() -> f64 {
+        FP8_BITS_PER_WEIGHT
+    }
+
+    /// `[rows, cols]` — the tile is two-dimensional, so the shape must be.
+    fn matrix(shape: &[usize], tensor: &str) -> Result<(usize, usize), CodecError> {
+        match shape {
+            [rows, cols] => Ok((*rows, *cols)),
+            other => Err(CodecError::Geometry {
+                tensor: tensor.into(),
+                label: DTYPE_FP8_BLOCK.into(),
+                shape: other.to_vec(),
+                why: "fine-grained FP8 tiles a `[out, in]` matrix and has no reading of any \
+                      other rank"
+                    .into(),
+            }),
+        }
+    }
+
+    /// The grid the shapes describe, or why they describe none.
+    fn grid(
+        shape: &[usize],
+        scale_shape: &[usize],
+        tensor: &str,
+    ) -> Result<(Fp8Grid, (usize, usize)), CodecError> {
+        let (rows, cols) = Self::matrix(shape, tensor)?;
+        let unusable = |why: String| CodecError::AuxiliaryGeometry {
+            tensor: tensor.into(),
+            label: DTYPE_FP8_BLOCK.into(),
+            name: SCALES.into(),
+            why,
+        };
+        let [scale_rows, scale_cols] = scale_shape else {
+            return Err(unusable(format!(
+                "the scale grid has shape {scale_shape:?}, which is not two-dimensional"
+            )));
+        };
+        let grid = Fp8Grid {
+            rows,
+            cols,
+            scale_rows: *scale_rows,
+            scale_cols: *scale_cols,
+        };
+        let tile = grid.tile().map_err(|e| unusable(e.to_string()))?;
+        Ok((grid, tile))
+    }
+
+    /// The resolved scales, judged again on the values: the shape was
+    /// admitted from metadata before any byte was read
+    /// ([`RepresentationCodec::validate_auxiliary`]), and a grid whose
+    /// values fall short of its shape would index past its end.
+    fn scales<'a>(
+        &self,
+        operands: &CodecOperands<'a>,
+        shape: &[usize],
+        tensor: &str,
+    ) -> Result<ResolvedGrid<'a>, CodecError> {
+        let resolved = operands
+            .auxiliaries
+            .require(SCALES, DTYPE_FP8_BLOCK, tensor)?;
+        let (grid, (block_rows, block_cols)) = Self::grid(shape, resolved.shape, tensor)?;
+        if resolved.values.len() != grid.scales() {
+            return Err(CodecError::AuxiliaryGeometry {
+                tensor: tensor.into(),
+                label: DTYPE_FP8_BLOCK.into(),
+                name: SCALES.into(),
+                why: format!(
+                    "the resolved grid is {:?} with {} values; {} are required",
+                    resolved.shape,
+                    resolved.values.len(),
+                    grid.scales()
+                ),
+            });
+        }
+        Ok(ResolvedGrid {
+            grid,
+            block_rows,
+            block_cols,
+            values: resolved.values,
+        })
+    }
+}
+
+impl RepresentationCodec for Fp8BlockCodec {
+    fn encoding_label(&self) -> &'static str {
+        DTYPE_FP8_BLOCK
+    }
+
+    fn identity(&self) -> CodecIdentity {
+        CodecIdentity {
+            family: FP8_BLOCK_FAMILY.into(),
+            revision: FP8_BLOCK_REVISION,
+            // The group is the tile, and the tile is a per-tensor fact of
+            // the artifact; the identity states that it is not fixed.
+            group_elems: UNGROUPED,
+            element: ELEMENT_E4M3.into(),
+            group_scale: GROUP_SCALE_TILE_GRID.into(),
+            tensor_scale: SCALE_NONE.into(),
+            layout: LAYOUT_ROW_MAJOR_CODES.into(),
+        }
+    }
+
+    fn streams(&self) -> &'static [StreamSpec] {
+        &FP8_STREAMS
+    }
+
+    fn required_auxiliaries(&self, _: RepresentationExtent) -> &'static [AuxiliarySpec] {
+        // One extent, one requirement: the codes mean nothing without it.
+        &FP8_AUXILIARIES
+    }
+
+    fn validate_auxiliary(
+        &self,
+        _: &str,
+        target: &AuxiliaryMetadata,
+        shape: &[usize],
+        _: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        // The grid's shape is this codec's business: it must tile the
+        // matrix evenly, and the tile it implies is the only tile there
+        // is. Its LABEL is not judged — the grid arrives decoded through
+        // its own codec, and what this one needs is values.
+        Self::grid(shape, &target.shape, tensor).map(|_| ())
+    }
+
+    fn capabilities(&self) -> CodecCapabilities {
+        CodecCapabilities {
+            // One byte per weight and a scale looked up per element: any
+            // row is addressable, and a row needs only its own tile row.
+            access: AccessGranularity::RowRandom,
+            group_elems: UNGROUPED,
+            row_align_elems: UNGROUPED,
+            physical_align_bytes: BYTE_ALIGN,
+        }
+    }
+
+    fn extents(&self) -> Vec<ExtentCertificate> {
+        vec![ExtentCertificate::terminal(Self::bits_per_weight())]
+    }
+
+    fn stored_bytes(
+        &self,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<u64, CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let (rows, cols) = Self::matrix(shape, tensor)?;
+        Ok((rows * cols) as u64)
+    }
+
+    fn validate(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        extent: RepresentationExtent,
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        self.certificate_at(extent, tensor)?;
+        // The codes first, from the shape alone: a short stream is refused
+        // by its name before any dependency is consulted, the same order
+        // every other codec judges a header in.
+        let (rows, cols) = Self::matrix(shape, tensor)?;
+        let codes = operands.stream(VALUES, DTYPE_FP8_BLOCK, tensor)?;
+        if codes.len() != rows * cols {
+            return Err(CodecError::StreamLength {
+                tensor: tensor.into(),
+                label: DTYPE_FP8_BLOCK.into(),
+                stream: VALUES.name.into(),
+                need: rows * cols,
+                have: codes.len(),
+            });
+        }
+        self.scales(operands, shape, tensor).map(|_| ())
+    }
+
+    fn decode_rows(
+        &self,
+        operands: &CodecOperands<'_>,
+        shape: &[usize],
+        rows: Range<usize>,
+        extent: RepresentationExtent,
+        dst: &mut [f32],
+        tensor: &str,
+    ) -> Result<(), CodecError> {
+        self.certificate_at(extent, tensor)?;
+        let ResolvedGrid {
+            grid,
+            block_rows,
+            block_cols,
+            values: scales,
+        } = self.scales(operands, shape, tensor)?;
+        let geometry = RowGeometry {
+            rows: grid.rows,
+            k: grid.cols,
+        };
+        geometry.check_rows(&rows, DTYPE_FP8_BLOCK, tensor)?;
+        geometry.check_destination(&rows, dst.len(), tensor)?;
+        let codes = operands.stream_of_len(VALUES, grid.elements(), DTYPE_FP8_BLOCK, tensor)?;
+        // The reference's arithmetic, row by row: one f32 multiply per
+        // element, the scale row hoisted per matrix row — bit-exact
+        // against `fp8_finegrained::dequantize_into`, which is the
+        // transcription of upstream's `Fp8Dequantize`.
+        for (out, r) in dst.chunks_exact_mut(grid.cols).zip(rows) {
+            let scale_row = &scales[(r / block_rows) * grid.scale_cols..][..grid.scale_cols];
+            let src = &codes[r * grid.cols..][..grid.cols];
+            for (c, (d, &code)) in out.iter_mut().zip(src).enumerate() {
+                *d = e4m3_to_f32(code) * scale_row[c / block_cols];
+            }
+        }
+        Ok(())
+    }
+
+    fn decode_residency(&self) -> ResidencyProfile {
+        ResidencyProfile::DECODED_F32
+    }
+
+    fn accelerations(&self) -> Vec<Acceleration> {
+        // The checkpoint's bytes executed in place — decoded and
+        // tile-scaled in registers — with the scale grid RETAINED beside
+        // them, which is the dependency lifetime the ledger prices for a
+        // direct kernel over codes. `stored` at the codes' width; the
+        // retained grid is accounted on the pin's dependency, not here.
+        vec![Acceleration::cpu(
+            PhysicalProjectionPlan::FusedFp8Block,
+            ResidencyProfile::stored(Self::bits_per_weight()),
+        )]
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/kquant.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/kquant.rs
@@ -3,11 +3,15 @@
 //! One stream, because the scales ride inside the blocks; row-random,
 //! because the container refuses a row that is not a whole number of
 //! blocks, so every row starts on one. Directly realized on this
-//! executor by [`PhysicalProjectionPlan::FusedKQuant`], which runs the
-//! stored blocks in place through the codec's own kernel — a `stored`
-//! residency at the block's own bit width, not a decode to f32. The
-//! grouped Metal kernels that serve K-quant expert banks are a separate
-//! device realization, declared by the crate that owns them.
+//! executor by [`PhysicalProjectionPlan::FusedKQuant`] — for the members
+//! whose kernel exists — which runs the stored blocks in place through
+//! the codec's own kernel: a `stored` residency at the block's own bit
+//! width, not a decode to f32. `Q5_K` and `Q3_K` are registered with no
+//! direct realization: this workspace decodes them (a GGUF import, a
+//! pack another tool wrote) and does not yet run them in place, and a
+//! codec that said otherwise would pin a kernel that returns nothing.
+//! The grouped Metal kernels that serve K-quant expert banks are a
+//! separate device realization, declared by the crate that owns them.
 
 use std::ops::Range;
 
@@ -41,6 +45,12 @@ pub const Q6_K: KQuantCodec = KQuantCodec {
 };
 pub const Q8_0: KQuantCodec = KQuantCodec {
     quant: kquant::Q8_0,
+};
+pub const Q5_K: KQuantCodec = KQuantCodec {
+    quant: kquant::Q5_K,
+};
+pub const Q3_K: KQuantCodec = KQuantCodec {
+    quant: kquant::Q3_K,
 };
 
 impl KQuantCodec {
@@ -140,15 +150,24 @@ impl RepresentationCodec for KQuantCodec {
 
     fn accelerations(&self) -> Vec<Acceleration> {
         // The stored blocks are executed in place by the codec's own
-        // kernel — no decode, no re-quantise. One plan serves all three
-        // K-quants: the codec identity rides in the bound operand, not in
-        // the resident `WeightFormat`, so `WeightFormat::KQuant` names the
-        // family and the bytes name the member. `stored`, at the block's
-        // own bit width, because that is what the kernel touches.
+        // kernel — no decode, no re-quantise. One plan serves every
+        // K-quant with a kernel: the codec identity rides in the bound
+        // operand, not in the resident `WeightFormat`, so
+        // `WeightFormat::KQuant` names the family and the bytes name the
+        // member. `stored`, at the block's own bit width, because that is
+        // what the kernel touches.
+        //
+        // Declared only where [`KQuant::gemv`] answers — the one place
+        // that association lives — so a member without a kernel executes
+        // through decode, flagged, rather than pinning a realization that
+        // would refuse at the first token.
         //
         // Qualified end to end as PARETO-1's v3 arm: on Qwen3.8-27B the
         // direct path matched decode-then-f32-GEMV to 5 orders below the
         // pre-registered KL gate on all three K-quant anchors.
+        if !self.quant.has_direct_gemv() {
+            return Vec::new();
+        }
         vec![Acceleration::cpu(
             PhysicalProjectionPlan::FusedKQuant,
             ResidencyProfile::stored(self.quant.bits_per_weight()),

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/codecs/mod.rs
@@ -9,6 +9,7 @@
 pub mod bf16_zlib;
 pub mod f32_planes;
 pub mod float;
+pub mod fp8_block;
 pub mod kquant;
 pub mod lyrw2;
 pub mod mxfp4;

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/registry.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/registry.rs
@@ -9,7 +9,7 @@
 
 use std::sync::OnceLock;
 
-use super::codecs::{bf16_zlib, f32_planes, float, kquant, mxfp4, nvfp4, vq8_shared};
+use super::codecs::{bf16_zlib, f32_planes, float, fp8_block, kquant, mxfp4, nvfp4, vq8_shared};
 use super::error::CodecError;
 use super::RepresentationCodec;
 use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
@@ -57,6 +57,13 @@ impl CodecRegistry {
                 .and_then(|r| r.register(Box::new(bf16_zlib::BF16_ZLIB)))
                 .and_then(|r| r.register(Box::new(f32_planes::F32_PLANES)))
                 .and_then(|r| r.register(Box::new(vq8_shared::VQ8_SHARED)))
+                // The checkpoint-native FP8 estate, and the two K-quants
+                // this workspace decodes but does not yet compile —
+                // registered after the forcing codecs because that is the
+                // order they were admitted, and the order a refusal lists.
+                .and_then(|r| r.register(Box::new(fp8_block::FP8_BLOCK)))
+                .and_then(|r| r.register(Box::new(kquant::Q5_K)))
+                .and_then(|r| r.register(Box::new(kquant::Q3_K)))
                 .expect("the built-in codecs carry distinct labels and families")
         })
     }

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/auxiliary.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/auxiliary.rs
@@ -182,9 +182,10 @@ fn metadata(shape: &[usize]) -> AuxiliaryMetadata {
     }
 }
 
-/// Exactly one shipped codec depends on another object, and it says which
-/// object by name at every extent it declares. Every other reads only its
-/// own bytes.
+/// Exactly two shipped codecs depend on another object — the forcing one
+/// (a codebook) and the production one (fine-grained FP8's scale grid) —
+/// and each says which object by name at every extent it declares. Every
+/// other reads only its own bytes.
 ///
 /// This asserted that NO shipped codec required anything, which was true
 /// of what had been implemented rather than of the contract. What survives
@@ -193,7 +194,7 @@ fn metadata(shape: &[usize]) -> AuxiliaryMetadata {
 /// silently dropping a requirement at one depth would make a stored
 /// container's meaning depend on how much of it someone chose to read.
 #[test]
-fn exactly_one_shipped_codec_depends_on_another_object() {
+fn exactly_two_shipped_codecs_depend_on_another_object() {
     let dependants: Vec<&str> = builtin()
         .into_iter()
         .filter(|codec| {
@@ -204,7 +205,7 @@ fn exactly_one_shipped_codec_depends_on_another_object() {
         })
         .map(|codec| codec.encoding_label())
         .collect();
-    assert_eq!(dependants, [DTYPE_VQ8_SHARED]);
+    assert_eq!(dependants, [DTYPE_VQ8_SHARED, DTYPE_FP8_BLOCK]);
 
     for codec in builtin() {
         let names_at = |extent| -> Vec<&str> {
@@ -224,10 +225,10 @@ fn exactly_one_shipped_codec_depends_on_another_object() {
                 certificate.extent.depth
             );
         }
-        if codec.encoding_label() == DTYPE_VQ8_SHARED {
-            assert_eq!(base, vec![CODEBOOK]);
-        } else {
-            assert!(base.is_empty(), "{}", codec.encoding_label());
+        match codec.encoding_label() {
+            DTYPE_VQ8_SHARED => assert_eq!(base, vec![CODEBOOK]),
+            DTYPE_FP8_BLOCK => assert_eq!(base, vec![FP8_SCALES]),
+            other => assert!(base.is_empty(), "{other}"),
         }
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/closure.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/closure.rs
@@ -1,0 +1,124 @@
+//! **Every direct CPU kernel over stored bytes is declared by a registered
+//! codec** — the closure that makes "all codecs use the registry" a
+//! checked statement rather than a belief.
+//!
+//! A kernel the executor ships and no codec declares is reachable only by
+//! a caller that already knows the answer: selection derives candidates
+//! from declarations, so such a kernel is dead to the plan and alive to a
+//! privileged path — which is what fine-grained FP8 was until it became
+//! a codec. The converse holds too: the executor's own re-quantised forms
+//! are not any codec's realization, and a codec that claimed one would be
+//! declaring a lossy image of its bytes as a direct reading of them.
+//!
+//! The plan list is exhaustive by construction: a new variant must be
+//! placed on one side or the other here before the crate compiles.
+
+use super::*;
+use crate::format::vindex3::opplan::exec::cpu::arithmetic::WeightRep;
+use crate::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
+
+/// Every plan the executor can run, and which side of the line it is on:
+/// `true` for a kernel over STORED bytes (a codec must declare it), `false`
+/// for the executor's own re-quantised image (no codec may).
+fn every_plan() -> Vec<(PhysicalProjectionPlan, bool)> {
+    use PhysicalProjectionPlan::*;
+    let all = [
+        ScalarF32,
+        FusedQ8,
+        FusedQ4,
+        FusedNvfp4,
+        FusedKQuant,
+        FusedFp8Block,
+        BlasF32,
+        FusedBf16,
+        Q8xQ8,
+        Q4xQ8,
+        Bf16xQ8,
+    ];
+    all.into_iter()
+        .map(|plan| {
+            let stored = match plan.weight_rep() {
+                WeightRep::F32
+                | WeightRep::Bf16
+                | WeightRep::Nvfp4
+                | WeightRep::KQuant
+                | WeightRep::Fp8Block => true,
+                WeightRep::Q8 { .. } | WeightRep::Q4 { .. } => false,
+            };
+            // The match above is what makes the list honest: a variant
+            // added to the enum and not to `all` still compiles, so the
+            // count is pinned to the enum here, by hand, on purpose.
+            (plan, stored)
+        })
+        .collect()
+}
+
+const PLAN_COUNT: usize = 11;
+
+fn declared_by(plan: PhysicalProjectionPlan) -> Vec<&'static str> {
+    builtin()
+        .into_iter()
+        .filter(|codec| codec.accelerations().iter().any(|a| a.plan == plan))
+        .map(|codec| codec.encoding_label())
+        .collect()
+}
+
+#[test]
+fn every_direct_kernel_over_stored_bytes_is_declared_by_a_registered_codec() {
+    let plans = every_plan();
+    assert_eq!(
+        plans.len(),
+        PLAN_COUNT,
+        "the plan list drifted from the enum"
+    );
+    for (plan, stored) in plans {
+        let declared = declared_by(plan);
+        if stored {
+            assert!(
+                !declared.is_empty(),
+                "{plan:?} runs over stored bytes and no registered codec declares it — \
+                 selection cannot reach it, so only a privileged caller can"
+            );
+        } else {
+            assert!(
+                declared.is_empty(),
+                "{plan:?} is the executor's own re-quantised image; {declared:?} claim it as \
+                 a direct realization"
+            );
+        }
+    }
+}
+
+/// And the control: the scan finds what is there. The FP8 kernel was the
+/// undeclared one before this rung, so its declaration is asserted by
+/// name rather than left to the loop above.
+#[test]
+fn the_fp8_kernel_is_declared_by_exactly_the_fp8_codec() {
+    assert_eq!(
+        declared_by(PhysicalProjectionPlan::FusedFp8Block),
+        [DTYPE_FP8_BLOCK]
+    );
+    assert_eq!(
+        declared_by(PhysicalProjectionPlan::FusedKQuant),
+        ["Q4_K", "Q6_K", "Q8_0"],
+        "the K-quant kernel is declared by the members it has a kernel for, and no other"
+    );
+}
+
+/// A codec with no kernel executes through decode, flagged — never through
+/// a kernel that would answer `None`.
+#[test]
+fn a_kquant_without_a_kernel_declares_no_direct_realization() {
+    for codec in [Q5_K, Q3_K] {
+        assert!(
+            codec.accelerations().is_empty(),
+            "{} has no gemv and must not declare one",
+            codec.encoding_label()
+        );
+        assert!(!codec.quant().has_direct_gemv());
+    }
+    for codec in [Q4_K, Q6_K, Q8_0] {
+        assert!(codec.quant().has_direct_gemv());
+        assert_eq!(codec.accelerations().len(), 1, "{}", codec.encoding_label());
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/contract.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/contract.rs
@@ -134,7 +134,17 @@ fn only_a_lossless_carrier_declares_a_radius_and_a_progressive_one_declares_one_
     const LOSSLESS: [&str; 4] = ["BF16", "F16", "F32", "BF16_ZLIB"];
     // Codecs that fit their source, and so certify nothing without an
     // attestation for the instance.
-    const FITTED: [&str; 6] = ["Q4_K", "Q6_K", "Q8_0", "NVFP4", "MXFP4", "VQ8_SHARED"];
+    const FITTED: [&str; 9] = [
+        "Q4_K",
+        "Q6_K",
+        "Q8_0",
+        "NVFP4",
+        "MXFP4",
+        "VQ8_SHARED",
+        "F8_E4M3",
+        "Q5_K",
+        "Q3_K",
+    ];
 
     let progressive: Vec<&str> = builtin()
         .into_iter()
@@ -258,12 +268,10 @@ fn label_of(format: WeightFormat) -> Option<&'static str> {
         // in the bound operand, not the format — so this cannot name one.
         // `every_acceleration_...` checks the family membership directly.
         WeightFormat::KQuant => None,
-        // A SOURCE format, not a REPRESENT target: fine-grained FP8
-        // arrives in the checkpoint and this build never compiles a
-        // tensor into it, so no `represent` codec answers to it. `None`
-        // here is that fact, not an omission — if a codec ever emits
-        // FP8, this arm names it and the assertion above starts applying.
-        WeightFormat::Fp8Block => None,
+        // The checkpoint's own fine-grained FP8, executed in place: the
+        // codec that answers to it is the one registered under the
+        // safetensors dtype the encoder carries through.
+        WeightFormat::Fp8Block => Some("F8_E4M3"),
     }
 }
 
@@ -316,21 +324,34 @@ fn codecs_with_no_direct_cpu_realization_say_so_rather_than_claim_one() {
         .filter(|c| c.accelerations().is_empty())
         .map(|c| c.encoding_label())
         .collect();
-    // K-quants gained a direct CPU realization (FusedKQuant); the
+    // K-quants with a kernel gained a direct CPU realization
+    // (FusedKQuant); Q5_K and Q3_K have no kernel and say so; the
     // entropy-coded codec registers none, and neither do the progressive
     // or the codebook-dependent ones — deliberately, so an extent and a
     // dependency can each be shown to work without any kernel knowing
-    // they exist.
+    // they exist. Fine-grained FP8 is the dependency-bearing codec WITH
+    // a kernel: the grid is retained beside the codes it scales.
     assert_eq!(
         without,
-        ["F16", "MXFP4", "BF16_ZLIB", "F32_PLANES", "VQ8_SHARED"]
+        [
+            "F16",
+            "MXFP4",
+            "BF16_ZLIB",
+            "F32_PLANES",
+            "VQ8_SHARED",
+            "Q5_K",
+            "Q3_K"
+        ]
     );
     let with: Vec<&str> = builtin()
         .into_iter()
         .filter(|c| !c.accelerations().is_empty())
         .map(|c| c.encoding_label())
         .collect();
-    assert_eq!(with, ["BF16", "F32", "Q4_K", "Q6_K", "Q8_0", "NVFP4"]);
+    assert_eq!(
+        with,
+        ["BF16", "F32", "Q4_K", "Q6_K", "Q8_0", "NVFP4", "F8_E4M3"]
+    );
 }
 
 #[test]

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/decode.rs
@@ -54,7 +54,7 @@ fn floats_decode_through_the_operand_widener() {
 
 #[test]
 fn kquants_decode_through_the_workspace_decoder() {
-    for codec in [Q4_K, Q6_K, Q8_0] {
+    for codec in [Q4_K, Q6_K, Q8_0, Q5_K, Q3_K] {
         let fixture = fixtures()
             .into_iter()
             .find(|f| f.label() == codec.encoding_label())

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/fp8_block.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/fp8_block.rs
@@ -1,0 +1,164 @@
+//! `F8_E4M3` — fine-grained FP8 — decodes to what the reference decodes
+//! to, and refuses a grid that is not its grid.
+
+use super::*;
+use larql_models::quant::fp8_finegrained::{dequantize, Fp8Grid};
+
+fn fixture() -> Fixture {
+    fixtures()
+        .into_iter()
+        .find(|f| f.label() == DTYPE_FP8_BLOCK)
+        .expect("the FP8 fixture is registered")
+}
+
+#[test]
+fn the_codes_decode_bit_exactly_through_the_reference_dequantiser() {
+    let fixture = fixture();
+    let scales = fp8_scales();
+    let grid = Fp8Grid {
+        rows: ROWS,
+        cols: K,
+        scale_rows: FP8_SCALE_ROWS,
+        scale_cols: FP8_SCALE_COLS,
+    };
+    let expected = dequantize(&fixture.buffers[0], &scales, grid).unwrap();
+    let decoded = fixture
+        .codec
+        .decode_all(
+            &fixture.operands(),
+            &fixture.shape,
+            RepresentationExtent::BASE,
+            TENSOR,
+        )
+        .unwrap();
+    let bits = |v: &[f32]| v.iter().map(|x| x.to_bits()).collect::<Vec<u32>>();
+    assert_eq!(bits(&decoded), bits(&expected));
+    // And the fixture is a quantisation of the ramp, not noise: E4M3 has
+    // three mantissa bits, so every value lands within a sixteenth of
+    // itself (relative), and the scale grid is what puts it there.
+    let values = ramp(ROWS * K);
+    for (got, want) in decoded.iter().zip(&values) {
+        assert!(
+            (got - want).abs() <= want.abs() * 0.0625 + 1e-3,
+            "{got} vs {want}"
+        );
+    }
+}
+
+#[test]
+fn the_identity_names_the_family_and_the_label_is_the_checkpoints_dtype() {
+    let id = FP8_BLOCK.identity();
+    assert_eq!(FP8_BLOCK.encoding_label(), "F8_E4M3");
+    assert_eq!(id.family, "fp8-block");
+    assert_eq!(id.element, "e4m3");
+    assert_eq!(
+        FP8_BLOCK
+            .required_auxiliaries(RepresentationExtent::BASE)
+            .len(),
+        1
+    );
+    assert_eq!(
+        FP8_BLOCK.required_auxiliaries(RepresentationExtent::BASE)[0].name,
+        FP8_SCALES
+    );
+    // Codes only: the grid is another operand's footprint.
+    assert_eq!(
+        FP8_BLOCK
+            .stored_bytes(&[ROWS, K], RepresentationExtent::BASE, TENSOR)
+            .unwrap(),
+        (ROWS * K) as u64
+    );
+}
+
+#[test]
+fn a_grid_that_does_not_tile_the_matrix_is_refused_from_metadata() {
+    let judge = |shape: Vec<usize>| {
+        FP8_BLOCK.validate_auxiliary(
+            FP8_SCALES,
+            &AuxiliaryMetadata {
+                object: "o".into(),
+                tensor: "s".into(),
+                label: "F32".into(),
+                shape,
+                identity: None,
+            },
+            &[ROWS, K],
+            RepresentationExtent::BASE,
+            TENSOR,
+        )
+    };
+    judge(vec![FP8_SCALE_ROWS, FP8_SCALE_COLS]).expect("the fixture's grid tiles");
+    judge(vec![1, 1]).expect("one tile over the whole matrix tiles");
+    // Two tile rows over three matrix rows: no even tiling.
+    let err = judge(vec![2, FP8_SCALE_COLS]).unwrap_err();
+    assert!(
+        matches!(&err, CodecError::AuxiliaryGeometry { name, .. } if name == FP8_SCALES),
+        "{err}"
+    );
+    assert!(err.to_string().contains("not evenly tiled"), "{err}");
+    // A one-dimensional grid is not a grid.
+    let err = judge(vec![FP8_SCALE_COLS]).unwrap_err();
+    assert!(
+        matches!(&err, CodecError::AuxiliaryGeometry { .. }),
+        "{err}"
+    );
+    // A zero axis would divide by zero.
+    let err = judge(vec![0, FP8_SCALE_COLS]).unwrap_err();
+    assert!(err.to_string().contains("zero axis"), "{err}");
+}
+
+#[test]
+fn the_codes_without_their_grid_are_refused_by_name() {
+    let fixture = fixture();
+    let operands = CodecOperands::from_streams(
+        FP8_BLOCK
+            .bind_packed(&fixture.buffers[0], &fixture.shape, TENSOR)
+            .unwrap(),
+    );
+    let err = FP8_BLOCK
+        .validate(
+            &operands,
+            &fixture.shape,
+            RepresentationExtent::BASE,
+            TENSOR,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(&err, CodecError::MissingAuxiliary { name, .. } if name == FP8_SCALES),
+        "{err}"
+    );
+}
+
+#[test]
+fn a_grid_short_of_its_declared_shape_is_refused_on_the_values() {
+    let fixture = fixture();
+    let short = fp8_scales()[..FP8_SCALE_ROWS * FP8_SCALE_COLS - 1].to_vec();
+    let short_fixture = Fixture {
+        codec: fixture.codec,
+        shape: fixture.shape.clone(),
+        buffers: fixture.buffers.clone(),
+        packed: true,
+        auxiliaries: vec![(FP8_SCALES, vec![FP8_SCALE_ROWS, FP8_SCALE_COLS], short)],
+    };
+    let err = FP8_BLOCK
+        .validate(
+            &short_fixture.operands(),
+            &short_fixture.shape,
+            RepresentationExtent::BASE,
+            TENSOR,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(&err, CodecError::AuxiliaryGeometry { name, .. } if name == FP8_SCALES),
+        "{err}"
+    );
+}
+
+#[test]
+fn a_rank_other_than_two_has_no_reading() {
+    let err = FP8_BLOCK
+        .stored_bytes(&[2, ROWS, K], RepresentationExtent::BASE, TENSOR)
+        .unwrap_err();
+    assert!(matches!(&err, CodecError::Geometry { .. }), "{err}");
+    assert!(err.to_string().contains("[out, in]"), "{err}");
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/mod.rs
@@ -8,12 +8,14 @@ mod auxiliary;
 mod baseline;
 mod bf16_zlib;
 mod capability;
+mod closure;
 mod composition;
 mod contract;
 mod decode;
 mod f32_planes;
 mod fidelity;
 mod fixtures;
+mod fp8_block;
 mod geometry;
 mod lyrw2;
 mod ranges;
@@ -25,7 +27,8 @@ mod vq8_shared;
 use super::codecs::bf16_zlib::BF16_ZLIB;
 use super::codecs::f32_planes::{F32PlanesCodec, F32_PLANES};
 use super::codecs::float::{BF16, F16, F32};
-use super::codecs::kquant::{Q4_K, Q6_K, Q8_0};
+use super::codecs::fp8_block::{DTYPE_FP8_BLOCK, FP8_BLOCK, SCALES as FP8_SCALES};
+use super::codecs::kquant::{KQuantCodec, Q3_K, Q4_K, Q5_K, Q6_K, Q8_0};
 use super::codecs::mxfp4::{DTYPE_MXFP4, MXFP4};
 use super::codecs::nvfp4::NVFP4;
 use super::codecs::vq8_shared::{
@@ -38,6 +41,7 @@ use super::*;
 use crate::format::vindex3::fixtures::encode_bf16_zlib;
 use crate::format::vindex3::opplan::exec::weights::{quantize_mxfp4, LoadedWeight};
 use crate::format::vindex3::represent::nvfp4_pack::{encode as encode_nvfp4, PackLayout};
+use larql_models::quant::fp8::f32_to_e4m3;
 use larql_models::quant::half::{encode_bf16, encode_f16};
 use larql_models::quant::mxfp4::{MXFP4_GROUP_BYTES, MXFP4_GROUP_ELEMS};
 
@@ -84,6 +88,68 @@ pub(super) fn vq_codebook() -> Vec<f32> {
 
 pub(super) fn builtin() -> Vec<&'static dyn RepresentationCodec> {
     CodecRegistry::builtin().codecs().collect()
+}
+
+/// The FP8 fixture's scale grid over `[ROWS, K]`: one tile row per matrix
+/// row and four tile columns, so the grid is non-square and a transposed
+/// scale index is visible.
+pub(super) const FP8_SCALE_ROWS: usize = ROWS;
+pub(super) const FP8_SCALE_COLS: usize = 4;
+
+pub(super) fn fp8_scales() -> Vec<f32> {
+    (0..FP8_SCALE_ROWS * FP8_SCALE_COLS)
+        .map(|i| 0.0625 * (1 + i % 5) as f32)
+        .collect()
+}
+
+/// The ramp quantised against [`fp8_scales`]: each value divided by its
+/// tile's scale before encoding, so decoding recovers it to E4M3
+/// resolution rather than to noise.
+pub(super) fn fp8_codes(values: &[f32], scales: &[f32]) -> Vec<u8> {
+    let (block_rows, block_cols) = (ROWS / FP8_SCALE_ROWS, K / FP8_SCALE_COLS);
+    (0..ROWS * K)
+        .map(|i| {
+            let (r, c) = (i / K, i % K);
+            let s = scales[(r / block_rows) * FP8_SCALE_COLS + c / block_cols];
+            f32_to_e4m3(values[i] / s)
+        })
+        .collect()
+}
+
+/// Blocks for a K-quant this workspace decodes but cannot encode: a
+/// deterministic byte pattern with the f16 fields set to finite, ordinary
+/// magnitudes, so every decoder in the workspace reads the same finite
+/// values from them. Not a quantisation of anything — the fixture exists
+/// so range decode, stream binding and refusals can be exercised over the
+/// codec, and its decode is judged against the ggml dispatch, not a ramp.
+pub(super) fn synthetic_kquant_blocks(codec: &KQuantCodec) -> Vec<u8> {
+    let quant = codec.quant();
+    let blocks = ROWS * K / quant.elements_per_block;
+    let mut state = 0x9E37_79B9_u32.wrapping_add(quant.bytes_per_block as u32);
+    let mut out: Vec<u8> = (0..blocks * quant.bytes_per_block)
+        .map(|_| {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (state >> 24) as u8
+        })
+        .collect();
+    let scale = encode_f16(&[0.015_625]);
+    let min = encode_f16(&[0.25]);
+    for block in out.chunks_exact_mut(quant.bytes_per_block) {
+        match quant.name {
+            // d at 0..2, dmin at 2..4.
+            "Q5_K" => {
+                block[..2].copy_from_slice(&scale);
+                block[2..4].copy_from_slice(&min);
+            }
+            // d at the tail.
+            "Q3_K" => {
+                let n = block.len();
+                block[n - 2..].copy_from_slice(&scale);
+            }
+            other => panic!("no synthetic layout for {other}"),
+        }
+    }
+    out
 }
 
 /// One encoded fixture: the bytes a container would hold, how they bind
@@ -146,20 +212,30 @@ pub(super) fn fixtures() -> Vec<Fixture> {
         packed(&F16, encode_f16(&values)),
         packed(&F32, f32_bytes),
     ];
-    for k in [Q4_K, Q6_K, Q8_0] {
+    for k in [&Q4_K, &Q6_K, &Q8_0] {
         let bytes = k.quant().encode(&values, TENSOR).expect("encodes");
-        out.push(Fixture {
-            codec: match k.quant().name {
-                "Q4_K" => &Q4_K,
-                "Q6_K" => &Q6_K,
-                _ => &Q8_0,
-            },
-            shape: shape.clone(),
-            buffers: vec![bytes],
-            packed: true,
-            auxiliaries: Vec::new(),
-        });
+        out.push(packed(k, bytes));
     }
+    // The two K-quants this build reads and does not write: their blocks
+    // are synthetic, because a fixture is what a container holds and no
+    // encoder here can produce one.
+    for k in [&Q5_K, &Q3_K] {
+        out.push(packed(k, synthetic_kquant_blocks(k)));
+    }
+    // The dependency-bearing PRODUCTION codec: E4M3 codes, and the scale
+    // grid they mean nothing without — resolved, as the loader hands it
+    // over once the container's reference table addresses it.
+    let scales = fp8_scales();
+    out.push(Fixture {
+        codec: &FP8_BLOCK,
+        shape: shape.clone(),
+        buffers: vec![fp8_codes(&values, &scales)],
+        // One stream, but not ONE PAYLOAD: the codes bind alone and mean
+        // nothing alone, so the packed path — bind, validate, decode from
+        // a single slice — is not a path this codec has.
+        packed: false,
+        auxiliaries: vec![(FP8_SCALES, vec![FP8_SCALE_ROWS, FP8_SCALE_COLS], scales)],
+    });
     let layout = PackLayout::derive(&shape, TENSOR).expect("layout");
     let matrix = larql_models::quant::nvfp4::quantize(&values, ROWS, K).expect("nvfp4");
     out.push(packed(
@@ -215,6 +291,7 @@ pub(super) fn fixtures() -> Vec<Fixture> {
     });
     assert_eq!(out.len(), builtin().len(), "one fixture per built-in codec");
     assert!(out.iter().any(|f| f.label() == DTYPE_MXFP4));
+    assert!(out.iter().any(|f| f.label() == DTYPE_FP8_BLOCK));
     out
 }
 

--- a/crates/larql-vindex/src/format/vindex3/represent/codec/tests/registry.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/codec/tests/registry.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::format::vindex3::represent::nvfp4_pack::CodecIdentity;
 
 #[test]
-fn the_built_in_registry_carries_the_eleven_encodings_in_declaration_order() {
+fn the_built_in_registry_carries_the_fourteen_encodings_in_declaration_order() {
     assert_eq!(
         CodecRegistry::builtin().labels(),
         [
@@ -18,7 +18,10 @@ fn the_built_in_registry_carries_the_eleven_encodings_in_declaration_order() {
             "MXFP4",
             "BF16_ZLIB",
             "F32_PLANES",
-            "VQ8_SHARED"
+            "VQ8_SHARED",
+            "F8_E4M3",
+            "Q5_K",
+            "Q3_K"
         ]
     );
     assert_eq!(
@@ -34,7 +37,10 @@ fn the_built_in_registry_carries_the_eleven_encodings_in_declaration_order() {
             "mxfp4",
             "BF16_ZLIB",
             "F32_PLANES",
-            "VQ8_SHARED"
+            "VQ8_SHARED",
+            "fp8-block",
+            "Q5_K",
+            "Q3_K"
         ]
     );
 }
@@ -69,13 +75,13 @@ fn a_label_and_a_family_resolve_to_the_same_codec() {
 #[test]
 fn an_unregistered_label_is_refused_naming_every_registered_one() {
     let err = CodecRegistry::builtin()
-        .resolve("Q5_K", TENSOR)
+        .resolve("Q2_K", TENSOR)
         .unwrap_err();
     assert_eq!(
         err,
         CodecError::UnknownEncoding {
             tensor: TENSOR.into(),
-            label: "Q5_K".into(),
+            label: "Q2_K".into(),
             registered: CodecRegistry::builtin().labels(),
         }
     );

--- a/crates/larql-vindex/src/format/vindex3/represent/kquant.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/kquant.rs
@@ -20,19 +20,27 @@
 //! test rather than silently mis-sizing a 20 GB segment.
 //!
 //! ```text
-//! encoding   elements/block   bytes/block   bits/weight
-//! Q8_0             32              34          8.5
-//! Q6_K            256             210          6.5625
-//! Q4_K            256             144          4.5
+//! encoding   elements/block   bytes/block   bits/weight   encoder   kernel
+//! Q8_0             32              34          8.5          yes       yes
+//! Q6_K            256             210          6.5625       yes       yes
+//! Q5_K            256             176          5.5          no        no
+//! Q4_K            256             144          4.5          yes       yes
+//! Q3_K            256             110          3.4375       no        no
 //! ```
 //!
-//! ## Not the whole family
+//! ## Two tables, because two questions
 //!
-//! The *decoders* in `larql_models::quant::ggml` already cover Q2_K,
-//! Q3_K and Q5_K. Only these three have encoders in the workspace, and
-//! an encoding whose bytes we cannot write is not a representation this
-//! compiler can offer. Adding one here means adding its encoder, not
-//! adding a row.
+//! [`COMPILABLE`] is what this compiler can WRITE: an encoding whose
+//! bytes we cannot produce is not a representation `vindex represent`
+//! can offer, and adding one there means adding its encoder. [`DECODABLE`]
+//! is what this build can READ — the codecs the registry ships — and is
+//! wider: `Q5_K` and `Q3_K` arrive from a GGUF import or a pack another
+//! tool wrote, decode through the workspace's ggml dispatch, and fill the
+//! ~5.5 and ~3.4 bits-per-weight points on the physical frontier that
+//! the K-quant ladder otherwise skips. Q2_K stays out until footprint
+//! pressure earns it. Which members have a direct kernel is a third
+//! fact, answered by [`KQuant::has_direct_gemv`] beside the kernel
+//! itself.
 
 use super::nvfp4_pack::CodecIdentity;
 use crate::error::VindexError;
@@ -79,8 +87,30 @@ pub const Q4_K: KQuant = KQuant {
     bytes_per_block: 144,
 };
 
+/// 256-element super-block: 4-bit lows, 1-bit highs, 6-bit scales/mins,
+/// f16 d and dmin. Decoded, not compiled: no encoder in the workspace.
+pub const Q5_K: KQuant = KQuant {
+    name: "Q5_K",
+    ggml_type: larql_models::quant::ggml::TYPE_Q5_K,
+    elements_per_block: 256,
+    bytes_per_block: 176,
+};
+
+/// 256-element super-block: 2-bit lows, 1-bit highs, 6-bit signed
+/// scales, f16 d. Decoded, not compiled: no encoder in the workspace.
+pub const Q3_K: KQuant = KQuant {
+    name: "Q3_K",
+    ggml_type: larql_models::quant::ggml::TYPE_Q3_K,
+    elements_per_block: 256,
+    bytes_per_block: 110,
+};
+
 /// Every encoding this compiler can write, in ascending bit order.
 pub const COMPILABLE: [KQuant; 3] = [Q4_K, Q6_K, Q8_0];
+
+/// Every encoding this build can read, in ascending bit order — the
+/// members the codec registry ships. A superset of [`COMPILABLE`].
+pub const DECODABLE: [KQuant; 5] = [Q3_K, Q4_K, Q5_K, Q6_K, Q8_0];
 
 /// The encoding named, or `None` if this compiler cannot write it.
 ///
@@ -265,6 +295,16 @@ impl KQuant {
             "Q4_K" => CpuBackend.quant_matvec(QuantFormat::Q4_K, blocks, x, rows, in_dim),
             _ => None,
         }
+    }
+
+    /// Whether [`Self::gemv`] has a kernel for this member — the fact a
+    /// codec consults before DECLARING the direct realization, stated
+    /// beside the dispatch so the two cannot drift. A member listed here
+    /// and not there would pin a kernel that returns `None` at the first
+    /// token; one there and not here would ship a kernel selection can
+    /// never reach. `kquant_direct_tests` holds the two together.
+    pub fn has_direct_gemv(&self) -> bool {
+        matches!(self.name, "Q8_0" | "Q6_K" | "Q4_K")
     }
 }
 

--- a/crates/larql-vindex/src/format/vindex3/represent/kquant_direct_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/kquant_direct_tests.rs
@@ -251,3 +251,32 @@ fn the_larql_q8_0_format_does_not_answer_for_ggml_blocks() {
          and a silent answer is the 34-vs-18 byte stride bug returning"
     );
 }
+
+/// [`kquant::KQuant::has_direct_gemv`] is the fact a codec consults before
+/// DECLARING the direct realization, and [`kquant::KQuant::gemv`] is the
+/// dispatch it stands for. Held together over every member this build
+/// reads: a member declared without a kernel would pin a realization that
+/// answers `None` at the first token; one with a kernel and no
+/// declaration would ship a kernel selection can never reach.
+#[test]
+fn has_direct_gemv_agrees_with_the_dispatch_for_every_decodable_member() {
+    let (rows, k) = (2usize, 256usize);
+    let x = activations(k);
+    for quant in kquant::DECODABLE {
+        let bytes = vec![0u8; quant.row_bytes(k).expect("256 is a whole block") * rows];
+        let answered = quant.gemv(&bytes, &x, rows, k).is_some();
+        assert_eq!(
+            answered,
+            quant.has_direct_gemv(),
+            "{}: gemv answers {answered}, the declaration says {}",
+            quant.name,
+            quant.has_direct_gemv()
+        );
+    }
+    let with_kernel: Vec<&str> = kquant::DECODABLE
+        .iter()
+        .filter(|q| q.has_direct_gemv())
+        .map(|q| q.name)
+        .collect();
+    assert_eq!(with_kernel, ["Q4_K", "Q6_K", "Q8_0"]);
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/nvfp4_pack.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/nvfp4_pack.rs
@@ -302,11 +302,23 @@ impl CodecIdentity {
     /// is its OWN contract — `Q4_K` and `Q6_K` are different block
     /// layouts, and filing them under one family would let a reader that
     /// implements one accept the other's bytes on a revision match.
+    ///
+    /// The registry is a parameter, never the built-in default: this is
+    /// the gate a container's pack meets at open, and a store opened with
+    /// an external provider's registry must admit that provider's packs
+    /// here. A built-in default would have refused them before the
+    /// registry the store decodes through was ever consulted — the F8
+    /// falsifier, one seam further in.
+    pub fn admit_in(&self, registry: &super::codec::CodecRegistry) -> Result<(), VindexError> {
+        registry.admit(self).map(|_| ()).map_err(Into::into)
+    }
+
+    /// [`Self::admit_in`] against the built-in registry — a test's
+    /// shorthand, and test-only so no production path can reach a
+    /// registry that registration cannot.
+    #[cfg(test)]
     pub fn admit(&self) -> Result<(), VindexError> {
-        super::codec::CodecRegistry::builtin()
-            .admit(self)
-            .map(|_| ())
-            .map_err(Into::into)
+        self.admit_in(super::codec::CodecRegistry::builtin())
     }
 }
 

--- a/crates/larql-vindex/src/format/vindex3/represent/physical.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/physical.rs
@@ -511,15 +511,33 @@ impl ExpertEncoding {
         }
     }
 
+    /// The codec this encoding IS.
+    ///
+    /// Each arm names a shipped codec directly rather than resolving its
+    /// label through a registry: this enum enumerates the four encodings
+    /// the grouped expert kernels read, every one of them built in, so
+    /// there is no registry to consult and a hidden built-in lookup here
+    /// would be a second registry that registration cannot reach.
+    pub fn codec(self) -> &'static dyn super::codec::RepresentationCodec {
+        use super::codec::codecs::{float, kquant};
+        match self {
+            ExpertEncoding::Bf16 => &float::BF16,
+            ExpertEncoding::Q80 => &kquant::Q8_0,
+            ExpertEncoding::Q6K => &kquant::Q6_K,
+            ExpertEncoding::Q4K => &kquant::Q4_K,
+        }
+    }
+
     /// Bytes an `[n, k]` matrix occupies in this encoding.
     ///
     /// Priced by the codec the encoding names, so the block geometry has
     /// one home: a table here that repeated it was the drift the codec
     /// contract exists to remove.
     pub fn matrix_bytes(self, n: usize, k: usize) -> Result<u64, VindexError> {
-        use super::codec::{CodecRegistry, RepresentationExtent};
-        let codec = CodecRegistry::builtin().resolve(self.name(), EXPERT_BANK_OPERAND)?;
-        Ok(codec.stored_bytes(&[n, k], RepresentationExtent::BASE, EXPERT_BANK_OPERAND)?)
+        use super::codec::RepresentationExtent;
+        Ok(self
+            .codec()
+            .stored_bytes(&[n, k], RepresentationExtent::BASE, EXPERT_BANK_OPERAND)?)
     }
 }
 

--- a/crates/larql-vindex/tests/external_attested_provider/container.rs
+++ b/crates/larql-vindex/tests/external_attested_provider/container.rs
@@ -76,6 +76,7 @@ impl Built {
         let store = OperandStore::open(&self.container(), &inspection)
             .unwrap()
             .with_registry(registry)
+            .unwrap()
             .with_recognised(recognised);
         (plan, store)
     }

--- a/crates/larql-vindex/tests/external_auxiliary_provider.rs
+++ b/crates/larql-vindex/tests/external_auxiliary_provider.rs
@@ -357,7 +357,8 @@ impl Built {
             .unwrap_or_else(|| panic!("the external fixture must plan: {:?}", outcome.defects));
         let store = OperandStore::open(&container, &inspection)
             .unwrap()
-            .with_registry(registry);
+            .with_registry(registry)
+            .unwrap();
         (plan, store)
     }
 

--- a/crates/larql-vindex/tests/external_codec_provider.rs
+++ b/crates/larql-vindex/tests/external_codec_provider.rs
@@ -24,12 +24,13 @@ use larql_vindex::format::filenames::INDEX_JSON;
 use larql_vindex::format::vindex3::encode::segment::{
     read_segment_header, write_segment, PlannedTensor,
 };
+use larql_vindex::format::vindex3::encode::REPRESENTATION_ID_SEP;
 use larql_vindex::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
-use larql_vindex::format::vindex3::index::Vindex3Index;
+use larql_vindex::format::vindex3::index::{RepresentationEntry, Vindex3Index};
 use larql_vindex::format::vindex3::inspect::inspect_container;
 use larql_vindex::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
 use larql_vindex::format::vindex3::opplan::exec::execute_plan;
-use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::operands::{OperandStore, RepresentationSource};
 use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
 use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
 use larql_vindex::format::vindex3::opplan::exec::realization::RealizationRecord;
@@ -281,7 +282,8 @@ impl Container {
             .expect("the dense fixture plans");
         let store = OperandStore::open(self.dir.path(), &inspection)
             .unwrap()
-            .with_registry(registry);
+            .with_registry(registry)
+            .unwrap();
         (plan, store)
     }
 
@@ -399,4 +401,149 @@ fn without_the_provider_the_candidate_is_refused_by_name_and_a_prepared_image_is
         .unwrap()
         .ensure_providers_in(CodecRegistry::builtin())
         .unwrap();
+}
+
+// ── The admission seam ───────────────────────────────────────────────
+
+/// A pack whose identity names a family only the provider registers is
+/// admitted by the registry the store is OPENED with, and refused — by
+/// family, naming the registered ones — by the built-in one.
+///
+/// Admission at open used to consult the built-in registry whatever the
+/// store was later re-pointed at, so a provider's own pack was refused
+/// before the provider's registry was ever asked: the F8 falsifier (three
+/// hidden built-in registries at execution) one seam further in, at
+/// open. Now the registry is the constructor's parameter, and re-pointing
+/// an opened store re-runs the admission against the new registry.
+#[test]
+fn a_pack_under_the_external_identity_is_admitted_through_the_registry_the_store_opens_with() {
+    let registry = registry_with_provider();
+    let candidate = Container::build(true);
+    let root = candidate.dir.path();
+
+    // Write the relabelled objects' bytes a second time as compiled packs
+    // under the provider's identity — a segment of their own that names
+    // the pack id, the `codec` entry `vindex represent` writes — so
+    // opening with a wanted encoding selects them and meets the admission
+    // gate the way a real pack does.
+    let index_path = root.join(INDEX_JSON);
+    let mut index: Vindex3Index =
+        serde_json::from_str(&std::fs::read_to_string(&index_path).unwrap()).unwrap();
+    let mut packs: Vec<(String, RepresentationEntry)> = Vec::new();
+    for entry in index.representations.values() {
+        if !candidate
+            .relabelled
+            .iter()
+            .any(|(object, _, _)| *object == entry.object)
+        {
+            continue;
+        }
+        let pack_id = format!("{}{REPRESENTATION_ID_SEP}{LABEL}", entry.object);
+        let source = root.join(&entry.segment);
+        let (header, payload_start) = read_segment_header(&source).unwrap();
+        let file = std::fs::read(&source).unwrap();
+        let payload = &file[payload_start as usize..];
+        let mut bytes_by_name = std::collections::BTreeMap::new();
+        let planned = header
+            .tensors
+            .iter()
+            .map(|t| {
+                bytes_by_name.insert(
+                    t.name.clone(),
+                    payload[t.offset as usize..(t.offset + t.len) as usize].to_vec(),
+                );
+                PlannedTensor {
+                    relative_name: t.name.clone(),
+                    source_name: t.name.clone(),
+                    dtype: t.dtype.clone(),
+                    shape: t.shape.clone(),
+                    len: t.len,
+                }
+            })
+            .collect();
+        let segment_key = format!("segments/{pack_id}");
+        let segment_rel = format!("{segment_key}.bin");
+        let written = write_segment(
+            &root.join(&segment_rel),
+            &pack_id,
+            planned,
+            |name, w, hash| {
+                let bytes = &bytes_by_name[name];
+                w.write_all(bytes).map_err(VindexError::Io)?;
+                hash(bytes);
+                Ok(bytes.len() as u64)
+            },
+        )
+        .unwrap();
+        let mut pack = entry.clone();
+        pack.encoding = LABEL.to_string();
+        pack.segment = segment_rel;
+        pack.tensor_count = written.tensor_count;
+        pack.payload_bytes = written.payload_bytes;
+        pack.payload_sha256 = written.payload_sha256;
+        pack.segment_sha256 = written.segment_sha256;
+        pack.codec = Some(ExternalF32.identity());
+        index.segments.insert(segment_key, 1);
+        packs.push((pack_id, pack));
+    }
+    assert!(!packs.is_empty(), "the relabelled objects carry packs");
+    index.representations.extend(packs);
+    std::fs::write(&index_path, serde_json::to_string_pretty(&index).unwrap()).unwrap();
+    let inspection = inspect_container(root, false).unwrap();
+    assert!(
+        inspection.defects.is_empty(),
+        "the packs are coherent with their segments: {:?}",
+        inspection.defects
+    );
+
+    // Through the built-in registry the pack is refused at open, by its
+    // family, and the refusal names every family that IS registered.
+    let refused =
+        OperandStore::open_for(root, &inspection, Some(LABEL), RepresentationSource::Stored)
+            .err()
+            .expect("the built-in registry knows no such family")
+            .to_string();
+    assert!(refused.contains("external-f32x"), "{refused}");
+    assert!(
+        refused.contains("nvfp4") && refused.contains("Q4_K"),
+        "the refusal names the registered families: {refused}"
+    );
+
+    // Through the provider's registry the same pack is admitted, selected
+    // as the stored representation, and executes bit-exact to the control.
+    let store = OperandStore::open_in(
+        root,
+        &inspection,
+        Some(LABEL),
+        RepresentationSource::Stored,
+        registry,
+    )
+    .expect("the provider's registry admits its own pack");
+    let stored: Vec<&str> = store
+        .selection()
+        .values()
+        .filter(|s| s.stored)
+        .map(|s| s.encoding.as_str())
+        .collect();
+    assert!(
+        !stored.is_empty() && stored.iter().all(|e| *e == LABEL),
+        "{stored:?}"
+    );
+    let plan = plan_component_ops(&inspection, root, "target")
+        .unwrap()
+        .plan
+        .expect("the dense fixture plans");
+    let trace = execute_plan(&plan, &store, &TOKENS, &ProductionBackend::new()).unwrap();
+    let bits = |v: &[f32]| v.iter().map(|x| x.to_bits()).collect::<Vec<u32>>();
+    let (control_logits, _) = Container::build(false).logits_and_hidden(registry);
+    assert_eq!(bits(&trace.logits.expect("a head")), control_logits);
+
+    // And an admitted store cannot be re-pointed at a registry that does
+    // not implement the contract its pack was written under.
+    let err = store
+        .with_registry(CodecRegistry::builtin())
+        .err()
+        .expect("re-pointing re-runs admission")
+        .to_string();
+    assert!(err.contains("external-f32x"), "{err}");
 }

--- a/crates/larql-vindex/tests/external_progressive_provider.rs
+++ b/crates/larql-vindex/tests/external_progressive_provider.rs
@@ -344,7 +344,8 @@ impl Container {
             .unwrap_or_else(|| panic!("the fixture must plan: {:?}", outcome.defects));
         let store = OperandStore::open(self.dir.path(), &inspection)
             .unwrap()
-            .with_registry(registry);
+            .with_registry(registry)
+            .unwrap();
         (plan, store)
     }
 

--- a/docs/represent-codec-contract.md
+++ b/docs/represent-codec-contract.md
@@ -247,3 +247,87 @@ across 33 files and is measured debt, not the next task), or any
 performance. The architecture phase has turned K3 failures from
 format-specific surprises into named missing realizations with physical
 costs; the next work binds a real K3 plan through this machinery.
+
+## Rung 4 — the registry closed over its consumers: FP8, Q5_K/Q3_K, and the admission seam
+
+Built after the v1 freeze and inside it: no invariant of the nine moved, and
+the change is what the freeze was for — a consumer that had been routed
+*around* the contract brought through it, with the evidence that nothing
+else still is.
+
+**Fine-grained FP8 was the conspicuous exception.** GLM-5.3-Flash's own
+bytes — 95.8 % of a 306 GiB checkpoint — had a loader, a `WeightSlice`, a
+resident format and a fused kernel (`FusedFp8Block`), and no codec. The
+loader spelled the checkpoint's sibling name, a `companion` accessor existed
+for that one format, the planner skipped the scale grid by its spelling, and
+the kernel was reachable only by a caller that already knew the answer:
+selection could not offer it, the reference oracle could not decode it, and
+an external provider could not have done what it did.
+
+It is now `F8_E4M3` (family `fp8-block`), the twelfth registered codec, and
+the first PRODUCTION codec whose bytes mean nothing on their own:
+
+| | |
+|---|---|
+| streams | one, the E4M3 codes |
+| dependency | the f32 scale grid, named `scales`, **another represented object** addressed by the container's reference table and decoded through its own codec |
+| tile | derived per tensor from the two shapes — never a config field, never a stream: a stream is bytes and the tile needs the grid's SHAPE, which is why the grid is a dependency and not a second stream (the VQ codebook's rule, met in production) |
+| certificate | codes at 8 bits/weight; the grid is the grid's own footprint. No radius: a fitted codec, like every quantiser here |
+| decode | bit-exact to `fp8_finegrained::dequantize_into`, the transcription of upstream's `Fp8Dequantize` |
+| direct realization | `FusedFp8Block`, declared, with the grid **retained** — the first pin in the tree whose dependency lifetime is `Retained`, priced by the ledger that had been waiting for one |
+
+Three things had to move for that to be one registration rather than a
+special case:
+
+- **The encoder declares the dependency.** The checkpoint's
+  `*.weight_scale_inv` convention is consumed exactly once, at encode, where
+  it becomes a row in the auxiliary reference table beside the segment it
+  describes. The planner's name-based skip is gone: a grid is skipped
+  because something *references* it, and an orphan is the unclassified
+  operand it always was. A container encoded before the encoder declared
+  dependencies migrates with `larql vindex3 references --declare`, which
+  applies the encoder's rule late to the headers on disk and refuses to
+  touch a table that already exists.
+- **The dependency lifetime is the realization's.** Every pin used to be
+  `PreparationOnly` because every realization decoded. A direct kernel over
+  codes keeps its dependency for every token, so the lifetime is set from
+  the pinned realization — and re-set by every re-pin, budget re-selection
+  included, through one method.
+- **The CPU policy ranks the stored FP8 bytes with the compiled packs.**
+  Executed in place, never widened: on GLM the alternative is 612 GB of a
+  306 GB checkpoint, which stays a candidate for the oracle.
+
+**Q5_K and Q3_K** fill the ~5.5 and ~3.4 bits-per-weight points the
+K-quant ladder skipped. This workspace decodes them (a GGUF import, a pack
+another tool wrote) and does not compile them, so the K-quant vocabulary now
+keeps two tables: `COMPILABLE`, what `vindex represent` can write, and
+`DECODABLE`, what the registry ships. Neither has a kernel, and neither
+declares one: the direct realization is declared only where the dispatch
+answers, and a test holds the declaration and the dispatch together over
+every member.
+
+**The admission seam.** `OperandStore::open` admitted a pack's declared
+identity against the built-in registry before `with_registry` could point
+the store anywhere else — the F8 falsifier one seam further in. The
+registry is now the constructor's parameter (`open_in`), re-pointing an
+opened store re-runs the admission, and `ExpertEncoding` prices a bank
+through the codec it *is* rather than a registry lookup. The witness is
+external: a pack under the provider's identity is refused by the built-in
+registry naming every family it does know, admitted by the provider's, and
+executes bit-exact to the control.
+
+**The closure.** Every direct CPU kernel over stored bytes is declared by a
+registered codec, and the executor's own re-quantised forms by none —
+checked over the plan enum, exhaustively, so a kernel added without a
+declaration is a red test rather than a privileged path
+(`codec/tests/closure.rs`).
+
+Fourteen codecs: BF16, F16, F32, Q4_K, Q6_K, Q8_0, NVFP4, MXFP4,
+BF16_ZLIB, F32_PLANES, VQ8_SHARED, F8_E4M3, Q5_K, Q3_K. Eight are the
+production estate, three forced the contract, and the last three arrived
+through it.
+
+Not claimed: a device realization of FP8 (a device backend still narrows
+only floats, and an FP8 operand under it is refused at load rather than at
+selection — the next thing to make honest), a Q5_K or Q3_K kernel, or any
+change to the lowering plane.

--- a/docs/represent-v1-contract-index.md
+++ b/docs/represent-v1-contract-index.md
@@ -214,6 +214,7 @@ no core file names it.
 | negative | `losing_or_substituting_either_provider_invalidates_preparation` — `crates/larql-vindex/tests/external_attested_provider/main.rs` |
 | negative | `losing_the_dependencys_provider_invalidates_the_image_by_name` — `crates/larql-vindex/tests/external_auxiliary_provider.rs` |
 | negative | `a_provider_that_disappears_invalidates_the_preparation_rather_than_falling_back` — `…/exec/tests/accounting.rs` |
+| admission | `a_pack_under_the_external_identity_is_admitted_through_the_registry_the_store_opens_with` — `crates/larql-vindex/tests/external_codec_provider.rs` (refused by the built-in registry naming every family it knows; admitted by the registry the store is opened with; re-pointing re-runs the admission) |
 | genericity | `no_external_identity_or_role_appears_in_production_larql` — `crates/larql-vindex/tests/external_attested_provider/genericity.rs` |
 | scan control | `the_scan_would_have_found_an_identity_that_was_there` — same file (a shipped label *is* found by the same walk, so an empty result means "nothing there", not "nothing looked at") |
 | qualified by | PR #441 (`85b46061`), PR #447 (`202ffb7b`) |
@@ -267,6 +268,23 @@ And the physical semantics:
 | isolation | `verification_changes_preparation_reads_and_no_other_resource` — same file (stored footprint, residency, staging peak, per-token touch and device all unmoved) |
 | mutant | drop the `attestation_verification` term in `ResourceLedger::aggregate` (`…/exec/accounting.rs`) → four arms fail; the three zero-read arms stay green, which is the correct signature |
 | qualified by | PR #457 |
+
+---
+
+## Consumer closure — evidence, not a tenth contract
+
+The nine contracts say what a codec declares. These witnesses say that
+nothing in the executor is reachable *around* those declarations — the
+property "every codec uses the registry" stated as tests. They are listed
+so a kernel or a loader path added without a declaration goes red here.
+
+| | |
+|---|---|
+| closure | `every_direct_kernel_over_stored_bytes_is_declared_by_a_registered_codec` — `…/codec/tests/closure.rs` |
+| control | `the_fp8_kernel_is_declared_by_exactly_the_fp8_codec` — `…/codec/tests/closure.rs` |
+| production dependant | `selection_pins_the_fp8_kernel_and_retains_its_grid` — `…/exec/tests/fp8_carriage.rs` (the first `Retained` dependency lifetime in the tree) |
+| production dependant | `the_canonical_decode_is_the_reference_dequantisation_bit_for_bit` — `…/exec/tests/fp8_carriage.rs` |
+| declared, not spelled | `the_encoder_declares_the_scale_grid_as_the_codes_dependency` — `…/exec/tests/fp8_carriage.rs` |
 
 ---
 


### PR DESCRIPTION
## What

The audit behind this PR asked one question of the codec plane: does every stored representation the executor runs go through `RepresentationCodec` and `CodecRegistry`, with nothing reachable around them? Three things did not, and each is closed here with a witness.

### Fine-grained FP8 becomes a codec (`F8_E4M3`, family `fp8-block`)

GLM's stored estate had a loader, a `WeightSlice`, a resident format and `FusedFp8Block`, and no codec: the loader spelled `weight_scale_inv`, a `companion` accessor existed for one format, the planner skipped the grid by its spelling, and the kernel was reachable only by a caller that knew the answer. Selection could not offer it and the reference oracle could not decode it.

- The E4M3 codes are the one stream; the f32 scale grid is a **declared dependency** named `scales`, addressed through the reference table and decoded through its own codec. The tile is derived from the grid's *shape*, and a stream is only bytes — so the grid is a dependency, not a second stream (the VQ codebook's rule, met in production).
- Direct realization `FusedFp8Block` is declared with the grid **retained** — the first `Retained` dependency lifetime in the tree. Lifetimes are set from the pinned realization and re-set by every re-pin (budget re-selection included) through `RealizationRecord::repin`.
- The CPU policy ranks the stored FP8 bytes with the compiled packs; the decode stays a candidate for the oracle.
- Canonical decode is bit-exact to `fp8_finegrained::dequantize_into`; production and reference agree on the FP8 fixture through selection.

### The encoder declares the dependency

`*.weight_scale_inv` is consumed once, at encode, and becomes a row in `auxiliary_references.json`. The planner's name-based skip is removed; a grid is skipped because something references it.

**Behaviour change for existing containers:** an FP8 container encoded before this change has the pair and no table. It now refuses at planning (the grid is an unclassified operand) and at decode (`F8_E4M3` requires `scales`), and migrates with:

```
larql vindex3 references --declare <container>
```

which applies the encoder's rule late to the segment headers and refuses to touch a table that already exists. Existing GLM-5.3-Flash containers on disk need this once.

### Q5_K and Q3_K

Registered as decodable K-quants (`DECODABLE` beside `COMPILABLE`), no encoder, no kernel, and no direct realization declared — the declaration is made only where `KQuant::gemv` answers, and a test holds the two together over every member.

### The admission seam

`OperandStore::open` admitted a pack's declared identity against the built-in registry before `with_registry` could re-point the store — the F8 falsifier one seam further in. Now: `open_in(…, registry)`, `with_registry` re-runs admission and is fallible, `CodecIdentity::admit_in(registry)`, and `ExpertEncoding` prices through the codec it is. External witness in `external_codec_provider.rs`: a pack under the provider's identity is refused by the built-in registry naming every family it knows, admitted by the provider's, executes bit-exact, and cannot be re-pointed at a registry that does not know it.

### Closure

`codec/tests/closure.rs`: every direct CPU kernel over stored bytes is declared by a registered codec, and the executor's re-quantised forms by none — exhaustive over `PhysicalProjectionPlan`.

Fourteen codecs registered. `docs/represent-codec-contract.md` gains a rung-4 section; the v1 index gains the admission row under §8 and a "consumer closure" evidence table (no invariant changed; `scripts/check_contract_index.py` passes).

## Not claimed

- A device realization of FP8: a device backend still narrows only floats, so an FP8 operand under `--backend metal` is refused at load rather than at selection. Next thing to make honest.
- A Q5_K or Q3_K kernel.
- Any change to the lowering plane (inventory in a separate PR).

## Verified

- `cargo clippy -p larql-vindex -p larql-models -p larql-cli --tests -- -D warnings`: clean
- `cargo test -p larql-vindex --lib`: 4646 passed
- external provider suites (codec, auxiliary, progressive, attested): all pass
- `cargo test -p larql-cli realizations`, `cargo test -p larql-models fp8`: pass
- `cargo fmt --all --check`, `scripts/check_contract_index.py`: clean

Not run locally: the full `make ci` / `make test-full` across the workspace (CI).
