### PR TITLE
feat(lowering): L3 — every production path obtains its provider from the carried registry

### DIFF
--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/prepare.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/prepare.rs
@@ -8,17 +8,18 @@
 //! close the plan, bind the operands — and `larql serve` binds through
 //! the same call. What this module owns is the CLI's side of that line:
 //! which encoding a `--backend` asks for, whether the runtime may
-//! manufacture it, and handing the chosen backend — a concrete type,
-//! chosen exactly once — to a [`BackendVisitor`]. Realisation is not
-//! interpretation, so it stays here.
+//! manufacture it, and composing the lowering registry a `--backend`
+//! names — in [`lowerings_for`], the one place this crate constructs a
+//! provider — then resolving the provider by identity and handing it to
+//! a [`BackendVisitor`]. Realisation is not interpretation, so it stays
+//! here.
 
 use std::path::Path;
 
 use larql_inference::vindex3::{open_component, OpenPolicy, OpenedComponent};
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+use larql_vindex::format::vindex3::opplan::exec::lowering::{LoweringIdentity, LoweringRegistry};
 use larql_vindex::format::vindex3::opplan::exec::operands::RepresentationSource;
-use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
-use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
 
 use super::ExecBackend;
 
@@ -171,47 +172,58 @@ pub(super) fn lowered_formats(
     }
 }
 
-/// Work that runs against a backend chosen at runtime.
+/// Work that runs against a provider resolved at runtime.
 ///
-/// The backends are distinct concrete types and the interpreter is
-/// generic over them, so the choice cannot be a trait object; it is made
-/// once, in [`with_plan_backend`], and the visitor sees the concrete
-/// type.
+/// The interpreter is generic over the provider type; the visitor sees
+/// the shared handle the registry hands out, which implements the trait
+/// by delegation, so the choice is made once — in [`lowerings_for`] —
+/// and the work is written once.
 pub(crate) trait BackendVisitor {
     type Out;
     fn visit<B: PlanBackend>(self, backend: &B) -> Result<Self::Out, BoxErr>;
 }
 
-/// Construct the interpreted backend `backend` names and hand it to
-/// `visitor` — the single place a `--backend` value becomes a type.
+/// The lowering registry a `--backend` value composes, and the identity
+/// it asks that registry for — **the single place a provider is
+/// constructed in this crate** (LOWERING-PLUGIN-1, L3).
 ///
-/// The lowered arms are not interpreted backends and are refused here:
-/// they run through `lowered::run_lowered`, which the exec verb reaches
-/// via [`lowered_formats`] before it comes this way.
-pub(crate) fn with_plan_backend<V: BackendVisitor>(
+/// The shipped providers come from the registry's own constructor. A
+/// device arm registers the device provider it configures — the injected
+/// Metal device and the per-class format table that make that arm what it
+/// is — under the device provider's identity, and asks for it by that
+/// identity. Nothing downstream constructs a provider: every verb
+/// resolves through the registry this returns.
+pub(crate) fn lowerings_for(
     backend: ExecBackend,
-    visitor: V,
-) -> Result<V::Out, BoxErr> {
+) -> Result<(LoweringRegistry, LoweringIdentity), BoxErr> {
+    let shipped = LoweringRegistry::shipped();
     match backend {
-        ExecBackend::Reference => visitor.visit(&ReferenceBackend::new()),
-        ExecBackend::Production => visitor.visit(&ProductionBackend::new()),
-        // Same kernels as `production`; the difference is upstream, in
-        // `wanted_representation`, which makes the store bind the
-        // compiled NVFP4 pack instead of the canonical bytes. The
-        // projector then dispatches `FusedNvfp4` off the resident
-        // representation, exactly as it dispatches every other arm.
-        ExecBackend::ProductionNvfp4 => visitor.visit(&ProductionBackend::new()),
-        // Same kernels again, and the same policy: a stored K-quant pack
-        // is bound and executed IN PLACE by its codec's kernel
-        // (`FusedKQuant`), or — under `LARQL_KQUANT_EXEC=widen` — decoded
-        // to f32 in `OperandStore::load` and run through BLAS as rung A's
-        // authority path did. The two arms read the same stored bytes and
-        // differ only in where the arithmetic happens; the executor
-        // reports which one ran in its `projection plans:` line rather
-        // than leaving it to the backend's name.
-        ExecBackend::ProductionQ8 | ExecBackend::ProductionQ6k | ExecBackend::ProductionQ4k => {
-            visitor.visit(&ProductionBackend::new())
-        }
+        ExecBackend::Reference => Ok((shipped, LoweringIdentity::reference())),
+        // Same kernels for every production arm; the arms differ
+        // upstream, in `wanted_representation`, which makes the store
+        // bind a compiled NVFP4 or K-quant pack instead of the canonical
+        // bytes. The projector then dispatches `FusedNvfp4` /
+        // `FusedKQuant` off the resident representation — or, under
+        // `LARQL_KQUANT_EXEC=widen`, a stored K-quant is decoded to f32
+        // in `OperandStore::load` and run through BLAS as rung A's
+        // authority path did. The executor reports which one ran in its
+        // `projection plans:` line rather than leaving it to the
+        // provider's name.
+        ExecBackend::Production
+        | ExecBackend::ProductionNvfp4
+        | ExecBackend::ProductionQ8
+        | ExecBackend::ProductionQ6k
+        | ExecBackend::ProductionQ4k => Ok((shipped, LoweringIdentity::cpu_production())),
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
+        ExecBackend::MetalLowered
+        | ExecBackend::MetalLoweredFfn
+        | ExecBackend::MetalLoweredNoHead
+        | ExecBackend::MetalLoweredMxfp4
+        | ExecBackend::MetalLoweredMxfp4Ffn
+        | ExecBackend::MetalLoweredF16 => Err(format!(
+            "`{backend:?}` is a lowered arm: it does not execute through the interpreter"
+        )
+        .into()),
         #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::MetalMxfp4 => {
             let gpu = larql_compute_metal::MetalBackend::new()
@@ -226,7 +238,7 @@ pub(crate) fn with_plan_backend<V: BackendVisitor>(
             use larql_vindex::format::vindex3::opplan::exec::backend::{
                 WeightFormat, WeightFormats,
             };
-            let backend =
+            let device =
                 larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::with_formats(
                     gpu,
                     "metal-q1-mxfp4-ffn",
@@ -236,18 +248,11 @@ pub(crate) fn with_plan_backend<V: BackendVisitor>(
                         head: WeightFormat::F16,
                     },
                 );
-            visitor.visit(&backend)
+            Ok((
+                shipped.register(Box::new(device))?,
+                LoweringIdentity::device_matmul(),
+            ))
         }
-        #[cfg(all(feature = "gpu", target_os = "macos"))]
-        ExecBackend::MetalLowered
-        | ExecBackend::MetalLoweredFfn
-        | ExecBackend::MetalLoweredNoHead
-        | ExecBackend::MetalLoweredMxfp4
-        | ExecBackend::MetalLoweredMxfp4Ffn
-        | ExecBackend::MetalLoweredF16 => Err(format!(
-            "`{backend:?}` is a lowered arm: it does not execute through the interpreter"
-        )
-        .into()),
         #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::MetalMxfp4All => {
             let gpu = larql_compute_metal::MetalBackend::new()
@@ -258,13 +263,16 @@ pub(crate) fn with_plan_backend<V: BackendVisitor>(
             use larql_vindex::format::vindex3::opplan::exec::backend::{
                 WeightFormat, WeightFormats,
             };
-            let backend =
+            let device =
                 larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::with_formats(
                     gpu,
                     "metal-q1-mxfp4-all",
                     WeightFormats::uniform(WeightFormat::Mxfp4),
                 );
-            visitor.visit(&backend)
+            Ok((
+                shipped.register(Box::new(device))?,
+                LoweringIdentity::device_matmul(),
+            ))
         }
         #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::MetalNvfp4 | ExecBackend::MetalNvfp4Ffn | ExecBackend::MetalNvfp4NoHead => {
@@ -309,11 +317,14 @@ pub(crate) fn with_plan_backend<V: BackendVisitor>(
                     },
                 ),
             };
-            let backend =
+            let device =
                 larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::with_formats(
                     gpu, name, formats,
                 );
-            visitor.visit(&backend)
+            Ok((
+                shipped.register(Box::new(device))?,
+                LoweringIdentity::device_matmul(),
+            ))
         }
         #[cfg(all(feature = "gpu", target_os = "macos"))]
         ExecBackend::Metal => {
@@ -324,13 +335,42 @@ pub(crate) fn with_plan_backend<V: BackendVisitor>(
             // mistaken for the f32 r1 lowering.
             let gpu = larql_compute_metal::MetalBackend::new()
                 .ok_or("no Metal device available for --backend metal")?;
-            let backend =
+            let device =
                 larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::new(
                     gpu,
                     "metal-r3-f16",
                     larql_vindex::format::vindex3::opplan::exec::backend::WeightFormat::F16,
                 );
-            visitor.visit(&backend)
+            Ok((
+                shipped.register(Box::new(device))?,
+                LoweringIdentity::device_matmul(),
+            ))
         }
     }
