### PR TITLE
docs(optimizer): OPT-CONTRACT-1 — five optimizer contracts, and a checker something actually runs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -231,6 +231,17 @@ jobs:
       - name: Check documentation code references
         run: python3 scripts/check_doc_references.py --strict
 
+      # A contract index names the test that pins each frozen invariant, and
+      # that citation is exactly the kind that rots silently: renaming a test
+      # is a green refactor which leaves the freeze pointing at nothing, and
+      # nothing else in CI reads the index at all. The checker has existed
+      # since the v1 index landed and NOTHING RAN IT -- enforcement in
+      # principle only -- which is the state the optimizer index would have
+      # inherited. It checks existence and location; `cargo test` decides
+      # whether the contracts still hold.
+      - name: Contract indexes name tests that exist
+        run: python3 scripts/check_contract_index.py
+
   ci-instrument:
     name: ci throughput instrument
     runs-on: ubuntu-latest

--- a/docs/optimizer-contract-index.md
+++ b/docs/optimizer-contract-index.md
@@ -1,0 +1,179 @@
+# REPRESENT / optimizer — contract index
+
+**Status: frozen at OPT-CONTRACT-1.**
+Qualified against main `2944ace6` (ACTUATION-1, #463).
+
+A second index, not an extension of the first.
+[`represent-v1-contract-index.md`](represent-v1-contract-index.md) defines
+itself as the frozen REPRESENT/accounting v1 contract set of nine, and the
+optimizer's invariants are a different programme with a different freeze.
+Appending to it would make "v1" mean two things.
+
+Same discipline: for each contract below, **here is what must go red if you
+violate it.**
+
+> **"Frozen" does not mean immutable code.** It means any semantic change to
+> one of these contracts requires an explicit new transition, with its own
+> evidence and controls, rather than silently redefining it.
+
+Every row names a test that exists at the path recorded.
+`scripts/check_contract_index.py` reads this file alongside the v1 index,
+extracts every `name` — `path` pair, and fails when a test cannot be found
+where the index says it is. It checks EXISTENCE and LOCATION; `cargo test`
+decides whether the contracts still hold. It fails closed: a citation row it
+cannot parse is an error, not a row it quietly skips.
+
+Paths are relative to the repository root. `…/actuate/` abbreviates
+`crates/larql-vindex/src/format/vindex3/represent/actuate/`, and `…/state/`
+abbreviates `crates/larql-vindex/src/format/vindex3/represent/state/`.
+
+## What these five protect
+
+The first four protect scientific identity along the forward path. The fifth
+protects the failure path that surrounds all four.
+
+```text
+selection  →  protocol  →  preparation  →  execution        1, 2, 3, 4
+
+when any of those boundaries refuses, the reason may not lose
+the evidence needed to act on it                                     5
+```
+
+---
+
+## 1. Selected identity is reconstructable
+
+**Invariant.** A selected `MeasurementKey` becomes exactly one truthful
+`MeasurementRequest`. Resolving the request's candidate map over the record's
+own surface, under the record's own layout policy, yields the physical state
+the key names — and the whole four-part key is re-derivable from the request
+alone. A map that presents a different state cannot be handed out as a request
+for that key.
+
+**Authority.** `MeasurementRequest::of`, `MeasurementRequest::derived_key`.
+
+| | |
+|---|---|
+| positive | `a_request_re_derives_the_whole_experiment_from_itself` — `…/actuate/tests/request.rs` |
+| positive | `a_record_that_prices_and_declares_its_protocol_prepares_a_real_experiment` — `…/actuate/tests/prepare.rs` |
+| negative | `a_request_for_a_state_the_map_does_not_present_is_refused_naming_both` — `…/actuate/tests/request.rs` |
+| negative | `an_applied_set_the_vocabulary_does_not_have_builds_no_map` — same file |
+| qualified by | PR #463 |
+
+---
+
+## 2. Protocol identity has authoritative declarations
+
+**Invariant.** A digest alone is not enough. The record carries the
+`EvidenceBank` and `InstrumentSemantics` its standing intent's digests stand
+for, and they self-check against those digests — against the intent, and
+separately against the key actually selected. A record that declares one
+protocol and searches under another is refused.
+
+**Authority.** `MeasurementProtocol::describes`,
+`MeasurementProtocol::describes_key`.
+
+| | |
+|---|---|
+| positive | `the_record_s_protocol_describes_the_experiment_it_searches_under` — `…/state/protocol_tests.rs` |
+| positive | `describing_the_intent_does_not_describe_every_key` — same file |
+| negative | `a_protocol_declaring_another_corpus_is_refused_naming_both_digests` — same file |
+| negative | `a_protocol_declaring_another_meaning_is_refused_distinctly` — same file |
+| negative | `a_record_that_names_its_protocol_only_by_digest_refuses_and_says_so` — `…/actuate/tests/prepare.rs` |
+| qualified by | PR #463 |
+
+---
+
+## 3. Preparation cannot author an experiment
+
+**Invariant.** The bridge restates a selection; it may not change what is
+measured. Every control reaches the request from the record — never from an
+adapter's default — preparation follows the route the policy ranked first, is
+idempotent, and writes nothing. A gate the build cannot resolve, or has
+redefined under the same name, is refused rather than silently applied.
+
+**Authority.** `PreparedExperiment::of`, `RequestRefusal::GateRedefined`.
+
+| | |
+|---|---|
+| positive | `the_request_follows_the_route_the_policy_ranked_first` — `…/actuate/tests/prepare.rs` |
+| positive | `preparing_twice_gives_the_same_request_and_changes_nothing` — same file |
+| positive | `the_controls_come_from_the_record_and_never_from_the_adapters_defaults` — `…/actuate/tests/request.rs` |
+| negative | `a_record_whose_gate_this_build_has_redefined_is_refused` — same file |
+| negative | `a_record_naming_a_gate_this_build_does_not_implement_is_refused` — same file |
+| qualified by | PR #463 |
+
+---
+
+## 4. Execution cannot substitute an experiment
+
+**Invariant.** An executor is selected by the procedure the record declares,
+in any registration order, and two executors may not claim one procedure. The
+observation it returns must be an observation of the experiment it was handed;
+one about another experiment is refused rather than recorded.
+
+**Authority.** `ExecutorRegistry::execute`,
+`ExecutionRefusal::ObservedAnotherExperiment`.
+
+| | |
+|---|---|
+| positive | `two_distinct_procedures_dispatch_by_name_in_either_registration_order` — `…/actuate/tests/executor.rs` |
+| negative | `an_executor_that_answers_about_another_experiment_is_refused` — same file |
+| negative | `two_executors_claiming_one_procedure_are_refused` — same file |
+| qualified by | PR #463 |
+
+---
+
+## 5. A refusal preserves its actionable authority when rendered
+
+**Invariant.**
+
+> A typed refusal is not complete merely because it contains the facts needed
+> to diagnose or repair the failure. Its rendered form must preserve: what
+> failed; the expected authority or identity; the conflicting observed
+> authority or identity where one exists; and any actionable alternative the
+> refusal promises to provide.
+
+**Scope.** OPTIMIZER refusals — the refusal types on the actuation and
+protocol path named below. This is not a claim that every `Display` in LARQL is
+normative: an internal diagnostic must not be pulled into a scientific-
+interface guarantee it was never designed to carry. A refusal enters this
+contract when it is part of the optimizer's answer to an operator or an agent.
+
+**Why it is a contract and not error-message hygiene.** ACT1-N8 is the
+evidence. The per-file coverage gate on #463 found that a third of stage 5b's
+refusals held exactly the right facts and had never had their rendered form
+read by anything. The variant containing useful facts is not the same claim as
+the caller being able to act on the refusal, and only the second is what a
+refusal is for.
+
+**Authority.** The `must_say` matches in `…/actuate/tests/refusals.rs`, which
+are exhaustive — a new refusal arm cannot be added without deciding what its
+message must say.
+
+| | |
+|---|---|
+| positive | `every_request_refusal_names_what_it_promises` — `…/actuate/tests/refusals.rs` |
+| positive | `every_locator_refusal_names_what_it_promises` — same file |
+| positive | `every_execution_refusal_names_what_it_promises` — same file |
+| positive | `wrapping_a_refusal_keeps_the_inner_ones_message` — same file |
+| qualified by | PR #463 |
+
+---
+
+## What this index does not yet cover
+
+Stated so absence is a fact rather than an oversight.
+
+- **Ingestion.** Nothing here governs how an observation becomes part of
+  `SearchFacts`. That is OPT-6, which inherits contract 5 rather than
+  reinventing it for a nastier set of refusals — stale artifact, conflicting
+  duplicate observation, wrong protocol identity, candidate bytes that cannot
+  establish the state they claim to measure.
+- **The candidate's bytes.** Contract 1 establishes that a request names the
+  state the optimiser selected. It does NOT establish that a compiled overlay
+  presents it: a locator resolves one by state id and verifies nothing about
+  its contents (ACT1-N3).
+- **A second real procedure.** Contract 4's dispatch is witnessed with stub
+  procedures. ACT1-N5 stays open: no semantic relationship between an
+  instrument's declared procedure and an execution procedure is claimed.

--- a/scripts/check_contract_index.py
+++ b/scripts/check_contract_index.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
-"""Verify every test named in the v1 contract index still exists.
+"""Verify every test named by a contract index still exists.
 
 A freeze that names tests is only worth something if the names are true.
-This reads `docs/represent-v1-contract-index.md`, extracts every
-`name` / `path` pair from its tables, and fails when a test cannot be
-found at the path recorded — which is exactly what a rename or a move
-would cause.
+This reads each contract index below, extracts every `name` / `path` pair
+from its tables, and fails when a test cannot be found at the path
+recorded — which is exactly what a rename or a move would cause.
 
 It checks EXISTENCE and LOCATION, not outcome: `cargo test` decides
 whether the contracts hold. This decides whether the index is honest
 about where they are pinned.
+
+There is more than one index because there is more than one freeze. The
+REPRESENT/accounting v1 set and the optimizer set are different programmes
+with different qualifying commits, so each carries its OWN abbreviations —
+`…/state/` in one index must not silently resolve against the other's
+vocabulary.
 """
 
 from __future__ import annotations
@@ -18,16 +23,30 @@ import re
 import sys
 from pathlib import Path
 
-INDEX = Path("docs/represent-v1-contract-index.md")
-# `…/exec/` and `…/codec/` are abbreviations the document defines.
-ABBREVIATIONS = {
-    "…/exec/": "crates/larql-vindex/src/format/vindex3/opplan/exec/",
-    "…/codec/": "crates/larql-vindex/src/format/vindex3/represent/codec/",
-    "…/auxiliary_references/": "crates/larql-vindex/src/format/vindex3/auxiliary_references/",
-    "…/representation_attestations/": (
-        "crates/larql-vindex/src/format/vindex3/representation_attestations/"
+REPRESENT = "crates/larql-vindex/src/format/vindex3/represent/"
+# Each index and the abbreviations that index defines for itself.
+INDEXES: list[tuple[Path, dict[str, str]]] = [
+    (
+        Path("docs/represent-v1-contract-index.md"),
+        {
+            "…/exec/": "crates/larql-vindex/src/format/vindex3/opplan/exec/",
+            "…/codec/": REPRESENT + "codec/",
+            "…/auxiliary_references/": (
+                "crates/larql-vindex/src/format/vindex3/auxiliary_references/"
+            ),
+            "…/representation_attestations/": (
+                "crates/larql-vindex/src/format/vindex3/representation_attestations/"
+            ),
+        },
     ),
-}
+    (
+        Path("docs/optimizer-contract-index.md"),
+        {
+            "…/actuate/": REPRESENT + "actuate/",
+            "…/state/": REPRESENT + "state/",
+        },
+    ),
+]
 # `name` — `path`, where the path ends in `.rs`. The name pattern is
 # deliberately permissive: a citation whose name does not match must be
 # reported as MISSING, never quietly skipped.
@@ -41,66 +60,83 @@ CITATION = re.compile(r"^\|.*(`[^`]+\.rs`|same file)")
 MUTANT = re.compile(r"^\|\s*mutant\s*\|")
 
 
-def expand(path: str) -> str:
-    for short, full in ABBREVIATIONS.items():
+def expand(path: str, abbreviations: dict[str, str]) -> str:
+    for short, full in abbreviations.items():
         if path.startswith(short):
             return full + path[len(short) :]
     return path
 
 
-def main() -> int:
-    root = Path(__file__).resolve().parent.parent
-    index = root / INDEX
-    if not index.is_file():
-        print(f"{INDEX} not found", file=sys.stderr)
-        return 2
-
+def check(root: Path, index: Path, abbreviations: dict[str, str]) -> tuple[int, list[str]]:
+    """Return how many tests this index named, and everything wrong with it."""
     missing: list[str] = []
     checked = 0
+    # Reset per index: a `same file` row may only inherit a path named by
+    # the SAME document.
     last_path: str | None = None
 
-    for number, line in enumerate(index.read_text().splitlines(), start=1):
+    for number, line in enumerate((root / index).read_text().splitlines(), start=1):
         pairs: list[tuple[str, str]] = []
         cites = bool(CITATION.search(line)) and not MUTANT.search(line)
         for name, path in ROW.findall(line):
-            last_path = expand(path)
+            last_path = expand(path, abbreviations)
             pairs.append((name, last_path))
         if not pairs:
             for name in SAME_FILE.findall(line):
                 if last_path is None:
-                    missing.append(f"line {number}: `{name}` says 'same file' with no file yet")
+                    missing.append(f"{index}:{number}: `{name}` says 'same file' with no file yet")
                     continue
                 pairs.append((name, last_path))
 
         if cites and not pairs:
             missing.append(
-                f"line {number}: cites a test but no `name` — `path` pair could be read "
+                f"{index}:{number}: cites a test but no `name` — `path` pair could be read "
                 f"from it, so nothing was checked: {line.strip()[:90]}"
             )
         for name, path in pairs:
             checked += 1
             target = root / path
             if not target.is_file():
-                missing.append(f"line {number}: {path} does not exist (for `{name}`)")
+                missing.append(f"{index}:{number}: {path} does not exist (for `{name}`)")
                 continue
             if not re.search(rf"^\s*fn {re.escape(name)}\b", target.read_text(), re.M):
-                missing.append(f"line {number}: {path} has no `fn {name}`")
+                missing.append(f"{index}:{number}: {path} has no `fn {name}`")
 
-    if checked == 0:
-        print("the index named no tests — the parser is looking at the wrong shape", file=sys.stderr)
-        return 2
-    for problem in missing:
+    return checked, missing
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+
+    total = 0
+    problems: list[str] = []
+    for index, abbreviations in INDEXES:
+        if not (root / index).is_file():
+            print(f"{index} not found", file=sys.stderr)
+            return 2
+        checked, missing = check(root, index, abbreviations)
+        if checked == 0:
+            print(
+                f"{index} named no tests — the parser is looking at the wrong shape",
+                file=sys.stderr,
+            )
+            return 2
+        total += checked
+        problems.extend(missing)
+
+    for problem in problems:
         print(problem, file=sys.stderr)
-    if missing:
+    if problems:
         print(
-            f"\n{len(missing)} of {checked} named tests could not be found. "
-            "Either the move was unintended, or this index must be updated in the "
+            f"\n{len(problems)} of {total} named tests could not be found. "
+            "Either the move was unintended, or the index must be updated in the "
             "same change — a freeze that names tests that no longer exist is worse "
             "than no freeze.",
             file=sys.stderr,
         )
         return 1
-    print(f"all {checked} tests named by the v1 contract index exist where it says")
+    names = ", ".join(index.name for index, _ in INDEXES)
+    print(f"all {total} tests named by {names} exist where they say")
     return 0
 
 


### PR DESCRIPTION
Five optimizer contracts, frozen and qualified against main `2944ace6`
(ACTUATION-1, #463), together with the enforcement that makes "frozen" mean
something operational.

## The two commits belong together

`0b2888cb` freezes the contracts. `b0fc2657` obliges something to check them.

Without the second, OPT-CONTRACT-1 would repeat the exact hollow claim this
transition discovered in the v1 index: a checker exists, and nobody is
obliged to run it.

```text
existing REPRESENT contracts
        +
new optimizer contracts
        ↓
one checker
        ↓
85 named witnesses resolve
        ↓
4 fail-closed controls
        ↓
CI actually invokes it
```

## What the index says

Four contracts protect scientific identity along the forward path --
selection, protocol, preparation, execution. The fifth protects the failure
path that surrounds all four: when any of those boundaries refuses, the
reason may not lose the evidence needed to act on it.

A SECOND index, not an extension of the first.
`docs/represent-v1-contract-index.md` defines itself as the frozen
REPRESENT/accounting v1 set of nine; the optimizer's invariants are a
different programme with a different freeze and a different qualifying
commit. Appending to it would make "v1" mean two things.

Contract 5 would not exist without a gate. ACT1-N8 is its evidence: the
per-file coverage gate on #463 found that a third of stage 5b's refusals held
exactly the right facts and had never had their rendered form read by
anything. A refusal containing what you need is not the same claim as a
caller being able to act on it, and only the second is what a refusal is for.
Its scope is deliberately narrow -- optimizer refusals on the actuation and
protocol path -- so an internal diagnostic is not pulled into a
scientific-interface guarantee it was never designed to carry.

Three absences are stated as facts rather than left as oversights: ingestion
is OPT-6 and inherits contract 5 rather than reinventing it; contract 1
establishes that a request names the state the optimiser selected but NOT
that a compiled overlay presents it (ACT1-N3); contract 4's dispatch is
witnessed with stub procedures, so ACT1-N5 stays open.

## The finding

**This transition discovered that its own intended authority was not
enforced.**

`scripts/check_contract_index.py` has existed since the v1 index landed.
Nothing ran it. At `origin/main` the only two references to it in the entire
tracked tree are:

- `docs/represent-v1-contract-index.md:18` -- the prose "That is enforced
  rather than asked for"
- `docs/represent/forecasts/lowering-plugin-1.json:154` --
  LOWERING-PLUGIN-1's gate list

Neither invokes it. No workflow, no Makefile target, no hook. So the v1
index's sentence about itself has been false since it was written, and
LOWERING-PLUGIN-1 has been counting on a gate that ran only when someone
typed it by hand. Independently confirmed by the session working that
programme, which has recorded it as gate hygiene rather than continuing to
claim the gate.

That is a finding OF OPT-CONTRACT-1, not incidental CI cleanup: landing a
second frozen index under enforcement that does not exist would have doubled
a hollow claim rather than added a real one.

## Reading two indexes is not one index twice

Each index carries its OWN abbreviations, so `…/state/` in the optimizer
index cannot silently resolve against the v1 vocabulary, and `last_path`
resets per document so a `same file` row can only inherit a path named by the
same index. Both are regressions a shared parser introduces QUIETLY -- the
row resolves to a real file in the wrong crate and passes.

## Controls

Run against a copy so the tree stayed clean. Each confirms the checker FAILS
rather than passing quietly:

| control | result |
|---|---|
| a renamed test | `has no fn ...` |
| a moved file | `does not exist` |
| `same file` with no file yet | reported, not inherited across indexes |
| a citation row with no name/path pair | reported, not skipped |

85 named tests resolve across the two indexes -- 64 v1, 21 optimizer.

## Scope

No Rust changed (0 `.rs` files), so `cargo test` outcome is unchanged from
main. The new step runs in the `quality` workflow beside `check_doc_links.py`
and `check_doc_references.py --strict`, the gates that exist because this
same class of rot was found by audit rather than by CI.

## A defect found here and deliberately NOT fixed here

`scripts/check_doc_references.py` skips any path containing `/.claude/`, and
every worktree in this repo lives under `.claude/worktrees/`. Run from one it
prints "no broken references" after checking 0 references across 0 documents,
and exits 0. CI checks out at a clean path and sees 1441 references across
242 documents, so the gate is sound where it runs -- but every local
pre-push run from a worktree has been vacuous, and it fails OPEN while doing
it. Two sessions hit it independently in one evening.

That is a different invariant -- "did the instrument examine anything?"
rather than "are these contracts continuously enforced?" -- so it gets its
own transition, DOC-GATE-1: skip semantics relative to the repository root, a
zero-scan hard failure so no future path or filter bug can produce another
vacuous green, and a same-corpus equivalence witness between an ordinary
checkout and one under `.claude/`.

It does not block this PR. The GitHub Actions checkout does not suffer the
path pathology, so the contract-index gate wired here is independently real.
