### PR TITLE
feat(represent): independently reconstruct candidate representation authority

### DIFF
--- a/crates/larql-vindex/src/format/vindex3/represent/candidate_authority.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/candidate_authority.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use super::compile::hash_bytes;
-use super::compiler::CandidateIndex;
+use super::compiler::{read_source_identity, CandidateIndex};
 use super::state::{
     RepresentationState, RepresentationStateId, ResolvedDecisionVector, TensorSurface,
     STATE_ID_VERSION,
@@ -35,6 +35,17 @@ pub struct CandidatePayload {
     pub sha256: String,
 }
 
+/// How the persisted authority relates to the executable artifact's root.
+/// This is artifact integrity evidence, never an input to representation
+/// identity. An inline bank index already carries its own authority; a
+/// sidecar must also bind the separate VINDEX3 root that execution reads.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ExecutableRootBinding {
+    InlineCandidate,
+    Vindex3 { semantic_digest: String },
+}
+
 /// The two previously absent identity inputs, bound to completed bytes
 /// and the source authority and seals already owned by `CandidateIndex`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -46,6 +57,7 @@ pub struct CandidateRepresentationAuthority {
     /// One payload file per compiled object. File names locate bytes;
     /// they do not participate in RepresentationStateId.
     pub payloads: BTreeMap<String, CandidatePayload>,
+    pub executable_root: ExecutableRootBinding,
     pub binding_sha256: String,
     /// A cross-check only. Corrupting it cannot supply an identity.
     pub state_id: RepresentationStateId,
@@ -128,6 +140,7 @@ fn binding(
         &authority.decisions,
         &index.ledger.sealed,
         &authority.payloads,
+        &authority.executable_root,
     ))
     .map_err(|e| VindexError::Parse(e.to_string()))?;
     Ok(hash_bytes(&bytes))