+}
+
+/// Resolve the provider `backend` names and hand it to `visitor`:
+/// compose the registry, then [`with_lowerings`]. The visitor sees a
+/// shared handle to the registered provider, never a type this function
+/// constructed for it.
+pub(crate) fn with_plan_backend<V: BackendVisitor>(
+    backend: ExecBackend,
+    visitor: V,
+) -> Result<V::Out, BoxErr> {
+    let (lowerings, identity) = lowerings_for(backend)?;
+    with_lowerings(&lowerings, &identity, visitor)
+}
+
+/// Hand `visitor` the provider `identity` names in `lowerings`, or
+/// refuse by identity naming every provider the registry holds — before
+/// the visitor runs, so before any operand is read. The seam a test hands
+/// a registry of its own to: a registry without the provider must refuse
+/// here, and nothing underneath may construct one to answer anyway.
+pub(crate) fn with_lowerings<V: BackendVisitor>(
+    lowerings: &LoweringRegistry,
+    identity: &LoweringIdentity,
+    visitor: V,
+) -> Result<V::Out, BoxErr> {
+    let provider = lowerings.provider_shared(identity)?;
+    visitor.visit(&provider)
 }

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/realizations.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/realizations.rs
@@ -25,7 +25,6 @@ use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
 use larql_vindex::format::vindex3::opplan::exec::prepared::{
     select_realizations_within, ExecutionSlice, PreparedOperands,
 };
-use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
 use larql_vindex::format::vindex3::opplan::exec::realization::SelectionReason;
 use larql_vindex::format::vindex3::opplan::ComponentOpPlan;
 
@@ -86,13 +85,9 @@ fn bind_and_reconcile(
     budget: &ResidencyBudget,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let started = std::time::Instant::now();
-    let ops = PreparedOperands::load_within(
-        plan,
-        store,
-        &ProductionBackend::new(),
-        ExecutionSlice::Full,
-        budget,
-    )?;
+    let (lowerings, identity) = super::prepare::lowerings_for(super::ExecBackend::Production)?;
+    let backend = lowerings.provider_shared(&identity)?;
+    let ops = PreparedOperands::load_within(plan, store, &backend, ExecutionSlice::Full, budget)?;
     let bound_in = started.elapsed().as_secs_f64();
     let reconciled = ops.reconcile(plan, store.into())?;
     println!("bound, from the container:");
@@ -127,7 +122,8 @@ pub(super) fn report_through(
     store: &OperandStore,
     budget: &ResidencyBudget,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let backend = ProductionBackend::new();
+    let (lowerings, identity) = super::prepare::lowerings_for(super::ExecBackend::Production)?;
+    let backend = lowerings.provider_shared(&identity)?;
     let planned = plan.planned_operands().len();
     println!("planned operands: {planned}");
     println!("budget: {}", describe(budget));

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/sensitivity.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/sensitivity.rs
@@ -378,17 +378,13 @@ fn capture_moments(
     let token_digest = calibration_digest(&entries);
 
     // The f16 Metal realisation, the same one `exec --backend metal` uses
-    // and the one Granite's external oracle was verified against. The
-    // naive f32 reference is correct and takes hours on a 40-layer model
-    // with no KV cache, which would make the screen more expensive than
-    // the Q-BANK run it exists to avoid.
-    let gpu = larql_compute_metal::MetalBackend::new()
-        .ok_or("no Metal device available for the sensitivity capture")?;
-    let backend = larql_vindex::format::vindex3::opplan::exec::device::DevicePlanBackend::new(
-        gpu,
-        "metal-r3-f16",
-        larql_vindex::format::vindex3::opplan::exec::backend::WeightFormat::F16,
-    );
+    // and the one Granite's external oracle was verified against — asked
+    // for through the same composition that arm uses, so this file spells
+    // no provider of its own. The naive f32 reference is correct and takes
+    // hours on a 40-layer model with no KV cache, which would make the
+    // screen more expensive than the Q-BANK run it exists to avoid.
+    let (lowerings, identity) = super::prepare::lowerings_for(super::ExecBackend::Metal)?;
+    let backend = lowerings.provider_shared(&identity)?;
     let mut collector = MomentCollector::default();
     let started = std::time::Instant::now();
     let mut positions = 0usize;

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/lowerings.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/lowerings.rs
@@ -1,0 +1,142 @@
+//! LOWERING-PLUGIN-1, L3: every CLI verb obtains its provider from the
+//! registry `lowerings_for` composes, and the seam it resolves through
+//! refuses a provider the registry lacks before any operand is read.
+
+use super::*;
+use crate::commands::primary::vindex3_cmd::prepare::{
+    lowerings_for, with_lowerings, BackendVisitor,
+};
+use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+use larql_vindex::format::vindex3::opplan::exec::lowering::{LoweringIdentity, LoweringRegistry};
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
+use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use larql_vindex::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
+
+fn encoded_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = fixture_dir(true);
+    let out = dir.path().join("container");
+    run(Vindex3Command::Encode(EncodeArgs {
+        capability: None,
+        artifacts: vec![dir.path().to_path_buf()],
+        output: out.clone(),
+    }))
+    .unwrap();
+    (dir, out)
+}
+
+/// A visitor that would prepare the plan — the first thing every verb
+/// does with its provider — so that if the seam handed it anything, the
+/// store's load count would move.
+struct Prepare<'a> {
+    plan: &'a ComponentOpPlan,
+    store: &'a OperandStore,
+}
+
+impl BackendVisitor for Prepare<'_> {
+    type Out = String;
+
+    fn visit<B: PlanBackend>(self, backend: &B) -> Result<String, Box<dyn std::error::Error>> {
+        PreparedOperands::load(self.plan, self.store, backend, ExecutionSlice::Full)?;
+        Ok(backend.identity().to_string())
+    }
+}
+
+/// The CLI's backend choices resolve to the same providers they used to
+/// construct, now by identity from the composed registry.
+#[test]
+fn every_interpreted_backend_choice_resolves_to_its_provider_by_identity() {
+    for (choice, identity, name) in [
+        (
+            ExecBackend::Reference,
+            LoweringIdentity::reference(),
+            "reference-f32",
+        ),
+        (
+            ExecBackend::Production,
+            LoweringIdentity::cpu_production(),
+            "production-larql-compute",
+        ),
+        (
+            ExecBackend::ProductionNvfp4,
+            LoweringIdentity::cpu_production(),
+            "production-larql-compute",
+        ),
+        (
+            ExecBackend::ProductionQ8,
+            LoweringIdentity::cpu_production(),
+            "production-larql-compute",
+        ),
+        (
+            ExecBackend::ProductionQ6k,
+            LoweringIdentity::cpu_production(),
+            "production-larql-compute",
+        ),
+        (
+            ExecBackend::ProductionQ4k,
+            LoweringIdentity::cpu_production(),
+            "production-larql-compute",
+        ),
+    ] {
+        let (lowerings, resolved) = lowerings_for(choice).unwrap();
+        assert_eq!(resolved, identity, "{choice:?}");
+        let provider = lowerings.provider(&resolved).unwrap();
+        assert_eq!(provider.name(), name, "{choice:?}");
+        assert_eq!(provider.identity(), identity, "{choice:?}");
+        // The interpreted arms compose exactly the shipped providers.
+        assert_eq!(
+            lowerings.identities(),
+            LoweringRegistry::shipped().identities(),
+            "{choice:?}"
+        );
+    }
+}
+
+/// F4 through the CLI seam: a registry without the production provider,
+/// asked to prepare as it, is refused by identity naming what it holds,
+/// and the store has read nothing — no provider was constructed
+/// underneath to answer anyway. The same seam with the shipped registry
+/// prepares, so the refusal is the registry's and not the fixture's.
+#[test]
+fn the_seam_refuses_an_absent_provider_with_nothing_read() {
+    let (_dir, out) = encoded_fixture();
+    let inspection = inspect_container(&out, false).unwrap();
+    let plan = plan_component_ops(&inspection, &out, "target")
+        .unwrap()
+        .plan
+        .expect("the fixture plans");
+    let store = OperandStore::open(&out, &inspection).unwrap();
+
+    let without_production = LoweringRegistry::new()
+        .register(Box::new(ReferenceBackend::new()))
+        .unwrap();
+    let err = with_lowerings(
+        &without_production,
+        &LoweringIdentity::cpu_production(),
+        Prepare {
+            plan: &plan,
+            store: &store,
+        },
+    )
+    .expect_err("refused by identity")
+    .to_string();
+    assert!(err.contains("cpu-production/v1"), "{err}");
+    assert!(err.contains("registered: reference/v1"), "{err}");
+    assert_eq!(store.load_count(), 0, "nothing was read");
+
+    let identity = with_lowerings(
+        &LoweringRegistry::shipped(),
+        &LoweringIdentity::cpu_production(),
+        Prepare {
+            plan: &plan,
+            store: &store,
+        },
+    )
+    .expect("the shipped registry prepares");
+    assert_eq!(identity, "cpu-production/v1");
+    assert!(
+        store.load_count() > 0,
+        "the positive control read its operands"
+    );
+}

--- a/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/mod.rs
+++ b/crates/larql-cli/src/commands/primary/vindex3_cmd/tests/mod.rs
@@ -4,6 +4,7 @@ mod calibration_digest;
 mod decode;
 mod exec_resume;
 mod generate;
+mod lowerings;
 mod realizations;
 mod sizes;
 

--- a/crates/larql-inference/src/vindex3/mod.rs
+++ b/crates/larql-inference/src/vindex3/mod.rs
@@ -52,6 +52,9 @@ mod tests;
 pub use generate::{
     continue_session, continue_session_masked, generate_session, LogitsMask, SessionGeneration,
 };
+pub use larql_vindex::format::vindex3::opplan::exec::lowering::{
+    LoweringError, LoweringIdentity, LoweringRegistry, SharedProvider,
+};
 pub use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
 pub use runtime::{open_component, OpenPolicy, OpenedComponent, PreparedVindex3, Vindex3Runtime};
 pub use session::{LogitsSession, Vindex3Session};

--- a/crates/larql-inference/src/vindex3/runtime.rs
+++ b/crates/larql-inference/src/vindex3/runtime.rs
@@ -14,6 +14,9 @@ use std::path::Path;
 use larql_vindex::format::vindex3::inspect::{inspect_container, SystemInspection};
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
 use larql_vindex::format::vindex3::opplan::exec::kv::KvState;
