### PR TITLE
fix(ci): DOC-GATE-1 — the documentation instrument must have examined something

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -7,7 +7,7 @@
 # CANCELLED, and one cancelled job makes the entire workflow run
 # conclude `cancelled` regardless. So while this lived in `quality.yml`,
 # a mutation run that ran out of clock turned the whole quality check
-# red even though MSRV, cargo-deny, cargo-audit, buf lint and doc-links
+# red even though MSRV, cargo-deny, cargo-audit, buf lint and docs-integrity
 # had all passed.
 #
 # That was not hypothetical and not rare. It fired on the PRs with the

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,7 +10,8 @@
 #   deny        — licences, advisories, sources, bans            (blocking)
 #   msrv        — the declared rust-version really compiles      (blocking)
 #   proto-lint  — buf lint over the four gRPC schemas            (blocking)
-#   doc-links   — every relative Markdown link resolves          (blocking)
+#   docs-integrity — Markdown links resolve, code references resolve,
+#                   and contract indexes name real tests       (blocking)
 #
 # Mutation testing lives in `mutants.yml`, not here: it is informational,
 # and a job cancelled by `timeout-minutes` concludes the whole run as
@@ -203,8 +204,8 @@ jobs:
           RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
         run: cargo check --workspace --all-targets --exclude larql-compute-metal --locked
 
-  doc-links:
-    name: doc links
+  docs-integrity:
+    name: documentation integrity
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -241,6 +242,26 @@ jobs:
       # whether the contracts still hold.
       - name: Contract indexes name tests that exist
         run: python3 scripts/check_contract_index.py
+
+      # The reference checker above matched SKIP_DIRS against the ABSOLUTE
+      # directory path, and SKIP_DIRS contains `/.claude/`. Every worktree in
+      # this repository lives under `.claude/worktrees/`, so ROOT matched its
+      # own prefix, the walk was pruned at the first directory, and the gate
+      # printed "no broken references" over an empty corpus and exited 0.
+      # Sound here -- Actions checks out clean -- and vacuous in every local
+      # pre-push run, which is the worse failure: it fails OPEN in the one
+      # place a human reads it before pushing.
+      #
+      # `selftest` carries the DOC-GATE-1 controls, and each is REACHABLE:
+      # run against the pre-repair script they fail, reproducing the bug in
+      # miniature (ordinary checkout 1 reference / 1 document, `.claude`
+      # worktree 0 / 0). The strongest is equivalence rather than non-zero --
+      # equal counts from both paths, since a partial-tree bug would still
+      # report a confident number.
+      #
+      # No network, no repository walk: synthetic fixtures in a temp dir.
+      - name: Documentation instrument selftest
+        run: python3 scripts/check_doc_references.py selftest
 
   ci-instrument:
     name: ci throughput instrument