@@ -141,6 +154,7 @@ pub(crate) fn finish(
     surface: TensorSurface,
     decisions: ResolvedDecisionVector,
     files: BTreeMap<String, String>,
+    executable_root: ExecutableRootBinding,
 ) -> Result<(), VindexError> {
     for seal in index.ledger.sealed.values() {
         if !matches!(decisions.get(&seal.object, &seal.tensor), Some(super::state::ResolvedEncoding::Compiled(enc)) if enc == &seal.encoding)
@@ -172,6 +186,7 @@ pub(crate) fn finish(
         surface,
         decisions,
         payloads,
+        executable_root,
         binding_sha256: String::new(),
         state_id: state.id().clone(),
     };
@@ -184,7 +199,8 @@ pub(crate) fn finish(
 /// memory, a locator's state-id key, or a requested PrecisionMap.
 pub fn read_candidate(path: &Path) -> Result<RepresentationState, CandidateAuthorityRefusal> {
     let sidecar = path.join(CANDIDATE_INDEX_FILE);
-    let file = if sidecar.try_exists().map_err(invalid)? {
+    let is_sidecar = sidecar.try_exists().map_err(invalid)?;
+    let file = if is_sidecar {
         sidecar
     } else {
         path.join("index.json")
@@ -218,6 +234,26 @@ pub fn read_candidate(path: &Path) -> Result<RepresentationState, CandidateAutho
             expected: a.binding_sha256.clone(),
             observed,
         });
+    }
+    match (&a.executable_root, is_sidecar) {
+        (ExecutableRootBinding::InlineCandidate, false) => {}
+        (ExecutableRootBinding::Vindex3 { semantic_digest }, true) => {
+            let observed = read_source_identity(path)
+                .map_err(|e| invalid(format!("executable root: {e}")))?
+                .semantic_digest();
+            if &observed != semantic_digest {
+                return Err(CandidateAuthorityRefusal::Binding {
+                    what: "executable root".into(),
+                    expected: semantic_digest.clone(),
+                    observed,
+                });
+            }
+        }
+        _ => {
+            return Err(invalid(
+                "executable root binding does not match the candidate authority carrier",
+            ))
+        }
     }
     // Derived serde can bypass sorted/unique constructors. Re-establish
     // the surface and vector invariants before normative identification.

--- a/crates/larql-vindex/src/format/vindex3/represent/candidate_authority.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/candidate_authority.rs
@@ -1,0 +1,333 @@
+//! Persisted compilation results, independently read back from disk.
+//!
+//! The writer takes completed decisions and payloads, never a requested
+//! measurement key. The reader supplies independently verified inputs to
+//! the existing state identity function. This establishes an artifact's
+//! representation, not its admission as scientific evidence or promotion.
+
+pub(crate) mod producer;
+
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Component, Path};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::compile::hash_bytes;
+use super::compiler::CandidateIndex;
+use super::state::{
+    RepresentationState, RepresentationStateId, ResolvedDecisionVector, TensorSurface,
+    STATE_ID_VERSION,
+};
+use crate::error::VindexError;
+
+pub const CANDIDATE_AUTHORITY_SCHEMA: &str = "represent-candidate-authority/v1";
+/// A full VINDEX3 container keeps its existing index and stores the same
+/// CandidateIndex beside it. Candidate provenance must not enter the source
+/// semantic identity through Vindex3Index.extra.
+pub const CANDIDATE_INDEX_FILE: &str = "candidate.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CandidatePayload {
+    pub file: String,
+    pub len: u64,
+    pub sha256: String,
+}
+
+/// The two previously absent identity inputs, bound to completed bytes
+/// and the source authority and seals already owned by `CandidateIndex`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CandidateRepresentationAuthority {
+    pub schema: String,
+    pub state_semantics: String,
+    pub surface: TensorSurface,
+    pub decisions: ResolvedDecisionVector,
+    /// One payload file per compiled object. File names locate bytes;
+    /// they do not participate in RepresentationStateId.
+    pub payloads: BTreeMap<String, CandidatePayload>,
+    pub binding_sha256: String,
+    /// A cross-check only. Corrupting it cannot supply an identity.
+    pub state_id: RepresentationStateId,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CandidateAuthorityRefusal {
+    #[error("candidate authority could not be read or verified: {0}")]
+    Invalid(String),
+    #[error("candidate independently establishes {observed}, but the requested representation state is {expected}")]
+    RequestedState {
+        expected: RepresentationStateId,
+        observed: RepresentationStateId,
+    },
+    #[error("candidate has no completed representation authority")]
+    Missing,
+    #[error("candidate {field} declares {observed}, expected {expected}")]
+    Version {
+        field: String,
+        expected: String,
+        observed: String,
+    },
+    #[error("candidate {what} binding expected {expected}, observed {observed}")]
+    Binding {
+        what: String,
+        expected: String,
+        observed: String,
+    },
+    #[error("candidate stored state id {stored} disagrees with independently reconstructed {recomputed}")]
+    StoredState {
+        stored: RepresentationStateId,
+        recomputed: RepresentationStateId,
+    },
+}
+
+fn invalid(error: impl std::fmt::Display) -> CandidateAuthorityRefusal {
+    CandidateAuthorityRefusal::Invalid(error.to_string())
+}
+
+fn relative_file(root: &Path, file: &str) -> Result<std::path::PathBuf, CandidateAuthorityRefusal> {
+    if file.is_empty()
+        || Path::new(file)
+            .components()
+            .any(|c| !matches!(c, Component::Normal(_)))
+    {
+        return Err(invalid(format!(
+            "payload locator `{file}` is not a relative file"
+        )));
+    }
+    Ok(root.join(file))
+}
+
+/// Bounded streaming reads; sealing a large bank never materialises it.
+pub(crate) fn digest_range(path: &Path, offset: u64, len: u64) -> Result<String, VindexError> {
+    let mut file = std::fs::File::open(path)?;
+    file.seek(SeekFrom::Start(offset))?;
+    let mut hash = Sha256::new();
+    let mut remaining = len;
+    let mut buffer = vec![0u8; 1 << 20];
+    while remaining != 0 {
+        let n = remaining.min(buffer.len() as u64) as usize;
+        file.read_exact(&mut buffer[..n])?;
+        hash.update(&buffer[..n]);
+        remaining -= n as u64;
+    }
+    Ok(format!("{:x}", hash.finalize()))
+}
+
+fn binding(
+    index: &CandidateIndex,
+    authority: &CandidateRepresentationAuthority,
+) -> Result<String, VindexError> {
+    // Provenance, requested map and promotion are deliberately absent.
+    // The binding is an artifact integrity seal, NOT a second state-id recipe.
+    let bytes = serde_json::to_vec(&(
+        &authority.schema,
+        &authority.state_semantics,
+        &index.source.identity.semantic,
+        &authority.surface,
+        &authority.decisions,
+        &index.ledger.sealed,
+        &authority.payloads,
+    ))
+    .map_err(|e| VindexError::Parse(e.to_string()))?;
+    Ok(hash_bytes(&bytes))
+}
+
+/// Called only by producers after their actual encoding/write decisions.
+/// No state id, request, layout policy or precision map is an input.
+pub(crate) fn finish(
+    index: &mut CandidateIndex,
+    root: &Path,
+    surface: TensorSurface,
+    decisions: ResolvedDecisionVector,
+    files: BTreeMap<String, String>,
+) -> Result<(), VindexError> {
+    for seal in index.ledger.sealed.values() {
+        if !matches!(decisions.get(&seal.object, &seal.tensor), Some(super::state::ResolvedEncoding::Compiled(enc)) if enc == &seal.encoding)
+        {
+            return Err(VindexError::Parse(format!(
+                "completed seal {}/{} is outside the compilation's effective surface",
+                seal.object, seal.tensor
+            )));
+        }
+    }
+    let mut payloads = BTreeMap::new();
+    for (object, file) in files {
+        let path = relative_file(root, &file).map_err(|e| VindexError::Parse(e.to_string()))?;
+        let len = std::fs::metadata(&path)?.len();
+        payloads.insert(
+            object,
+            CandidatePayload {
+                file,
+                len,
+                sha256: digest_range(&path, 0, len)?,
+            },
+        );
+    }
+    let state =
+        RepresentationState::from_decisions(&index.source.identity, &surface, decisions.clone());
+    let mut authority = CandidateRepresentationAuthority {
+        schema: CANDIDATE_AUTHORITY_SCHEMA.into(),
+        state_semantics: STATE_ID_VERSION.into(),
+        surface,
+        decisions,
+        payloads,
+        binding_sha256: String::new(),
+        state_id: state.id().clone(),
+    };
+    authority.binding_sha256 = binding(index, &authority)?;
+    index.authority = Some(authority);
+    Ok(())
+}
+
+/// Open only the persisted artifact. This path never consults compiler
+/// memory, a locator's state-id key, or a requested PrecisionMap.
+pub fn read_candidate(path: &Path) -> Result<RepresentationState, CandidateAuthorityRefusal> {
+    let sidecar = path.join(CANDIDATE_INDEX_FILE);
+    let file = if sidecar.try_exists().map_err(invalid)? {
+        sidecar
+    } else {
+        path.join("index.json")
+    };
+    let index: CandidateIndex =
+        serde_json::from_slice(&std::fs::read(file).map_err(invalid)?).map_err(invalid)?;
+    let a = index
+        .authority
+        .as_ref()
+        .ok_or(CandidateAuthorityRefusal::Missing)?;
+    for (field, expected, observed) in [
+        ("schema", CANDIDATE_AUTHORITY_SCHEMA, a.schema.as_str()),
+        (
+            "state semantics",
+            STATE_ID_VERSION,
+            a.state_semantics.as_str(),
+        ),
+    ] {
+        if expected != observed {
+            return Err(CandidateAuthorityRefusal::Version {
+                field: field.into(),
+                expected: expected.into(),
+                observed: observed.into(),
+            });
+        }
+    }
+    let observed = binding(&index, a).map_err(invalid)?;
+    if observed != a.binding_sha256 {
+        return Err(CandidateAuthorityRefusal::Binding {
+            what: "metadata".into(),
+            expected: a.binding_sha256.clone(),
+            observed,
+        });
+    }
+    // Derived serde can bypass sorted/unique constructors. Re-establish
+    // the surface and vector invariants before normative identification.
+    let surface = TensorSurface::new(a.surface.entries().iter().cloned()).map_err(invalid)?;
+    if surface != a.surface {
+        return Err(invalid("tensor surface is not in canonical order"));
+    }
+    let decisions =
+        ResolvedDecisionVector::from_entries(&surface, a.decisions.decisions().to_vec())
+            .map_err(invalid)?;
+    if decisions != a.decisions {
+        return Err(invalid("decision vector is not in canonical order"));
+    }
+    for (object, payload) in &a.payloads {
+        let file = relative_file(path, &payload.file)?;
+        let len = std::fs::metadata(&file).map_err(invalid)?.len();
+        let observed = digest_range(&file, 0, len).map_err(invalid)?;
+        if len != payload.len || observed != payload.sha256 {
+            return Err(CandidateAuthorityRefusal::Binding {
+                what: format!(
+                    "payload `{object}` (expected {} bytes, observed {len})",
+                    payload.len
+                ),
+                expected: payload.sha256.clone(),
+                observed,
+            });
+        }
+    }
+    let mut spans: BTreeMap<&str, Vec<(u64, u64)>> = BTreeMap::new();
+    for seal in index.ledger.sealed.values() {
+        let payload = a
+            .payloads
+            .get(&seal.object)
+            .ok_or_else(|| invalid(format!("no payload for sealed object {}", seal.object)))?;
+        let end = seal
+            .target_offset
+            .checked_add(seal.target_len)
+            .filter(|end| *end <= payload.len)
+            .ok_or_else(|| invalid(format!("seal for {} is outside its payload", seal.tensor)))?;
+        if !matches!(decisions.get(&seal.object, &seal.tensor), Some(super::state::ResolvedEncoding::Compiled(enc)) if enc == &seal.encoding)
+        {
+            return Err(invalid(format!(
+                "seal for {}/{} disagrees with effective decisions",
+                seal.object, seal.tensor
+            )));
+        }
+        if index.ledger.get(&seal.object, &seal.tensor) != Some(seal) {
+            return Err(invalid("ledger key disagrees with sealed operand identity"));
+        }
+        let observed = digest_range(
+            &relative_file(path, &payload.file)?,
+            seal.target_offset,
+            seal.target_len,
+        )
+        .map_err(invalid)?;
+        if observed != seal.target_hash {
+            return Err(CandidateAuthorityRefusal::Binding {
+                what: format!("operand {}/{}", seal.object, seal.tensor),
+                expected: seal.target_hash.clone(),
+                observed,
+            });
+        }
+        spans
+            .entry(&seal.object)
+            .or_default()
+            .push((seal.target_offset, end));
+    }
+    for ranges in spans.values_mut() {
+        ranges.sort_unstable();
+        if ranges.windows(2).any(|w| w[0].1 > w[1].0) {
+            return Err(invalid("compiled operand seals overlap"));
+        }
+    }
+    for d in decisions
+        .decisions()
+        .iter()
+        .filter(|d| d.encoding.is_compiled())
+    {
+        if index.ledger.get(&d.object, &d.tensor).is_none() {
+            return Err(invalid(format!(
+                "compiled decision {}/{} has no completed seal",
+                d.object, d.tensor
+            )));
+        }
+    }
+    let state = RepresentationState::from_decisions(&index.source.identity, &surface, decisions);
+    if state.id() != &a.state_id {
+        return Err(CandidateAuthorityRefusal::StoredState {
+            stored: a.state_id.clone(),
+            recomputed: state.id().clone(),
+        });
+    }
+    Ok(state)
+}
+
+/// Establish validity first, then compare experiment identity. A valid Y
+/// remains independently readable even when a caller requested X.
+pub fn verify_candidate(
+    path: &Path,
+    expected: &RepresentationStateId,
+) -> Result<RepresentationState, CandidateAuthorityRefusal> {
+    let state = read_candidate(path)?;
+    if state.id() != expected {
+        return Err(CandidateAuthorityRefusal::RequestedState {
+            expected: expected.clone(),
+            observed: state.id().clone(),
+        });
+    }
+    Ok(state)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/larql-vindex/src/format/vindex3/represent/candidate_authority/producer.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/candidate_authority/producer.rs
@@ -1,0 +1,158 @@
+//! Compilation-side collection of actual decisions. The fresh reader
+//! never calls this module or resolves the producer's requested map.
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use super::{digest_range, finish};
+use crate::error::VindexError;
+use crate::format::vindex3::encode::segment::read_segment_header;
+use crate::format::vindex3::index::{RepresentationEntry, Vindex3Index};
+use crate::format::vindex3::represent::{
+    compile::OperandSeal,
+    compiler::{read_source_identity, CandidateIndex, SourceDependency},
+    map::PrecisionMap,
+    plan_roles::PlanRoles,
+    policy::classify_in,
+    state::{
+        ResolvedDecision, ResolvedDecisionVector, ResolvedEncoding, SurfaceTensor, TensorSurface,
+    },
+};
+
+pub(crate) struct CompilationAuthority {
+    index: CandidateIndex,
+    surface: TensorSurface,
+    decisions: BTreeMap<(String, String), ResolvedEncoding>,
+    files: BTreeMap<String, String>,
+}
+
+impl CompilationAuthority {
+    pub(crate) fn new(
+        src: &Path,
+        index: &Vindex3Index,
+        map: PrecisionMap,
+        text: &BTreeSet<String>,
+        roles: &PlanRoles,
+    ) -> Result<Self, VindexError> {
+        let mut tensors = BTreeMap::new();
+        let mut files = BTreeMap::new();
+        for entry in index.representations.values() {
+            let (header, _) = read_segment_header(&src.join(&entry.segment))?;
+            files
+                .entry(entry.object.clone())
+                .or_insert_with(|| entry.segment.clone());
+            for t in header.tensors {
+                let role = roles
+                    .get(&(entry.object.clone(), t.name.clone()))
+                    .copied()
+                    .filter(|_| text.contains(&entry.object))
+                    .unwrap_or_else(|| {
+                        classify_in(
+                            text.contains(&entry.object),
+                            &entry.object,
+                            &t.name,
+                            &t.shape,
+                        )
+                    });
+                let tensor = SurfaceTensor::new(&entry.object, &t.name, role, t.shape);
+                let key = (entry.object.clone(), t.name);
+                if let Some(old) = tensors.insert(key, tensor.clone()) {
+                    if old != tensor {
+                        return Err(VindexError::Parse(format!(
+                            "source representations disagree about surface tensor {}/{}",
+                            tensor.object, tensor.tensor
+                        )));
+                    }
+                }
+            }
+        }
+        let surface = TensorSurface::new(tensors.into_values())?;
+        let decisions = surface
+            .entries()
+            .iter()
+            .map(|t| {
+                (
+                    (t.object.clone(), t.tensor.clone()),
+                    ResolvedEncoding::Source,
+                )
+            })
+            .collect();
+        Ok(Self {
+            index: CandidateIndex::new(
+                &index.model,
+                SourceDependency {
+                    identity: read_source_identity(src)?,
+                    locator_hint: src.display().to_string(),
+                },
+                "",
+                map,
+            ),
+            surface,
+            decisions,
+            files,
+        })
+    }
+
+    pub(crate) fn decided(&mut self, object: &str, tensor: &str, encoding: ResolvedEncoding) {
+        self.decisions
+            .insert((object.into(), tensor.into()), encoding);
+    }
+
+    /// Read the completed segment table and seal precisely the ranges the
+    /// writer emitted. Layout-refused and protected tensors remain source.
+    pub(crate) fn written(
+        &mut self,
+        src: &Path,
+        out: &Path,
+        entry: &RepresentationEntry,
+        target_file: &str,
+    ) -> Result<(), VindexError> {
+        let source_path = src.join(&entry.segment);
+        let target_path = out.join(target_file);
+        let (source_header, source_start) = read_segment_header(&source_path)?;
+        let (target_header, target_start) = read_segment_header(&target_path)?;
+        for t in target_header.tensors {
+            let Some(ResolvedEncoding::Compiled(encoding)) =
+                self.decisions.get(&(entry.object.clone(), t.name.clone()))
+            else {
+                continue;
+            };
+            let original = source_header
+                .tensors
+                .iter()
+                .find(|s| s.name == t.name)
+                .ok_or_else(|| {
+                    VindexError::Parse(format!("compiled tensor {} has no source", t.name))
+                })?;
+            self.index.ledger.seal(OperandSeal {
+                object: entry.object.clone(),
+                tensor: t.name,
+                encoding: encoding.clone(),
+                source_hash: digest_range(
+                    &source_path,
+                    source_start + original.offset,
+                    original.len,
+                )?,
+                target_hash: digest_range(&target_path, target_start + t.offset, t.len)?,
+                target_offset: target_start + t.offset,
+                target_len: t.len,
+            });
+        }
+        self.files.insert(entry.object.clone(), target_file.into());
+        Ok(())
+    }
+
+    pub(crate) fn finish(mut self, out: &Path) -> Result<CandidateIndex, VindexError> {
+        let entries = self
+            .decisions
+            .into_iter()
+            .map(|((object, tensor), encoding)| ResolvedDecision {
+                object,
+                tensor,
+                encoding,
+            })
+            .collect();
+        let decisions = ResolvedDecisionVector::from_entries(&self.surface, entries)?;
+        finish(&mut self.index, out, self.surface, decisions, self.files)?;
+        Ok(self.index)
+    }
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/candidate_authority/producer.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/candidate_authority/producer.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use super::{digest_range, finish};
+use super::{digest_range, finish, ExecutableRootBinding};
 use crate::error::VindexError;
 use crate::format::vindex3::encode::segment::read_segment_header;
 use crate::format::vindex3::index::{RepresentationEntry, Vindex3Index};
@@ -152,7 +152,20 @@ impl CompilationAuthority {
             })
             .collect();
         let decisions = ResolvedDecisionVector::from_entries(&self.surface, entries)?;
-        finish(&mut self.index, out, self.surface, decisions, self.files)?;
+        // The compiler has already persisted the executable index. Bind
+        // its catalogue and declared graph through the existing semantic
+        // identity machinery, independently of this candidate's state id.
+        let executable_root = ExecutableRootBinding::Vindex3 {
+            semantic_digest: read_source_identity(out)?.semantic_digest(),
+        };
+        finish(
+            &mut self.index,
+            out,
+            self.surface,
+            decisions,
+            self.files,
+            executable_root,
+        )?;
         Ok(self.index)
     }
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/candidate_authority/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/candidate_authority/tests.rs
@@ -192,9 +192,19 @@ fn finalising_cannot_claim_a_seal_outside_the_completed_surface() {
         empty,
         ResolvedDecisionVector::default(),
         a.payloads.into_iter().map(|(o, p)| (o, p.file)).collect(),
+        a.executable_root,
     )
     .unwrap_err();
     assert!(err
         .to_string()
         .contains("outside the compilation's effective surface"));
+}
+
+#[test]
+fn a_sidecar_cannot_downgrade_its_root_binding_to_an_inline_candidate() {
+    let dir = candidate();
+    let mut idx = index(dir.path());
+    idx.authority.as_mut().unwrap().executable_root = ExecutableRootBinding::InlineCandidate;
+    persist(dir.path(), idx); // valid outer binding, wrong relationship
+    assert_invalid(dir.path(), "does not match the candidate authority carrier");
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/candidate_authority/tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/candidate_authority/tests.rs
@@ -1,0 +1,200 @@
+//! Structured hostile controls re-seal metadata deliberately: these must
+//! reach relation checks, not merely fail the outer integrity checksum.
+use super::*;
+use crate::format::vindex3::fixtures::{dense_f32_model, encode_fixture_container};
+use crate::format::vindex3::represent::{compile_representation, RepresentSpec};
+
+fn candidate() -> tempfile::TempDir {
+    let source = tempfile::tempdir().unwrap();
+    let checkpoint = source.path().join("checkpoint");
+    std::fs::create_dir(&checkpoint).unwrap();
+    let container = source.path().join("source");
+    encode_fixture_container(dense_f32_model, &checkpoint, &container, "target");
+    let out = tempfile::tempdir().unwrap();
+    compile_representation(&container, out.path(), &RepresentSpec::nvfp4()).unwrap();
+    out
+}
+
+fn index(dir: &Path) -> CandidateIndex {
+    serde_json::from_slice(&std::fs::read(dir.join(CANDIDATE_INDEX_FILE)).unwrap()).unwrap()
+}
+
+fn persist(dir: &Path, mut index: CandidateIndex) {
+    let digest = binding(&index, index.authority.as_ref().unwrap()).unwrap();
+    index.authority.as_mut().unwrap().binding_sha256 = digest;
+    super::super::compiler::write_index_atomically(&index, &dir.join(CANDIDATE_INDEX_FILE))
+        .unwrap();
+}
+
+fn assert_invalid(dir: &Path, text: &str) {
+    let refusal = read_candidate(dir).unwrap_err();
+    assert!(
+        matches!(refusal, CandidateAuthorityRefusal::Invalid(_)),
+        "{refusal}"
+    );
+    assert!(refusal.to_string().contains(text), "{refusal}");
+}
+
+#[test]
+fn deserialisation_cannot_bypass_surface_and_decision_invariants() {
+    let dir = candidate();
+    let original = index(dir.path());
+    for arm in [
+        "surface-order",
+        "duplicate",
+        "decision-order",
+        "missing",
+        "empty-encoding",
+    ] {
+        let mut changed = serde_json::to_value(&original).unwrap();
+        match arm {
+            "surface-order" => changed["authority"]["surface"]["entries"]
+                .as_array_mut()
+                .unwrap()
+                .reverse(),
+            "duplicate" => {
+                let entries = changed["authority"]["surface"]["entries"]
+                    .as_array_mut()
+                    .unwrap();
+                entries.push(entries[0].clone());
+            }
+            "decision-order" => changed["authority"]["decisions"]["decisions"]
+                .as_array_mut()
+                .unwrap()
+                .reverse(),
+            "missing" => {
+                changed["authority"]["decisions"]["decisions"]
+                    .as_array_mut()
+                    .unwrap()
+                    .pop();
+            }
+            "empty-encoding" => {
+                changed["authority"]["decisions"]["decisions"][0]["encoding"] =
+                    serde_json::json!({"Compiled":""})
+            }
+            _ => unreachable!(),
+        }
+        persist(dir.path(), serde_json::from_value(changed).unwrap());
+        let expected = match arm {
+            "surface-order" | "decision-order" => "canonical order",
+            "duplicate" => "twice",
+            "missing" => "every surface tensor exactly once",
+            "empty-encoding" => "non-source encoding",
+            _ => unreachable!(),
+        };
+        assert_invalid(dir.path(), expected);
+    }
+}
+
+#[test]
+fn individually_valid_payloads_do_not_excuse_inconsistent_ledger_relations() {
+    let dir = candidate();
+    let original = index(dir.path());
+    for arm in [
+        "missing-payload",
+        "outside",
+        "encoding",
+        "key",
+        "unsealed",
+        "overlap",
+        "unsafe-path",
+    ] {
+        let mut changed = original.clone();
+        let first = changed.ledger.sealed.values().next().unwrap().clone();
+        match arm {
+            "missing-payload" => {
+                changed
+                    .authority
+                    .as_mut()
+                    .unwrap()
+                    .payloads
+                    .remove(&first.object);
+            }
+            "outside" => {
+                changed
+                    .ledger
+                    .sealed
+                    .values_mut()
+                    .next()
+                    .unwrap()
+                    .target_offset = u64::MAX
+            }
+            "encoding" => {
+                changed.ledger.sealed.values_mut().next().unwrap().encoding = "wrong".into()
+            }
+            "key" => {
+                let (key, seal) = changed.ledger.sealed.pop_first().unwrap();
+                changed.ledger.sealed.insert(format!("bad-{key}"), seal);
+            }
+            "unsealed" => {
+                changed.ledger.sealed.pop_first();
+            }
+            "overlap" => {
+                let second = changed.ledger.sealed.values_mut().nth(1).unwrap();
+                second.target_offset = first.target_offset;
+                second.target_len = first.target_len;
+                second.target_hash = first.target_hash;
+            }
+            "unsafe-path" => {
+                changed
+                    .authority
+                    .as_mut()
+                    .unwrap()
+                    .payloads
+                    .values_mut()
+                    .next()
+                    .unwrap()
+                    .file = "../outside".into()
+            }
+            _ => unreachable!(),
+        }
+        persist(dir.path(), changed);
+        let expected = match arm {
+            "missing-payload" => "no payload for sealed object",
+            "outside" => "outside its payload",
+            "encoding" => "disagrees with effective decisions",
+            "key" => "ledger key",
+            "unsealed" => "no completed seal",
+            "overlap" => "seals overlap",
+            "unsafe-path" => "not a relative file",
+            _ => unreachable!(),
+        };
+        assert_invalid(dir.path(), expected);
+    }
+}
+
+#[test]
+fn operand_hash_still_binds_after_the_outer_metadata_is_resealed() {
+    let dir = candidate();
+    let mut changed = index(dir.path());
+    changed
+        .ledger
+        .sealed
+        .values_mut()
+        .next()
+        .unwrap()
+        .target_hash = "wrong".into();
+    persist(dir.path(), changed);
+    assert!(
+        matches!(read_candidate(dir.path()), Err(CandidateAuthorityRefusal::Binding { what, .. }) if what.starts_with("operand"))
+    );
+}
+
+#[test]
+fn finalising_cannot_claim_a_seal_outside_the_completed_surface() {
+    let dir = candidate();
+    let mut idx = index(dir.path());
+    let a = idx.authority.take().unwrap();
+    let empty = TensorSurface::new([]).unwrap();
+    let err = finish(
+        &mut idx,
+        dir.path(),
+        empty,
+        ResolvedDecisionVector::default(),
+        a.payloads.into_iter().map(|(o, p)| (o, p.file)).collect(),
+    )
+    .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("outside the compilation's effective surface"));
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/compiler.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/compiler.rs
@@ -168,6 +168,9 @@ pub struct CandidateIndex {
     /// otherwise — see [`Self::apply_promotion`].
     pub selected_representation: String,
     pub ledger: CompilationLedger,
+    /// Completed byte-bound representation authority; absent on legacy or in-progress artifacts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority: Option<super::candidate_authority::CandidateRepresentationAuthority>,
 }
 
 impl CandidateIndex {
@@ -189,6 +192,7 @@ impl CandidateIndex {
             }
         }
         Self {
+            authority: None,
             model: model.into(),
             source,
             object: object.into(),
@@ -235,7 +239,9 @@ pub struct CompileOptions<'a> {
     pub object: &'a str,
     pub role: Role,
     pub experts: u32,
-    /// Where the execution-shaped bank is written.
+    /// Where the execution-shaped bank is written. With no checkpoint,
+    /// completed authority paths are relative to this file's parent;
+    /// persist the index there, or supply its location through checkpoint.
     pub out: &'a Path,
     /// Where the index is persisted MID-RUN, and after how many seals.
     ///
@@ -267,6 +273,7 @@ pub fn compile_expert_bank(
     progress: &mut dyn FnMut(&CompileOutcome),
 ) -> Result<CompileOutcome, VindexError> {
     let (object, role, experts, out) = (opts.object, opts.role, opts.experts, opts.out);
+    index.authority = None;
     let arena = RepresentationArena::new(index.map.clone());
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -438,6 +445,14 @@ pub fn compile_expert_bank(
         progress(&outcome);
     }
     file.flush()?;
+    finish_bank_authority(
+        index,
+        tensors,
+        object,
+        role,
+        out,
+        opts.checkpoint.map(|(p, _)| p),
+    )?;
     if let Some((path, _)) = opts.checkpoint {
         write_index_atomically(index, path)?;
     }
@@ -490,3 +505,56 @@ pub fn expert_of(tensor: &str) -> Option<u32> {
 #[cfg(test)]
 #[path = "compiler_tests.rs"]
 mod tests;
+
+/// Establish only what this completed bank actually stores. The supplied
+/// tensors are the compilation surface; a wider search surface must not
+/// silently be substituted for it by a consumer.
+pub(crate) fn finish_bank_authority(
+    index: &mut CandidateIndex,
+    tensors: &[SourceTensor],
+    object: &str,
+    role: Role,
+    out: &Path,
+    checkpoint: Option<&Path>,
+) -> Result<(), VindexError> {
+    use super::state::{
+        ResolvedDecision, ResolvedDecisionVector, ResolvedEncoding, SurfaceTensor, TensorSurface,
+    };
+    let surface = TensorSurface::new(
+        tensors
+            .iter()
+            .map(|t| SurfaceTensor::new(object, &t.name, role, t.shape.clone())),
+    )?;
+    let decisions = ResolvedDecisionVector::from_entries(
+        &surface,
+        surface
+            .entries()
+            .iter()
+            .map(|t| ResolvedDecision {
+                object: t.object.clone(),
+                tensor: t.tensor.clone(),
+                encoding: index
+                    .ledger
+                    .get(&t.object, &t.tensor)
+                    .map_or(ResolvedEncoding::Source, |s| {
+                        ResolvedEncoding::Compiled(s.encoding.clone())
+                    }),
+            })
+            .collect(),
+    )?;
+    let root = checkpoint
+        .and_then(Path::parent)
+        .unwrap_or_else(|| out.parent().unwrap_or(Path::new(".")));
+    let relative = out.strip_prefix(root).map_err(|e| {
+        VindexError::Parse(format!(
+            "candidate bank must be inside its index directory: {e}"
+        ))
+    })?;
+    super::candidate_authority::finish(
+        index,
+        root,
+        surface,
+        decisions,
+        [(object.to_string(), relative.to_string_lossy().into_owned())].into(),
+    )
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/compiler.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/compiler.rs
@@ -556,5 +556,6 @@ pub(crate) fn finish_bank_authority(
         surface,
         decisions,
         [(object.to_string(), relative.to_string_lossy().into_owned())].into(),
+        super::candidate_authority::ExecutableRootBinding::InlineCandidate,
     )
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/compiler_tests.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/compiler_tests.rs
@@ -925,3 +925,32 @@ fn placement_bases_and_refusals() {
         .expect_err("per-projection mixing within a layer must refuse");
     assert!(format!("{err}").contains("ONE encoding"), "{err}");
 }
+
+#[test]
+fn completed_bank_authority_is_read_from_disk_and_rejects_changed_bytes() {
+    use super::super::candidate_authority::{read_candidate, CandidateAuthorityRefusal};
+    let dir = tempfile::tempdir().unwrap();
+    let bank = dir.path().join("bank.bin");
+    {
+        let (source, tensors) = Fake::kimi_layer(1, 0.3);
+        let mut idx = index(map_for(vec![]));
+        compile_expert_bank(
+            &source,
+            &tensors,
+            &opts("target.expert_bank", EXPERTS, &bank),
+            &mut idx,
+            &mut |_| {},
+        )
+        .unwrap();
+        write_index_atomically(&idx, &dir.path().join("index.json")).unwrap();
+    }
+    let state = read_candidate(dir.path()).unwrap();
+    assert_eq!(state.decisions().compiled(), (EXPERTS * 3) as usize);
+    let mut bytes = std::fs::read(&bank).unwrap();
+    bytes[0] ^= 1;
+    std::fs::write(&bank, bytes).unwrap();
+    assert!(matches!(
+        read_candidate(dir.path()),
+        Err(CandidateAuthorityRefusal::Binding { .. })
+    ));
+}

--- a/crates/larql-vindex/src/format/vindex3/represent/kda_candidate.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/kda_candidate.rs
@@ -193,6 +193,7 @@ pub fn compile_kda_bank(
     progress: &mut dyn FnMut(&CompileOutcome),
 ) -> Result<CompileOutcome, VindexError> {
     let role = Role::DecoderLinear;
+    index.authority = None;
     let arena = RepresentationArena::new(index.map.clone());
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -353,6 +354,14 @@ pub fn compile_kda_bank(
         progress(&outcome);
     }
     file.flush()?;
+    super::compiler::finish_bank_authority(
+        index,
+        tensors,
+        object,
+        role,
+        out,
+        checkpoint.map(|(p, _)| p),
+    )?;
     if let Some((path, _)) = checkpoint {
         write_index_atomically(index, path)?;
     }

--- a/crates/larql-vindex/src/format/vindex3/represent/mod.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/mod.rs
@@ -51,6 +51,7 @@ pub mod arena;
 pub mod assessment;
 pub mod bank;
 pub mod byte_ledger;
+pub mod candidate_authority;
 pub mod codec;
 pub mod compile;
 pub mod compiler;
@@ -372,6 +373,13 @@ pub fn compile_representation(
     // Best-effort: a component whose plan does not build contributes
     // nothing here and its tensors fall back to name classification.
     let declared_roles = plan_roles::plan_roles(src, &inspection);
+    let mut candidate = candidate_authority::producer::CompilationAuthority::new(
+        src,
+        &index,
+        PrecisionMap::from_policy(spec.map_name(), &spec.encoding, &spec.roles, &spec.protect),
+        &primary_text,
+        &declared_roles,
+    )?;
     let store = OperandStore::open(src, &inspection)?;
     let source = OperandSource::from(&store);
 
@@ -464,6 +472,17 @@ pub fn compile_representation(
                         .map(|len| TensorEncoding::KQuant(k, len)),
                 })
                 .flatten();
+            candidate.decided(
+                &entry.object,
+                &t.name,
+                match encoded {
+                    Some(_) => state::ResolvedEncoding::Compiled(spec.encoding.clone()),
+                    None if eligible => state::ResolvedEncoding::LayoutRefused {
+                        encoding: spec.encoding.clone(),
+                    },
+                    None => state::ResolvedEncoding::Source,
+                },
+            );
             match encoded {
                 Some(encoding) => {
                     source_bytes += t.len;
@@ -633,6 +652,8 @@ pub fn compile_representation(
             }
         })?;
 
+        candidate.written(src, out, entry, &segment_rel)?;
+
         report.compiled_objects.push(CompiledObject {
             object: entry.object.clone(),
             representation_id: target_id.clone(),
@@ -798,6 +819,11 @@ pub fn compile_representation(
     let serialised = serde_json::to_string_pretty(&index)
         .map_err(|e| VindexError::Parse(format!("serialise {INDEX_JSON}: {e}")))?;
     std::fs::write(out.join(INDEX_JSON), serialised)?;
+    let completed_candidate = candidate.finish(out)?;
+    compiler::write_index_atomically(
+        &completed_candidate,
+        &out.join(candidate_authority::CANDIDATE_INDEX_FILE),
+    )?;
 
     Ok(report)
 }

--- a/crates/larql-vindex/src/format/vindex3/represent/state/resolved.rs
+++ b/crates/larql-vindex/src/format/vindex3/represent/state/resolved.rs
@@ -204,6 +204,29 @@ pub struct ResolvedDecisionVector {
 }
 
 impl ResolvedDecisionVector {
+    /// Validate already-produced decisions against their complete surface.
+    /// This constructs a vector; it does not resolve a requested policy.
+    pub fn from_entries(
+        surface: &TensorSurface,
+        mut decisions: Vec<ResolvedDecision>,
+    ) -> Result<Self, VindexError> {
+        decisions.sort_by(|a, b| (&a.object, &a.tensor).cmp(&(&b.object, &b.tensor)));
+        if decisions.len() != surface.len()
+            || decisions
+                .iter()
+                .zip(surface.entries())
+                .any(|(d, t)| (d.object.as_str(), d.tensor.as_str()) != t.key())
+        {
+            return Err(VindexError::Parse(
+                "effective decisions must name every surface tensor exactly once".into(),
+            ));
+        }
+        if decisions.iter().any(|d| matches!(&d.encoding, ResolvedEncoding::Compiled(e) if e.is_empty() || e == SOURCE_PRECISION)) {
+            return Err(VindexError::Parse("compiled decisions require a non-source encoding".into()));
+        }
+        Ok(Self { decisions })
+    }
+
     pub fn decisions(&self) -> &[ResolvedDecision] {
         &self.decisions
     }

--- a/crates/larql-vindex/tests/candidate_authority/main.rs
+++ b/crates/larql-vindex/tests/candidate_authority/main.rs
@@ -290,3 +290,75 @@ fn actual_layout_refusal_persists_source_despite_the_requested_encoding() {
         );
     }
 }
+
+#[test]
+fn executable_root_mutation_refuses_with_untouched_candidate_authority_and_payloads() {
+    let f = fixture();
+    for arm in ["segment", "graph-locator", "graph-content"] {
+        let out = compile(&f, arm, &RepresentSpec::nvfp4());
+        assert_eq!(read_candidate(&out).unwrap().id(), &f.expected);
+        let sidecar_before = std::fs::read(out.join(CANDIDATE_INDEX_FILE)).unwrap();
+        let root_file = out.join("index.json");
+        let mut root: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&root_file).unwrap()).unwrap();
+        if arm == "segment" {
+            root["representations"]
+                .as_object_mut()
+                .unwrap()
+                .values_mut()
+                .next()
+                .unwrap()["segment"] = serde_json::json!("segments/substituted.bin");
+            std::fs::write(&root_file, serde_json::to_vec(&root).unwrap()).unwrap();
+        } else {
+            let graph_file = out.join(root["system_graph"].as_str().unwrap());
+            let mut graph: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&graph_file).unwrap()).unwrap();
+            graph["components"][0]["hidden_size"] = serde_json::json!(128);
+            if arm == "graph-locator" {
+                std::fs::write(
+                    out.join("replacement-graph.json"),
+                    serde_json::to_vec(&graph).unwrap(),
+                )
+                .unwrap();
+                root["system_graph"] = serde_json::json!("replacement-graph.json");
+                std::fs::write(&root_file, serde_json::to_vec(&root).unwrap()).unwrap();
+            } else {
+                std::fs::write(&graph_file, serde_json::to_vec(&graph).unwrap()).unwrap();
+            }
+        }
+        assert_eq!(
+            std::fs::read(out.join(CANDIDATE_INDEX_FILE)).unwrap(),
+            sidecar_before
+        );
+        assert!(
+            matches!(read_candidate(&out), Err(CandidateAuthorityRefusal::Binding { what, .. }) if what == "executable root"),
+            "{arm}: changed executable artifact must refuse at its root binding"
+        );
+    }
+}
+
+#[test]
+fn equivalent_root_serialisation_and_graph_relocation_preserve_candidate_identity() {
+    let f = fixture();
+    let out = compile(&f, "equivalent-root", &RepresentSpec::nvfp4());
+    let root_file = out.join("index.json");
+    let mut root: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&root_file).unwrap()).unwrap();
+    std::fs::write(&root_file, serde_json::to_vec(&root).unwrap()).unwrap();
+    assert_eq!(read_candidate(&out).unwrap().id(), &f.expected);
+    let graph_file = out.join(root["system_graph"].as_str().unwrap());
+    std::fs::rename(&graph_file, out.join("same-graph.json")).unwrap();
+    root["system_graph"] = serde_json::json!("same-graph.json");
+    std::fs::write(root_file, serde_json::to_vec(&root).unwrap()).unwrap();
+    assert_eq!(read_candidate(&out).unwrap().id(), &f.expected);
+}
+
+#[test]
+fn a_sidecar_cannot_establish_a_candidate_without_a_readable_executable_root() {
+    let f = fixture();
+    let out = compile(&f, "broken-root", &RepresentSpec::nvfp4());
+    std::fs::write(out.join("index.json"), b"not a container index").unwrap();
+    assert!(
+        matches!(read_candidate(&out), Err(CandidateAuthorityRefusal::Invalid(detail)) if detail.contains("executable root"))
+    );
+}

--- a/crates/larql-vindex/tests/candidate_authority/main.rs
+++ b/crates/larql-vindex/tests/candidate_authority/main.rs
@@ -1,0 +1,292 @@
+//! Independent consumer crate: only public APIs, no writer-side object
+//! survives fixture construction. Every hostile case starts from real bytes.
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use larql_vindex::format::vindex3::{
+    encode::segment::read_segment_header,
+    fixtures::{dense_f32_model, encode_fixture_container},
+    index::Vindex3Index,
+    represent::{
+        candidate_authority::{
+            read_candidate, verify_candidate, CandidateAuthorityRefusal, CANDIDATE_INDEX_FILE,
+        },
+        compile_representation,
+        compiler::read_source_identity,
+        map::PrecisionMap,
+        policy::classify_in,
+        state::{
+            PackLayoutAdmission, RepresentationState, RepresentationStateId, SurfaceTensor,
+            TensorSurface,
+        },
+        RepresentSpec,
+    },
+};
+
+struct Fixture {
+    dir: tempfile::TempDir,
+    source: PathBuf,
+    expected: RepresentationStateId,
+    surface: TensorSurface,
+}
+
+fn fixture() -> Fixture {
+    let dir = tempfile::tempdir().unwrap();
+    let checkpoint = dir.path().join("checkpoint");
+    std::fs::create_dir(&checkpoint).unwrap();
+    let source = dir.path().join("source");
+    encode_fixture_container(dense_f32_model, &checkpoint, &source, "target");
+    let index: Vindex3Index =
+        serde_json::from_slice(&std::fs::read(source.join("index.json")).unwrap()).unwrap();
+    let mut tensors = BTreeMap::new();
+    for entry in index.representations.values() {
+        let (header, _) = read_segment_header(&source.join(&entry.segment)).unwrap();
+        for t in header.tensors {
+            let role = classify_in(true, &entry.object, &t.name, &t.shape);
+            let tensor = SurfaceTensor::new(&entry.object, &t.name, role, t.shape);
+            tensors.insert((entry.object.clone(), t.name), tensor);
+        }
+    }
+    let surface = TensorSurface::new(tensors.into_values()).unwrap();
+    let spec = RepresentSpec::nvfp4();
+    let map =
+        PrecisionMap::from_policy(spec.map_name(), &spec.encoding, &spec.roles, &spec.protect);
+    let expected = RepresentationState::resolve(
+        &read_source_identity(&source).unwrap(),
+        &surface,
+        &map,
+        &PackLayoutAdmission,
+    )
+    .id()
+    .clone();
+    Fixture {
+        dir,
+        source,
+        expected,
+        surface,
+    }
+}
+
+fn compile(f: &Fixture, name: &str, spec: &RepresentSpec) -> PathBuf {
+    let out = f.dir.path().join(name);
+    // The report is dropped here; every compiler/store/arena/file handle
+    // created by the public compiler has already been dropped on return.
+    drop(compile_representation(&f.source, &out, spec).unwrap());
+    out
+}
+
+fn edit(out: &Path, f: impl FnOnce(&mut serde_json::Value)) {
+    let path = out.join(CANDIDATE_INDEX_FILE);
+    let mut doc: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    f(&mut doc);
+    std::fs::write(path, serde_json::to_vec_pretty(&doc).unwrap()).unwrap();
+}
+
+#[test]
+fn fresh_public_reader_reconstructs_the_independently_predicted_state() {
+    let f = fixture();
+    let out = compile(&f, "candidate", &RepresentSpec::nvfp4());
+    let expected = f.expected.clone();
+    let moved = tempfile::tempdir().unwrap();
+    let destination = moved.path().join("renamed");
+    std::fs::rename(out, &destination).unwrap();
+    drop(f); // checkpoint, source container and compiler-side fixture gone
+    let state = read_candidate(&destination).unwrap();
+    assert_eq!(state.id(), &expected);
+    assert!(state.decisions().compiled() > 0);
+}
+
+#[test]
+fn payload_mutation_refuses_even_when_every_metadata_field_is_unchanged() {
+    let f = fixture();
+    let out = compile(&f, "candidate", &RepresentSpec::nvfp4());
+    let doc: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(out.join(CANDIDATE_INDEX_FILE)).unwrap()).unwrap();
+    let payloads = doc["authority"]["payloads"].as_object().unwrap();
+    let payload = payloads
+        .iter()
+        .find(|(object, _)| object.contains("decoder"))
+        .unwrap()
+        .1;
+    let file = out.join(payload["file"].as_str().unwrap());
+    let mut bytes = std::fs::read(&file).unwrap();
+    let last = bytes.len() - 1;
+    bytes[last] ^= 1;
+    std::fs::write(file, bytes).unwrap();
+    assert!(
+        matches!(read_candidate(&out), Err(CandidateAuthorityRefusal::Binding { what, .. }) if what.contains("payload"))
+    );
+}
+
+#[test]
+fn effective_decisions_surface_and_source_are_bound_individually() {
+    let f = fixture();
+    for field in ["decisions", "surface", "source"] {
+        let out = compile(&f, field, &RepresentSpec::nvfp4());
+        edit(&out, |index| match field {
+            "decisions" => {
+                index["authority"]["decisions"]["decisions"][0]["encoding"] =
+                    serde_json::json!({"Compiled":"Q6_K"})
+            }
+            "surface" => {
+                index["authority"]["surface"]["entries"][0]["shape"][0] = serde_json::json!(999)
+            }
+            "source" => {
+                index["source"]["identity"]["semantic"]["graph_hash"] = serde_json::json!("changed")
+            }
+            _ => unreachable!(),
+        });
+        assert!(
+            matches!(read_candidate(&out), Err(CandidateAuthorityRefusal::Binding { what, .. }) if what == "metadata"),
+            "{field}"
+        );
+    }
+}
+
+#[test]
+fn a_corrupt_stored_id_is_detected_and_the_recomputed_id_is_reported() {
+    let f = fixture();
+    let out = compile(&f, "candidate", &RepresentSpec::nvfp4());
+    edit(&out, |index| {
+        index["authority"]["state_id"] = serde_json::json!("invented")
+    });
+    match read_candidate(&out).unwrap_err() {
+        CandidateAuthorityRefusal::StoredState { stored, recomputed } => {
+            assert_eq!(stored.as_str(), "invented");
+            assert_eq!(recomputed, f.expected);
+        }
+        e => panic!("wrong refusal: {e}"),
+    }
+}
+
+#[test]
+fn caller_request_cannot_author_the_compilation_and_valid_y_is_not_requested_x() {
+    let f = fixture();
+    let source_state = RepresentationState::resolve(
+        &read_source_identity(&f.source).unwrap(),
+        &f.surface,
+        &source_map(),
+        &PackLayoutAdmission,
+    );
+    use larql_vindex::format::vindex3::represent::{
+        measurement::EvidenceScale,
+        state::{EvidenceBank, InstrumentSemantics, MeasurementKey},
+    };
+    let bank = EvidenceBank::new("fixture/v1", "manifest", ["one"], 1);
+    let instrument = InstrumentSemantics::new("kl", "distribution", "all", "fixture/v1");
+    let key = MeasurementKey::new(
+        source_state.id(),
+        &bank.id(),
+        EvidenceScale::Diagnostic,
+        &instrument.id(),
+    );
+    let executor_restatement = key.clone();
+    assert_eq!(executor_restatement, key);
+    let requested = key.state().clone();
+    assert_ne!(requested, f.expected);
+    let out = compile(&f, "caller-asks-for-source", &RepresentSpec::nvfp4());
+    let established = read_candidate(&out).unwrap();
+    assert_eq!(established.id(), &f.expected);
+    let refusal = verify_candidate(&out, &requested).unwrap_err();
+    assert!(refusal.to_string().contains(requested.as_str()));
+    assert!(refusal.to_string().contains(f.expected.as_str()));
+    assert!(
+        matches!(refusal, CandidateAuthorityRefusal::RequestedState { expected, observed } if expected == requested && observed == f.expected)
+    );
+    assert_eq!(verify_candidate(&out, &f.expected).unwrap(), established);
+}
+
+#[test]
+fn requested_map_provenance_and_lowering_choices_do_not_replace_results() {
+    let f = fixture();
+    let out = compile(&f, "candidate", &RepresentSpec::nvfp4());
+    edit(&out, |index| {
+        index["map"] = serde_json::to_value(source_map()).unwrap();
+        index["source"]["locator_hint"] = serde_json::json!("/elsewhere");
+        index["source"]["identity"]["artifact"] = serde_json::json!("re-exported");
+        index["selected_representation"] = serde_json::json!("source");
+        index["lowering_provider"] = serde_json::json!("outside/v999");
+    });
+    assert_eq!(read_candidate(&out).unwrap().id(), &f.expected);
+}
+
+#[test]
+fn missing_and_unknown_authority_refuse() {
+    let f = fixture();
+    for field in ["absent", "schema", "state_semantics"] {
+        let out = compile(&f, field, &RepresentSpec::nvfp4());
+        edit(&out, |index| {
+            if field == "absent" {
+                index.as_object_mut().unwrap().remove("authority");
+            } else {
+                index["authority"][field] = serde_json::json!("unknown/v9");
+            }
+        });
+        assert!(match read_candidate(&out) {
+            Err(CandidateAuthorityRefusal::Missing) => field == "absent",
+            Err(CandidateAuthorityRefusal::Version { .. }) => field != "absent",
+            result => panic!("unexpected {result:?}"),
+        });
+    }
+}
+
+fn source_map() -> PrecisionMap {
+    PrecisionMap {
+        name: "source".into(),
+        encoding: "NVFP4_PACK_V1".into(),
+        roles: vec![],
+        exceptions: vec![],
+    }
+}
+
+#[test]
+fn actual_layout_refusal_persists_source_despite_the_requested_encoding() {
+    use larql_vindex::format::vindex3::represent::{
+        kquant,
+        state::{LayoutAdmission, NoLayoutConstraint, ResolvedEncoding},
+    };
+    struct KQuantAdmission;
+    impl LayoutAdmission for KQuantAdmission {
+        fn admits(&self, encoding: &str, tensor: &SurfaceTensor) -> bool {
+            kquant::lookup(encoding)
+                .unwrap()
+                .plan(&tensor.shape, &tensor.tensor)
+                .is_ok()
+        }
+    }
+    let f = fixture();
+    let mut spec = RepresentSpec::nvfp4();
+    spec.encoding = "Q6_K".into();
+    let map =
+        PrecisionMap::from_policy(spec.map_name(), &spec.encoding, &spec.roles, &spec.protect);
+    let model = read_source_identity(&f.source).unwrap();
+    let effective = RepresentationState::resolve(&model, &f.surface, &map, &KQuantAdmission);
+    let requested = RepresentationState::resolve(&model, &f.surface, &map, &NoLayoutConstraint);
+    assert_ne!(effective.id(), requested.id());
+    assert!(effective.decisions().compiled() > 0);
+    assert!(!effective.decisions().layout_refused().is_empty());
+    let out = compile(&f, "mixed-layout", &spec);
+    let read = read_candidate(&out).unwrap();
+    assert_eq!(read, effective);
+    let doc: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(out.join(CANDIDATE_INDEX_FILE)).unwrap()).unwrap();
+    for refused in read.decisions().layout_refused() {
+        assert!(matches!(
+            refused.encoding,
+            ResolvedEncoding::LayoutRefused { .. }
+        ));
+        let payload = &doc["authority"]["payloads"][&refused.object];
+        let (header, _) =
+            read_segment_header(&out.join(payload["file"].as_str().unwrap())).unwrap();
+        assert_eq!(
+            header
+                .tensors
+                .iter()
+                .find(|t| t.name == refused.tensor)
+                .unwrap()
+                .dtype,
+            "F32"
+        );
+    }
+}