+use larql_vindex::format::vindex3::opplan::exec::lowering::{
+    LoweringIdentity, LoweringRegistry, SharedProvider,
+};
 use larql_vindex::format::vindex3::opplan::exec::operands::{
     OperandOverrides, OperandSource, OperandStore, RepresentationSource,
 };
@@ -384,6 +387,46 @@ impl<B: PlanBackend> Vindex3Runtime<B> {
             model_name: self.model_name,
             family: self.family,
         })
+    }
+}
+
+impl Vindex3Runtime<SharedProvider> {
+    /// [`open`](Self::open) on the provider `provider` names in
+    /// `lowerings` — the registry-carried path every production caller
+    /// opens through (LOWERING-PLUGIN-1, L3).
+    pub fn open_via(
+        container: &Path,
+        component: &str,
+        lowerings: &LoweringRegistry,
+        provider: &LoweringIdentity,
+    ) -> Result<Self, InferenceError> {
+        Self::open_with_via(
+            container,
+            component,
+            lowerings,
+            provider,
+            OpenPolicy::default(),
+        )
+    }
+
+    /// [`open_with`](Self::open_with) through a registry.
+    ///
+    /// The provider is resolved FIRST and the container opened second: a
+    /// provider the registry does not hold is refused by identity, naming
+    /// every provider it does hold, before any file is touched — so the
+    /// refusal is the same on a container that does not exist. Nothing
+    /// here constructs a provider the caller did not register.
+    pub fn open_with_via(
+        container: &Path,
+        component: &str,
+        lowerings: &LoweringRegistry,
+        provider: &LoweringIdentity,
+        policy: OpenPolicy,
+    ) -> Result<Self, InferenceError> {
+        let backend = lowerings
+            .provider_shared(provider)
+            .map_err(larql_vindex::error::VindexError::from)?;
+        Self::open_with(container, component, backend, policy)
     }
 }
 

--- a/crates/larql-inference/src/vindex3/tests/mod.rs
+++ b/crates/larql-inference/src/vindex3/tests/mod.rs
@@ -896,3 +896,68 @@ fn overlaid_entry_points_are_bit_identical_when_empty_and_observe_edits() {
     let base_gate = effective.load(&gate).unwrap();
     assert_ne!(&base_gate[..gate.shape[1]], &vec![5.0; gate.shape[1]][..]);
 }
+
+/// LOWERING-PLUGIN-1, L3: the runtime — the path the server and LQL open
+/// through — resolves its provider from the registry it is handed, and
+/// constructs none.
+mod via_tests {
+    use std::path::Path;
+
+    use super::super::*;
+    use larql_vindex::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
+    use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+    use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+    use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
+
+    /// F4 through a production path. A registry that omits the
+    /// production provider, asked to open as it, is refused by identity
+    /// naming what the registry holds — and the container path does not
+    /// even exist, so the refusal provably happened before any I/O and no
+    /// provider was constructed underneath to answer anyway.
+    #[test]
+    fn a_registry_without_the_provider_refuses_before_touching_the_container() {
+        let without_production = LoweringRegistry::new()
+            .register(Box::new(ReferenceBackend::new()))
+            .unwrap();
+        let err = Vindex3Runtime::open_via(
+            Path::new("/definitely/not/a/container"),
+            "target",
+            &without_production,
+            &LoweringIdentity::cpu_production(),
+        )
+        .err()
+        .expect("refused")
+        .to_string();
+        assert!(err.contains("cpu-production/v1"), "{err}");
+        assert!(err.contains("registered: reference/v1"), "{err}");
+        assert!(
+            !err.contains("not/a/container") && !err.to_lowercase().contains("no such file"),
+            "the refusal is the registry's, not the filesystem's: {err}"
+        );
+    }
+
+    /// Through the shipped registry the runtime opens on the same
+    /// provider the direct constructor would have handed it, by identity
+    /// and by name, and prepares.
+    #[test]
+    fn the_shipped_registry_opens_the_production_provider_the_direct_path_did() {
+        let tmp = tempfile::tempdir().unwrap();
+        let checkpoint = tmp.path().join("ckpt");
+        std::fs::create_dir_all(&checkpoint).unwrap();
+        let container = tmp.path().join("out.vindex3");
+        encode_fixture_container(dense_f32_model, &checkpoint, &container, "target");
+
+        let via = Vindex3Runtime::open_via(
+            &container,
+            "target",
+            &LoweringRegistry::shipped(),
+            &LoweringIdentity::cpu_production(),
+        )
+        .expect("the shipped registry holds the production provider");
+        let direct = Vindex3Runtime::open(&container, "target", ProductionBackend::new()).unwrap();
+        assert_eq!(via.backend().identity(), direct.backend().identity());
+        assert_eq!(via.backend().name(), direct.backend().name());
+        assert_eq!(via.model_name(), direct.model_name());
+        via.prepare().expect("prepares through the shared provider");
+    }
+}