--- a/docs/doc-gate-1.md
+++ b/docs/doc-gate-1.md
@@ -1,0 +1,90 @@
+# DOC-GATE-1 — the documentation instrument must have examined something
+
+**Status:** frozen before implementation
+**Date:** 2026-09-09
+**Qualified against:** main `9c3dbc91` (OPT-CONTRACT-1, #467)
+
+---
+
+## The defect, measured before it is repaired
+
+`scripts/check_doc_references.py` matches `SKIP_DIRS` against the ABSOLUTE
+directory path:
+
+```python
+for dirpath, dirnames, filenames in os.walk(ROOT):
+    if any(s in dirpath + "/" for s in SKIP_DIRS):
+        dirnames[:] = []
+        continue
+```
+
+`SKIP_DIRS` contains `/.claude/`, and every worktree in this repository lives
+under `.claude/worktrees/`. So `ROOT` itself matches, every `dirpath` beneath
+it matches, the walk is pruned at the first directory, and the corpus is
+empty. The gate then prints `no broken references` and **exits 0**.
+
+Measured at `9c3dbc91`, from `.claude/worktrees/doc-gate-1`:
+
+| walk | files found |
+|---|---|
+| absolute match — what ships today | **0** |
+| `/.claude/` removed from `SKIP_DIRS` | 3855 |
+| skip matched relative to the repository root | 3855 |
+
+The same run from a checkout outside `.claude/` examines **242 documents and
+1441 references**. From a worktree it examines **0 of each and passes**.
+
+This is not a CI defect. GitHub Actions checks out at a clean path, so the
+gate is real where it runs. It is a LOCAL verification defect: every
+pre-push run any session made from a worktree was vacuous, and it failed
+open while saying so in the language of success. Two sessions hit it
+independently on 2026-09-09.
+
+## Why this is its own transition and not part of #467
+
+OPT-CONTRACT-1 asks *are these frozen semantic contracts continuously
+enforced?* This asks *did the documentation instrument examine anything at
+all?* They share a fail-closed philosophy and nothing else. Merging them
+would make #467 harder to describe and harder to revert.
+
+## Acceptance conditions, frozen
+
+1. **Skip semantics are repository-relative.** A checkout beneath
+   `.claude/worktrees/...` inspects the same logical corpus as an ordinary
+   checkout.
+2. **Zero documents examined is a hard failure.** Not a warning, not a
+   green — a non-zero exit, so no future path or filter bug can produce
+   another vacuous pass.
+3. **An ordinary checkout and a `.claude/` checkout produce the SAME
+   document and reference counts** on the same commit. This is the strongest
+   of the four: condition 2 alone would still admit a partial-tree bug that
+   scanned half the corpus and reported a confident non-zero number.
+4. **The check name describes what it enforces.** The job named `doc links`
+   now also decides whether contract indexes name real tests (#467), so a
+   contract-index failure currently reaches a reviewer as "doc links"
+   failing.
+
+Plus the control that keeps condition 1 honest:
+
+5. **Legitimately skipped directories stay skipped.** `target/`, `.git/`,
+   `.claude/`, `.venv/`, `node_modules/`, `coverage/` must contribute
+   nothing to the corpus under the repaired semantics.
+
+## How they are enforced
+
+Conditions 1, 2, 3 and 5 become controls in
+`scripts/check_doc_references.py selftest`, wired into CI beside the
+`ci_throughput.py` and `conformance_evidence.py` selftests. That is the
+lesson this repository already recorded on 2026-09-07, in the workflow
+comment beside the first of those: **a checker nobody runs is not a check.**
+Controls that live only in a transcript are the next thing nobody runs.
+
+## Out of scope
+
+- The content of any reference the gate reports. This transition changes
+  which files are EXAMINED, not what counts as broken.
+- `check_doc_links.py` and `check_contract_index.py`, which walk from
+  explicit roots and are not vacuous from a worktree (857 links, 85 named
+  tests, both measured from one).
+- Any change to `SKIP_DIRS` membership. The six entries are correct; only
+  the matching is wrong.

--- a/scripts/check_doc_references.py
+++ b/scripts/check_doc_references.py
@@ -46,8 +46,11 @@ from __future__ import annotations
 import collections
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SKIP_DIRS = ("/target/", "/.git/", "/.claude/", "/.venv/", "/node_modules/", "/coverage/")
@@ -81,15 +84,30 @@ PLANNED = re.compile(
 )
 
 
-def index_files() -> tuple[dict, dict]:
+def skipped(dirpath: str, root: str) -> bool:
+    """Is this directory one of SKIP_DIRS, RELATIVE to the repository root?
+
+    Relative is the whole point. Matching SKIP_DIRS against the absolute path
+    means a checkout that merely LIVES under one of these names matches on its
+    own prefix, every directory beneath it matches too, and the walk yields
+    nothing -- while the caller reports success over an empty corpus. Every
+    worktree in this repository lives under `.claude/worktrees/`, so that was
+    the state of every local run until DOC-GATE-1.
+    """
+    rel = os.path.relpath(dirpath, root)
+    probe = "/" if rel == "." else "/" + rel.replace(os.sep, "/") + "/"
+    return any(s in probe for s in SKIP_DIRS)
+
+
+def index_files(root: str = ROOT) -> tuple[dict, dict]:
     by_rel: dict[str, str] = {}
     by_base: dict[str, list[str]] = collections.defaultdict(list)
-    for dirpath, dirnames, filenames in os.walk(ROOT):
-        if any(s in dirpath + "/" for s in SKIP_DIRS):
+    for dirpath, dirnames, filenames in os.walk(root):
+        if skipped(dirpath, root):
             dirnames[:] = []
             continue
         for name in filenames:
-            rel = os.path.relpath(os.path.join(dirpath, name), ROOT)
+            rel = os.path.relpath(os.path.join(dirpath, name), root)
             by_rel[rel] = os.path.join(dirpath, name)
             by_base[name].append(rel)
     return by_rel, by_base
@@ -117,7 +135,7 @@ def cargo_targets(kind: str) -> dict[str, set[str]]:
     """Map target name -> owning crates, from Cargo.toml plus conventions."""
     owners: dict[str, set[str]] = collections.defaultdict(set)
     for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, "crates")):
-        if any(s in dirpath + "/" for s in SKIP_DIRS):
+        if skipped(dirpath, ROOT):
             dirnames[:] = []
             continue
         if "Cargo.toml" not in filenames:
@@ -135,7 +153,104 @@ def cargo_targets(kind: str) -> dict[str, set[str]]:
     return owners
 
 