--- a/crates/larql-vindex/tests/candidate_authority/main.rs
+++ b/crates/larql-vindex/tests/candidate_authority/main.rs
@@ -68,7 +68,9 @@ fn fixture() -> Fixture {
 }
 
 fn compile(f: &Fixture, name: &str, spec: &RepresentSpec) -> PathBuf {
-    let out = f.dir.path().join(name);
+    // Hostile case labels include "source"; none may alias the immutable
+    // source container, even on platforms that permit rewriting open files.
+    let out = f.dir.path().join("candidates").join(name);
     // The report is dropped here; every compiler/store/arena/file handle
     // created by the public compiler has already been dropped on return.
     drop(compile_representation(&f.source, &out, spec).unwrap());

--- a/docs/represent-optimizer-mcp.md
+++ b/docs/represent-optimizer-mcp.md
@@ -1711,10 +1711,29 @@ Deliberately boring, so MCTS is a policy swap and not a rewrite.
 | 4b | The source identity the optimizer prices from (§4i) | **done** |
 | 5a | A run is instructed, not configured; co-execution (§4j) | **done** |
 | 5b | The actuation bridge — a selected experiment becomes a request (§4j) | **done** |
+| A | Independent candidate-byte authority (REPRESENT-LOOP-1 prerequisite) | implemented; see witnesses below |
 | 6 | The measurement artifact, and ingestion that checks it names its key | |
 | 7 | The loop — reload, derive, execute, ingest, repeat | |
 | 8 | PUCT as another `SearchPolicy`; same states, actions, evidence | |
 | 9 | Extend `PhysicalState` with residency; optimise measured tok/s | |
+
+The pre-K3 milestone is [REPRESENT-LOOP-1](represent/forecasts/represent-loop-1.json):
+**A**, independently establish the compiled artifact; **B**, resume OPT-6 and
+admit observations transactionally; **C**, show accepted evidence changes
+future selection while rejected evidence cannot. K3 follows all three.
+
+Transition A extends the existing `CandidateIndex`. The bank compilers persist
+completed authority in their index; the general representation compiler writes
+the same type as `candidate.json` beside its ordinary container index. The
+[public reader](../crates/larql-vindex/src/format/vindex3/represent/candidate_authority.rs)
+verifies metadata, payloads and operand seals, then feeds persisted source,
+surface and effective decisions into `RepresentationState::from_decisions`.
+It never resolves the requested map or accepts a stored state id as authority.
+[The witnesses and limits](represent/forecasts/represent-candidate-authority-1-notes.json)
+include a fresh read after deleting the source fixture, actual layout fallback,
+and valid-Y/requested-X refusal. Scientific ingestion and the closed-loop
+witness remain separate transitions; establishing candidate validity does not
+append evidence or grant a promotion.
 
 Provenance lives on **incoming edges**, not baked into the node:
 

--- a/docs/represent-optimizer-mcp.md
+++ b/docs/represent-optimizer-mcp.md
@@ -1726,8 +1726,11 @@ Transition A extends the existing `CandidateIndex`. The bank compilers persist
 completed authority in their index; the general representation compiler writes
 the same type as `candidate.json` beside its ordinary container index. The
 [public reader](../crates/larql-vindex/src/format/vindex3/represent/candidate_authority.rs)
-verifies metadata, payloads and operand seals, then feeds persisted source,
-surface and effective decisions into `RepresentationState::from_decisions`.
+verifies metadata, payloads and operand seals. For a full-container sidecar,
+it also reopens the executable root and compares its output-container semantic
+digest. It then feeds persisted source, surface and effective decisions into
+`RepresentationState::from_decisions`; the root binding is artifact-integrity
+evidence and never another state-identity input.
 It never resolves the requested map or accepts a stored state id as authority.
 [The witnesses and limits](represent/forecasts/represent-candidate-authority-1-notes.json)
 include a fresh read after deleting the source fixture, actual layout fallback,

--- a/docs/represent/forecasts/represent-candidate-authority-1-notes.json
+++ b/docs/represent/forecasts/represent-candidate-authority-1-notes.json
@@ -4,7 +4,7 @@
   "branch": "represent-candidate-authority-impl",
   "base": "eadc43a88f5b3252e8bfe4bb463f7c7845b42a29",
   "date": "2026-09-12",
-  "status": "implemented and locally verified; ready for transition-A review",
+  "status": "executable-root review blocker fixed and locally verified; ready for transition-A review",
   "carrier": "CandidateIndex gains optional completed authority: schema and state-semantics version, TensorSurface, effective ResolvedDecisionVector, payload bindings, a metadata binding, and a convenience state_id. Legacy and in-progress candidates carry no completed authority and the independent reader refuses them.",
   "writers": {
     "bank_compilers": "Expert and KDA bank completion derives effective encodings from completed operand seals over the supplied compilation surface. An unsealed surface tensor remains source. Completion never takes a requested MeasurementKey or state id. Checkpoints emitted during a run have no completed authority.",
@@ -12,7 +12,7 @@
     "full_container_carriage": "The general compiler stores the same CandidateIndex as candidate.json beside its ordinary VINDEX3 index. Adding candidate provenance to Vindex3Index.extra would feed it into the existing source semantic catalogue digest. The sidecar avoids that accidental identity change; it is not a new manifest type.",
     "cost": "Payload and range digests use bounded streaming reads. Compilation now pays extra verification reads; this transition makes no throughput claim and does not price them as runtime preparation."
   },
-  "reader": "read_candidate opens only persisted files, validates metadata and payload binding, validates canonical surface/vector shape and seal relations, and calls RepresentationState::from_decisions. verify_candidate separately compares that established identity with the caller's expected identity. Neither reader resolves CandidateIndex.map.",
+  "reader": "read_candidate opens only persisted files, validates metadata and payload binding, re-establishes a full-container sidecar's executable-root semantic digest, validates canonical surface/vector shape and seal relations, and calls RepresentationState::from_decisions. verify_candidate separately compares that established identity with the caller's expected identity. Neither reader resolves CandidateIndex.map.",
   "witnesses": {
     "integration_file": "crates/larql-vindex/tests/candidate_authority/main.rs",
     "round_trip_and_move": "fresh_public_reader_reconstructs_the_independently_predicted_state moves the completed artifact, drops the entire fixture including checkpoint/source container, and then reads it through public API from a separate integration crate.",
@@ -21,7 +21,7 @@
     "stored_id": "a_corrupt_stored_id_is_detected_and_the_recomputed_id_is_reported",
     "request_independence_and_xy": "caller_request_cannot_author_the_compilation_and_valid_y_is_not_requested_x carries a requested MeasurementKey and matching executor restatement, compiles another state, independently establishes it, then refuses the mismatch naming both states.",
     "layout": "actual_layout_refusal_persists_source_despite_the_requested_encoding uses real Q6_K compilation: some dense-fixture matrices compile, while short rows remain F32. The state differs from the requested map resolved without layout admission and equals the effective vector.",
-    "plane_boundary": "requested_map_provenance_and_lowering_choices_do_not_replace_results",
+    "plane_boundary": "Structural boundary: the authority inputs and normative state identity exclude lowering facts. requested_map_provenance_and_lowering_choices_do_not_replace_results only witnesses ignored unknown JSON metadata, not a real RealizationRecord/lowering variation; this remains a weak behavioral witness and is not presented as stronger evidence.",
     "malformed_relations": "crates/larql-vindex/src/format/vindex3/represent/candidate_authority/tests.rs deliberately re-seals metadata to exercise surface ordering, duplicate/missing decisions, invalid encodings, missing payloads/seals, overflowing extents, wrong operand hashes, wrong ledger keys, overlaps and invalid file locators beyond the outer checksum.",
     "bank_reader": "completed_bank_authority_is_read_from_disk_and_rejects_changed_bytes in crates/larql-vindex/src/format/vindex3/represent/compiler_tests.rs"
   },
@@ -32,10 +32,23 @@
     "No execution or performance claim for K3, no lowering vocabulary change, and no promotion policy change."
   ],
   "validation": {
-    "crate_tests": "cargo test -p larql-vindex passed; the final coverage run passed 5,055 tests across 39 suites, with 7 model-backed tests ignored.",
-    "coverage": "Policy passed: 93.74% total, 465 files checked. New reader 92.73%; new producer 92.37%. No policy exemption added.",
+    "crate_tests": "The final full-crate coverage run passed 5,059 tests across 39 suites, with 7 model-backed tests ignored; the 11 independent candidate-authority integration tests passed.",
+    "coverage": "Policy passed: 93.74% total, 465 files checked. Reader 91.29%; producer 92.13%. No policy exemption added.",
     "static_checks": "cargo fmt --all --check; cargo clippy -p larql-vindex --all-targets -- -D warnings; cargo check --workspace --all-targets.",
     "documentation": "Contract index, documentation links and strict documentation-reference checks passed.",
     "environment": "The sandbox prevented local HTTP mock servers in the first full test attempt. Re-running with the required network permission passed. No model download or K3 measurement was performed."
+  },
+  "root_binding_review": {
+    "finding": "c84872ea let a full-container sidecar establish X after the executable index.json changed, because it bound only candidate metadata and listed payloads. The regression test failed before the repair when only representation.segment was changed.",
+    "repair": "ExecutableRootBinding is included in the metadata integrity seal. Full-container completion records read_source_identity(output).semantic_digest() after index.json is persisted. The fresh reader reopens that executable root and compares its semantic digest before establishing the candidate state. Inline bank authority is distinguished explicitly; a sidecar cannot downgrade itself to the inline case even with a recomputed outer binding.",
+    "identity_boundary": "The output root digest is artifact-integrity evidence only. It is not passed to RepresentationState::from_decisions, and neither normative identity algorithm nor version is changed. The existing semantic identity machinery binds the representation catalogue and the declared graph by content; root formatting and relocating the same graph bytes therefore preserve candidate identity.",
+    "hostile_witnesses": [
+      "executable_root_mutation_refuses_with_untouched_candidate_authority_and_payloads: segment locator, replacement graph locator, and graph content each change without touching candidate authority or segment bytes; each must refuse specifically at the executable root binding.",
+      "a_sidecar_cannot_establish_a_candidate_without_a_readable_executable_root",
+      "a_sidecar_cannot_downgrade_its_root_binding_to_an_inline_candidate"
+    ],
+    "positive_control": "equivalent_root_serialisation_and_graph_relocation_preserve_candidate_identity",
+    "compatibility": "The root-binding field is required. Candidate authorities from the unmerged c84872ea implementation lack it and are refused rather than accepted without root evidence.",
+    "validation": "The root-mutation test failed on c84872ea before production code changed, then passed with the executable-root binding. All 39 crate suites, coverage policy, clippy, workspace/all-target checks, formatting and documentation gates passed after the repair."
   }
 }

