### PR TITLE
feat(lowering): L2 — a lowering registry, carried as a value

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -755,6 +755,14 @@ pub struct DispatchStats {
     pub submissions: u64,
 }
 
+/// A provider names itself by presentation name and identity, so a
+/// refusal or a test can say which one it was talking about.
+impl std::fmt::Debug for dyn PlanBackend + '_ {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "provider {} ({})", self.name(), self.identity())
+    }
+}
+
 pub trait PlanBackend: Sync {
     /// A name for diagnostics and parity reports. Not dispatched on, and
     /// not an identity: two instances of one provider may carry different

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/lowering.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/lowering.rs
@@ -19,13 +19,15 @@
 //! injected `MatMul` — is not identity; what it changes is already pinned
 //! in the realization form.
 //!
-//! Nothing dispatches on this yet. L2 keys a registry by it, L4 records
-//! it in every pin and invalidates preparation by it. L1 only makes it
-//! exist and be stated by every provider, which is the smallest thing
-//! that can be falsified.
+//! L2 keys a registry by it — [`LoweringRegistry`], a VALUE a caller
+//! carries and asks, never a default anything consults on its own. L4
+//! records it in every pin and invalidates preparation by it. L1 only
+//! made it exist and be stated by every provider, which was the smallest
+//! thing that could be falsified.
 
 use std::fmt;
 
+use super::backend::PlanBackend;
 use crate::error::VindexError;
 
 /// A lowering provider's semantic identity: family and revision.
@@ -113,5 +115,142 @@ mod tests {
         assert!(slashed.to_string().contains("`/`"), "{slashed}");
         let unstated = LoweringIdentity::new("cpu", 0).validate().unwrap_err();
         assert!(unstated.to_string().contains("revision 0"), "{unstated}");
+    }
+}
+
+/// Why a registry refused.
+#[derive(Debug, thiserror::Error)]
+pub enum LoweringError {
+    /// An identity that could not key a registry (see
+    /// [`LoweringIdentity::validate`]).
+    #[error("{0}")]
+    Invalid(VindexError),
+
+    /// The same family and revision registered twice. Refused rather than
+    /// replaced: "which of the two did the caller mean" has no answer, and
+    /// a registry whose answer depended on registration order would be a
+    /// registry whose meaning depended on the caller's program text.
+    #[error("lowering provider `{identity}` is already registered")]
+    Duplicate { identity: LoweringIdentity },
+
+    /// No provider under that identity. Names every identity that IS
+    /// registered, so the remedy is in the refusal: a family that is
+    /// there at another revision is a different provider, and the
+    /// refusal says which revisions exist.
+    #[error("no lowering provider `{identity}` is registered; registered: {}", registered.iter().map(|i| i.to_string()).collect::<Vec<_>>().join(", "))]
+    Unregistered {
+        identity: LoweringIdentity,
+        registered: Vec<LoweringIdentity>,
+    },
+}
+
+impl From<LoweringError> for VindexError {
+    fn from(e: LoweringError) -> Self {
+        match e {
+            LoweringError::Invalid(inner) => inner,
+            other => VindexError::Parse(other.to_string()),
+        }
+    }
+}
+
+/// The lowering providers a caller carries, keyed by identity.
+///
+/// **A value, not a default.** There is no static registry and no
+/// `builtin()` anything consults when a caller says nothing: the codec
+/// plane found three hidden built-in registries at execution (rung 3, F8)
+/// and one more at open (#461), and each was a place registration could
+/// not reach. Here the registry exists only where a caller constructed
+/// one, and every path that resolves a provider is handed it explicitly
+/// ([`super::prepared::PreparedOperands::load_via`],
+/// [`super::execute_plan_via`]). [`Self::shipped`] builds the providers
+/// this crate ships as a fresh value each time it is asked.
+///
+/// One configured INSTANCE per identity. A provider is registered as the
+/// instance the caller built — a device provider with the device it was
+/// handed and the format table it was given — and a second instance
+/// under the same identity is a duplicate, not an alternative. That is
+/// the registry answering L1's open question the only way it can: the
+/// identity is the provider's, the configuration is the registration's,
+/// and a caller that wants two differently configured device providers
+/// side by side has two providers to name.
+#[derive(Default)]
+pub struct LoweringRegistry {
+    providers: Vec<Box<dyn PlanBackend + Send>>,
+}
+
+impl fmt::Debug for LoweringRegistry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list()
+            .entries(self.providers.iter().map(|p| p.identity()))
+            .finish()
+    }
+}
+
+impl LoweringRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a provider under the identity it states, refusing an
+    /// identity that could not be keyed and one already taken.
+    pub fn register(
+        mut self,
+        provider: Box<dyn PlanBackend + Send>,
+    ) -> Result<Self, LoweringError> {
+        let identity = provider.identity();
+        identity.validate().map_err(LoweringError::Invalid)?;
+        if self.providers.iter().any(|p| p.identity() == identity) {
+            return Err(LoweringError::Duplicate { identity });
+        }
+        self.providers.push(provider);
+        Ok(self)
+    }
+
+    /// The providers this crate ships and needs no device to build: the
+    /// reference oracle and the production CPU executor. A device
+    /// provider is registered by whoever holds the device. A fresh value
+    /// on every call — two callers asking get two registries, and neither
+    /// is the other's default.
+    pub fn shipped() -> Self {
+        Self::new()
+            .register(Box::new(super::reference::ReferenceBackend::new()))
+            .and_then(|r| r.register(Box::new(super::production::ProductionBackend::new())))
+            .expect("the shipped providers carry distinct, valid identities")
+    }
+
+    /// The provider `identity` names, or a refusal naming every provider
+    /// that is registered.
+    pub fn provider(&self, identity: &LoweringIdentity) -> Result<&dyn PlanBackend, LoweringError> {
+        self.providers
+            .iter()
+            .find(|p| p.identity() == *identity)
+            .map(|p| p.as_ref() as &dyn PlanBackend)
+            .ok_or_else(|| LoweringError::Unregistered {
+                identity: identity.clone(),
+                registered: self.identities(),
+            })
+    }
+
+    /// Every registered provider of `family`, at every revision, in
+    /// registration order.
+    pub fn family(&self, family: &str) -> Vec<&dyn PlanBackend> {
+        self.providers
+            .iter()
+            .filter(|p| p.identity().family == family)
+            .map(|p| p.as_ref() as &dyn PlanBackend)
+            .collect()
+    }
+
+    /// Registered identities, in registration order — what a refusal lists.
+    pub fn identities(&self) -> Vec<LoweringIdentity> {
+        self.providers.iter().map(|p| p.identity()).collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -416,6 +416,25 @@ pub fn execute_plan<'s, B: PlanBackend + ?Sized>(
     execute_slice(plan, store, tokens, backend, ExecutionSlice::Full)
 }
 