--- a/crates/larql-lql/src/executor/backend.rs
+++ b/crates/larql-lql/src/executor/backend.rs
@@ -55,7 +55,7 @@ pub(crate) enum Backend {
         #[allow(dead_code)]
         path: PathBuf,
         runtime: larql_inference::Vindex3Runtime<
-            larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend,
+            larql_vindex::format::vindex3::opplan::exec::lowering::SharedProvider,
         >,
         /// The container's tokenizer, when it carries one — the text
         /// capability. INFER requires it; USE/STATS/SHOW do not.

--- a/crates/larql-lql/src/executor/mutation/insert/compose_v3/mod.rs
+++ b/crates/larql-lql/src/executor/mutation/insert/compose_v3/mod.rs
@@ -46,7 +46,7 @@ pub(crate) use balance::probe_target_prob;
 mod tests;
 
 use larql_inference::vindex3::Vindex3Runtime;
-use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+use larql_vindex::format::vindex3::opplan::exec::lowering::SharedProvider;
 use larql_vindex::format::vindex3::opplan::LayerFfn;
 
 use super::compose::{median_or, unit_vector};
@@ -75,7 +75,7 @@ const NORM_SAMPLE_SIZE: usize = 100;
 /// check caught the first version of this function computing real
 /// medians V2 never sees).
 fn layer_median_norms(
-    runtime: &Vindex3Runtime<ProductionBackend>,
+    runtime: &Vindex3Runtime<SharedProvider>,
     layer: usize,
 ) -> Result<(f32, f32, f32), LqlError> {
     let Some(LayerFfn::Dense(ffn)) = &runtime.plan().layers[layer].ffn else {

--- a/crates/larql-lql/src/executor/vindex3.rs
+++ b/crates/larql-lql/src/executor/vindex3.rs
@@ -16,7 +16,9 @@ use larql_kv::CanonicalKvState;
 use larql_vindex::format::vindex3::opplan::exec::continuation::{
     plan_continuation_geometry, LayerContinuationGeometry,
 };
-use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+use larql_vindex::format::vindex3::opplan::exec::lowering::{
+    LoweringIdentity, LoweringRegistry, SharedProvider,
+};
 use larql_vindex::format::vindex3::opplan::LayerAttention;
 use larql_vindex::tokenizers::Tokenizer;
 
@@ -39,7 +41,9 @@ pub(crate) const SUPPORTED: &str = "SELECT, DESCRIBE, WALK, EXPLAIN WALK, \
 /// Component id a container's text stack is bound under.
 pub(crate) const V3_COMPONENT: &str = "target";
 
-pub(crate) type V3Runtime = Vindex3Runtime<ProductionBackend>;
+/// The served realisation, resolved from the shipped registry by
+/// identity rather than constructed here (LOWERING-PLUGIN-1, L3).
+pub(crate) type V3Runtime = Vindex3Runtime<SharedProvider>;
 
 /// The capability refusal for statements a V3 binding does not serve.
 pub(crate) fn unsupported(what: &str) -> LqlError {
@@ -830,8 +834,13 @@ pub(crate) type V3Knowledge = larql_vindex::format::vindex3::knowledge::Knowledg
 pub(crate) fn bind(
     path: &std::path::Path,
 ) -> Result<(V3Runtime, Option<Tokenizer>, Option<V3Knowledge>), LqlError> {
-    let runtime = Vindex3Runtime::open(path, V3_COMPONENT, ProductionBackend::new())
-        .map_err(|e| LqlError::exec("failed to open VINDEX3 container", e))?;
+    let runtime = Vindex3Runtime::open_via(
+        path,
+        V3_COMPONENT,
+        &LoweringRegistry::shipped(),
+        &LoweringIdentity::cpu_production(),
+    )
+    .map_err(|e| LqlError::exec("failed to open VINDEX3 container", e))?;
     let tokenizer = larql_vindex::load_vindex_tokenizer(path).ok();
     // The browse view needs the tokenizer (feature annotations decode
     // token ids); a tokenizer-less container binds without it.

--- a/crates/larql-server/src/vindex3.rs
+++ b/crates/larql-server/src/vindex3.rs
@@ -35,7 +35,9 @@ use larql_inference::vindex3::{
 };
 use larql_inference::{EosConfig, SamplingConfig};
 use larql_kv::CanonicalKvState;
-use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+use larql_vindex::format::vindex3::opplan::exec::lowering::{
+    LoweringIdentity, LoweringRegistry, SharedProvider,
+};
 use larql_vindex::tokenizers;
 
 use crate::error::ServerError;
@@ -55,7 +57,7 @@ pub struct V3Model {
     /// The program with its operands already lowered into the
     /// backend's execution form — model lifetime, shared by every
     /// request. Requests contribute only continuation state.
-    pub runtime: PreparedVindex3<ProductionBackend>,
+    pub runtime: PreparedVindex3<SharedProvider>,
     /// Tokenizer for the text-facing API (`tokenizer.json` in the
     /// container directory).
     pub tokenizer: tokenizers::Tokenizer,
@@ -132,10 +134,17 @@ pub fn resolve_chat_template(family: &str, id: &str) -> larql_inference::prompt:
 /// and operand store (refusing closure defects), and load the
 /// container's tokenizer — the text API cannot serve ids-only.
 pub fn load_v3_model(path: &Path) -> Result<V3Model, Box<dyn std::error::Error + Send + Sync>> {
-    let runtime = Vindex3Runtime::open(path, SERVED_COMPONENT, ProductionBackend::new())
-        .map_err(|e| format!("open VINDEX3 container: {e}"))?
-        .prepare()
-        .map_err(|e| format!("prepare VINDEX3 operands: {e}"))?;
+    // The served provider is resolved from the shipped registry by
+    // identity, never constructed here (LOWERING-PLUGIN-1, L3).
+    let runtime = Vindex3Runtime::open_via(
+        path,
+        SERVED_COMPONENT,
+        &LoweringRegistry::shipped(),
+        &LoweringIdentity::cpu_production(),
+    )
+    .map_err(|e| format!("open VINDEX3 container: {e}"))?
+    .prepare()
+    .map_err(|e| format!("prepare VINDEX3 operands: {e}"))?;
     let tokenizer = larql_vindex::load_vindex_tokenizer(path)
         .map_err(|e| format!("VINDEX3 container has no servable tokenizer.json: {e}"))?;
     // The container names itself (`index.model`); the directory name is

--- a/crates/larql-server/tests/test_capabilities.rs
+++ b/crates/larql-server/tests/test_capabilities.rs
@@ -363,14 +363,20 @@ fn source_kinds_come_from_the_resolver() {
 /// would tell the Explorer it can offer a GPU run this server cannot
 /// perform. When a real Metal V3 binding lands, this test fails and
 /// `V3_BACKENDS` grows with it.
+///
+/// Since LOWERING-PLUGIN-1's L3 the loader does not CONSTRUCT its
+/// provider — it resolves one from a carried registry by identity — so
+/// the fact this reads is the identity the loader names. A Metal V3
+/// binding would appear here as the device provider's identity, or as a
+/// device backend constructed to register; either widens the list.
 #[test]
 fn backends_match_the_v3_binding() {
     let binding = include_str!("../src/vindex3.rs");
     assert!(
-        binding.contains("ProductionBackend"),
-        "the V3 loader no longer names ProductionBackend — re-derive V3_BACKENDS"
+        binding.contains("cpu_production"),
+        "the V3 loader no longer resolves `cpu-production` — re-derive V3_BACKENDS"
     );
-    let metal_bound = binding.contains("MetalBackend");
+    let metal_bound = binding.contains("MetalBackend") || binding.contains("device_matmul");
     assert_eq!(
         metal_bound,
         V3_BACKENDS.contains(&"metal"),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/backend.rs
@@ -755,6 +755,93 @@ pub struct DispatchStats {
     pub submissions: u64,
 }
 
+/// A shared handle IS the provider it holds: every method, the provided
+/// ones included, goes to the provider underneath. Spelled out rather
+/// than left to defaults on purpose — a `select` or `dense_projector`
+/// that fell back to the trait's default here would quietly hand a
+/// device provider the reference oracle's selection.
+impl<T: PlanBackend + Send + ?Sized> PlanBackend for std::sync::Arc<T> {
+    fn name(&self) -> &str {
+        (**self).name()
+    }
+
+    fn identity(&self) -> LoweringIdentity {
+        (**self).identity()
+    }
+
+    fn dispatch_stats(&self) -> Option<DispatchStats> {
+        (**self).dispatch_stats()
+    }
+
+    fn select(
+        &self,
+        operand: &PlannedOperand,
+        facts: &RepresentationFacts,
+    ) -> Result<Selection, Box<SelectionRefusal>> {
+        (**self).select(operand, facts)
+    }
+
+    fn dense_projector(&self) -> &dyn super::gated_delta::DenseProjections {
+        (**self).dense_projector()
+    }
+
+    fn prepare(&self, weights: &[WeightSlice<'_>]) {
+        (**self).prepare(weights)
+    }
+
+    fn embed(&self, table: &[f32], hidden: usize, token: u32, scale: Option<f32>) -> Vec<f32> {
+        (**self).embed(table, hidden, token, scale)
+    }
+
+    fn norm(&self, call: NormCall<'_>) -> Vec<f32> {
+        (**self).norm(call)
+    }
+
+    fn project(&self, call: ProjectCall<'_>) -> Result<Vec<f32>, VindexError> {
+        (**self).project(call)
+    }
+
+    fn attention(&self, call: AttentionCall<'_>) -> Result<AttentionOut, VindexError> {
+        (**self).attention(call)
+    }
+
+    fn attention_step(&self, call: AttentionStepCall<'_>) -> Result<AttentionStepOut, VindexError> {
+        (**self).attention_step(call)
+    }
+
+    fn ffn(&self, call: FfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        (**self).ffn(call)
+    }
+
+    fn ffn_many(&self, call: FfnManyCall<'_>) -> Result<Vec<Vec<f32>>, VindexError> {
+        (**self).ffn_many(call)
+    }
+
+    fn scale_row(&self, row: &mut [f32], scale: f32) {
+        (**self).scale_row(row, scale)
+    }
+
+    fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        (**self).routed_ffn(call)
+    }
+
+    fn output_head(
+        &self,
+        projection: WeightSlice<'_>,
+        vocab: usize,
+        hidden: usize,
+        x: &[f32],
+        multiplier: Option<f64>,
+        softcapping: Option<f32>,
+    ) -> Result<Vec<f32>, VindexError> {
+        (**self).output_head(projection, vocab, hidden, x, multiplier, softcapping)
+    }
+
+    fn residual_add(&self, acc: &mut [f32], delta: &[f32]) {
+        (**self).residual_add(acc, delta)
+    }
+}
+
 /// A provider names itself by presentation name and identity, so a
 /// refusal or a test can say which one it was talking about.
 impl std::fmt::Debug for dyn PlanBackend + '_ {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/lowering.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/lowering.rs
@@ -26,9 +26,17 @@
 //! thing that could be falsified.
 
 use std::fmt;
+use std::sync::Arc;
 
 use super::backend::PlanBackend;
 use crate::error::VindexError;
+
+/// A provider as a registry hands it out: shared, so a runtime can own
+/// the provider it resolved while the registry keeps holding it.
+/// `PlanBackend` is implemented for `Arc<T>` by delegating every method,
+/// so a shared handle never falls back to a trait default the provider
+/// underneath overrides.
+pub type SharedProvider = Arc<dyn PlanBackend + Send>;
 
 /// A lowering provider's semantic identity: family and revision.
 #[derive(
@@ -48,6 +56,31 @@ impl LoweringIdentity {
             family: family.into(),
             revision,
         }
+    }
+
+    /// The reference oracle's identity, read from the provider's own
+    /// constants — no caller spells a family.
+    pub fn reference() -> Self {
+        Self::new(
+            super::reference::IDENTITY_FAMILY,
+            super::reference::IDENTITY_REVISION,
+        )
+    }
+
+    /// The production CPU executor's identity.
+    pub fn cpu_production() -> Self {
+        Self::new(
+            super::production::IDENTITY_FAMILY,
+            super::production::IDENTITY_REVISION,
+        )
+    }
+
+    /// The device-over-`MatMul` provider's identity.
+    pub fn device_matmul() -> Self {
+        Self::new(
+            super::device::IDENTITY_FAMILY,
+            super::device::IDENTITY_REVISION,
+        )
     }
 
     /// Refuse an identity that could not key a registry or name a
@@ -175,7 +208,7 @@ impl From<LoweringError> for VindexError {
 /// side by side has two providers to name.
 #[derive(Default)]
 pub struct LoweringRegistry {
-    providers: Vec<Box<dyn PlanBackend + Send>>,
+    providers: Vec<SharedProvider>,
 }
 
 impl fmt::Debug for LoweringRegistry {
@@ -202,7 +235,7 @@ impl LoweringRegistry {
         if self.providers.iter().any(|p| p.identity() == identity) {
             return Err(LoweringError::Duplicate { identity });
         }
-        self.providers.push(provider);
+        self.providers.push(Arc::from(provider));
         Ok(self)
     }
 
@@ -221,14 +254,34 @@ impl LoweringRegistry {
     /// The provider `identity` names, or a refusal naming every provider
     /// that is registered.
     pub fn provider(&self, identity: &LoweringIdentity) -> Result<&dyn PlanBackend, LoweringError> {
+        self.provider_shared(identity).map(|_| ()).and_then(|()| {
+            self.providers
+                .iter()
+                .find(|p| p.identity() == *identity)
+                .map(|p| p.as_ref() as &dyn PlanBackend)
+                .ok_or_else(|| self.unregistered(identity))
+        })
+    }
+
+    /// The provider `identity` names as a shared handle a caller can own
+    /// — a runtime, a session, a server holding the model for its
+    /// lifetime — or the same refusal as [`Self::provider`].
+    pub fn provider_shared(
+        &self,
+        identity: &LoweringIdentity,
+    ) -> Result<SharedProvider, LoweringError> {
         self.providers
             .iter()
             .find(|p| p.identity() == *identity)
-            .map(|p| p.as_ref() as &dyn PlanBackend)
-            .ok_or_else(|| LoweringError::Unregistered {
-                identity: identity.clone(),
-                registered: self.identities(),
-            })
+            .cloned()
+            .ok_or_else(|| self.unregistered(identity))
+    }
+
+    fn unregistered(&self, identity: &LoweringIdentity) -> LoweringError {
+        LoweringError::Unregistered {
+            identity: identity.clone(),
+            registered: self.identities(),
+        }
     }
 
     /// Every registered provider of `family`, at every revision, in

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -90,7 +90,6 @@ use prepared::{
     PreparedOperands,
 };
 use rayon::prelude::*;
-use reference::ReferenceBackend;
 use weights::{load_weight, LoadedWeight};
 
 /// One plane of the traversal — the residual at a layer boundary, one
@@ -399,7 +398,15 @@ pub fn execute_text<'s>(
     store: impl Into<OperandSource<'s>>,
     tokens: &[u32],
 ) -> Result<ExecutionTrace, VindexError> {
-    execute_plan(plan, store.into(), tokens, &ReferenceBackend::new())
+    // The oracle by request, from the shipped registry — not by
+    // privileged construction (LOWERING-PLUGIN-1, L3).
+    execute_plan_via(
+        plan,
+        store.into(),
+        tokens,
+        &lowering::LoweringRegistry::shipped(),
+        &lowering::LoweringIdentity::reference(),
+    )
 }
 
 /// Execute a text-component plan over `tokens` on `backend`, tracing

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_identity.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_identity.rs
@@ -10,8 +10,8 @@
 //! identities, and one identity under two names.
 
 use super::super::backend::{
-    AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, FfnCall, NormCall,
-    PlanBackend, ProjectCall, RoutedFfnCall, WeightFormat, WeightFormats, WeightSlice,
+    AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, DispatchStats, FfnCall,
+    NormCall, PlanBackend, ProjectCall, RoutedFfnCall, WeightFormat, WeightFormats, WeightSlice,
 };
 use super::super::device::DevicePlanBackend;
 use super::super::lowering::LoweringIdentity;
@@ -75,6 +75,31 @@ fn identity_is_the_providers_not_its_configurations() {
     assert_eq!(f32_device.identity().to_string(), "device-matmul/v1");
 }
 
+/// The identity constructors read the PROVIDERS' own constants, so no
+/// caller anywhere spells a family string (L3). Held against the
+/// providers themselves: a constant that moved without its constructor
+/// makes these disagree, which is the only way this could go wrong
+/// quietly.
+#[test]
+fn the_identity_constructors_name_the_providers_they_stand_for() {
+    assert_eq!(
+        LoweringIdentity::reference(),
+        ReferenceBackend::new().identity()
+    );
+    assert_eq!(
+        LoweringIdentity::cpu_production(),
+        ProductionBackend::new().identity()
+    );
+    assert_eq!(
+        LoweringIdentity::device_matmul(),
+        DevicePlanBackend::new(CpuBackend, "cpu-as-device", WeightFormat::F32).identity()
+    );
+    assert_eq!(
+        LoweringIdentity::cpu_production().to_string(),
+        "cpu-production/v1"
+    );
+}
+
 /// A backend that answers for another's arithmetic under a name and an
 /// identity of its own choosing — so the two fields can be varied
 /// independently, which is the only way to show one is not derived from
@@ -83,6 +108,11 @@ pub(super) struct Relabelled {
     inner: ReferenceBackend,
     name: &'static str,
     identity: LoweringIdentity,
+    /// How many times this provider was asked to place its operands.
+    /// `prepare` returns nothing, so a provider that records being asked
+    /// is the only way to see whether a shared handle delegated it or
+    /// swallowed it into the trait's empty default.
+    prepares: std::sync::atomic::AtomicUsize,
 }
 
 impl Relabelled {
@@ -91,7 +121,12 @@ impl Relabelled {
             inner: ReferenceBackend::new(),
             name,
             identity: LoweringIdentity::new(family, revision),
+            prepares: std::sync::atomic::AtomicUsize::new(0),
         }
+    }
+
+    pub(super) fn prepares(&self) -> usize {
+        self.prepares.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 
@@ -148,7 +183,38 @@ impl PlanBackend for Relabelled {
     fn residual_add(&self, acc: &mut [f32], delta: &[f32]) {
         self.inner.residual_add(acc, delta)
     }
+
+    // ── two PROVIDED methods, deliberately overridden ────────────────
+    //
+    // Everything above is a required method: a provider that did not
+    // implement it would not compile. These two have trait defaults, so
+    // they are the ones that can silently answer for a provider that
+    // meant to answer for itself — which is what L3's shared handle has
+    // to be shown not to do.
+
+    fn prepare(&self, weights: &[WeightSlice<'_>]) {
+        self.prepares
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.inner.prepare(weights);
+    }
+
+    fn scale_row(&self, row: &mut [f32], _scale: f32) {
+        row.fill(RELABELLED_MARK);
+    }
+
+    fn dispatch_stats(&self) -> Option<DispatchStats> {
+        Some(DispatchStats {
+            device_nanos: 0,
+            submissions: RELABELLED_SUBMISSIONS,
+        })
+    }
 }
+
+/// What [`Relabelled`]'s own `scale_row` writes, and what its own
+/// `dispatch_stats` reports. Distinctive on purpose: the trait's defaults
+/// produce neither.
+pub(super) const RELABELLED_MARK: f32 = -42.0;
+pub(super) const RELABELLED_SUBMISSIONS: u64 = 7;
 
 /// The control. One diagnostic name over two identities are two
 /// providers; one identity under two names is one provider. A field that

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_registry.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_registry.rs
@@ -10,18 +10,22 @@
 //! production provider, handed to the carried path, refuses rather than
 //! constructing the provider anyway.
 
-use super::super::backend::{PlanBackend, WeightFormat, WeightFormats};
+use super::super::backend::{PlanBackend, ProjectCall, WeightFormat, WeightFormats, WeightSlice};
 use super::super::device::DevicePlanBackend;
-use super::super::lowering::{LoweringError, LoweringIdentity, LoweringRegistry};
+use super::super::lowering::{LoweringError, LoweringIdentity, LoweringRegistry, SharedProvider};
 use super::super::prepared::{ExecutionSlice, PreparedOperands};
 use super::super::production::{self, ProductionBackend};
 use super::super::reference::{self, ReferenceBackend};
 use super::super::{execute_plan, execute_plan_via};
-use super::lowering_identity::Relabelled;
+use super::lowering_identity::{Relabelled, RELABELLED_MARK, RELABELLED_SUBMISSIONS};
+use crate::error::VindexError;
 use crate::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
 use crate::format::vindex3::inspect::inspect_container;
 use crate::format::vindex3::opplan::exec::operands::OperandStore;
+use crate::format::vindex3::opplan::exec::realization::RepresentationFacts;
+use crate::format::vindex3::opplan::planned::Operation;
 use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
+use crate::format::vindex3::represent::codec::CodecRegistry;
 use larql_compute::cpu::CpuBackend;
 
 const SCRATCH_FAMILY: &str = "scratch-provider";
@@ -278,6 +282,151 @@ fn the_carried_path_refuses_an_absent_provider_rather_than_constructing_one() {
     .to_string();
     assert!(err.contains("cpu-production/v1"), "{err}");
     assert_eq!(fixture.store.load_count(), 0);
+}
+
+/// A registry says what it holds. Empty until something is registered,
+/// and its `Debug` is the identities it holds, in registration order —
+/// what a caller sees when it prints the authority it is carrying.
+#[test]
+fn an_empty_registry_says_so_and_debug_lists_what_it_holds() {
+    let empty = LoweringRegistry::new();
+    assert!(empty.is_empty());
+    assert_eq!(empty.len(), 0);
+
+    let shipped = LoweringRegistry::shipped();
+    assert!(!shipped.is_empty());
+    let rendered = format!("{shipped:?}");
+    for identity in shipped.identities() {
+        assert!(
+            rendered.contains(&identity.family),
+            "{identity} is registered and unlisted: {rendered}"
+        );
+    }
+    assert!(
+        rendered.find("reference").unwrap() < rendered.find("cpu-production").unwrap(),
+        "registration order: {rendered}"
+    );
+
+    // An identity that could not be keyed converts to the parse error it
+    // carried rather than to a second wrapping of it: the caller sees
+    // what is wrong with the identity, not that a registry was involved.
+    let invalid = LoweringRegistry::new()
+        .register(Box::new(Relabelled::new("x", "not a family", 1)))
+        .unwrap_err();
+    let carried: VindexError = invalid.into();
+    assert!(
+        carried.to_string().contains("` `") && !carried.to_string().contains("already"),
+        "{carried}"
+    );
+}
+
+/// **A shared handle IS the provider it wraps.** L3 hands registry
+/// entries out as `Arc<dyn PlanBackend + Send>` so a runtime can own what
+/// it resolved, and `PlanBackend` is implemented for `Arc<T>` by
+/// delegating every method. Held here rather than assumed: a whole
+/// traversal through the handle — embed, norm, attention, feed-forward,
+/// the head, the residual write — is bit-identical to the same provider
+/// called directly, and the methods a dense stack does not reach are
+/// asked directly beside it.
+#[test]
+fn a_shared_handle_is_the_provider_it_wraps() {
+    let fixture = dense();
+    let registry = LoweringRegistry::shipped();
+    let shared = registry.provider_shared(&production_id()).unwrap();
+    let direct = ProductionBackend::new();
+
+    assert_eq!(shared.name(), direct.name());
+    assert_eq!(shared.identity(), direct.identity());
+    assert_eq!(shared.dispatch_stats(), direct.dispatch_stats());
+
+    let through = execute_plan(&fixture.plan, &fixture.store, &TOKENS, &shared).unwrap();
+    let beside = execute_plan(&fixture.plan, &fixture.store, &TOKENS, &direct).unwrap();
+    assert_eq!(
+        bits(through.logits.as_deref().unwrap()),
+        bits(beside.logits.as_deref().unwrap()),
+        "the handle executes what the provider executes"
+    );
+    assert_eq!(through.final_hidden(), beside.final_hidden());
+
+    // The projection entry point, which a dense softmax stack never
+    // reaches through `project` — asked of both, compared.
+    let weight = [1.0f32, 2.0, 3.0, 4.0];
+    let x = [1.0f32, -1.0];
+    let call = || ProjectCall {
+        weight: WeightSlice::F32(&weight),
+        out_dim: 2,
+        in_dim: 2,
+        x: &x,
+    };
+    assert_eq!(
+        shared.project(call()).unwrap(),
+        direct.project(call()).unwrap()
+    );
+
+    // The provided methods, which are the ones a delegation could quietly
+    // drop: a selection, the scalar row scale, the residency hint, and
+    // the dense projector the recurrences dispatch through.
+    let planned = fixture
+        .plan
+        .planned_operands()
+        .into_iter()
+        .find(|p| matches!(p.operation, Operation::Project(_)))
+        .expect("the fixture plans projections");
+    let facts = RepresentationFacts::resolve_in(CodecRegistry::builtin(), "F32");
+    assert_eq!(
+        shared.select(&planned, &facts).unwrap(),
+        direct.select(&planned, &facts).unwrap()
+    );
+    let (mut a, mut b) = ([1.0f32, 2.0], [1.0f32, 2.0]);
+    shared.scale_row(&mut a, 3.0);
+    direct.scale_row(&mut b, 3.0);
+    assert_eq!(a, b);
+    shared.prepare(&[WeightSlice::F32(&weight)]);
+    let _ = shared.dense_projector();
+}
+
+/// And the sharper half of the same claim: a handle must never fall back
+/// to a trait DEFAULT for a provider that overrode it. `Relabelled`
+/// overrides two provided methods with answers no default produces, and
+/// both survive the trip through the `Arc`.
+#[test]
+fn a_shared_handle_never_falls_back_to_a_trait_default() {
+    let identity = LoweringIdentity::new(SCRATCH_FAMILY, 1);
+    let registry = LoweringRegistry::new()
+        .register(scratch("marked", 1))
+        .unwrap();
+    let shared = registry.provider_shared(&identity).unwrap();
+
+    let mut row = [1.0f32, 2.0, 3.0];
+    shared.scale_row(&mut row, 2.0);
+    assert_eq!(
+        row, [RELABELLED_MARK; 3],
+        "the handle answered with the trait default instead of the provider's own scale_row"
+    );
+    assert_eq!(
+        shared.dispatch_stats().map(|s| s.submissions),
+        Some(RELABELLED_SUBMISSIONS),
+        "the handle answered `None` — the trait default — for a provider that reports stats"
+    );
+
+    // `prepare` returns nothing, so the only way to see whether the
+    // handle delegated it or swallowed it into the trait's empty default
+    // is a provider that records being asked.
+    let recording = std::sync::Arc::new(Relabelled::new("recording", SCRATCH_FAMILY, 2));
+    let handle: SharedProvider = recording.clone();
+    handle.prepare(&[WeightSlice::F32(&[1.0, 2.0])]);
+    assert_eq!(
+        recording.prepares(),
+        1,
+        "the handle swallowed `prepare` instead of delegating it"
+    );
+
+    // The borrowed form the carried path uses answers the same way, so
+    // the two ways of holding one provider cannot disagree.
+    let borrowed = registry.provider(&identity).unwrap();
+    let mut row = [1.0f32, 2.0, 3.0];
+    borrowed.scale_row(&mut row, 2.0);
+    assert_eq!(row, [RELABELLED_MARK; 3]);
 }
 
 /// And the positive control: through a registry that holds the provider,

--- a/crates/larql-vindex/tests/lowering_closure.rs
+++ b/crates/larql-vindex/tests/lowering_closure.rs
@@ -1,0 +1,127 @@
+//! **The closure over provider construction** — LOWERING-PLUGIN-1, L3.
+//!
+//! The fate of every provider construction site was frozen in
+//! `docs/represent/forecasts/lowering-plugin-1-notes.json` before any was
+//! touched: route through the registry, move into the one composition
+//! site, or stay as an implementation detail inside a provider. This is
+//! the assertion that the table holds — every non-test source file in the
+//! workspace that still spells a provider constructor is one of the
+//! files the table says may. A forgotten `ProductionBackend::new()`
+//! anywhere else is the hidden default the programme exists to prevent,
+//! and it goes red here rather than surviving as an unregistered path.
+//!
+//! Examples are excluded as tests are: not shipped, not production paths.
+
+use std::path::{Path, PathBuf};
+
+/// What a construction looks like in source.
+const CONSTRUCTORS: [&str; 4] = [
+    "ProductionBackend::new()",
+    "ReferenceBackend::new()",
+    "DevicePlanBackend::new(",
+    "DevicePlanBackend::with_formats(",
+];
+
+/// The files the fate table permits to construct a provider, and why.
+const PERMITTED: [(&str, &str); 3] = [
+    (
+        "larql-vindex/src/format/vindex3/opplan/exec/lowering.rs",
+        "the registry's own `shipped()` — the one place the shipped providers are built, as a value",
+    ),
+    (
+        "larql-vindex/src/format/vindex3/opplan/exec/device.rs",
+        "the device provider's CPU glue — an implementation detail inside a provider, not authority over which provider runs",
+    ),
+    (
+        "larql-cli/src/commands/primary/vindex3_cmd/prepare.rs",
+        "the CLI's composition site `lowerings_for` — the device arms register the provider they configure",
+    ),
+];
+
+/// Every `.rs` file under a crate's `src/` that is not itself a test.
+fn production_sources() -> Vec<PathBuf> {
+    let crates = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/")
+        .to_path_buf();
+    let mut out = Vec::new();
+    let mut stack = vec![crates];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if path.is_dir() {
+                if !matches!(name.as_str(), "target" | "tests" | "benches" | "examples") {
+                    stack.push(path);
+                }
+                continue;
+            }
+            if name.ends_with(".rs")
+                && !name.ends_with("_tests.rs")
+                && !name.starts_with("tests")
+                && path.components().any(|c| c.as_os_str() == "src")
+            {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+fn constructs(path: &Path) -> Vec<&'static str> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    CONSTRUCTORS
+        .into_iter()
+        .filter(|needle| text.contains(needle))
+        .collect()
+}
+
+fn permitted(path: &Path) -> bool {
+    let shown = path.to_string_lossy().replace('\\', "/");
+    PERMITTED.iter().any(|(suffix, _)| shown.ends_with(suffix))
+}
+
+#[test]
+fn only_the_fate_table_s_permitted_files_construct_a_provider() {
+    let sources = production_sources();
+    assert!(
+        sources.len() > 100,
+        "the scan found only {} files, so it is not looking where it thinks",
+        sources.len()
+    );
+    let strays: Vec<String> = sources
+        .iter()
+        .filter(|p| !permitted(p))
+        .filter_map(|p| {
+            let found = constructs(p);
+            (!found.is_empty()).then(|| format!("{} constructs {found:?}", p.display()))
+        })
+        .collect();
+    assert!(
+        strays.is_empty(),
+        "a provider is constructed outside the fate table's permitted sites — the hidden \
+         default the programme exists to prevent: {strays:?}"
+    );
+}
+
+/// The control: the scan finds every permitted site, so an empty stray
+/// list above means "nothing there" rather than "nothing looked at".
+#[test]
+fn the_scan_finds_each_permitted_site_constructing_a_provider() {
+    let sources = production_sources();
+    for (suffix, why) in PERMITTED {
+        let found = sources
+            .iter()
+            .find(|p| p.to_string_lossy().replace('\\', "/").ends_with(suffix))
+            .unwrap_or_else(|| panic!("{suffix} is not in the scan"));
+        assert!(
+            !constructs(found).is_empty(),
+            "{suffix} no longer constructs a provider; the fate table says it does ({why})"
+        );
+    }
+}

--- a/docs/represent/forecasts/lowering-plugin-1-notes.json
+++ b/docs/represent/forecasts/lowering-plugin-1-notes.json
@@ -102,6 +102,50 @@
         "cargo test -p larql-vindex --no-run"
       ],
       "deviations_from_forecast": "None. Selection, accounting and execution unchanged: the diff touches `lowering.rs`, one method in `backend.rs` (a Debug impl), one method each in `mod.rs` and `prepared.rs`, and tests."
+    },
+    "L3": {
+      "name": "existing providers behind the registry",
+      "status": "fate table frozen before any replacement; implementation follows in this branch",
+      "branch": "lowering-l3",
+      "base": "L2 (#466) on main 4e8147ef — the tree main will be once #466 merges; rebased onto that merge before the PR",
+      "date": "2026-09-09",
+      "the_question": "Can every production selection path obtain its lowering provider from the carried registry, with zero behavioural movement and no hidden construction fallback?",
+      "rule": "Every construction site recorded by L2 is assigned a fate HERE, before it is touched. At the end a source scan asserts that exactly the sites marked `stays` still construct a provider, so a forgotten `ProductionBackend::new()` cannot become the hidden default that defeats the programme.",
+      "fates": {
+        "larql-cli/src/commands/primary/vindex3_cmd/prepare.rs:196  ExecBackend::Reference → ReferenceBackend::new()": "route — the composition site resolves `reference/v1` from the registry",
+        "larql-cli/src/commands/primary/vindex3_cmd/prepare.rs:197  ExecBackend::Production → ProductionBackend::new()": "route — `cpu-production/v1`",
+        "larql-cli/src/commands/primary/vindex3_cmd/prepare.rs:203  ExecBackend::ProductionNvfp4 → ProductionBackend::new()": "route — `cpu-production/v1` (the arm differs upstream, in the wanted representation, not in the provider)",
+        "larql-cli/src/commands/primary/vindex3_cmd/prepare.rs:213  ExecBackend::ProductionQ8 | Q6k | Q4k → ProductionBackend::new()": "route — `cpu-production/v1`",
+        "larql-cli/src/commands/primary/vindex3_cmd/prepare.rs:230  ExecBackend::MetalMxfp4 → DevicePlanBackend::with_formats(metal-q1-mxfp4-ffn)": "construction moves INTO the composition site: the configured device provider is registered under `device-matmul/v1` and resolved by identity",
+        "larql-cli/src/commands/primary/vindex3_cmd/prepare.rs:262  ExecBackend::MetalMxfp4All → DevicePlanBackend::with_formats(metal-q1-mxfp4-all)": "same",
+        "larql-cli/src/commands/primary/vindex3_cmd/prepare.rs:313  ExecBackend::MetalNvfp4 | NoHead | Ffn → DevicePlanBackend::with_formats(metal-q2-nvfp4-*)": "same",
+        "larql-cli/src/commands/primary/vindex3_cmd/prepare.rs:328  ExecBackend::Metal → DevicePlanBackend::new(metal-r3-f16)": "same",
+        "larql-cli/src/commands/primary/vindex3_cmd/realizations.rs:92  bind_and_reconcile → ProductionBackend::new()": "route — through the composition site as `ExecBackend::Production`",
+        "larql-cli/src/commands/primary/vindex3_cmd/realizations.rs:130  report_through → ProductionBackend::new()": "route — same",
+        "larql-cli/src/commands/primary/vindex3_cmd/sensitivity.rs:387  DevicePlanBackend::new(metal-r3-f16)": "route — through the composition site as `ExecBackend::Metal`, which is the identical configuration; one fewer place that spells `metal-r3-f16`",
+        "larql-server/src/vindex3.rs:135  Vindex3Runtime::open(.., ProductionBackend::new())": "route — `Vindex3Runtime::open_via(.., &LoweringRegistry::shipped(), &LoweringIdentity::cpu_production())`",
+        "larql-lql/src/executor/vindex3.rs:833  Vindex3Runtime::open(.., ProductionBackend::new())": "route — same; the `V3Runtime` alias becomes `Vindex3Runtime<SharedProvider>`",
+        "larql-vindex/src/format/vindex3/opplan/exec/mod.rs  execute_text → ReferenceBackend::new()": "route — through `LoweringRegistry::shipped()` and `reference/v1`; it is the oracle by request, not by privileged construction",
+        "larql-vindex/src/format/vindex3/opplan/exec/device.rs:122  glue: ProductionBackend::new()": "STAYS — the device provider's own CPU glue, an implementation detail inside a provider, not authority over which provider runs",
+        "larql-vindex/src/format/vindex3/opplan/exec/lowering.rs  shipped()": "STAYS — the one place the shipped providers are constructed, as a value",
+        "larql-server/examples/v3_request_phase_profile.rs, larql-vindex/examples/cpu7c_arms.rs": "out of the gate — examples are not production paths; the scan excludes `examples/` as it excludes `tests/`; untouched in L3"
+      },
+      "closure_assertion": "`crates/larql-vindex/tests/lowering_closure.rs` walks every non-test `.rs` under `crates/*/src` and refuses any file that spells `ProductionBackend::new()`, `ReferenceBackend::new()`, `DevicePlanBackend::new(` or `DevicePlanBackend::with_formats(` other than the two `STAYS` files and the CLI composition site — with a positive control that the walk finds those three.",
+      "design_frozen_before_implementation": {
+        "shared_provider": "Registry entries become `Arc<dyn PlanBackend + Send>` (`SharedProvider`), with `PlanBackend` implemented for `Arc<T>` by delegation of EVERY method, provided ones included, so a shared handle never falls back to a trait default the inner provider overrides. A runtime can then own the provider it resolved.",
+        "runtime": "`Vindex3Runtime::open_via(container, component, &registry, &identity)` resolves the provider FIRST and opens the container second, so a refusal costs no I/O — the witness is a refusal on a container path that does not exist. The runtime holds the resolved provider, not the registry; whether it must hold the registry to invalidate is L4's.",
+        "cli": "`with_plan_backend` keeps its visitor and becomes compose-then-resolve: `lowerings_for(ExecBackend) -> (LoweringRegistry, LoweringIdentity)` is the single composition site (shipped providers plus the configured device provider for the device arms), and `with_lowerings(&registry, &identity, visitor)` is the seam a test hands a registry of its own to.",
+        "identities": "`LoweringIdentity::reference()`, `::cpu_production()`, `::device_matmul()` read the providers' own constants; no caller spells a family string."
+      },
+      "success_conditions_pinned": [
+        "13 construction sites outside larql-vindex → 1 composition site (prepare.rs); server and LQL resolve by identity from `shipped()` and construct nothing",
+        "`execute_text` loses its direct backend construction",
+        "existing CLI backend choices resolve to the same provider identities and the same provider names as before",
+        "for every existing fixture: selected RealizationId, logits, hidden state, resource ledger unchanged — the existing suites are the witness, with no assertion changed",
+        "kernel-plane files: 33",
+        "no RealizationRecord schema change (L4); no capability work; no metal-lowered migration",
+        "F4 through a production path: `Vindex3Runtime::open_via` with a registry missing `cpu-production/v1` refuses by identity naming the registered providers, before any I/O; and the CLI seam `with_lowerings` refuses the same way with the store's load count at zero"
+      ]
     }
   }
 }

--- a/docs/represent/forecasts/lowering-plugin-1-notes.json
+++ b/docs/represent/forecasts/lowering-plugin-1-notes.json
@@ -105,7 +105,7 @@
     },
     "L3": {
       "name": "existing providers behind the registry",
-      "status": "fate table frozen before any replacement; implementation follows in this branch",
+      "status": "built and held",
       "branch": "lowering-l3",
       "base": "L2 (#466) on main 4e8147ef — the tree main will be once #466 merges; rebased onto that merge before the PR",
       "date": "2026-09-09",
@@ -145,7 +145,57 @@
         "kernel-plane files: 33",
         "no RealizationRecord schema change (L4); no capability work; no metal-lowered migration",
         "F4 through a production path: `Vindex3Runtime::open_via` with a registry missing `cpu-production/v1` refuses by identity naming the registered providers, before any I/O; and the CLI seam `with_lowerings` refuses the same way with the store's load count at zero"
-      ]
+      ],
+      "what_landed": [
+        "Registry entries are `SharedProvider = Arc<dyn PlanBackend + Send>`; `provider_shared(&id)` hands out a handle a runtime can own while the registry keeps holding it. `PlanBackend` is implemented for `Arc<T: PlanBackend + Send + ?Sized>` by delegating every method, provided ones included.",
+        "`LoweringIdentity::reference() / ::cpu_production() / ::device_matmul()` read the providers' own constants; no caller spells a family.",
+        "`Vindex3Runtime::open_via` / `open_with_via` resolve the provider FIRST and open the container second. Server (`load_v3_model`) and LQL (`bind`) open through them from `LoweringRegistry::shipped()` with `cpu-production/v1`; `V3Runtime` and `V3Model::runtime` are typed over `SharedProvider`.",
+        "CLI: `lowerings_for(ExecBackend) -> (LoweringRegistry, LoweringIdentity)` is the single composition site — the device arms register the provider they configure — `with_plan_backend` is compose-then-resolve, and `with_lowerings(&registry, &identity, visitor)` is the seam a test hands its own registry to. `realizations` (both sites) and `sensitivity` route through `lowerings_for`.",
+        "`execute_text` asks the shipped registry for `reference/v1`.",
+        "`crates/larql-vindex/tests/lowering_closure.rs` holds the fate table: the only non-test files constructing a provider are `lowering.rs` (`shipped()`), `device.rs` (glue) and `prepare.rs` (composition), with a control that the scan finds all three."
+      ],
+      "witnesses": {
+        "closure": "`only_the_fate_table_s_permitted_files_construct_a_provider` + control `the_scan_finds_each_permitted_site_constructing_a_provider` — larql-vindex/tests/lowering_closure.rs",
+        "F4_runtime_path": "`a_registry_without_the_provider_refuses_before_touching_the_container` — larql-inference/src/vindex3/tests/mod.rs: `open_via` on a container path that does not exist, with a registry holding only `reference/v1`, refuses naming `cpu-production/v1` and `registered: reference/v1`, and the message is the registry's, not the filesystem's — resolution provably precedes any I/O",
+        "runtime_positive_control": "`the_shipped_registry_opens_the_production_provider_the_direct_path_did` — same identity, same name, prepares",
+        "F4_cli_seam": "`the_seam_refuses_an_absent_provider_with_nothing_read` — larql-cli vindex3_cmd/tests/lowerings.rs: `with_lowerings` with a registry lacking production refuses by identity with the store's load count at 0; the shipped registry prepares and reads",
+        "cli_choices_unchanged": "`every_interpreted_backend_choice_resolves_to_its_provider_by_identity` — each interpreted `--backend` resolves to the identity and the provider NAME it constructed before, and composes exactly the shipped identities"
+      },
+      "measurements": {
+        "kernel_plane_files": 33,
+        "provider_construction_files_outside_vindex_non_test": {
+          "before": "3 files, 13 sites",
+          "after": "1 file (prepare.rs), 4 sites — all device configurations inside `lowerings_for`"
+        },
+        "provider_construction_files_inside_vindex_non_test": "2 — `lowering.rs` (shipped) and `device.rs` (glue), both `STAYS` in the fate table",
+        "existing_suites": "larql-vindex lib 4659 (unchanged), larql-lql lib 743, larql-server lib 591, larql-cli vindex3_cmd 58 (56 before + 2), external provider suites all pass; no existing assertion changed"
+      },
+      "observations_for_later_waves": [
+        "A provider must be `Send` to be shared: the `Arc<T>` delegation needs it for the trait's `Sync` supertrait to hold on the handle. Every in-tree provider is; an external one that is not would be refused at registration by the type system, which is the right place.",
+        "The runtime owns the RESOLVED provider, not the registry it resolved through; the registry is dropped after `open_via` in the server and LQL paths. L4's invalidation-by-name needs the runtime (or the prepared image) to hold what it resolved against — that is L4's first decision.",
+        "`lowerings_for` registers ONE device instance per invocation, chosen by the arm, so a process runs one device configuration at a time — the same shape the CLI already had. A caller wanting several device configurations resident at once needs distinct identities (L2's forced answer), which no CLI arm asks for today.",
+        "`sensitivity` now fails on a missing Metal device with the `--backend metal` arm's message rather than its own; one fewer place spells `metal-r3-f16`.",
+        "F4 held on both production seams without a finding — the class the forecast predicted did not appear, because the fate table was frozen first and the closure scan refuses a stray. The two examples that construct providers stay outside the gate."
+      ],
+      "deviations_from_forecast": "None. Selection, accounting, execution untouched (no file under `represent/`, no `select`, no `prepared.rs` beyond `load_via` from L2, no `accounting.rs`); kernel-plane count 33.",
+      "found_in_ci_after_the_local_gates_passed": {
+        "rule": "Written here rather than quietly fixed: two defects reached CI because the wave's own gate list was narrower than CI's, and the gate list is corrected below.",
+        "1_a_source_scan_guard_fired_correctly": "`larql-server/tests/test_capabilities.rs::backends_match_the_v3_binding` derives the advertised `runtime.backends` from what the V3 loader actually binds, by reading the loader's source for `ProductionBackend`. L3 made that loader RESOLVE `cpu-production/v1` from the carried registry instead of constructing a provider, so the guard did exactly its job. Re-derived against the new authority: it reads the identity the loader names, and treats `device_matmul` or `MetalBackend` as the Metal signal that would widen the list. The guard's meaning is unchanged; only the fact it reads moved, because the authority moved.",
+        "2_the_coverage_policy_caught_an_untested_claim": "`exec/backend.rs` fell 99.22% → 73.58% and `exec/lowering.rs` sat at 88.51%, both under the 90% per-file minimum. The uncovered code was L3's own `impl PlanBackend for Arc<T>` delegation, plus `LoweringIdentity::cpu_production()` / `::device_matmul()`, the registry's `Debug` and `is_empty`, and the `LoweringError::Invalid` conversion. Nothing inside larql-vindex exercised the delegation: the carried path BORROWS (`provider`) and only the inference runtime SHARES (`provider_shared`), which is another crate. So the wave's own design claim — 'a shared handle never falls back to a trait default the provider underneath overrides' — was stated in a doc comment and asserted nowhere.",
+        "fixed_by": [
+          "`a_shared_handle_is_the_provider_it_wraps` — a whole traversal through the `Arc` handle, bit-identical to the same provider called directly, plus `project`, `select`, `scale_row`, `prepare`, `dense_projector` and `dispatch_stats` asked of both and compared.",
+          "`a_shared_handle_never_falls_back_to_a_trait_default` — the test double now overrides two PROVIDED methods (`scale_row`, `dispatch_stats`) with answers no default produces, and both survive the trip through the handle; the borrowed form answers identically, so the two ways of holding one provider cannot disagree.",
+          "`the_identity_constructors_name_the_providers_they_stand_for` — each constructor equals the provider's own `identity()`, so a constant that moved without its constructor cannot pass.",
+          "`an_empty_registry_says_so_and_debug_lists_what_it_holds` — `is_empty`, the `Debug` listing in registration order, and the `Invalid` conversion carrying the parse error rather than re-wrapping it."
+        ],
+        "why_the_local_gates_missed_them": "The gate list ran `cargo test -p larql-server --lib`, which excludes `tests/` — where that guard lives — and never ran the coverage policy at all. Neither omission is CI's fault.",
+        "gate_list_corrected": [
+          "every dependent crate's FULL target set, not `--lib`: `cargo test -p larql-server -p larql-lql -p larql-inference -p larql-cli` (5,091 tests, 0 failed)",
+          "the coverage policy the vindex workflow runs: `cargo llvm-cov --package larql-vindex` then `scripts/check_coverage_policy.py coverage/larql-vindex/summary.json crates/larql-vindex/coverage-policy.json`",
+          "`cargo mutants --in-diff` is informational in CI but reads the wave's own diff: read what it MISSED before merging, and kill the ones that are the wave's."
+        ],
+        "3_the_informational_mutants_run": "`cargo mutants --in-diff` on the PR reported three MISSED before the job was canceled at 45 minutes. One was L3's own: `<impl PlanBackend for Arc<T>>::prepare` replaced with an empty body SURVIVED, because `prepare` returns nothing and the new delegation test merely called it — coverage without a claim. Killed by giving the test double a counter and asserting the handle reached it, and verified by applying the mutant by hand and watching that assertion fail. The other two are pre-existing gaps in CLI report paths L3 happened to touch (`realizations::bind_and_reconcile`, `sensitivity::capture_moments`): each prints a report and returns `Ok(())`, and nothing asserts the printing, so a body replaced with `Ok(())` survives. Recorded rather than fixed — out of this wave's scope, and the check is informational."
+      }
     }
   }
 }


### PR DESCRIPTION
## What

Wave L3 of LOWERING-PLUGIN-1 (forecast #464, L1 #465, L2 #466), answering one question: can every production selection path obtain its lowering provider from the carried registry, with zero behavioural movement and no hidden construction fallback?

The rule the wave was built under: **every construction site L2 recorded is assigned a fate before any of them is touched**, and a source scan then holds the table to account — so a forgotten `ProductionBackend::new()` cannot become the hidden default that defeats the programme. The fate table is in `docs/represent/forecasts/lowering-plugin-1-notes.json` and was frozen in the first commit of this PR.

- Registry entries become `SharedProvider = Arc<dyn PlanBackend + Send>`, with `PlanBackend` implemented for `Arc<T>` by delegating **every** method — provided ones included — so a shared handle never falls back to a trait default the provider underneath overrides.
- `Vindex3Runtime::open_via` / `open_with_via` resolve the provider **first** and open the container **second**. The server (`load_v3_model`) and LQL (`bind`) open through them from `LoweringRegistry::shipped()` by identity; `V3Runtime` and `V3Model::runtime` are typed over the shared handle.
- CLI: `lowerings_for(ExecBackend) -> (LoweringRegistry, LoweringIdentity)` is the single composition site — the device arms register the provider they configure — `with_plan_backend` becomes compose-then-resolve, and `with_lowerings(&registry, &identity, visitor)` is the seam a test hands its own registry to. `realizations` (both sites) and `sensitivity` route through it.
- `execute_text` asks the shipped registry for `reference/v1`: the oracle by request, not by privileged construction.

## The closure

| | before | after |
|---|---|---|
| provider construction outside `larql-vindex` (non-test) | 3 files, 13 sites | **1 file, 4 sites** — all device configurations inside `lowerings_for` |
| inside `larql-vindex` (non-test) | — | **2** — `lowering.rs` (`shipped()`) and `device.rs` (the device provider's own CPU glue) |

`crates/larql-vindex/tests/lowering_closure.rs` walks every non-test `.rs` under `crates/*/src` and refuses any file that spells `ProductionBackend::new()`, `ReferenceBackend::new()`, `DevicePlanBackend::new(` or `DevicePlanBackend::with_formats(` other than those three, with a positive control that the scan finds all three.

## F4, on two production seams

The falsifier this wave existed to test: *an externally registered provider succeeds at selection, but execution or serving later consults a built-in backend anyway.*

| seam | witness |
|---|---|
| runtime | `a_registry_without_the_provider_refuses_before_touching_the_container` — `open_via` with a registry holding only `reference/v1`, on a container path that **does not exist**, refuses naming `cpu-production/v1` and `registered: reference/v1`. The message is the registry's, not the filesystem's, so resolution provably precedes any I/O. |
| CLI | `the_seam_refuses_an_absent_provider_with_nothing_read` — `with_lowerings` refuses the same way with the store's load count at **0**. |
| positive control | `the_shipped_registry_opens_the_production_provider_the_direct_path_did` — same identity, same provider name, prepares. |
| choices unchanged | `every_interpreted_backend_choice_resolves_to_its_provider_by_identity` — each interpreted `--backend` resolves to the identity and the provider name it constructed before. |

F4 held on both seams without a finding: the class the forecast predicted did not appear, because the fate table was frozen first and the closure scan refuses a stray.

## Unchanged

- Selection, accounting, execution semantics: **0 changes**. No file under `represent/`, no `select`, no `accounting.rs`, nothing in `prepared.rs` beyond L2's `load_via`.
- For every existing fixture: selected `RealizationId`, logits, hidden state and resource ledger unchanged — the existing suites are the witness, with no assertion changed.
- Kernel-plane files: **33**.
- No `RealizationRecord` schema change (that is L4), no capability work, no `metal-lowered` migration.

## Gates

`cargo fmt --all --check`; clippy `-D warnings` on larql-vindex / larql-cli / larql-inference; `cargo test -p larql-vindex`; `cargo check --workspace --all-targets`; kernel-plane count measured with the inventory's method; `scripts/check_contract_index.py` and `scripts/check_doc_links.py`.

Rebased onto `097d54a5` (the merge of #466) and re-verified there: `larql-vindex` 4,699 lib tests pass, 0 failed — the wave's own tests on top of what ACTUATION-1 (#463) added to main.
