### PR TITLE
feat(lowering): L1 — a lowering provider names itself

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -28,6 +28,7 @@ use larql_models::config::{
 
 use super::super::super::graph::policy::AttentionSpan;
 use super::cpu::WeightRows;
+use super::lowering::LoweringIdentity;
 use super::quantise::SUM_BLOCK;
 use super::realization::{RepresentationFacts, Selection, SelectionRefusal};
 use crate::error::VindexError;
@@ -755,8 +756,18 @@ pub struct DispatchStats {
 }
 
 pub trait PlanBackend: Sync {
-    /// A name for diagnostics and parity reports. Not dispatched on.
+    /// A name for diagnostics and parity reports. Not dispatched on, and
+    /// not an identity: two instances of one provider may carry different
+    /// names (a device backend names its device and realisation), and the
+    /// name says nothing a registry or a pin can rely on.
     fn name(&self) -> &str;
+
+    /// **The provider's identity** — family and revision — which is the
+    /// authority a pin will record and a registry will key. Required, so
+    /// a provider that says nothing does not exist; never derived from
+    /// [`Self::name`]. See [`super::lowering`] for what the two fields
+    /// mean and when the revision moves.
+    fn identity(&self) -> LoweringIdentity;
 
     /// Cumulative device-dispatch accounting, when the backend keeps it.
     /// `None` for backends with no device to account for.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/device.rs
@@ -62,6 +62,7 @@ use larql_compute::cpu::ops::geglu::{geglu_silu_alloc, silu};
 use ndarray::ArrayView2;
 use rayon::prelude::*;
 
+use super::lowering::LoweringIdentity;
 use super::production::unsupported_activation;
 use super::realization::{
     class_of, common_selection, resident_profile, RealizationBackend, RealizationForm,
@@ -69,6 +70,11 @@ use super::realization::{
 };
 use crate::format::vindex3::opplan::planned::PlannedOperand;
 use larql_compute::ffn::gelu_tanh;
+
+/// The provider's family ([`PlanBackend::identity`]): the plan's matrix
+/// work on an injected [`MatMul`] device, production CPU glue between.
+pub const IDENTITY_FAMILY: &str = "device-matmul";
+pub const IDENTITY_REVISION: u32 = 1;
 
 /// One MXFP4 matrix as the device trait consumes it:
 /// `(packed, scales, n, k)`.
@@ -344,6 +350,17 @@ impl<M: MatMul + Send> DevicePlanBackend<M> {
 impl<M: MatMul + Send> PlanBackend for DevicePlanBackend<M> {
     fn name(&self) -> &str {
         &self.name
+    }
+
+    /// One identity for every instance, whatever device was injected and
+    /// whatever format table it was built with: the PROVIDER is the plan's
+    /// matrix work over a `MatMul` device with production glue, and that
+    /// is what a pin will hold it to. The device and the per-class formats
+    /// are configuration — the format is already pinned in the
+    /// realization form, and the device is the caller's to name in
+    /// [`Self::name`].
+    fn identity(&self) -> LoweringIdentity {
+        LoweringIdentity::new(IDENTITY_FAMILY, IDENTITY_REVISION)
     }
 
     fn dispatch_stats(&self) -> Option<DispatchStats> {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/lowering.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/lowering.rs
@@ -1,0 +1,117 @@
+//! **The lowering identity** — what a realization provider IS, as distinct
+//! from what it is called.
+//!
+//! L1 of LOWERING-PLUGIN-1 (`docs/represent/forecasts/lowering-plugin-1.json`).
+//! Before this module a [`PlanBackend`](super::backend::PlanBackend) had a
+//! name "for diagnostics and parity reports, not dispatched on" and no
+//! identity: a prepared image could say which CODEC produced its bytes by
+//! family and revision, and which LOWERING qualified its pin only as
+//! `Cpu | Device`. This is the identity the codec plane already carries
+//! ([`CodecIdentity`](crate::format::vindex3::represent::nvfp4_pack::CodecIdentity)),
+//! brought to the other half of the contract.
+//!
+//! Two fields, on purpose. The **family** names the provider — the code
+//! that derives candidates from representation facts and realizes what
+//! it pinned. The **revision** says whether that code still means what
+//! it meant: bump it when the same pin would compute a different number,
+//! never for a faster kernel that computes the same one. Configuration a
+//! provider is constructed with — a device's per-class format table, the
+//! injected `MatMul` — is not identity; what it changes is already pinned
+//! in the realization form.
+//!
+//! Nothing dispatches on this yet. L2 keys a registry by it, L4 records
+//! it in every pin and invalidates preparation by it. L1 only makes it
+//! exist and be stated by every provider, which is the smallest thing
+//! that can be falsified.
+
+use std::fmt;
+
+use crate::error::VindexError;
+
+/// A lowering provider's semantic identity: family and revision.
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+pub struct LoweringIdentity {
+    /// Which provider. Stable across builds; a registry keys on it.
+    pub family: String,
+    /// Which meaning. Two revisions of one family may compute different
+    /// numbers for the same pin, and a prepared image records which.
+    pub revision: u32,
+}
+
+impl LoweringIdentity {
+    pub fn new(family: impl Into<String>, revision: u32) -> Self {
+        Self {
+            family: family.into(),
+            revision,
+        }
+    }
+
+    /// Refuse an identity that could not key a registry or name a
+    /// refusal: an empty or blank family, one that would not survive a
+    /// file name or a flag (anything outside `[A-Za-z0-9_-]`), or a
+    /// revision of zero, which is the "unstated" value and never a real
+    /// one.
+    pub fn validate(&self) -> Result<(), VindexError> {
+        if self.family.trim().is_empty() {
+            return Err(VindexError::Parse(
+                "lowering identity: the family is empty".into(),
+            ));
+        }
+        if let Some(bad) = self
+            .family
+            .chars()
+            .find(|c| !(c.is_ascii_alphanumeric() || *c == '_' || *c == '-'))
+        {
+            return Err(VindexError::Parse(format!(
+                "lowering identity: family `{}` contains `{bad}`; only ASCII letters, digits, \
+                 `_` and `-` name a provider",
+                self.family
+            )));
+        }
+        if self.revision == 0 {
+            return Err(VindexError::Parse(format!(
+                "lowering identity: `{}` declares revision 0, which means unstated",
+                self.family
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for LoweringIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/v{}", self.family, self.revision)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_valid_identity_displays_as_family_and_revision() {
+        let id = LoweringIdentity::new("cpu-production", 1);
+        id.validate().unwrap();
+        assert_eq!(id.to_string(), "cpu-production/v1");
+        assert_eq!(id, LoweringIdentity::new("cpu-production".to_string(), 1));
+        assert_ne!(id, LoweringIdentity::new("cpu-production", 2));
+    }
+
+    #[test]
+    fn an_invalid_identity_is_refused_naming_what_is_wrong() {
+        let empty = LoweringIdentity::new("", 1).validate().unwrap_err();
+        assert!(empty.to_string().contains("empty"), "{empty}");
+        let blank = LoweringIdentity::new("  ", 1).validate().unwrap_err();
+        assert!(blank.to_string().contains("empty"), "{blank}");
+        let spaced = LoweringIdentity::new("cpu production", 1)
+            .validate()
+            .unwrap_err();
+        assert!(spaced.to_string().contains("` `"), "{spaced}");
+        let slashed = LoweringIdentity::new("cpu/v1", 1).validate().unwrap_err();
+        assert!(slashed.to_string().contains("`/`"), "{slashed}");
+        let unstated = LoweringIdentity::new("cpu", 0).validate().unwrap_err();
+        assert!(unstated.to_string().contains("revision 0"), "{unstated}");
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -44,6 +44,7 @@ pub mod kimi_router;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
 pub mod kimi_source;
 pub mod kv;
+pub mod lowering;
 pub mod mamba2;
 pub mod mla;
 pub mod narrow;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/production.rs
@@ -48,6 +48,7 @@ use super::cpu::PhysicalProjectionPlan;
 use super::kernels::{
     gather_fused_half, mrope_rotate_scaled, rope_rotate, rope_rotate_scaled, sigmoid, FusedHalf,
 };
+use super::lowering::LoweringIdentity;
 use super::prefetch;
 use super::realization::{
     class_of, common_selection, cpu_projection_candidates, realization_residency, RealizationForm,
@@ -71,6 +72,12 @@ use rayon::prelude::*;
 
 /// Name reported by [`PlanBackend::name`].
 const NAME: &str = "production-larql-compute";
+/// The provider's family ([`PlanBackend::identity`]): the CPU executor
+/// over `larql-compute`'s kernels. Revision 1 is the arithmetic this
+/// module binds today; it moves when the same pin would compute a
+/// different number, never for a faster kernel computing the same one.
+pub const IDENTITY_FAMILY: &str = "cpu-production";
+pub const IDENTITY_REVISION: u32 = 1;
 
 /// `larql-compute` realisation of every plan operation.
 #[derive(Debug, Default, Clone, Copy)]
@@ -922,6 +929,10 @@ impl PlanBackend for ProductionBackend {
 
     fn name(&self) -> &str {
         NAME
+    }
+
+    fn identity(&self) -> LoweringIdentity {
+        LoweringIdentity::new(IDENTITY_FAMILY, IDENTITY_REVISION)
     }
 
     fn embed(&self, table: &[f32], hidden: usize, token: u32, scale: Option<f32>) -> Vec<f32> {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/reference.rs
@@ -27,6 +27,7 @@ use super::kernels::{
     partial_rotary_frequencies, partial_rotary_slice, rope_rotate, rope_rotate_scaled, sigmoid,
     softcap, softmax, softmax_with_sink, yarn_frequencies, FusedHalf, GateMutation,
 };
+use super::lowering::LoweringIdentity;
 use crate::error::VindexError;
 use larql_models::config::NormType;
 use larql_models::config::{PositionPolicy, RotaryFrequencyBasis};
@@ -34,6 +35,12 @@ use rayon::prelude::*;
 
 /// Name reported by [`PlanBackend::name`].
 const NAME: &str = "reference-f32";
+/// The provider's family ([`PlanBackend::identity`]): the literal f32
+/// transcription that defines correctness. Its revision moves only if the
+/// transcription itself is corrected — which is a change to what every
+/// other provider is judged against, and is recorded as one.
+pub const IDENTITY_FAMILY: &str = "reference";
+pub const IDENTITY_REVISION: u32 = 1;
 
 /// Naive f32 realisation of every plan operation.
 #[derive(Debug, Default, Clone, Copy)]
@@ -671,6 +678,10 @@ fn add_in_place(x: &mut [f32], b: &[f32]) {
 impl PlanBackend for ReferenceBackend {
     fn name(&self) -> &str {
         NAME
+    }
+
+    fn identity(&self) -> LoweringIdentity {
+        LoweringIdentity::new(IDENTITY_FAMILY, IDENTITY_REVISION)
     }
 
     fn embed(&self, table: &[f32], hidden: usize, token: u32, scale: Option<f32>) -> Vec<f32> {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_backend_decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/coverage_backend_decode.rs
@@ -18,6 +18,7 @@ use crate::format::vindex3::opplan::exec::backend::{
 };
 use crate::format::vindex3::opplan::exec::decode::DecodeSession;
 use crate::format::vindex3::opplan::exec::execute_plan;
+use crate::format::vindex3::opplan::exec::lowering::LoweringIdentity;
 use crate::format::vindex3::opplan::exec::operands::OperandStore;
 use crate::format::vindex3::opplan::exec::production::ProductionBackend;
 use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
@@ -311,6 +312,10 @@ impl RefusingBackend {
 impl PlanBackend for RefusingBackend {
     fn name(&self) -> &str {
         "refusing"
+    }
+
+    fn identity(&self) -> LoweringIdentity {
+        LoweringIdentity::new("test-refusing", 1)
     }
 
     fn embed(&self, table: &[f32], hidden: usize, token: u32, scale: Option<f32>) -> Vec<f32> {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_identity.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_identity.rs
@@ -1,0 +1,198 @@
+//! **L1 of LOWERING-PLUGIN-1: a lowering provider names itself.**
+//!
+//! The forecast (`docs/represent/forecasts/lowering-plugin-1.json`)
+//! predicts that every `PlanBackend` states a versioned identity and that
+//! the diagnostic name stays non-authoritative. Three things are held
+//! here, and the third is the control that keeps the first two from being
+//! a rename: the in-tree providers each state a valid, distinct identity;
+//! an identity is the PROVIDER's and not its configuration's; and the two
+//! fields are independent in both directions — one name over two
+//! identities, and one identity under two names.
+
+use super::super::backend::{
+    AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, FfnCall, NormCall,
+    PlanBackend, ProjectCall, RoutedFfnCall, WeightFormat, WeightFormats, WeightSlice,
+};
+use super::super::device::DevicePlanBackend;
+use super::super::lowering::LoweringIdentity;
+use super::super::production::ProductionBackend;
+use super::super::reference::ReferenceBackend;
+use crate::error::VindexError;
+use larql_compute::cpu::CpuBackend;
+
+fn in_tree() -> Vec<(&'static str, LoweringIdentity)> {
+    vec![
+        ("reference", ReferenceBackend::new().identity()),
+        ("production", ProductionBackend::new().identity()),
+        (
+            "device",
+            DevicePlanBackend::new(CpuBackend, "cpu-as-device", WeightFormat::F32).identity(),
+        ),
+    ]
+}
+
+#[test]
+fn every_in_tree_provider_states_a_valid_distinct_identity() {
+    let providers = in_tree();
+    for (who, id) in &providers {
+        id.validate().unwrap_or_else(|e| panic!("{who}: {e}"));
+        assert_eq!(id.revision, 1, "{who}: every provider starts at revision 1");
+    }
+    let families: Vec<&str> = providers.iter().map(|(_, id)| id.family.as_str()).collect();
+    assert_eq!(families, ["reference", "cpu-production", "device-matmul"]);
+    let mut distinct = providers
+        .iter()
+        .map(|(_, id)| id.clone())
+        .collect::<Vec<_>>();
+    distinct.sort();
+    distinct.dedup();
+    assert_eq!(
+        distinct.len(),
+        providers.len(),
+        "two providers share an identity"
+    );
+}
+
+/// A provider's identity is stable across instances and across the
+/// configuration it is built with. The device backend is the case that
+/// matters: its NAME is per instance and names the device and realisation
+/// (`metal-r2-f16`), and its format table changes what it asks the loader
+/// for — neither is who the provider is.
+#[test]
+fn identity_is_the_providers_not_its_configurations() {
+    assert_eq!(
+        ProductionBackend::new().identity(),
+        ProductionBackend::new().identity()
+    );
+    let f32_device = DevicePlanBackend::new(CpuBackend, "device-r1-f32", WeightFormat::F32);
+    let f16_device = DevicePlanBackend::with_formats(
+        CpuBackend,
+        "device-r2-f16",
+        WeightFormats::uniform(WeightFormat::F16),
+    );
+    assert_ne!(f32_device.name(), f16_device.name());
+    assert_eq!(f32_device.identity(), f16_device.identity());
+    assert_eq!(f32_device.identity().to_string(), "device-matmul/v1");
+}
+
+/// A backend that answers for another's arithmetic under a name and an
+/// identity of its own choosing — so the two fields can be varied
+/// independently, which is the only way to show one is not derived from
+/// the other.
+struct Relabelled {
+    inner: ReferenceBackend,
+    name: &'static str,
+    identity: LoweringIdentity,
+}
+
+impl Relabelled {
+    fn new(name: &'static str, family: &str, revision: u32) -> Self {
+        Self {
+            inner: ReferenceBackend::new(),
+            name,
+            identity: LoweringIdentity::new(family, revision),
+        }
+    }
+}
+
+impl PlanBackend for Relabelled {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn identity(&self) -> LoweringIdentity {
+        self.identity.clone()
+    }
+
+    fn embed(&self, table: &[f32], hidden: usize, token: u32, scale: Option<f32>) -> Vec<f32> {
+        self.inner.embed(table, hidden, token, scale)
+    }
+
+    fn norm(&self, call: NormCall<'_>) -> Vec<f32> {
+        self.inner.norm(call)
+    }
+
+    fn project(&self, call: ProjectCall<'_>) -> Result<Vec<f32>, VindexError> {
+        self.inner.project(call)
+    }
+
+    fn attention(&self, call: AttentionCall<'_>) -> Result<AttentionOut, VindexError> {
+        self.inner.attention(call)
+    }
+
+    fn attention_step(&self, call: AttentionStepCall<'_>) -> Result<AttentionStepOut, VindexError> {
+        self.inner.attention_step(call)
+    }
+
+    fn ffn(&self, call: FfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        self.inner.ffn(call)
+    }
+
+    fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        self.inner.routed_ffn(call)
+    }
+
+    fn output_head(
+        &self,
+        projection: WeightSlice<'_>,
+        vocab: usize,
+        hidden: usize,
+        x: &[f32],
+        multiplier: Option<f64>,
+        softcapping: Option<f32>,
+    ) -> Result<Vec<f32>, VindexError> {
+        self.inner
+            .output_head(projection, vocab, hidden, x, multiplier, softcapping)
+    }
+
+    fn residual_add(&self, acc: &mut [f32], delta: &[f32]) {
+        self.inner.residual_add(acc, delta)
+    }
+}
+
+/// The control. One diagnostic name over two identities are two
+/// providers; one identity under two names is one provider. A field that
+/// were a rename of the name could satisfy neither half.
+#[test]
+fn identity_is_authority_and_name_is_presentation() {
+    let same_name_a = Relabelled::new("metal", "provider-a", 1);
+    let same_name_b = Relabelled::new("metal", "provider-b", 1);
+    assert_eq!(same_name_a.name(), same_name_b.name());
+    assert_ne!(same_name_a.identity(), same_name_b.identity());
+
+    let same_id_a = Relabelled::new("metal-r2-f16", "provider-a", 1);
+    let same_id_b = Relabelled::new("metal-r3-nvfp4", "provider-a", 1);
+    assert_ne!(same_id_a.name(), same_id_b.name());
+    assert_eq!(same_id_a.identity(), same_id_b.identity());
+
+    // And a revision is part of the identity: the same family at another
+    // revision is a different authority, whatever it is called.
+    let revised = Relabelled::new("metal-r2-f16", "provider-a", 2);
+    assert_eq!(revised.name(), same_id_a.name());
+    assert_ne!(revised.identity(), same_id_a.identity());
+
+    // Dispatched through the trait object, the identity is the one the
+    // provider stated — nothing between the caller and the provider
+    // substitutes a default.
+    let erased: &dyn PlanBackend = &same_name_b;
+    assert_eq!(erased.identity(), LoweringIdentity::new("provider-b", 1));
+}
+
+/// An identity a provider could state and a registry could not key is
+/// refused by name — the shape L2 will lean on.
+#[test]
+fn an_unkeyable_identity_is_refused_before_anything_relies_on_it() {
+    for (family, revision, what) in [
+        ("", 1, "empty"),
+        ("cpu production", 1, "` `"),
+        ("cpu/v1", 1, "`/`"),
+        ("cpu-production", 0, "revision 0"),
+    ] {
+        let err = Relabelled::new("x", family, revision)
+            .identity()
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains(what), "{family:?}/{revision}: {err}");
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -58,6 +58,7 @@ mod kimi_moe_real;
 mod kimi_router;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
 mod kimi_two_layer;
+mod lowering_identity;
 mod mamba2_exec;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
 mod mla_metal;

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/seam.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/seam.rs
@@ -25,6 +25,7 @@ use crate::format::vindex3::opplan::exec::backend::{
     AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, FfnCall, NormCall,
     PlanBackend, ProjectCall, RoutedFfnCall, WeightSlice,
 };
+use crate::format::vindex3::opplan::exec::lowering::LoweringIdentity;
 use crate::format::vindex3::opplan::exec::operands::OperandStore;
 use crate::format::vindex3::opplan::exec::production::ProductionBackend;
 use crate::format::vindex3::opplan::exec::reference::ReferenceBackend;
@@ -58,6 +59,10 @@ impl RecordingBackend {
 impl PlanBackend for RecordingBackend {
     fn name(&self) -> &str {
         "recording"
+    }
+
+    fn identity(&self) -> LoweringIdentity {
+        LoweringIdentity::new("test-recording", 1)
     }
 
     fn embed(&self, table: &[f32], hidden: usize, token: u32, scale: Option<f32>) -> Vec<f32> {
@@ -123,6 +128,10 @@ struct PerturbedBackend(ReferenceBackend);
 impl PlanBackend for PerturbedBackend {
     fn name(&self) -> &str {
         "perturbed"
+    }
+
+    fn identity(&self) -> LoweringIdentity {
+        LoweringIdentity::new("test-perturbed", 1)
     }
 
     fn embed(&self, table: &[f32], hidden: usize, token: u32, scale: Option<f32>) -> Vec<f32> {

--- a/docs/represent/forecasts/lowering-plugin-1-notes.json
+++ b/docs/represent/forecasts/lowering-plugin-1-notes.json
@@ -1,0 +1,57 @@
+{
+  "programme": "LOWERING-PLUGIN-1",
+  "forecast": "lowering-plugin-1.json (frozen 2026-09-08, PR #464)",
+  "rule": "The forecast is not edited. Every deviation, measurement and surprise is written here with its reason.",
+  "waves": {
+    "L1": {
+      "name": "lowering identity",
+      "status": "built and held",
+      "branch": "lowering-l1",
+      "base": "a03efc29 (main; #461, #462 and #464 open beside it, none required)",
+      "date": "2026-09-09",
+      "what_landed": [
+        "`exec/lowering.rs`: `LoweringIdentity { family: String, revision: u32 }` — Eq/Ord/Hash/serde, `validate()` refusing an empty or blank family, a family outside `[A-Za-z0-9_-]`, and revision 0 (the unstated value); Display `family/vN`.",
+        "`PlanBackend::identity() -> LoweringIdentity` is REQUIRED — no default, nothing derived from `name()`. `name()` stays, documented as presentation.",
+        "In-tree identities: `reference/v1`, `cpu-production/v1`, `device-matmul/v1`, each a pair of `pub const`s beside the provider's `NAME`.",
+        "Every implementor in the workspace states one: three providers, three test backends (`test-recording`, `test-perturbed`, `test-refusing`). `cargo check --workspace --all-targets` is the proof there is no fourth provider hiding behind a cfg."
+      ],
+      "witnesses": {
+        "every_in_tree_provider_states_a_valid_distinct_identity": "exec/tests/lowering_identity.rs — valid, revision 1, three distinct families in the expected order",
+        "identity_is_the_providers_not_its_configurations": "same file — two device instances with different names and format tables share one identity; two production instances agree",
+        "identity_is_authority_and_name_is_presentation": "same file — the control: one name over two identities differ, one identity under two names agree, a revision bump is a different identity under the same name, and the trait object returns what the provider stated",
+        "an_unkeyable_identity_is_refused_before_anything_relies_on_it": "same file, plus `lowering::tests` for the refusal texts"
+      },
+      "required_at_end_of_L1": {
+        "PlanBackend::identity_exists": true,
+        "every_in_tree_backend_has_stable_family_and_revision": true,
+        "identity_not_inferred_from_name": "true — required method, no default; the control test varies the two independently",
+        "duplicate_or_invalid_identities_testable": "true — `validate()`, and the distinctness assertion over the in-tree set (a duplicate fails it; a registry refusing duplicates is L2)",
+        "selection_changes": 0,
+        "accounting_changes": 0,
+        "execution_changes": 0,
+        "codec_api_changes": 0,
+        "kernel_plane_files": 32
+      },
+      "evidence_for_the_zeros": "The diff touches `backend.rs` (trait method and its doc), `lowering.rs` (new), and one `identity()` plus two constants in each of `reference.rs`, `production.rs`, `device.rs`; no file under `represent/`, no `select`, no `prepared.rs`, no `accounting.rs`. `cargo test -p larql-vindex --lib`: 4638 passed, 0 failed, 7 ignored — the same suite as base plus the six new tests, with no existing assertion changed.",
+      "measurement_correction": {
+        "what": "The inventory (#462) reported the kernel-plane file count as 33 'unchanged since 2026-09-05'. Measured with the inventory's own method on main `a03efc29` the count is 32; the 33 was taken in the #461 worktree, where the new FP8 codec file names `PhysicalProjectionPlan::FusedFp8Block`. So the honest baseline is 32 on main and 33 once #461 merges, and L1 adds none: 32 on this branch.",
+        "consequence_for_F3": "F3's prediction is unchanged in meaning — the count does not move through L1–L5 — and is read against whichever base the wave branches from: 32 without #461, 33 with it. Written here rather than in the forecast, per its immutability clause.",
+        "method": "non-test `.rs` files under `opplan/exec/` and `represent/` containing `<Enum>::` for any of the five kernel-plane enums; `grep -rl` then exclude `/tests/`, `_tests.rs`, `tests.rs`."
+      },
+      "observations_for_later_waves": [
+        "Device identity is the provider's, not the injected device's: `DevicePlanBackend<MetalBackend>` and `DevicePlanBackend<CpuBackend>` both answer `device-matmul/v1`. L2 must decide whether a registry entry is per provider type or per (provider, injected device); L4 must decide whether a pin that recorded `device-matmul/v1` is invalidated when the injected device changes — today the realization FORM pins the resident format, and nothing pins the device. Raised here, not resolved.",
+        "`identity()` returns an owned value on every call (String family), mirroring `CodecIdentity`. Fine at preparation; if L4 needs it per token, intern it then.",
+        "The `metal-lowered` driver (2,890 lines, CLI) has no `PlanBackend` and therefore no identity — as the inventory recorded. Untouched by design; it is F1's subject.",
+        "Nothing dispatches on identity yet. The 'authority' claim at L1 is structural (required, independent of name); it becomes operational at L2 and L4."
+      ],
+      "gates_run": [
+        "cargo fmt --all",
+        "cargo check --workspace --all-targets",
+        "cargo clippy -p larql-vindex -p larql-cli -p larql-inference --all-targets -- -D warnings",
+        "cargo test -p larql-vindex --lib (4638 passed)",
+        "cargo test -p larql-vindex --no-run (integration targets compile against the exported trait)"
+      ],
+      "deviations_from_forecast": "None in scope. One measurement correction, recorded above."
+    }
+  }
+}


### PR DESCRIPTION
## What

Wave L1 of LOWERING-PLUGIN-1 (forecast frozen in #464), kept as narrow as the forecast asks.

- `LoweringIdentity { family, revision }` in `exec/lowering.rs`, with `validate()` and `Display` (`cpu-production/v1`).
- `PlanBackend::identity()` is **required**: no default, not derived from `name()`. `name()` stays, documented as presentation.
- In-tree providers: `reference/v1`, `cpu-production/v1`, `device-matmul/v1`.
- Every implementor in the workspace states one (`cargo check --workspace --all-targets` is the proof there is no other).

## The control

`exec/tests/lowering_identity.rs`: one name over two identities differ; one identity under two names agree; a revision bump is a different identity under the same name; two device instances with different names and format tables share one identity; the trait object returns what the provider stated. Plus refusals for an unkeyable identity.

## What did not change

| | |
|---|---|
| selection, accounting, execution, codec API | 0 changes (diff touches `backend.rs`, `lowering.rs`, one `identity()` per provider, tests) |
| library suite | 4638 passed, 0 failed, 7 ignored — base suite plus six new tests, no existing assertion changed |
| kernel-plane files | 32 |

## Measurement correction (recorded in the notes, not the forecast)

The inventory's "33 files" was measured in the #461 worktree, where the FP8 codec names `FusedFp8Block`. On main `a03efc29` the same method gives 32; with #461 merged it is 33; L1 adds none. F3's meaning is unchanged. `docs/represent/forecasts/lowering-plugin-1-notes.json` records this and two questions raised for L2/L4 (device identity versus injected device; per-token identity cost).

## Not in this PR

No `LoweringRegistry` (L2), no identity in `RealizationRecord` (L4), no change to device selection, nothing touching the `metal-lowered` bypass, no new `WeightFormat` / `WeightSlice` / `WeightRows` / `LoadedWeight` / `PhysicalProjectionPlan` variant.

Independent of #461, #462 and #464; branches from `a03efc29`.

## Gates

fmt, `cargo check --workspace --all-targets`, clippy `-D warnings` on larql-vindex / larql-cli / larql-inference, `cargo test -p larql-vindex --lib`, integration targets compiled.