--- a/docs/represent/forecasts/represent-candidate-authority-1-notes.json
+++ b/docs/represent/forecasts/represent-candidate-authority-1-notes.json
@@ -1,0 +1,41 @@
+{
+  "programme": "REPRESENT-CANDIDATE-AUTHORITY-1",
+  "milestone": "REPRESENT-LOOP-1 transition A",
+  "branch": "represent-candidate-authority-impl",
+  "base": "eadc43a88f5b3252e8bfe4bb463f7c7845b42a29",
+  "date": "2026-09-12",
+  "status": "implemented and locally verified; ready for transition-A review",
+  "carrier": "CandidateIndex gains optional completed authority: schema and state-semantics version, TensorSurface, effective ResolvedDecisionVector, payload bindings, a metadata binding, and a convenience state_id. Legacy and in-progress candidates carry no completed authority and the independent reader refuses them.",
+  "writers": {
+    "bank_compilers": "Expert and KDA bank completion derives effective encodings from completed operand seals over the supplied compilation surface. An unsealed surface tensor remains source. Completion never takes a requested MeasurementKey or state id. Checkpoints emitted during a run have no completed authority.",
+    "general_representation_compiler": "Records each encoding decision after real layout admission, including LayoutRefused, and seals the actual ranges in the completed segment tables. Thus the real fallback path, which the bank compilers do not implement, is covered as well.",
+    "full_container_carriage": "The general compiler stores the same CandidateIndex as candidate.json beside its ordinary VINDEX3 index. Adding candidate provenance to Vindex3Index.extra would feed it into the existing source semantic catalogue digest. The sidecar avoids that accidental identity change; it is not a new manifest type.",
+    "cost": "Payload and range digests use bounded streaming reads. Compilation now pays extra verification reads; this transition makes no throughput claim and does not price them as runtime preparation."
+  },
+  "reader": "read_candidate opens only persisted files, validates metadata and payload binding, validates canonical surface/vector shape and seal relations, and calls RepresentationState::from_decisions. verify_candidate separately compares that established identity with the caller's expected identity. Neither reader resolves CandidateIndex.map.",
+  "witnesses": {
+    "integration_file": "crates/larql-vindex/tests/candidate_authority/main.rs",
+    "round_trip_and_move": "fresh_public_reader_reconstructs_the_independently_predicted_state moves the completed artifact, drops the entire fixture including checkpoint/source container, and then reads it through public API from a separate integration crate.",
+    "payload": "payload_mutation_refuses_even_when_every_metadata_field_is_unchanged",
+    "metadata": "effective_decisions_surface_and_source_are_bound_individually",
+    "stored_id": "a_corrupt_stored_id_is_detected_and_the_recomputed_id_is_reported",
+    "request_independence_and_xy": "caller_request_cannot_author_the_compilation_and_valid_y_is_not_requested_x carries a requested MeasurementKey and matching executor restatement, compiles another state, independently establishes it, then refuses the mismatch naming both states.",
+    "layout": "actual_layout_refusal_persists_source_despite_the_requested_encoding uses real Q6_K compilation: some dense-fixture matrices compile, while short rows remain F32. The state differs from the requested map resolved without layout admission and equals the effective vector.",
+    "plane_boundary": "requested_map_provenance_and_lowering_choices_do_not_replace_results",
+    "malformed_relations": "crates/larql-vindex/src/format/vindex3/represent/candidate_authority/tests.rs deliberately re-seals metadata to exercise surface ordering, duplicate/missing decisions, invalid encodings, missing payloads/seals, overflowing extents, wrong operand hashes, wrong ledger keys, overlaps and invalid file locators beyond the outer checksum.",
+    "bank_reader": "completed_bank_authority_is_read_from_disk_and_rejects_changed_bytes in crates/larql-vindex/src/format/vindex3/represent/compiler_tests.rs"
+  },
+  "limits": [
+    "This establishes the candidate artifact and the X/Y comparison boundary. OPT-6's full MeasurementArtifact/protocol/transactional SearchFacts witness remains transition B; this transition does not claim ingestion exists.",
+    "Bank authority describes the exact tensor surface supplied to compilation. A wider search surface yields a different RepresentationStateId and must refuse, rather than silently borrowing the request's surface.",
+    "Representation identity and source semantic identity algorithms and version constants are unchanged. Authority binding is an artifact integrity check, not a second state-id recipe or a signature proving a compiler is trusted.",
+    "No execution or performance claim for K3, no lowering vocabulary change, and no promotion policy change."
+  ],
+  "validation": {
+    "crate_tests": "cargo test -p larql-vindex passed; the final coverage run passed 5,055 tests across 39 suites, with 7 model-backed tests ignored.",
+    "coverage": "Policy passed: 93.74% total, 465 files checked. New reader 92.73%; new producer 92.37%. No policy exemption added.",
+    "static_checks": "cargo fmt --all --check; cargo clippy -p larql-vindex --all-targets -- -D warnings; cargo check --workspace --all-targets.",
+    "documentation": "Contract index, documentation links and strict documentation-reference checks passed.",
+    "environment": "The sandbox prevented local HTTP mock servers in the first full test attempt. Re-running with the required network permission passed. No model download or K3 measurement was performed."
+  }
+}

