### PR TITLE
feat(lowering): L4 — the pin remembers which provider decided it

### DIFF
--- a/crates/larql-inference/src/vindex3/runtime.rs
+++ b/crates/larql-inference/src/vindex3/runtime.rs
@@ -10,6 +10,7 @@
 //! handed in as the backend.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use larql_vindex::format::vindex3::inspect::{inspect_container, SystemInspection};
 use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
@@ -138,6 +139,18 @@ pub struct Vindex3Runtime<B: PlanBackend> {
     plan: ComponentOpPlan,
     store: OperandStore,
     backend: B,
+    /// The lowering authority this runtime was opened through, when it
+    /// was opened through one (LOWERING-PLUGIN-1, L4).
+    ///
+    /// Shared, not owned by the prepared image: the image records which
+    /// provider decided its pins, and this says which providers exist
+    /// now. Keeping them apart is what makes invalidation possible — an
+    /// image that held its own provider would keep a removed one alive.
+    ///
+    /// `None` on the direct-backend path, which named no authority: a
+    /// caller that hands a provider in has declared nothing for the pins
+    /// to be checked against.
+    lowerings: Option<Arc<LoweringRegistry>>,
     model_name: String,
     family: String,
 }
@@ -170,6 +183,7 @@ impl<B: PlanBackend> Vindex3Runtime<B> {
             plan,
             store,
             backend,
+            lowerings: None,
             model_name,
             family,
         })