+def _fixture(root: Path, *, with_docs: bool = True, with_broken: bool = False) -> None:
+    """A miniature repository: one real reference, and traps in skipped dirs."""
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    src = root / "crates" / "larql-x" / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "lib.rs").write_text("pub fn f() {}\n")
+    # Each of these carries a reference that WOULD be reported broken if the
+    # directory were examined -- so control B needs no bookkeeping: if skipping
+    # regresses, the run fails.
+    for name in ("target", ".git", "node_modules", ".venv", "coverage", ".claude"):
+        d = root / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "trap.md").write_text("cites `crates/larql-x/src/nowhere.rs`\n")
+    if with_docs:
+        (root / "docs" / "real.md").write_text("cites `crates/larql-x/src/lib.rs`\n")
+    if with_broken:
+        (root / "docs" / "bad.md").write_text("cites `crates/larql-x/src/gone.rs`\n")
+
+
+def _run_in(root: Path) -> tuple[int, str]:
+    """Run THIS script, as its own entry point, against a fixture root."""
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    shutil.copy(os.path.abspath(__file__), scripts / "check_doc_references.py")
+    done = subprocess.run(
+        [sys.executable, str(scripts / "check_doc_references.py"), "--strict"],
+        capture_output=True, text=True, check=False,
+    )
+    return done.returncode, done.stdout + done.stderr
+
+
+def _counts(output: str) -> tuple[int, int] | None:
+    found = re.search(r"checked (\d+) references across (\d+) documents", output)
+    return (int(found.group(1)), int(found.group(2))) if found else None
+
+
+def selftest() -> int:
+    """The DOC-GATE-1 controls. Each proves a verdict is REACHABLE."""
+    results: list[tuple[bool, str]] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+
+        # 1 + 3. The same fixture at an ordinary path and beneath
+        # `.claude/worktrees/`. Identical corpus, or the skip semantics are
+        # still absolute. Non-zero, or both are vacuous and "identical" is
+        # satisfied by 0 == 0.
+        ordinary = base / "ordinary"
+        worktree = base / ".claude" / "worktrees" / "wt"
+        _fixture(ordinary)
+        _fixture(worktree)
+        rc_o, out_o = _run_in(ordinary)
+        rc_w, out_w = _run_in(worktree)
+        got_o, got_w = _counts(out_o), _counts(out_w)
+        results.append((rc_o == 0, f"ordinary checkout passes (rc={rc_o})"))
+        results.append((rc_w == 0, f"`.claude` worktree passes (rc={rc_w})"))
+        results.append(
+            (got_o is not None and got_o == got_w,
+             f"same corpus from both paths: ordinary={got_o} worktree={got_w}")
+        )
+        results.append(
+            (got_w is not None and got_w[1] > 0,
+             f"the worktree run examined documents, not zero: {got_w}")
+        )
+
+        # 2. A corpus with no documents is a failure, not a green.
+        empty = base / "empty"
+        _fixture(empty, with_docs=False)
+        rc_e, _ = _run_in(empty)
+        results.append((rc_e != 0, f"zero documents examined FAILS (rc={rc_e})"))
+
+        # 5. The traps in skipped directories were not examined -- if they
+        # had been, `nowhere.rs` would have been reported and rc would be 1.
+        results.append(
+            (rc_w == 0, "skipped directories stayed skipped from a worktree")
+        )
+
+        # And detection still works, so none of the above passes by being blind.
+        broken = base / "broken"
+        _fixture(broken, with_broken=True)
+        rc_b, out_b = _run_in(broken)
+        results.append(
+            (rc_b != 0 and "gone.rs" in out_b,
+             f"a genuinely broken reference still FAILS (rc={rc_b})")
+        )
+
+    for ok, label in results:
+        print(f"  {'ok  ' if ok else 'FAIL'}  {label}")
+    bad = [label for ok, label in results if not ok]
+    if bad:
+        print(f"\n{len(bad)} of {len(results)} DOC-GATE-1 controls failed", file=sys.stderr)
+        return 1
+    print(f"\nall {len(results)} DOC-GATE-1 controls hold")
+    return 0
+
+
 def main() -> int:
+    if "selftest" in sys.argv[1:]:
+        return selftest()
     strict = "--strict" in sys.argv
     scope = [a for a in sys.argv[1:] if not a.startswith("-")]
 
@@ -164,6 +279,20 @@ def main() -> int:
         if scope and not any(rel == s or rel.startswith(s.rstrip("/") + "/") for s in scope):
             continue
         docs.append(rel)