--- a/docs/represent/forecasts/represent-candidate-authority-1-notes.json
+++ b/docs/represent/forecasts/represent-candidate-authority-1-notes.json
@@ -4,7 +4,7 @@
   "branch": "represent-candidate-authority-impl",
   "base": "eadc43a88f5b3252e8bfe4bb463f7c7845b42a29",
   "date": "2026-09-12",
-  "status": "executable-root review blocker fixed and locally verified; ready for transition-A review",
+  "status": "transition-A design review cleared; merge awaits green CI",
   "carrier": "CandidateIndex gains optional completed authority: schema and state-semantics version, TensorSurface, effective ResolvedDecisionVector, payload bindings, a metadata binding, and a convenience state_id. Legacy and in-progress candidates carry no completed authority and the independent reader refuses them.",
   "writers": {
     "bank_compilers": "Expert and KDA bank completion derives effective encodings from completed operand seals over the supplied compilation surface. An unsealed surface tensor remains source. Completion never takes a requested MeasurementKey or state id. Checkpoints emitted during a run have no completed authority.",
@@ -37,6 +37,11 @@
     "static_checks": "cargo fmt --all --check; cargo clippy -p larql-vindex --all-targets -- -D warnings; cargo check --workspace --all-targets.",
     "documentation": "Contract index, documentation links and strict documentation-reference checks passed.",
     "environment": "The sandbox prevented local HTTP mock servers in the first full test attempt. Re-running with the required network permission passed. No model download or K3 measurement was performed."
+  },
+  "windows_fixture_review": {
+    "finding": "The Windows integration run on 22f29ff6 failed with sharing violation OS error 32 during the metadata test. Its source mutation case used the output label source, aliasing the fixture's immutable source directory. Linux and macOS allowed that accidental in-place compilation.",
+    "repair": "All integration fixture outputs now live under a separate candidates directory, so case labels cannot alias the source container. No production authority or state-identity behavior changes.",
+    "validation": "The 11 candidate-authority integration tests are rerun after this fixture correction; platform CI must confirm the Windows result. The earlier 5,059-test and coverage results above describe the production root-binding repair. The informational mutants job on 22f29ff6 timed out and is incomplete, not clean."
   },
   "root_binding_review": {
     "finding": "c84872ea let a full-container sidecar establish X after the executable index.json changed, because it bound only candidate metadata and listed payloads. The regression test failed before the repair when only representation.segment was changed.",

--- a/docs/represent/forecasts/represent-loop-1.json
+++ b/docs/represent/forecasts/represent-loop-1.json
@@ -1,0 +1,39 @@
+{
+  "programme": "REPRESENT-LOOP-1 — independently established evidence changes future search",
+  "status": "milestone frozen before implementation",
+  "base": "eadc43a88f5b3252e8bfe4bb463f7c7845b42a29",
+  "date": "2026-09-12",
+  "claim": "Accepted evidence changes future search behaviour; rejected evidence cannot.",
+  "transitions": [
+    {
+      "id": "A",
+      "programme": "REPRESENT-CANDIDATE-AUTHORITY-1",
+      "scope": "Implement the existing ten-arm freeze by extending CandidateIndex with effective decisions and tensor-surface authority, bound to the actual persisted payload. Reuse RepresentationState::from_decisions without changing its canonical input or version.",
+      "acceptance": "Compile X; drop all compiler objects; reopen through a separate public reader; verify the persisted payload and reconstruct X. The requested MeasurementKey is never a writer input.",
+      "controls": "Payload mutation refuses; metadata mutation moves identity or refuses; corrupt convenience state id is detected; a caller requesting Y cannot change authority for compilation X; moving the artifact leaves identity unchanged; layout-refused decisions describe source bytes."
+    },
+    {
+      "id": "B",
+      "programme": "OPT-6",
+      "depends_on": "A",
+      "scope": "Resume the paused ingestion implementation and its existing frozen arms, consuming candidate authority earned in A.",
+      "acceptance": "A valid Y artifact independently establishes Y when requested X and the executor restates X; ingestion refuses naming both. All scientific-state inputs remain observably identical after rejection, including measurements, graph, ranking/promotion inputs and resulting snapshot/search identity. Duplicate acceptance changes facts only once."
+    },
+    {
+      "id": "C",
+      "programme": "REPRESENT-LOOP-1 closed-loop witness",
+      "depends_on": "B",
+      "scope": "A tiny deterministic fixture with two or three possible transitions, exercised through selection, actuation, independent verification and ingestion.",
+      "positive": "S0 selects A; valid observation of A is accepted; SearchFacts changes once; S1 selects predetermined B.",
+      "negative": "The same S0 selects A; plausible wrong or invalid evidence is refused; all scientific facts remain equivalent to S0 and the next experiment remains A.",
+      "failure": "Appending an observation without a demonstrated effect on future selection does not establish the claim."
+    }
+  ],
+  "sequencing": "Separate reviewable transitions A, B and C, each verified before its successor. Use a fresh worktree from the stated base; do not rebase the unrelated experimental checkout. K3 follows all three gates.",
+  "parallel_debts": [
+    {"id": "LOWERING-AUTHORITY-2", "scope": "Shared/exported gate-policy judgement", "blocks_loop": false},
+    {"id": "LOWERING-VOCABULARY-1", "scope": "Externally extensible realization/kernel vocabulary", "blocks_loop": false}
+  ],
+  "k3_question_afterwards": "Can an independently evidenced optimizer discover a better physical representation of a heterogeneous frontier model under a real laptop resource envelope?",
+  "out_of_scope": "K3 execution or performance measurements, new lowering mechanisms, and a new general candidate-artifact subsystem."
+}


### PR DESCRIPTION
A compiled candidate previously persisted its requested PrecisionMap without enough information for an independent consumer to reconstruct its effective RepresentationStateId. This adds completed authority to the existing CandidateIndex, plus a filesystem reader that verifies bindings and passes persisted source, surface and effective decisions to RepresentationState::from_decisions.

The milestone freeze ec9089ee precedes the implementation c84872ea. Commit 22f29ff6 closes the executable-root binding defect found in review: a full-container sidecar now binds the output index and its declared graph through the existing container semantic identity machinery. This PR remains scoped to Transition A; OPT-6 ingestion and the closed-loop witness are separate transitions.

[Implementation notes](https://github.com/chrishayuk/larql/blob/07c1cb3b/docs/represent/forecasts/represent-candidate-authority-1-notes.json) · [Milestone freeze](https://github.com/chrishayuk/larql/blob/ec9089ee/docs/represent/forecasts/represent-loop-1.json)

Five review points:

1. **Effective decisions.** The general compiler records decisions after actual layout admission; bank compilers derive encodings from completed operand seals. The reader never resolves CandidateIndex.map. The [Q6_K witness](https://github.com/chrishayuk/larql/blob/22f29ff6/crates/larql-vindex/tests/candidate_authority/main.rs#L244) contains both successfully compiled matrices and rows carried as F32 after layout refusal.
2. **Cold reader.** The [integration witness](https://github.com/chrishayuk/larql/blob/22f29ff6/crates/larql-vindex/tests/candidate_authority/main.rs#L87) moves the artifact, drops the fixture including checkpoint, source container and surface, then calls the public reader. Only the independently predicted expected ID survives for comparison.
3. **Physical binding.** The [reader](https://github.com/chrishayuk/larql/blob/22f29ff6/crates/larql-vindex/src/format/vindex3/represent/candidate_authority.rs#L200) verifies whole payload-file SHA-256 and length, then each sealed operand range. A separate metadata digest binds source semantic authority, full surface, decisions, ledger, payload descriptors and the executable-root binding. For full containers, the reader reopens index.json and compares read_source_identity(output).semantic_digest() before establishing the candidate state. The [byte mutation](https://github.com/chrishayuk/larql/blob/22f29ff6/crates/larql-vindex/tests/candidate_authority/main.rs#L101) reaches the candidate payload-binding refusal. Additional tests deliberately re-seal inconsistent metadata to exercise relation checks beyond the outer digest.
4. **Requested-key independence.** The [caller-scope witness](https://github.com/chrishayuk/larql/blob/22f29ff6/crates/larql-vindex/tests/candidate_authority/main.rs#L164) constructs a MeasurementKey for another state and a matching restatement; neither reaches compilation. The actual candidate establishes its own state and the subsequent comparison names both IDs. This is the candidate half of the X/Y witness, not OPT-6's full executor/artifact/transactional-ingestion proof.
5. **Surface authority.** The complete TensorSurface is persisted. For full containers, the [producer](https://github.com/chrishayuk/larql/blob/22f29ff6/crates/larql-vindex/src/format/vindex3/represent/candidate_authority/producer.rs#L29) enumerates source segment headers and classifies roles using the existing plan/name policy. Bank authority covers the exact supplied compilation surface; a wider requested surface must refuse by identity mismatch. The reader validates canonical ordering/completeness and the integrity binding; it does not borrow a caller's surface.

The [executable-root mutation witness](https://github.com/chrishayuk/larql/blob/22f29ff6/crates/larql-vindex/tests/candidate_authority/main.rs#L295) failed before the fix. It now rejects changed segment locators, replacement graph locators and changed graph contents with untouched candidate.json and segment bytes. The positive control accepts equivalent root formatting and relocation of unchanged graph bytes. A sidecar cannot downgrade to the inline-bank binding, even after re-sealing its metadata. Older unmerged authorities missing the required root-binding field refuse.

Arm 9 remains a weak behavioral witness: inserting an unknown lowering_provider JSON field only proves unknown metadata is ignored. The real structural boundary is that authority construction and the normative three-input state identity exclude lowering facts; this PR does not claim a RealizationRecord variation test.

Full containers store the same CandidateIndex as candidate.json beside their ordinary index, avoiding candidate provenance entering Vindex3Index.extra and hence source semantic identity. The output-root binding is artifact-integrity evidence and is never passed to RepresentationState::from_decisions. State identity algorithms and versions are unchanged. Compilation pays additional bounded streaming digest reads. The binding is an integrity seal, not a signature establishing compiler trust.

Validation: 5,059 tests across 39 coverage suites; 7 ignored model-backed tests; coverage policy passes at 93.74%, with no exemptions. Formatting, clippy with -D warnings, workspace/all-target checks, and all three documentation integrity gates pass locally. Local HTTP mock tests required execution outside the network sandbox.

Windows CI exposed a fixture collision: the metadata test case named source compiled into its own source directory. Commit 07c1cb3b isolates every fixture output under candidates/. All 11 integration tests pass locally after this correction; platform CI is pending. The informational mutants run on 22f29ff6 timed out and is incomplete.

Inherited limitation: SourceSemanticIdentity seals moe_manifest by filename, not content. This PR preserves that authority contract; SOURCE-AUTHORITY-MANIFEST-1 should close the gap before manifest-only routed containers supply high-authority closed-loop evidence.