@@ -383,6 +397,7 @@ impl<B: PlanBackend> Vindex3Runtime<B> {
             plan: self.plan,
             store: self.store,
             backend: self.backend,
+            lowerings: self.lowerings,
             operands,
             model_name: self.model_name,
             family: self.family,
@@ -397,7 +412,7 @@ impl Vindex3Runtime<SharedProvider> {
     pub fn open_via(
         container: &Path,
         component: &str,
-        lowerings: &LoweringRegistry,
+        lowerings: Arc<LoweringRegistry>,
         provider: &LoweringIdentity,
     ) -> Result<Self, InferenceError> {
         Self::open_with_via(
@@ -416,17 +431,23 @@ impl Vindex3Runtime<SharedProvider> {
     /// every provider it does hold, before any file is touched — so the
     /// refusal is the same on a container that does not exist. Nothing
     /// here constructs a provider the caller did not register.
+    ///
+    /// The registry is kept, shared, as this runtime's current authority
+    /// (L4): the resolved provider answers calls, and the registry is
+    /// what a prepared image's pins are held against before every use.
     pub fn open_with_via(
         container: &Path,
         component: &str,
-        lowerings: &LoweringRegistry,
+        lowerings: Arc<LoweringRegistry>,
         provider: &LoweringIdentity,
         policy: OpenPolicy,
     ) -> Result<Self, InferenceError> {
         let backend = lowerings
             .provider_shared(provider)
             .map_err(larql_vindex::error::VindexError::from)?;
-        Self::open_with(container, component, backend, policy)
+        let mut runtime = Self::open_with(container, component, backend, policy)?;
+        runtime.lowerings = Some(lowerings);
+        Ok(runtime)
     }
 }
 
@@ -446,18 +467,40 @@ pub struct PreparedVindex3<B: PlanBackend> {
     plan: ComponentOpPlan,
     store: OperandStore,
     backend: B,
+    /// The current lowering authority — see
+    /// [`Vindex3Runtime::lowerings`](Vindex3Runtime).
+    lowerings: Option<Arc<LoweringRegistry>>,
     operands: PreparedOperands,
     model_name: String,
     family: String,
 }
 
 impl<B: PlanBackend> PreparedVindex3<B> {
+    /// Hold this image's historical decision against the current
+    /// authority, before anything executes on it (LOWERING-PLUGIN-1, L4).
+    ///
+    /// The image records which lowering provider qualified its pins; the
+    /// runtime carries which providers exist now. A provider that has
+    /// gone, or that is present only at another revision, invalidates the
+    /// preparation by name — another provider being available is not a
+    /// fallback, and nothing re-selects.
+    ///
+    /// A model opened on a directly handed provider named no authority,
+    /// and there is nothing to check it against.
+    fn ensure_current_lowerings(&self) -> Result<(), InferenceError> {
+        match &self.lowerings {
+            Some(registry) => Ok(self.operands.ensure_lowerings_in(registry)?),
+            None => Ok(()),
+        }
+    }
+
     /// Open an incremental session over the resident operands, with the
     /// caller's continuation state. Cheap: no operand touches disk.
     pub fn session_with_kv<'a>(
         &'a self,
         kv: &'a mut dyn KvState,
     ) -> Result<Vindex3Session<'a, B>, InferenceError> {
+        self.ensure_current_lowerings()?;
         Vindex3Session::over_prepared(&self.plan, &self.operands, &self.backend, kv)
     }
 
@@ -468,6 +511,7 @@ impl<B: PlanBackend> PreparedVindex3<B> {
         tokens: &[u32],
         kv: &mut dyn KvState,
     ) -> Result<Vec<f32>, InferenceError> {
+        self.ensure_current_lowerings()?;
         let out = prefill_prepared(&self.plan, &self.operands, tokens, &self.backend, kv)?;
         out.logits.ok_or_else(headless_prefill_error)
     }
@@ -512,5 +556,25 @@ impl<B: PlanBackend> PreparedVindex3<B> {
     /// head is present.
     pub fn operands(&self) -> &PreparedOperands {
         &self.operands
+    }
+
+    /// The lowering authority this model is held against, if it was
+    /// opened through one.
+    pub fn lowerings(&self) -> Option<&Arc<LoweringRegistry>> {
+        self.lowerings.as_ref()
+    }
+
+    /// The same model, held against another lowering authority — the
+    /// operand store's [`with_registry`](OperandStore::with_registry) for
+    /// the other plane (LOWERING-PLUGIN-1, L4).
+    ///
+    /// Not checked here: re-pointing is not an execution, and the pins
+    /// are judged in the one place that matters — before anything runs on
+    /// them. A model re-pointed at an authority that no longer holds the
+    /// provider its pins were made by refuses at its next use rather than
+    /// executing a decision that authority never made.
+    pub fn with_lowerings(mut self, lowerings: Arc<LoweringRegistry>) -> Self {
+        self.lowerings = Some(lowerings);
+        self
     }
 }

--- a/crates/larql-inference/src/vindex3/tests/mod.rs
+++ b/crates/larql-inference/src/vindex3/tests/mod.rs
@@ -922,7 +922,7 @@ mod via_tests {
         let err = Vindex3Runtime::open_via(
             Path::new("/definitely/not/a/container"),
             "target",
-            &without_production,
+            std::sync::Arc::new(without_production),
             &LoweringIdentity::cpu_production(),
         )
         .err()
@@ -950,7 +950,7 @@ mod via_tests {
         let via = Vindex3Runtime::open_via(
             &container,
             "target",
-            &LoweringRegistry::shipped(),
+            std::sync::Arc::new(LoweringRegistry::shipped()),
             &LoweringIdentity::cpu_production(),
         )
         .expect("the shipped registry holds the production provider");
@@ -959,5 +959,78 @@ mod via_tests {
         assert_eq!(via.backend().name(), direct.backend().name());
         assert_eq!(via.model_name(), direct.model_name());
         via.prepare().expect("prepares through the shared provider");
+    }
+
+    /// LOWERING-PLUGIN-1, L4, through the production path that HOLDS
+    /// prepared state: a served model prepares once and answers requests
+    /// for the life of the process, so it is the one place where a pin
+    /// can outlive the authority that made it.
+    ///
+    /// The image records which provider decided its pins; the runtime
+    /// carries which providers exist now. Re-pointed at an authority
+    /// without that provider, the model refuses at its next use — every
+    /// use, sessions and batch prefill alike — naming the provider the
+    /// pins recorded and the ones on offer. The reference provider is
+    /// registered and perfectly able to execute this plan, and is not a
+    /// substitute for the provider that pinned it.
+    #[test]
+    fn a_served_model_refuses_when_the_provider_that_pinned_it_is_gone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let checkpoint = tmp.path().join("ckpt");
+        std::fs::create_dir_all(&checkpoint).unwrap();
+        let container = tmp.path().join("out.vindex3");
+        encode_fixture_container(dense_f32_model, &checkpoint, &container, "target");
+
+        let served = Vindex3Runtime::open_via(
+            &container,
+            "target",
+            std::sync::Arc::new(LoweringRegistry::shipped()),
+            &LoweringIdentity::cpu_production(),
+        )
+        .unwrap()
+        .prepare()
+        .unwrap();
+        assert!(served.lowerings().is_some(), "opened through an authority");
+
+        let tokens = [3u32, 17, 28];
+        let mut kv = RowKvState::default();
+        served
+            .session_with_kv(&mut kv)
+            .expect("the provider that pinned the image is still registered");
+        let mut kv = RowKvState::default();
+        served
+            .prefill_into(&tokens, &mut kv)
+            .expect("and batch prefill runs on it");
+
+        let stale = served.with_lowerings(std::sync::Arc::new(
+            LoweringRegistry::new()
+                .register(Box::new(ReferenceBackend::new()))
+                .unwrap(),
+        ));
+        for err in [
+            {
+                let mut kv = RowKvState::default();
+                stale
+                    .session_with_kv(&mut kv)
+                    .err()
+                    .expect("a session over a pin whose provider is gone is refused")
+                    .to_string()
+            },
+            {
+                let mut kv = RowKvState::default();
+                stale
+                    .prefill_into(&tokens, &mut kv)
+                    .expect_err("and so is a prefill")
+                    .to_string()
+            },
+        ] {
+            assert!(err.contains("cpu-production/v1"), "{err}");
+            assert!(err.contains("reference/v1"), "{err}");
+            assert!(err.contains("re-prepare"), "{err}");
+            assert!(
+                err.contains("no other provider stands in for it"),
+                "an available provider is not a fallback: {err}"
+            );
+        }
     }
 }

--- a/crates/larql-lql/src/executor/vindex3.rs
+++ b/crates/larql-lql/src/executor/vindex3.rs
@@ -837,7 +837,7 @@ pub(crate) fn bind(
     let runtime = Vindex3Runtime::open_via(
         path,
         V3_COMPONENT,
-        &LoweringRegistry::shipped(),
+        std::sync::Arc::new(LoweringRegistry::shipped()),
         &LoweringIdentity::cpu_production(),
     )
     .map_err(|e| LqlError::exec("failed to open VINDEX3 container", e))?;

--- a/crates/larql-server/src/vindex3.rs
+++ b/crates/larql-server/src/vindex3.rs
@@ -139,7 +139,7 @@ pub fn load_v3_model(path: &Path) -> Result<V3Model, Box<dyn std::error::Error +
     let runtime = Vindex3Runtime::open_via(
         path,
         SERVED_COMPONENT,
-        &LoweringRegistry::shipped(),
+        std::sync::Arc::new(LoweringRegistry::shipped()),
         &LoweringIdentity::cpu_production(),
     )
     .map_err(|e| format!("open VINDEX3 container: {e}"))?

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/decode.rs
@@ -248,6 +248,7 @@ impl<'a, B: PlanBackend> DecodeSession<'a, B> {
         mut kv: KvSlot<'a>,
     ) -> Result<Self, VindexError> {
         ops.get().ensure_providers_in(ops.get().registry())?;
+        ops.get().ensure_lowered_by(backend)?;
         // The FULL continuation geometry, KV and recurrent alike.
         // `plan_kv_geometry` is the KV-only adapter and refuses a hybrid
         // plan; a session over one needs both forms announced.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/mod.rs
@@ -545,6 +545,9 @@ fn execute_prepared_streaming_with<B: PlanBackend + ?Sized>(
     // nothing here falls back to another realization. The registry is
     // the image's own — the store's — never a built-in default.
     ops.ensure_providers_in(ops.registry())?;
+    // And the pin's OTHER authority: the provider executing these pins
+    // is the provider that decided them (LOWERING-PLUGIN-1, L4).
+    ops.ensure_lowered_by(backend)?;
     // A one-shot forward owns whatever continuation state the plan needs.
     //
     // For a wholly-softmax stack that is nothing: `None` keeps the

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/prepared.rs
@@ -57,8 +57,9 @@ use super::kda::KdaOutputGateWeights;
 use super::lowering::{LoweringIdentity, LoweringRegistry};
 use super::operands::{OperandSource, SourceStamp};
 use super::realization::{
-    realization_residency, DependencyLifetime, DependencyPin, ExtentOption, ExtentPin,
-    RealizationId, RealizationRecord, RepresentationFacts, SelectionReason, SelectionRefusals,
+    lowerings_stand_in, realization_residency, DependencyLifetime, DependencyPin, ExtentOption,
+    ExtentPin, PinnedAuthorities, RealizationId, RealizationRecord, RepresentationFacts,
+    SelectionReason, SelectionRefusals,
 };
 use super::weights::{load_weight, LoadedWeight};
 use super::AttentionOperands;
@@ -1616,6 +1617,10 @@ fn select_records<B: PlanBackend + ?Sized>(
     slice: &ExecutionSlice,
 ) -> Result<Vec<(RealizationRecord, RepresentationFacts)>, VindexError> {
     let registry = store.registry();
+    // Who is lowering this plan, asked once: the pin records the
+    // provider that qualified it, whether the caller resolved that
+    // provider through a registry or handed it in directly.
+    let lowering_provider = backend.identity();
     let whole = slice.is_whole_stack();
     let range = slice.layers(plan);
     let mut records = Vec::new();
@@ -1640,7 +1645,7 @@ fn select_records<B: PlanBackend + ?Sized>(
         if store.is_overridden(&planned.operand) {
             facts = facts.overlaid();
         }
-        let provider = facts.registered.as_ref().map(|r| r.identity.clone());
+        let codec_provider = facts.registered.as_ref().map(|r| r.identity.clone());
         // What the ARTIFACT offers, priced per extent from the codec's own
         // declaration. The pin starts on the whole of it; a budget may
         // move it shallower, and nothing else may.
@@ -1664,7 +1669,8 @@ fn select_records<B: PlanBackend + ?Sized>(
                 records.push((
                     RealizationRecord {
                         representation: label.to_string(),
-                        provider,
+                        codec_provider,
+                        lowering_provider: lowering_provider.clone(),
                         planned,
                         selection,
                         extent,
@@ -2430,7 +2436,7 @@ impl PreparedOperands {
             }
         };
         for r in &self.realizations {
-            note(&r.representation, &r.provider);
+            note(&r.representation, &r.codec_provider);
             // A DEPENDENCY's provider is a provider. An image prepared
             // while a codebook's codec was registered is not executable
             // once that codec is gone, however well the codes' own
@@ -2443,29 +2449,81 @@ impl PreparedOperands {
         out
     }
 
+    /// The lowering providers that qualified this image's pins, once
+    /// each, in pin order (LOWERING-PLUGIN-1, L4).
+    ///
+    /// One today: an image is prepared by one provider. A list because
+    /// nothing in the contract says it must stay one, and because the
+    /// check below should not have to change if it stops being one.
+    pub fn lowerings(&self) -> Vec<LoweringIdentity> {
+        let mut out: Vec<LoweringIdentity> = Vec::new();
+        for r in &self.realizations {
+            if !out.contains(&r.lowering_provider) {
+                out.push(r.lowering_provider.clone());
+            }
+        }
+        out
+    }
+
+    /// Both authorities this image was pinned under, as one value — what
+    /// was DECIDED, holding neither the codecs nor the providers that
+    /// decided it.
+    pub fn authorities(&self) -> PinnedAuthorities {
+        PinnedAuthorities {
+            codecs: self.providers(),
+            lowerings: self.lowerings(),
+        }
+    }
+
     /// Refuse to execute this image against a registry that no longer
     /// resolves every provider it was prepared with to the same identity
     /// — a provider that disappeared or changed invalidates the
     /// preparation; nothing falls back.
     pub fn ensure_providers_in(&self, registry: &CodecRegistry) -> Result<(), VindexError> {
-        let describe = |identity: &Option<CodecIdentity>| {
-            identity
-                .as_ref()
-                .map(|i| format!("{} r{}", i.family, i.revision))
-                .unwrap_or_else(|| "no registered codec".to_string())
-        };
-        for (label, prepared) in self.providers() {
-            let now = registry.by_label(&label).map(|c| c.identity());
-            if now != prepared {
+        self.authorities().ensure_codecs_in(registry)
+    }
+
+    /// Refuse to execute this image on a provider that did not prepare
+    /// it (LOWERING-PLUGIN-1, L4).
+    ///
+    /// The registry check above asks whether the pinned provider still
+    /// EXISTS. This asks the question available where no registry is —
+    /// at the execution seam, which is handed a provider directly —
+    /// namely whether the provider about to run these pins is the one
+    /// that made them. A pin is a decision one provider took from one
+    /// set of declared facts; another provider running it is that
+    /// decision reinterpreted, which is exactly what this wave forbids.
+    pub fn ensure_lowered_by<B: PlanBackend + ?Sized>(
+        &self,
+        backend: &B,
+    ) -> Result<(), VindexError> {
+        let executing = backend.identity();
+        for pinned in self.lowerings() {
+            if pinned != executing {
                 return Err(VindexError::Parse(format!(
-                    "representation `{label}` was prepared against {} and the registry now \
-                     offers {}; re-prepare rather than execute a pin whose provider changed",
-                    describe(&prepared),
-                    describe(&now)
+                    "this image's realizations were pinned by lowering provider `{pinned}` and \
+                     `{executing}` is executing them; re-prepare rather than run a pin another \
+                     provider decided"
                 )));
             }
         }
         Ok(())
+    }
+
+    /// The same question of the LOWERING plane: is the provider that
+    /// qualified these pins still in `registry`, under exactly the
+    /// identity the pins recorded (LOWERING-PLUGIN-1, L4)?
+    ///
+    /// The registry is the caller's — a session's current authority —
+    /// because a lowering registry is a carried value and not a
+    /// `&'static` the image can hold. What the image holds is the
+    /// decision, never the provider: an image that owned its provider
+    /// would keep a removed one alive and could never be invalidated by
+    /// its disappearance.
+    pub fn ensure_lowerings_in(&self, registry: &LoweringRegistry) -> Result<(), VindexError> {
+        // The lowering half only: an image asking whether its provider
+        // still exists has no reason to build its codec half first.
+        lowerings_stand_in(&self.lowerings(), registry)
     }
 
     pub fn residency_census(&self) -> ResidencyCensus {

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/realization.rs
@@ -18,11 +18,13 @@
 //! bank sliced per expert from stored rows, a decoded table gathered per
 //! token, or a device backend's own resident form.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use super::backend::{MatrixClass, WeightFormat};
 use super::cpu::physical::PhysicalProjectionPlan;
+use super::lowering::{LoweringIdentity, LoweringRegistry};
+use crate::error::VindexError;
 use crate::format::vindex3::opplan::planned::{Operation, PlannedOperand};
 use crate::format::vindex3::opplan::OperandRef;
 use crate::format::vindex3::represent::codec::{
@@ -508,7 +510,24 @@ pub struct RealizationRecord {
     pub representation: String,
     /// The identity the stored label resolved to at preparation; `None`
     /// for a label no codec claims.
-    pub provider: Option<CodecIdentity>,
+    ///
+    /// The CODEC plane's authority: what the bytes are.
+    pub codec_provider: Option<CodecIdentity>,
+    /// The lowering provider that qualified this realization — the
+    /// LOWERING plane's authority: what implementation decided the pin
+    /// (LOWERING-PLUGIN-1, L4).
+    ///
+    /// Not optional, and not derived from the other: a record exists
+    /// because some provider selected it, and since L1 every provider
+    /// states an identity. The two authorities move independently — a
+    /// codec revision can change under an unchanged lowering and the
+    /// reverse — so the pin names both and invalidation says which.
+    ///
+    /// The provider's SEMANTIC identity, never its configuration: two
+    /// device providers built with different format tables share
+    /// `device-matmul/v1`, and what their configurations changed is
+    /// pinned in [`Selection::realization`] instead.
+    pub lowering_provider: LoweringIdentity,
     pub selection: Selection,
     /// How much of the stored representation this pin reads.
     ///
@@ -545,6 +564,107 @@ impl RealizationRecord {
             dependency.lifetime = lifetime;
         }
     }
+}
+
+/// The authorities a prepared image was pinned under, both planes, as a
+/// value that survives being written down.
+///
+/// Two independent authorities. The CODEC plane says what the stored
+/// bytes are, keyed by the representation label each pin read; the
+/// LOWERING plane says which implementation qualified the realization.
+/// Neither implies the other, so an image carries both and a refusal
+/// names which one moved.
+///
+/// Separated from [`PreparedOperands`](super::prepared::PreparedOperands)
+/// so that the SAME code judges a live image and one that was serialized
+/// and reloaded: an image is judged through the authorities it yields,
+/// and a reloaded record of those authorities yields the same two
+/// verdicts. Nothing here holds a codec or a provider — only what was
+/// decided — because an image that held its providers would keep a
+/// removed one alive and could never be invalidated by its
+/// disappearance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PinnedAuthorities {
+    /// Every representation the image pinned, once each, with the
+    /// identity its label resolved to at preparation. `None` is an
+    /// overlay edit's f32-space fact, never a label a loader judged for
+    /// itself.
+    pub codecs: Vec<(String, Option<CodecIdentity>)>,
+    /// Every lowering provider that qualified a pin, once each, in pin
+    /// order. One today — a prepared image is lowered by one provider —
+    /// and a list because nothing in the contract says it must stay one.
+    pub lowerings: Vec<LoweringIdentity>,
+}
+
+impl PinnedAuthorities {
+    /// Refuse an image whose codec authority has moved: a representation
+    /// that resolves to a different identity than it did at preparation,
+    /// or to none at all.
+    pub fn ensure_codecs_in(&self, registry: &CodecRegistry) -> Result<(), VindexError> {
+        let describe = |identity: &Option<CodecIdentity>| {
+            identity
+                .as_ref()
+                .map(|i| format!("{} r{}", i.family, i.revision))
+                .unwrap_or_else(|| "no registered codec".to_string())
+        };
+        for (label, prepared) in &self.codecs {
+            let now = registry.by_label(label).map(|c| c.identity());
+            if now != *prepared {
+                return Err(VindexError::Parse(format!(
+                    "representation `{label}` was prepared against {} and the registry now \
+                     offers {}; re-prepare rather than execute a pin whose provider changed",
+                    describe(prepared),
+                    describe(&now)
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Refuse an image whose lowering authority has moved: the provider
+    /// that qualified a pin is not in `registry` under exactly the
+    /// identity the pin recorded.
+    ///
+    /// A family present at another revision is a different provider and
+    /// is refused; so is a registry full of perfectly good alternatives.
+    /// Nothing re-selects and nothing substitutes — the refusal names the
+    /// identity the pin recorded and every identity the registry holds,
+    /// and re-preparation is the only way forward.
+    pub fn ensure_lowerings_in(&self, registry: &LoweringRegistry) -> Result<(), VindexError> {
+        lowerings_stand_in(&self.lowerings, registry)
+    }
+}
+
+/// The lowering plane's judgment itself — see
+/// [`PinnedAuthorities::ensure_lowerings_in`], which is this over what was
+/// written down.
+///
+/// A free function so that a prepared image can ask the question without
+/// first building its codec half, and so that the live image and the
+/// reloaded record cannot drift into two judgments of one contract.
+pub(super) fn lowerings_stand_in(
+    pinned: &[LoweringIdentity],
+    registry: &LoweringRegistry,
+) -> Result<(), VindexError> {
+    for identity in pinned {
+        if registry.provider(identity).is_err() {
+            let held = registry.identities();
+            let held = if held.is_empty() {
+                "none".to_string()
+            } else {
+                held.iter()
+                    .map(|i| i.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            return Err(VindexError::Parse(format!(
+                "lowering provider `{identity}` qualified this preparation and the registry \
+                 now holds {held}; re-prepare rather than execute a pin whose provider is \
+                 gone — no other provider stands in for it"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// What a realization does with a dependency once it has read it.

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/accounting.rs
@@ -10,6 +10,7 @@ use super::super::accounting::{
 use super::super::backend::{MatrixClass, WeightFormat};
 use super::super::cpu::ledger::{ledger, thread_projection_calls};
 use super::super::cpu::physical::{KQuantExecution, PhysicalProjectionPlan};
+use super::super::lowering::LoweringIdentity;
 use super::super::operands::OperandStore;
 use super::super::prepared::{ExecutionSlice, PreparedOperands};
 use super::super::production::{select_cpu, ProductionBackend};
@@ -116,7 +117,8 @@ fn record(
             logical_elements: operand.shape.iter().product(),
         },
         representation: operand.dtype.clone(),
-        provider: None,
+        codec_provider: None,
+        lowering_provider: LoweringIdentity::cpu_production(),
         // A terminal representation: one extent, unpriced here because
         // this helper's subject is residency, not what a plane costs.
         extent: ExtentPin::unknown(),
@@ -270,7 +272,8 @@ fn every_resident_form_reconciles_with_its_declaration_and_a_mutated_geometry_br
     let pinned = |selection: &Selection| RealizationRecord {
         planned: planned.clone(),
         representation: packed.dtype.clone(),
-        provider: None,
+        codec_provider: None,
+        lowering_provider: LoweringIdentity::cpu_production(),
         extent: ExtentPin::unknown(),
         verified_bytes: 0,
         dependencies: Vec::new(),

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/fp8_carriage.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/fp8_carriage.rs
@@ -256,7 +256,7 @@ fn selection_pins_the_fp8_kernel_and_retains_its_grid() {
         let record = record_for(prepared);
         assert_eq!(record.representation, DTYPE_FP8_BLOCK);
         assert_eq!(
-            record.provider.as_ref().map(|p| p.family.as_str()),
+            record.codec_provider.as_ref().map(|p| p.family.as_str()),
             Some("fp8-block")
         );
         assert_eq!(

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/kquant_projection.rs
@@ -33,6 +33,7 @@ use crate::format::vindex3::opplan::exec::cpu::kernels::ScalarF32;
 use crate::format::vindex3::opplan::exec::cpu::physical::project_matrix;
 use crate::format::vindex3::opplan::exec::cpu::projector::{DenseProjector, WeightRows};
 use crate::format::vindex3::opplan::exec::cpu::{ledger, PhysicalProjectionPlan};
+use crate::format::vindex3::opplan::exec::lowering::LoweringIdentity;
 use crate::format::vindex3::opplan::exec::operands::{
     OperandSource, OperandStore, RepresentationSource,
 };
@@ -520,7 +521,8 @@ fn a_stored_pack_has_one_stored_footprint_and_two_realization_costs() {
         let record = RealizationRecord {
             planned: planned.clone(),
             representation: Q6_K.name.to_string(),
-            provider: facts.registered.as_ref().map(|r| r.identity.clone()),
+            codec_provider: facts.registered.as_ref().map(|r| r.identity.clone()),
+            lowering_provider: LoweringIdentity::cpu_production(),
             selection,
             extent: ExtentPin::unknown(),
             verified_bytes: 0,

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_pin.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_pin.rs
@@ -1,0 +1,376 @@
+//! **L4 of LOWERING-PLUGIN-1: the decision survives preparation.**
+//!
+//! The forecast predicts that every selected pin records both provider
+//! identities and that "loss or revision substitution of either
+//! invalidates preparation distinctly by name", with fallback to another
+//! lowering provider named as the thing that must not happen.
+//!
+//! What is held here is the seven controls the wave froze before it was
+//! built: the pinned provider still registered keeps the preparation
+//! valid; removed invalidates it; the same family at another revision
+//! invalidates it; a registry full of other providers is STILL invalid
+//! and never a substitution; each plane refuses on its own authority and
+//! not the other's; and a pin that was serialized and reloaded yields the
+//! same two verdicts.
+//!
+//! Plus the question L1 left open and this wave had to answer: whether a
+//! provider's CONFIGURATION — the injected device, the format table — is
+//! a second authority prepared state must record. The experiment is at
+//! the bottom of the file, with the decision rule frozen in the notes
+//! before it ran.
+
+use super::super::backend::{PlanBackend, WeightFormat, WeightFormats};
+use super::super::device::DevicePlanBackend;
+use super::super::lowering::{LoweringIdentity, LoweringRegistry};
+use super::super::prepared::{ExecutionSlice, PreparedOperands};
+use super::super::production::ProductionBackend;
+use super::super::realization::PinnedAuthorities;
+use super::super::reference::ReferenceBackend;
+use super::super::{execute_prepared_streaming, PlaneEvent};
+use super::accounting::ProviderStub;
+use super::device::LoopDevice;
+use super::lowering_identity::Relabelled;
+use super::lowering_registry::{bits, dense, Fixture, SCRATCH_FAMILY, TOKENS};
+use crate::format::vindex3::represent::codec::CodecRegistry;
+
+fn scratch_id(revision: u32) -> LoweringIdentity {
+    LoweringIdentity::new(SCRATCH_FAMILY, revision)
+}
+
+/// A registry holding one scratch provider, at `revision`.
+fn scratch_registry(revision: u32) -> LoweringRegistry {
+    LoweringRegistry::new()
+        .register(Box::new(Relabelled::new(
+            "scratch",
+            SCRATCH_FAMILY,
+            revision,
+        )))
+        .unwrap()
+}
+
+/// An image prepared by the scratch provider at revision 1 — a provider
+/// this build does not ship, so every verdict below is about the pin and
+/// not about anything privileged.
+fn pinned_by_scratch(f: &Fixture) -> PreparedOperands {
+    PreparedOperands::load_via(
+        &f.plan,
+        &f.store,
+        &scratch_registry(1),
+        &scratch_id(1),
+        ExecutionSlice::Full,
+    )
+    .unwrap()
+}
+
+/// A codec registry that answers for the fixture's stored label under a
+/// different identity — the codec plane moving while the lowering plane
+/// stands still.
+fn codecs_moved() -> CodecRegistry {
+    CodecRegistry::new()
+        .register(Box::new(ProviderStub { label: "F32" }))
+        .unwrap()
+}
+
+/// Both authorities, on every pin, neither derived from the other: the
+/// lowering provider changes while the codec identity does not, and the
+/// pin records both.
+#[test]
+fn every_pin_names_both_authorities_and_the_two_move_independently() {
+    let f = dense();
+    let shipped = LoweringRegistry::shipped();
+    let by_production = PreparedOperands::load_via(
+        &f.plan,
+        &f.store,
+        &shipped,
+        &LoweringIdentity::cpu_production(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let by_reference = PreparedOperands::load_via(
+        &f.plan,
+        &f.store,
+        &shipped,
+        &LoweringIdentity::reference(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+
+    assert!(!by_production.realizations().is_empty());
+    for record in by_production.realizations() {
+        assert_eq!(record.lowering_provider, LoweringIdentity::cpu_production());
+        assert_eq!(
+            record.codec_provider.as_ref().map(|i| i.family.as_str()),
+            Some("F32"),
+            "the fixture is stored f32 and the codec plane says so"
+        );
+    }
+    assert_eq!(
+        by_production.lowerings(),
+        [LoweringIdentity::cpu_production()],
+        "one image, one lowering provider"
+    );
+    assert_eq!(by_reference.lowerings(), [LoweringIdentity::reference()]);
+
+    // The lowering authority moved; the codec authority did not.
+    assert_eq!(
+        by_production.authorities().codecs,
+        by_reference.authorities().codecs
+    );
+    assert_ne!(
+        by_production.authorities().lowerings,
+        by_reference.authorities().lowerings
+    );
+
+    // And a provider this build does not ship is recorded exactly as a
+    // shipped one is.
+    assert_eq!(pinned_by_scratch(&f).lowerings(), [scratch_id(1)]);
+}
+
+/// Controls 1–4. One image, four registries: the provider that pinned it,
+/// no provider, the same family at another revision, and a registry full
+/// of perfectly good other providers. Only the first stands.
+#[test]
+fn only_the_provider_that_pinned_the_image_keeps_it_valid() {
+    let f = dense();
+    let ops = pinned_by_scratch(&f);
+    let before = ops.authorities();
+
+    // 1 — the same provider is still registered.
+    ops.ensure_lowerings_in(&scratch_registry(1)).unwrap();
+
+    // 2 — the provider is gone.
+    let err = ops
+        .ensure_lowerings_in(&LoweringRegistry::new())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("scratch-provider/v1"), "{err}");
+    assert!(err.contains("holds none"), "{err}");
+    assert!(err.contains("re-prepare"), "{err}");
+
+    // 3 — the same family at another revision is another provider.
+    let err = ops
+        .ensure_lowerings_in(&scratch_registry(2))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("scratch-provider/v1") && err.contains("scratch-provider/v2"),
+        "the refusal names the pin's revision and the one on offer: {err}"
+    );
+
+    // 4 — other providers are not a fallback. The shipped registry holds
+    // two working providers, and neither stands in for the one that made
+    // these pins.
+    let err = ops
+        .ensure_lowerings_in(&LoweringRegistry::shipped())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("scratch-provider/v1"), "{err}");
+    assert!(
+        err.contains("reference/v1") && err.contains("cpu-production/v1"),
+        "the refusal names what IS registered: {err}"
+    );
+    assert!(err.contains("no other provider stands in for it"), "{err}");
+
+    // Nothing re-selected on the way through any of that: a refusal is a
+    // refusal, not a re-pin.
+    assert_eq!(ops.authorities(), before);
+}
+
+/// Controls 5 and 6. Each plane refuses on its own authority, in its own
+/// vocabulary, and neither refusal can be mistaken for the other's.
+#[test]
+fn each_plane_refuses_on_its_own_authority() {
+    let f = dense();
+    let ops = PreparedOperands::load_via(
+        &f.plan,
+        &f.store,
+        &LoweringRegistry::shipped(),
+        &LoweringIdentity::cpu_production(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+
+    // 5 — codec valid, lowering invalid: fails on the lowering plane.
+    ops.ensure_providers_in(CodecRegistry::builtin()).unwrap();
+    let err = ops
+        .ensure_lowerings_in(&scratch_registry(1))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("lowering provider `cpu-production/v1`"),
+        "{err}"
+    );
+    assert!(
+        !err.contains("representation"),
+        "a lowering refusal does not talk about representations: {err}"
+    );
+
+    // 6 — lowering valid, codec invalid: fails on the codec plane.
+    ops.ensure_lowerings_in(&LoweringRegistry::shipped())
+        .unwrap();
+    let err = ops
+        .ensure_providers_in(&codecs_moved())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("representation `F32`"), "{err}");
+    assert!(
+        err.contains("F32 r1") && err.contains("stub-F32 r7"),
+        "{err}"
+    );
+    assert!(
+        !err.contains("lowering"),
+        "a codec refusal does not talk about lowering providers: {err}"
+    );
+}
+
+/// Control 7. The authorities are a value: written down, read back, and
+/// judged by exactly the code that judges a live image — so a pin that
+/// outlives the process it was made in still knows what decided it.
+#[test]
+fn a_serialized_and_reloaded_pin_retains_both_authorities() {
+    let f = dense();
+    let ops = pinned_by_scratch(&f);
+    let authorities = ops.authorities();
+
+    let json = serde_json::to_string(&authorities).unwrap();
+    assert!(
+        json.contains("scratch-provider") && json.contains("F32"),
+        "both planes are written down: {json}"
+    );
+    let reloaded: PinnedAuthorities = serde_json::from_str(&json).unwrap();
+    assert_eq!(reloaded, authorities);
+
+    // The same seven-control verdicts, from the reloaded value.
+    reloaded.ensure_lowerings_in(&scratch_registry(1)).unwrap();
+    assert!(reloaded.ensure_lowerings_in(&scratch_registry(2)).is_err());
+    assert!(reloaded
+        .ensure_lowerings_in(&LoweringRegistry::shipped())
+        .is_err());
+    reloaded.ensure_codecs_in(CodecRegistry::builtin()).unwrap();
+    assert!(reloaded.ensure_codecs_in(&codecs_moved()).is_err());
+}
+
+/// The seam where no registry is available: execution is handed a
+/// provider directly, and the pin says which provider decided it. A
+/// different provider running these pins is the decision reinterpreted,
+/// which is the fallback this wave forbids — so it is refused, by both
+/// identities.
+#[test]
+fn a_pin_is_executed_by_the_provider_that_decided_it_or_not_at_all() {
+    let f = dense();
+    let ops = PreparedOperands::load(
+        &f.plan,
+        &f.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let mut sink = |_: PlaneEvent| Ok(());
+    execute_prepared_streaming(
+        &f.plan,
+        &ops,
+        &TOKENS,
+        &ProductionBackend::new(),
+        None,
+        &mut sink,
+    )
+    .expect("the provider that pinned the image executes it");
+
+    let err = execute_prepared_streaming(
+        &f.plan,
+        &ops,
+        &TOKENS,
+        &ReferenceBackend::new(),
+        None,
+        &mut sink,
+    )
+    .expect_err("another provider may not run another's pins")
+    .to_string();
+    assert!(
+        err.contains("cpu-production/v1") && err.contains("reference/v1"),
+        "{err}"
+    );
+    assert!(err.contains("re-prepare"), "{err}");
+}
+
+// ── the device-instance question L1 left open ────────────────────────
+
+/// **The experiment.** Same `LoweringIdentity`, two configurations: does
+/// prepared state become invalid or semantically different?
+///
+/// Two `DevicePlanBackend`s over the same injected device, differing only
+/// in the per-class format table they ask the loader for. Both answer
+/// `device-matmul/v1`, so identity-level authority cannot tell them
+/// apart — and the question is whether it needed to.
+///
+/// The decision rule was frozen in the wave's notes before this ran: if
+/// the image refuses or computes different numbers under the other
+/// instance, a SECOND authority exists and is named separately; if it
+/// does not, none is invented.
+///
+/// The answer is in two halves. The configuration IS load-bearing — the
+/// two instances prepare different images from the same plan — and yet
+/// any one image means the same thing under either instance, because the
+/// format table is asked at preparation and never again: what it decided
+/// is already in the pinned realization and in the operands materialised
+/// under it. So the pin needs the provider's identity and not its
+/// configuration, and no second authority is invented here.
+#[test]
+fn one_identity_over_two_configurations_prepares_differently_and_executes_one_image_identically() {
+    let f = dense();
+    let asks_f32 = DevicePlanBackend::new(LoopDevice, "loop-device-f32", WeightFormat::F32);
+    let asks_f16 = DevicePlanBackend::with_formats(
+        LoopDevice,
+        "loop-device-f16",
+        WeightFormats::uniform(WeightFormat::F16),
+    );
+    assert_eq!(asks_f32.identity(), asks_f16.identity());
+    assert_ne!(asks_f32.name(), asks_f16.name());
+
+    let image = PreparedOperands::load(&f.plan, &f.store, &asks_f32, ExecutionSlice::Full).unwrap();
+    assert_eq!(image.lowerings(), [LoweringIdentity::device_matmul()]);
+
+    // Identity-level authority is satisfied by the OTHER instance. That
+    // is the sharp edge of the question, not a defect: the registry holds
+    // one configured instance per identity (L2) and the pin records the
+    // identity, not the instance.
+    let other_instance = LoweringRegistry::new()
+        .register(Box::new(DevicePlanBackend::with_formats(
+            LoopDevice,
+            "loop-device-f16",
+            WeightFormats::uniform(WeightFormat::F16),
+        )))
+        .unwrap();
+    image.ensure_lowerings_in(&other_instance).unwrap();
+    image.ensure_lowered_by(&asks_f16).unwrap();
+
+    // Half one: the configuration is load-bearing. The same plan
+    // prepared by the other instance is a different image — different
+    // resident representation, different numbers — which is why
+    // configuration could have been a second authority.
+    let other_image =
+        PreparedOperands::load(&f.plan, &f.store, &asks_f16, ExecutionSlice::Full).unwrap();
+    let mut sink = |_: PlaneEvent| Ok(());
+    let own_preparation =
+        execute_prepared_streaming(&f.plan, &image, &TOKENS, &asks_f32, None, &mut sink).unwrap();
+    let other_preparation =
+        execute_prepared_streaming(&f.plan, &other_image, &TOKENS, &asks_f16, None, &mut sink)
+            .unwrap();
+    assert_ne!(
+        bits(own_preparation.logits.as_deref().unwrap()),
+        bits(other_preparation.logits.as_deref().unwrap()),
+        "two configurations under one identity prepare two different images"
+    );
+
+    // Half two, and the answer: ONE image executes identically under
+    // either instance. The format table was consumed at preparation; what
+    // it decided is pinned, so the other instance reinterprets nothing.
+    let under_other =
+        execute_prepared_streaming(&f.plan, &image, &TOKENS, &asks_f16, None, &mut sink).unwrap();
+    assert_eq!(
+        bits(own_preparation.logits.as_deref().unwrap()),
+        bits(under_other.logits.as_deref().unwrap()),
+        "one preparation, two same-identity configurations, identical numbers"
+    );
+    assert_eq!(own_preparation.final_hidden(), under_other.final_hidden());
+}

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_registry.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/lowering_registry.rs
@@ -28,9 +28,9 @@ use crate::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
 use crate::format::vindex3::represent::codec::CodecRegistry;
 use larql_compute::cpu::CpuBackend;
 
-const SCRATCH_FAMILY: &str = "scratch-provider";
+pub(super) const SCRATCH_FAMILY: &str = "scratch-provider";
 /// A prompt over the dense fixture's 128-token vocabulary.
-const TOKENS: [u32; 5] = [3, 17, 28, 0, 11];
+pub(super) const TOKENS: [u32; 5] = [3, 17, 28, 0, 11];
 
 fn reference_id() -> LoweringIdentity {
     LoweringIdentity::new(reference::IDENTITY_FAMILY, reference::IDENTITY_REVISION)
@@ -212,13 +212,13 @@ fn the_shipped_registry_is_a_value_and_one_instance_per_identity() {
 
 // ── F4: the carried path constructs nothing ──────────────────────────
 
-struct Fixture {
+pub(super) struct Fixture {
     _tmp: tempfile::TempDir,
-    plan: ComponentOpPlan,
-    store: OperandStore,
+    pub(super) plan: ComponentOpPlan,
+    pub(super) store: OperandStore,
 }
 
-fn dense() -> Fixture {
+pub(super) fn dense() -> Fixture {
     let tmp = tempfile::tempdir().unwrap();
     let checkpoint = tmp.path().join("ckpt");
     std::fs::create_dir_all(&checkpoint).unwrap();
@@ -237,7 +237,7 @@ fn dense() -> Fixture {
     }
 }
 
-fn bits(v: &[f32]) -> Vec<u32> {
+pub(super) fn bits(v: &[f32]) -> Vec<u32> {
     v.iter().map(|x| x.to_bits()).collect()
 }
 

--- a/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/opplan/exec/tests/mod.rs
@@ -59,6 +59,7 @@ mod kimi_router;
 #[cfg(all(feature = "gpu", target_os = "macos"))]
 mod kimi_two_layer;
 mod lowering_identity;
+mod lowering_pin;
 mod lowering_registry;
 mod mamba2_exec;
 #[cfg(all(feature = "gpu", target_os = "macos"))]

--- a/crates/larql-vindex/tests/external_codec_provider.rs
+++ b/crates/larql-vindex/tests/external_codec_provider.rs
@@ -357,7 +357,11 @@ fn an_external_codec_executes_through_registration_alone_with_the_shipped_select
     assert_eq!(external_records.len(), candidate.relabelled.len());
     for r in &external_records {
         assert_eq!(r.representation, LABEL, "{r:?}");
-        assert_eq!(r.provider.as_ref(), Some(&ExternalF32.identity()), "{r:?}");
+        assert_eq!(
+            r.codec_provider.as_ref(),
+            Some(&ExternalF32.identity()),
+            "{r:?}"
+        );
     }
     // And the bytes really are the shipped image: each relabelled tensor
     // is stored at exactly f32's width.

--- a/docs/represent-v1-contract-index.md
+++ b/docs/represent-v1-contract-index.md
@@ -200,12 +200,17 @@ filters candidates by the same floor.
 ## 8. Provider-identity carriage and invalidation
 
 **Invariant.** A prepared image records the provider identity each pin
-resolved to. Losing a provider, or substituting one at a revision that means
-different bytes, **invalidates the preparation by name** rather than falling
-back. An out-of-tree provider reaches selection through registration alone:
-no core file names it.
+resolved to, on **both planes**: the codec that says what the stored bytes
+are, and the lowering provider that qualified the realization. Losing
+either, or substituting one at a revision that means something different,
+**invalidates the preparation by name** rather than falling back — and each
+plane refuses in its own vocabulary, so a refusal says which authority
+moved. An out-of-tree provider reaches selection through registration
+alone: no core file names it.
 
-**Authority.** `PreparedOperands::ensure_providers_in`, `CodecIdentity`.
+**Authority.** `PreparedOperands::ensure_providers_in`, `CodecIdentity`;
+`PreparedOperands::ensure_lowerings_in`, `LoweringIdentity`
+(LOWERING-PLUGIN-1, L4).
 
 | | |
 |---|---|
@@ -217,6 +222,13 @@ no core file names it.
 | admission | `a_pack_under_the_external_identity_is_admitted_through_the_registry_the_store_opens_with` — `crates/larql-vindex/tests/external_codec_provider.rs` (refused by the built-in registry naming every family it knows; admitted by the registry the store is opened with; re-pointing re-runs the admission) |
 | genericity | `no_external_identity_or_role_appears_in_production_larql` — `crates/larql-vindex/tests/external_attested_provider/genericity.rs` |
 | scan control | `the_scan_would_have_found_an_identity_that_was_there` — same file (a shipped label *is* found by the same walk, so an empty result means "nothing there", not "nothing looked at") |
+| lowering positive | `every_pin_names_both_authorities_and_the_two_move_independently` — `…/exec/tests/lowering_pin.rs` (the lowering identity changes while the codec identity does not, on the same fixture) |
+| lowering negative | `only_the_provider_that_pinned_the_image_keeps_it_valid` — same file (gone, present at another revision, and a registry full of other providers: all invalid, none a fallback) |
+| plane separation | `each_plane_refuses_on_its_own_authority` — same file (codec valid / lowering moved and the reverse; neither refusal speaks the other's vocabulary) |
+| carriage | `a_serialized_and_reloaded_pin_retains_both_authorities` — same file (`PinnedAuthorities` written down and read back yields the same verdicts) |
+| execution seam | `a_pin_is_executed_by_the_provider_that_decided_it_or_not_at_all` — same file (the check available where no registry is: the executing provider is the one that pinned) |
+| configuration control | `one_identity_over_two_configurations_prepares_differently_and_executes_one_image_identically` — same file (one identity, two format tables: two preparations, but either instance means the same thing by a given one — why configuration is not a second authority) |
+| production path | `a_served_model_refuses_when_the_provider_that_pinned_it_is_gone` — `crates/larql-inference/src/vindex3/tests/mod.rs` (the served model, re-pointed at an authority without its provider, refuses at session and at prefill) |
 | qualified by | PR #441 (`85b46061`), PR #447 (`202ffb7b`) |
 
 ---

--- a/docs/represent/forecasts/lowering-plugin-1-notes.json
+++ b/docs/represent/forecasts/lowering-plugin-1-notes.json
@@ -199,7 +199,7 @@
     },
     "L4": {
       "name": "provider identity in prepared state",
-      "status": "design frozen before implementation",
+      "status": "built and held",
       "branch": "lowering-l4",
       "base": "L3 (`lowering-l3`) on L2 (#466); rebased onto main once both merge",
       "date": "2026-09-09",
@@ -231,6 +231,16 @@
           "if_the_image_refuses_or_computes_different_numbers_under_B": "a second authority exists. Name it separately — `ProviderBinding` / `EnvironmentIdentity`, what configured execution environment a preparation is tied to — and NEVER by putting hardware or configuration identity into `LoweringIdentity`.",
           "if_the_image_computes_identically_under_B": "do not invent it. Record the negative result together with the experiment's limit: `CpuBackend`-as-device holds no device-resident buffers, so this cannot speak for a preparation whose storage lives on an injected Metal device.",
           "either_way": "the result is written here before the wave is called held."
+        },
+        "answer": {
+          "result": "NO second authority — and the question was worth asking, because the configuration is genuinely load-bearing.",
+          "what_was_observed": [
+            "Two `DevicePlanBackend`s over one injected device (`LoopDevice`), differing only in the per-class format table, answer one identity `device-matmul/v1`; the registry (one instance per identity) and the pin cannot tell them apart.",
+            "They prepare DIFFERENT images from the same plan — different resident representation, different logits — so configuration decides what a preparation contains.",
+            "And yet ONE image executes bit-identically under either instance: the format table is consumed at preparation and never consulted again, so what the configuration decided is already in the pinned realization and in the operands materialised under it. Nothing is reinterpreted."
+          ],
+          "conclusion": "The pin needs the provider's semantic identity, not its configuration. `LoweringIdentity` stays `device-matmul/v1`. No `ProviderBinding` / `EnvironmentIdentity` is invented, per the frozen decision rule.",
+          "limit_recorded_honestly": "The experiment ran over a host-memory device (`LoopDevice`). No prepared form in this build holds device-resident storage — `PreparedOperands` holds stable page-aligned HOST allocations and a device's residency is a buffer cache keyed on `(pointer, length)` (see `exec/device.rs`) — so changing the injected device costs an upload, not correctness. A future provider whose prepared form held device-resident handles WOULD make the environment load-bearing after preparation, and that is when the second authority gets named, not before."
         }
       },
       "out_of_scope": [
@@ -238,7 +248,48 @@
         "capability matching (F2's subject, not L4's)",
         "Metal-lowered migration",
         "any new kernel-plane variant — the count stays 33 (F3)"
-      ]
+      ],
+      "what_landed": [
+        "`RealizationRecord.provider` is now `codec_provider`, joined by `lowering_provider: LoweringIdentity` — non-optional, stamped by `select_records` from the backend that selected, so the pin names both authorities whether the caller resolved its provider through a registry or handed it in directly.",
+        "`PinnedAuthorities { codecs, lowerings }` in `exec/realization.rs`: a serializable value carrying both planes, with `ensure_codecs_in` and `ensure_lowerings_in` on it. `PreparedOperands::ensure_providers_in` (unchanged in behaviour and message) and the new `ensure_lowerings_in` delegate to it, so a live image and a reloaded record of one are judged by the same code.",
+        "`PreparedOperands::lowerings()` and `::authorities()`; `::ensure_lowered_by(backend)` for the seam where no registry exists.",
+        "`Vindex3Runtime` / `PreparedVindex3` carry `Option<Arc<LoweringRegistry>>` — `Some` on the registry-carried path (`open_via` / `open_with_via` now take `Arc<LoweringRegistry>` and KEEP it), `None` when a provider was handed in directly. `session_with_kv` and `prefill_into` hold the image's pins against that authority before anything runs; `PreparedVindex3::with_lowerings` re-points a prepared model at another authority, the lowering plane's `OperandStore::with_registry`.",
+        "`exec/tests/lowering_pin.rs`: the seven controls, the execution seam, and the device-instance experiment. The L2 fixture (`dense()`, `bits()`, `TOKENS`) became the wave's shared harness."
+      ],
+      "witnesses": {
+        "both_authorities_on_every_pin": "`every_pin_names_both_authorities_and_the_two_move_independently` — the lowering identity changes (production → reference → an unshipped scratch provider) while the codec identity does not, on one fixture",
+        "controls_1_to_4": "`only_the_provider_that_pinned_the_image_keeps_it_valid` — one image pinned by `scratch-provider/v1`, four registries: it alone stands; empty, `scratch-provider/v2`, and the shipped registry (two working providers) all refuse, naming the pin's identity and what is on offer; the image's authorities are unchanged after every refusal, so nothing re-pinned on the way through",
+        "controls_5_and_6": "`each_plane_refuses_on_its_own_authority` — codec valid / lowering moved and the reverse; the lowering refusal never says `representation` and the codec refusal never says `lowering`",
+        "control_7": "`a_serialized_and_reloaded_pin_retains_both_authorities` — `PinnedAuthorities` through `serde_json` and back, identical, and yielding the same verdicts on both planes",
+        "execution_seam": "`a_pin_is_executed_by_the_provider_that_decided_it_or_not_at_all` — a production-pinned image handed to the reference provider is refused naming both identities",
+        "production_path": "`a_served_model_refuses_when_the_provider_that_pinned_it_is_gone` (larql-inference) — the served model, re-pointed at an authority holding only `reference/v1`, refuses at BOTH uses (session and batch prefill); the reference provider can execute this plan perfectly well and is not a substitute"
+      },
+      "measurements": {
+        "kernel_plane_files": 33,
+        "larql_vindex_lib_tests": "4665 (4659 at L3 + the wave's 6; no existing assertion changed)",
+        "larql_vindex_all_suites": "39 suites, 4989 tests, 0 failed",
+        "existing_assertions_changed": 0,
+        "selection_changes": 0,
+        "accounting_changes": 0,
+        "numerical_changes": 0,
+        "record_schema": "one field renamed (`provider` → `codec_provider`), one added (`lowering_provider`); four read sites and three literal sites in tests followed",
+        "dependent_crate_suites": "larql-inference lib 1536 (+1), larql-lql 743, larql-server 591, larql-cli vindex3_cmd 64 — all unchanged apart from the wave's own test"
+      },
+      "observations_for_later_waves": [
+        "The execution-seam check (`ensure_lowered_by`) was added as a measurement and kept: the whole larql-vindex suite passes unchanged with it in place, so NOTHING in this build ever executed a prepared image on a provider that did not pin it. That is a stronger statement than the registry check alone can make, and it is the check available to a caller who was handed a provider rather than a registry.",
+        "A prepared image carries exactly one lowering identity today. `lowerings()` returns a list so that a future image lowered by several providers (a device provider for the FFN, a CPU provider for the head) needs no change to the invalidation contract — only to what fills it.",
+        "`Vindex3Runtime` carries `Option<Arc<LoweringRegistry>>`: `None` is the direct-backend path, which named no authority and therefore has nothing to be checked against. After L3 no production path can reach that arm without going through the CLI's own composition site, whose images are prepared and executed in one breath — the staleness window this wave closes only exists where prepared state OUTLIVES its resolution, which is the served model.",
+        "L5's external provider now has one more thing to prove: that its identity survives into the pin and invalidates by name like any shipped one. `lowering_pin.rs` already exercises that with `scratch-provider/v1`, an identity this build does not ship, so L5's provider inherits a working contract rather than discovering one."
+      ],
+      "gates_run": [
+        "cargo fmt --all (and --check)",
+        "cargo clippy -p larql-vindex -p larql-cli -p larql-inference --all-targets -- -D warnings",
+        "cargo test -p larql-vindex (lib 4665 (4659 at L3 + the wave's 6; no existing assertion changed); 39 suites, 4989 tests, 0 failed)",
+        "cargo check --workspace --all-targets",
+        "kernel-plane file count, the inventory's method: 33",
+        "scripts/check_contract_index.py (71 named tests), scripts/check_doc_links.py"
+      ],
+      "deviations_from_forecast": "None. The wave stayed inside the frozen design: no selection change, no capability work, no Metal migration, kernel-plane count 33. Two things were added beyond the seven controls and are recorded above rather than in the forecast: `ensure_lowered_by` at the execution seam (kept because it held with no existing assertion changed) and `PreparedVindex3::with_lowerings`, without which no production-path witness of invalidation was possible."
     }
   }
 }

--- a/docs/represent/forecasts/lowering-plugin-1-notes.json
+++ b/docs/represent/forecasts/lowering-plugin-1-notes.json
@@ -196,6 +196,49 @@
         ],
         "3_the_informational_mutants_run": "`cargo mutants --in-diff` on the PR reported three MISSED before the job was canceled at 45 minutes. One was L3's own: `<impl PlanBackend for Arc<T>>::prepare` replaced with an empty body SURVIVED, because `prepare` returns nothing and the new delegation test merely called it — coverage without a claim. Killed by giving the test double a counter and asserting the handle reached it, and verified by applying the mutant by hand and watching that assertion fail. The other two are pre-existing gaps in CLI report paths L3 happened to touch (`realizations::bind_and_reconcile`, `sensitivity::capture_moments`): each prints a report and returns `Ok(())`, and nothing asserts the printing, so a body replaced with `Ok(())` survives. Recorded rather than fixed — out of this wave's scope, and the check is informational."
       }
+    },
+    "L4": {
+      "name": "provider identity in prepared state",
+      "status": "design frozen before implementation",
+      "branch": "lowering-l4",
+      "base": "L3 (`lowering-l3`) on L2 (#466); rebased onto main once both merge",
+      "date": "2026-09-09",
+      "the_question": "Can the lowering decision survive preparation and be invalidated by the authority it was made against — without the prepared image owning the provider that would keep it alive?",
+      "rule": "The design below and the device-instance experiment's DECISION RULE are frozen before any code is written, so the experiment's answer cannot be chosen after seeing its result.",
+      "design_frozen_before_implementation": {
+        "the_pin_names_both_authorities": "`RealizationRecord.provider: Option<CodecIdentity>` becomes `codec_provider`, joined by `lowering_provider: LoweringIdentity`. The lowering one is NOT optional: a record exists because a provider selected it, and since L1 every provider states an identity. Two independent authorities, both named on the pin, neither derived from the other.",
+        "record_the_identity_not_the_provider": "The prepared image records what was decided; it does not hold `Arc<dyn PlanBackend>`. A prepared image that held its provider would keep a removed provider alive and could never be invalidated by its disappearance — that is resolution turned into possession, the contract defeated rather than kept.",
+        "lifetime": "Execution session/runtime holds `Arc<LoweringRegistry>` — current authority — beside the prepared image, which holds the historical decision. Before prepared state is USED, `PreparedOperands::ensure_lowerings_in(&LoweringRegistry)` asks whether that decision still stands. The shape is the codec plane's, with the registry carried rather than `&'static`.",
+        "one_judge_for_a_live_and_a_reloaded_pin": "`PreparedOperands::authorities() -> PinnedAuthorities { codecs, lowerings }` is a serializable value carrying both planes, and `ensure_providers_in` / `ensure_lowerings_in` delegate to it — so a pin that was serialized and reloaded is judged by exactly the code that judges a live one (control 7), and neither plane gets a second implementation.",
+        "no_fallback_and_no_reinterpretation": "A registry that holds SOME other provider is not an alternative. The refusal names the identity the pin recorded and every identity the registry holds; nothing re-selects, nothing widens, nothing substitutes a same-family provider at another revision.",
+        "distinct_by_plane": "A codec refusal names the representation whose provider moved; a lowering refusal names the lowering provider. Neither message can be mistaken for the other plane's (controls 5 and 6).",
+        "device_instance_stays_out_of_identity": "`LoweringIdentity` remains implementation semantics: `device-matmul/v1`, never `device-matmul-on-device-123/v1`. If the experiment below proves a configured environment is load-bearing for prepared state, it is named as a SECOND authority, not folded into the first."
+      },
+      "controls_frozen": [
+        "1 — same provider registered: prepared state remains valid",
+        "2 — provider removed: invalid, by name",
+        "3 — same family, different revision: invalid",
+        "4 — another provider available: STILL invalid; never a fallback",
+        "5 — codec valid, lowering invalid: fails specifically on the lowering plane",
+        "6 — lowering valid, codec invalid: fails specifically on the codec plane",
+        "7 — a serialized and reloaded pin retains both authorities and yields the same two verdicts"
+      ],
+      "device_instance_experiment": {
+        "question": "Same `LoweringIdentity`, different injected device/configuration — does any prepared state become invalid or semantically different?",
+        "why_it_must_be_asked_here": "L1 recorded that `DevicePlanBackend<MetalBackend>` and `DevicePlanBackend<CpuBackend>` both answer `device-matmul/v1`, and claimed that what the configuration changes is already pinned in the realization FORM. L4 is where that claim either holds or produces a second authority.",
+        "method": "Two `DevicePlanBackend` instances over the same injected `MatMul` (`CpuBackend`, so the experiment runs everywhere), differing only in the per-class `WeightFormats` table; both answer `device-matmul/v1`. Prepare an image with A, then execute it with B and compare bit-for-bit against executing it with A.",
+        "decision_rule": {
+          "if_the_image_refuses_or_computes_different_numbers_under_B": "a second authority exists. Name it separately — `ProviderBinding` / `EnvironmentIdentity`, what configured execution environment a preparation is tied to — and NEVER by putting hardware or configuration identity into `LoweringIdentity`.",
+          "if_the_image_computes_identically_under_B": "do not invent it. Record the negative result together with the experiment's limit: `CpuBackend`-as-device holds no device-resident buffers, so this cannot speak for a preparation whose storage lives on an injected Metal device.",
+          "either_way": "the result is written here before the wave is called held."
+        }
+      },
+      "out_of_scope": [
+        "selection changes of any kind",
+        "capability matching (F2's subject, not L4's)",
+        "Metal-lowered migration",
+        "any new kernel-plane variant — the count stays 33 (F3)"
+      ]
     }
   }
 }


### PR DESCRIPTION
## What

Wave L4 of LOWERING-PLUGIN-1 (forecast #464, L1 #465, L2 #466, L3 #468), answering one question: can the lowering decision survive preparation and be invalidated by the authority it was made against — **without the prepared image owning the provider that would keep it alive**?

The design and the device-instance experiment's decision rule were frozen in the first commit of this PR, before any code.

- **The pin names both authorities.** `RealizationRecord.provider` becomes `codec_provider` (what the bytes are), joined by `lowering_provider: LoweringIdentity` (what implementation qualified the realization). Not optional, and not derived from the other: a record exists because some provider selected it, and since L1 every provider states an identity.
- **The image records the decision, never the provider.** An image holding `Arc<dyn PlanBackend>` would keep a removed provider alive and could never be invalidated by its disappearance — resolution turned into possession. So `PinnedAuthorities { codecs, lowerings }` is a serializable value carrying both planes, and `ensure_providers_in` / `ensure_lowerings_in` are judged over it: a live image and a reloaded record of one cannot drift into two readings of one contract.
- **The session carries current authority.** `Vindex3Runtime::open_via` now takes and keeps an `Arc<LoweringRegistry>`; `PreparedVindex3` carries it and holds the image's pins against it before every use — `session_with_kv` and `prefill_into`. `with_lowerings` re-points a prepared model at another authority, the lowering plane's `OperandStore::with_registry`.

## The seven controls

All in `…/exec/tests/lowering_pin.rs`, over an image pinned by `scratch-provider/v1` — a provider this build does not ship, so no verdict below is about anything privileged.

| control | outcome |
|---|---|
| 1 same provider registered | valid |
| 2 provider removed | invalid, by name |
| 3 same family, another revision | invalid — the refusal names both `…/v1` and `…/v2` |
| 4 a registry full of other working providers | **still invalid**; "no other provider stands in for it" |
| 5 codec valid, lowering moved | fails on the lowering plane; the message never says `representation` |
| 6 lowering valid, codec moved | fails on the codec plane; the message never says `lowering` |
| 7 serialized and reloaded | identical value, identical verdicts on both planes |

And the image's authorities are unchanged after every refusal — nothing re-pinned on the way through.

## Two additions beyond the frozen list

- `PreparedOperands::ensure_lowered_by(backend)` — the check available at the execution seam, where a caller is handed a provider and no registry: the provider running these pins is the provider that made them. Added as a *measurement* and kept, because the whole suite passes unchanged with it in place: **nothing in this build has ever executed a prepared image on a provider that did not pin it.**
- `PreparedVindex3::with_lowerings`, without which no production path could witness invalidation: `a_served_model_refuses_when_the_provider_that_pinned_it_is_gone` re-points a served model at an authority holding only `reference/v1` and it refuses at **both** uses, session and batch prefill, with a perfectly capable provider registered and not substituted.

## The device-instance question L1 left open

Two `DevicePlanBackend`s over one injected device, differing only in the per-class format table, both answering `device-matmul/v1`. They **prepare different images** — configuration is genuinely load-bearing — and yet **one image executes bit-identically under either**, because the format table is consumed at preparation and what it decided is already pinned. So no second authority (`ProviderBinding` / `EnvironmentIdentity`) is invented, per the rule frozen before the experiment ran.

The limit is recorded rather than glossed: no prepared form in this build holds device-resident storage — `PreparedOperands` holds page-aligned **host** allocations and a device's residency is a buffer cache keyed on `(pointer, length)` — so a future provider whose prepared form held device handles is when that authority gets named.

## Unchanged

Selection, capability matching and `metal-lowered` untouched; kernel-plane files **33**; no existing assertion changed. `larql-vindex` 4665 lib tests over 39 suites (4989 total) on the pre-rebase base, with the dependent crates unchanged.

## Gates

`cargo fmt --all --check`; clippy `-D warnings`; `cargo test -p larql-vindex`; `cargo check --workspace --all-targets`; kernel-plane count by the inventory's method; `scripts/check_contract_index.py` (§8 now names both planes and cites the new rows) and `scripts/check_doc_links.py`.

Rebased onto `68e50625` (the merge of #468) and re-verified there. Pre-cleared against both classes of defect #468 hit in CI: every dependent crate's FULL target set passes (not just `--lib`), and `cargo llvm-cov --package larql-vindex` + `scripts/check_coverage_policy.py` passes at 93.75% with no file under its minimum.