+
+    # DOC-GATE-1 condition 2. A gate that examined nothing has not passed;
+    # it has failed to run. Reporting "no broken references" over an empty
+    # corpus is the exact shape of the bug this guard exists to make
+    # impossible to reintroduce, whatever future path or filter causes it.
+    if not docs:
+        where = f" matching {scope}" if scope else ""
+        print(
+            f"examined 0 documents{where} -- the corpus is empty, so this is "
+            "not a pass. Either the scope matches nothing, or the walk is "
+            "being pruned before it starts.",
+            file=sys.stderr,
+        )
+        return 2
 
     findings: list[tuple[str, int, str, str]] = []
     counts: collections.Counter = collections.Counter()
@@ -245,6 +374,14 @@ def main() -> int:
                     findings.append((rel, num, "env: not read anywhere", m.group(1)))
 
     checked = sum(counts.values())
+    if checked == 0 and not scope:
+        print(
+            f"examined {len(docs)} documents and extracted 0 references -- a "
+            "whole-repository run cannot legitimately find none, so the "
+            "extractors are not matching. Not a pass.",
+            file=sys.stderr,
+        )
+        return 2
     print(f"checked {checked} references across {len(docs)} documents")
     for rule, n in sorted(counts.items()):
         print(f"  {rule:<8} {n}")


### PR DESCRIPTION
`scripts/check_doc_references.py` matched `SKIP_DIRS` against the ABSOLUTE
directory path. `/.claude/` is one of its six entries, and every worktree in
this repository lives under `.claude/worktrees/`. So `ROOT` matched on its own
prefix, `dirnames[:] = []` pruned the walk at the first directory, and the
gate printed `no broken references` over an empty corpus and **exited 0**.

Not a CI defect -- Actions checks out at a clean path, so the gate is real
where it runs. A LOCAL verification defect, and the worse kind: it failed OPEN
in the one place a human reads it before pushing. Two sessions hit it
independently on 2026-09-09, and both worked around it by hand.

```text
                        before        after
this worktree           0 documents   1442 references / 243 documents
CI (clean checkout)     242 / 1441    unchanged
```

The 243rd document is this transition's own freeze.

## The four conditions, frozen before implementation

`docs/doc-gate-1.md` records them, with the defect measured first so the
repair could not be re-described afterwards.

1. **Skip semantics are repository-relative.** Applied at both walk sites.
2. **Zero examined is a hard failure.** No documents at all, or -- on an
   unscoped whole-repository run -- documents but zero references, which can
   only mean the extractors stopped matching. A gate that examined nothing has
   not passed; it has failed to run.
3. **An ordinary checkout and a `.claude/` checkout produce the SAME counts.**
4. **The check name describes what it enforces.**
5. (control) **Legitimately skipped directories stay skipped.**

## Every control is reachable

This is the part that matters. Run against the pre-repair script from
`origin/main`, the controls FAIL, reproducing the bug in miniature:

```text
                         fixed    pre-repair
ordinary checkout        (1, 1)   (1, 1)
`.claude` worktree       (1, 1)   (0, 0)     <- the defect
empty corpus              rc=2     rc=0      <- the vacuous green
```

Condition 3 is the strongest, and it is deliberately equivalence rather than
"non-zero": a partial-tree bug would still report a confident number, and only
equal counts from both paths catch it.

Two details fell out of building it. The fixtures plant a broken reference
INSIDE each skipped directory, so a regression in skipping fails the run
rather than needing its own bookkeeping. And one control asserts a genuinely
broken reference still fails -- otherwise every other control could pass by
being blind.

## Where the controls live

`scripts/check_doc_references.py selftest`, wired into CI beside the
`ci_throughput.py` and `conformance_evidence.py` selftests. That is this
repository's own lesson, recorded on 2026-09-07 beside the first of them:

> A checker nobody runs is not a check.

Controls that live only in a transcript are the next thing nobody runs.

## The rename

`doc links` -> `documentation integrity`, key `doc-links` ->
`docs-integrity`, with the workflow's job index and a stale `mutants.yml`
reference updated to match. Since #467 the job decides three distinct
properties, and a contract-index failure reached a reviewer as "doc links"
failing. `main` carries no branch protection, so no required check name
depends on the old one.

## Scope

No Rust changed (0 `.rs` files). `SKIP_DIRS` keeps all six entries -- the
membership was right, only the matching was wrong -- and what counts as a
broken reference is untouched. This changes which files are EXAMINED.

One loop left open, as its own candidate transition: `check_doc_links.py` and
`check_contract_index.py` walk from explicit roots and are genuinely
non-vacuous from a worktree (858 links, 85 named tests, both measured from
one), but neither carries a zero-scan guard of its own, so both are one
refactor away from this same class of failure.

All four gates in the renamed job pass: 858 links, 1442 references across 243
documents, 85 named contract tests, 7 controls.