+/// [`execute_plan`] on the provider `provider` names in `lowerings` — the
+/// registry-carried path (LOWERING-PLUGIN-1, L2).
+///
+/// The registry is the caller's value and the identity is the caller's
+/// choice; a provider the registry does not hold is refused here, by
+/// identity and naming every provider it does hold, before any operand
+/// is read. Nothing below constructs a provider the caller did not
+/// register.
+pub fn execute_plan_via<'s>(
+    plan: &ComponentOpPlan,
+    store: impl Into<OperandSource<'s>>,
+    tokens: &[u32],
+    lowerings: &lowering::LoweringRegistry,
+    provider: &lowering::LoweringIdentity,
+) -> Result<ExecutionTrace, VindexError> {
+    let backend = lowerings.provider(provider)?;
+    execute_plan(plan, store, tokens, backend)
+}
+
 /// [`execute_plan`] over a chosen [`ExecutionSlice`].
 ///
 /// `execute_plan` is this with [`ExecutionSlice::Full`], so the two can

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -54,6 +54,7 @@ use super::backend::{MatrixClass, NormCall, PlanBackend, WeightFormat, WeightSli
 use super::experts::FfnOperands;
 use super::hyper_connection::{HeadWeights, SiteWeights, HC_HEAD_SCALE_LEN, HC_SCALE_LEN};
 use super::kda::KdaOutputGateWeights;
+use super::lowering::{LoweringIdentity, LoweringRegistry};
 use super::operands::{OperandSource, SourceStamp};
 use super::realization::{
     realization_residency, DependencyLifetime, DependencyPin, ExtentOption, ExtentPin,
@@ -1957,6 +1958,24 @@ impl PreparedOperands {
         slice: ExecutionSlice,
     ) -> Result<Self, VindexError> {
         Self::load_within(plan, store, backend, slice, &ResidencyBudget::UNBOUNDED)
+    }
+
+    /// [`Self::load`] on the provider `provider` names in `lowerings` —
+    /// the registry-carried path (LOWERING-PLUGIN-1, L2).
+    ///
+    /// A provider the registry does not hold is refused here, by identity
+    /// and naming every provider it does hold, before selection and
+    /// before any byte. Nothing below constructs a provider the caller
+    /// did not register.
+    pub fn load_via<'s>(
+        plan: &ComponentOpPlan,
+        store: impl Into<OperandSource<'s>>,
+        lowerings: &LoweringRegistry,
+        provider: &LoweringIdentity,
+        slice: ExecutionSlice,
+    ) -> Result<Self, VindexError> {
+        let backend = lowerings.provider(provider)?;
+        Self::load(plan, store, backend, slice)
     }
 
     /// [`Self::load`] under a residency budget: the pins are chosen so the

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_identity.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_identity.rs
@@ -79,14 +79,14 @@ fn identity_is_the_providers_not_its_configurations() {
 /// identity of its own choosing — so the two fields can be varied
 /// independently, which is the only way to show one is not derived from
 /// the other.
-struct Relabelled {
+pub(super) struct Relabelled {
     inner: ReferenceBackend,
     name: &'static str,
     identity: LoweringIdentity,
 }
 
 impl Relabelled {
-    fn new(name: &'static str, family: &str, revision: u32) -> Self {
+    pub(super) fn new(name: &'static str, family: &str, revision: u32) -> Self {
         Self {
             inner: ReferenceBackend::new(),
             name,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_registry.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_registry.rs
@@ -1,0 +1,346 @@
+//! **L2 of LOWERING-PLUGIN-1: lowering providers are registered and
+//! carried as explicit authority.**
+//!
+//! One question, per the forecast: can providers be registered and carried
+//! as a VALUE without changing what any existing backend selects or
+//! executes? Held here as the five properties the wave named — registered
+//! is discoverable, unregistered is refused by identity, a duplicate is
+//! refused, another revision is another provider, registration order
+//! decides nothing — and the F4 anti-cheat: a registry that omits the
+//! production provider, handed to the carried path, refuses rather than
+//! constructing the provider anyway.
+
+use super::super::backend::{PlanBackend, WeightFormat, WeightFormats};
+use super::super::device::DevicePlanBackend;
+use super::super::lowering::{LoweringError, LoweringIdentity, LoweringRegistry};
+use super::super::prepared::{ExecutionSlice, PreparedOperands};
+use super::super::production::{self, ProductionBackend};
+use super::super::reference::{self, ReferenceBackend};
+use super::super::{execute_plan, execute_plan_via};
+use super::lowering_identity::Relabelled;
+use crate::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
+use crate::format::vindex3::inspect::inspect_container;
+use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
+use larql_compute::cpu::CpuBackend;
+
+const SCRATCH_FAMILY: &str = "scratch-provider";
+/// A prompt over the dense fixture's 128-token vocabulary.
+const TOKENS: [u32; 5] = [3, 17, 28, 0, 11];
+
+fn reference_id() -> LoweringIdentity {
+    LoweringIdentity::new(reference::IDENTITY_FAMILY, reference::IDENTITY_REVISION)
+}
+
+fn production_id() -> LoweringIdentity {
+    LoweringIdentity::new(production::IDENTITY_FAMILY, production::IDENTITY_REVISION)
+}
+
+fn scratch(name: &'static str, revision: u32) -> Box<dyn PlanBackend + Send> {
+    Box::new(Relabelled::new(name, SCRATCH_FAMILY, revision))
+}
+
+#[test]
+fn a_registered_provider_is_discoverable_and_an_unregistered_one_is_refused_naming_the_registered()
+{
+    let registry = LoweringRegistry::shipped()
+        .register(scratch("scratch", 1))
+        .unwrap();
+    let scratch_id = LoweringIdentity::new(SCRATCH_FAMILY, 1);
+    assert_eq!(registry.provider(&scratch_id).unwrap().name(), "scratch");
+    assert_eq!(
+        registry.provider(&production_id()).unwrap().name(),
+        ProductionBackend::new().name()
+    );
+
+    let absent = LoweringIdentity::new("device-matmul", 1);
+    let err = registry.provider(&absent).unwrap_err();
+    match &err {
+        LoweringError::Unregistered {
+            identity,
+            registered,
+        } => {
+            assert_eq!(*identity, absent);
+            assert_eq!(
+                *registered,
+                [reference_id(), production_id(), scratch_id.clone()],
+                "every registered identity, in registration order"
+            );
+        }
+        other => panic!("{other}"),
+    }
+    let text = err.to_string();
+    assert!(text.contains("device-matmul/v1"), "{text}");
+    assert!(
+        text.contains("reference/v1") && text.contains("cpu-production/v1"),
+        "the refusal names what IS registered: {text}"
+    );
+}
+
+#[test]
+fn a_duplicate_identity_is_refused_and_an_invalid_one_never_enters() {
+    let err = LoweringRegistry::shipped()
+        .register(Box::new(ProductionBackend::new()))
+        .expect_err("the production provider is already there");
+    assert!(
+        matches!(&err, LoweringError::Duplicate { identity } if *identity == production_id()),
+        "{err}"
+    );
+    // A scratch provider under the same identity as a shipped one is a
+    // duplicate too — the identity is what is keyed, not the type.
+    let impostor = Box::new(Relabelled::new(
+        "impostor",
+        production::IDENTITY_FAMILY,
+        production::IDENTITY_REVISION,
+    ));
+    let err = LoweringRegistry::shipped().register(impostor).unwrap_err();
+    assert!(matches!(err, LoweringError::Duplicate { .. }), "{err}");
+
+    let err = LoweringRegistry::new()
+        .register(Box::new(Relabelled::new("x", "not a family", 1)))
+        .unwrap_err();
+    assert!(matches!(err, LoweringError::Invalid(_)), "{err}");
+    let err = LoweringRegistry::new()
+        .register(Box::new(Relabelled::new("x", "unstated", 0)))
+        .unwrap_err();
+    assert!(err.to_string().contains("revision 0"), "{err}");
+}
+
+#[test]
+fn two_revisions_of_one_family_are_distinct_providers() {
+    let registry = LoweringRegistry::new()
+        .register(scratch("one", 1))
+        .and_then(|r| r.register(scratch("two", 2)))
+        .unwrap();
+    assert_eq!(registry.len(), 2);
+    assert_eq!(
+        registry
+            .provider(&LoweringIdentity::new(SCRATCH_FAMILY, 1))
+            .unwrap()
+            .name(),
+        "one"
+    );
+    assert_eq!(
+        registry
+            .provider(&LoweringIdentity::new(SCRATCH_FAMILY, 2))
+            .unwrap()
+            .name(),
+        "two"
+    );
+    assert_eq!(registry.family(SCRATCH_FAMILY).len(), 2);
+    // A third revision is refused, and the refusal says which exist.
+    let err = registry
+        .provider(&LoweringIdentity::new(SCRATCH_FAMILY, 3))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("scratch-provider/v1") && err.contains("scratch-provider/v2"),
+        "{err}"
+    );
+}
+
+#[test]
+fn registration_order_has_no_effect_on_who_answers() {
+    let forward = LoweringRegistry::new()
+        .register(Box::new(ReferenceBackend::new()))
+        .and_then(|r| r.register(Box::new(ProductionBackend::new())))
+        .and_then(|r| r.register(scratch("scratch", 1)))
+        .unwrap();
+    let backward = LoweringRegistry::new()
+        .register(scratch("scratch", 1))
+        .and_then(|r| r.register(Box::new(ProductionBackend::new())))
+        .and_then(|r| r.register(Box::new(ReferenceBackend::new())))
+        .unwrap();
+    assert_ne!(forward.identities(), backward.identities());
+    let mut sorted = (forward.identities(), backward.identities());
+    sorted.0.sort();
+    sorted.1.sort();
+    assert_eq!(sorted.0, sorted.1);
+    for identity in forward.identities() {
+        assert_eq!(
+            forward.provider(&identity).unwrap().name(),
+            backward.provider(&identity).unwrap().name(),
+            "{identity}"
+        );
+        assert_eq!(
+            forward.provider(&identity).unwrap().identity(),
+            backward.provider(&identity).unwrap().identity()
+        );
+    }
+}
+
+/// `shipped()` is a value: what a build registers when a caller says
+/// nothing else, built fresh on each call, holding the two providers that
+/// need no device. A device provider is the caller's to add — and a
+/// SECOND device instance is a duplicate, which is the registry answering
+/// L1's open question the only way it can: one configured instance per
+/// identity.
+#[test]
+fn the_shipped_registry_is_a_value_and_one_instance_per_identity() {
+    let a = LoweringRegistry::shipped();
+    let b = LoweringRegistry::shipped();
+    assert_eq!(a.identities(), b.identities());
+    assert_eq!(a.identities(), [reference_id(), production_id()]);
+    assert!(a
+        .provider(&LoweringIdentity::new("device-matmul", 1))
+        .is_err());
+
+    let with_device = a
+        .register(Box::new(DevicePlanBackend::new(
+            CpuBackend,
+            "cpu-as-device-f32",
+            WeightFormat::F32,
+        )))
+        .unwrap();
+    assert_eq!(with_device.len(), 3);
+    let err = with_device
+        .register(Box::new(DevicePlanBackend::with_formats(
+            CpuBackend,
+            "cpu-as-device-f16",
+            WeightFormats::uniform(WeightFormat::F16),
+        )))
+        .unwrap_err();
+    assert!(
+        matches!(&err, LoweringError::Duplicate { identity } if identity.to_string() == "device-matmul/v1"),
+        "{err}"
+    );
+}
+
+// ── F4: the carried path constructs nothing ──────────────────────────
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    plan: ComponentOpPlan,
+    store: OperandStore,
+}
+
+fn dense() -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let checkpoint = tmp.path().join("ckpt");
+    std::fs::create_dir_all(&checkpoint).unwrap();
+    let container = tmp.path().join("out.vindex3");
+    encode_fixture_container(dense_f32_model, &checkpoint, &container, "target");
+    let inspection = inspect_container(&container, false).unwrap();
+    let plan = plan_component_ops(&inspection, &container, "target")
+        .unwrap()
+        .plan
+        .expect("the dense fixture plans");
+    let store = OperandStore::open(&container, &inspection).unwrap();
+    Fixture {
+        _tmp: tmp,
+        plan,
+        store,
+    }
+}
+
+fn bits(v: &[f32]) -> Vec<u32> {
+    v.iter().map(|x| x.to_bits()).collect()
+}
+
+/// A registry that omits the production provider, handed to the carried
+/// path with the production identity: refused by identity, before
+/// preparation and before execution, naming what the registry holds. No
+/// path underneath constructs `ProductionBackend` to answer anyway.
+#[test]
+fn the_carried_path_refuses_an_absent_provider_rather_than_constructing_one() {
+    let fixture = dense();
+    let without_production = LoweringRegistry::new()
+        .register(Box::new(ReferenceBackend::new()))
+        .unwrap();
+    assert!(without_production.provider(&production_id()).is_err());
+
+    let err = PreparedOperands::load_via(
+        &fixture.plan,
+        &fixture.store,
+        &without_production,
+        &production_id(),
+        ExecutionSlice::Full,
+    )
+    .err()
+    .expect("preparation through a registry without the provider is refused")
+    .to_string();
+    assert!(err.contains("cpu-production/v1"), "{err}");
+    assert!(err.contains("registered: reference/v1"), "{err}");
+    assert_eq!(
+        fixture.store.load_count(),
+        0,
+        "refused before any operand was read"
+    );
+
+    let err = execute_plan_via(
+        &fixture.plan,
+        &fixture.store,
+        &TOKENS,
+        &without_production,
+        &production_id(),
+    )
+    .expect_err("execution through a registry without the provider is refused")
+    .to_string();
+    assert!(err.contains("cpu-production/v1"), "{err}");
+    assert_eq!(fixture.store.load_count(), 0);
+}
+
+/// And the positive control: through a registry that holds the provider,
+/// the carried path is the direct path — bit for bit, for both shipped
+/// providers — so carrying the registry changed nothing about what
+/// executes.
+#[test]
+fn the_carried_path_executes_exactly_what_the_direct_path_executes() {
+    let fixture = dense();
+    let shipped = LoweringRegistry::shipped();
+    for (identity, direct) in [
+        (
+            reference_id(),
+            execute_plan(
+                &fixture.plan,
+                &fixture.store,
+                &TOKENS,
+                &ReferenceBackend::new(),
+            ),
+        ),
+        (
+            production_id(),
+            execute_plan(
+                &fixture.plan,
+                &fixture.store,
+                &TOKENS,
+                &ProductionBackend::new(),
+            ),
+        ),
+    ] {
+        let direct = direct.unwrap();
+        let carried =
+            execute_plan_via(&fixture.plan, &fixture.store, &TOKENS, &shipped, &identity).unwrap();
+        assert_eq!(
+            bits(carried.logits.as_deref().unwrap()),
+            bits(direct.logits.as_deref().unwrap()),
+            "{identity}"
+        );
+        assert_eq!(carried.final_hidden(), direct.final_hidden(), "{identity}");
+        let prepared = PreparedOperands::load_via(
+            &fixture.plan,
+            &fixture.store,
+            &shipped,
+            &identity,
+            ExecutionSlice::Full,
+        )
+        .unwrap();
+        let pinned: Vec<String> = prepared
+            .realizations()
+            .iter()
+            .map(|r| r.selection.realization.name())
+            .collect();
+        let direct_pins: Vec<String> = PreparedOperands::load(
+            &fixture.plan,
+            &fixture.store,
+            shipped.provider(&identity).unwrap(),
+            ExecutionSlice::Full,
+        )
+        .unwrap()
+        .realizations()
+        .iter()
+        .map(|r| r.selection.realization.name())
+        .collect();
+        assert_eq!(pinned, direct_pins, "{identity}: the same pins");
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -59,6 +59,7 @@ mod kimi_router;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
 mod kimi_two_layer;
 mod lowering_identity;
+mod lowering_registry;
 mod mamba2_exec;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
 mod mla_metal;

--- a/docs/represent/forecasts/lowering-plugin-1-notes.json
+++ b/docs/represent/forecasts/lowering-plugin-1-notes.json
@@ -52,6 +52,56 @@
         "cargo test -p larql-vindex --no-run (integration targets compile against the exported trait)"
       ],
       "deviations_from_forecast": "None in scope. One measurement correction, recorded above."
+    },
+    "L2": {
+      "name": "lowering registry",
+      "status": "built and held",
+      "branch": "lowering-l2",
+      "base": "4e8147ef (main after #462, #464, #461, #465 merged in that order)",
+      "date": "2026-09-09",
+      "the_question": "Can lowering providers be registered and carried as explicit authority, without changing what any existing backend selects or executes? Yes, and the carried path is bit-identical to the direct one for both shipped providers.",
+      "what_landed": [
+        "`LoweringRegistry` in `exec/lowering.rs`: `register(Box<dyn PlanBackend + Send>)` keyed by identity, refusing an identity `validate()` refuses (`LoweringError::Invalid`) and one already taken (`Duplicate`); `provider(&LoweringIdentity)` or `Unregistered` naming every registered identity in registration order; `family(name)` for every revision of one family; `identities()`, `len()`, `is_empty()`.",
+        "`LoweringRegistry::shipped()`: the two providers that need no device (`reference/v1`, `cpu-production/v1`), built as a FRESH VALUE on every call. There is no static, no `builtin()`, and no path that consults a registry the caller did not hand it.",
+        "The carried path: `PreparedOperands::load_via(plan, store, &registry, &identity, slice)` and `execute_plan_via(plan, store, tokens, &registry, &identity)`. Each resolves the provider through the registry it was handed and refuses by identity before selection and before any byte; neither constructs a provider.",
+        "`Debug` for `dyn PlanBackend` (`provider NAME (family/vN)`) and for the registry (its identities), so a refusal or a test can say which provider it meant."
+      ],
+      "witnesses": {
+        "registered_is_discoverable_unregistered_is_refused_naming_the_registered": "exec/tests/lowering_registry.rs — `a_registered_provider_is_discoverable_and_an_unregistered_one_is_refused_naming_the_registered`",
+        "duplicate_refused_invalid_never_enters": "`a_duplicate_identity_is_refused_and_an_invalid_one_never_enters` — a scratch provider under the production identity is a duplicate too: the identity is keyed, not the type",
+        "revision_mismatch_is_a_distinct_provider": "`two_revisions_of_one_family_are_distinct_providers` — v1 and v2 coexist and answer separately; v3 is refused naming both",
+        "registry_order_has_no_effect": "`registration_order_has_no_effect_on_who_answers` — forward and reverse registration differ only in `identities()` order",
+        "value_not_default_and_one_instance_per_identity": "`the_shipped_registry_is_a_value_and_one_instance_per_identity`",
+        "F4_anti_cheat": "`the_carried_path_refuses_an_absent_provider_rather_than_constructing_one` — a registry holding only `reference/v1`, asked to prepare and to execute as `cpu-production/v1`, refuses both naming `registered: reference/v1`, and the store's load count stays 0: nothing underneath constructed `ProductionBackend` to answer anyway",
+        "positive_control": "`the_carried_path_executes_exactly_what_the_direct_path_executes` — through `shipped()`, logits and final hidden are bit-identical to `execute_plan` with the provider constructed directly, and the pinned realizations are the same list, for both shipped providers"
+      },
+      "L1_open_question_forced": {
+        "type_or_instance": "The registry holds one configured INSTANCE per identity: a provider is registered as the instance the caller built, and a second `DevicePlanBackend` under `device-matmul/v1` — another name, another format table — is a `Duplicate`, not an alternative. So identity is the provider's (type/semantic implementation), configuration is the registration's, and a caller wanting two differently configured device providers side by side needs two providers to name. This is the default the forecast's author expected; the registry forced it rather than us choosing it.",
+        "device_swap_invalidation": "Still open for L4. Nothing in L2 records which injected device stood behind `device-matmul/v1`; whether a pin is invalidated when the concrete device changes is the question L4 must answer, and the registry has not forced it."
+      },
+      "measurements": {
+        "kernel_plane_files": 33,
+        "kernel_plane_files_note": "33 with #461 merged, as the L1 notes predicted; L2 adds none.",
+        "provider_construction_sites_outside_vindex_non_test": 13,
+        "provider_construction_sites_inside_vindex_non_test": {
+          "count": 2,
+          "sites": [
+            "`exec/device.rs`: `glue: ProductionBackend::new()` — the device provider's own CPU glue, an internal part of that provider and not a fallback; stays",
+            "`exec/mod.rs`: `execute_text` runs `ReferenceBackend::new()` — a convenience entry that hard-codes the oracle; L3 routes it or retires it"
+          ]
+        },
+        "production_callers_of_the_registry": 0,
+        "production_callers_note": "By design: L2 introduces the registry and the carried path and moves no construction site. That the count is 0 is L2's boundary and L3's target — the 13 outside sites (`ExecBackend`'s arms, the runtime, the server, LQL) become lookups."
+      },
+      "F4_status": "Not falsified in L2's scope: the only path that takes a registry refuses rather than defaults. The class F4 predicts — a downstream path that consults a built-in provider after registration ostensibly worked — cannot appear until L3 puts the registry on the production paths, which is where to expect it.",
+      "gates_run": [
+        "cargo fmt --all",
+        "cargo check --workspace --all-targets",
+        "cargo clippy -p larql-vindex -p larql-cli -p larql-inference --all-targets -- -D warnings",
+        "cargo test -p larql-vindex --lib (4659 passed: the merged-main suite of 4652 plus seven L2 tests)",
+        "cargo test -p larql-vindex --no-run"
+      ],
+      "deviations_from_forecast": "None. Selection, accounting and execution unchanged: the diff touches `lowering.rs`, one method in `backend.rs` (a Debug impl), one method each in `mod.rs` and `prepared.rs`, and tests."
     }
   }
 }


### PR DESCRIPTION
## What

Wave L2 of LOWERING-PLUGIN-1 (forecast #464, L1 #465), answering one question: can lowering providers be registered and carried as explicit authority without changing what any existing backend selects or executes?

- `LoweringRegistry` in `exec/lowering.rs`: `register(Box<dyn PlanBackend + Send>)` keyed by identity, refusing an invalid or duplicate identity; `provider(&id)` or `Unregistered` naming every registered identity; `family(name)` for every revision.
- `shipped()` builds `reference/v1` and `cpu-production/v1` as a **fresh value** per call. No static, no `builtin()`, no implicit consultation anywhere.
- The carried path: `PreparedOperands::load_via` and `execute_plan_via` resolve through the registry they are handed and refuse by identity before selection and before any byte.

## The five properties, plus the anti-cheat

| property | witness |
|---|---|
| registered → discoverable | `a_registered_provider_is_discoverable_and_an_unregistered_one_is_refused_naming_the_registered` |
| unregistered → refused by identity, naming the registered | same |
| duplicate identity → refused (including a scratch provider under a shipped identity) | `a_duplicate_identity_is_refused_and_an_invalid_one_never_enters` |
| revision mismatch → distinct provider | `two_revisions_of_one_family_are_distinct_providers` |
| registry order → no effect | `registration_order_has_no_effect_on_who_answers` |
| **F4 anti-cheat**: registry without `cpu-production/v1`, asked to prepare and execute as it | refused both times naming `registered: reference/v1`; store load count 0 — nothing constructed `ProductionBackend` underneath |
| positive control | `the_carried_path_executes_exactly_what_the_direct_path_executes` — bit-identical logits, final hidden, and the same pinned realizations for both shipped providers |

## What the registry forced

One configured **instance per identity**: a second `DevicePlanBackend` under `device-matmul/v1` with another name and format table is a `Duplicate`. So identity is the provider's and configuration is the registration's — the default you expected, arrived at by the registry rather than chosen. Whether a pin is invalidated when the injected device changes stays open for L4.

## Unchanged

- Selection, accounting, execution: 0 changes. Diff is `lowering.rs`, a `Debug` impl in `backend.rs`, one method each in `exec/mod.rs` and `prepared.rs`, tests, notes.
- Library suite: 4659 passed (merged-main 4652 plus seven L2 tests).
- Kernel-plane files: 33, as the L1 notes predicted with #461 merged.
- Production callers of the registry: 0 — by design; the 13 construction sites outside `larql-vindex` are L3's target and are recorded in the notes, with the two inside (`device.rs` glue, which stays; `execute_text`, which L3 routes).

## Gates

fmt, `cargo check --workspace --all-targets`, clippy `-D warnings` on larql-vindex / larql-cli / larql-inference, `cargo test -p larql-vindex --lib`, integration targets compiled.
