### PR TITLE
feat(lowering): L5 — a provider from outside the tree goes the whole way

### DIFF
--- a/crates/larql-vindex/tests/external_lowering_provider/genericity.rs
+++ b/crates/larql-vindex/tests/external_lowering_provider/genericity.rs
@@ -1,0 +1,107 @@
+//! The plugin-plane claim at the LOWERING seam, checked against the
+//! source rather than asserted in prose: **no identity this test crate
+//! invented appears anywhere in production LARQL code.**
+//!
+//! The codec plane holds the same line for representations
+//! (`external_attested_provider/genericity.rs`); this is its other half.
+//! A lowering plane that works only for the providers its own build
+//! happens to know is not a plane, it is a match arm with extra steps.
+//! Both families and both diagnostic names are spelled in `provider.rs`
+//! and must be spelled nowhere that ships.
+//!
+//! Test code inside `src/` is excluded — a fixture naming a fixture is
+//! not a hardcoded architecture — and identified structurally rather than
+//! by guessing at names.
+
+use std::path::{Path, PathBuf};
+
+use crate::provider::{FAMILY, NAME, SIBLING_FAMILY, SIBLING_NAME};
+
+/// A family this build DOES ship, for the control below: the production
+/// CPU provider's, spelled in `exec/production.rs`.
+const SHIPPED_FAMILY: &str = "cpu-production";
+
+/// Every `.rs` file under a crate's `src/` that is not itself a test.
+fn production_sources() -> Vec<PathBuf> {
+    let crates = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/")
+        .to_path_buf();
+    let mut out = Vec::new();
+    let mut stack = vec![crates];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if path.is_dir() {
+                // `target/` is build output; `tests/`, `benches/` and
+                // `examples/` are not shipped; a `tests` module inside
+                // `src` is test code.
+                if !matches!(name.as_str(), "target" | "tests" | "benches" | "examples") {
+                    stack.push(path);
+                }
+                continue;
+            }
+            if name.ends_with(".rs")
+                && !name.ends_with("_tests.rs")
+                && !name.starts_with("tests")
+                && path.components().any(|c| c.as_os_str() == "src")
+            {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn no_external_provider_identity_appears_in_production_larql() {
+    let sources = production_sources();
+    assert!(
+        sources.len() > 100,
+        "the scan found only {} files, so it is not looking where it thinks",
+        sources.len()
+    );
+    let mut found = Vec::new();
+    for path in &sources {
+        let Ok(text) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        for needle in [
+            FAMILY,
+            NAME,
+            SIBLING_FAMILY,
+            SIBLING_NAME,
+            "OutsideProvider",
+        ] {
+            if text.contains(needle) {
+                found.push(format!("{} names `{needle}`", path.display()));
+            }
+        }
+    }
+    assert!(
+        found.is_empty(),
+        "production code must not know this provider: {found:?}"
+    );
+}
+
+/// And the scan can fail — a lowering family this build DOES ship is
+/// found by the same walk, so an empty result above means "nothing
+/// there" rather than "nothing looked at".
+#[test]
+fn the_scan_would_have_found_a_provider_that_was_there() {
+    let sources = production_sources();
+    let shipped = sources.iter().any(|p| {
+        std::fs::read_to_string(p)
+            .map(|t| t.contains(SHIPPED_FAMILY))
+            .unwrap_or(false)
+    });
+    assert!(
+        shipped,
+        "the family `{SHIPPED_FAMILY}` this build DOES ship was not found, so the scan proves \
+         nothing"
+    );
+}

--- a/crates/larql-vindex/tests/external_lowering_provider/main.rs
+++ b/crates/larql-vindex/tests/external_lowering_provider/main.rs
@@ -1,0 +1,409 @@
+//! **L5 of LOWERING-PLUGIN-1: a lowering provider from outside the tree
+//! goes the whole way.**
+//!
+//! The forecast predicts that a crate which is not `larql-vindex` can
+//! register a lowering provider this build does not ship and reach
+//! register → candidate derivation → selection → accounting → pin →
+//! preparation → authority validation → execute, "without core naming its
+//! identity" and without opening the kernel plane.
+//!
+//! This is that journey, in one test, on a container this build wrote —
+//! with the controls that keep it from being a demonstration of nothing:
+//! the numbers are the provider's own (its kernel multiplies every
+//! feed-forward matrix and the vocabulary head, and perturbing it moves
+//! the logits); its pins are its own (they record `outside-lowering/v1`, and
+//! L4's invalidation refuses by name once it is gone, with the shipped
+//! registry NOT a fallback); its refusal is its own; and the source scan
+//! in `genericity.rs` says core never learned its name.
+//!
+//! An integration test is a separate crate in cargo's model, so this file
+//! sees only what `larql-vindex` exports. Anything the proof had needed
+//! from the crate's internals would have been a leak in the contract.
+
+mod genericity;
+mod provider;
+
+use larql_vindex::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
+use larql_vindex::format::vindex3::inspect::inspect_container;
+use larql_vindex::format::vindex3::opplan::exec::accounting::{
+    execution_touch, expectations, render_selection_summary, stored_footprint, BlockGeometry,
+    ResourceLedger,
+};
+use larql_vindex::format::vindex3::opplan::exec::backend::PlanBackend;
+use larql_vindex::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
+use larql_vindex::format::vindex3::opplan::exec::lowering::{LoweringIdentity, LoweringRegistry};
+use larql_vindex::format::vindex3::opplan::exec::operands::OperandStore;
+use larql_vindex::format::vindex3::opplan::exec::prepared::{ExecutionSlice, PreparedOperands};
+use larql_vindex::format::vindex3::opplan::exec::production::ProductionBackend;
+use larql_vindex::format::vindex3::opplan::exec::realization::{
+    RealizationForm, RealizationId, RefusalKind, RepresentationFacts,
+};
+use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use larql_vindex::format::vindex3::opplan::exec::{execute_plan, execute_plan_via};
+use larql_vindex::format::vindex3::opplan::planned::Operation;
+use larql_vindex::format::vindex3::opplan::{plan_component_ops, ComponentOpPlan};
+use larql_vindex::format::vindex3::represent::codec::CodecRegistry;
+
+use provider::{identity, sibling_identity, Dispatches, OutsideProvider, Tally, NAME};
+
+/// A prompt over the dense fixture's 128-token vocabulary — the same one
+/// the L2 and L4 witnesses read.
+const TOKENS: [u32; 5] = [3, 17, 28, 0, 11];
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    plan: ComponentOpPlan,
+    store: OperandStore,
+}
+
+fn dense() -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let checkpoint = tmp.path().join("ckpt");
+    std::fs::create_dir_all(&checkpoint).unwrap();
+    let container = tmp.path().join("out.vindex3");
+    encode_fixture_container(dense_f32_model, &checkpoint, &container, "target");
+    let inspection = inspect_container(&container, false).unwrap();
+    let plan = plan_component_ops(&inspection, &container, "target")
+        .unwrap()
+        .plan
+        .expect("the dense fixture plans");
+    let store = OperandStore::open(&container, &inspection).unwrap();
+    Fixture {
+        _tmp: tmp,
+        plan,
+        store,
+    }
+}
+
+fn bits(v: &[f32]) -> Vec<u32> {
+    v.iter().map(|x| x.to_bits()).collect()
+}
+
+/// The registry a caller composes: what this build ships, plus a provider
+/// it has never heard of.
+fn registry_with_outside(provider: OutsideProvider) -> LoweringRegistry {
+    LoweringRegistry::shipped()
+        .register(Box::new(provider))
+        .expect("an identity no shipped provider claims")
+}
+
+/// This provider's own pin: decode to f32, then its own scalar kernel.
+fn decode_pin() -> RealizationId {
+    RealizationId::cpu(RealizationForm::Decode(PhysicalProjectionPlan::ScalarF32))
+}
+
+/// **The journey.** Register → candidates → selection → accounting → pin
+/// → preparation → authority validation → execute, with nothing in core
+/// naming the provider at any step.
+#[test]
+fn an_external_provider_reaches_execution_through_registration_alone() {
+    let f = dense();
+    let outside = OutsideProvider::new();
+    let tally: Tally = outside.tally();
+
+    // Register. The registry keys on the identity the provider states,
+    // and the provider is a `Box<dyn PlanBackend>` from here on — its
+    // concrete type is gone.
+    let registry = registry_with_outside(outside);
+    assert!(registry.identities().contains(&identity()));
+    assert_eq!(registry.provider(&identity()).unwrap().name(), NAME);
+
+    // Candidates and selection: derived from the codec's declarations,
+    // and the choice is the provider's. The f32 codec declares a direct
+    // BLAS realization; this provider records it as considered and takes
+    // the decode it has a kernel for.
+    let ops = PreparedOperands::load_via(
+        &f.plan,
+        &f.store,
+        &registry,
+        &identity(),
+        ExecutionSlice::Full,
+    )
+    .expect("the external provider prepares the plan");
+    let records = ops.realizations();
+    assert!(!records.is_empty());
+    let projections: Vec<_> = records
+        .iter()
+        .filter(|r| r.selection.candidates.len() > 1)
+        .collect();
+    assert!(
+        !projections.is_empty(),
+        "no operand offered this provider a choice, so nothing was derived"
+    );
+    for record in &projections {
+        assert_eq!(record.selection.realization, decode_pin(), "{record:?}");
+        assert!(
+            record
+                .selection
+                .candidates
+                .contains(&RealizationId::cpu(RealizationForm::Direct(
+                    PhysicalProjectionPlan::BlasF32
+                ))),
+            "the declined direct realization is recorded as considered: {record:?}"
+        );
+    }
+
+    // The pin is the provider's, on both authorities (L4).
+    assert_eq!(ops.lowerings(), [identity()]);
+    for record in records {
+        assert_eq!(record.lowering_provider, identity());
+    }
+
+    // Accounting prices what THIS provider selected, from tensor tables
+    // alone — no payload has been read to get here beyond preparation's
+    // own loads.
+    let priced = expectations(
+        records,
+        |op| f.store.stored_len(op),
+        BlockGeometry::executor(),
+    );
+    let ledger = ResourceLedger::aggregate(&priced);
+    assert!(ledger.stored > 0 && ledger.resident > 0, "{ledger:?}");
+    assert!(execution_touch(&priced) > 0);
+    assert!(stored_footprint(&priced).operands > 0);
+    let summary = render_selection_summary(records);
+    assert!(
+        summary.contains(&decode_pin().name()),
+        "the summary names what the provider pinned: {summary}"
+    );
+
+    // Authority validation (L4): the registry that holds it says the
+    // preparation stands; the shipped registry — two working providers,
+    // neither of them this one — says it does not.
+    ops.ensure_lowerings_in(&registry).unwrap();
+    let err = ops
+        .ensure_lowerings_in(&LoweringRegistry::shipped())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("outside-lowering/v1"), "{err}");
+    assert!(err.contains("no other provider stands in for it"), "{err}");
+
+    // Execute. The interpreter drives the whole traversal through this
+    // provider, and the logits are what its own kernel computed — here,
+    // bit for bit what the reference oracle computes, because this
+    // provider's kernel is an honest scalar transcription and its glue is
+    // the oracle's.
+    let trace = execute_plan_via(&f.plan, &f.store, &TOKENS, &registry, &identity())
+        .expect("the external provider executes");
+    let oracle = execute_plan(&f.plan, &f.store, &TOKENS, &ReferenceBackend::new()).unwrap();
+    assert_eq!(
+        bits(trace.logits.as_deref().unwrap()),
+        bits(oracle.logits.as_deref().unwrap())
+    );
+    assert_eq!(trace.final_hidden(), oracle.final_hidden());
+
+    // And what the seam actually asked this provider for — reported
+    // rather than assumed.
+    let d = tally.dispatches();
+    eprintln!("the interpreter's dispatches to the external provider: {d:?}");
+    assert!(
+        d.output_head > 0,
+        "its own kernel produced the logits: {d:?}"
+    );
+    assert!(
+        d.matrices >= 3 * d.ffn + d.output_head,
+        "every feed-forward matrix and the head went through its own kernel: {d:?}"
+    );
+    assert!(d.embed > 0 && d.norm > 0 && d.residual_add > 0, "{d:?}");
+    assert!(d.attention > 0 || d.attention_step > 0, "{d:?}");
+    assert!(d.total() > 0);
+}
+
+/// **Named, not merely available.** A second external provider with the
+/// same capabilities — the same candidate derivation, the same kernel,
+/// its own identity — is registered beside the first, and the caller's
+/// named provider is still the one that runs: its counters move and the
+/// sibling's stay at zero, and asking for the sibling instead reaches the
+/// sibling. Without this, "the registry resolved the identity the caller
+/// named" and "it was the only implementation that could have run this
+/// plan" would look identical from the outside.
+///
+/// This is about RESOLUTION BY IDENTITY, which is L2's contract, and not
+/// about a registry matching declared capabilities to pick a provider on
+/// the caller's behalf — that is F2, and it stays out of scope. Nothing
+/// here asks the registry to choose; the caller chooses, and the registry
+/// is held to the choice.
+#[test]
+fn the_named_provider_is_reached_even_beside_an_equally_capable_one() {
+    let f = dense();
+    let outside = OutsideProvider::new();
+    let sibling = OutsideProvider::sibling();
+    let (named, other) = (outside.tally(), sibling.tally());
+    let registry = LoweringRegistry::shipped()
+        .register(Box::new(outside))
+        .and_then(|r| r.register(Box::new(sibling)))
+        .expect("two external identities, both free");
+    assert!(registry.identities().contains(&identity()));
+    assert!(registry.identities().contains(&sibling_identity()));
+
+    let ops = PreparedOperands::load_via(
+        &f.plan,
+        &f.store,
+        &registry,
+        &identity(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    assert_eq!(ops.lowerings(), [identity()], "pinned by the one named");
+    execute_plan_via(&f.plan, &f.store, &TOKENS, &registry, &identity()).unwrap();
+    assert!(named.dispatches().total() > 0);
+    assert_eq!(
+        other.dispatches(),
+        Dispatches::default(),
+        "the equally capable sibling was never asked for anything"
+    );
+
+    // And the sibling is reachable in its turn, by its own name — so the
+    // registry is resolving identities and not preferring the first
+    // provider that could have answered.
+    let theirs = PreparedOperands::load_via(
+        &f.plan,
+        &f.store,
+        &registry,
+        &sibling_identity(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    assert_eq!(theirs.lowerings(), [sibling_identity()]);
+    execute_plan_via(&f.plan, &f.store, &TOKENS, &registry, &sibling_identity()).unwrap();
+    assert!(other.dispatches().total() > 0);
+}
+
+/// The instrument control. A defect in the provider's OWN kernel moves
+/// the logits — so the numbers above came from it, and not from a shipped
+/// path quietly answering underneath.
+#[test]
+fn the_numbers_are_the_external_providers_own() {
+    let f = dense();
+    let honest = registry_with_outside(OutsideProvider::new());
+    let defective = registry_with_outside(OutsideProvider::with_defect(1e-3));
+
+    let good = execute_plan_via(&f.plan, &f.store, &TOKENS, &honest, &identity()).unwrap();
+    let bad = execute_plan_via(&f.plan, &f.store, &TOKENS, &defective, &identity()).unwrap();
+    assert_ne!(
+        bits(good.logits.as_deref().unwrap()),
+        bits(bad.logits.as_deref().unwrap()),
+        "the provider's kernel is not what produced the logits"
+    );
+}
+
+/// The plan follows the PROVIDER's policy, not a shipped default: the
+/// production provider, handed the same operands, pins the direct BLAS
+/// realization this one declines.
+#[test]
+fn the_pins_are_the_providers_choice_and_not_a_shipped_default() {
+    let f = dense();
+    let registry = registry_with_outside(OutsideProvider::new());
+    let outside = PreparedOperands::load_via(
+        &f.plan,
+        &f.store,
+        &registry,
+        &identity(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let shipped = PreparedOperands::load(
+        &f.plan,
+        &f.store,
+        &ProductionBackend::new(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+
+    let pins = |ops: &PreparedOperands| -> Vec<String> {
+        ops.realizations()
+            .iter()
+            .filter(|r| r.selection.candidates.len() > 1)
+            .map(|r| r.selection.realization.name())
+            .collect()
+    };
+    let (mine, theirs) = (pins(&outside), pins(&shipped));
+    assert!(!mine.is_empty() && mine.len() == theirs.len());
+    assert_ne!(mine, theirs, "the two providers pin the same realizations");
+    assert!(
+        theirs.iter().all(|p| p.contains("BlasF32")),
+        "the production provider takes the codec's declared direct kernel: {theirs:?}"
+    );
+    assert!(
+        mine.iter().all(|p| p == &decode_pin().name()),
+        "and this one decodes, every time, because that is what it has a kernel for: {mine:?}"
+    );
+}
+
+/// Its refusal is its own, and it is a refusal rather than a fallback:
+/// facts that name no registered codec admit nothing, and the provider
+/// says so in the contract's vocabulary without any shipped provider
+/// answering in its place.
+#[test]
+fn it_refuses_on_its_own_terms_when_the_facts_admit_nothing() {
+    let f = dense();
+    let outside = OutsideProvider::new();
+    // A projection-class operand: the operations the CONTRACT answers
+    // for every backend (an embedding gather, a bank slice) are not this
+    // provider's choice to make, and say nothing about its policy.
+    let planned = f
+        .plan
+        .planned_operands()
+        .into_iter()
+        .find(|p| matches!(p.operation, Operation::Project(_)))
+        .expect("the fixture plans projections");
+
+    // Facts resolved through a registry that knows nothing: the label
+    // names no codec, so there is no decode and nothing to derive from.
+    let empty: &'static CodecRegistry = Box::leak(Box::new(CodecRegistry::new()));
+    let nothing = RepresentationFacts::resolve_in(empty, "F32");
+    let refusal = outside
+        .select(&planned, &nothing)
+        .expect_err("nothing is admissible");
+    assert_eq!(refusal.kind, RefusalKind::UnregisteredRepresentation);
+    assert!(refusal.considered.is_empty());
+    let text = refusal.to_string();
+    assert!(text.contains("F32"), "{text}");
+
+    // And with the codec registered, the same provider selects — so the
+    // refusal was about the facts, not about the provider being unable.
+    let known = RepresentationFacts::resolve_in(CodecRegistry::builtin(), "F32");
+    let selection = outside.select(&planned, &known).expect("f32 is admissible");
+    assert_eq!(selection.realization, decode_pin());
+}
+
+/// L4's contract, inherited by a provider core has never heard of: an
+/// image it pinned may not be executed by another provider.
+#[test]
+fn another_provider_may_not_run_the_external_providers_pins() {
+    let f = dense();
+    let registry = registry_with_outside(OutsideProvider::new());
+    let ops = PreparedOperands::load_via(
+        &f.plan,
+        &f.store,
+        &registry,
+        &identity(),
+        ExecutionSlice::Full,
+    )
+    .unwrap();
+    let err = ops
+        .ensure_lowered_by(&ProductionBackend::new())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("outside-lowering/v1"), "{err}");
+    assert!(err.contains("cpu-production/v1"), "{err}");
+    ops.ensure_lowered_by(registry.provider(&identity()).unwrap())
+        .expect("its own provider may");
+}
+
+/// A control on the identity itself: an external provider is refused
+/// registration under an identity a shipped provider already holds, and a
+/// second revision of its own family is a different provider — the
+/// registry does not care that it comes from outside.
+#[test]
+fn the_registry_treats_an_outside_identity_exactly_as_a_shipped_one() {
+    let registry = registry_with_outside(OutsideProvider::new());
+    let again = registry.register(Box::new(OutsideProvider::new()));
+    assert!(again.is_err(), "a duplicate identity is refused");
+
+    let other_revision = LoweringIdentity::new(provider::FAMILY, provider::REVISION + 1);
+    let registry = registry_with_outside(OutsideProvider::new());
+    let err = registry.provider(&other_revision).unwrap_err().to_string();
+    assert!(err.contains("outside-lowering/v2"), "{err}");
+    assert!(err.contains("outside-lowering/v1"), "{err}");
+}

--- a/crates/larql-vindex/tests/external_lowering_provider/provider.rs
+++ b/crates/larql-vindex/tests/external_lowering_provider/provider.rs
@@ -1,0 +1,361 @@
+//! **The provider this build does not ship.**
+//!
+//! An integration test is a separate crate in cargo's model, so
+//! everything below is written against what `larql-vindex` exports and
+//! nothing else. What the provider OWNS is the part that has to be its
+//! own for the claim to mean anything: the candidates it derives from
+//! declared representation facts, the realization it pins, the refusal it
+//! raises when nothing is admissible, and the kernel that multiplies. The
+//! glue between projections — norms, RoPE, softmax, activations, the
+//! residual write — it borrows from the reference oracle, exactly as the
+//! in-tree device provider borrows the production CPU glue, and for the
+//! same reason: what is being demonstrated is authority, not arithmetic.
+//!
+//! Every method counts its dispatches, so the test can say which parts of
+//! the seam the interpreter actually asked this provider for rather than
+//! assuming.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use larql_vindex::error::VindexError;
+use larql_vindex::format::vindex3::opplan::exec::backend::{
+    AttentionCall, AttentionOut, AttentionStepCall, AttentionStepOut, FfnCall, NormCall,
+    PlanBackend, ProjectCall, RoutedFfnCall, WeightFormat, WeightSlice,
+};
+use larql_vindex::format::vindex3::opplan::exec::cpu::physical::PhysicalProjectionPlan;
+use larql_vindex::format::vindex3::opplan::exec::kernels::activate;
+use larql_vindex::format::vindex3::opplan::exec::lowering::LoweringIdentity;
+use larql_vindex::format::vindex3::opplan::exec::realization::{
+    common_selection, realization_residency, RealizationForm, RealizationId, RefusalKind,
+    RepresentationFacts, Selection, SelectionReason, SelectionRefusal,
+};
+use larql_vindex::format::vindex3::opplan::exec::reference::ReferenceBackend;
+use larql_vindex::format::vindex3::opplan::planned::PlannedOperand;
+
+/// The family this crate registers and `larql-vindex` does not. The
+/// genericity scan is over this string.
+pub const FAMILY: &str = "outside-lowering";
+pub const REVISION: u32 = 1;
+/// The diagnostic name — also scanned for, since a provider leaking into
+/// core by its NAME would be no better than by its family.
+pub const NAME: &str = "outside-lowering-r1";
+
+/// A SECOND external provider, equally capable: the same candidate
+/// derivation, the same kernel, a different identity. It exists so that
+/// "the caller named this provider and got it" can be told apart from
+/// "it was the only implementation that could have run this plan".
+pub const SIBLING_FAMILY: &str = "outside-lowering-sibling";
+pub const SIBLING_NAME: &str = "outside-lowering-sibling-r1";
+
+pub fn identity() -> LoweringIdentity {
+    LoweringIdentity::new(FAMILY, REVISION)
+}
+
+pub fn sibling_identity() -> LoweringIdentity {
+    LoweringIdentity::new(SIBLING_FAMILY, REVISION)
+}
+
+/// What the interpreter asked this provider for, by seam method.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Dispatches {
+    pub embed: u64,
+    pub norm: u64,
+    pub project: u64,
+    pub attention: u64,
+    pub attention_step: u64,
+    pub ffn: u64,
+    pub routed_ffn: u64,
+    pub output_head: u64,
+    pub residual_add: u64,
+    /// Matrices this provider multiplied with its OWN kernel — the work,
+    /// as distinct from the calls.
+    pub matrices: u64,
+}
+
+impl Dispatches {
+    pub fn total(&self) -> u64 {
+        self.embed
+            + self.norm
+            + self.project
+            + self.attention
+            + self.attention_step
+            + self.ffn
+            + self.routed_ffn
+            + self.output_head
+            + self.residual_add
+    }
+}
+
+#[derive(Default)]
+pub struct Counts {
+    embed: AtomicU64,
+    norm: AtomicU64,
+    project: AtomicU64,
+    attention: AtomicU64,
+    attention_step: AtomicU64,
+    ffn: AtomicU64,
+    routed_ffn: AtomicU64,
+    output_head: AtomicU64,
+    residual_add: AtomicU64,
+    matrices: AtomicU64,
+}
+
+/// A handle on one provider's dispatch counters, kept by the test after
+/// the registry has taken ownership of the provider itself — registration
+/// is by `Box<dyn PlanBackend>`, so the concrete type is gone the moment
+/// it is registered, which is itself part of the claim.
+#[derive(Clone, Default)]
+pub struct Tally(Arc<Counts>);
+
+impl Tally {
+    pub fn dispatches(&self) -> Dispatches {
+        let c = &*self.0;
+        Dispatches {
+            embed: c.embed.load(Ordering::Relaxed),
+            norm: c.norm.load(Ordering::Relaxed),
+            project: c.project.load(Ordering::Relaxed),
+            attention: c.attention.load(Ordering::Relaxed),
+            attention_step: c.attention_step.load(Ordering::Relaxed),
+            ffn: c.ffn.load(Ordering::Relaxed),
+            routed_ffn: c.routed_ffn.load(Ordering::Relaxed),
+            output_head: c.output_head.load(Ordering::Relaxed),
+            residual_add: c.residual_add.load(Ordering::Relaxed),
+            matrices: c.matrices.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// A lowering provider from outside the tree.
+pub struct OutsideProvider {
+    /// Which of the two external identities this instance states.
+    family: &'static str,
+    name: &'static str,
+    /// The glue, borrowed through exported API.
+    glue: ReferenceBackend,
+    /// A deliberate defect in this provider's OWN kernel, for the control
+    /// that the numbers are its: `0.0` is the honest provider.
+    defect: f32,
+    counts: Arc<Counts>,
+}
+
+impl Default for OutsideProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OutsideProvider {
+    pub fn new() -> Self {
+        Self::with_defect(0.0)
+    }
+
+    /// The equally capable second provider — same policy, same kernel,
+    /// its own identity.
+    pub fn sibling() -> Self {
+        Self {
+            family: SIBLING_FAMILY,
+            name: SIBLING_NAME,
+            ..Self::new()
+        }
+    }
+
+    /// The same provider with a deliberate defect in its projection
+    /// kernel — the instrument control: if the logits do not move, the
+    /// numbers were never this provider's.
+    pub fn with_defect(defect: f32) -> Self {
+        Self {
+            family: FAMILY,
+            name: NAME,
+            glue: ReferenceBackend::new(),
+            defect,
+            counts: Arc::new(Counts::default()),
+        }
+    }
+
+    /// A handle on this provider's counters that outlives handing the
+    /// provider to a registry.
+    pub fn tally(&self) -> Tally {
+        Tally(Arc::clone(&self.counts))
+    }
+
+    /// This provider's own kernel: one row-major `[out, in]` matrix
+    /// against one vector, accumulated in order. Not borrowed — the
+    /// arithmetic that makes the logits this provider's.
+    fn project_rows(
+        &self,
+        weight: WeightSlice<'_>,
+        out_dim: usize,
+        in_dim: usize,
+        x: &[f32],
+    ) -> Result<Vec<f32>, VindexError> {
+        // One kernel, over f32 values. Anything else is refused by name
+        // rather than silently widened — this provider does not pretend
+        // to formats it has no code for.
+        let w = weight.as_f32()?;
+        self.counts.matrices.fetch_add(1, Ordering::Relaxed);
+        let mut out = vec![0.0f32; out_dim];
+        for (row, slot) in out.iter_mut().enumerate() {
+            let mut acc = 0.0f32;
+            for (w, v) in w[row * in_dim..(row + 1) * in_dim].iter().zip(x) {
+                acc += w * v;
+            }
+            *slot = acc + self.defect;
+        }
+        Ok(out)
+    }
+}
+
+impl PlanBackend for OutsideProvider {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn identity(&self) -> LoweringIdentity {
+        LoweringIdentity::new(self.family, REVISION)
+    }
+
+    /// **This provider's own selection.** Candidates are derived from
+    /// what the registry DECLARES for the stored representation — never
+    /// from its label — and the one it takes is the one it has a kernel
+    /// for: the universal decode to f32, which is what its single scalar
+    /// kernel reads. A direct realization the codec declares is
+    /// considered and recorded as a candidate, and declined, because this
+    /// provider has no kernel over stored bytes; nothing about that
+    /// choice is core's to make.
+    fn select(
+        &self,
+        operand: &PlannedOperand,
+        facts: &RepresentationFacts,
+    ) -> Result<Selection, Box<SelectionRefusal>> {
+        // The operations no backend chooses between — embedding gather,
+        // bank slicing, the mapped bank — answered the one way the
+        // contract defines them.
+        if let Some(common) = common_selection(operand, facts, WeightFormat::F32) {
+            return common;
+        }
+        let refuse = |kind, considered: Vec<(RealizationId, String)>| {
+            Box::new(SelectionRefusal {
+                operand: operand.operand.clone(),
+                operation: operand.operation,
+                representation: facts.label.clone(),
+                requested: operand.access,
+                kind,
+                considered,
+            })
+        };
+        if facts.registered.is_none() {
+            return Err(refuse(RefusalKind::UnregisteredRepresentation, Vec::new()));
+        }
+        let decode = RealizationId::cpu(RealizationForm::Decode(PhysicalProjectionPlan::ScalarF32));
+        let mut candidates: Vec<RealizationId> = facts
+            .direct_cpu_plans()
+            .into_iter()
+            .map(|plan| RealizationId::cpu(RealizationForm::Direct(plan)))
+            .collect();
+        let declined = candidates.len();
+        candidates.push(decode);
+        Ok(Selection {
+            realization: decode,
+            residency: realization_residency(facts, decode),
+            reason: if declined > 0 {
+                SelectionReason::ArmPrefersDecode
+            } else {
+                SelectionReason::NoDirectRealization
+            },
+            candidates,
+        })
+    }
+
+    fn embed(&self, table: &[f32], hidden: usize, token: u32, scale: Option<f32>) -> Vec<f32> {
+        self.counts.embed.fetch_add(1, Ordering::Relaxed);
+        self.glue.embed(table, hidden, token, scale)
+    }
+
+    fn norm(&self, call: NormCall<'_>) -> Vec<f32> {
+        self.counts.norm.fetch_add(1, Ordering::Relaxed);
+        self.glue.norm(call)
+    }
+
+    fn project(&self, call: ProjectCall<'_>) -> Result<Vec<f32>, VindexError> {
+        self.counts.project.fetch_add(1, Ordering::Relaxed);
+        self.project_rows(call.weight, call.out_dim, call.in_dim, call.x)
+    }
+
+    fn attention(&self, call: AttentionCall<'_>) -> Result<AttentionOut, VindexError> {
+        self.counts.attention.fetch_add(1, Ordering::Relaxed);
+        self.glue.attention(call)
+    }
+
+    fn attention_step(&self, call: AttentionStepCall<'_>) -> Result<AttentionStepOut, VindexError> {
+        self.counts.attention_step.fetch_add(1, Ordering::Relaxed);
+        self.glue.attention_step(call)
+    }
+
+    /// The dense feed-forward — three matrices, this provider's own
+    /// kernel for each, and the plan's own semantics between them.
+    ///
+    /// The gate POLICY is the plan's meaning, not a lowering choice: this
+    /// provider honours the plain gated policy and refuses anything else
+    /// by name, exactly as the contract requires of every backend. It
+    /// states that refusal itself because the shipped helper that states
+    /// it (`require_executable_gate`) is crate-internal — an outside
+    /// provider can read the policy and must re-derive what honouring it
+    /// means, which is a real limit of the seam and is recorded as one.
+    fn ffn(&self, call: FfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        self.counts.ffn.fetch_add(1, Ordering::Relaxed);
+        if !matches!(call.gate_policy, larql_models::ExpertGatePolicy::Gated) {
+            return Err(VindexError::Parse(format!(
+                "`{}` implements only the plain gated feed-forward policy; this plan declares \
+                 {:?} and this provider will not approximate it",
+                self.name, call.gate_policy
+            )));
+        }
+        let up = self.project_rows(call.up, call.intermediate, call.hidden, call.x)?;
+        let inner: Vec<f32> = match call.gate {
+            Some(gate) => {
+                let gate = self.project_rows(gate, call.intermediate, call.hidden, call.x)?;
+                gate.iter()
+                    .zip(&up)
+                    .map(|(g, u)| activate(call.activation, *g) * u)
+                    .collect()
+            }
+            None => up.iter().map(|u| activate(call.activation, *u)).collect(),
+        };
+        self.project_rows(call.down, call.hidden, call.intermediate, &inner)
+    }
+
+    fn routed_ffn(&self, call: RoutedFfnCall<'_>) -> Result<Vec<f32>, VindexError> {
+        self.counts.routed_ffn.fetch_add(1, Ordering::Relaxed);
+        self.glue.routed_ffn(call)
+    }
+
+    /// The vocabulary projection — this provider's own kernel, so the
+    /// logits a caller reads are literally what it computed.
+    fn output_head(
+        &self,
+        projection: WeightSlice<'_>,
+        vocab: usize,
+        hidden: usize,
+        x: &[f32],
+        multiplier: Option<f64>,
+        softcapping: Option<f32>,
+    ) -> Result<Vec<f32>, VindexError> {
+        self.counts.output_head.fetch_add(1, Ordering::Relaxed);
+        let mut logits = self.project_rows(projection, vocab, hidden, x)?;
+        for logit in &mut logits {
+            if let Some(multiplier) = multiplier {
+                *logit *= multiplier as f32;
+            }
+            if let Some(cap) = softcapping {
+                *logit = (*logit / cap).tanh() * cap;
+            }
+        }
+        Ok(logits)
+    }
+
+    fn residual_add(&self, acc: &mut [f32], delta: &[f32]) {
+        self.counts.residual_add.fetch_add(1, Ordering::Relaxed);
+        self.glue.residual_add(acc, delta);
+    }
+}

--- a/docs/represent-v1-contract-index.md
+++ b/docs/represent-v1-contract-index.md
@@ -229,6 +229,11 @@ alone: no core file names it.
 | execution seam | `a_pin_is_executed_by_the_provider_that_decided_it_or_not_at_all` — same file (the check available where no registry is: the executing provider is the one that pinned) |
 | configuration control | `one_identity_over_two_configurations_prepares_differently_and_executes_one_image_identically` — same file (one identity, two format tables: two preparations, but either instance means the same thing by a given one — why configuration is not a second authority) |
 | production path | `a_served_model_refuses_when_the_provider_that_pinned_it_is_gone` — `crates/larql-inference/src/vindex3/tests/mod.rs` (the served model, re-pointed at an authority without its provider, refuses at session and at prefill) |
+| lowering plugin | `an_external_provider_reaches_execution_through_registration_alone` — `crates/larql-vindex/tests/external_lowering_provider/main.rs` (register → candidates → selection → accounting → pin → preparation → authority validation → execute, for a provider this build does not ship; its logits are bit-identical to the oracle's) |
+| named, not merely available | `the_named_provider_is_reached_even_beside_an_equally_capable_one` — same file (a second, equally capable external provider is registered; the one the caller named runs and the sibling's dispatch counters stay at zero) |
+| instrument | `the_numbers_are_the_external_providers_own` — same file (a defect in its kernel moves the logits, so no shipped path answered underneath) |
+| lowering genericity | `no_external_provider_identity_appears_in_production_larql` — `crates/larql-vindex/tests/external_lowering_provider/genericity.rs` (neither external family, neither name, nor the type appears in any non-test source under `crates/*/src`) |
+| scan control | `the_scan_would_have_found_a_provider_that_was_there` — same file (the same walk finds `cpu-production`) |
 | qualified by | PR #441 (`85b46061`), PR #447 (`202ffb7b`) |
 
 ---

--- a/docs/represent/forecasts/lowering-plugin-1-notes.json
+++ b/docs/represent/forecasts/lowering-plugin-1-notes.json
@@ -290,6 +290,37 @@
         "scripts/check_contract_index.py (71 named tests), scripts/check_doc_links.py"
       ],
       "deviations_from_forecast": "None. The wave stayed inside the frozen design: no selection change, no capability work, no Metal migration, kernel-plane count 33. Two things were added beyond the seven controls and are recorded above rather than in the forecast: `ensure_lowered_by` at the execution seam (kept because it held with no existing assertion changed) and `PreparedVindex3::with_lowerings`, without which no production-path witness of invalidation was possible."
+    },
+    "L5": {
+      "name": "hostile external provider",
+      "status": "design frozen before implementation",
+      "branch": "lowering-l5",
+      "base": "L4 (`lowering-l4`) on L3 on L2 (#466)",
+      "date": "2026-09-09",
+      "the_question": "Can a lowering provider this build neither ships nor names go the whole way — register → candidate derivation → selection → accounting → pin → preparation → authority validation → execute — with no provider-specific branch in core, and the kernel plane still closed?",
+      "rule": "Frozen before implementation, as L3 and L4 were. What the provider may borrow from the crate is decided HERE, so a proof that needed an internal cannot be quietly re-described as a proof that did not.",
+      "design_frozen_before_implementation": {
+        "where": "`crates/larql-vindex/tests/external_lowering_provider/`. An integration test is a separate crate in cargo's model, so it sees only what `larql-vindex` exports — the same standard the codec plane's proof met (`external_codec_provider.rs`, `external_attested_provider/`), where anything the proof had needed from the crate's internals would have been a leak in the contract.",
+        "identity": "`outside-lowering/v1`, spelled in the test crate and nowhere that ships. The genericity scan is over that family, the provider's name and its own constants.",
+        "shape": "The provider owns its candidate derivation, its selection, its refusal and its projection kernel, and borrows the reference oracle for the glue between projections — the same composition the in-tree device provider takes with the production CPU glue (`exec/device.rs`), and the shape a real out-of-tree provider starts life in. Borrowing is through exported API, which is the point: an external provider is allowed to USE the crate; core is not allowed to know it.",
+        "reuses_an_existing_realization": "Per F3 it pins forms that already exist — the codec-declared direct plan when the facts declare one, else the universal decode — and adds no `PhysicalProjectionPlan`, `WeightFormat`, `WeightSlice`, `WeightRows` or `LoadedWeight` variant. The kernel-plane count stays 33.",
+        "what_it_must_borrow_and_that_is_a_finding": "`SelectionReason` is a closed vocabulary an external provider must choose from. Whether every arm it needs is provider-agnostic is measured, not assumed, and recorded either way."
+      },
+      "controls_frozen": [
+        "the journey, in one test on a container this build wrote: register → candidates → selection → accounting → pin → preparation → authority validation → execute",
+        "the arithmetic is the provider's own: a variant of it that computes differently produces different logits, so the numbers come from the external provider and not from a shipped path shadowing it",
+        "core never names it: a source scan over every non-test `.rs` under `crates/*/src` for the family, the name and the provider's constants — with the positive control that the same scan finds a family this build DOES ship",
+        "the pin is its own: every record says `outside-lowering/v1`, and L4's invalidation refuses by name once the provider is gone, with the shipped registry NOT a fallback",
+        "the accounting prices what IT selected, not what a shipped provider would have selected for the same operands",
+        "its refusal is its own: facts that admit no realization are refused naming the candidates it considered, before any byte, with nothing underneath constructing a provider to answer anyway"
+      ],
+      "kernel_plane_files_expected": 33,
+      "out_of_scope": [
+        "capability matching (F2)",
+        "opening the kernel vocabulary (F3 — the whole point is that the first external provider does not need it)",
+        "Metal-lowered migration (F1)",
+        "any change to selection, accounting or execution semantics in core"
+      ]
     }
   }
 }

--- a/docs/represent/forecasts/lowering-plugin-1-notes.json
+++ b/docs/represent/forecasts/lowering-plugin-1-notes.json
@@ -2,6 +2,7 @@
   "programme": "LOWERING-PLUGIN-1",
   "forecast": "lowering-plugin-1.json (frozen 2026-09-08, PR #464)",
   "rule": "The forecast is not edited. Every deviation, measurement and surprise is written here with its reason.",
+  "merge_policy": "Set while landing L3 (2026-09-10). Mutation testing is NOT a merge authority — the `cargo-mutants` job is informational and can be canceled by its own runtime — but any COMPLETED mutants result is read before merging, because it reads the wave's own diff. A survivor that belongs to the wave is killed before the merge (L3's `Arc<T>::prepare` delegation was one: execution coverage with no assertion). A survivor that is pre-existing debt in code the wave merely touched is classified and recorded, not folded in, so the wave boundary stays legible. A RE-RUN need not be waited for once the required checks are green, the wave's own survivor has been reproduced by hand and shown to be killed by the new assertion, and the remaining survivors are already classified — read it when it finishes and fix forward only if it reveals a defect in a LATER wave's claim.",
   "waves": {
     "L1": {
       "name": "lowering identity",
@@ -293,7 +294,7 @@
     },
     "L5": {
       "name": "hostile external provider",
-      "status": "design frozen before implementation",
+      "status": "built and held",
       "branch": "lowering-l5",
       "base": "L4 (`lowering-l4`) on L3 on L2 (#466)",
       "date": "2026-09-09",
@@ -320,7 +321,61 @@
         "opening the kernel vocabulary (F3 — the whole point is that the first external provider does not need it)",
         "Metal-lowered migration (F1)",
         "any change to selection, accounting or execution semantics in core"
-      ]
+      ],
+      "what_landed": [
+        "`crates/larql-vindex/tests/external_lowering_provider/` — `provider.rs` (two external providers), `main.rs` (the journey and its controls), `genericity.rs` (the source scan and its positive control). Nine tests.",
+        "The provider states `outside-lowering/v1`, derives its candidates from the codec's declarations, records the direct BLAS realization the f32 codec declares as CONSIDERED and declines it, and pins the universal decode — because its one kernel reads f32 values. It owns its selection, its refusal, its projection kernel, the whole dense feed-forward (three matrices per call) and the vocabulary head; it borrows the reference oracle's glue, as the in-tree device provider borrows the production CPU glue.",
+        "A second external provider — `outside-lowering-sibling/v1`, same derivation, same kernel — exists so that 'the caller named it' can be told apart from 'it was the only implementation that could have run'.",
+        "**No production file changed.** The whole wave is a new test target: `git diff --stat HEAD -- crates` over the implementation commit is empty apart from the new directory."
+      ],
+      "witnesses": {
+        "the_journey": "`an_external_provider_reaches_execution_through_registration_alone` — register → candidates (the declined direct realization is in `candidates`) → selection → accounting (`expectations` → `ResourceLedger::aggregate`, non-zero stored/resident/touch, and `render_selection_summary` naming what IT pinned) → pin (`lowering_provider == outside-lowering/v1` on every record) → preparation → authority validation (`ensure_lowerings_in` stands in its registry, refuses in the shipped one) → execute",
+        "named_not_merely_available": "`the_named_provider_is_reached_even_beside_an_equally_capable_one` — with the sibling registered, executing via `outside-lowering/v1` moves that provider's dispatch counters and leaves the sibling's at exactly zero; asking for the sibling reaches the sibling and pins its identity",
+        "the_numbers_are_its_own": "`the_numbers_are_the_external_providers_own` — a defect in its kernel moves the logits, so no shipped path was quietly answering underneath",
+        "its_choice_not_a_default": "`the_pins_are_the_providers_choice_and_not_a_shipped_default` — the production provider, handed the same operands, pins `cpu:direct/BlasF32` every time; this one pins `cpu:decode/ScalarF32` every time",
+        "its_own_refusal": "`it_refuses_on_its_own_terms_when_the_facts_admit_nothing` — facts naming no registered codec are refused by the provider itself with `UnregisteredRepresentation` and no candidates, and the same provider selects once the codec is registered",
+        "L4_inherited": "`another_provider_may_not_run_the_external_providers_pins` — `ensure_lowered_by` refuses the production provider over these pins, naming both identities",
+        "the_registry_is_indifferent": "`the_registry_treats_an_outside_identity_exactly_as_a_shipped_one` — duplicate refused, another revision of its family is another provider",
+        "genericity": "`no_external_provider_identity_appears_in_production_larql` — both families, both names and the type name appear in no non-test `.rs` under any crate's `src/` (>100 files scanned)",
+        "scan_control": "`the_scan_would_have_found_a_provider_that_was_there` — the same walk finds `cpu-production`, so the empty result means 'nothing there' rather than 'nothing looked at'",
+        "correctness": "the external path's logits and final hidden state are BIT-IDENTICAL to the reference oracle's — its own kernels compute the model exactly, not approximately"
+      },
+      "controls_added_after_the_freeze": {
+        "control": "`the_named_provider_is_reached_even_beside_an_equally_capable_one`",
+        "why": "Raised in review: the six frozen controls could not distinguish 'the registry resolved the identity the caller named' from 'the external provider was the only implementation that could have run this plan' — the journey passes either way, and 'the accounting prices what IT selected' is about pricing, not about why it was reached.",
+        "where_it_sits_relative_to_F2": "This is resolution BY IDENTITY — L2's contract, where the CALLER chooses and the registry is held to the choice. It is not the registry matching declared capabilities to pick a provider on the caller's behalf, which is F2 and remains out of scope. Nothing in the test asks the registry to choose.",
+        "recorded_here": "rather than by editing the frozen list, per the programme's rule."
+      },
+      "measurements": {
+        "kernel_plane_files": 33,
+        "production_files_changed": 0,
+        "larql_vindex_lib_tests": "4665, unchanged — the wave adds no lib test",
+        "external_lowering_provider_suite": "9 passed",
+        "what_the_interpreter_asked_the_provider_for": "embed 5, norm 21, project 0, attention 2, attention_step 0, ffn 10, routed_ffn 0, output_head 1, residual_add 20 — and 31 matrices multiplied by its own kernel (3 per feed-forward call, plus the head)",
+        "larql_vindex_all_suites": "39 suites, 4998 tests, 0 failed (4989 at L4 plus this wave's 9)"
+      },
+      "findings": [
+        "**`project` is dispatched zero times.** On a dense softmax stack the seam dispatches WHOLE OPERATIONS — `attention`, `ffn`, `output_head` — and `PlanBackend::project` is never called; the projections inside attention belong to `attention`. So an external provider that wants to own the matmuls must implement those methods, which is what this one does for the feed-forward and the head. Measured rather than assumed, and directly relevant to F1: the granularity question is not only 'is per-operation too fine for Metal', it is also 'which per-operation methods are actually on the path'.",
+        "**A provider owns realization and borrows plan semantics — but the shipped JUDGEMENT about semantics is not exported.** `kernels::activate` is public, so the activation is shared rather than re-transcribed; `production::require_executable_gate` — the shipped statement of which gate policies are executable — is `pub(super)`, so this provider states its own refusal for policies it does not implement. The contract says every backend must honour the gate policy or refuse; outside the crate that is enforced by convention alone. Naming a limit, not a defect: it is what a later wave would fix by exporting the judgement, not the policy.",
+        "**`SelectionReason` is a closed vocabulary and every arm this provider needed is provider-agnostic** (`ArmPrefersDecode`, `NoDirectRealization`), so it borrowed without distorting anything. `DeviceClassTable` is the one provider-flavoured arm in the enum, and nothing outside a device backend needs it.",
+        "**F3 held for the reason the forecast predicted, and the reason is worth stating.** The external provider needed no new kernel-plane variant because `Decode(ScalarF32)` is an HONEST description of what it does — decode to f32, project with a scalar loop. A provider whose kernel had a genuinely novel shape would have nothing honest to name, and would face the choice between misdescribing itself as a shipped plan and opening the vocabulary. That is precisely the question the forecast defers to after provider openness, and it is now the sharpest open question in the lane.",
+        "**The wave required zero production changes.** L1–L4 built the plane; L5 only had to use it. That is the strongest form the claim could take: the first out-of-tree provider is not a special case anywhere in the tree."
+      ],
+      "gates_run": [
+        "cargo fmt --all (and --check)",
+        "cargo clippy -p larql-vindex --all-targets -- -D warnings",
+        "cargo test -p larql-vindex — 39 suites, 4998 tests, 0 failed (4989 at L4 plus this wave's 9)",
+        "cargo check --workspace --all-targets",
+        "kernel-plane file count, the inventory's method: 33",
+        "scripts/check_contract_index.py (76 named tests), scripts/check_doc_links.py (857 links), scripts/check_doc_references.py --strict (735 path references) — the last two run from a checkout OUTSIDE `.claude/`, see the gate-hygiene note below"
+      ],
+      "deviations_from_forecast": "None. One control was added after the freeze and is recorded above with its reason. No production file changed; kernel-plane count 33; no capability matching, no Metal migration, no new kernel.",
+      "gate_hygiene_found_while_running_them": {
+        "check_doc_references_is_vacuous_in_a_worktree": "It skips any path containing `/.claude/`, so run from `.claude/worktrees/<branch>` it checks 0 documents across 0 references and exits 0 — green and meaningless. Re-run from a checkout outside that directory: 735 path references, none broken. CI checks out clean and sees the real set (`quality.yml` runs it `--strict`).",
+        "check_contract_index_is_not_wired_into_CI": "At `origin/main` (2944ace6) the only two references to `scripts/check_contract_index.py` in the tracked tree are prose in the v1 index — \"That is enforced rather than asked for\" — and this programme's own gate list. No workflow, no make target, no hook invokes it. So the index's citation discipline has been holding only because someone ran the script by hand, which is what happened for L4 and L5 here. Raised by the OPT-CONTRACT-1 session, verified independently, and being fixed on that branch by wiring the script into `quality.yml`. Recorded here because a gate list that names an unwired script is a gate list that overstates itself.",
+        "checked_from": "`git grep -n check_contract_index origin/main` and `.github/workflows/quality.yml` at origin/main (which does run check_doc_links.py and check_doc_references.py --strict)."
+      },
+      "rebase_check": "Replayed for real: #466 merged as 097d54a5 and L3→L5 (six commits) rebased onto it with no conflict — the same clean replay a trial rebase onto 2944ace6 had predicted before the merge. On the rebased stack: 19 lowering lib tests, the 9 external-provider tests and the 3 inference `via_tests` pass, the contract index resolves its 76 named tests and the 857 documentation links resolve. Main has not touched `docs/represent-v1-contract-index.md` since the base, so the index this wave extends is main's plus L4's rows and L5's."
     }
   }
 }


### PR DESCRIPTION
## What

Wave L5 of LOWERING-PLUGIN-1 (forecast #464, L1 #465, L2 #466, L3 #468, L4 #471) — the wave the programme existed for, and **it required no change to production code at all**. The whole diff is a new integration-test crate.

A crate that is not `larql-vindex` registers a lowering provider this build does not ship, `outside-lowering/v1`, and reaches:

```text
register → candidate derivation → selection → accounting → pin
        → preparation → authority validation → execute
```

An integration test is a separate crate in cargo's model, so it sees only what `larql-vindex` exports. Anything the proof had needed from the crate's internals would have been a leak in the contract.

## What the provider owns, and what it borrows

It **owns** its candidate derivation (from the codec's declarations, never from a label), its selection, its refusal, its projection kernel, the whole dense feed-forward and the vocabulary head — 31 matrices multiplied by its own loop on the dense fixture. It **borrows** the reference oracle's glue between projections, exactly as the in-tree device provider borrows the production CPU glue. Borrowing is through exported API, which is the point: an external provider may use the crate; core may not know it.

Its logits and final hidden state are **bit-identical to the reference oracle's** — it computes the model exactly, not approximately.

## The controls

| control | witness |
|---|---|
| the journey, end to end | `an_external_provider_reaches_execution_through_registration_alone` — the declined direct realization is recorded as *considered*, the ledger prices what it pinned, `render_selection_summary` names its choice, `ensure_lowerings_in` stands in its registry and refuses in the shipped one |
| **named, not merely available** | `the_named_provider_is_reached_even_beside_an_equally_capable_one` — a second equally capable external provider registered beside it stays at **exactly zero** dispatches while the named one runs, and is reached in its turn when named |
| the numbers are its own | `the_numbers_are_the_external_providers_own` — a defect in its kernel moves the logits, so nothing shipped answered underneath |
| its choice, not a default | `the_pins_are_the_providers_choice_and_not_a_shipped_default` — production pins `cpu:direct/BlasF32` for the same operands where this one pins `cpu:decode/ScalarF32` |
| its refusal is its own | `it_refuses_on_its_own_terms_when_the_facts_admit_nothing` |
| L4 inherited | `another_provider_may_not_run_the_external_providers_pins` |
| genericity | `no_external_provider_identity_appears_in_production_larql` — neither family, neither name nor the type appears in any non-test source under `crates/*/src` |
| scan control | `the_scan_would_have_found_a_provider_that_was_there` — the same walk finds `cpu-production`, so the empty result means "nothing there", not "nothing looked at" |

The "named, not merely available" control was added after the freeze, in review: without it, *"the caller named it"* and *"it was the only implementation that could have run"* are indistinguishable. It is resolution **by identity** — L2's contract, where the caller chooses — not the registry matching capabilities on the caller's behalf, which is F2 and stays out of scope.

## Three findings, recorded in the notes

- **`PlanBackend::project` is dispatched zero times** on a dense softmax stack. The seam's real granularity is whole operations — `attention`, `ffn`, `output_head`. Measured, not assumed, and it is F1's question asked from the other side.
- **An outside provider can read a gate policy but not the shipped judgement about it**: `require_executable_gate` is crate-internal, so this provider states its own refusal for policies it does not implement. The contract's "honour it or refuse" is, outside the crate, enforced by convention.
- **F3 held for a reason worth stating**: `Decode(ScalarF32)` is an *honest* description of this provider's kernel. A genuinely novel kernel shape would have nothing honest to name — misdescribe itself as a shipped plan, or open the vocabulary. That is exactly the question the forecast defers to after provider openness, and it is now the sharpest open one in the lane.

## Unchanged

`git diff --stat` over the implementation commit touches nothing outside `crates/larql-vindex/tests/external_lowering_provider/` and the two documents. Kernel-plane files **33**. `larql-vindex`: 39 suites, 4998 tests, 0 failed.

## Gates

`cargo fmt --all --check`; clippy `-D warnings`; `cargo test -p larql-vindex`; `cargo check --workspace --all-targets`; kernel-plane count; `scripts/check_contract_index.py` and `scripts/check_doc_links.py`, plus `scripts/check_doc_references.py --strict` run from a checkout outside `.claude/` (735 path references) — it is vacuous when run from a worktree, which the notes record.

Rebased onto `e1052f91` (the merge of #471) and re-verified there. Pre-cleared against both classes of defect #468 hit in CI: every dependent crate's FULL target set passes, and `cargo llvm-cov --package larql-vindex` + `scripts/check_coverage_policy.py` passes at 93.75% with no file under its minimum.
